### PR TITLE
ratarmount: add macOS support

### DIFF
--- a/Formula/r/ratarmount.rb
+++ b/Formula/r/ratarmount.rb
@@ -12,12 +12,14 @@ class Ratarmount < Formula
   end
 
   depends_on "libffi"
-  depends_on "libfuse"
   depends_on "libgit2"
-  depends_on :linux
   depends_on "python@3.13"
   depends_on "zlib"
   depends_on "zstd"
+
+  on_linux do
+    depends_on "libfuse"
+  end
 
   resource "cffi" do
     url "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz"
@@ -76,6 +78,13 @@ class Ratarmount < Formula
 
   def install
     virtualenv_install_with_resources
+  end
+
+  def caveats
+    <<~EOS
+      To use `ratarmount` on macOS:
+        brew install --cask macfuse
+    EOS
   end
 
   test do


### PR DESCRIPTION
ratarmount runs on macOS if cask macFUSE is installed

Copied caveat language from formula alluxio

https://github.com/Homebrew/homebrew-core/blob/8bd0989ef864e38e17094ebcdb296a06dced194f/Formula/a/alluxio.rb#L55-L56

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
