### PR TITLE
libavif: use patch, not sed

### DIFF
--- a/Formula/lib/libavif.rb
+++ b/Formula/lib/libavif.rb
@@ -22,6 +22,13 @@ class Libavif < Formula
 
   uses_from_macos "zlib"
 
+  # Review for removal on 1.2.1 release
+  # https://github.com/AOMediaCodec/libavif/issues/2653
+  patch do
+    url "https://github.com/AOMediaCodec/libavif/commit/7cc1dccabd45864dc0945882faa0348dcded847f.patch?full_index=1"
+    sha256 "904feeb044dc3e8dc9029764125333bcd3a48e400691f9c67f64929ab20cff89"
+  end
+
   def install
     args = %W[
       -DCMAKE_INSTALL_RPATH=#{rpath}


### PR DESCRIPTION
Upstream patch for https://github.com/AOMediaCodec/libavif/issues/2653, review for removal when v1.2.1 is released.

Resolves https://github.com/orgs/Homebrew/discussions/5997.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
