### PR TITLE
exomizer 3.1.2 (restored formula)

### DIFF
--- a/Formula/e/exomizer.rb
+++ b/Formula/e/exomizer.rb
@@ -1,0 +1,30 @@
+class Exomizer < Formula
+  desc "File compressor optimized for decompression in 8-bit environments"
+  homepage "https://bitbucket.org/magli143/exomizer/wiki/Home"
+  url "https://bitbucket.org/magli143/exomizer/wiki/downloads/exomizer-3.1.2.zip"
+  sha256 "8896285e48e89e29ba962bc37d8f4dcd506a95753ed9b8ebf60e43893c36ce3a"
+  license all_of: [
+    "Zlib",
+    "GPL-3.0-or-later" => { with: "Bison-exception-2.2" },
+  ]
+
+  livecheck do
+    url "https://bitbucket.org/magli143/exomizer/wiki/browse/downloads/"
+    regex(/href=.*?exomizer[._-]v?(\d+(?:\.\d+)+)\.zip/i)
+  end
+
+  def install
+    cd "src" do
+      system "make"
+      bin.install %w[exobasic exomizer]
+    end
+  end
+
+  test do
+    (testpath/"test.txt").write("Hello World! Hello World! Hello World! Hello World!\n")
+    system bin/"exomizer", "raw", "test.txt", "-o", "compressed.exo"
+    system bin/"exomizer", "raw", "-d", "compressed.exo", "-o", "expanded.txt"
+    assert_match "iHelo", File.binread("compressed.exo")
+    assert_match File.read("test.txt"), File.read("expanded.txt")
+  end
+end

--- a/Formula/e/exomizer.rb
+++ b/Formula/e/exomizer.rb
@@ -13,6 +13,15 @@ class Exomizer < Formula
     regex(/href=.*?exomizer[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "93a5cf305a6a643351a6335ce2555628f9448b9010009475e77ffa6d8a54b441"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "a7292bb3eeaffac34f6540a029f6e21b79089b66e498d9e3bfa611cd44189b48"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "1e4a5b210dbdfaca2b71eb4c5d78401e5029667d6be88fe44d7aad0c2f4abc1b"
+    sha256 cellar: :any_skip_relocation, sonoma:        "9cdb28fa2ff68d518ed22b2399155c532059e2145753ff10cd9a9f201fb46632"
+    sha256 cellar: :any_skip_relocation, ventura:       "dfc125e3ac9f7799f2a733c9b24e9270751f8d4091ab12d9bf5ae1247c76a612"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c0fae099202b6a7ca59dd64e37fc4ffbe8f4612b2b4dd9e266053a7810c9bdac"
+  end
+
   def install
     cd "src" do
       system "make"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
> Exomizer is a file compression utility which is designed so that files can be compressed quickly and efficiently on a PC and decompressed on 8-bit machines, such as the Amstrad CPC, where memory and processing power are much more limited. Across the 8-bit programming scene, it is generally regarded as the most efficient compressor that is currently available.
-- https://www.cpcwiki.eu/index.php/Exomizer

Requested in https://github.com/lifepillar/homebrew-appleii/issues/43, but should be suitable for here. (It was originally removed in https://github.com/Homebrew/homebrew-core/pull/67573, but has since [migrated to the Zlib license](https://bitbucket.org/magli143/exomizer/src/master/changelog.txt).)

Currently not passing the notability check due to having been migrated to Bitbucket from its [original site](https://web.archive.org/web/20160917094645/http://hem.bredband.net/magli143/exo/).