### PR TITLE
mimalloc: fix SIGILL on systems without AVX

### DIFF
--- a/Formula/m/mimalloc.rb
+++ b/Formula/m/mimalloc.rb
@@ -22,7 +22,7 @@ class Mimalloc < Formula
   depends_on "cmake" => :build
 
   def install
-    system "cmake", "-S", ".", "-B", "build", "-DMI_INSTALL_TOPLEVEL=ON", *std_cmake_args
+    system "cmake", "-S", ".", "-B", "build", "-DMI_INSTALL_TOPLEVEL=ON", "-DMI_OPT_ARCH=OFF", *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
     pkgshare.install "test"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Hi, sorry if the format for the pull request or the commit is not right, but I couldn't use `bump-formula-pr` with `mimalloc`.

`raku` and `mold` don't work on my Core 2 Duo. Both crash with a SIGILL on `mimalloc`:
```plain
$ lldb raku 
(lldb) target create "raku"
Current executable set to '/home/linuxbrew/.linuxbrew/bin/raku' (x86_64).
(lldb) run
Process 3519 launched: '/home/linuxbrew/.linuxbrew/bin/raku' (x86_64)
Process 3519 stopped
* thread #1, name = 'raku', stop reason = signal SIGILL: illegal operand
    frame #0: 0x00007ffff7f7b430 libmimalloc.so.3`mi_stats_reset + 96
libmimalloc.so.3`mi_stats_reset:
->  0x7ffff7f7b430 <+96>:  vxorps %xmm0, %xmm0, %xmm0
    0x7ffff7f7b434 <+100>: vcvtsi2sdq 0x11573(%rip), %xmm0, %xmm0 ; mi_clock_diff
    0x7ffff7f7b43d <+109>: vucomisd 0x30a3(%rip), %xmm0
    0x7ffff7f7b445 <+117>: jp     0x7ffff7f7b449 ; <+121>
(lldb) ^D
$ lldb mold
(lldb) target create "mold"
Current executable set to '/home/linuxbrew/.linuxbrew/bin/mold' (x86_64).
(lldb) run
Process 7953 launched: '/home/linuxbrew/.linuxbrew/bin/mold' (x86_64)
Process 7953 stopped
* thread #1, name = 'mold', stop reason = signal SIGILL: illegal operand
    frame #0: 0x00007ffff7e8c268 libmimalloc.so.3`mi_stats_reset + 88
libmimalloc.so.3`mi_stats_reset:
->  0x7ffff7e8c268 <+88>:  vxorps %xmm0, %xmm0, %xmm0
    0x7ffff7e8c26c <+92>:  vcvtsi2sdq 0x106fb(%rip), %xmm0, %xmm0 ; mi_clock_diff
    0x7ffff7e8c275 <+101>: vucomisd 0x32f3(%rip), %xmm0
    0x7ffff7e8c27d <+109>: jp     0x7ffff7e8c281 ; <+113>
(lldb) ^D
```
`vxorps` is part of AVX. `MI_OPT_ARCH=OFF` is documented here:

https://github.com/microsoft/mimalloc/blob/dev/CMakeLists.txt

Similar problem:

https://github.com/microsoft/mimalloc/issues/1016