### PR TITLE
coin3d: unbundle `expat`, split out `pivy`; pivy 0.6.9 (new formula)

### DIFF
--- a/Formula/c/coin3d.rb
+++ b/Formula/c/coin3d.rb
@@ -20,11 +20,11 @@ class Coin3d < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:  "788e8af8f7eef2baecbe637c9b749b0bbb3374cac3480ea4ebbbf98f5ea0d24c"
-    sha256 cellar: :any,                 arm64_ventura: "5ff987acf7ede22752c4d4b193d4ec8f63a9f402737eb8078d675e1a0db8b2fd"
-    sha256 cellar: :any,                 sonoma:        "af3184b755a9830954954132172e9f911df140e598a02c2b8c5d7cf6b7081370"
-    sha256 cellar: :any,                 ventura:       "8ff9c323ded49fc7207e7802e7fdb952867ee494ba56bc33bf5a30b73af5c0ab"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "6a099ddb5fad2794a8c8591fb702c3ec710b9773c8969d08c17e9ef3d2f5b516"
+    sha256 cellar: :any,                 arm64_sonoma:  "7a755e0c179f8d762196729ea039512ffc0814e929cd1f19c1026d151041b30e"
+    sha256 cellar: :any,                 arm64_ventura: "8742ecfd7f6ccea840603cb18083525d2711acee00fd9e0a6bb163f25b4e9029"
+    sha256 cellar: :any,                 sonoma:        "38224963f262dd3b3a0ee96c8deb8c8bb092bfa9e01ea15465ad50fe0c3d36d0"
+    sha256 cellar: :any,                 ventura:       "ac4d1a600375e93f86891c3b45c9fb5a93d6fef296d867a0d4e9dddcfcb774ab"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "9e5a6317d138ef6f2b147179e4e1ac4f029543d499d276f47d94958148fa4b28"
   end
 
   head do

--- a/Formula/p/pivy.rb
+++ b/Formula/p/pivy.rb
@@ -15,6 +15,14 @@ class Pivy < Formula
     end
   end
 
+  bottle do
+    sha256 cellar: :any,                 arm64_sonoma:  "49312c6ceb49fc4e4141430afe844ed52fb2f828445497fb74a695dd1c7c23dc"
+    sha256 cellar: :any,                 arm64_ventura: "37951e1aeb75c56bcb13e495dc15a70b7658c75bdc2ae782cdec2adf5b4180e4"
+    sha256 cellar: :any,                 sonoma:        "4aef1788e33fd3bed8094c79592e374525d579068517e7e4a6c66f4f36669343"
+    sha256 cellar: :any,                 ventura:       "73554f28642f20a5c770d7dd948f6cc44c140f0a0ce142f4754de42621d02f5b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "773ce675502fc88dd841d625e99b748d03b7519a962a3deb7239d456810491cf"
+  end
+
   depends_on "cmake" => :build
   depends_on "swig" => :build
   depends_on "coin3d"

--- a/Formula/p/pivy.rb
+++ b/Formula/p/pivy.rb
@@ -1,0 +1,55 @@
+class Pivy < Formula
+  desc "Python bindings to coin3d"
+  homepage "https://github.com/coin3d/pivy"
+  license "ISC"
+  head "https://github.com/coin3d/pivy.git", branch: "master"
+
+  stable do
+    url "https://github.com/coin3d/pivy/archive/refs/tags/0.6.9.tar.gz"
+    sha256 "c207f5ed73089b2281356da4a504c38faaab90900b95639c80772d9d25ba0bbc"
+
+    # Backport fix for Qt6 QtOpenGLWidgets
+    patch do
+      url "https://github.com/coin3d/pivy/commit/e81c5f32538891c740b90b5d2eb77fa6a9e1cb43.patch?full_index=1"
+      sha256 "c54b660f09957ad7673d29328fb1cbe77b9eb4b090f2371b6e16b4c333e679c4"
+    end
+  end
+
+  depends_on "cmake" => :build
+  depends_on "swig" => :build
+  depends_on "coin3d"
+  depends_on "pyside"
+  depends_on "python@3.13"
+  depends_on "qt"
+
+  def python3
+    "python3.13"
+  end
+
+  def install
+    site_packages = prefix/Language::Python.site_packages(python3)
+    rpaths = [rpath(source: site_packages/"pivy"), rpath(source: site_packages/"pivy/gui")]
+
+    system "cmake", "-S", ".", "-B", "build",
+                    "-DCMAKE_INSTALL_RPATH=#{rpaths.join(";")}",
+                    "-DPython_EXECUTABLE=#{which(python3)}",
+                    "-DPIVY_Python_SITEARCH=#{site_packages}",
+                    "-DPIVY_USE_QT6=ON",
+                    *std_cmake_args(find_framework: "FIRST")
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    # Set QT_QPA_PLATFORM to minimal to avoid error:
+    # "This application failed to start because no Qt platform plugin could be initialized."
+    ENV["QT_QPA_PLATFORM"] = "minimal" if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"]
+
+    system python3, "-c", <<~PYTHON
+      import shiboken6
+      from pivy.quarter import QuarterWidget
+      from pivy.sogui import SoGui
+      assert SoGui.init("test") is not None
+    PYTHON
+  end
+end


### PR DESCRIPTION
Also some fixes so that `pivy.quarter` import works

---

EDIT: Trying splitting out `pivy` now to deal with `expat` linkage. Also divides parts under different license. 

https://repology.org/project/python%3Apivy/versions