### PR TITLE
wfa2-lib 2.3.5 (new formula)

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -3572,6 +3572,7 @@ weechat
 wego
 werf
 west
+wfa2-lib
 wgcf
 wget2
 wgo

--- a/Formula/w/wfa2-lib.rb
+++ b/Formula/w/wfa2-lib.rb
@@ -1,0 +1,27 @@
+class Wfa2Lib < Formula
+  desc "Wavefront alignment algorithm library v2"
+  homepage "https://github.com/smarco/WFA2-lib"
+  url "https://github.com/smarco/WFA2-lib/archive/refs/tags/v2.3.5.tar.gz"
+  sha256 "2609d5f267f4dd91dce1776385b5a24a2f1aa625ac844ce0c3571c69178afe6e"
+  license "MIT"
+  head "https://github.com/smarco/WFA2-lib.git", branch: "main"
+
+  depends_on "cmake" => :build
+  depends_on "pkgconf" => :build
+
+  on_macos do
+    depends_on "libomp"
+  end
+
+  def install
+    system "cmake", "-S", ".", "-B", "build", "-DCMAKE_INSTALL_RPATH=#{rpath}", "-DOPENMP=ON", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+    pkgshare.install "examples"
+  end
+
+  test do
+    system ENV.cc, pkgshare/"examples/wfa_basic.c", "-o", "test", "-I#{include}/wfa2lib", "-L#{lib}", "-lwfa2", "-lm"
+    assert_match "WFA-Alignment returns score -24", shell_output("./test 2>&1")
+  end
+end

--- a/Formula/w/wfa2-lib.rb
+++ b/Formula/w/wfa2-lib.rb
@@ -6,6 +6,15 @@ class Wfa2Lib < Formula
   license "MIT"
   head "https://github.com/smarco/WFA2-lib.git", branch: "main"
 
+  bottle do
+    sha256 cellar: :any,                 arm64_sequoia: "1b837b83b531386b7c1812a251f2eb030761e51799f4c812b8428844219cc670"
+    sha256 cellar: :any,                 arm64_sonoma:  "fa2570af22fdf64cd38c65d1835596370dee30ca4f8c93beae65082d171ad0d0"
+    sha256 cellar: :any,                 arm64_ventura: "c2b2cd3b72cad2bc5f8444f748310bd3ea87c2b8f5fc7d61892e9afb82991bc3"
+    sha256 cellar: :any,                 sonoma:        "19a6a9bcef73e9d4ab9499360046695c51e256e45f34aa20509aa67672ebd38d"
+    sha256 cellar: :any,                 ventura:       "22063cfd7b43825c734ed23deecc19193774a819ea75e29d3b27b84e8b67f905"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4f2df560ffb8551153a89a0c9ee9be215798c7adbac8f075ca8650538f7b20a7"
+  end
+
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Repology: https://repology.org/project/wfa2-lib/versions

Can be used as dependency when building `vcflib` for `freebayes`.

`vcflib` would need a couple fixes to be considered as formula though. Currently it only supports static lib and installs libs into bindir.