### PR TITLE
workflows: remove '--delete-branch' from gh pr automerge

### DIFF
--- a/.github/workflows/create-replacement-pr.yml
+++ b/.github/workflows/create-replacement-pr.yml
@@ -265,7 +265,6 @@ jobs:
           gh pr merge "$REPLACEMENT_PR" \
             --auto \
             --merge \
-            --delete-branch \
             --match-head-commit "$(git rev-parse HEAD)" \
             --repo "$GITHUB_REPOSITORY"
 

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -470,7 +470,6 @@ jobs:
           gh pr merge "$PR" \
             --auto \
             --merge \
-            --delete-branch \
             --match-head-commit "$EXPECTED_SHA" \
             --repo "$GITHUB_REPOSITORY"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`gh pr merge` command no longer supports the explicit `-d/--delete-branch` flag when a repo is using the Github merge queue, and so bot-initiated automerging is currently not working. (recently-shipped change in the gh CLI: https://github.com/cli/cli/commit/439cfa08bb5dad177aed9f5ae882652aab2a7d83)