### PR TITLE
Remove unnecessary livecheck comments

### DIFF
--- a/Formula/i/irssi.rb
+++ b/Formula/i/irssi.rb
@@ -6,8 +6,6 @@ class Irssi < Formula
   license "GPL-2.0-or-later" => { with: "openvpn-openssl-exception" }
   revision 1
 
-  # This formula uses a file from a GitHub release, so we check the latest
-  # release version instead of Git tags.
   livecheck do
     url :stable
     strategy :github_latest

--- a/Formula/k/knock.rb
+++ b/Formula/k/knock.rb
@@ -5,8 +5,6 @@ class Knock < Formula
   sha256 "698d8c965624ea2ecb1e3df4524ed05afe387f6d20ded1e8a231209ad48169c7"
   license "GPL-2.0-or-later"
 
-  # This formula uses a file from a GitHub release, so we check the latest
-  # release version instead of Git tags.
   livecheck do
     url :stable
     strategy :github_latest

--- a/Formula/s/sdl2_image.rb
+++ b/Formula/s/sdl2_image.rb
@@ -6,8 +6,6 @@ class Sdl2Image < Formula
   license "Zlib"
   head "https://github.com/libsdl-org/SDL_image.git", branch: "main"
 
-  # This formula uses a file from a GitHub release, so we check the latest
-  # release version instead of Git tags.
   livecheck do
     url :stable
     regex(/release[._-]v?(2(?:\.\d+)+)/i)

--- a/Formula/s/sdl2_mixer.rb
+++ b/Formula/s/sdl2_mixer.rb
@@ -5,8 +5,7 @@ class Sdl2Mixer < Formula
   sha256 "cb760211b056bfe44f4a1e180cc7cb201137e4d1572f2002cc1be728efd22660"
   license "Zlib"
   revision 1
-  # This formula uses a file from a GitHub release, so we check the latest
-  # release version instead of Git tags.
+
   livecheck do
     url :stable
     regex(/release[._-]v?(\d+(?:\.\d+)+)/i)


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This removes a few older `livecheck` block comments that unnecessarily document use of the `GithubLatest` strategy. In these cases, the `stable` URL is a GitHub release asset, so using `GithubLatest` (or `GithubReleases`) doesn't need to be explained unless there's more to be said about the situation. [To be clear, we _do_ add an explanatory comment before the `livecheck` block when either of the GitHub strategies are used and the `stable` URL isn't a GitHub release asset (e.g., a tag tarball instead).]

These particular comments were added by me years ago, presumably before we standardized on our current approach, so this is me cleaning them up.