### PR TITLE
percona-*: update livecheck

### DIFF
--- a/Formula/p/percona-server.rb
+++ b/Formula/p/percona-server.rb
@@ -6,8 +6,10 @@ class PerconaServer < Formula
   license "BSD-3-Clause"
 
   livecheck do
-    url "https://docs.percona.com/percona-server/#{version.major_minor}/"
-    regex(/href=.*?v?(\d+(?:[.-]\d+)+)\.html/i)
+    url "https://www.percona.com/products-api.php", post_form: {
+      version: "Percona-Server-#{version.major_minor}",
+    }
+    regex(/value=["']?[^"' >]*?v?(\d+(?:[.-]\d+)+)["' >]/i)
     strategy :page_match do |page, regex|
       page.scan(regex).map do |match|
         # Convert a version like 1.2.3-4.0 to 1.2.3-4 (but leave a version like

--- a/Formula/p/percona-server@8.0.rb
+++ b/Formula/p/percona-server@8.0.rb
@@ -6,8 +6,10 @@ class PerconaServerAT80 < Formula
   license "BSD-3-Clause"
 
   livecheck do
-    url "https://docs.percona.com/percona-server/#{version.major_minor}/"
-    regex(/href=.*?v?(\d+(?:[.-]\d+)+)\.html/i)
+    url "https://www.percona.com/products-api.php", post_form: {
+      version: "Percona-Server-#{version.major_minor}",
+    }
+    regex(/value=["']?[^"' >]*?v?(\d+(?:[.-]\d+)+)["' >]/i)
     strategy :page_match do |page, regex|
       page.scan(regex).map do |match|
         # Convert a version like 1.2.3-4.0 to 1.2.3-4 (but leave a version like

--- a/Formula/p/percona-toolkit.rb
+++ b/Formula/p/percona-toolkit.rb
@@ -7,8 +7,10 @@ class PerconaToolkit < Formula
   head "lp:percona-toolkit", using: :bzr
 
   livecheck do
-    url "https://docs.percona.com/percona-toolkit/version.html"
-    regex(/Percona\s+Toolkit\s+v?(\d+(?:\.\d+)+)\s+released/im)
+    url "https://www.percona.com/products-api.php", post_form: {
+      version: "percona-toolkit",
+    }
+    regex(/value=["']?[^"' >]*?v?(\d+(?:[.-]\d+)+)["' >]/i)
   end
 
   bottle do

--- a/Formula/p/percona-xtrabackup.rb
+++ b/Formula/p/percona-xtrabackup.rb
@@ -6,8 +6,10 @@ class PerconaXtrabackup < Formula
   license "GPL-2.0-only"
 
   livecheck do
-    url "https://docs.percona.com/percona-xtrabackup/#{version.major_minor}/"
-    regex(/href=.*?v?(\d+(?:[.-]\d+)+)\.html/i)
+    url "https://www.percona.com/products-api.php", post_form: {
+      version: "Percona-XtraBackup-#{version.major_minor}",
+    }
+    regex(/value=["']?[^"' >]*?v?(\d+(?:[.-]\d+)+)["' >]/i)
     strategy :page_match do |page, regex|
       page.scan(regex).map do |match|
         # Convert a version like 1.2.3-4.0 to 1.2.3-4 (but leave a version like

--- a/Formula/p/percona-xtrabackup@8.0.rb
+++ b/Formula/p/percona-xtrabackup@8.0.rb
@@ -6,8 +6,10 @@ class PerconaXtrabackupAT80 < Formula
   license "GPL-2.0-only"
 
   livecheck do
-    url "https://docs.percona.com/percona-xtrabackup/#{version.major_minor}/"
-    regex(/href=.*?v?(\d+(?:[.-]\d+)+)\.html/i)
+    url "https://www.percona.com/products-api.php", post_form: {
+      version: "Percona-XtraBackup-#{version.major_minor}",
+    }
+    regex(/value=["']?[^"' >]*?v?(\d+(?:[.-]\d+)+)["' >]/i)
     strategy :page_match do |page, regex|
       page.scan(regex).map do |match|
         # Convert a version like 1.2.3-4.0 to 1.2.3-4 (but leave a version like


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates the `livecheck` blocks for the various Percona formulae to use the upstream `products-api.php` endpoint that the first-party website uses to populate the download options fields.

We didn't do this before because it requires a `POST` request, so I'm reworking these now that livecheck supports it. For what it's worth, the response body for these is pretty small (typically less than 1 KB compressed), so these new checks involve less data transfer than the existing checks.