### PR TITLE
cp2k: use fails_with cause DSL

### DIFF
--- a/Formula/c/cp2k.rb
+++ b/Formula/c/cp2k.rb
@@ -31,7 +31,9 @@ class Cp2k < Formula
   depends_on "openblas"
   depends_on "scalapack"
 
-  fails_with :clang # needs OpenMP support
+  fails_with :clang do
+    cause "needs OpenMP support for C/C++ and Fortran"
+  end
 
   resource "libint" do
     url "https://github.com/cp2k/libint-cp2k/releases/download/v2.6.0/libint-v2.6.0-cp2k-lmax-5.tgz"


### PR DESCRIPTION
Use the DSL style for fails_with (which we could display in the future).

Also mention OpenMP for Fortran is required - https://github.com/cp2k/cp2k/blob/v2025.1/CMakeLists.txt#L606
```cmake
find_package(OpenMP REQUIRED COMPONENTS Fortran C CXX)
```