### PR TITLE
digdag: update test to check JDK compatibility

### DIFF
--- a/Formula/d/digdag.rb
+++ b/Formula/d/digdag.rb
@@ -23,5 +23,9 @@ class Digdag < Formula
 
   test do
     assert_match version.to_s, shell_output("#{bin}/digdag --version")
+    system bin/"digdag", "init", "mydag"
+    cd "mydag" do
+      system bin/"digdag", "run", "mydag.dig"
+    end
   end
 end


### PR DESCRIPTION
Just sample workflow from https://github.com/treasure-data/digdag/blob/master/digdag-docs/src/getting_started.md#3-running-sample-workflow

The version check would pass on newer JDK which is actually not compatible.

Extra checks will correctly fail on incompatible JDK like `openjdk@17`:

```
==> Testing digdag
==> /opt/homebrew/Cellar/digdag/0.10.5.1/bin/digdag --version
==> /opt/homebrew/Cellar/digdag/0.10.5.1/bin/digdag init mydag
2025-03-07 15:46:37 -0500: Digdag v0.10.5.1
  Creating mydag/mydag.dig
  Creating mydag/.gitignore
Done. Type `cd mydag` and then `digdag run mydag.dig` to run the workflow. Enjoy!
==> /opt/homebrew/Cellar/digdag/0.10.5.1/bin/digdag run mydag.dig
2025-03-07 15:46:37 -0500: Digdag v0.10.5.1
2025-03-07 15:46:38 -0500 [ERROR] (local-agent-0) io.digdag.core.agent.MultiThreadAgent: Uncaught exception during acquiring tasks from a server. Ignoring. Agent thread will be retried.
java.lang.ExceptionInInitializerError: null
	at org.skife.jdbi.v2.sqlobject.SqlObject.buildSqlObject(SqlObject.java:68)
	at org.skife.jdbi.v2.sqlobject.SqlObjectBuilder.attach(SqlObjectBuilder.java:36)
```