### PR TITLE
workflows/publish-commit-bottles: remove deprecated input

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -299,7 +299,6 @@ jobs:
       - name: Set up commit signing
         uses: Homebrew/actions/setup-commit-signing@master
         with:
-          ssh: true
           signing_key: ${{ secrets.BREWTESTBOT_SSH_SIGNING_KEY }}
 
       - name: Checkout PR branch


### PR DESCRIPTION
This is a no-op after https://github.com/Homebrew/actions/commit/16b62cd376a5f908d77107982e8ba2f82074c46d. Let's remove it to stop printing a deprecation warning every time we publish a PR.