### PR TITLE
grpcui: add livecheck and autobump

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -1341,6 +1341,7 @@ groovy
 groovysdk
 grpc
 grpc-swift
+grpcui
 grype
 gsan
 gsettings-desktop-schemas

--- a/Formula/g/grpcui.rb
+++ b/Formula/g/grpcui.rb
@@ -5,6 +5,11 @@ class Grpcui < Formula
   sha256 "8548a3ccde0b886ae14ea78fae3e58d28922079e78a08d29e6ef7b9230190375"
   license "MIT"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "d539469158ca6d9251f59f73f8e28fde16cb9ac1aa4b020779dff541a598c4e3"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

upstream made a 1.5.1 tag, but it is [not really a release](https://github.com/fullstorydev/grpcui/pull/364#issuecomment-2641579833), so worth using github-latest strategy, also adding the formula into autobump list.

also relates to https://github.com/Homebrew/homebrew-core/pull/206798