### PR TITLE
python@3.13: bundle `expat` on Ventura/Sonoma

### DIFF
--- a/Formula/p/python@3.13.rb
+++ b/Formula/p/python@3.13.rb
@@ -27,7 +27,7 @@ class PythonAT313 < Formula
   depends_on "xz"
 
   uses_from_macos "bzip2"
-  uses_from_macos "expat", since: :sequoia
+  uses_from_macos "expat"
   uses_from_macos "libedit"
   uses_from_macos "libffi", since: :catalina
   uses_from_macos "ncurses"
@@ -132,10 +132,13 @@ class PythonAT313 < Formula
       --enable-loadable-sqlite-extensions
       --with-openssl=#{Formula["openssl@3"].opt_prefix}
       --enable-optimizations
-      --with-system-expat
       --with-system-libmpdec
       --with-readline=editline
     ]
+    # Use bundled expat for Ventura and Sonoma as Apple updated libexpat to 2.6.3 but
+    # kept headers/tbd on 2.5.0 in macOS 14.7.2 / 13.7.2. This means bottles built on
+    # particular macOS patch version may not be compatible with other patch versions.
+    args << "--with-system-expat" if !OS.mac? || MacOS.version > :sonoma || MacOS.version < :ventura
 
     # Python re-uses flags when building native modules.
     # Since we don't want native modules prioritizing the brew


### PR DESCRIPTION
Possible ways to handle this that are being considered:

1. Use bundled `expat` (this PR)
    * Pros: Simplest to maintain (functionally a 1 line change), avoid brew `expat` in dependency tree
    * Cons: Problems of bundled dependencies
2. Add workaround to allow building with system `expat` (#207767)
    * Pros: Aligns with our preferred way of handling `expat` dependency
    * Cons: Bottle's `pyexpat` may no longer work on Ventura < 13.7.2 and Sonoma < 14.7.2, lengthy workaround that would remain for years and end up in multiple formulae (Python 3.13, 3.14, ...)
3. Keep brew `expat` and add workaround in brew to prevent propagation of brew `expat` linkage:
    * Pros: Uses latest `expat` with all CVE fixes
    * Cons: Need to maintain formula-specific hacks inside brew
4. Keep brew `expat` and modify all dependents to `uses_from_macos "expat", since: :sequoia`.
    * Pros: Uses latest `expat` with all CVE fixes across dependency tree
    * Cons: Will cause issues on Intel Sequoia as dependency tree is not resolved correctly without bottles.
