### PR TITLE
podman 5.4.0

### DIFF
--- a/Formula/p/podman.rb
+++ b/Formula/p/podman.rb
@@ -1,10 +1,9 @@
 class Podman < Formula
   desc "Tool for managing OCI containers and pods"
   homepage "https://podman.io/"
-  url "https://github.com/containers/podman/archive/refs/tags/v5.3.2.tar.gz"
-  sha256 "e7d7abf2d4ecae7217af017a4199d555563721bf6c3ae52e68704ee8268c432b"
+  url "https://github.com/containers/podman/archive/refs/tags/v5.4.0.tar.gz"
+  sha256 "e5efb825558624d0539dac94847c39aafec68e6d4dd712435ff4ec1b17044b69"
   license all_of: ["Apache-2.0", "GPL-3.0-or-later"]
-  revision 1
   head "https://github.com/containers/podman.git", branch: "main"
 
   # There can be a notable gap between when a version is tagged and a
@@ -58,8 +57,8 @@ class Podman < Formula
   # More context: https://github.com/Homebrew/homebrew-core/pull/205303
   resource "gvproxy" do
     on_macos do
-      url "https://github.com/containers/gvisor-tap-vsock/archive/refs/tags/v0.8.1.tar.gz"
-      sha256 "9b7fb12dfc37b0a727f2209ff8b557c4ec922d11cec30a778c192da360db4a2f"
+      url "https://github.com/containers/gvisor-tap-vsock/archive/refs/tags/v0.8.3.tar.gz"
+      sha256 "5dd666c3d599c80c15182f80d848446482bdd7937b780517e591f5681a0b6889"
     end
   end
 
@@ -94,6 +93,7 @@ class Podman < Formula
   def install
     if OS.mac?
       ENV["CGO_ENABLED"] = "1"
+      ENV["BUILD_ORIGIN"] = "brew"
 
       system "gmake", "podman-remote"
       bin.install "bin/darwin/podman" => "podman-remote"
@@ -131,6 +131,7 @@ class Podman < Formula
       ENV.O0
       ENV["PREFIX"] = prefix
       ENV["HELPER_BINARIES_DIR"] = opt_libexec/"podman"
+      ENV["BUILD_ORIGIN"] = "brew"
 
       system "make"
       system "make", "install", "install.completions"

--- a/Formula/p/podman.rb
+++ b/Formula/p/podman.rb
@@ -17,12 +17,12 @@ class Podman < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "8d3c5a1c99fe2e4309ea96158e12f9132da072786b5cca5d2a6ddeb57a9b49eb"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "2d54aef6a18d43715e8cc5e1e486cf255e3e5931654e46bf95012a83c7341904"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "b2779601ca3ae538593ee8399591f51c625027194d28d2c9768b7831f4b8f261"
-    sha256 cellar: :any_skip_relocation, sonoma:        "2aab6be60b444c3dd2470f3b11a5414bb19901f27b6f49e64716f093801e2a9d"
-    sha256 cellar: :any_skip_relocation, ventura:       "4de740a6f9e3a1d5dd61985d03c6a5e5ba0ac62aee27ab1219f2bb617f831fa5"
-    sha256                               x86_64_linux:  "eb228f53621c5be1b1fcec6efca2b06790cd8f1d5ea602e1b91e33de30d0d4b1"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "39b29d9f45b76993bf471174c7bf5bc3ffbdfaacad5406a18d2fd203bb221f58"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "8000fe73e511908388ca85e95fdddcb69bca121ef920aaf922fac46e8167afaf"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "a6cbe0f0c8a6ccd8b25fad0bb1b330a8fb0b04711e1e92534ddd12c5ad1ee704"
+    sha256 cellar: :any_skip_relocation, sonoma:        "aea19cb2fa59cfe149c5ce7ea75071edbd9e9df42cee087cab744462036dc810"
+    sha256 cellar: :any_skip_relocation, ventura:       "b8c247a4cdbc95ff13fb42839e8bb04bc721578b2b13a0ade01a86fbb8524b8e"
+    sha256                               x86_64_linux:  "96c4efce605131f7952989bb0101db40a84d12e7febe0881bb252c6892d5f948"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
Bump podman to 5.4.0, gvproxy to 0.8.3.
Also, set BUILD_ORIGIN to brew, this helps maintainers keep track of different installation origins, to help with debugging build-specfic issues.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
