### PR TITLE
zig: update dependencies

### DIFF
--- a/Formula/z/zig.rb
+++ b/Formula/z/zig.rb
@@ -23,11 +23,12 @@ class Zig < Formula
   depends_on "lld"
   depends_on "llvm"
   depends_on macos: :big_sur # https://github.com/ziglang/zig/issues/13313
-  depends_on "z3"
-  depends_on "zstd"
 
-  uses_from_macos "ncurses"
-  uses_from_macos "zlib"
+  # NOTE: `z3` should be macOS-only dependency whenever we need to re-add
+  on_macos do
+    depends_on "z3"
+    depends_on "zstd"
+  end
 
   # https://github.com/Homebrew/homebrew-core/issues/209483
   skip_clean "lib/zig/libc/darwin/libSystem.tbd"


### PR DESCRIPTION
Doesn't seem easily possible to remove linkage so just keep them as macOS-only.

Zig doesn't expose `-dead_strip_dylibs` in `zig build` so would require patching build.zig to pass in `exe.dead_strip_dylibs = true`.