### PR TITLE
formulae(zig): use `std_zig_args`

### DIFF
--- a/Formula/b/bold.rb
+++ b/Formula/b/bold.rb
@@ -24,15 +24,11 @@ class Bold < Formula
     else Hardware.oldest_cpu
     end
 
-    args = %W[
-      --prefix #{prefix}
-      -Doptimize=ReleaseSafe
-      -Dstrip=true
-    ]
+    args = ["-Dstrip=true"]
 
     args << "-Dcpu=#{cpu}" if build.bottle?
 
-    system "zig", "build", *args
+    system "zig", "build", *args, *std_zig_args
   end
 
   test do

--- a/Formula/h/hevi.rb
+++ b/Formula/h/hevi.rb
@@ -24,13 +24,9 @@ class Hevi < Formula
     else Hardware.oldest_cpu
     end
 
-    args = %W[
-      --prefix #{prefix}
-      -Doptimize=ReleaseSafe
-    ]
-
+    args = []
     args << "-Dcpu=#{cpu}" if build.bottle?
-    system "zig", "build", *args
+    system "zig", "build", *args, *std_zig_args
   end
 
   test do

--- a/Formula/n/ncdu.rb
+++ b/Formula/n/ncdu.rb
@@ -34,7 +34,7 @@ class Ncdu < Formula
     else Hardware.oldest_cpu
     end
 
-    args = %W[--prefix #{prefix} --release=fast]
+    args = []
     args << "-Dpie=true" if OS.mac?
     args << "-Dcpu=#{cpu}" if build.bottle?
 
@@ -48,7 +48,7 @@ class Ncdu < Formula
 
     # Avoid the Makefile for now so that we can pass `-Dcpu` to `zig build`.
     # https://code.blicky.net/yorhel/ncdu/issues/185
-    system "zig", "build", *args
+    system "zig", "build", *args, *std_zig_args
     man1.install "ncdu.1"
   end
 

--- a/Formula/s/superhtml.rb
+++ b/Formula/s/superhtml.rb
@@ -25,12 +25,11 @@ class Superhtml < Formula
     end
 
     args = %W[
-      --prefix #{prefix}
       -Dforce-version=#{version}
     ]
 
     args << "-Dcpu=#{cpu}" if build.bottle?
-    system "zig", "build", *args
+    system "zig", "build", *args, *std_zig_args
   end
 
   test do

--- a/Formula/z/zf.rb
+++ b/Formula/z/zf.rb
@@ -4,7 +4,7 @@ class Zf < Formula
   url "https://github.com/natecraddock/zf/archive/refs/tags/0.10.2.tar.gz"
   sha256 "b8e41f942c7033536fd64f9edea467a7ff4f45d52885d585f0adafb7803ac0ed"
   license "MIT"
-  head "https://github.com/natecraddock/zf.git", branch: "master"
+  head "https://github.com/natecraddock/zf.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "ca18e30ed084337c77376f0af8b97d3f10bc3ccb20660f7d74c15644fbcae1e7"
@@ -18,9 +18,8 @@ class Zf < Formula
   depends_on "zig" => :build
 
   def install
-    system "zig", "build", "-Doptimize=ReleaseSafe"
+    system "zig", "build", *std_zig_args
 
-    bin.install "zig-out/bin/zf"
     man1.install "doc/zf.1"
     bash_completion.install "complete/zf"
     fish_completion.install "complete/zf.fish"

--- a/Formula/z/zigmod.rb
+++ b/Formula/z/zigmod.rb
@@ -30,15 +30,17 @@ class Zigmod < Formula
     else Hardware.oldest_cpu
     end
 
+    # do not use std_zig_args
+    # https://github.com/nektro/zigmod/pull/109
     args = %W[
       --prefix #{prefix}
       -Dtag=#{version}
       -Dmode=ReleaseSafe
       -Dstrip=true
+      -fno-rosetta
     ]
 
     args << "-Dcpu=#{cpu}" if build.bottle?
-
     system "zig", "build", *args
   end
 

--- a/Formula/z/zigup.rb
+++ b/Formula/z/zigup.rb
@@ -24,13 +24,9 @@ class Zigup < Formula
     else Hardware.oldest_cpu
     end
 
-    args = %W[
-      --prefix #{prefix}
-      -Doptimize=ReleaseSafe
-    ]
-
+    args = []
     args << "-Dcpu=#{cpu}" if build.bottle?
-    system "zig", "build", *args
+    system "zig", "build", *args, *std_zig_args(release_mode: :safe)
   end
 
   test do

--- a/Formula/z/zls.rb
+++ b/Formula/z/zls.rb
@@ -27,10 +27,10 @@ class Zls < Formula
     else Hardware.oldest_cpu
     end
 
-    args = %W[--prefix #{prefix} -Doptimize=ReleaseFast]
+    args = []
     args << "-Dcpu=#{cpu}" if build.bottle?
 
-    system "zig", "build", *args
+    system "zig", "build", *args, *std_zig_args
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
`zigmod` owner didn't want to add `-Doptimize` flag support ([gh pr](https://github.com/nektro/zigmod/pull/109#issuecomment-2675593823)) so we have to specify flags manually. Other projects work fine