### PR TITLE
render: update version flag to render-oss

### DIFF
--- a/Formula/r/render.rb
+++ b/Formula/r/render.rb
@@ -20,7 +20,7 @@ class Render < Formula
   def install
     ldflags = %W[
       -s -w
-      -X github.com/renderinc/cli/pkg/cfg.Version=#{version}
+      -X github.com/render-oss/cli/pkg/cfg.Version=#{version}
     ]
     system "go", "build", *std_go_args(ldflags:)
   end

--- a/Formula/r/render.rb
+++ b/Formula/r/render.rb
@@ -7,12 +7,13 @@ class Render < Formula
   head "https://github.com/render-oss/cli.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "681dddef0b20697c1913c74aea32849ab4764d08d0c77d1c7380348b288accf6"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "681dddef0b20697c1913c74aea32849ab4764d08d0c77d1c7380348b288accf6"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "681dddef0b20697c1913c74aea32849ab4764d08d0c77d1c7380348b288accf6"
-    sha256 cellar: :any_skip_relocation, sonoma:        "135115371cc49b22b825566d5e4ad40f3f46a3d302a22ae8e403844cb1cc8bac"
-    sha256 cellar: :any_skip_relocation, ventura:       "135115371cc49b22b825566d5e4ad40f3f46a3d302a22ae8e403844cb1cc8bac"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "6304d7700a199f1684d339d7dfeecd67949a86373fcaed0b6b585437fe3a29ee"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e96e67b0026c03994984904c9f04b34bfbc1618f00cf2620c42698763b7bb49a"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "e96e67b0026c03994984904c9f04b34bfbc1618f00cf2620c42698763b7bb49a"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "e96e67b0026c03994984904c9f04b34bfbc1618f00cf2620c42698763b7bb49a"
+    sha256 cellar: :any_skip_relocation, sonoma:        "668d6be46967a7a95f0fe53479f86ebebda33997781fd65f92e0200599c0fe73"
+    sha256 cellar: :any_skip_relocation, ventura:       "668d6be46967a7a95f0fe53479f86ebebda33997781fd65f92e0200599c0fe73"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3bdaed3e1e32be9841660912c4bf07003306532d1952957b2551c821f72017c2"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
The package namespace for `render` was [updated from renderinc to render-oss](https://github.com/render-oss/cli/commit/043e0c2db414f3da22c65805d753637c55ae9dce). This updates the brew install command to reflect that.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
