### PR TITLE
youtube-dl: point to yt-dlp in disabled note

### DIFF
--- a/Formula/y/youtube-dl.rb
+++ b/Formula/y/youtube-dl.rb
@@ -33,7 +33,8 @@ class YoutubeDl < Formula
 
   # https://github.com/ytdl-org/youtube-dl/issues/31585
   # https://github.com/ytdl-org/youtube-dl/issues/31067
-  disable! date: "2024-11-23", because: "has a failing test since forever and no new release since 2021"
+  disable! date: "2024-11-23", because: "has a failing test since forever and no new release since 2021",
+    replacement: "yt-dlp"
 
   depends_on "python@3.13"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This adds a little text to `youtube-dl`'s disabled `because` text to point users to the `yt-dlp` alternative.

This text is shown in `brew info youtube-dl` and when you try to `brew install youtube-dl` (which doesn't work because it's disabled). It's helpful to point out the functional alternative there, so folks don't have to try another step to find it. I may be wrong but it looks like the `caveat` (which notes `yt-dlp`) only displays on the [formula website](https://formulae.brew.sh/formula/youtube-dl).