### PR TITLE
trino: add workarounds, restore test, replace pre-builts

### DIFF
--- a/Formula/t/trino.rb
+++ b/Formula/t/trino.rb
@@ -13,12 +13,13 @@ class Trino < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "bf70f9698c1dac9c120467670cffc7ad149706b54edda218814393bf387c4254"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "bf70f9698c1dac9c120467670cffc7ad149706b54edda218814393bf387c4254"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "bf70f9698c1dac9c120467670cffc7ad149706b54edda218814393bf387c4254"
-    sha256 cellar: :any_skip_relocation, sonoma:        "9f8bb27342cf756944cdc66656c5f4182cab93793e8860f010eee1a66cabf5c3"
-    sha256 cellar: :any_skip_relocation, ventura:       "9f8bb27342cf756944cdc66656c5f4182cab93793e8860f010eee1a66cabf5c3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b84832d1333092cb734e687856c8ffcdf0e1f86f7b2077e64c2600501ac097dc"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "96c60c8ff89e7861b914097fbd2f826d688b8487ebdf48194a0a7d2f2d314cd8"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "96c60c8ff89e7861b914097fbd2f826d688b8487ebdf48194a0a7d2f2d314cd8"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "96c60c8ff89e7861b914097fbd2f826d688b8487ebdf48194a0a7d2f2d314cd8"
+    sha256 cellar: :any_skip_relocation, sonoma:        "fcae76bf95503a48c172a19a293bcb507d1167e984c09c26301fff4543279e6b"
+    sha256 cellar: :any_skip_relocation, ventura:       "fcae76bf95503a48c172a19a293bcb507d1167e984c09c26301fff4543279e6b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b94a1d2777883a6e33f705c247d8a4126bf6e6209b549667245ddb571a9e031e"
   end
 
   depends_on "go" => :build

--- a/Formula/t/trino.rb
+++ b/Formula/t/trino.rb
@@ -3,7 +3,7 @@ class Trino < Formula
 
   desc "Distributed SQL query engine for big data"
   homepage "https://trino.io"
-  url "https://search.maven.org/remotecontent?filepath=io/trino/trino-server/472/trino-server-472.tar.gz", using: :nounzip
+  url "https://search.maven.org/remotecontent?filepath=io/trino/trino-server/472/trino-server-472.tar.gz"
   sha256 "9fba8cbc593f07e0fcb8fe55d44956e99412b7817106c979b306c28313cc6ded"
   license "Apache-2.0"
 
@@ -21,13 +21,11 @@ class Trino < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "b84832d1333092cb734e687856c8ffcdf0e1f86f7b2077e64c2600501ac097dc"
   end
 
-  depends_on "gnu-tar" => :build
+  depends_on "go" => :build
   depends_on "openjdk"
 
-  uses_from_macos "python"
-
   resource "trino-src" do
-    url "https://github.com/trinodb/trino/archive/refs/tags/472.tar.gz", using: :nounzip
+    url "https://github.com/trinodb/trino/archive/refs/tags/472.tar.gz"
     sha256 "3bb5a4ae8f9a797110f49ae728bee6266cd2194561b11326a1901e91ebbc7ae4"
 
     livecheck do
@@ -44,44 +42,63 @@ class Trino < Formula
     end
   end
 
+  # Update by finding airbase version at https://github.com/trinodb/trino/blob/#{version}/pom.xml#L8 and then
+  # get dep.launcher.version at https://github.com/airlift/airbase/blob/<airbase-version>/airbase/pom.xml#L225
+  resource "launcher" do
+    url "https://github.com/airlift/launcher/archive/refs/tags/303.tar.gz"
+    sha256 "14e6ecbcbee3f0d24b9de1f7be6f3a220153ea17d3fc88d05bbb12292b3dd52c"
+  end
+
+  resource "procname" do
+    on_linux do
+      url "https://github.com/airlift/procname/archive/c75422ec5950861852570a90df56551991399d8c.tar.gz"
+      sha256 "95b04f7525f041c1fa651af01dced18c4e9fb68684fb21a298684e56eee53f48"
+    end
+  end
+
   def install
     odie "trino-src resource needs to be updated" if version != resource("trino-src").version
     odie "trino-cli resource needs to be updated" if version != resource("trino-cli").version
 
-    # Manually extract tarball to avoid losing hardlinks which increases bottle
-    # size from MBs to GBs. Remove once Homebrew is able to preserve hardlinks.
-    # Ref: https://github.com/Homebrew/brew/pull/13154
-    libexec.mkpath
-    system "tar", "-C", libexec.to_s, "--strip-components", "1", "-xzf", "trino-server-#{version}.tar.gz"
+    # Workaround for https://github.com/airlift/launcher/issues/8
+    inreplace "bin/launcher", 'case "$(arch)" in', 'case "$(uname -m)" in' if OS.mac? && Hardware::CPU.intel?
 
-    # Manually untar, since macOS-bundled tar produces the error:
-    #   trino-363/plugin/trino-hive/src/test/resources/<truncated>.snappy.orc.crc: Failed to restore metadata
-    # Remove when https://github.com/trinodb/trino/issues/8877 is fixed
-    resource("trino-src").stage do |r|
-      ENV.prepend_path "PATH", Formula["gnu-tar"].opt_libexec/"gnubin"
-      system "tar", "-xzf", "trino-#{r.version}.tar.gz"
-      (libexec/"etc").install Dir["trino-#{r.version}/core/docker/default/etc/*"]
+    # Replace pre-build binaries
+    rm_r(Dir["bin/{darwin,linux}-*"])
+    arch = Hardware::CPU.intel? ? "amd64" : Hardware::CPU.arch.to_s
+    platform_dir = buildpath/"bin/#{OS.kernel_name.downcase}-#{arch}"
+    resource("launcher").stage do |r|
+      ldflags = "-s -w -X launcher/args.Version=#{r.version}"
+      system "go", "build", "-C", "src/main/go", *std_go_args(ldflags:, output: platform_dir/"launcher")
+    end
+    if OS.linux?
+      resource("procname").stage do
+        system "make"
+        platform_dir.install "libprocname.so"
+      end
+    end
+
+    libexec.install Dir["*"]
+    libexec.install resource("trino-cli")
+    bin.write_jar_script libexec/"trino-cli-#{version}-executable.jar", "trino"
+    (bin/"trino-server").write_env_script libexec/"bin/launcher", Language::Java.overridable_java_home_env
+
+    resource("trino-src").stage do
+      (libexec/"etc").install Dir["core/docker/default/etc/*"]
       inreplace libexec/"etc/node.properties", "docker", tap.user.downcase
       inreplace libexec/"etc/node.properties", "/data/trino", var/"trino/data"
       inreplace libexec/"etc/jvm.config", %r{^-agentpath:/usr/lib/trino/bin/libjvmkill.so$\n}, ""
     end
 
-    rewrite_shebang detected_python_shebang(use_python_from_path: true), libexec/"bin/launcher.py"
-    (bin/"trino-server").write_env_script libexec/"bin/launcher", Language::Java.overridable_java_home_env
-
-    resource("trino-cli").stage do
-      libexec.install "trino-cli-#{version}-executable.jar"
-      bin.write_jar_script libexec/"trino-cli-#{version}-executable.jar", "trino"
-    end
-
-    # Remove incompatible pre-built binaries
-    launcher_dirs = libexec.glob("bin/{darwin,linux}-*")
-    # Keep the linux-amd64 directory to make bottles identical
-    launcher_dirs.reject! { |dir| dir.basename.to_s == "linux-amd64" } if build.bottle?
-    launcher_dirs.reject! do |dir|
-      dir.basename.to_s == "#{OS.kernel_name.downcase}-#{Hardware::CPU.intel? ? "amd64" : "arm64"}"
-    end
-    rm_r launcher_dirs
+    # Work around OpenJDK / Apple (FB12076992) issue causing crashes with brew-built OpenJDK.
+    # TODO: May want to look into privileges/signing as this doesn't happen on casks like Temurin & Zulu
+    #
+    # Ref: https://github.com/trinodb/trino/issues/18983#issuecomment-1794206475
+    # Ref: https://bugs.openjdk.org/browse/CODETOOLS-7903447
+    (libexec/"etc/jvm.config").append_lines <<~CONFIG if OS.mac?
+      # https://bugs.openjdk.org/browse/CODETOOLS-7903447
+      -Djol.skipHotspotSAAttach=true
+    CONFIG
   end
 
   def post_install
@@ -95,10 +112,26 @@ class Trino < Formula
 
   test do
     assert_match version.to_s, shell_output("#{bin}/trino --version")
-    # A more complete test existed before but we removed it because it crashes macOS
-    # https://github.com/Homebrew/homebrew-core/pull/153348
-    # You can add it back when the following issue is fixed:
-    # https://github.com/trinodb/trino/issues/18983#issuecomment-1794206475
-    # https://bugs.openjdk.org/browse/CODETOOLS-7903448
+
+    ENV["CATALOG_MANAGEMENT"] = "static"
+    port = free_port
+    cp libexec/"etc/config.properties", testpath/"config.properties"
+    inreplace testpath/"config.properties", "8080", port.to_s
+    server = spawn bin/"trino-server", "run", "--verbose",
+                                              "--data-dir", testpath,
+                                              "--config", testpath/"config.properties"
+    sleep 30
+    sleep 30 if OS.mac? && Hardware::CPU.intel?
+
+    query = "SELECT state FROM system.runtime.nodes"
+    output = shell_output("#{bin}/trino --debug --server localhost:#{port} --execute '#{query}'")
+    assert_match '"active"', output
+  ensure
+    Process.kill("TERM", server)
+    begin
+      Process.wait(server)
+    rescue Errno::ECHILD
+      quiet_system "pkill", "-9", "-P", server.to_s
+    end
   end
 end


### PR DESCRIPTION
Need new bottle for updated jvm.config

This is the workaround mentioned on https://bugs.openjdk.org/browse/CODETOOLS-7903447
> The JOL-specific workaround would be "-Djol.skipHotspotSAAttach=true".

Only applied on macOS as we don't have `:all` bottle.

It may be worth looking into how Temurin, Zulu, Amazon, etc. create their releases as it looks like their JDK works. Above issue mentions possibility of privileges/signing (so maybe adhoc signatures aren't enough).

Resulting jvm.config looks like:
```
-server
-XX:InitialRAMPercentage=80
-XX:MaxRAMPercentage=80
-XX:G1HeapRegionSize=32M
-XX:+ExplicitGCInvokesConcurrent
-XX:+HeapDumpOnOutOfMemoryError
-XX:+ExitOnOutOfMemoryError
-XX:-OmitStackTraceInFastThrow
-XX:ReservedCodeCacheSize=256M
-XX:PerMethodRecompilationCutoff=10000
-XX:PerBytecodeRecompilationCutoff=10000
-Djdk.attach.allowAttachSelf=true
-Djdk.nio.maxCachedBufferSize=2000000
-Dfile.encoding=UTF-8
# Allow loading dynamic agent used by JOL
-XX:+EnableDynamicAgentLoading
# https://bugs.openjdk.org/browse/JDK-8327134
-Djava.security.manager=allow
# https://bugs.openjdk.org/browse/CODETOOLS-7903447
-Djol.skipHotspotSAAttach=true
```

