### PR TITLE
terrahub: deprecate

### DIFF
--- a/Formula/t/terrahub.rb
+++ b/Formula/t/terrahub.rb
@@ -1,14 +1,9 @@
 class Terrahub < Formula
   desc "Terraform automation and orchestration tool"
-  homepage "https://docs.terrahub.io"
+  homepage "https://web.archive.org/web/20240302100339/https://docs.terrahub.io/"
   url "https://registry.npmjs.org/terrahub/-/terrahub-0.5.9.tgz"
   sha256 "0288f47ab305550d0f21633a9a487e1de688556229242bf0c86e120d1240e1c4"
   license "MPL-2.0"
-
-  livecheck do
-    url "https://registry.npmjs.org/terrahub/latest"
-    regex(/"version":\s*?"([^"]+)"/i)
-  end
 
   bottle do
     rebuild 1
@@ -21,6 +16,8 @@ class Terrahub < Formula
     sha256 cellar: :any_skip_relocation, monterey:       "bf9b067ad0af2c0b17f573103306810203382430682d497201701f944d4394b8"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "4916e5335be420a247d7aa5785bb29ac1e17d3bd55015e3cb8d75e726b73d656"
   end
+
+  deprecate! date: "2025-02-13", because: :unmaintained
 
   depends_on "node"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`https://docs.terrahub.io/` is no longer accessible and [the repo](https://github.com/tfxor/terrahub) has no activity over the past three years.
