### PR TITLE
zig 0.14.0: re-enable static llvm for macos only

### DIFF
--- a/Formula/z/zig.rb
+++ b/Formula/z/zig.rb
@@ -55,7 +55,13 @@ class Zig < Formula
     else Hardware.oldest_cpu
     end
 
-    args = ["-DZIG_SHARED_LLVM=ON"]
+    # Workaround for https://github.com/Homebrew/homebrew-core/issues/210073
+    # Suggested by https://github.com/Homebrew/homebrew-core/pull/210107#issuecomment-2706566289
+    if OS.linux?
+      args = ["-DZIG_SHARED_LLVM=ON"]
+    elsif OS.mac?
+      args = ["-DZIG_STATIC_LLVM=ON"]
+    end
     args << "-DZIG_TARGET_MCPU=#{cpu}" if build.bottle?
 
     system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args


### PR DESCRIPTION
Hello there 👋
as suggested by https://github.com/Homebrew/homebrew-core/pull/210107#issuecomment-2706566289  (@cho-m thanks), I implemented this workaround to fix https://github.com/Homebrew/homebrew-core/issues/210073

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
fixes: https://github.com/Homebrew/homebrew-core/issues/210073