### PR TITLE
morpheus: fix app bundle code signing, fix checksum, bump revision

### DIFF
--- a/Formula/m/morpheus.rb
+++ b/Formula/m/morpheus.rb
@@ -12,12 +12,12 @@ class Morpheus < Formula
   end
 
   bottle do
-    sha256                               arm64_sequoia: "e5b99913c66785c4df9f1c817dea7b459d799b2acb8dc71992dc15abdcbf109f"
-    sha256                               arm64_sonoma:  "08f5ca07e9f086c265eea28368b54f3372a43f1cee0995cdb80362c6f4a325e1"
-    sha256                               arm64_ventura: "c236a0b101aef381e2e0b906303cd7a792bfcc7b434f11500d88fda3f99b298b"
-    sha256 cellar: :any,                 sonoma:        "404c1b6d8e89639ef8fc8bcf98913522a3f7b9aed62d405d3147d3435436bddb"
-    sha256 cellar: :any,                 ventura:       "30fd1987a9df02e998951e99ebb91358923348c7236bff102eaa531652e706cd"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d34c85f01b5da908e9b659468f9108cc245b40893018c739781e1f25975b0ce6"
+    sha256                               arm64_sequoia: "11e3811c5e5932f71678bea042c542a8a9ca5e0e24be85d4ce37f04b2096af1f"
+    sha256                               arm64_sonoma:  "5875ccd833c4e41e3c0d6a92a6e345bebf5b79cb6fddde17e25383dc20a7330c"
+    sha256                               arm64_ventura: "e7e28d8b1bd4020ca3e99ddcceeb9c3af6abc63bb4bdc60bfd6302f04f50d849"
+    sha256 cellar: :any,                 sonoma:        "31b3c036148a0c2ffbd42abc324e85fd5709323ef52977340b128ff92cac7c86"
+    sha256 cellar: :any,                 ventura:       "29d8f5b2730cbda1d887ea580c643d26f80bcd224de09f27245595361f820862"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "ac0786ead33d0beb6c8fd5ba6554e2de1df213ba821576fa849a1a8dff1fb4a0"
   end
 
   depends_on "boost" => :build

--- a/Formula/m/morpheus.rb
+++ b/Formula/m/morpheus.rb
@@ -2,8 +2,9 @@ class Morpheus < Formula
   desc "Modeling environment for multi-cellular systems biology"
   homepage "https://morpheus.gitlab.io/"
   url "https://gitlab.com/morpheus.lab/morpheus/-/archive/v2.3.9/morpheus-v2.3.9.tar.gz"
-  sha256 "2c948b6537dfc09b3a7fe536c722a6effbf0dbad30341f0aec0635a2806bd0f8"
+  sha256 "d27b7c2b5ecf503fd11777b3a75d4658a6926bfd9ae78ef97abf5e9540a6fb29"
   license "BSD-3-Clause"
+  revision 1
 
   livecheck do
     url :stable
@@ -56,6 +57,13 @@ class Morpheus < Formula
     inreplace "#{prefix}/Morpheus.app/Contents/Info.plist", "HOMEBREW_BIN_PATH", "#{HOMEBREW_PREFIX}/bin"
   end
 
+  def post_install
+    return unless OS.mac?
+
+    # Sign to ensure proper execution of the app bundle
+    system "/usr/bin/codesign", "-f", "-s", "-", "#{prefix}/Morpheus.app" if Hardware::CPU.arm?
+  end
+
   test do
     (testpath/"test.xml").write <<~XML
       <?xml version='1.0' encoding='UTF-8'?>
@@ -67,9 +75,9 @@ class Morpheus < Formula
           <Space>
               <Lattice class="linear">
                   <Neighborhood>
-                      <Order>1</Order>
+                      <Order>optimal</Order>
                   </Neighborhood>
-                  <Size value="100,  0.0,  0.0" symbol="size"/>
+                  <Size symbol="size" value="1.0, 1.0, 0.0"/>
               </Lattice>
               <SpaceSymbol symbol="space"/>
           </Space>
@@ -79,7 +87,7 @@ class Morpheus < Formula
               <TimeSymbol symbol="time"/>
           </Time>
           <Analysis>
-              <ModelGraph include-tags="#untagged" format="dot" reduced="false"/>
+              <ModelGraph format="dot" reduced="false" include-tags="#untagged"/>
           </Analysis>
       </MorpheusModel>
     XML


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
## Issue
The `Morpheus.app` bundle fails to open on macOS Sequoia 15.3.1 (ARM) with error `-54` after installation. This occurs because the `Info.plist` is modified post-installation to adapt to the user's Homebrew path, which invalidates the code signature.

### Fix
Add code signing after the `Info.plist` modification, following the same pattern used in the [`tart`](https://github.com/Homebrew/homebrew-core/blob/57fb9f3ade89f291219ac19fac764ee451e4bba6/Formula/t/tart.rb) formula. This ensures the app bundle has a valid signature with properly bound `Info.plist` and sealed resources.

### Technical details

#### Before

- App bundle fails to open with error `-54`
- Code signature shows `Info.plist=not bound`
- Resources are not sealed

#### After
- App bundle opens correctly
- `Info.plist` is properly bound (`14 entries`)
- Resources are properly sealed (`version=2, 13 rules, 4 files`)

The fix uses `/usr/bin/codesign` with minimal flags (`-f -s -`) to create an ad-hoc signature, consistent with other formulas in Homebrew Core that handle app bundles.

## Note about checksum change
The checksum has changed due to a re-issued release tag:
1. The release tag was temporarily set to `v2.3.9` on February 24, 2025.
2. Homebrew's `livecheck` caught this change and updated the formula.
3. The actual `v2.3.9` release was published on March 04, 2025, with the correct checksum, and the incident was documented upstream in the [release notes](https://gitlab.com/morpheus.lab/morpheus/-/releases/v2.3.9).