### PR TITLE
cabin: minimum Apple Clang 1500

### DIFF
--- a/Formula/c/cabin.rb
+++ b/Formula/c/cabin.rb
@@ -27,12 +27,12 @@ class Cabin < Formula
   depends_on "tbb"
 
   on_macos do
-    depends_on "llvm" => [:build, :test] if DevelopmentTools.clang_build_version <= 1200
+    depends_on "llvm" => :build if DevelopmentTools.clang_build_version <= 1499
   end
 
   on_ventura do
     # Ventura seems to be missing the `source_location` header.
-    depends_on "llvm" => [:build, :test]
+    depends_on "llvm" => :build
   end
 
   on_linux do
@@ -40,7 +40,7 @@ class Cabin < Formula
   end
 
   fails_with :clang do
-    build 1200
+    build 1499
     cause "Requires C++20"
   end
 
@@ -50,14 +50,13 @@ class Cabin < Formula
   end
 
   def install
-    ENV.llvm_clang if OS.mac? && (DevelopmentTools.clang_build_version <= 1200 || MacOS.version == :ventura)
+    ENV.llvm_clang if OS.mac? && (DevelopmentTools.clang_build_version <= 1499 || MacOS.version == :ventura)
     # Avoid cloning `toml11` at build-time.
     (buildpath/"build/DEPS/toml11").install_symlink Formula["toml11"].opt_include
     system "make", "RELEASE=1", "PREFIX=#{prefix}", "install"
   end
 
   test do
-    ENV.clang if OS.mac? && (DevelopmentTools.clang_build_version <= 1200 || MacOS.version == :ventura)
     system bin/"cabin", "new", "hello_world"
     cd "hello_world" do
       assert_equal "Hello, world!", shell_output("#{bin}/cabin run").split("\n").last


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`source_location` seems to be added in Swift 6 / Xcode 16 (https://github.com/swiftlang/llvm-project/commit/73d94b19161355d06f20678d628555719eebbdcc) though it looks like Sonoma CLT has it (maybe included with Xcode 15.3?) so can keep odd logic for handling Apple Clang 1500 differently on Ventura vs Sonoma.