### PR TITLE
visp: update postinstall to support API

### DIFF
--- a/Formula/v/visp.rb
+++ b/Formula/v/visp.rb
@@ -154,13 +154,19 @@ class Visp < Formula
     # Replace SDK paths in bottle when pouring on different OS version than bottle OS.
     # This avoids error like https://github.com/orgs/Homebrew/discussions/5853
     # TODO: Consider handling this in brew, e.g. as part of keg cleaner or bottle relocation
-    if OS.mac? && Tab.for_formula(self).poured_from_bottle && MacOS.version != bottle&.tag&.to_macos_version
+    if OS.mac? && (tab = Tab.for_formula(self)).poured_from_bottle
+      bottle_os = bottle&.tag&.to_macos_version
+      if bottle_os.nil? && (os_version = tab.built_on.fetch("os_version", "")[/\d+(?:\.\d+)*$/])
+        bottle_os = MacOSVersion.new(os_version).strip_patch
+      end
+      return if bottle_os.nil? || MacOS.version == bottle_os
+
       sdk_path_files = [
         lib/"cmake/visp/VISPConfig.cmake",
         lib/"cmake/visp/VISPModules.cmake",
         lib/"pkgconfig/visp.pc",
       ]
-      bottle_sdk_path = MacOS.sdk_for_formula(self, bottle&.tag&.to_macos_version).path
+      bottle_sdk_path = MacOS.sdk_for_formula(self, bottle_os).path
       inreplace sdk_path_files, bottle_sdk_path, MacOS.sdk_for_formula(self).path, audit_result: false
     end
   end


### PR DESCRIPTION
Looks like #208060 only worked via tap since JSON API has `bottle == nil`.

Not sure if there is a better way, but trying to parse OS information from tab (e.g. `os_version` is `macOS 14.7`).

Also provide output similar to keg relocation. `odebug` would be better but looks like we never added support for that in postinstall.

Output would look like:
```
==> Changing SDK path in /opt/homebrew/Cellar/visp/3.6.0_12/lib/cmake/visp/VISPConfig.cmake
  from /Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk
    to /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk
==> Changing SDK path in /opt/homebrew/Cellar/visp/3.6.0_12/lib/cmake/visp/VISPModules.cmake
  from /Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk
    to /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk
==> Changing SDK path in /opt/homebrew/Cellar/visp/3.6.0_12/lib/pkgconfig/visp.pc
  from /Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk
    to /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk
```

One issue is output is always shown, even with `brew postinstall visp --quiet`. May want to consider adding odebug support first to avoid this.

Note that `odebug` in current brew postinstall is pretty much a code comment since `--debug` is dropped when executing `postinstall.rb`.
