### PR TITLE
trafficserver: add `pcre2` dependency

### DIFF
--- a/Formula/t/trafficserver.rb
+++ b/Formula/t/trafficserver.rb
@@ -27,6 +27,7 @@ class Trafficserver < Formula
   depends_on "nuraft"
   depends_on "openssl@3"
   depends_on "pcre" # PCRE2 issue: https://github.com/apache/trafficserver/issues/8780
+  depends_on "pcre2"
   depends_on "xz"
   depends_on "yaml-cpp"
 


### PR DESCRIPTION
`pcre` is still needed as not fully migrated to PCRE2

---

See linkage in https://github.com/Homebrew/homebrew-core/actions/runs/13080104445/job/36501669668#step:4:189