### PR TITLE
virgil: disable formula

### DIFF
--- a/Formula/v/virgil.rb
+++ b/Formula/v/virgil.rb
@@ -18,6 +18,8 @@ class Virgil < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux: "05da77ebed1e01c11281b7f148441a6aa22f9be8d219037913c238d95c615425"
   end
 
+  disable! date: "2025-03-02", because: :does_not_build
+
   depends_on "go" => :build
   # https://github.com/VirgilSecurity/virgil-cli/issues/58
   depends_on arch: :x86_64


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
There was not commits in last 5 years, it doesn't support arm architecture, and it is not popular (18 installations in last month). I think these are good reasons to deprecate this formula

UPD: apparently it doesn't build even on x86 macs (and it has 7 build errors for the last months, which is a lot for 18 installation). Have to be disabled