### PR TITLE
asdf: disable cgo for linux to improve portability

### DIFF
--- a/Formula/a/asdf.rb
+++ b/Formula/a/asdf.rb
@@ -23,6 +23,10 @@ class Asdf < Formula
   depends_on "go" => :build
 
   def install
+    # fix https://github.com/asdf-vm/asdf/issues/1992
+    # relates to https://github.com/Homebrew/homebrew-core/issues/163826
+    ENV["CGO_ENABLED"] = OS.mac? ? "1" : "0"
+
     system "go", "build", *std_go_args(ldflags: "-s -w -X main.version=#{version}"), "./cmd/asdf"
     generate_completions_from_executable(bin/"asdf", "completion")
     libexec.install Dir["asdf.*"]

--- a/Formula/a/asdf.rb
+++ b/Formula/a/asdf.rb
@@ -12,12 +12,13 @@ class Asdf < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "afceac20abb167cd85d4da04e1c89acdd06098f2aa4373deb640729bf7c0012f"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "afceac20abb167cd85d4da04e1c89acdd06098f2aa4373deb640729bf7c0012f"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "afceac20abb167cd85d4da04e1c89acdd06098f2aa4373deb640729bf7c0012f"
-    sha256 cellar: :any_skip_relocation, sonoma:        "27e44c008fffe03e266a992090543f73f66d189b68579a6e6e1048c969a3e89e"
-    sha256 cellar: :any_skip_relocation, ventura:       "27e44c008fffe03e266a992090543f73f66d189b68579a6e6e1048c969a3e89e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1b804f7d106519efff0a355dcf4c62b8edea0997abef667a1c9b4d5462fd9000"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "90346d0b6c2cb065be3deee9dc0b0e4c903984a9f047ba7c481020efbe9f368a"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "90346d0b6c2cb065be3deee9dc0b0e4c903984a9f047ba7c481020efbe9f368a"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "90346d0b6c2cb065be3deee9dc0b0e4c903984a9f047ba7c481020efbe9f368a"
+    sha256 cellar: :any_skip_relocation, sonoma:        "29933f1ae2ea276c92d7a22df8aa27ce74863d9889e76b361d5eff9424861997"
+    sha256 cellar: :any_skip_relocation, ventura:       "29933f1ae2ea276c92d7a22df8aa27ce74863d9889e76b361d5eff9424861997"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1e4548068a801b520156702ed76fb907b80e9f0518151a89b9b724b62cfdfda2"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Improves portability for linux builds in particular.

Fixes: https://github.com/asdf-vm/asdf/issues/1992