### PR TITLE
Fix rubocop-performance violations

### DIFF
--- a/Formula/d/deark.rb
+++ b/Formula/d/deark.rb
@@ -33,7 +33,7 @@ class Deark < Formula
       H4sICKU51VoAA3Rlc3QudHh0APNIzcnJ11HwyM9NTSpKLVfkAgBuKJNJEQAAAA==
     EOS
     system bin/"deark", "test.gz"
-    file = (testpath/"output.000.test.txt").readlines.first
+    file = File.open(testpath/"output.000.test.txt").first
     assert_match "Hello, Homebrew!", file
   end
 end

--- a/Formula/h/hpack.rb
+++ b/Formula/h/hpack.rb
@@ -57,6 +57,6 @@ class Hpack < Formula
     system bin/"hpack"
 
     # Skip the first lines because they contain the hpack version number.
-    assert_equal expected, (testpath/"homebrew.cabal").read.lines[6..].join
+    assert_equal expected, (testpath/"homebrew.cabal").readlines.drop(6).join
   end
 end

--- a/Formula/l/lilypond.rb
+++ b/Formula/l/lilypond.rb
@@ -110,7 +110,7 @@ class Lilypond < Formula
              .encode("UTF-8", invalid: :replace, replace: "\ufffd")
     common_styles = ["Regular", "Bold", "Italic", "Bold Italic"]
     {
-      "C059"            => ["Roman", *common_styles[1..]],
+      "C059"            => ["Roman", *common_styles.drop(1)],
       "Nimbus Mono PS"  => common_styles,
       "Nimbus Sans"     => common_styles,
       "TeX Gyre Cursor" => common_styles,

--- a/Formula/p/pgtoolkit.rb
+++ b/Formula/p/pgtoolkit.rb
@@ -17,7 +17,7 @@ class Pgtoolkit < Formula
 
   test do
     output = IO.popen("#{bin}/pgcompact --help")
-    matches = output.readlines.select { |line| line.include?("pgcompact - PostgreSQL bloat reducing tool") }
+    matches = output.each_line.select { |line| line.include?("pgcompact - PostgreSQL bloat reducing tool") }
     !matches.empty?
   end
 end

--- a/Formula/t/tremor-runtime.rb
+++ b/Formula/t/tremor-runtime.rb
@@ -130,6 +130,6 @@ class TremorRuntime < Formula
 
     system bin/"tremor-wrapper", "run", testpath/"test.troy"
 
-    assert_match(/^HELLO/, (testpath/"out.txt").readlines.first)
+    assert_match(/^HELLO/, File.open(testpath/"out.txt").first)
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
See https://github.com/Homebrew/brew/actions/runs/13479808839/job/37663632834?pr=19329