### PR TITLE
golangci-lint: revision bump (go 1.24.0)

### DIFF
--- a/Formula/g/golangci-lint.rb
+++ b/Formula/g/golangci-lint.rb
@@ -5,6 +5,7 @@ class GolangciLint < Formula
         tag:      "v1.64.4",
         revision: "04aec4f787c25a737641f3d434059880d2af0f53"
   license "GPL-3.0-only"
+  revision 1
   head "https://github.com/golangci/golangci-lint.git", branch: "master"
 
   bottle do

--- a/Formula/g/golangci-lint.rb
+++ b/Formula/g/golangci-lint.rb
@@ -9,12 +9,12 @@ class GolangciLint < Formula
   head "https://github.com/golangci/golangci-lint.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "887027f627be3d610c0a2e5de4518b24086a429d9cdbf4ad04be73b4ed71c81c"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "a3f2d5916fe812ace5210ddf3c1387fe858be3f00feffbbf037fa3835153a25d"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "0084ea555b229defc51b4362a3807371f551d786a4d39b86f043e3b296e8b188"
-    sha256 cellar: :any_skip_relocation, sonoma:        "6793fa430f5bb5c38e9c45fc3c9ecc449f7a2cbd907614b7bf21fffa1a21e3b2"
-    sha256 cellar: :any_skip_relocation, ventura:       "3b3f46957266b94048e1fddcb10a31e46432f1a50bb9d1210eecbabaae414fd3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "16966a71f297e28dd5e00bf80e7d48dac843a7d4ccc0dadf6d7b0496adc3c015"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "ff6934550e6c9d569ab6d7095877b6d0b7c9fd24b24323bf88b93f3ddf4184d9"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "a1b95780aaa5aca6b2976d77385219d947e87506ac7fb72e15dff9bc4a412052"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "53317789dbb552b29667a91b53693332161a0e57a430fef6e9ab7525aa33d522"
+    sha256 cellar: :any_skip_relocation, sonoma:        "26378f7b74cb02a947f6d2811e9140d60ee06cc26c693b506873cbbd7d2e7569"
+    sha256 cellar: :any_skip_relocation, ventura:       "0eff7791e51ea56e6f05cc280f2afd73801e20b331a5b1b62df89a59fc19ac5c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "6d977eec6a83b5d7f72604d718a910a74fa944b494cd7183d95bae3b652650cf"
   end
 
   depends_on "go"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

seeing

```
$ golangci-lint run
Error: can't load config: the Go language version (go1.23) used to build golangci-lint is lower than the targeted Go version (1.24.0)
Failed executing command with error: can't load config: the Go language version (go1.23) used to build golangci-lint is lower than the targeted Go version (1.24.0)
```