### PR TITLE
ksops: fix checksum for 4.3.3

### DIFF
--- a/Formula/k/ksops.rb
+++ b/Formula/k/ksops.rb
@@ -2,7 +2,7 @@ class Ksops < Formula
   desc "Flexible Kustomize Plugin for SOPS Encrypted Resources"
   homepage "https://github.com/viaduct-ai/kustomize-sops"
   url "https://github.com/viaduct-ai/kustomize-sops/archive/refs/tags/v4.3.3.tar.gz"
-  sha256 "a843b5bbb036027c72bc37fce29135362b8a13e58e6d53a760ed0b7dbe8fe66b"
+  sha256 "9943f47cb1c469316d28f11f845c44e63802e9cd37d28b6a20b1890f4c2133d7"
   license "Apache-2.0"
 
   bottle do
@@ -15,12 +15,6 @@ class Ksops < Formula
   end
 
   depends_on "go" => :build
-
-  # update go.mod, upstream pr ref, https://github.com/viaduct-ai/kustomize-sops/pull/269
-  patch do
-    url "https://github.com/viaduct-ai/kustomize-sops/commit/feb0eae92c10c1e248928be55f6577f28b6468a8.patch?full_index=1"
-    sha256 "a9dbae051b35f209bb64bf783f3d2c36f6b26cd395abe3d92dbbd996793a965d"
-  end
 
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w")


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

found in
* https://github.com/Homebrew/homebrew-core/pull/201070

Tag moving evidence: https://github.com/viaduct-ai/kustomize-sops/actions/workflows/release.yml
<img width="1056" alt="image" src="https://github.com/user-attachments/assets/edb3b025-1bd3-4ccf-8723-f3fda563a3c2" />

Removed patch, because it was made redundant in https://github.com/viaduct-ai/kustomize-sops/compare/bc3d055c89eeefe652ffda4cf9be9cf4c28cbe1b...v4.3.3