### PR TITLE
exiftool: add brotli support

### DIFF
--- a/Formula/e/exiftool.rb
+++ b/Formula/e/exiftool.rb
@@ -14,12 +14,13 @@ class Exiftool < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "29fd8dbeda720f5d00dc1bdc834a3649a76ac520129cfb175edc074e39de30fe"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "29fd8dbeda720f5d00dc1bdc834a3649a76ac520129cfb175edc074e39de30fe"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "af264f92e9f7a49f0fe0fd2223c2bb515b3624b95adbe07f34d38d3df0842e58"
-    sha256 cellar: :any_skip_relocation, sonoma:        "154a40158762db56b0f8644e2afe265476191a3907450734b7abad6824384075"
-    sha256 cellar: :any_skip_relocation, ventura:       "28df6e34d8bf602c5facaadd5efe85d7ca8b67eb5c2b2a7ca58d619868e01a61"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d55bfc592867a88920fdb6687a5d6b83c4b842a7a4f09d01490c7156641cb245"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "bf0a297965b43e49f314d7e517031a6042b56e87e7c1aded5dab54892b518db2"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "85e7cd59d232f2f68d991515a9aa292c70cc67c7f2f8f3add7927044347bab01"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "f15e5fb708305cf1f845452f0cdf79f64c0453cf9575ec00dbe0e83b664acf9d"
+    sha256 cellar: :any_skip_relocation, sonoma:        "b4fa352aa6dedef57625d850dd1dfbe54e895a5b6cd95a5caa298668df2065b1"
+    sha256 cellar: :any_skip_relocation, ventura:       "69bd0f39288c627797e2169e51b3f29ae58a374f1c8c0e626b2d931a0fd7eb33"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "9238991716985f3ead7fcd0055738c8ff691842dbcb6b4091f5494658f2ac37d"
   end
 
   depends_on "cmake" => :build

--- a/Formula/e/exiftool.rb
+++ b/Formula/e/exiftool.rb
@@ -22,15 +22,90 @@ class Exiftool < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "d55bfc592867a88920fdb6687a5d6b83c4b842a7a4f09d01490c7156641cb245"
   end
 
+  depends_on "cmake" => :build
+
   uses_from_macos "perl"
 
-  def install
-    # replace the hard-coded path to the lib directory
-    inreplace "exiftool", "unshift @INC, $incDir;", "unshift @INC, \"#{libexec}/lib\";"
+  resource "FFI::CheckLib" do
+    url "https://cpan.metacpan.org/authors/id/P/PL/PLICEASE/FFI-CheckLib-0.31.tar.gz"
+    sha256 "04d885fc377d44896e5ea1c4ec310f979bb04f2f18658a7e7a4d509f7e80bb80"
+  end
 
-    system "perl", "Makefile.PL"
-    system "make", "all"
-    libexec.install "lib"
+  resource "File::Which" do
+    url "https://cpan.metacpan.org/authors/id/P/PL/PLICEASE/File-Which-1.27.tar.gz"
+    sha256 "3201f1a60e3f16484082e6045c896842261fc345de9fb2e620fd2a2c7af3a93a"
+  end
+
+  resource "Capture::Tiny" do
+    url "https://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN/Capture-Tiny-0.48.tar.gz"
+    sha256 "6c23113e87bad393308c90a207013e505f659274736638d8c79bac9c67cc3e19"
+  end
+
+  resource "File::chdir" do
+    url "https://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN/File-chdir-0.1011.tar.gz"
+    sha256 "31ebf912df48d5d681def74b9880d78b1f3aca4351a0ed1fe3570b8e03af6c79"
+  end
+
+  resource "Path::Tiny" do
+    url "https://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN/Path-Tiny-0.144.tar.gz"
+    sha256 "f6ea094ece845c952a02c2789332579354de8d410a707f9b7045bd241206487d"
+  end
+
+  resource "Alien::Build" do
+    url "https://cpan.metacpan.org/authors/id/P/PL/PLICEASE/Alien-Build-2.84.tar.gz"
+    sha256 "8e891fd3acbac39dd8fdc01376b9abff931e625be41e0910ca30ad59363b4477"
+  end
+
+  resource "Mozilla::CA" do
+    url "https://cpan.metacpan.org/authors/id/L/LW/LWP/Mozilla-CA-20250202.tar.gz"
+    sha256 "32d43ce8cb3b201813898f0c4c593a08df350c1e47484e043fc8adebbda60dbf"
+  end
+
+  resource "Sort::Versions" do
+    url "https://cpan.metacpan.org/authors/id/N/NE/NEILB/Sort-Versions-1.62.tar.gz"
+    sha256 "bf5f3307406ebe2581237f025982e8c84f6f6625dd774e457c03f8994efd2eaa"
+  end
+
+  resource "Alien::cmake3" do
+    url "https://cpan.metacpan.org/authors/id/P/PL/PLICEASE/Alien-cmake3-0.08.tar.gz"
+    sha256 "93dfb1146f0053ec1ed59558f5f6d8f85d87b822a8433c6485d419c4f0182f1f"
+  end
+
+  resource "File::Slurper" do
+    url "https://cpan.metacpan.org/authors/id/L/LE/LEONT/File-Slurper-0.014.tar.gz"
+    sha256 "d5a36487339888c3cd758e648160ee1d70eb4153cacbaff57846dbcefb344b0c"
+  end
+
+  resource "IO::Compress::Brotli" do
+    url "https://cpan.metacpan.org/authors/id/T/TI/TIMLEGGE/IO-Compress-Brotli-0.019.tar.gz"
+    sha256 "37f40dd7cee44acea26f2f763a773e61d4ec223305ddeeca4612443cbf288fbf"
+  end
+
+  def install
+    perl_lib = libexec/"lib/perl5"
+    ENV.prepend_create_path "PERL5LIB", perl_lib
+
+    resources.each do |r|
+      r.stage do
+        system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}"
+        if r.name == "IO::Compress::Brotli"
+          ENV.deparallelize { system "make", "install" }
+        else
+          system "make", "install"
+        end
+      end
+    end
+
+    system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}"
+    system "make", "install"
+
+    # replace the hard-coded path to the lib directory
+    inreplace "exiftool", "unshift @INC, $incDir;", <<~EOS
+      use Config;
+      unshift @INC, "#{perl_lib}";
+      unshift @INC, "#{perl_lib}/$Config{archname}";
+    EOS
+
     bin.install "exiftool"
     doc.install Dir["html/*"]
     man1.install "blib/man1/exiftool.1"
@@ -41,5 +116,15 @@ class Exiftool < Formula
     test_image = test_fixtures("test.jpg")
     assert_match %r{MIME Type\s+: image/jpeg},
                  shell_output("#{bin}/exiftool #{test_image}")
+
+    resource "sunset-logo-jxl" do
+      url "https://github.com/libjxl/conformance/blob/5399ecf01e50ec5230912aa2df82286dc1c379c9/testcases/sunset_logo/input.jxl?raw=true"
+      sha256 "6617480923e1fdef555e165a1e7df9ca648068dd0bdbc41a22c0e4213392d834"
+    end
+
+    resource("sunset-logo-jxl").stage do
+      system bin/"exiftool", "-api", "Compress=1", "-Artist=homebrew", "-m", "input.jxl"
+      assert_match "BrotliEXIF", shell_output("#{bin}/exiftool -verbose input.jxl")
+    end
   end
 end

--- a/Formula/g/grokj2k.rb
+++ b/Formula/g/grokj2k.rb
@@ -14,12 +14,13 @@ class Grokj2k < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "cabdf80b062bd6d4c9feca303d914cfd55a059472db1c377fb06b7f7fb0dc608"
-    sha256 cellar: :any,                 arm64_sonoma:  "c7cc9733e185533df52da8a683438dad8ca8930bd43df11ac737a22c1c8595e9"
-    sha256 cellar: :any,                 arm64_ventura: "e2520c5e92f5fd63c0e7b240bab1a4d1a2ee8a7bb8292e5c9c94e564de81fa8a"
-    sha256 cellar: :any,                 sonoma:        "002121ff77b1e45b4231c757c4ab652a0288021d734b7c0b796292c77d2716f4"
-    sha256 cellar: :any,                 ventura:       "d46acfb58425dea5f9bd6a928b04ab662f0a21e868779db1988953b6bde69917"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4f90e1bf0b372c9ce3534011e2dc1ba6c16e77c5989168286f210835d99522c9"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "5149d78f8c62ba15378406a5cf7069664610210b6217407a84f525b8d4f3a503"
+    sha256 cellar: :any,                 arm64_sonoma:  "77b72bff592cea45f9a58ac582c40936a40f43c5043a03f776c66ebcb243c4a8"
+    sha256 cellar: :any,                 arm64_ventura: "671bcbcd63e92dcec776dd40f283af775c20ac48b8db218df2bf434b1e2745bc"
+    sha256 cellar: :any,                 sonoma:        "9ced0cf80ece1940de03f7aa539c7ab8343cee8e180322bbd13746d715f47fb5"
+    sha256 cellar: :any,                 ventura:       "55af09dd82eabdd8ccdec7300c92598cc194f59d4f67c7f7dfd36abc99617c37"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "61435c3633d1ba62db43e0ade8388ed6fe95e4c6601ef6446223d1e9f2527cd4"
   end
 
   depends_on "cmake" => :build

--- a/Formula/g/grokj2k.rb
+++ b/Formula/g/grokj2k.rb
@@ -56,7 +56,7 @@ class Grokj2k < Formula
     ENV.llvm_clang if OS.mac? && (DevelopmentTools.clang_build_version <= 1200)
 
     # Fix: ExifTool Perl module not found
-    ENV.prepend_path "PERL5LIB", Formula["exiftool"].opt_libexec/"lib"
+    ENV.prepend_path "PERL5LIB", Formula["exiftool"].opt_libexec/"lib/perl5"
 
     # Ensure we use Homebrew libraries
     %w[liblcms2 libpng libtiff libz].each { |l| rm_r(buildpath/"thirdparty"/l) }


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

exiftool requires brotli to be able to read compressed metadata from JPEG XL files.