### PR TITLE
ddcutil: add `libx11` and `libxext` dependencies

### DIFF
--- a/Formula/d/ddcutil.rb
+++ b/Formula/d/ddcutil.rb
@@ -21,6 +21,8 @@ class Ddcutil < Formula
   depends_on "kmod"
   depends_on "libdrm"
   depends_on "libusb"
+  depends_on "libx11"
+  depends_on "libxext"
   depends_on "libxrandr"
   depends_on :linux
   depends_on "systemd"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
