### PR TITLE
unciv 4.15.14 (new formula)

### DIFF
--- a/Formula/u/unciv.rb
+++ b/Formula/u/unciv.rb
@@ -10,6 +10,10 @@ class Unciv < Formula
     regex(/^v?(\d+(?:\.\d+)+(?:[._-]?patch\d*)?)$/i)
   end
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, all: "8cc59207c5c11d4f31a168392e0e377bc66675ffb7db83c07aad3630dd63ee7e"
+  end
+
   depends_on "openjdk"
 
   def install

--- a/Formula/u/unciv.rb
+++ b/Formula/u/unciv.rb
@@ -1,0 +1,24 @@
+class Unciv < Formula
+  desc "Open-source Android/Desktop remake of Civ V"
+  homepage "https://github.com/yairm210/Unciv"
+  url "https://github.com/yairm210/Unciv/releases/download/4.15.14/Unciv.jar"
+  sha256 "23ba482998b212579f53f677e014fc12cd7b9fa8fe3ffb6c4dbe9a03fcf1be6c"
+  license "MPL-2.0"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+(?:[._-]?patch\d*)?)$/i)
+  end
+
+  depends_on "openjdk"
+
+  def install
+    libexec.install "Unciv.jar"
+    bin.write_jar_script libexec/"Unciv.jar", "unciv"
+  end
+
+  test do
+    # Unciv is a GUI application, so there is no cli functionality to test
+    assert_match version.to_str, shell_output("#{bin}/unciv --version")
+  end
+end


### PR DESCRIPTION
[Unciv](https://github.com/yairm210/Unciv) is a multiplatform open-source remake of Civilization V

Regarding version updates: Do you prefer having autobump find the next version? Or do you prefer I add a "brew bump" command in the CI that releases a version? I'm fine with both

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?