### PR TITLE
tgenv 1.2.1 (switch to maintained fork)

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -3396,6 +3396,7 @@ tfproviderlint
 tfschema
 tfsec
 tfupdate
+tgenv
 tgpt
 tgui
 thanos

--- a/Formula/t/tgenv.rb
+++ b/Formula/t/tgenv.rb
@@ -1,15 +1,10 @@
 class Tgenv < Formula
   desc "Terragrunt version manager inspired by tfenv"
-  homepage "https://github.com/cunymatthieu/tgenv"
-  url "https://github.com/cunymatthieu/tgenv/archive/refs/tags/v0.0.3.tar.gz"
-  sha256 "e59c4cc9dfccb7d52b9ff714b726ceee694cfa389474cbe01a65c5f9bc13eca4"
+  homepage "https://github.com/tgenv/tgenv"
+  url "https://github.com/tgenv/tgenv/archive/refs/tags/v1.2.1.tar.gz"
+  sha256 "241b18ee59bd993256c9dc0847e23824c9ebf42b4d121db11fbdff9ddb6432b2"
   license "MIT"
-  head "https://github.com/cunymatthieu/tgenv.git", branch: "master"
-
-  livecheck do
-    url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
-  end
+  head "https://github.com/tgenv/tgenv.git", branch: "master"
 
   bottle do
     rebuild 1
@@ -26,6 +21,7 @@ class Tgenv < Formula
   end
 
   test do
-    assert_match "0.69.9", shell_output("#{bin}/tgenv list-remote")
+    ret_status = OS.mac? ? 1 : 0
+    assert_match "0.73.6", shell_output("#{bin}/tgenv list-remote 2>&1", ret_status)
   end
 end

--- a/Formula/t/tgenv.rb
+++ b/Formula/t/tgenv.rb
@@ -7,8 +7,7 @@ class Tgenv < Formula
   head "https://github.com/tgenv/tgenv.git", branch: "master"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, all: "5d9c35f1dd3856a985c721d8e0f2d33b656f207092ea5f836ed878e03bba7505"
+    sha256 cellar: :any_skip_relocation, all: "b51fcece0e2a8b77f96f8460b123aedb1ab6cd9497b5da570e00639258324ece"
   end
 
   uses_from_macos "unzip"


### PR DESCRIPTION
The current tgenv (https://github.com/cunymatthieu/tgenv) is not maintained and hasn't had a release since 2019. It was forked to https://github.com/tgenv/tgenv in 2023 and is actively worked on.

Update formula to this new repo

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
