### PR TITLE
tldr: deprecate

### DIFF
--- a/Formula/t/tldr.rb
+++ b/Formula/t/tldr.rb
@@ -17,6 +17,8 @@ class Tldr < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "e1e92ca409631c8006533f00706aeb966dcd6d7ee175b51c8aceeab523ebb3f5"
   end
 
+  deprecate! date: "2024-10-24", because: :unmaintained, replacement: "tlrc"
+
   depends_on "pkgconf" => :build
   depends_on "libzip"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The tldr-c-client is now unmaintained. According
to their README, tlrc is one of the alternatives.
And according to benchmarks, tlrc is faster than
the other offered alternatives (python or node).

See https://github.com/tldr-pages/tldr-c-client
See https://github.com/buonomo/tldr-benchmarks