### PR TITLE
libidl: fix homepage

### DIFF
--- a/Formula/lib/libidl.rb
+++ b/Formula/lib/libidl.rb
@@ -1,6 +1,6 @@
 class Libidl < Formula
   desc "Library for creating CORBA IDL files"
-  homepage "https://ftp.acc.umu.se/pub/gnome/sources/libIDL/0.8/"
+  homepage "https://download.gnome.org/sources/libIDL/0.8/"
   url "https://download.gnome.org/sources/libIDL/0.8/libIDL-0.8.14.tar.bz2"
   sha256 "c5d24d8c096546353fbc7cedf208392d5a02afe9d56ebcc1cccb258d7c4d2220"
   license "LGPL-2.0-or-later"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The homepage is unreachable and has been for a few days now. This links to the same site of the download link. If you check the internet archive for the old link, you'll see that there wasn't any more content than this new URL.