### PR TITLE
opencv: modify CMake config to avoid Cellar paths

### DIFF
--- a/Formula/o/opencv.rb
+++ b/Formula/o/opencv.rb
@@ -185,6 +185,14 @@ class Opencv < Formula
 
     # Prevent dependents from using fragile Cellar paths
     inreplace lib/"pkgconfig/opencv#{version.major}.pc", prefix, opt_prefix
+    inreplace lib/"cmake/opencv#{version.major}/OpenCVConfig.cmake" do |s|
+      s.gsub! 'get_filename_component(OpenCV_CONFIG_PATH "${CMAKE_CURRENT_LIST_DIR}" REALPATH)',
+              'get_filename_component(OpenCV_CONFIG_PATH "${CMAKE_CURRENT_LIST_DIR}" ABSOLUTE)'
+      s.gsub! 'get_filename_component(OpenCV_INSTALL_PATH "${OpenCV_CONFIG_PATH}/../../../" REALPATH)',
+              'get_filename_component(OpenCV_INSTALL_PATH "${OpenCV_CONFIG_PATH}/../../../" ABSOLUTE)'
+      s.gsub! 'get_filename_component(__d "${d}" REALPATH)',
+              'get_filename_component(__d "${d}" ABSOLUTE)'
+    end
   end
 
   test do


### PR DESCRIPTION
Homebrew-specific workaround due to our symlink directory structure.

REALPATH would usually be the better option since it avoids other symlink issues (e.g. if you only symlink CMake files and then try to use those, they can end up using incorrect paths if `CMAKE_CURRENT_LIST_DIR` isn't resolved first).

In Homebrew, for standard layout, this isn't usually not an issue as we symlink all parts of keg. It mainly becomes an issue if using `libexec` or other non-linked directories.

---

Specifically to avoid having to patch these up afterwards like in `visp`:

https://github.com/Homebrew/homebrew-core/blob/dc51e30cdd09ad66ff77620b56bfdda1d5c2ff8c/Formula/v/visp.rb#L133-L144

https://github.com/Homebrew/homebrew-core/blob/dc51e30cdd09ad66ff77620b56bfdda1d5c2ff8c/Formula/v/visp.rb#L148-L150
