### PR TITLE
eksctl: simplify binary build

### DIFF
--- a/Formula/e/eksctl.rb
+++ b/Formula/e/eksctl.rb
@@ -16,16 +16,10 @@ class Eksctl < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "efcd6814978a781db4e305a197f1f0ea5b3feaa70b0610600bf5b489f6f8caa8"
   end
 
-  depends_on "counterfeiter" => :build
   depends_on "go" => :build
-  depends_on "go-bindata" => :build
-  depends_on "ifacemaker" => :build
-  depends_on "mockery" => :build
 
   def install
-    ENV["GOBIN"] = HOMEBREW_PREFIX/"bin"
-    ENV.deparallelize # Makefile prerequisites need to be run in order
-    system "make", "build"
+    system "make", "binary"
     bin.install "eksctl"
 
     generate_completions_from_executable(bin/"eksctl", "completion")

--- a/Formula/e/eksctl.rb
+++ b/Formula/e/eksctl.rb
@@ -8,12 +8,13 @@ class Eksctl < Formula
   head "https://github.com/eksctl-io/eksctl.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "c837034a688e9ba35d9bb117dd71b73466a18b494101b3ec78e0eef8d88fea37"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "29530c1956323cb5c92e8c36c3c75eecf0c63df6e93aaded3e4fa70fdd8ddac8"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "283d4708543ffe32796b7feeade29c1201646f5c69e887289c437ebca5cdbbdd"
-    sha256 cellar: :any_skip_relocation, sonoma:        "580893f1a3bdfd9adfb8010a0360b100b93c512e6a6a19efa41c4f605481f2ec"
-    sha256 cellar: :any_skip_relocation, ventura:       "08f50044e4f75419a55a1a7201a61f67ce262a409b610eef3d518b762dd72cf3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "efcd6814978a781db4e305a197f1f0ea5b3feaa70b0610600bf5b489f6f8caa8"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "8bea552f9d81b62d5a53973af929c82f66288b6795bcf7c18db43f19c6b70d5d"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "b7c28b6dc430756329d46668989a4eba7c125d1e18f2320e91a60420db3f509e"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "80ff5949907f4e87d6c260e1db19db4b926e5cefbb795ab423619a6493374f76"
+    sha256 cellar: :any_skip_relocation, sonoma:        "2ecf18f8c2186895d23712a62101d172cdc71b002cb7376d47fcc03c63d2368a"
+    sha256 cellar: :any_skip_relocation, ventura:       "27bac6b0d8e693739bba37c453ec03ab15a076b1da7e1f6d957ceb416fb1baf2"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8d440beb94532a2b45ea204cc96f5350bdf5ad607ba7e50b18ea1c376409b9c3"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR resolves building eksctl with Go 1.24, see Homebrew/homebrew-core#201070:

> eksctl: [build failure](https://github.com/Homebrew/homebrew-core/actions/runs/12678456461/job/35339620740?pr=201070#step:3:6505): internal error: package "fmt" without types was imported from "github.com/aws/aws-sdk-go/aws/client"

### Explanation

#### Short

The problem lies in generating test mocks using `mockery`. However, these mocks are already checked out in the repo, and we don't need them for the `eksctl` binary. We can just call `make binary` that will produce our binary.

<details><summary>Error Details</summary>
<p>

Running locally with Go 1.24 gives us an error when executing `mockery`:

```
❯ make generate-always
go generate ./pkg/apis/eksctl.io/v1alpha5/generate.go
Writing docs schema to assets/schema.json
go generate ./pkg/nodebootstrap
Writing `FakeBootstrapper` to `fakes/fake_bootstrapper.go`... Done
go generate ./pkg/addons
go generate ./pkg/authconfigmap
go generate ./pkg/awsapi/...
+ '[' 2 -eq 2 ']'
+ SERVICE_NAME=autoscaling
+ INTERFACE_NAME=ASG
+ PACKAGE_NAME=github.com/aws/aws-sdk-go-v2/service/autoscaling
+ go get github.com/aws/aws-sdk-go-v2/service/autoscaling
++ go list -m -f '{{.Dir}}' github.com/aws/aws-sdk-go-v2/service/autoscaling
+ AWS_SDK_DIR=/Users/Oleksandr_Redko/go/pkg/mod/github.com/aws/aws-sdk-go-v2/service/autoscaling@v1.51.12
+ /Users/Oleksandr_Redko/src/github.com/eksctl-io/eksctl/bin/ifacemaker -f '/Users/Oleksandr_Redko/go/pkg/mod/github.com/aws/aws-sdk-go-v2/service/autoscaling@v1.51.12/*.go' -s Client -i ASG -p awsapi -y 'ASG provides an interface to the AWS ASG service.' -c 'Code generated by ifacemaker; DO NOT EDIT.' -m github.com/aws/aws-sdk-go-v2/service/autoscaling
+ '[' 2 -eq 2 ']'
+ SERVICE_NAME=cloudwatchlogs
+ INTERFACE_NAME=CloudWatchLogs
+ PACKAGE_NAME=github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs
+ go get github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs
++ go list -m -f '{{.Dir}}' github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs
+ AWS_SDK_DIR=/Users/Oleksandr_Redko/go/pkg/mod/github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs@v1.45.12
+ /Users/Oleksandr_Redko/src/github.com/eksctl-io/eksctl/bin/ifacemaker -f '/Users/Oleksandr_Redko/go/pkg/mod/github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs@v1.45.12/*.go' -s Client -i CloudWatchLogs -p awsapi -y 'CloudWatchLogs provides an interface to the AWS CloudWatchLogs service.' -c 'Code generated by ifacemaker; DO NOT EDIT.' -m github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs
+ '[' 2 -eq 2 ']'
+ SERVICE_NAME=cloudformation
+ INTERFACE_NAME=CloudFormation
+ PACKAGE_NAME=github.com/aws/aws-sdk-go-v2/service/cloudformation
+ go get github.com/aws/aws-sdk-go-v2/service/cloudformation
++ go list -m -f '{{.Dir}}' github.com/aws/aws-sdk-go-v2/service/cloudformation
+ AWS_SDK_DIR=/Users/Oleksandr_Redko/go/pkg/mod/github.com/aws/aws-sdk-go-v2/service/cloudformation@v1.57.0
+ /Users/Oleksandr_Redko/src/github.com/eksctl-io/eksctl/bin/ifacemaker -f '/Users/Oleksandr_Redko/go/pkg/mod/github.com/aws/aws-sdk-go-v2/service/cloudformation@v1.57.0/*.go' -s Client -i CloudFormation -p awsapi -y 'CloudFormation provides an interface to the AWS CloudFormation service.' -c 'Code generated by ifacemaker; DO NOT EDIT.' -m github.com/aws/aws-sdk-go-v2/service/cloudformation
+ '[' 2 -eq 2 ']'
+ SERVICE_NAME=cloudtrail
+ INTERFACE_NAME=CloudTrail
+ PACKAGE_NAME=github.com/aws/aws-sdk-go-v2/service/cloudtrail
+ go get github.com/aws/aws-sdk-go-v2/service/cloudtrail
++ go list -m -f '{{.Dir}}' github.com/aws/aws-sdk-go-v2/service/cloudtrail
+ AWS_SDK_DIR=/Users/Oleksandr_Redko/go/pkg/mod/github.com/aws/aws-sdk-go-v2/service/cloudtrail@v1.47.4
+ /Users/Oleksandr_Redko/src/github.com/eksctl-io/eksctl/bin/ifacemaker -f '/Users/Oleksandr_Redko/go/pkg/mod/github.com/aws/aws-sdk-go-v2/service/cloudtrail@v1.47.4/*.go' -s Client -i CloudTrail -p awsapi -y 'CloudTrail provides an interface to the AWS CloudTrail service.' -c 'Code generated by ifacemaker; DO NOT EDIT.' -m github.com/aws/aws-sdk-go-v2/service/cloudtrail
+ '[' 2 -eq 2 ']'
+ SERVICE_NAME=elasticloadbalancing
+ INTERFACE_NAME=ELB
+ PACKAGE_NAME=github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing
+ go get github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing
++ go list -m -f '{{.Dir}}' github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing
+ AWS_SDK_DIR=/Users/Oleksandr_Redko/go/pkg/mod/github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing@v1.28.17
+ /Users/Oleksandr_Redko/src/github.com/eksctl-io/eksctl/bin/ifacemaker -f '/Users/Oleksandr_Redko/go/pkg/mod/github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing@v1.28.17/*.go' -s Client -i ELB -p awsapi -y 'ELB provides an interface to the AWS ELB service.' -c 'Code generated by ifacemaker; DO NOT EDIT.' -m github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing
+ '[' 2 -eq 2 ']'
+ SERVICE_NAME=elasticloadbalancingv2
+ INTERFACE_NAME=ELBV2
+ PACKAGE_NAME=github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2
+ go get github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2
++ go list -m -f '{{.Dir}}' github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2
+ AWS_SDK_DIR=/Users/Oleksandr_Redko/go/pkg/mod/github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2@v1.43.12
+ /Users/Oleksandr_Redko/src/github.com/eksctl-io/eksctl/bin/ifacemaker -f '/Users/Oleksandr_Redko/go/pkg/mod/github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2@v1.43.12/*.go' -s Client -i ELBV2 -p awsapi -y 'ELBV2 provides an interface to the AWS ELBV2 service.' -c 'Code generated by ifacemaker; DO NOT EDIT.' -m github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2
+ '[' 2 -eq 2 ']'
+ SERVICE_NAME=ssm
+ INTERFACE_NAME=SSM
+ PACKAGE_NAME=github.com/aws/aws-sdk-go-v2/service/ssm
+ go get github.com/aws/aws-sdk-go-v2/service/ssm
++ go list -m -f '{{.Dir}}' github.com/aws/aws-sdk-go-v2/service/ssm
+ AWS_SDK_DIR=/Users/Oleksandr_Redko/go/pkg/mod/github.com/aws/aws-sdk-go-v2/service/ssm@v1.56.12
+ /Users/Oleksandr_Redko/src/github.com/eksctl-io/eksctl/bin/ifacemaker -f '/Users/Oleksandr_Redko/go/pkg/mod/github.com/aws/aws-sdk-go-v2/service/ssm@v1.56.12/*.go' -s Client -i SSM -p awsapi -y 'SSM provides an interface to the AWS SSM service.' -c 'Code generated by ifacemaker; DO NOT EDIT.' -m github.com/aws/aws-sdk-go-v2/service/ssm
+ '[' 2 -eq 2 ']'
+ SERVICE_NAME=iam
+ INTERFACE_NAME=IAM
+ PACKAGE_NAME=github.com/aws/aws-sdk-go-v2/service/iam
+ go get github.com/aws/aws-sdk-go-v2/service/iam
++ go list -m -f '{{.Dir}}' github.com/aws/aws-sdk-go-v2/service/iam
+ AWS_SDK_DIR=/Users/Oleksandr_Redko/go/pkg/mod/github.com/aws/aws-sdk-go-v2/service/iam@v1.39.1
+ /Users/Oleksandr_Redko/src/github.com/eksctl-io/eksctl/bin/ifacemaker -f '/Users/Oleksandr_Redko/go/pkg/mod/github.com/aws/aws-sdk-go-v2/service/iam@v1.39.1/*.go' -s Client -i IAM -p awsapi -y 'IAM provides an interface to the AWS IAM service.' -c 'Code generated by ifacemaker; DO NOT EDIT.' -m github.com/aws/aws-sdk-go-v2/service/iam
+ '[' 2 -eq 2 ']'
+ SERVICE_NAME=eks
+ INTERFACE_NAME=EKS
+ PACKAGE_NAME=github.com/aws/aws-sdk-go-v2/service/eks
+ go get github.com/aws/aws-sdk-go-v2/service/eks
++ go list -m -f '{{.Dir}}' github.com/aws/aws-sdk-go-v2/service/eks
+ AWS_SDK_DIR=/Users/Oleksandr_Redko/go/pkg/mod/github.com/aws/aws-sdk-go-v2/service/eks@v1.58.0
+ /Users/Oleksandr_Redko/src/github.com/eksctl-io/eksctl/bin/ifacemaker -f '/Users/Oleksandr_Redko/go/pkg/mod/github.com/aws/aws-sdk-go-v2/service/eks@v1.58.0/*.go' -s Client -i EKS -p awsapi -y 'EKS provides an interface to the AWS EKS service.' -c 'Code generated by ifacemaker; DO NOT EDIT.' -m github.com/aws/aws-sdk-go-v2/service/eks
+ '[' 2 -eq 2 ']'
+ SERVICE_NAME=outposts
+ INTERFACE_NAME=Outposts
+ PACKAGE_NAME=github.com/aws/aws-sdk-go-v2/service/outposts
+ go get github.com/aws/aws-sdk-go-v2/service/outposts
++ go list -m -f '{{.Dir}}' github.com/aws/aws-sdk-go-v2/service/outposts
+ AWS_SDK_DIR=/Users/Oleksandr_Redko/go/pkg/mod/github.com/aws/aws-sdk-go-v2/service/outposts@v1.48.7
+ /Users/Oleksandr_Redko/src/github.com/eksctl-io/eksctl/bin/ifacemaker -f '/Users/Oleksandr_Redko/go/pkg/mod/github.com/aws/aws-sdk-go-v2/service/outposts@v1.48.7/*.go' -s Client -i Outposts -p awsapi -y 'Outposts provides an interface to the AWS Outposts service.' -c 'Code generated by ifacemaker; DO NOT EDIT.' -m github.com/aws/aws-sdk-go-v2/service/outposts
go generate ./pkg/eks

WARNING: Invoking counterfeiter multiple times from "go generate" is slow.
Consider using counterfeiter:generate directives to speed things up.
See https://github.com/maxbrunsfeld/counterfeiter#step-2b---add-counterfeitergenerate-directives for more information.
Set the "COUNTERFEITER_NO_GENERATE_WARNING" environment variable to suppress this message.

Writing `FakeKubeProvider` to `fakes/fake_kube_provider.go`... Done
Writing `FakeAWSConfigurationLoader` to `fakes/fake_configuration_loader.go`... Done
Writing `FakeFargateClient` to `fakes/fargate_client.go`... Done
Writing `FakeInstanceSelector` to `fakes/fake_instance_selector.go`... Done
Writing `FakeClusterVersionsManagerInterface` to `fakes/fake_cluster_versions_manager.go`... Done
Writing `FakeAWSConfigurationLoader` to `fakes/fake_configuration_loader.go`... Done
Writing `FakeFargateClient` to `fakes/fargate_client.go`... Done
Writing `FakeInstanceSelector` to `fakes/fake_instance_selector.go`... Done
Writing `FakeClusterVersionsManagerInterface` to `fakes/fake_cluster_versions_manager.go`... Done
/Users/Oleksandr_Redko/src/github.com/eksctl-io/eksctl/bin/mockery
12 Feb 25 22:47 EET INF Starting mockery dry-run=false version=v2.38.0
12 Feb 25 22:47 EET INF Using config: /Users/Oleksandr_Redko/src/github.com/eksctl-io/eksctl/.mockery.yaml dry-run=false version=v2.38.0
2025/02/12 22:47:33 internal error: package "fmt" without types was imported from "github.com/aws/aws-sdk-go/aws/client"
make: *** [Makefile:149: generate-always] Error 1
```


</p>
</details> 

#### Long

`make build` [calls](https://github.com/eksctl-io/eksctl/blob/c0c9c1bbf70ba696a7b04ab70c69e76a1549a6a9/Makefile#L48) the `generate-always` and `binary` targets.

`make generate-always` [generates](https://github.com/eksctl-io/eksctl/blob/c0c9c1bbf70ba696a7b04ab70c69e76a1549a6a9/Makefile#L142-L154) documentation, test doubles, fakes, interfaces, mocks, etc. All of this is already checked out into the repo and is usually generated during development. `generate-always` for code generation uses the `counterfeiter`, `ifacemaker`, and `mockery` tools which are defined by this formula. `go-bindata` is not used and was removed by eksctl-io/eksctl#4370.

`make binary` is our target that [builds](https://github.com/eksctl-io/eksctl/blob/c0c9c1bbf70ba696a7b04ab70c69e76a1549a6a9/Makefile#L51-L52) the binary. Since generated files are already in the repo, we don't need to re-generate them again.