### PR TITLE
various: drop brewed curl requirement where unnecessary

### DIFF
--- a/Formula/c/cubelib.rb
+++ b/Formula/c/cubelib.rb
@@ -1,7 +1,7 @@
 class Cubelib < Formula
-  desc "Cube, is a performance report explorer for Scalasca and Score-P"
+  desc "Performance report explorer for Scalasca and Score-P"
   homepage "https://scalasca.org/software/cube-4.x/download.html"
-  url "https://apps.fz-juelich.de/scalasca/releases/cube/4.8/dist/cubelib-4.8.2.tar.gz", using: :homebrew_curl
+  url "https://apps.fz-juelich.de/scalasca/releases/cube/4.8/dist/cubelib-4.8.2.tar.gz"
   sha256 "d6fdef57b1bc9594f1450ba46cf08f431dd0d4ae595c47e2f3454e17e4ae74f4"
   license "BSD-3-Clause"
 

--- a/Formula/f/freetds.rb
+++ b/Formula/f/freetds.rb
@@ -1,7 +1,7 @@
 class Freetds < Formula
   desc "Libraries to talk to Microsoft SQL Server and Sybase databases"
   homepage "https://www.freetds.org/"
-  url "https://www.freetds.org/files/stable/freetds-1.4.26.tar.bz2", using: :homebrew_curl
+  url "https://www.freetds.org/files/stable/freetds-1.4.26.tar.bz2"
   sha256 "74641a66cc2bfae302c2a64a4b268a3db8fb0cc7364dc7975c44c57d65cd8d1c"
   license "GPL-2.0-or-later"
 

--- a/Formula/k/kim-api.rb
+++ b/Formula/k/kim-api.rb
@@ -1,7 +1,7 @@
 class KimApi < Formula
   desc "Knowledgebase of Interatomic Models (KIM) API"
   homepage "https://openkim.org"
-  url "https://s3.openkim.org/kim-api/kim-api-2.3.0.txz", using: :homebrew_curl
+  url "https://s3.openkim.org/kim-api/kim-api-2.3.0.txz"
   sha256 "93673bb8fbc0625791f2ee67915d1672793366d10cabc63e373196862c14f991"
   license "CDDL-1.0"
   revision 1

--- a/Formula/lib/libopusenc.rb
+++ b/Formula/lib/libopusenc.rb
@@ -1,7 +1,8 @@
 class Libopusenc < Formula
   desc "Convenience library for creating .opus files"
-  homepage "https://opus-codec.org/"
-  url "https://archive.mozilla.org/pub/opus/libopusenc-0.2.1.tar.gz", using: :homebrew_curl
+  homepage "https://www.opus-codec.org/"
+  url "https://ftp.osuosl.org/pub/xiph/releases/opus/libopusenc-0.2.1.tar.gz"
+  mirror "https://archive.mozilla.org/pub/opus/libopusenc-0.2.1.tar.gz"
   sha256 "8298db61a8d3d63e41c1a80705baa8ce9ff3f50452ea7ec1c19a564fe106cbb9"
   license "BSD-3-Clause"
 
@@ -23,7 +24,7 @@ class Libopusenc < Formula
   end
 
   head do
-    url "https://gitlab.xiph.org/xiph/libopusenc.git"
+    url "https://gitlab.xiph.org/xiph/libopusenc.git", branch: "master"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build

--- a/Formula/m/mikutter.rb
+++ b/Formula/m/mikutter.rb
@@ -1,7 +1,7 @@
 class Mikutter < Formula
   desc "Extensible Twitter client"
   homepage "https://mikutter.hachune.net/"
-  url "https://mikutter.hachune.net/bin/mikutter-5.1.1.tar.gz", using: :homebrew_curl
+  url "https://mikutter.hachune.net/bin/mikutter-5.1.1.tar.gz"
   sha256 "ddff538aae249bd636604128bac1ccb526a4ed5c32f00b45d3c3c1dbcdb655de"
   license "MIT"
   head "git://mikutter.hachune.net/mikutter.git", branch: "develop"

--- a/Formula/o/openkim-models.rb
+++ b/Formula/o/openkim-models.rb
@@ -1,7 +1,7 @@
 class OpenkimModels < Formula
   desc "All OpenKIM Models compatible with kim-api"
   homepage "https://openkim.org"
-  url "https://s3.openkim.org/archives/collection/openkim-models-2021-08-11.txz", using: :homebrew_curl
+  url "https://s3.openkim.org/archives/collection/openkim-models-2021-08-11.txz"
   sha256 "f42d241969787297d839823bdd5528bc9324cd2d85f5cf2054866e654ce576da"
   license "CDDL-1.0"
   revision 1

--- a/Formula/o/opus-tools.rb
+++ b/Formula/o/opus-tools.rb
@@ -1,7 +1,8 @@
 class OpusTools < Formula
   desc "Utilities to encode, inspect, and decode .opus files"
-  homepage "https://www.opus-codec.org"
-  url "https://archive.mozilla.org/pub/opus/opus-tools-0.2.tar.gz", using: :homebrew_curl
+  homepage "https://www.opus-codec.org/"
+  url "https://ftp.osuosl.org/pub/xiph/releases/opus/opus-tools-0.2.tar.gz"
+  mirror "https://archive.mozilla.org/pub/opus/opus-tools-0.2.tar.gz"
   sha256 "b4e56cb00d3e509acfba9a9b627ffd8273b876b4e2408642259f6da28fa0ff86"
   license "BSD-2-Clause"
   revision 1

--- a/Formula/o/otf2.rb
+++ b/Formula/o/otf2.rb
@@ -2,7 +2,7 @@ class Otf2 < Formula
   desc "Open Trace Format 2 file handling library"
   homepage "https://www.vi-hps.org/projects/score-p/"
   # TODO: check if we can remove `autoconf` + `automake` at version bump.
-  url "https://perftools.pages.jsc.fz-juelich.de/cicd/otf2/tags/otf2-3.0.3/otf2-3.0.3.tar.gz", using: :homebrew_curl
+  url "https://perftools.pages.jsc.fz-juelich.de/cicd/otf2/tags/otf2-3.0.3/otf2-3.0.3.tar.gz"
   sha256 "18a3905f7917340387e3edc8e5766f31ab1af41f4ecc5665da6c769ca21c4ee8"
   license "BSD-3-Clause"
 

--- a/Formula/v/vttest.rb
+++ b/Formula/v/vttest.rb
@@ -1,7 +1,7 @@
 class Vttest < Formula
   desc "Test compatibility of VT100-compatible terminals"
   homepage "https://invisible-island.net/vttest/"
-  url "https://invisible-mirror.net/archives/vttest/vttest-20241208.tgz", using: :homebrew_curl
+  url "https://invisible-mirror.net/archives/vttest/vttest-20241208.tgz"
   sha256 "8fee3bac7e87d4aa4a217bd2b38ab9910c3b8cf9a605b450c76ccc0ad2a6519d"
   license "BSD-3-Clause"
 


### PR DESCRIPTION
The `using: :homebrew_curl` implicit requirement was added to compensate for a bug in system `curl` on macOS Monterey that prevented it from downloading sources from servers that only provided TLS v1.3, and was later extended to apply to homepage fetches and livechecks. Since then, the affected servers for these formulae have been modified to not fail in the same way as before, as shown with `/usr/bin/curl -I --tls-max 1.2 <url>`, so the requirement can be removed. PRs where the requirement was added for each are listed below. 

- [cubelib](https://github.com/Homebrew/homebrew-core/pull/99115)
- [freetds](https://github.com/Homebrew/homebrew-core/pull/91223)
- [otf2](https://github.com/Homebrew/homebrew-core/pull/98207)
- [vttest](https://github.com/Homebrew/homebrew-core/pull/95243)

The homepage URLs in these formulae still require TLS 1.3 as shown with `/usr/bin/curl -I --tls-max 1.2 <url>`, but `brew fetch -s <formula>` and `brew audit --online --skip-style --only homepage <formula>` still pass on macOS 12+ and Linux, so the requirement can be dropped.
 
- [kim-api & openkim-models](https://github.com/Homebrew/homebrew-core/pull/101163)
- [mikutter](https://github.com/Homebrew/homebrew-core/pull/106595)
- [libopusenc](https://github.com/Homebrew/homebrew-core/pull/84068)
- [opus-tools](https://github.com/Homebrew/homebrew-core/pull/84305)

The requirement is still needed for [memtester](https://github.com/Homebrew/homebrew-core/pull/118624): with system curl on Ubuntu, it's repeatedly given redirects to the same URL.
```
$ curl -I https://pyropus.ca./software/memtester/old-versions/memtester-4.7.0.tar.gz
HTTP/1.1 301 Moved Permanently
Date: Thu, 20 Feb 2025 14:56:44 GMT
Server: Apache/2.4.62 (Debian)
Location: https://pyropus.ca./software/memtester/old-versions/memtester-4.7.0.tar.gz
Content-Type: text/html; charset=iso-8859-1
```