### PR TITLE
workflows/publish-commit-bottles: handle PRs that only remove formulae

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -149,9 +149,10 @@ jobs:
 
           if [[ "$bottles" = "true" ]]
           then
-            if jq --exit-status 'any(.[].filename; startswith("Formula/")) | not'
+            array_has_unremoved_formulae_filter='any((.filename | startswith("Formula/")) and (.status != "removed"))'
+            if jq --exit-status ". | $array_has_unremoved_formulae_filter | not"
             then
-              echo '::notice ::PR does not modify formulae; no bottles to publish.'
+              echo '::notice ::PR does not add or modify formulae; no bottles to publish.'
               bottles=false
             fi < <(
               gh api \


### PR DESCRIPTION
Previously, we checked only if a PR does not touch any formulae before
we decide that it has no bottles to publish.

After this change, we now check that a PR touches a formula and does not
remove at least one of them before deciding that a PR does not have any
bottles to publish.

This fixes failed bottle publish attempts like what is seen at #209657.
