### PR TITLE
squid 6.13

### DIFF
--- a/Formula/s/squid.rb
+++ b/Formula/s/squid.rb
@@ -13,12 +13,12 @@ class Squid < Formula
   end
 
   bottle do
-    sha256 arm64_sequoia: "46834c46b9dfba33e335871ea5521c52f0970e22492a10a7652e4c6ce7ad60d9"
-    sha256 arm64_sonoma:  "0e5e93eebd07b2919e38a59becf1738a94d36d2ab36e8244fd0f50fb557acab0"
-    sha256 arm64_ventura: "066142a4881ba69f68ab5c80f8997392225b44a3ffe1f6c098a457476ca55eec"
-    sha256 sonoma:        "e47b6716e23cfe55ebc170cc8a563883e2d12bd2a0f7c190dbeaff3dcc3456d0"
-    sha256 ventura:       "66876aa03fd2e9937b29cdb881fb1ced3ffd269209e282a4f2586f61fe3577ae"
-    sha256 x86_64_linux:  "6706fe36e154fa9191414c35176698c6c3204ddae2ee3bdb415bbf5636b3099f"
+    sha256 arm64_sequoia: "d2cd4e77ccc3da42ec7ded1f1f1a4a2e754734e17bf369b0dd99d542642ac4bd"
+    sha256 arm64_sonoma:  "be53c543fec807a6841cc164cb9edb1433d26b8b4730bb0accacfdcebed45c63"
+    sha256 arm64_ventura: "e7ef982e31124eb3b920cdc13351547b3bce8d574c8dddf18de73474dab7ae09"
+    sha256 sonoma:        "472c374fa36f3e97a90d192d1fa4fcecfdd9cd45d5069e8c93ebd080ba581094"
+    sha256 ventura:       "81747c30da12ba7291b8353836cea7708983d2e0775672462764076e5f1d4cdf"
+    sha256 x86_64_linux:  "86929f4464c2dd41698c7c68936bab3b9a716635cd57e5ab125086fcb23abca4"
   end
 
   head do

--- a/Formula/s/squid.rb
+++ b/Formula/s/squid.rb
@@ -1,13 +1,15 @@
 class Squid < Formula
   desc "Advanced proxy caching server for HTTP, HTTPS, FTP, and Gopher"
   homepage "https://www.squid-cache.org/"
-  url "http://www.squid-cache.org/Versions/v6/squid-6.12.tar.xz"
-  sha256 "f3df3abb2603a513266f24a5d4699a9f0d76b9f554d1848b67f9c51cd3b3cb50"
+  url "https://github.com/squid-cache/squid/releases/download/SQUID_6_13/squid-6.13.tar.xz"
+  sha256 "232e0567946ccc0115653c3c18f01e83f2d9cc49c43d9dead8b319af0b35ad52"
   license "GPL-2.0-or-later"
 
+  # The Git repository contains tags for a higher major version that isn't the
+  # current release series yet, so we check the latest GitHub release instead.
   livecheck do
-    url "https://www.squid-cache.org/Versions/"
-    regex(%r{<td>\s*v?(\d+(?:\.\d+)+)\s*</td>}im)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do
@@ -20,7 +22,7 @@ class Squid < Formula
   end
 
   head do
-    url "https://git.launchpad.net/squid", using: :git, branch: "v6"
+    url "https://github.com/squid-cache/squid.git", branch: "v6"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build

--- a/audit_exceptions/head_non_default_branch_allowlist.json
+++ b/audit_exceptions/head_non_default_branch_allowlist.json
@@ -1,3 +1,4 @@
 {
-  "botan@2": "release-2"
+  "botan@2": "release-2",
+  "squid": "v6"
 }


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `squid` to the latest stable version, 6.13.

[The `squid` website now links to the GitHub repository](https://www.squid-cache.org/Versions/) as the source for new versions. Upstream did not publish a `squid-6.13.tar.xz` file on the first-party website (the URL simply redirects to the `/Versions/` page), so I've switched to the bootstrapped tarball that's published as a GitHub release asset for 6.13.

This also updates the `livecheck` block to use the `GithubLatest` strategy, as there are Git tags for a higher major version that use the same tag format as the current release series (e.g., `SQUID_7_0_1`).

It was necessary to add this to `head_non_default_branch_allowlist.json`, as we're using the `v6` branch as `head` instead of `master`.