### PR TITLE
pkgconf: rebottle to remove workaround

### DIFF
--- a/Formula/p/pkgconf.rb
+++ b/Formula/p/pkgconf.rb
@@ -31,10 +31,6 @@ class Pkgconf < Formula
     depends_on "libtool" => :build
   end
 
-  # FIXME: The bottle is mistakenly considered relocatable on Linux.
-  # See https://github.com/Homebrew/homebrew-core/pull/85032.
-  pour_bottle? only_if: :default_prefix
-
   def install
     if build.head?
       ENV["LIBTOOLIZE"] = "glibtoolize"


### PR DESCRIPTION
Draft to check that Linux bottle is no longer incorrectly marked relocatable after https://github.com/Homebrew/brew/pull/19357

---

```
  bottle do
    rebuild 2
    sha256 x86_64_linux: "67699e7fc430708e7e591e1af5d088e719293018e87a9bccd664ad401f18b6f2"
  end
```