### PR TITLE
man-db: update homepage

### DIFF
--- a/Formula/m/man-db.rb
+++ b/Formula/m/man-db.rb
@@ -1,7 +1,7 @@
 class ManDb < Formula
   desc "Unix documentation system"
-  homepage "https://www.nongnu.org/man-db/"
-  url "https://download.savannah.gnu.org/releases/man-db/man-db-2.13.0.tar.xz", using: :homebrew_curl
+  homepage "https://man-db.gitlab.io/man-db/"
+  url "https://download.savannah.gnu.org/releases/man-db/man-db-2.13.0.tar.xz"
   mirror "https://download-mirror.savannah.gnu.org/releases/man-db/man-db-2.13.0.tar.xz"
   sha256 "82f0739f4f61aab5eb937d234de3b014e777b5538a28cbd31433c45ae09aefb9"
   license "GPL-2.0-or-later"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Repo and homepage have now moved to GitLab. Also removes `:homebrew_curl` requirement, added in #120113. 

Audits for the reachability of the source package might still fail. Doing repeated HEAD requests with `curl -I https://download.savannah.gnu.org/releases/man-db/man-db-2.13.0.tar.xz` shows that download.savannah.gnu.org always returns a 302 redirect to one of its mirrors, and [one of those mirrors](https://quantum-mirror.hu/mirrors/pub/gnusavannah/man-db/man-db-2.13.0.tar.xz) is currently unresponsive, as it [has been recently](https://archlinux.org/mirrors/quantum-mirror.hu/).