### PR TITLE
sdl2*: add/update livecheck

### DIFF
--- a/Formula/s/sdl2.rb
+++ b/Formula/s/sdl2.rb
@@ -7,7 +7,7 @@ class Sdl2 < Formula
 
   livecheck do
     url :stable
-    regex(/release[._-](2(?:\.\d+)+)/i)
+    regex(/^(?:release[._-])?v?(2(?:\.\d+)+)$/i)
   end
 
   bottle do

--- a/Formula/s/sdl2_image.rb
+++ b/Formula/s/sdl2_image.rb
@@ -8,8 +8,7 @@ class Sdl2Image < Formula
 
   livecheck do
     url :stable
-    regex(/release[._-]v?(2(?:\.\d+)+)/i)
-    strategy :github_releases
+    regex(/^(?:release[._-])?v?(2(?:\.\d+)+)$/i)
   end
 
   bottle do

--- a/Formula/s/sdl2_mixer.rb
+++ b/Formula/s/sdl2_mixer.rb
@@ -8,8 +8,7 @@ class Sdl2Mixer < Formula
 
   livecheck do
     url :stable
-    regex(/release[._-]v?(\d+(?:\.\d+)+)/i)
-    strategy :github_latest
+    regex(/^(?:release[._-])?v?(2(?:\.\d+)+)$/i)
   end
 
   bottle do

--- a/Formula/s/sdl2_net.rb
+++ b/Formula/s/sdl2_net.rb
@@ -5,12 +5,9 @@ class Sdl2Net < Formula
   sha256 "4e4a891988316271974ff4e9585ed1ef729a123d22c08bd473129179dc857feb"
   license "Zlib"
 
-  # NOTE: This should be updated to use the `GithubLatest` strategy if/when the
-  # GitHub releases provide downloadable artifacts and the formula uses one as
-  # the `stable` URL (like `sdl2_image`, `sdl2_mixer`, etc.).
   livecheck do
-    url :head
-    regex(/^release[._-]v?(\d+(?:\.\d+)+)$/i)
+    url :stable
+    regex(/^(?:release[._-])?v?(2(?:\.\d+)+)$/i)
   end
 
   bottle do

--- a/Formula/s/sdl2_sound.rb
+++ b/Formula/s/sdl2_sound.rb
@@ -9,6 +9,11 @@ class Sdl2Sound < Formula
   ]
   head "https://github.com/icculus/SDL_sound.git", branch: "main"
 
+  livecheck do
+    url :stable
+    regex(/^(?:release[._-])?v?(2(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "ebf816ab8b81d1c57a8fa8464015be9e6e7c1bb59e6756cb1ab955193468933d"
     sha256 cellar: :any,                 arm64_sonoma:  "1a336df9cbf4dbecdf17c4bd11f1d4fa86a8f8d7b4e31f90e2cd61f80d12b211"

--- a/Formula/s/sdl2_ttf.rb
+++ b/Formula/s/sdl2_ttf.rb
@@ -5,12 +5,9 @@ class Sdl2Ttf < Formula
   sha256 "0b2bf1e7b6568adbdbc9bb924643f79d9dedafe061fa1ed687d1d9ac4e453bfd"
   license "Zlib"
 
-  # Upstream creates releases that use a stable tag (e.g., `v1.2.3`) but are
-  # labeled as "pre-release" on GitHub before the version is released, so it's
-  # necessary to use the `GithubLatest` strategy.
   livecheck do
     url :stable
-    strategy :github_latest
+    regex(/^(?:release[._-])?v?(2(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `sdl2` is intended to match tags like `release-2.32.2` but the repository also contains unstable tags like `prerelease-2.29.3`. The current `livecheck` block regex does not restrict the start/end of the regex, so it will also match prerelease versions. This updates the regex accordingly and makes the `release-` prefix optional, as some SDL repositories have used both tag formats.

This also adds/updates `livecheck` blocks for the other `sdl2_` formulae (excluding `sdl2_gfx`) to bring them in line with `sdl2`. Most of these other formulae don't have an SDL3 release yet but livecheck is returning 3.2.0 as the newest `sdl2_ttf` version, so this PR fixes that issue (and will prevent similar issues for the others in the future).

For context, the `sdl2` formula's `livecheck` block was previously updated to check the Git tags instead of GitHub releases, as there are now SDL3 versions but we need to specifically match SDL2 versions. The `stable` URL is a GitHub release asset and using the `GithubReleases` strategy would work for now but eventually it may fail if/when there aren't any SDL2 versions in the most recent releases, so we're using the Git strategy instead. It's not ideal but it may stand a better chance of continuing to work into the future.