### PR TITLE
cloudflare-quiche: add livecheck

### DIFF
--- a/Formula/c/cloudflare-quiche.rb
+++ b/Formula/c/cloudflare-quiche.rb
@@ -7,6 +7,11 @@ class CloudflareQuiche < Formula
   license "BSD-2-Clause"
   head "https://github.com/cloudflare/quiche.git", branch: "master"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "ce4557b96999526df17af6542bbe364a39b543e2439864be53014137397c69d1"
     sha256 cellar: :any,                 arm64_sonoma:  "220432f61056cebfe7c8ec17fb517952453129fbd1e901712ccf9778c5f8c067"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

add livecheck to ignore tags such as [h3i-0.3.0](https://github.com/cloudflare/quiche/releases/tag/h3i-0.3.0), [h3i-0.2.0](https://github.com/cloudflare/quiche/releases/tag/h3i-0.2.0) (they got regex matched as 3i-0.2.0, 3i-0.3.0)

```
Failed to download resource "cloudflare-quiche" Failure while executing; `/usr/bin/env git clone --branch 3i-0.3.0 --config advice.detachedHead=false --config core.fsmonitor=false https://github.com/cloudflare/quiche.git /home/linuxbrew/.cache/Homebrew/cloudflare-quiche--git` exited with 128. Here's the output: Cloning into '/home/linuxbrew/.cache/Homebrew/cloudflare-quiche--git'... fatal: Remote branch 3i-0.3.0 not found in upstream originShow more
```