### PR TITLE
comskip 0.83 (new formula)

### DIFF
--- a/Formula/c/comskip.rb
+++ b/Formula/c/comskip.rb
@@ -1,0 +1,30 @@
+class Comskip < Formula
+  desc "Free commercial detector"
+  homepage "https://www.comskip.org"
+  url "https://github.com/erikkaashoek/Comskip/archive/refs/tags/V0.83.tar.gz"
+  sha256 "bd90d7922916e0b04ea9f3426ea7747d347f218f3f915fb4d251961d0730876e"
+  license "GPL-2.0-or-later"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "pkgconf" => :build
+  depends_on "argtable"
+  depends_on "ffmpeg"
+  depends_on "sdl2"
+
+  def install
+    system "./autogen.sh"
+    system "./configure", "--disable-silent-rules", *std_configure_args
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    video = test_fixtures("test.gif")
+    shell_output("#{bin}/comskip #{video} --output #{testpath}", 1)
+    assert_path_exists testpath/"test.txt"
+
+    assert_match "Comskip #{version}", shell_output("#{bin}/comskip --help 2>&1", 2)
+  end
+end


### PR DESCRIPTION
New formula for comskip, a tool that detects commercials in recordings

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
