### PR TITLE
prestodb: migrate to `openjdk@17`

### DIFF
--- a/Formula/p/prestodb.rb
+++ b/Formula/p/prestodb.rb
@@ -19,7 +19,7 @@ class Prestodb < Formula
     sha256 cellar: :any_skip_relocation, all: "17327469b90b34fed7a4ec15f9de93dade68120221296b8962f53db98f0f66b4"
   end
 
-  depends_on "openjdk@11"
+  depends_on "openjdk@17"
   depends_on "python@3.13"
 
   resource "presto-cli" do
@@ -32,6 +32,7 @@ class Prestodb < Formula
   end
 
   def install
+    java_version = "17"
     odie "presto-cli resource needs to be updated" if version != resource("presto-cli").version
 
     # Manually extract tarball to avoid multiple copies/moves of over 2GB of files
@@ -71,13 +72,12 @@ class Prestodb < Formula
     (libexec/"etc/catalog/jmx.properties").write "connector.name=jmx"
 
     rewrite_shebang detected_python_shebang, libexec/"bin/launcher.py"
-    env = Language::Java.overridable_java_home_env("11")
-    env["PATH"] = "$JAVA_HOME/bin:$PATH"
+    env = Language::Java.overridable_java_home_env(java_version)
     (bin/"presto-server").write_env_script libexec/"bin/launcher", env
 
     resource("presto-cli").stage do
       libexec.install "presto-cli-#{version}-executable.jar"
-      bin.write_jar_script libexec/"presto-cli-#{version}-executable.jar", "presto", java_version: "11"
+      bin.write_jar_script(libexec/"presto-cli-#{version}-executable.jar", "presto", java_version:)
     end
 
     # Remove incompatible pre-built binaries

--- a/Formula/p/prestodb.rb
+++ b/Formula/p/prestodb.rb
@@ -16,7 +16,8 @@ class Prestodb < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "17327469b90b34fed7a4ec15f9de93dade68120221296b8962f53db98f0f66b4"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "1bc6a7c18c6d8b8cfa26f0b235c7d0b6e9706fe3d7a3feed66cede28b878bb39"
   end
 
   depends_on "openjdk@17"


### PR DESCRIPTION
Also remove PATH prepending as upstream now checks `JAVA_HOME`: https://github.com/prestodb/airlift/commit/a5f238a6ba3426264fad89422fabaf5ef3ae0f7d