### PR TITLE
misc: link all binaries

### DIFF
--- a/Formula/g/gitter-cli.rb
+++ b/Formula/g/gitter-cli.rb
@@ -21,7 +21,7 @@ class GitterCli < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink libexec/"bin/gitter-cli"
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/g/gitter-cli.rb
+++ b/Formula/g/gitter-cli.rb
@@ -6,15 +6,13 @@ class GitterCli < Formula
   license "MIT"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "87461a9980501e5c6dbed7e5ccb7e4410569a82fb16019ed8a556375eee13601"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "aa9eccb23942bcb3eb0178bba4d6855e5087343bf22750f3b932eb7e752f3a67"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "aa9eccb23942bcb3eb0178bba4d6855e5087343bf22750f3b932eb7e752f3a67"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "aa9eccb23942bcb3eb0178bba4d6855e5087343bf22750f3b932eb7e752f3a67"
-    sha256 cellar: :any_skip_relocation, sonoma:         "b9db9eac3088781fc38e0eb469a807562542d97a797986c7e7075f0eacf34c95"
-    sha256 cellar: :any_skip_relocation, ventura:        "b9db9eac3088781fc38e0eb469a807562542d97a797986c7e7075f0eacf34c95"
-    sha256 cellar: :any_skip_relocation, monterey:       "b9db9eac3088781fc38e0eb469a807562542d97a797986c7e7075f0eacf34c95"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d362ab733091481c4aa4d761e1d533e1b4c470231f25eeee6ef5cef74cbe0a64"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "59b7c17753a1b4e92a83ed41e22b7ff595cc2d2165d1fa95f0808109605f45c1"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "59b7c17753a1b4e92a83ed41e22b7ff595cc2d2165d1fa95f0808109605f45c1"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "59b7c17753a1b4e92a83ed41e22b7ff595cc2d2165d1fa95f0808109605f45c1"
+    sha256 cellar: :any_skip_relocation, sonoma:        "74f47c77f30e1b1cba0cac9a53221463728ea01f5b7e17b4bccf58795f3b08df"
+    sha256 cellar: :any_skip_relocation, ventura:       "74f47c77f30e1b1cba0cac9a53221463728ea01f5b7e17b4bccf58795f3b08df"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "59b7c17753a1b4e92a83ed41e22b7ff595cc2d2165d1fa95f0808109605f45c1"
   end
 
   depends_on "node"

--- a/Formula/j/jsrepo.rb
+++ b/Formula/j/jsrepo.rb
@@ -6,12 +6,13 @@ class Jsrepo < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "0696c30e6adb61c1211decd613cded096207d6c54967c0d00d8042e13c6a8e6d"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "0696c30e6adb61c1211decd613cded096207d6c54967c0d00d8042e13c6a8e6d"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "0696c30e6adb61c1211decd613cded096207d6c54967c0d00d8042e13c6a8e6d"
-    sha256 cellar: :any_skip_relocation, sonoma:        "73f4e978edff8159e9762734472fb74efe1998db8aea43e3c13d7bfdca9c68e8"
-    sha256 cellar: :any_skip_relocation, ventura:       "73f4e978edff8159e9762734472fb74efe1998db8aea43e3c13d7bfdca9c68e8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0696c30e6adb61c1211decd613cded096207d6c54967c0d00d8042e13c6a8e6d"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "35871b3db3a970d2ef7f098a272ace12715ac7afa9f92206a240635fc4671f4e"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "35871b3db3a970d2ef7f098a272ace12715ac7afa9f92206a240635fc4671f4e"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "35871b3db3a970d2ef7f098a272ace12715ac7afa9f92206a240635fc4671f4e"
+    sha256 cellar: :any_skip_relocation, sonoma:        "04847931900d298fb6afcdb6a717a64e195a7ab5ae3c0a34f5b1f195faf783fc"
+    sha256 cellar: :any_skip_relocation, ventura:       "04847931900d298fb6afcdb6a717a64e195a7ab5ae3c0a34f5b1f195faf783fc"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "35871b3db3a970d2ef7f098a272ace12715ac7afa9f92206a240635fc4671f4e"
   end
 
   depends_on "node"

--- a/Formula/j/jsrepo.rb
+++ b/Formula/j/jsrepo.rb
@@ -18,7 +18,7 @@ class Jsrepo < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink libexec/"bin/jsrepo"
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/r/redocly-cli.rb
+++ b/Formula/r/redocly-cli.rb
@@ -19,7 +19,7 @@ class RedoclyCli < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink libexec/"bin/redocly"
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/r/redocly-cli.rb
+++ b/Formula/r/redocly-cli.rb
@@ -7,12 +7,13 @@ class RedoclyCli < Formula
   head "https://github.com/redocly/redocly-cli.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "c628c034900b591dddf0bd84329c0c1e032090f1d68fc332f7231d87cdfdac43"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "c628c034900b591dddf0bd84329c0c1e032090f1d68fc332f7231d87cdfdac43"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "c628c034900b591dddf0bd84329c0c1e032090f1d68fc332f7231d87cdfdac43"
-    sha256 cellar: :any_skip_relocation, sonoma:        "a44777ef04cb8101c3e3d8f2ab99c11966271c348378de634c37481e9b919ffd"
-    sha256 cellar: :any_skip_relocation, ventura:       "a44777ef04cb8101c3e3d8f2ab99c11966271c348378de634c37481e9b919ffd"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c628c034900b591dddf0bd84329c0c1e032090f1d68fc332f7231d87cdfdac43"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "1b35707d4b27df65ad9445a314f771a311e9514f204920109a3f807f3a212b8a"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "1b35707d4b27df65ad9445a314f771a311e9514f204920109a3f807f3a212b8a"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "1b35707d4b27df65ad9445a314f771a311e9514f204920109a3f807f3a212b8a"
+    sha256 cellar: :any_skip_relocation, sonoma:        "74f4421b01e4f4ec84bf95ea4f6239423127b93f676111b22860df4dbe27d2f7"
+    sha256 cellar: :any_skip_relocation, ventura:       "74f4421b01e4f4ec84bf95ea4f6239423127b93f676111b22860df4dbe27d2f7"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1b35707d4b27df65ad9445a314f771a311e9514f204920109a3f807f3a212b8a"
   end
 
   depends_on "node"

--- a/Formula/s/sql-formatter.rb
+++ b/Formula/s/sql-formatter.rb
@@ -13,7 +13,7 @@ class SqlFormatter < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink libexec/"bin/sql-formatter"
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/s/sql-formatter.rb
+++ b/Formula/s/sql-formatter.rb
@@ -6,7 +6,8 @@ class SqlFormatter < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "f72f7d24b87e4051c9a0cdf673c00e9b718fd22e92e200ad633348b01d85ba31"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "2475f3bc8e434b5b474789fa78e7ffd1383f541e60d4e7c51b2385c5e16ed35e"
   end
 
   depends_on "node"

--- a/Formula/s/synchrony.rb
+++ b/Formula/s/synchrony.rb
@@ -6,7 +6,8 @@ class Synchrony < Formula
   license "GPL-3.0-only"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "cfdc7b740313472e31a522dc164bada69ff861e361bf7df460da30748c2c3fba"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "da3ca86b921e8277e72a226e53380a3baa661e6e09c9658231b4ab6a5b53569f"
   end
 
   depends_on "node"

--- a/Formula/s/synchrony.rb
+++ b/Formula/s/synchrony.rb
@@ -13,7 +13,7 @@ class Synchrony < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink libexec/"bin/synchrony"
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/v/vue-language-server.rb
+++ b/Formula/v/vue-language-server.rb
@@ -13,7 +13,7 @@ class VueLanguageServer < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink libexec/"bin/vue-language-server"
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/v/vue-language-server.rb
+++ b/Formula/v/vue-language-server.rb
@@ -6,7 +6,8 @@ class VueLanguageServer < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "5df80dac2b3068b7bb450ed9b818530a9846c7e07817f5f1a8f0a0fabaf804bb"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "14531671c5def6a50555531037e25ba5d420deb71cd5c8aa2cb91b9c93c8bf24"
   end
 
   depends_on "node"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

These node formuale were hardcoding a single binary rather than following our typical, formula-agnostic pattern of always linking all binaries. For redocly-cli, this fixes the missing [`openapi` binary](https://github.com/Redocly/redocly-cli/blob/84a62520065cadc76466a1fb0e9a27326eae88f2/packages/cli/package.json#L7-L8)
