### PR TITLE
spirv-cross: resolve rubocop violation

### DIFF
--- a/Formula/s/spirv-cross.rb
+++ b/Formula/s/spirv-cross.rb
@@ -63,7 +63,7 @@ class SpirvCross < Formula
 
     EOS
 
-    (Dir["*.comp"]).each do |shader_file|
+    Dir["*.comp"].each do |shader_file|
       inreplace shader_file, before, after
     end
 


### PR DESCRIPTION
See https://github.com/Homebrew/brew/actions/runs/13382176427/job/37372530039?pr=19320#step:6:15

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
