### PR TITLE
lfortran 0.48.0 (new formula)

### DIFF
--- a/Formula/l/lfortran.rb
+++ b/Formula/l/lfortran.rb
@@ -1,0 +1,33 @@
+class Lfortran < Formula
+  desc "Interactive Fortran compiler"
+  homepage "https://lfortran.org/"
+  url "https://github.com/lfortran/lfortran/releases/download/v0.48.0/lfortran-0.48.0.tar.gz"
+  sha256 "13569cd83a00ec03473f5425c31e9420f185bbc717d70919b14e7f3a7fb52bba"
+  license all_of: [
+    "BSD-3-Clause",
+    "MIT",
+    "NCSA",
+    "Apache-2.0" => { with: "LLVM-exception" },
+    any_of: ["MIT", "WTFPL"],
+  ]
+
+  depends_on "cmake" => :build
+  depends_on "llvm@18"
+  depends_on "zstd"
+
+  def install
+    system "cmake", "-S", ".", "-B", "build",
+                    "-DWITH_LLVM=ON",
+                    "-DWITH_RUNTIME_LIBRARY=OFF",
+                    "-DWITH_ZLIB=OFF",
+                    *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+    pkgshare.install "examples"
+  end
+
+  test do
+    cp pkgshare/"examples/expr2.f90", testpath
+    system bin/"lfortran", testpath/"expr2.f90"
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Notes

- Building with zlib on Mac requires [static zlib](https://github.com/lfortran/lfortran/blob/v0.48.0/cmake/FindStaticZLIB.cmake), which is available with `depends_on "zlib"`, but this causes the audit to fail, so using `-DWITH_ZLIB=OFF` for now