### PR TITLE
Rebuild `zellij` bottles using Rust 1.85 stable to pick up a UX/privacy fix

### DIFF
--- a/Formula/z/zellij.rb
+++ b/Formula/z/zellij.rb
@@ -4,6 +4,7 @@ class Zellij < Formula
   url "https://github.com/zellij-org/zellij/archive/refs/tags/v0.41.2.tar.gz"
   sha256 "12e7f0f80c1e39deed5638c4662fc070855cee0250a7eb1d76cefbeef8c2f376"
   license "MIT"
+  revision 1
   head "https://github.com/zellij-org/zellij.git", branch: "main"
 
   bottle do

--- a/Formula/z/zellij.rb
+++ b/Formula/z/zellij.rb
@@ -8,12 +8,12 @@ class Zellij < Formula
   head "https://github.com/zellij-org/zellij.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "3985d14a2d7fc0c66ed878ed2c600f5cd238229f694c9087d011b6a82b289185"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "acb39aaf105fbd7512268fa99df97b1869752078aeb8f76c84a4d5e196716738"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "6f7515d90e07423228cdc194e31352d808dae128ed5daa982bb8b570c14bd0ec"
-    sha256 cellar: :any_skip_relocation, sonoma:        "515bd15cac534bd20f41aa2ebc77c45646e2dd8bc1a8c41ef307e89988b52b8c"
-    sha256 cellar: :any_skip_relocation, ventura:       "0535d3328feca430ce40127148a36b13510d993f0f34977700edac74c136485b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8e3bf727ff5681b0f7a4b83173f259f7b34f6d95bccbc4d41669c481d3652800"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "655a14105b71be3b1700071975b75bfa48f975f37ce7926bece12b3a9e92028c"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "dc009615009b732e182ce55a7fcefb7509cc380b21291e2559474cc3df77c07d"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "fd94c8d0825ec15968d604d9c5f414294b45e475e2f2c5287edc9405b0d4a9cb"
+    sha256 cellar: :any_skip_relocation, sonoma:        "92066edbda62a75e2a33d4fb215a7d013b44750e30884714defcba388b9df8d2"
+    sha256 cellar: :any_skip_relocation, ventura:       "34dcb5019bec333fd3b6e0b7b104def083e545f0ef1555ad8d408bcbcfe8e2dc"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2fd72990ffbded09db184dfbce2e3fb5caf1cfc784cee5fa24978197a021f571"
   end
 
   depends_on "rust" => :build


### PR DESCRIPTION
`zellij` is written in Rust.

Until Rust 1.85.0, Rust's [`temp_dir()`](https://doc.rust-lang.org/std/env/fn.temp_dir.html) implementation made an assumption that would return inconsistent results for the same macOS user depending on whether they were accessing their terminal  directly (where `$TMPDIR` is populated by default) vs. over SSH (where `$TMPDIR` is not populated).

https://github.com/zellij-org/zellij/issues/3708#issuecomment-2550502104

This can cause a mild privacy/security leak, but more importantly it causes a bewildering UX issue for `zellij` users on macOS.

There is nothing for `zellij` to fix, as they are using the Rust API correctly and they do not publish the binaries used by Homebrew bottles.

However, `zellij` binaries need to be recompiled with Rust >= 1.85 in order for users to receive the fix. Since Rust 1.85 has landed in `homebrew-core` in https://github.com/Homebrew/homebrew-core/commit/6aa9a0903a22bba21c5604799fe306885751b897 I'm sending this PR to to trigger/request bottle updates.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
