### PR TITLE
i686-elf-grub 2.06, x86_64-elf-grub 2.06 (new formulae)

### DIFF
--- a/Formula/i/i686-elf-grub.rb
+++ b/Formula/i/i686-elf-grub.rb
@@ -1,0 +1,61 @@
+class I686ElfGrub < Formula
+  desc "GNU GRUB bootloader for i686-elf"
+  homepage "https://www.gnu.org/software/grub/"
+  url "https://ftp.gnu.org/gnu/grub/grub-2.06.tar.xz"
+  sha256 "b79ea44af91b93d17cd3fe80bdae6ed43770678a9a5ae192ccea803ebb657ee1"
+  license "GPL-3.0-or-later"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "gcc" => :build
+  depends_on "gettext" => :build
+  depends_on "help2man" => :build
+  depends_on "i686-elf-binutils" => :build
+  depends_on "i686-elf-gcc" => [:build, :test]
+  depends_on "make" => :build
+  depends_on "objconv" => :build
+  depends_on "texinfo" => :build
+  uses_from_macos "bison" => :build
+  uses_from_macos "flex" => :build
+
+  def install
+    target = "i686-elf"
+    ENV["CFLAGS"] = "-Os -Wno-error=incompatible-pointer-types"
+
+    mkdir "build" do
+      args = %W[
+        --disable-werror
+        --target=#{target}
+        --prefix=#{prefix}/#{target}
+        --bindir=#{bin}
+        --libdir=#{lib}/#{target}
+        --with-platform=pc
+        --program-prefix=#{target}-
+        TARGET_CC=#{target}-gcc
+        TARGET_OBJCOPY=#{target}-objcopy
+        TARGET_STRIP=#{target}-strip
+        TARGET_NM=#{target}-nm
+        TARGET_RANLIB=#{target}-ranlib
+      ]
+
+      system "../configure", *args
+      system "make"
+      system "make", "install"
+    end
+  end
+
+  test do
+    target = "i686-elf"
+    (testpath/"boot.c").write <<~C
+      __asm__(
+        ".align 4\\n"
+        ".long 0x1BADB002\\n"
+        ".long 0x0\\n"
+        ".long -(0x1BADB002 + 0x0)\\n"
+      );
+    C
+    system Formula["#{target}-gcc"].bin/"#{target}-gcc", "-c", "-o", "boot", "boot.c"
+    assert_match "0",
+      shell_output("#{bin}/#{target}-grub-file --is-x86-multiboot boot; echo $?")
+  end
+end

--- a/Formula/x/x86_64-elf-grub.rb
+++ b/Formula/x/x86_64-elf-grub.rb
@@ -1,0 +1,61 @@
+class X8664ElfGrub < Formula
+  desc "GNU GRUB bootloader for x86_64-elf"
+  homepage "https://www.gnu.org/software/grub/"
+  url "https://ftp.gnu.org/gnu/grub/grub-2.06.tar.xz"
+  sha256 "b79ea44af91b93d17cd3fe80bdae6ed43770678a9a5ae192ccea803ebb657ee1"
+  license "GPL-3.0-or-later"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "gcc" => :build
+  depends_on "gettext" => :build
+  depends_on "help2man" => :build
+  depends_on "make" => :build
+  depends_on "objconv" => :build
+  depends_on "texinfo" => :build
+  depends_on "x86_64-elf-binutils" => :build
+  depends_on "x86_64-elf-gcc" => [:build, :test]
+  uses_from_macos "bison" => :build
+  uses_from_macos "flex" => :build
+
+  def install
+    target = "x86_64-elf"
+    ENV["CFLAGS"] = "-Os -Wno-error=incompatible-pointer-types"
+
+    mkdir "build" do
+      args = %W[
+        --disable-werror
+        --target=#{target}
+        --prefix=#{prefix}/#{target}
+        --bindir=#{bin}
+        --libdir=#{lib}/#{target}
+        --with-platform=pc
+        --program-prefix=#{target}-
+        TARGET_CC=#{target}-gcc
+        TARGET_OBJCOPY=#{target}-objcopy
+        TARGET_STRIP=#{target}-strip
+        TARGET_NM=#{target}-nm
+        TARGET_RANLIB=#{target}-ranlib
+      ]
+
+      system "../configure", *args
+      system "make"
+      system "make", "install"
+    end
+  end
+
+  test do
+    target = "x86_64-elf"
+    (testpath/"boot.c").write <<~C
+      __asm__(
+        ".align 4\\n"
+        ".long 0x1BADB002\\n"
+        ".long 0x0\\n"
+        ".long -(0x1BADB002 + 0x0)\\n"
+      );
+    C
+    system Formula["#{target}-gcc"].bin/"#{target}-gcc", "-c", "-o", "boot", "boot.c"
+    assert_match "0",
+      shell_output("#{bin}/#{target}-grub-file --is-x86-multiboot boot; echo $?")
+  end
+end


### PR DESCRIPTION
Add cross-compiled GRUB bootloader formulae for i686-elf and x86_64-elf targets. These formulae provide GNU GRUB bootloader utilities for cross-compilation environments, used in operating system development and bootloader customization.

Both formulae:
- Use GRUB 2.06 stable release
- Include multiboot support
- Include standard build dependencies
- Feature verify multiboot header test

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
