### PR TITLE
opencv: drop workarounds, update test to use shared lib

### DIFF
--- a/Formula/o/opencv.rb
+++ b/Formula/o/opencv.rb
@@ -91,9 +91,6 @@ class Opencv < Formula
     # Avoid Accelerate.framework
     ENV["OpenBLAS_HOME"] = Formula["openblas"].opt_prefix
 
-    # Reset PYTHONPATH, workaround for https://github.com/Homebrew/homebrew-science/pull/4885
-    ENV.delete("PYTHONPATH")
-
     # Remove bundled libraries to make sure formula dependencies are used
     libdirs = %w[ffmpeg libjasper libjpeg libjpeg-turbo libpng libtiff libwebp openexr openjpeg protobuf tbb zlib]
     libdirs.each { |l| rm_r(buildpath/"3rdparty"/l) }
@@ -136,11 +133,6 @@ class Opencv < Formula
       -DBUILD_opencv_python2=OFF
       -DBUILD_opencv_python3=ON
       -DPYTHON3_EXECUTABLE=#{which(python3)}
-    ]
-
-    args += [
-      "-DCMAKE_FIND_PACKAGE_PREFER_CONFIG=ON", # https://github.com/protocolbuffers/protobuf/issues/12292
-      "-Dprotobuf_MODULE_COMPATIBLE=ON", # https://github.com/protocolbuffers/protobuf/issues/1931
     ]
 
     args += if OS.mac?
@@ -189,14 +181,22 @@ class Opencv < Formula
 
   test do
     (testpath/"test.cpp").write <<~CPP
+      #include <opencv2/core.hpp>
+      #include <opencv2/imgcodecs.hpp>
       #include <opencv2/opencv.hpp>
       #include <iostream>
       int main() {
         std::cout << CV_VERSION << std::endl;
+        cv::Mat img = cv::imread("#{test_fixtures("test.jpg")}", cv::IMREAD_COLOR);
+        if (img.empty()) {
+          std::cerr << "Could not read test.jpg fixture" << std::endl;
+          return 1;
+        }
         return 0;
       }
     CPP
-    system ENV.cxx, "-std=c++17", "test.cpp", "-I#{include}/opencv4", "-o", "test"
+    system ENV.cxx, "-std=c++17", "test.cpp", "-I#{include}/opencv4", "-o", "test",
+                    "-L#{lib}", "-lopencv_core", "-lopencv_imgcodecs"
     assert_equal version.to_s, shell_output("./test").strip
 
     output = shell_output("#{python3} -c 'import cv2; print(cv2.__version__)'")


### PR DESCRIPTION
Not sure what original reason for PYTHONPATH workaround but brew should sanitize environment variables. Within brew, only `Language::Python.each_python` manipulates PYTHONPATH but that isn't used within official taps.

Protobuf workarounds haven't been needed since 4.9.0 https://github.com/opencv/opencv/commit/6e4280ea81b59c6dca45bb9801b758377beead55

Test has been a simple version check which we usually don't like. Added a minor update to at least try using part of API that need shared libraries (some of https://docs.opencv.org/4.11.0/db/deb/tutorial_display_image.html). May be worth expanding to a larger example that uses more features.

---

Also trying to see if failure in #208051 is specific to those changes.