### PR TITLE
taglib@1 1.13.1 (new formula) & change easy-tag dependencies

### DIFF
--- a/Formula/e/easy-tag.rb
+++ b/Formula/e/easy-tag.rb
@@ -4,7 +4,7 @@ class EasyTag < Formula
   url "https://download.gnome.org/sources/easytag/2.4/easytag-2.4.3.tar.xz"
   sha256 "fc51ee92a705e3c5979dff1655f7496effb68b98f1ada0547e8cbbc033b67dd5"
   license "GPL-2.0-or-later"
-  revision 11
+  revision 12
 
   bottle do
     sha256 arm64_sequoia: "8c29dc74a17f41bde4c53800d5e27b53b3fe54e14231cf7bb4825826007edae9"
@@ -35,7 +35,7 @@ class EasyTag < Formula
   depends_on "libvorbis"
   depends_on "pango"
   depends_on "speex"
-  depends_on "taglib"
+  depends_on "taglib@1"
   depends_on "wavpack"
 
   uses_from_macos "perl" => :build
@@ -50,6 +50,8 @@ class EasyTag < Formula
   end
 
   def install
+    ENV.append_path "CMAKE_PREFIX_PATH", Formula["taglib@1"].prefix
+
     ENV.append "LIBS", "-lz"
     ENV["DESTDIR"] = "/"
 

--- a/Formula/t/taglib@1.rb
+++ b/Formula/t/taglib@1.rb
@@ -1,0 +1,24 @@
+class TaglibAT1 < Formula
+  desc "Audio metadata library"
+  homepage "https://taglib.org/"
+  url "https://taglib.github.io/releases/taglib-1.13.1.tar.gz"
+  sha256 "c8da2b10f1bfec2cd7dbfcd33f4a2338db0765d851a50583d410bacf055cfd0b"
+  license any_of: ["LGPL-2.1-only", "MPL-1.1"]
+
+  keg_only :versioned_formula
+
+  depends_on "cmake" => :build
+
+  uses_from_macos "zlib"
+
+  def install
+    args = ["-DWITH_MP4=ON", "-DWITH_ASF=ON", "-DBUILD_SHARED_LIBS=ON"]
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/taglib-config --version")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Easy-tag is incompatible with new versions of taglib and it didn't receive any updates in almost 9 years
related to #210191