### PR TITLE
golines: fix version report

### DIFF
--- a/Formula/g/golines.rb
+++ b/Formula/g/golines.rb
@@ -20,20 +20,25 @@ class Golines < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args(ldflags: "-s -w")
+    ldflags = "-s -w -X main.version=#{version} -X main.commit=#{tap.user} -X main.date=#{time.iso8601}"
+    system "go", "build", *std_go_args(ldflags:)
   end
 
   test do
+    assert_match version.to_s, shell_output("#{bin}/golines --version")
+
     (testpath/"given.go").write <<~GO
       package main
 
       var strings = []string{"foo", "bar", "baz"}
     GO
+
     (testpath/"expected.go").write <<~GO
       package main
 
       var strings = []string{\n\t"foo",\n\t"bar",\n\t"baz",\n}
     GO
+
     assert_equal (testpath/"expected.go").read, shell_output("#{bin}/golines --max-len=30 given.go")
   end
 end

--- a/Formula/g/golines.rb
+++ b/Formula/g/golines.rb
@@ -7,14 +7,13 @@ class Golines < Formula
   head "https://github.com/segmentio/golines.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "8628e4ccb364c54ea775fc8e57e384c069227c877da8e187ab8eea213f2b5dcd"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "0dc4bef5b399d03b8626c287f69dd1053f67a264745534ed74650b0f5836ed35"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "71db471b15d2097c568876c4d9bb1e518c464ab5975cc44319b62c1d8019cc82"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "8a66936ba1408201f4a983a97674df7f264d96faa3042eaea5d67e9e9399f243"
-    sha256 cellar: :any_skip_relocation, sonoma:         "0f9c40205f9bde8207f3c30d3b0188a68300f10f8bf2cdfce9f1e4c6156edf0e"
-    sha256 cellar: :any_skip_relocation, ventura:        "c70ffc9ce915ec300b0ca5320f144b282bf51f63fe5cf9879c75d2cd5adaf815"
-    sha256 cellar: :any_skip_relocation, monterey:       "9546e25a342e830eb4a307068167a68b4c5f714b1ae7fb0bc66242dacc72ce48"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c0fcaa9315813afba851b606dedde377a1083eeea1da796f0467cafd820cbba3"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "0253679e4f9c75f4481d25f95b06b22c67f7436b62120053fff951fe895be818"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "0253679e4f9c75f4481d25f95b06b22c67f7436b62120053fff951fe895be818"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "0253679e4f9c75f4481d25f95b06b22c67f7436b62120053fff951fe895be818"
+    sha256 cellar: :any_skip_relocation, sonoma:        "9fcbf1297b553332b33fd8da6646afd895379ff3614cecb10eebd844dd0031e6"
+    sha256 cellar: :any_skip_relocation, ventura:       "9fcbf1297b553332b33fd8da6646afd895379ff3614cecb10eebd844dd0031e6"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1869729349e1f224e3e615710ef606a79cf3bba1e03225e2633a78497fd5ee12"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

right now, the version reporting missed the version and build date info

```
$ golines --version
golines vdev

build information:
	build date: unknown
	git commit ref: none
```

after the update

```
$ golines --version
golines v0.12.2

build information:
	build date: 2024-01-22T20:56:05Z
	git commit ref: Homebrew
```