### PR TITLE
netpbm: generate man pages

### DIFF
--- a/Formula/n/netpbm.rb
+++ b/Formula/n/netpbm.rb
@@ -16,12 +16,13 @@ class Netpbm < Formula
   end
 
   bottle do
-    sha256 arm64_sequoia: "564aa426f9e1597c64ebb51b50b5c2776231517b423634764fa06fda93ebff49"
-    sha256 arm64_sonoma:  "e4b174e0c025ec65cfc1cb8567ae2124372a27864f5046af0da8928b8f45b921"
-    sha256 arm64_ventura: "d4bd64f740a35ca3c49a85d0c27950c67db45a10bd94cfad62fc43cc297e8484"
-    sha256 sonoma:        "31fd82cf18d2bc3cd9af829b1a2fc6cee96886acdf923620b3d046e71800ef80"
-    sha256 ventura:       "6c6baced2256efd2a0032c1282a2ec36d8c63573cfeb459edc34e6cd31ec9e98"
-    sha256 x86_64_linux:  "389525c1edd732598087f85a27752cf394815d6984321285f77941a0086ba366"
+    rebuild 1
+    sha256 arm64_sequoia: "b2121c4e691e7f230be38647042c7faeec8a715a845658e471dbc2bc2122d557"
+    sha256 arm64_sonoma:  "410e87a1757424c062803ef07a258c16580f84a537d95f80cf95949036d1e26f"
+    sha256 arm64_ventura: "c7483b4604b9748489fd2c633e52508be447487384283a604c102d0d45feb083"
+    sha256 sonoma:        "4a199d102aaa9b6f4b998d27bfa5d38a63d71e763ca44714a9adee5b167ca045"
+    sha256 ventura:       "1c19d83a21e36903ce4b4d2e1fb723fbedda5f47d4c32f604728cd1a31b3b08f"
+    sha256 x86_64_linux:  "352490e1f99270ae9d41e1d76ddc6cea1d3f36a1abca7a3f03bd76f172d75159"
   end
 
   depends_on "pkgconf" => :build


### PR DESCRIPTION
Also resolve FIXME; upstream [doesn't generate unversioned library symlinks at all](https://sourceforge.net/p/netpbm/code/5024/tree/stable/lib/Makefile#l266), and `make install` just prints instructions now.

Resolves https://github.com/orgs/Homebrew/discussions/5962.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
