### PR TITLE
glib: drop `python-packaging`, use macOS python3

### DIFF
--- a/Formula/g/glib.rb
+++ b/Formula/g/glib.rb
@@ -8,13 +8,13 @@ class Glib < Formula
   license "LGPL-2.1-or-later"
 
   bottle do
-    rebuild 1
-    sha256 arm64_sequoia: "cb7e1e45b994e3bf05cc2b21427368d9e417589017786f789c7aefa585b2c0b3"
-    sha256 arm64_sonoma:  "26c4a5cd06dc075dabe28e94dba63742d881343d4fde244b29126086eefb3711"
-    sha256 arm64_ventura: "7108b33ae6d63a669c4bc13a60c2c664b5498691c5dcdb3d40e0e8fbd66a0585"
-    sha256 sonoma:        "1c127e38938c337d06f4dcbee381249f5caee71ae479d2c69c2fe37aad02d0f6"
-    sha256 ventura:       "d13fc9b102ae989dcc0da96b2162269020479da5523f3df1d3d05373345a7ae2"
-    sha256 x86_64_linux:  "275da32f00d6860c91be2ece5094c320638252f1a066fd53ba891ecd378e694e"
+    rebuild 2
+    sha256 arm64_sequoia: "3dd032d1978adb4b1cf801c02b278ab430afc0dc893bd0f3edce5a5760a7c476"
+    sha256 arm64_sonoma:  "8a69737dcf16d172b8c0b5e9fba91ff7aae9ad55451c5b6476c989023b4ac872"
+    sha256 arm64_ventura: "55572696d934d71b9d69b69446b0c05e61a0f8632d842c8833ce85fff57bda00"
+    sha256 sonoma:        "6a2bf01e7cbb06e8193daed7182b6f8af724c04136ad847a33235fc426ba56e8"
+    sha256 ventura:       "1950cda37b931bde73fb608546efd096970055d8b5501abc1adc4c9dfc767491"
+    sha256 x86_64_linux:  "d7530b29cb310116fddf8aede139354881d8d4e8f435bb6666fb8b5828731699"
   end
 
   depends_on "bison" => :build # for gobject-introspection

--- a/Formula/g/glyr.rb
+++ b/Formula/g/glyr.rb
@@ -7,17 +7,12 @@ class Glyr < Formula
   revision 3
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia:  "75c0b25000de973e7ea592d3ae07a610f54038c6e73adddf93ca8f50e0df12ff"
-    sha256 cellar: :any,                 arm64_sonoma:   "74187740cb6f6aabc0c532714c8753435c33a49408407c3ba5b0236c5b85cc03"
-    sha256 cellar: :any,                 arm64_ventura:  "0b11085d86604b659fe43f99e91838695ff2c6bb4a1e5f2790e6af6fc90246da"
-    sha256 cellar: :any,                 arm64_monterey: "800ed9d047c06e8490f6318b36c88c34feb4dac7dbe60a539edd752f4568a08e"
-    sha256 cellar: :any,                 arm64_big_sur:  "498252c79958a96c42f3bea2936366f692d5c25cf12d6b3ee3c8ac1a5747f4b8"
-    sha256 cellar: :any,                 sonoma:         "8cb3930704acecdc21f9035ed8bccd3c326db8cdd14a3b03e731533c072aea3b"
-    sha256 cellar: :any,                 ventura:        "5c2a9dbf3b8f41d091f36b78e8c5597fe3ec3f5153eb5d60577b911b92d6a68b"
-    sha256 cellar: :any,                 monterey:       "ff357ecf355067543f989182c6dc6a113d0aa64dca00aa3df67a080d68ba2ca5"
-    sha256 cellar: :any,                 big_sur:        "86ce9cf96d67fdbe9b174f4bc302f9c31abffcfb7790ec07fef5294f66beca17"
-    sha256 cellar: :any,                 catalina:       "9ef809e699349c1fa1bb8e83f23aee567d1de60af6ddd7bef19409ecd58f8cf6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f147edbece71a6cac950c74f75b974da8d821139fbe1db95faeb0e08b67182af"
+    sha256 cellar: :any,                 arm64_sequoia: "9ff02541efeba578a7e20d6d3ba1cd80c71d4f80e37306a35cb9b13e1e9ef4e8"
+    sha256 cellar: :any,                 arm64_sonoma:  "783ce52f8a68f8d5900429fd33baf4d728523e19fe63fec93c1de3242ab157f3"
+    sha256 cellar: :any,                 arm64_ventura: "d2cf724c8cfdb04e0c94643c4fc456ca85a75148429198eb11b3746c1d23047b"
+    sha256 cellar: :any,                 sonoma:        "894c3d629641e0ed82a2f10ac0559658173e91d212605ffc32cfd824ef0c13e0"
+    sha256 cellar: :any,                 ventura:       "244b65728e18b1514ca9b3fb77c09d835ce07d98656567b0b62f90365716ea92"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "299191466994be32c6b0fd7ffe958623ddbffb940428b95c25eba2fa6b5bff21"
   end
 
   depends_on "cmake" => :build

--- a/Formula/g/glyr.rb
+++ b/Formula/g/glyr.rb
@@ -4,7 +4,7 @@ class Glyr < Formula
   url "https://github.com/sahib/glyr/archive/refs/tags/1.0.10.tar.gz"
   sha256 "77e8da60221c8d27612e4a36482069f26f8ed74a1b2768ebc373c8144ca806e8"
   license "LGPL-3.0-or-later"
-  revision 2
+  revision 3
 
   bottle do
     sha256 cellar: :any,                 arm64_sequoia:  "75c0b25000de973e7ea592d3ae07a610f54038c6e73adddf93ca8f50e0df12ff"

--- a/Formula/m/mercury.rb
+++ b/Formula/m/mercury.rb
@@ -12,16 +12,12 @@ class Mercury < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia:  "5b4083720e56ac9ae01b892e3e33658db3c236f16923155bb8d06f8ebaa46934"
-    sha256 cellar: :any,                 arm64_sonoma:   "19316e06cb23c30511f3e6698a7794659091ee7f8606103a9db54b56fbfff732"
-    sha256 cellar: :any,                 arm64_ventura:  "2b8d7c98d918811a42e554b8a8528d2e92fa318abd0aa09e9af0379e2df76081"
-    sha256 cellar: :any,                 arm64_monterey: "50dec0a2072f226596bdfbdf395f99b102f7a65f66ce96a2f045ba68e0f2780d"
-    sha256 cellar: :any,                 arm64_big_sur:  "11ca6af6293cfe4739d4d4b7afac1a923a805431f892f2b217cb575abe4a9c9b"
-    sha256 cellar: :any,                 sonoma:         "d79560ef5d6e2f9c0fb5fe44f6e65429ab007e4e30e4442f929647d24e3e9b05"
-    sha256 cellar: :any,                 ventura:        "3a2c5813d314b54387d4e48e35ebc92256a0caed5af9ee3a254c31a43a5e37c4"
-    sha256 cellar: :any,                 monterey:       "8479fd7c8fbf9f807f2062ad76f3cf53e1e10d5ae81a41d2cf48c5657d91b0ef"
-    sha256 cellar: :any,                 big_sur:        "fab2615bf575b450892b66f2ff28a2b5c82da34026b11b4875dc2e9db607058d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a808ee3d86cc43a43890838ce0bf4ca70f30471173d5ce78126f4d0d632f96a8"
+    sha256 cellar: :any,                 arm64_sequoia: "5a8c953a905318645766c0457bbe546a8bc7b0d65b04d98c838ddf996f5d885a"
+    sha256 cellar: :any,                 arm64_sonoma:  "8132aa81235d40e482e84630d4b6d8e037ec0176fbbf7dd0b7a2457ef781ea7a"
+    sha256 cellar: :any,                 arm64_ventura: "ff7e02ae589247c4a6c07d1f4c0a8277d000188d8c36920ca1769073b759d562"
+    sha256 cellar: :any,                 sonoma:        "70c6cd977d7485a229575d4a1db077245a7a1984b467e92f5061ce363aa54922"
+    sha256 cellar: :any,                 ventura:       "3a970961faf6783d4e1129368cda20f58ee36edab81a62c0eb23b99481b14d51"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "89b71d74d5df6b4a4c1efb4c0a68045c4c397967d88fcd8fcf44125d60d8ffad"
   end
 
   depends_on "openjdk"

--- a/Formula/m/mercury.rb
+++ b/Formula/m/mercury.rb
@@ -4,6 +4,7 @@ class Mercury < Formula
   url "https://dl.mercurylang.org/release/mercury-srcdist-22.01.8.tar.gz"
   sha256 "a097e8cc8eca0152ed9527c1caf73e5c9c83f6ada1d313a25b80fe79072fbad8"
   license all_of: ["GPL-2.0-only", "LGPL-2.0-only", "MIT"]
+  revision 1
 
   livecheck do
     url "https://dl.mercurylang.org/"


### PR DESCRIPTION
`packaging` requirement was removed 2.82.0 (https://gitlab.gnome.org/GNOME/glib/-/commit/38faeca62ebd5be89b1ec3e6c530e499ce2d7240) which allows us to restore macOS python3 and avoid the dependency propagation.

Also backport `/usr/bin/env python3` shebang so we don't have to manually `rewrite_shebang`.

---

Should also help avoid propagation of brew `sqlite` (and brew `expat` until we figure that out).