### PR TITLE
keep-sorted: set version in build info

### DIFF
--- a/Formula/k/keep-sorted.rb
+++ b/Formula/k/keep-sorted.rb
@@ -1,8 +1,9 @@
 class KeepSorted < Formula
   desc "Language-agnostic formatter that sorts selected lines"
   homepage "https://github.com/google/keep-sorted"
-  url "https://github.com/google/keep-sorted/archive/refs/tags/v0.6.0.tar.gz"
-  sha256 "28a8290da4908999712896ed0a94a0e26f290f22b565f290a0782220379a033c"
+  url "https://github.com/google/keep-sorted.git",
+      tag:      "v0.6.0",
+      revision: "df93c2722b6126556183749880f16a9beb664bb4"
   license "Apache-2.0"
 
   bottle do
@@ -21,6 +22,7 @@ class KeepSorted < Formula
   end
 
   test do
+    assert_match version.to_s, shell_output("#{bin}/keep-sorted --version")
     test_file = testpath + "test_input"
     test_file.write <<~EOS
       line will not be touched.

--- a/Formula/k/keep-sorted.rb
+++ b/Formula/k/keep-sorted.rb
@@ -7,12 +7,13 @@ class KeepSorted < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "797e297714c252a065978c49a89f01ebfc6c1752e53e02471655259fe247d88e"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "797e297714c252a065978c49a89f01ebfc6c1752e53e02471655259fe247d88e"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "797e297714c252a065978c49a89f01ebfc6c1752e53e02471655259fe247d88e"
-    sha256 cellar: :any_skip_relocation, sonoma:        "352cd36a00bd951afd2daa050b61e26152f45f8b6c6c1e10962b8647feb9d147"
-    sha256 cellar: :any_skip_relocation, ventura:       "352cd36a00bd951afd2daa050b61e26152f45f8b6c6c1e10962b8647feb9d147"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2e54d534f58e5b89b4e4d80f0f621b736704de48121ae6ed599d059e037a64f2"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "3a1bc62473d80f7809175c4b234a4802384e1c9c61e76d68d74e63b0547a48ca"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "3a1bc62473d80f7809175c4b234a4802384e1c9c61e76d68d74e63b0547a48ca"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "3a1bc62473d80f7809175c4b234a4802384e1c9c61e76d68d74e63b0547a48ca"
+    sha256 cellar: :any_skip_relocation, sonoma:        "ab10e635e641f4b72fc32aa7acb82d0672d509d625efa233205ec825f79428a7"
+    sha256 cellar: :any_skip_relocation, ventura:       "ab10e635e641f4b72fc32aa7acb82d0672d509d625efa233205ec825f79428a7"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1db18645ba138068b86a632c11652ba82715098395af15c8f87529400bdb9634"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This should fix #209113. In the case of `keep-sorted`, when Git history is available, `go` will automatically embed the tag/revision info in the resulting binary.