### PR TITLE
CI: fix tap syntax typecheck

### DIFF
--- a/cmd/determine-rebottle-runners.rb
+++ b/cmd/determine-rebottle-runners.rb
@@ -21,7 +21,7 @@ module Homebrew
 
       sig { override.void }
       def run
-        formula = Formula[args.named.first.to_s]
+        formula = Formula[T.must(args.named.first)]
         timeout = args.named.second.to_i
 
         linux_runner = if timeout > 360

--- a/cmd/determine-rebottle-runners.rb
+++ b/cmd/determine-rebottle-runners.rb
@@ -21,7 +21,7 @@ module Homebrew
 
       sig { override.void }
       def run
-        formula = Formula[args.named.first]
+        formula = Formula[args.named.first.to_s]
         timeout = args.named.second.to_i
 
         linux_runner = if timeout > 360


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Small fix of CI error
#208865 #208866 #208867 #208868 #208869 #208870