### PR TITLE
rnmr 1.0.0 (new formula)

### DIFF
--- a/Formula/r/rnmr.rb
+++ b/Formula/r/rnmr.rb
@@ -1,0 +1,19 @@
+class Rnmr < Formula
+  desc "Lightweight command-line tool for renaming files and directories"
+  homepage "https://github.com/moealkurdi/rnmr"
+  url "https://github.com/moealkurdi/rnmr/archive/refs/tags/v1.0.0.tar.gz"
+  sha256 "1de434586d7cefac1a76b31af56c485a69bd4689bbe90e3aa8b60346aab16860"
+  license "MIT"
+
+  depends_on "python@3.11"
+
+  def install
+    bin.install "rnmr.py" => "rnmr"
+  end
+
+  test do
+    (testpath/"test.txt").write("test")
+    system "#{bin}/rnmr", "test.txt", "renamed.txt"
+    assert_predicate testpath/"renamed.txt", :exist?
+  end
+end


### PR DESCRIPTION
RNMR is a lightweight command-line tool for renaming files and directories.

Features:
- Prevents accidental overwrites
- Supports both files and directories
- Provides color-coded output

Homepage: https://github.com/moealkurdi/rnmr

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
