### PR TITLE
qwt: use correct Qt dirs, patch pkgconfig file

### DIFF
--- a/Formula/q/qwt.rb
+++ b/Formula/q/qwt.rb
@@ -11,13 +11,12 @@ class Qwt < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "6adb7582cb3f3668fc541f8d087ea1941e1a875ef5d492f74a98c142655236bf"
-    sha256 cellar: :any,                 arm64_ventura:  "a9287c7fd09ae45bd5afc94788679c647b0f0d8b06c2150a8bb32ff19ccc6cb5"
-    sha256 cellar: :any,                 arm64_monterey: "193e2f4e05debf6af85ff273f263f625687855c1608a3273c967aa2923a6c5f6"
-    sha256 cellar: :any,                 sonoma:         "c0e5af00c8bd0937cc15c26ab5882805a523701688b39dfe9a4ae4c00ac79463"
-    sha256 cellar: :any,                 ventura:        "3123515f8b0dc54033fd148442dc8cc92b6d490209c3f474ff29db8abd794bed"
-    sha256 cellar: :any,                 monterey:       "b37d96c837d93dc53dcf9b97592a7f953651acae660b388e8800cffafb9bdcf8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "84711477f549b6b42ad1ad87bf333e94559836ad3637765c87fb3117f153325c"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sonoma:  "136f2812341e94fb98be285e00f938c7078aa855dd766be89e8b27b65ff61729"
+    sha256 cellar: :any,                 arm64_ventura: "be7a809955ab72f32520add889794883d4da77781387ba7110bf8ab75b03ce8d"
+    sha256 cellar: :any,                 sonoma:        "bf1e1368404ef259bdf0a446a2c5765ed38851d8fe8c050f5a6138a757f4044e"
+    sha256 cellar: :any,                 ventura:       "73c072ac764154eac4940a150ade2716b2b5240f0aec31438b808d1c80abc404"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "13db11bcb1836554ed9d2d1be1e2a09c645f4278eeb282c1386554865915adc0"
   end
 
   depends_on "qt"

--- a/Formula/q/qwt.rb
+++ b/Formula/q/qwt.rb
@@ -22,36 +22,43 @@ class Qwt < Formula
 
   depends_on "qt"
 
-  # Update designer plugin linking back to qwt framework/lib after install
-  # See: https://sourceforge.net/p/qwt/patches/45/
-  patch :DATA
+  # Apply Fedora patch to fix pkgconfig file.
+  # Issue ref: https://sourceforge.net/p/qwt/bugs/353/
+  patch do
+    url "https://src.fedoraproject.org/rpms/qwt/raw/ea40e765e46413ae865a00f606688ea05e378e8a/f/qwt-pkgconfig.patch"
+    sha256 "7ceb1153ba1d8da4dd61f343023fe742a304fba9f7ff8737c0e62f7dcb0e2bc2"
+  end
 
   def install
     inreplace "qwtconfig.pri" do |s|
-      s.gsub!(/^\s*QWT_INSTALL_PREFIX\s*=(.*)$/, "QWT_INSTALL_PREFIX=#{prefix}")
-
-      # Install Qt plugin in `lib/qt/plugins/designer`, not `plugins/designer`.
-      s.sub! %r{(= \$\$\{QWT_INSTALL_PREFIX\})/(plugins/designer)$},
-             "\\1/lib/qt/\\2"
+      s.gsub!(/^(\s*QWT_INSTALL_PREFIX\s*=).*$/, "\\1 #{prefix}")
+      s.gsub! "= $${QWT_INSTALL_PREFIX}/doc", "= #{doc}"
+      s.gsub! "= $${QWT_INSTALL_PREFIX}/plugins/designer", "= $${QWT_INSTALL_PREFIX}/share/qt/plugins/designer"
+      s.gsub! "= $${QWT_INSTALL_PREFIX}/features", "= $${QWT_INSTALL_PREFIX}/share/qt/mkspecs/features"
     end
 
-    args = ["-config", "release", "-spec"]
-    spec = if OS.linux?
-      "linux-g++"
-    elsif ENV.compiler == :clang
-      "macx-clang"
-    else
-      "macx-g++"
-    end
-    args << spec
+    os = OS.mac? ? "macx" : OS.kernel_name.downcase
+    compiler = ENV.compiler.to_s.match?("clang") ? "clang" : "g++"
 
-    qt = Formula["qt"]
-    system "#{qt.opt_prefix}/bin/qmake", *args
+    system "qmake", "-config", "release", "-spec", "#{os}-#{compiler}"
     system "make"
     system "make", "install"
+
+    # Backwards compatibility symlinks. Remove in a future release
+    odie "Remove backwards compatibility symlinks!" if version >= 7
+    prefix.install_symlink share/"qt/mkspecs/features"
+    (lib/"qt/plugins/designer").install_symlink share.glob("qt/plugins/designer/*")
   end
 
   test do
+    (testpath/"test.pro").write <<~QMAKE
+      CONFIG  += console qwt
+      CONFIG  -= app_bundle
+      SOURCES += test.cpp
+      TARGET   = test
+      TEMPLATE = app
+    QMAKE
+
     (testpath/"test.cpp").write <<~CPP
       #include <qwt_plot_curve.h>
       int main() {
@@ -59,51 +66,12 @@ class Qwt < Formula
         return (curve1 == NULL);
       }
     CPP
-    qt = Formula["qt"]
-    if OS.mac?
-      system ENV.cxx, "test.cpp", "-o", "out",
-        "-std=c++17",
-        "-framework", "qwt", "-framework", "QtCore",
-        "-F#{lib}", "-F#{qt.opt_lib}",
-        "-I#{lib}/qwt.framework/Headers",
-        "-I#{qt.opt_include}/QtCore",
-        "-I#{qt.opt_include}/QtGui"
-    else
-      system ENV.cxx,
-        "-I#{qt.opt_include}",
-        "-I#{qt.opt_include}/QtCore",
-        "-I#{qt.opt_include}/QtGui",
-        "test.cpp",
-        "-lqwt", "-lQt#{qt.version.major}Core", "-lQt#{qt.version.major}Gui",
-        "-L#{qt.opt_lib}",
-        "-L#{Formula["qwt"].opt_lib}",
-        "-Wl,-rpath=#{qt.opt_lib}",
-        "-Wl,-rpath=#{Formula["qwt"].opt_lib}",
-        "-o", "out", "-std=c++17", "-fPIC"
-    end
-    system "./out"
+
+    ENV.delete "CPATH"
+    ENV["LC_ALL"] = "en_US.UTF-8"
+
+    system Formula["qt"].bin/"qmake", "test.pro"
+    system "make"
+    system "./test"
   end
 end
-
-__END__
-diff --git a/designer/designer.pro b/designer/designer.pro
-index c269e9d..c2e07ae 100644
---- a/designer/designer.pro
-+++ b/designer/designer.pro
-@@ -126,6 +126,16 @@ contains(QWT_CONFIG, QwtDesigner) {
-
-     target.path = $${QWT_INSTALL_PLUGINS}
-     INSTALLS += target
-+
-+    macx {
-+        contains(QWT_CONFIG, QwtFramework) {
-+            QWT_LIB = qwt.framework/Versions/$${QWT_VER_MAJ}/qwt
-+        }
-+        else {
-+            QWT_LIB = libqwt.$${QWT_VER_MAJ}.dylib
-+        }
-+        QMAKE_POST_LINK = install_name_tool -change $${QWT_LIB} $${QWT_INSTALL_LIBS}/$${QWT_LIB} $(DESTDIR)$(TARGET)
-+    }
- }
- else {
-     TEMPLATE        = subdirs # do nothing


### PR DESCRIPTION
Draft as need to check on Linux (may need RPATH for test).

Changes:
* Didn't see impact of old patch so dropped it. Can re-add if needed though upstream has rejected it and closed issue.
* Apply Fedora's patch which is similar to patch posted on upstream issue. Issue still open.
* Move docs to our standard `doc` directory
* Move designer plugins to proper directory, i.e. will link to Qt's:
  ```console
  ❯ qmake -query QT_INSTALL_PLUGINS
  /opt/homebrew/share/qt/plugins
  ```
* Move features directory so that `CONFIG += qwt` works
* Retain backwards compatibility symlinks as some projects use original directories (can plan removal for next major release)
* Use qmake in test as better way to automatically handle flags