### PR TITLE
zig: re-enable static llvm

### DIFF
--- a/Formula/z/zig.rb
+++ b/Formula/z/zig.rb
@@ -55,7 +55,7 @@ class Zig < Formula
     else Hardware.oldest_cpu
     end
 
-    args = ["-DZIG_SHARED_LLVM=ON"]
+    args = ["-DZIG_STATIC_LLVM=ON"]
     args << "-DZIG_TARGET_MCPU=#{cpu}" if build.bottle?
 
     system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
@@ -64,6 +64,9 @@ class Zig < Formula
   end
 
   test do
+    version_output = shell_output("#{bin}/zig version").strip
+    assert_equal 1, version_output.lines.length
+
     (testpath/"hello.zig").write <<~ZIG
       const std = @import("std");
       pub fn main() !void {


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

After #209803 was merged, users (including myself) started experiencing the issue described by #210073

I also added a test to ensure that `zig version` works as intended to prevent future similar breakages

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

fixes #210073