### PR TITLE
libnsl: enable macos build

### DIFF
--- a/Formula/lib/libnsl.rb
+++ b/Formula/lib/libnsl.rb
@@ -13,18 +13,30 @@ class Libnsl < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux: "fa7613b30e9bfe15166339d119c19115ec21f13cea259280182e0c083502ff40"
   end
 
+  keg_only :shadowed_by_macos
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "gettext" => :build
+  depends_on "libtool" => :build
   depends_on "pkgconf" => :build
   depends_on "libtirpc"
-  depends_on :linux
 
   link_overwrite "include/rpcsvc"
   link_overwrite "lib/libnsl.a"
   link_overwrite "lib/libnsl.so"
 
+  # patch to support macos build, upstream pr ref, https://github.com/thkukuk/libnsl/pull/24
+  patch do
+    url "https://github.com/thkukuk/libnsl/commit/db614c41660fc8c06f7c4a40dd36cd82feb471d5.patch?full_index=1"
+    sha256 "60f4098fcb5d97fc2158e805ed8fe5936d50bfb6af57cab54a281fd9d8677b62"
+  end
+
   def install
-    system "./configure", *std_configure_args,
-                          "--disable-silent-rules"
-    system "make"
+    odie "check if autoreconf line can be removed" if version > "2.0.1"
+    system "autoreconf", "--force", "--install", "--verbose"
+
+    system "./configure", "--disable-silent-rules", *std_configure_args
     system "make", "install"
   end
 

--- a/Formula/lib/libtirpc.rb
+++ b/Formula/lib/libtirpc.rb
@@ -18,6 +18,9 @@ class Libtirpc < Formula
 
   depends_on "krb5"
 
+  # submitted the patch to libtirpc-devel@lists.sourceforge.net mailing list
+  patch :DATA
+
   def install
     ENV.append_to_cflags "-D__APPLE_USE_RFC_3542" if OS.mac?
     system "./configure", "--disable-silent-rules", *std_configure_args.reject { |s| s["--disable-debug"] }
@@ -44,3 +47,18 @@ class Libtirpc < Formula
     system "./test"
   end
 end
+
+__END__
+diff --git a/tirpc/rpc/rpcent.h b/tirpc/rpc/rpcent.h
+index 2e5fc0c..afde974 100644
+--- a/tirpc/rpc/rpcent.h
++++ b/tirpc/rpc/rpcent.h
+@@ -50,7 +50,7 @@ extern "C" {
+
+ /* These are defined in /usr/include/rpc/netdb.h, unless we are using
+    the C library without RPC support. */
+-#if defined(__UCLIBC__) && !defined(__UCLIBC_HAS_RPC__) || !defined(__GLIBC__) && !defined(HAVE_STRUCT_RPCENT)
++#if !defined(__APPLE__) && ((defined(__UCLIBC__) && !defined(__UCLIBC_HAS_RPC__)) || (!defined(__GLIBC__) && !defined(HAVE_STRUCT_RPCENT)))
+
+ struct rpcent {
+ 	char	*r_name;	/* name of server for this rpc program */


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- #208484 
- https://github.com/thkukuk/libnsl/pull/24

```
  * Header files that shadow system header files were installed to "/opt/homebrew/opt/libnsl/include"
    The offending files are:
      /opt/homebrew/opt/libnsl/include/rpcsvc/yp.h
      /opt/homebrew/opt/libnsl/include/rpcsvc/yp_prot.h
      /opt/homebrew/opt/libnsl/include/rpcsvc/ypclnt.h
      /opt/homebrew/opt/libnsl/include/rpcsvc/yppasswd.h
```