### PR TITLE
autobump: add gauge

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -1104,6 +1104,7 @@ gateway-go
 gator
 gatsby-cli
 gau
+gauge
 gawk
 gaze
 gcalcli


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR adds `gauge` to `autobump.txt`.

For context, upstream used to open version bump PRs themselves, but the past few PRs have not correctly updated the URL. See for example: #207553, #206413, #205874, #202532. Post discussion in https://github.com/getgauge/gauge/issues/2701, the issue was identified as a faulty regex in upstream's bump workflow, and upstream have expressed interest in having `gauge` included in our own autobump list.