### PR TITLE
xiph.org formulae: change source URLs, livechecks

### DIFF
--- a/Formula/e/ezstream.rb
+++ b/Formula/e/ezstream.rb
@@ -1,14 +1,14 @@
 class Ezstream < Formula
   desc "Client for Icecast streaming servers"
   homepage "https://icecast.org/ezstream/"
-  url "https://downloads.xiph.org/releases/ezstream/ezstream-1.0.2.tar.gz", using: :homebrew_curl
-  mirror "https://ftp.osuosl.org/pub/xiph/releases/ezstream/ezstream-1.0.2.tar.gz"
+  url "https://ftp.osuosl.org/pub/xiph/releases/ezstream/ezstream-1.0.2.tar.gz"
+  mirror "https://mirror.csclub.uwaterloo.ca/xiph/releases/ezstream/ezstream-1.0.2.tar.gz"
   sha256 "11de897f455a95ba58546bdcd40a95d3bda69866ec5f7879a83b024126c54c2a"
   license "GPL-2.0-only"
 
   livecheck do
     url "https://ftp.osuosl.org/pub/xiph/releases/ezstream/?C=M&O=D"
-    regex(/href=.*?ezstream[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(%r{href=(?:["']?|.*?/)ezstream[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
   bottle do

--- a/Formula/f/flac.rb
+++ b/Formula/f/flac.rb
@@ -1,8 +1,8 @@
 class Flac < Formula
   desc "Free lossless audio codec"
   homepage "https://xiph.org/flac/"
-  url "https://downloads.xiph.org/releases/flac/flac-1.5.0.tar.xz", using: :homebrew_curl
-  mirror "https://ftp.osuosl.org/pub/xiph/releases/flac/flac-1.5.0.tar.xz"
+  url "https://ftp.osuosl.org/pub/xiph/releases/flac/flac-1.5.0.tar.xz"
+  mirror "https://github.com/xiph/flac/releases/download/1.5.0/flac-1.5.0.tar.xz"
   sha256 "f2c1c76592a82ffff8413ba3c4a1299b6c7ab06c734dee03fd88630485c2b920"
   license all_of: [
     "BSD-3-Clause",
@@ -16,7 +16,7 @@ class Flac < Formula
 
   livecheck do
     url "https://ftp.osuosl.org/pub/xiph/releases/flac/?C=M&O=D"
-    regex(/href=.*?flac[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(%r{href=(?:["']?|.*?/)flac[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
   bottle do
@@ -29,7 +29,7 @@ class Flac < Formula
   end
 
   head do
-    url "https://gitlab.xiph.org/xiph/flac.git"
+    url "https://gitlab.xiph.org/xiph/flac.git", branch: "master"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build

--- a/Formula/i/icecast.rb
+++ b/Formula/i/icecast.rb
@@ -1,15 +1,15 @@
 class Icecast < Formula
   desc "Streaming MP3 audio server"
   homepage "https://icecast.org/"
-  url "https://downloads.xiph.org/releases/icecast/icecast-2.4.4.tar.gz", using: :homebrew_curl
-  mirror "https://ftp.osuosl.org/pub/xiph/releases/icecast/icecast-2.4.4.tar.gz"
+  url "https://ftp.osuosl.org/pub/xiph/releases/icecast/icecast-2.4.4.tar.gz"
+  mirror "https://mirror.csclub.uwaterloo.ca/xiph/releases/icecast/icecast-2.4.4.tar.gz"
   sha256 "49b5979f9f614140b6a38046154203ee28218d8fc549888596a683ad604e4d44"
   license "GPL-2.0-only"
   revision 2
 
   livecheck do
     url "https://ftp.osuosl.org/pub/xiph/releases/icecast/?C=M&O=D"
-    regex(/href=.*?icecast[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(%r{href=(?:["']?|.*?/)icecast[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
   bottle do
@@ -38,12 +38,11 @@ class Icecast < Formula
   def install
     args = %W[
       --disable-silent-rules
+      --without-speex
+      --without-theora
       --sysconfdir=#{etc}
       --localstatedir=#{var}
     ]
-    # HACK: Avoid linking brewed `curl` as side effect of `using: :homebrew_curl`
-    args << "--with-curl-config=/usr/bin/curl-config" if OS.mac?
-
     system "./configure", *args, *std_configure_args
     system "make", "install"
   end

--- a/Formula/lib/libfishsound.rb
+++ b/Formula/lib/libfishsound.rb
@@ -1,14 +1,14 @@
 class Libfishsound < Formula
   desc "Decode and encode audio data using the Xiph.org codecs"
   homepage "https://xiph.org/fishsound/"
-  url "https://downloads.xiph.org/releases/libfishsound/libfishsound-1.0.1.tar.gz", using: :homebrew_curl
-  mirror "https://ftp.osuosl.org/pub/xiph/releases/libfishsound/libfishsound-1.0.1.tar.gz"
+  url "https://ftp.osuosl.org/pub/xiph/releases/libfishsound/libfishsound-1.0.1.tar.gz"
+  mirror "https://mirror.csclub.uwaterloo.ca/xiph/releases/libfishsound/libfishsound-1.0.1.tar.gz"
   sha256 "03eb1601e2306adc88c776afdf212217c6547990d2d0f9ca544dad9a8a9dbb8f"
   license "BSD-3-Clause"
 
   livecheck do
     url "https://ftp.osuosl.org/pub/xiph/releases/libfishsound/?C=M&O=D"
-    regex(/href=.*?libfishsound[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(%r{href=(?:["']?|.*?/)libfishsound[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
   bottle do

--- a/Formula/lib/libogg.rb
+++ b/Formula/lib/libogg.rb
@@ -2,9 +2,15 @@ class Libogg < Formula
   desc "Ogg Bitstream Library"
   homepage "https://www.xiph.org/ogg/"
   url "https://ftp.osuosl.org/pub/xiph/releases/ogg/libogg-1.3.5.tar.gz"
+  mirror "https://github.com/xiph/ogg/releases/download/v1.3.5/libogg-1.3.5.tar.gz"
   sha256 "0eb4b4b9420a0f51db142ba3f9c64b333f826532dc0f48c6410ae51f4799b664"
   license "BSD-3-Clause"
   head "https://gitlab.xiph.org/xiph/ogg.git", branch: "master"
+
+  livecheck do
+    url "https://ftp.osuosl.org/pub/xiph/releases/ogg/?C=M&O=D"
+    regex(%r{href=(?:["']?|.*?/)libogg[._-]v?(\d+(?:\.\d+)+)\.t}i)
+  end
 
   bottle do
     rebuild 2

--- a/Formula/lib/libopusenc.rb
+++ b/Formula/lib/libopusenc.rb
@@ -6,6 +6,11 @@ class Libopusenc < Formula
   sha256 "8298db61a8d3d63e41c1a80705baa8ce9ff3f50452ea7ec1c19a564fe106cbb9"
   license "BSD-3-Clause"
 
+  livecheck do
+    url "https://ftp.osuosl.org/pub/xiph/releases/opus/?C=M&O=D"
+    regex(%r{href=(?:["']?|.*?/)libopusenc[._-]v?(\d+(?:\.\d+)+)\.t}i)
+  end
+
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_sequoia:  "9c857d079a3c385ac89d89869fa2ed74d6115a3b86d87149bd9d4d5796da3141"

--- a/Formula/lib/libshout.rb
+++ b/Formula/lib/libshout.rb
@@ -1,15 +1,15 @@
 class Libshout < Formula
-  desc "Data and connectivity library for the icecast server"
+  desc "Data and connectivity library for the Icecast server"
   homepage "https://icecast.org/"
-  url "https://downloads.xiph.org/releases/libshout/libshout-2.4.6.tar.gz", using: :homebrew_curl
-  mirror "https://ftp.osuosl.org/pub/xiph/releases/libshout/libshout-2.4.6.tar.gz"
+  url "https://ftp.osuosl.org/pub/xiph/releases/libshout/libshout-2.4.6.tar.gz"
+  mirror "https://mirror.csclub.uwaterloo.ca/xiph/releases/libshout/libshout-2.4.6.tar.gz"
   sha256 "39cbd4f0efdfddc9755d88217e47f8f2d7108fa767f9d58a2ba26a16d8f7c910"
   license "LGPL-2.0-or-later"
   revision 1
 
   livecheck do
     url "https://ftp.osuosl.org/pub/xiph/releases/libshout/?C=M&O=D"
-    regex(/href=.*?libshout[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(%r{href=(?:["']?|.*?/)libshout[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
   bottle do

--- a/Formula/lib/libvorbis.rb
+++ b/Formula/lib/libvorbis.rb
@@ -1,14 +1,14 @@
 class Libvorbis < Formula
-  desc "Vorbis General Audio Compression Codec"
+  desc "Vorbis general audio compression codec"
   homepage "https://xiph.org/vorbis/"
-  url "https://downloads.xiph.org/releases/vorbis/libvorbis-1.3.7.tar.xz", using: :homebrew_curl
-  mirror "https://ftp.osuosl.org/pub/xiph/releases/vorbis/libvorbis-1.3.7.tar.xz"
+  url "https://ftp.osuosl.org/pub/xiph/releases/vorbis/libvorbis-1.3.7.tar.xz"
+  mirror "https://github.com/xiph/vorbis/releases/download/v1.3.7/libvorbis-1.3.7.tar.xz"
   sha256 "b33cc4934322bcbf6efcbacf49e3ca01aadbea4114ec9589d1b1e9d20f72954b"
   license "BSD-3-Clause"
 
   livecheck do
     url "https://ftp.osuosl.org/pub/xiph/releases/vorbis/?C=M&O=D"
-    regex(/href=.*?libvorbis[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(%r{href=(?:["']?|.*?/)libvorbis[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
   bottle do

--- a/Formula/o/oggz.rb
+++ b/Formula/o/oggz.rb
@@ -1,14 +1,14 @@
 class Oggz < Formula
   desc "Command-line tool for manipulating Ogg files"
   homepage "https://www.xiph.org/oggz/"
-  url "https://downloads.xiph.org/releases/liboggz/liboggz-1.1.2.tar.gz", using: :homebrew_curl
-  mirror "https://ftp.osuosl.org/pub/xiph/releases/liboggz/liboggz-1.1.2.tar.gz"
+  url "https://ftp.osuosl.org/pub/xiph/releases/liboggz/liboggz-1.1.2.tar.gz"
+  mirror "https://ftp-chi.osuosl.org/pub/xiph/releases/liboggz/liboggz-1.1.2.tar.gz"
   sha256 "c97e4fba7954a9faf79ddcf406992c6f7bb0214e96d4957a07a2fda0265e5ab2"
   license "BSD-3-Clause"
 
   livecheck do
     url "https://ftp.osuosl.org/pub/xiph/releases/liboggz/?C=M&O=D"
-    regex(/href=.*?liboggz[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(%r{href=(?:["']?|.*?/)liboggz[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
   bottle do

--- a/Formula/o/opus-tools.rb
+++ b/Formula/o/opus-tools.rb
@@ -7,6 +7,11 @@ class OpusTools < Formula
   license "BSD-2-Clause"
   revision 2
 
+  livecheck do
+    url "https://ftp.osuosl.org/pub/xiph/releases/opus/?C=M&O=D"
+    regex(%r{href=(?:["']?|.*?/)opus-tools[._-]v?(\d+(?:\.\d+)+)\.t}i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "2e17161e605515377130ebeb2edecf02a4518a8c27373e3eca594cfd48ed6de5"
     sha256 cellar: :any,                 arm64_sonoma:  "1ccc81bd48aa589c8743efb2e88493da699be27e78a7c213616ddbde5caa24b2"

--- a/Formula/s/speex.rb
+++ b/Formula/s/speex.rb
@@ -1,14 +1,14 @@
 class Speex < Formula
   desc "Audio codec designed for speech"
   homepage "https://speex.org/"
-  url "https://downloads.xiph.org/releases/speex/speex-1.2.1.tar.gz", using: :homebrew_curl
-  mirror "https://ftp.osuosl.org/pub/xiph/releases/speex/speex-1.2.1.tar.gz"
+  url "https://ftp.osuosl.org/pub/xiph/releases/speex/speex-1.2.1.tar.gz"
+  mirror "https://mirror.csclub.uwaterloo.ca/xiph/releases/speex/speex-1.2.1.tar.gz"
   sha256 "4b44d4f2b38a370a2d98a78329fefc56a0cf93d1c1be70029217baae6628feea"
   license "BSD-3-Clause"
 
   livecheck do
     url "https://ftp.osuosl.org/pub/xiph/releases/speex/?C=M&O=D"
-    regex(/href=.*?speex[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(%r{href=(?:["']?|.*?/)speex[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
   bottle do
@@ -25,11 +25,19 @@ class Speex < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "3ea2ee48a402525421cb3ef8b83173d4bc57741c10e84fe6fae66691905293ec"
   end
 
+  head do
+    url "https://gitlab.xiph.org/xiph/speex.git", branch: "master"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+  end
+
   depends_on "pkgconf" => :build
   depends_on "libogg"
 
   def install
-    ENV.deparallelize
+    system "./autogen.sh" if build.head?
     system "./configure", *std_configure_args
     system "make", "install"
   end

--- a/Formula/t/theora.rb
+++ b/Formula/t/theora.rb
@@ -4,8 +4,8 @@ class Theora < Formula
   license "BSD-3-Clause"
 
   stable do
-    url "https://downloads.xiph.org/releases/theora/libtheora-1.1.1.tar.bz2", using: :homebrew_curl
-    mirror "https://ftp.osuosl.org/pub/xiph/releases/theora/libtheora-1.1.1.tar.bz2"
+    url "https://ftp.osuosl.org/pub/xiph/releases/theora/libtheora-1.1.1.tar.bz2"
+    mirror "https://mirror.csclub.uwaterloo.ca/xiph/releases/theora/libtheora-1.1.1.tar.bz2"
     sha256 "b6ae1ee2fa3d42ac489287d3ec34c5885730b1296f0801ae577a35193d3affbc"
 
     # Fix -flat_namespace being used on Big Sur and later.
@@ -17,7 +17,7 @@ class Theora < Formula
 
   livecheck do
     url "https://ftp.osuosl.org/pub/xiph/releases/theora/?C=M&O=D"
-    regex(/href=.*?libtheora[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(%r{href=(?:["']?|.*?/)libtheora[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
   bottle do

--- a/Formula/v/vorbis-tools.rb
+++ b/Formula/v/vorbis-tools.rb
@@ -1,8 +1,8 @@
 class VorbisTools < Formula
   desc "Ogg Vorbis CODEC tools"
   homepage "https://github.com/xiph/vorbis-tools"
-  url "https://downloads.xiph.org/releases/vorbis/vorbis-tools-1.4.2.tar.gz", using: :homebrew_curl
-  mirror "https://ftp.osuosl.org/pub/xiph/releases/vorbis/vorbis-tools-1.4.2.tar.gz"
+  url "https://ftp.osuosl.org/pub/xiph/releases/vorbis/vorbis-tools-1.4.2.tar.gz"
+  mirror "https://mirror.csclub.uwaterloo.ca/xiph/releases/vorbis/vorbis-tools-1.4.2.tar.gz"
   sha256 "db7774ec2bf2c939b139452183669be84fda5774d6400fc57fde37f77624f0b0"
   license all_of: [
     "LGPL-2.0-or-later", # intl/ (libintl)
@@ -13,7 +13,7 @@ class VorbisTools < Formula
 
   livecheck do
     url "https://ftp.osuosl.org/pub/xiph/releases/vorbis/?C=M&O=D"
-    regex(/href=.*?vorbis-tools[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(%r{href=(?:["']?|.*?/)vorbis-tools[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
   bottle do
@@ -43,20 +43,15 @@ class VorbisTools < Formula
   end
 
   def install
-    if OS.mac?
-      # Prevent linkage with Homebrew Curl on macOS because of `using: :homebrew_curl` above.
-      ENV.remove "HOMEBREW_DEPENDENCIES", "curl"
-      ENV.remove "HOMEBREW_INCLUDE_PATHS", Formula["curl"].opt_include
-      ENV.remove "HOMEBREW_LIBRARY_PATHS", Formula["curl"].opt_lib
-
+    if OS.mac? && (MacOS.version >= :monterey)
       # Workaround for Xcode 14 ld.
-      system "autoreconf", "--force", "--install", "--verbose" if MacOS.version >= :monterey
+      system "autoreconf", "--force", "--install", "--verbose"
     end
 
     # Fix compile with newer Clang
     ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
-    system "./configure", *std_configure_args, "--disable-nls"
+    system "./configure", *std_configure_args, "--disable-nls", "--without-speex"
     system "make", "install"
   end
 


### PR DESCRIPTION
Following #208589: since `downloads.xiph.org` now always does a 301 redirect to its mirror `https://ftp.osuosl.org/pub/xiph/`, drop it and its `:homebrew_curl` requirement entirely and use GitHub as a mirror, if available. This also adds or changes the URL used by the livecheck block to match. 