### PR TITLE
ratify: fix checksum for 1.4.0

### DIFF
--- a/Formula/r/ratify.rb
+++ b/Formula/r/ratify.rb
@@ -7,12 +7,13 @@ class Ratify < Formula
   head "https://github.com/ratify-project/ratify.git", branch: "dev"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "03d7fa6ea0483779ecd438b37ad4abf4e5b79bf813191fa38b351b4e724d9208"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "03d7fa6ea0483779ecd438b37ad4abf4e5b79bf813191fa38b351b4e724d9208"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "03d7fa6ea0483779ecd438b37ad4abf4e5b79bf813191fa38b351b4e724d9208"
-    sha256 cellar: :any_skip_relocation, sonoma:        "9bcf40d7cb491db9b40ef4264699b440acf5806f20bad0f2ee1a9333f93a74ed"
-    sha256 cellar: :any_skip_relocation, ventura:       "b04d93460c9b39d6541ee0c0e3a7bc93170f09b4008b72a66ea8ec97d37dc099"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "17f651e142921c2f9ae135a1bdcffc39bf0b8b55b1a4622beab5da1ff183aa09"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "76678d359f1e6ab18b91b1703a44b6171e3a03d200a41db6a7d3568a9727b334"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "76678d359f1e6ab18b91b1703a44b6171e3a03d200a41db6a7d3568a9727b334"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "76678d359f1e6ab18b91b1703a44b6171e3a03d200a41db6a7d3568a9727b334"
+    sha256 cellar: :any_skip_relocation, sonoma:        "4f8913f574364f7b1f4269e539bfe4b1ff128bf4ef3266c2c46c5121fc9132e9"
+    sha256 cellar: :any_skip_relocation, ventura:       "d446ade57aad5022820d43cff3e52206a2521189ea30fe1f39ba198d4789977d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e76330b293fc305772b44b705cc2d7700100276bb27981382984fa474824c851"
   end
 
   depends_on "go" => :build

--- a/Formula/r/ratify.rb
+++ b/Formula/r/ratify.rb
@@ -2,7 +2,7 @@ class Ratify < Formula
   desc "Artifact Ratification Framework"
   homepage "https://ratify.dev"
   url "https://github.com/ratify-project/ratify/archive/refs/tags/v1.4.0.tar.gz"
-  sha256 "ee4298819a6d72d1d35b2ee6ba52221800099ce88c360efd8a31d751027f6b35"
+  sha256 "36b18d2070d76a6e85aa86bf94e4e68350c6c277985d6bc8e87a28c78ebb08b8"
   license "Apache-2.0"
   head "https://github.com/ratify-project/ratify.git", branch: "dev"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
found in
* https://github.com/Homebrew/homebrew-core/pull/201070