### PR TITLE
chrpath: fix test

### DIFF
--- a/Formula/c/chrpath.rb
+++ b/Formula/c/chrpath.rb
@@ -24,9 +24,9 @@ class Chrpath < Formula
     assert_match "chrpath version #{version}", shell_output("#{bin}/chrpath -v")
     (testpath/"test.c").write "int main(){return 0;}"
     system ENV.cc, "test.c", "-Wl,-rpath,/usr/local/lib"
-    assert_match "a.out: RPATH=/usr/local/lib", shell_output("#{bin}/chrpath a.out")
-    assert_match "a.out: new RPATH: /usr/lib/", shell_output("#{bin}/chrpath -r /usr/lib/ a.out")
-    assert_match "a.out: RPATH=/usr/lib/",      shell_output("#{bin}/chrpath a.out")
+    assert_match "a.out: RUNPATH=/usr/local/lib", shell_output("#{bin}/chrpath a.out")
+    assert_match "a.out: new RUNPATH: /usr/lib/", shell_output("#{bin}/chrpath -r /usr/lib/ a.out")
+    assert_match "a.out: RUNPATH=/usr/lib/",      shell_output("#{bin}/chrpath a.out")
     system bin/"chrpath", "-d", "a.out"
     assert_match "a.out: no rpath or runpath tag found.", shell_output("#{bin}/chrpath a.out", 2)
   end

--- a/Formula/c/chrpath.rb
+++ b/Formula/c/chrpath.rb
@@ -10,7 +10,8 @@ class Chrpath < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "00a03fa6ee632a4c0dbba7e0b581501b3e6118fd1cc6cfe1c0e6f53b900dca68"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "5401a0819599b170252c91c03bbef3b8a4e7e61f3a4333fcc9c271afd897ee8c"
   end
 
   depends_on :linux


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`brew test chrpath` is currently [failing on master](https://github.com/Homebrew/homebrew-core/actions/runs/13357892777/job/37303180788#step:5:98). I spotted that when trying to rebottle for fix the missing attestations.