### PR TITLE
libunicode: minimum GCC 13 for std::format

### DIFF
--- a/Formula/lib/libunicode.rb
+++ b/Formula/lib/libunicode.rb
@@ -27,8 +27,8 @@ class Libunicode < Formula
   end
 
   fails_with :gcc do
-    version "11"
-    cause "Requires C++20"
+    version "12"
+    cause "Requires C++20 std::format, https://gcc.gnu.org/gcc-13/changes.html#libstdcxx"
   end
 
   def install


### PR DESCRIPTION
References:
* https://github.com/contour-terminal/libunicode/commit/ba352820286e28c009dd27c297496f4b1b758172
* https://gcc.gnu.org/gcc-13/changes.html#libstdcxx
* https://en.cppreference.com/w/cpp/20#cpp_lib_format_201907L
