### PR TITLE
libao: sync source and head URLs

### DIFF
--- a/Formula/lib/libao.rb
+++ b/Formula/lib/libao.rb
@@ -1,7 +1,7 @@
 class Libao < Formula
   desc "Cross-platform Audio Library"
   homepage "https://www.xiph.org/ao/"
-  url "https://github.com/xiph/libao/archive/refs/tags/1.2.2.tar.gz", using: :homebrew_curl
+  url "https://gitlab.xiph.org/xiph/libao/-/archive/1.2.2/libao-1.2.2.tar.gz"
   sha256 "df8a6d0e238feeccb26a783e778716fb41a801536fe7b6fce068e313c0e2bf4d"
   license "GPL-2.0-or-later"
   head "https://gitlab.xiph.org/xiph/libao.git", branch: "master"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Also drops outdated `:homebrew_curl` requirement.