### PR TITLE
goplus: test fix

### DIFF
--- a/Formula/g/goplus.rb
+++ b/Formula/g/goplus.rb
@@ -42,7 +42,7 @@ class Goplus < Formula
 
     assert_equal "v#{version}", shell_output("#{bin}/gop env GOPVERSION").chomp
     system bin/"gop", "fmt", "hello.gop"
-    assert_equal "Hello World\n", shell_output("#{bin}/gop run hello.gop")
+    assert_equal "Hello World\n", shell_output("#{bin}/gop run hello.gop 2>&1")
 
     (testpath/"go.mod").write <<~GOMOD
       module hello
@@ -50,6 +50,6 @@ class Goplus < Formula
 
     system "go", "get", "github.com/goplus/gop/builtin"
     system bin/"gop", "build", "-o", "hello"
-    assert_equal "Hello World\n", shell_output("./hello")
+    assert_equal "Hello World\n", shell_output("./hello 2>&1")
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Test failure noticed in
* https://github.com/Homebrew/homebrew-core/pull/201070

but pinning to go1.23 made no difference.

Not sure why it passed in previous runs on same version
* https://github.com/Homebrew/homebrew-core/pull/187839
* https://github.com/Homebrew/homebrew-core/pull/168867

Not the first upstream stdout/stderr inconsistency / wierdness:
* https://github.com/goplus/gop/issues/496
* https://github.com/goplus/gop/issues/497