### PR TITLE
alloy 6.2.0 (new formula)

### DIFF
--- a/Formula/a/alloy.rb
+++ b/Formula/a/alloy.rb
@@ -1,0 +1,26 @@
+class Alloy < Formula
+  desc "Open-source language and analyzer for software modeling"
+  homepage "https://alloytools.org"
+  url "https://search.maven.org/remotecontent?filepath=org/alloytools/org.alloytools.alloy.dist/6.2.0/org.alloytools.alloy.dist-6.2.0.jar"
+  sha256 "6037cbeee0e8423c1c468447ed10f5fcf2f2743a2ffc39cb1c81f2905c0fdb9d"
+  license "Apache-2.0"
+
+  livecheck do
+    url "https://search.maven.org/remotecontent?filepath=org/alloytools/org.alloytools.alloy.dist/maven-metadata.xml"
+    regex(%r{<version>(\d+(?:\.\d+)+)</version>}i)
+  end
+
+  depends_on "openjdk"
+
+  def install
+    libexec.install "org.alloytools.alloy.dist-#{version}.jar"
+    bin.write_jar_script libexec/"org.alloytools.alloy.dist-#{version}.jar", "alloy"
+  end
+
+  test do
+    output = shell_output("#{bin}/alloy version 2>&1")
+    filtered_output = output.lines.reject { |line| line.start_with?("Picked up") }.join
+    ohai "Expected version: #{version}"
+    assert_match version.to_s, filtered_output
+  end
+end


### PR DESCRIPTION
This is the initial submission of the Alloy formal specification tool. The formula uses openjdk to run the Alloy java archive. Alloy is a tool to create relational and temporal specifications that can be used to find examples or proof there are no counter examples.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
