### PR TITLE
opus & opusfile: change source URLs, livechecks

### DIFF
--- a/Formula/o/opus.rb
+++ b/Formula/o/opus.rb
@@ -2,6 +2,7 @@ class Opus < Formula
   desc "Audio codec"
   homepage "https://www.opus-codec.org/"
   url "https://ftp.osuosl.org/pub/xiph/releases/opus/opus-1.5.2.tar.gz"
+  mirror "https://github.com/xiph/opus/releases/download/v1.5.2/opus-1.5.2.tar.gz"
   sha256 "65c1d2f78b9f2fb20082c38cbe47c951ad5839345876e46941612ee87f9a7ce1"
   license "BSD-3-Clause"
 
@@ -31,8 +32,7 @@ class Opus < Formula
 
   def install
     system "./autogen.sh" if build.head?
-    system "./configure", "--disable-dependency-tracking",
-                          "--disable-doc", "--prefix=#{prefix}"
+    system "./configure", "--disable-doc", *std_configure_args
     system "make", "install"
   end
 

--- a/Formula/o/opusfile.rb
+++ b/Formula/o/opusfile.rb
@@ -1,15 +1,15 @@
 class Opusfile < Formula
   desc "API for decoding and seeking in .opus files"
   homepage "https://www.opus-codec.org/"
-  url "https://downloads.xiph.org/releases/opus/opusfile-0.12.tar.gz", using: :homebrew_curl
-  mirror "https://ftp.osuosl.org/pub/xiph/releases/opus/opusfile-0.12.tar.gz"
+  url "https://ftp.osuosl.org/pub/xiph/releases/opus/opusfile-0.12.tar.gz"
+  mirror "https://github.com/xiph/opusfile/releases/download/v0.12/opusfile-0.12.tar.gz"
   sha256 "118d8601c12dd6a44f52423e68ca9083cc9f2bfe72da7a8c1acb22a80ae3550b"
   license "BSD-3-Clause"
   revision 1
 
   livecheck do
-    url "https://www.opus-codec.org/downloads/"
-    regex(/href=.*?opusfile[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url "https://ftp.osuosl.org/pub/xiph/releases/opus/"
+    regex(%r{href=(?:["']?|.*?/)opusfile[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
   bottle do


### PR DESCRIPTION
Since `downloads.xiph.org` now always does a 301 redirect to its mirror `https://ftp.osuosl.org/pub/xiph/`, drop it and its `:homebrew_curl` requirement entirely and use GitHub as a mirror, if available. This also changes the URL used by the livecheck block to match. 