### PR TITLE
redwax-tool: Add missing deps nss/p11-kit/libical/ldns/unbound

### DIFF
--- a/Formula/r/redwax-tool.rb
+++ b/Formula/r/redwax-tool.rb
@@ -11,12 +11,13 @@ class RedwaxTool < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "f4bfdaf79e00c2210bfe58d5e1d8ed8ed6c8030f27f45e6489915f2d58f00e64"
-    sha256 cellar: :any,                 arm64_sonoma:  "cdec549c64d66941f7dc430f8e07a250be8618d8c148c820bf9b9fdadd89bca5"
-    sha256 cellar: :any,                 arm64_ventura: "fc00c0e3e33b710cc410aae1346ad44f62a970da7c28857353660ecca83300af"
-    sha256 cellar: :any,                 sonoma:        "f98470864037231a2c0233be3207e3f42fe425c4f2107a8ae49b0a0d47315a04"
-    sha256 cellar: :any,                 ventura:       "e14ff284ee29c52c18f0c3d7a5bc5c770d05f9a3c442e61bf814cb4874c8aabd"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "fa1966c450f5a57151f5c0f050f0e7628d48985a2d2e1acb3cf0e819e54d2fc3"
+    rebuild 1
+    sha256 arm64_sequoia: "34eff8a283e59a1c44b65e59c11bfb6626e54e848b441441a5ab7bc16bbc1402"
+    sha256 arm64_sonoma:  "2ea52c78dc303b33b192473aaf3b3f2766acd168d2002ac5173030c0e4109838"
+    sha256 arm64_ventura: "6c1582c3ddf1c69440b407e9108080dedd6f290ed7ed7e1a0ad00c4b20e04262"
+    sha256 sonoma:        "a6ee226d0dd5d1344a5406c2d47f3a818586d1d30ead84b86648403b2a3acf81"
+    sha256 ventura:       "07b54891be06b8e8347481b0ac8c6667f895f8fde8a64ad042af1b75c89aede8"
+    sha256 x86_64_linux:  "04dfeac846d6e6714d15df10879fd6f76950a54cc52a69e952c556bd4f3230b3"
   end
 
   depends_on "pkgconf" => :build


### PR DESCRIPTION
Add dependencies on nss, p11-kit, libical, ldns, unbound. Enable keychain.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
