### PR TITLE
*-gdb: update `expat` dependency

### DIFF
--- a/Formula/a/aarch64-elf-gdb.rb
+++ b/Formula/a/aarch64-elf-gdb.rb
@@ -29,9 +29,16 @@ class Aarch64ElfGdb < Formula
   depends_on "xz" # required for lzma support
   depends_on "zstd"
 
-  uses_from_macos "expat"
+  uses_from_macos "expat", since: :sequoia # minimum macOS due to python
   uses_from_macos "ncurses"
   uses_from_macos "zlib"
+
+  # Workaround for https://github.com/Homebrew/brew/issues/19315
+  on_sequoia :or_newer do
+    on_intel do
+      depends_on "expat"
+    end
+  end
 
   on_system :linux, macos: :ventura_or_newer do
     depends_on "texinfo" => :build

--- a/Formula/a/arm-none-eabi-gdb.rb
+++ b/Formula/a/arm-none-eabi-gdb.rb
@@ -26,9 +26,16 @@ class ArmNoneEabiGdb < Formula
   depends_on "python@3.13"
   depends_on "xz" # required for lzma support
 
-  uses_from_macos "expat"
+  uses_from_macos "expat", since: :sequoia # minimum macOS due to python
   uses_from_macos "ncurses"
   uses_from_macos "zlib"
+
+  # Workaround for https://github.com/Homebrew/brew/issues/19315
+  on_sequoia :or_newer do
+    on_intel do
+      depends_on "expat"
+    end
+  end
 
   on_system :linux, macos: :ventura_or_newer do
     depends_on "texinfo" => :build

--- a/Formula/i/i386-elf-gdb.rb
+++ b/Formula/i/i386-elf-gdb.rb
@@ -26,9 +26,16 @@ class I386ElfGdb < Formula
   depends_on "python@3.13"
   depends_on "xz" # required for lzma support
 
-  uses_from_macos "expat"
+  uses_from_macos "expat", since: :sequoia # minimum macOS due to python
   uses_from_macos "ncurses"
   uses_from_macos "zlib"
+
+  # Workaround for https://github.com/Homebrew/brew/issues/19315
+  on_sequoia :or_newer do
+    on_intel do
+      depends_on "expat"
+    end
+  end
 
   on_system :linux, macos: :ventura_or_newer do
     depends_on "texinfo" => :build

--- a/Formula/r/riscv64-elf-gdb.rb
+++ b/Formula/r/riscv64-elf-gdb.rb
@@ -26,9 +26,16 @@ class Riscv64ElfGdb < Formula
   depends_on "python@3.13"
   depends_on "xz" # required for lzma support
 
-  uses_from_macos "expat"
+  uses_from_macos "expat", since: :sequoia # minimum macOS due to python
   uses_from_macos "ncurses"
   uses_from_macos "zlib"
+
+  # Workaround for https://github.com/Homebrew/brew/issues/19315
+  on_sequoia :or_newer do
+    on_intel do
+      depends_on "expat"
+    end
+  end
 
   on_system :linux, macos: :ventura_or_newer do
     depends_on "texinfo" => :build

--- a/Formula/x/x86_64-elf-gdb.rb
+++ b/Formula/x/x86_64-elf-gdb.rb
@@ -27,9 +27,16 @@ class X8664ElfGdb < Formula
   depends_on "python@3.13"
   depends_on "xz" # required for lzma support
 
-  uses_from_macos "expat"
+  uses_from_macos "expat", since: :sequoia # minimum macOS due to python
   uses_from_macos "ncurses"
   uses_from_macos "zlib"
+
+  # Workaround for https://github.com/Homebrew/brew/issues/19315
+  on_sequoia :or_newer do
+    on_intel do
+      depends_on "expat"
+    end
+  end
 
   on_system :linux, macos: :ventura_or_newer do
     depends_on "texinfo" => :build


### PR DESCRIPTION
Update dependency for bottle usage until we figure out how to handle this better.

See linkage at https://github.com/Homebrew/homebrew-core/actions/runs/13292871865/job/37131575423#step:3:224
```
Warning: 5 failed steps ignored!
brew linkage --cached --test --strict aarch64-elf-gdb
brew linkage --cached --test --strict arm-none-eabi-gdb
brew linkage --cached --test --strict i386-elf-gdb
brew linkage --cached --test --strict riscv64-elf-gdb
brew linkage --cached --test --strict x86_64-elf-gdb
```

---

No mixing of `expat` in dependency tree and non-library formula so no risk in dependents. So can just add brew `expat`.