### PR TITLE
x86_64-elf-grub 2.12

### DIFF
--- a/Formula/x/x86_64-elf-grub.rb
+++ b/Formula/x/x86_64-elf-grub.rb
@@ -1,9 +1,9 @@
 class X8664ElfGrub < Formula
   desc "GNU GRUB bootloader for x86_64-elf"
   homepage "https://savannah.gnu.org/projects/grub"
-  url "https://ftp.gnu.org/gnu/grub/grub-2.06.tar.xz"
-  mirror "https://mirrors.ocf.berkeley.edu/gnu/grub/grub-2.06.tar.xz"
-  sha256 "b79ea44af91b93d17cd3fe80bdae6ed43770678a9a5ae192ccea803ebb657ee1"
+  url "https://ftp.gnu.org/gnu/grub/grub-2.12.tar.xz"
+  mirror "https://mirrors.ocf.berkeley.edu/gnu/grub/grub-2.12.tar.xz"
+  sha256 "f3c97391f7c4eaa677a78e090c7e97e6dc47b16f655f04683ebd37bef7fe0faa"
   license "GPL-3.0-or-later"
 
   bottle do
@@ -15,6 +15,7 @@ class X8664ElfGrub < Formula
     sha256 x86_64_linux:  "c578c06b175f785718eafaa9e54c45bd767ba73a041cf1db73a72a6103573375"
   end
 
+  depends_on "gawk" => :build
   depends_on "help2man" => :build
   depends_on "objconv" => :build
   depends_on "pkgconf" => :build
@@ -43,6 +44,9 @@ class X8664ElfGrub < Formula
 
   def install
     ENV.append_to_cflags "-Wno-error=incompatible-pointer-types"
+    ENV["PATH"]=prefix/"opt/gawk/libexec/gnubin:#{ENV["PATH"]}"
+
+    touch buildpath/"grub-core/extra_deps.lst"
 
     resource("unifont").stage do |r|
       buildpath.install "unifont-#{r.version}.pcf.gz" => "unifont.pcf.gz"

--- a/Formula/x/x86_64-elf-grub.rb
+++ b/Formula/x/x86_64-elf-grub.rb
@@ -7,12 +7,12 @@ class X8664ElfGrub < Formula
   license "GPL-3.0-or-later"
 
   bottle do
-    sha256 arm64_sequoia: "b76374ca36987f1bfef95216c14af606d263e17863df4d7b1a33b3cf65d953a3"
-    sha256 arm64_sonoma:  "b5687ab4349a959b3bae9afb76103ab55bb5f0902eb199ab4aba00d974fc6c49"
-    sha256 arm64_ventura: "406969f44c862754472dac117737965cf4c1ba427eba3ff478f0ce0bbfa75cc7"
-    sha256 sonoma:        "a9e8fd25bd063a89080bee2e33d88e70fcd0227a2a8fb20e43e270d59062da95"
-    sha256 ventura:       "e1770bd69fae7db684989eee7416337abb4f301a53a1034ab39efee73547cda9"
-    sha256 x86_64_linux:  "c578c06b175f785718eafaa9e54c45bd767ba73a041cf1db73a72a6103573375"
+    sha256 arm64_sequoia: "9e7f8e4ae40110b6b2ef9610497ecc11612f2c28c399ac3addf7587ddcb88284"
+    sha256 arm64_sonoma:  "66784aa8aecb9d70cab2eefb31b6f21cd0a2e29b3325c958abed5288c257b2e0"
+    sha256 arm64_ventura: "d5e9b928e26082ce63928c69575178c6deb912d36100ce95580b211c788b7f31"
+    sha256 sonoma:        "ee6afc8a7dd71bded334efa01e9df5aa578093bde953a392939175e4092b83b2"
+    sha256 ventura:       "6e256eb718661e554414730235ed267d15b10f928eaf8d47c27280a672321e48"
+    sha256 x86_64_linux:  "e164e802fcb5d850632334568f4af43abd00561bc635f54f207aad940cb04362"
   end
 
   depends_on "gawk" => :build


### PR DESCRIPTION
version bump 2.06 -> 2.12
added build-time gawk dependency
fixed compilation bug with missing extra_deps.lst

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
