### PR TITLE
tailwindcss: use NODE_PATH to resolve `@import`

### DIFF
--- a/Formula/t/tailwindcss.rb
+++ b/Formula/t/tailwindcss.rb
@@ -28,11 +28,15 @@ class Tailwindcss < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink libexec.glob("bin/*")
+    bin.install libexec.glob("bin/*")
+    bin.env_script_all_files libexec/"bin", NODE_PATH: libexec/"lib/node_modules/@tailwindcss/cli/node_modules"
   end
 
   test do
-    (testpath/"input.css").write("@tailwind base;")
+    (testpath/"input.css").write <<~CSS
+      @tailwind base;
+      @import "tailwindcss";
+    CSS
     system bin/"tailwindcss", "-i", "input.css", "-o", "output.css"
     assert_path_exists testpath/"output.css"
   end

--- a/Formula/t/tailwindcss.rb
+++ b/Formula/t/tailwindcss.rb
@@ -15,13 +15,13 @@ class Tailwindcss < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256                               arm64_sequoia: "305aea1ec37a55c2833681a410e7ce5218cbd8ff45a9538cbd59230447ef14b6"
-    sha256                               arm64_sonoma:  "ee848c629b5b22ec97ce2ae30c5c5ebdd6b7904ea780161ed9ccaaf1b046449a"
-    sha256                               arm64_ventura: "a5f166c9d0c9277a3d9ad2a2ac1cd6154c11346a5e61b57e24c3e635667deb7e"
-    sha256                               sonoma:        "17a16c0392a4e04666d4e948259affaacb096dc311449239926502c78147f5ee"
-    sha256                               ventura:       "5b911567cf0e39d764b3cc1961c4cca8ad08f83af85dfa0580f7ddb6b3186dcd"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a29ae308b2b26cfdf64dbe1641aec35628623ef63921b0b3ca056ef2bc893abc"
+    rebuild 2
+    sha256                               arm64_sequoia: "6ddcb14591250bac2b506d8cc3d161f3952bf4646a6c4993ce69d0b4d7c0cccc"
+    sha256                               arm64_sonoma:  "b2abd59f889f631763abaf580cdb77a3cd48062052a81cc5f11db1bf23b04625"
+    sha256                               arm64_ventura: "27f32f13c1337f9f9d5a181ea736e30d9f14fa18fdda0aa5d3d728a532127e61"
+    sha256                               sonoma:        "e40dff6e0235180c0fb521094240ba1e7f00e42a5e110ef734354232e3b550c4"
+    sha256                               ventura:       "7d74640a9d98207da0f65a0457f772238710e549e4969974f2cfe8655299debe"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3133d07f96695bc8115105f5033c85ba809063535603d2603c380ad5c053cfd1"
   end
 
   depends_on "node"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Upstream added resolving relative to single path in `NODE_PATH` with https://github.com/tailwindlabs/tailwindcss/commit/3f8e7647b6a47b944b363ab4af2a8cddd30d2e4a

Only `@tailwindcss/cli` would be in a different path (`libexec/"lib/node_modules"`) so cannot be resolved. Would need a different workaround for this if needed as multiple paths in `NODE_PATH` is not supported as tailwindcss does not split colons.

Perhaps if someone upstreams multiple path support we can switch to
```rb
"${NODE_PATH:+${NODE_PATH}:}#{libexec}/lib/node_modules:#{libexec}/lib/node_modules/@tailwindcss/cli/node_modules"
```