### PR TITLE
core-lightning: update livecheck

### DIFF
--- a/Formula/c/core-lightning.rb
+++ b/Formula/c/core-lightning.rb
@@ -10,6 +10,7 @@ class CoreLightning < Formula
   livecheck do
     url :stable
     regex(/^v(\d+(?:\.\d+)+)$/i)
+    strategy :github_latest
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `core-lightning` uses the Git and this is currently returning 25.02 as the newest version but there is no corresponding release after the better part of a day. The `stable` URL is a GitHub release asset, so this updates the `livecheck` block to use the `GithubLatest` strategy, which correctly returns 24.11.1 as the latest version.