### PR TITLE
ext2fuse: deprecate

### DIFF
--- a/Formula/e/ext2fuse.rb
+++ b/Formula/e/ext2fuse.rb
@@ -11,6 +11,9 @@ class Ext2fuse < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux: "fe9d3ea0a65c95de091aecb536ee498015bdc07b7c12e4367617cf9e78c76941"
   end
 
+  # Last release on 2008-06-26. Needs `libfuse@2` and patches to build
+  deprecate! date: "2025-03-06", because: :unmaintained
+
   depends_on "e2fsprogs"
   depends_on "libfuse@2"
   depends_on :linux # on macOS, requires closed-source macFUSE


### PR DESCRIPTION
Not commonly used on Linux as shown by low installs:
```
==> Analytics
install: 0 (30 days), 2 (90 days), 9 (365 days)
install-on-request: 0 (30 days), 2 (90 days), 9 (365 days)
build-error: 0 (30 days)
```

And also being packaged at only Homebrew & MacPorts
[![Packaging status](https://repology.org/badge/tiny-repos/ext2fuse.svg)](https://repology.org/project/ext2fuse/versions)
[![Packaging status](https://repology.org/badge/vertical-allrepos/ext2fuse.svg)](https://repology.org/project/ext2fuse/versions)

Also means it will never get FUSE 3 support unlike other formulae where distros like Debian are actively working on migration toward.

---

Probably causes more confusion leaving this around rather than users finding 3rd party taps for macOS like https://github.com/gromgit/homebrew-fuse/blob/main/Formula/ext2fuse-mac.rb