### PR TITLE
go@1.23 1.23.7

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -1261,7 +1261,7 @@ go-feature-flag-relay-proxy
 go-md2man
 go-size-analyzer
 go-task
-go@1.22
+go@1.23
 goaccess
 goawk
 gobject-introspection

--- a/Formula/g/go@1.23.rb
+++ b/Formula/g/go@1.23.rb
@@ -20,12 +20,12 @@ class GoAT123 < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "cf4db4579df6a906f27611a27613a8d6583292a50534470d101e276e5c4ee31b"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "cf4db4579df6a906f27611a27613a8d6583292a50534470d101e276e5c4ee31b"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "cf4db4579df6a906f27611a27613a8d6583292a50534470d101e276e5c4ee31b"
-    sha256 cellar: :any_skip_relocation, sonoma:        "4654e00aa7967d9c8cf325253d1f82896f2a6ea40de389879cdfffa235e374af"
-    sha256 cellar: :any_skip_relocation, ventura:       "4654e00aa7967d9c8cf325253d1f82896f2a6ea40de389879cdfffa235e374af"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "00ba9579754a0e0a4e6a6840dff51ad36c78cd8e4a3e820631083f09d32cc12b"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "361cb99ae614d2c54f66f843501ce987d541a61fe8aed8d46767fd3aeb97cb9a"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "361cb99ae614d2c54f66f843501ce987d541a61fe8aed8d46767fd3aeb97cb9a"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "361cb99ae614d2c54f66f843501ce987d541a61fe8aed8d46767fd3aeb97cb9a"
+    sha256 cellar: :any_skip_relocation, sonoma:        "2e5e5a4712cb4528af46112f7d3206adac31792190e2d661cb4ba1c17a2c423b"
+    sha256 cellar: :any_skip_relocation, ventura:       "2e5e5a4712cb4528af46112f7d3206adac31792190e2d661cb4ba1c17a2c423b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "70c9e0e9679f718dc2ecfe44d8791ed967495503da9d5cec3cdf7964d0d7b2cc"
   end
 
   keg_only :versioned_formula

--- a/Formula/g/go@1.23.rb
+++ b/Formula/g/go@1.23.rb
@@ -1,9 +1,9 @@
 class GoAT123 < Formula
   desc "Open source programming language to build simple/reliable/efficient software"
   homepage "https://go.dev/"
-  url "https://go.dev/dl/go1.23.6.src.tar.gz"
-  mirror "https://fossies.org/linux/misc/go1.23.6.src.tar.gz"
-  sha256 "039c5b04e65279daceee8a6f71e70bd05cf5b801782b6f77c6e19e2ed0511222"
+  url "https://go.dev/dl/go1.23.7.src.tar.gz"
+  mirror "https://fossies.org/linux/misc/go1.23.7.src.tar.gz"
+  sha256 "7cfabd46b73eb4c26b19d69515dd043d7183a6559acccd5cfdb25eb6b266a458"
   license "BSD-3-Clause"
 
   livecheck do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Ref:
* Announcement: https://groups.google.com/g/golang-announce/c/4t3lzH3I0eI
* go 1.24 was autobumped in https://github.com/Homebrew/homebrew-core/pull/209718
* Forgot to put go@1.23 into `autobump.txt` in https://github.com/Homebrew/homebrew-core/pull/201070
* go@1.22 was deprecated in https://github.com/Homebrew/homebrew-core/pull/207850