### PR TITLE
ltl2ba: add livecheck

### DIFF
--- a/Formula/l/ltl2ba.rb
+++ b/Formula/l/ltl2ba.rb
@@ -6,6 +6,13 @@ class Ltl2ba < Formula
   sha256 "912877cb2929cddeadfd545a467135a2c61c507bbd5ae0edb695f8b5af7ce9af"
   license "GPL-2.0-or-later"
 
+  livecheck do
+    url "http://www.lsv.fr/~gastin/ltl2ba/download.php", post_form: {
+      getltl2ba: "Get LTL2BA",
+    }
+    regex(/href=.*?ltl2ba[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "18b178bd47a42ca3c5ab755e80cb5ec5a087807c1bef4fc064aa97a3ff18d76a"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "5527191de9afab610f9d220b2c62ceed062df2e5e2c99b1743381c57067b9535"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck is unable to identify version information for `ltl2ba`. The first-party download page only provides a link to the latest tarball after submitting a form, so we haven't been able to add a check for this because it requires a `POST` request. I recently added `POST` support to livecheck and it is now in a tagged `brew` release, so we can use it in `livecheck` blocks.

This adds a `livecheck` block that makes a `POST` request, using the minimum form values required to receive the download page content.