### PR TITLE
rtabmap: remove SDK paths from CMake config files

### DIFF
--- a/Formula/r/rtabmap.rb
+++ b/Formula/r/rtabmap.rb
@@ -15,11 +15,12 @@ class Rtabmap < Formula
   end
 
   bottle do
-    sha256                               arm64_sonoma:  "6b2bccb0c4d696140dad2c085f6b1ff97d32d99f21d2e7fa4ba79fe4a159f959"
-    sha256                               arm64_ventura: "6c9dac80b27f6b0db9ee3bff683e06a307ae868a86fa64a732d439fe164a8639"
-    sha256                               sonoma:        "82dbd8db8bdf30a95da1e5588e2e6b17b7d1038e8d596e1daff56a1070c63005"
-    sha256                               ventura:       "d0cca5a2a6a11f4c551696ebb2fb05b55f84c0823979848c5ba9ca06ab8f2b83"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "7984f2493c45d8ab3c38774fe6cab20ece348639ade1c1d55653770770d20c2d"
+    rebuild 1
+    sha256                               arm64_sonoma:  "efd50883572aa0c10a2fa435f148bca43bf7822d0d65948b5fbfa21cfa052d80"
+    sha256                               arm64_ventura: "38d22af33407cf0e98dc8076775e55699f0c445311bac17bcfcbc2fefcbdd8ab"
+    sha256                               sonoma:        "44e60e0677742e0e9da6ec271c0080625abd04c05f58b38457ba286538643864"
+    sha256                               ventura:       "27c9873f7e95a90fddd2c15d7a57b71eba01714f314b84897c6f4a6ced24f798"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c80825db603f2696e1ddbbdd608c6422295fdd41d600482384b543b704bccecb"
   end
 
   depends_on "cmake" => [:build, :test]


### PR DESCRIPTION
~~Need #208051 first.~~ Dropped OpenCV change. Can handle in separate PR.

Different approach than #208060 as only `#{sdk_path}/usr/include` is used which is a default path and safe to remove (same behavior in our `pkgconf` formula).

---

Should help reduce noise in dependent tests output:
```
`brew test --retry --verbose rtabmap` failed on macOS Sequoia (15) on Apple Silicon!
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/c++/v1/cmath:316:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/c++/v1/limits:819:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/c++/v1/type_traits:425:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/c++/v1/__type_traits/add_pointer.h:17:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/c++/v1/__type_traits/remove_reference.h:13:
/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/c++/v1/cstddef:46:5: error: <cstddef> tried including <stddef.h> but didn't find libc++'s <stddef.h> header.           This usually means that your header search paths are not configured properly.           The header search paths should contain the C++ Standard Library headers before           any C Standard Library, and you are probably using compiler flags that make that           not be the case.
   46 | #   error <cstddef> tried including <stddef.h> but didn't find libc++'s <stddef.h> header. \
      |     ^
```