### PR TITLE
gnome-online-accounts libgoa 3.52.3.1 (new formula), keyutils 1.6.3 (new formula)

### DIFF
--- a/Formula/g/gnome-online-accounts.rb
+++ b/Formula/g/gnome-online-accounts.rb
@@ -6,6 +6,15 @@ class GnomeOnlineAccounts < Formula
   license "LGPL-2.0-or-later"
   head "https://gitlab.gnome.org/GNOME/gnome-online-accounts.git", branch: "master"
 
+  bottle do
+    sha256 arm64_sequoia: "3f255232ee5f8a201aef353309206f49c669b0aa317628f238a47876c7bd828c"
+    sha256 arm64_sonoma:  "fc2ba3422a641df17ce52b7853cf4a6d0c3936b47a932ae468a9b09fd511367e"
+    sha256 arm64_ventura: "d607be2571d60c9f1de21c1da9018e697ddfb9c2b2c124be6de3cc5c67628927"
+    sha256 sonoma:        "44a14c5ac71d8de101d4ce97fe355ee388035aa47d6cff4e35ce95e89e5302d0"
+    sha256 ventura:       "563e6665d4d778eacec2fc479533cca72fe49015a08c1ab1969debb9e7599b72"
+    sha256 x86_64_linux:  "56d71c5f46fecb992afc135e3f6734e6af7dc586d9e038f9921e31df7aa7a915"
+  end
+
   depends_on "dbus" => :build
   depends_on "docbook-xsl" => :build
   depends_on "gobject-introspection" => :build

--- a/Formula/g/gnome-online-accounts.rb
+++ b/Formula/g/gnome-online-accounts.rb
@@ -1,0 +1,122 @@
+class GnomeOnlineAccounts < Formula
+  desc "Single sign-on framework for GNOME"
+  homepage "https://gitlab.gnome.org/GNOME/gnome-online-accounts"
+  url "https://download.gnome.org/sources/gnome-online-accounts/3.52/gnome-online-accounts-3.52.3.1.tar.xz"
+  sha256 "49ed727d6fc49474996fa7edf0919b21e4fc856ea37e6e30f17b50b103af9701"
+  license "LGPL-2.0-or-later"
+  head "https://gitlab.gnome.org/GNOME/gnome-online-accounts.git", branch: "master"
+
+  depends_on "dbus" => :build
+  depends_on "docbook-xsl" => :build
+  depends_on "gobject-introspection" => :build
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+  depends_on "pkgconf" => [:build, :test]
+  depends_on "vala" => :build
+
+  depends_on "glib"
+  depends_on "gtk4"
+  depends_on "json-glib"
+  depends_on "libadwaita"
+  depends_on "libgoa"
+  depends_on "librest"
+  depends_on "libsecret"
+  depends_on "libsoup"
+
+  uses_from_macos "libxslt" => :build # for xsltproc
+  uses_from_macos "libxml2"
+
+  on_macos do
+    depends_on "gettext"
+  end
+
+  on_linux do
+    depends_on "gcr"
+    depends_on "keyutils"
+    depends_on "krb5"
+  end
+
+  def install
+    # NOTE: `libgoa` is split out to provide a lightweight formula with minimal dependencies
+    inreplace "src/meson.build", /^subdir\('goa'\)$/, "libgoa_dep = dependency(goa_api_name)"
+    rm_r("src/goa")
+
+    ENV["DESTDIR"] = "/"
+    ENV["XML_CATALOG_FILES"] = etc/"xml/catalog"
+
+    args = ["-Ddocumentation=false"]
+    args << "-Dkerberos=false" if OS.mac?
+
+    system "meson", "setup", "build", *args, *std_meson_args
+    system "meson", "compile", "-C", "build", "--verbose"
+    system "meson", "install", "-C", "build"
+  end
+
+  def post_install
+    system Formula["glib"].opt_bin/"glib-compile-schemas", HOMEBREW_PREFIX/"share/glib-2.0/schemas"
+    system Formula["gtk4"].opt_bin/"gtk4-update-icon-cache", "-f", "-t", HOMEBREW_PREFIX/"share/icons/hicolor"
+  end
+
+  test do
+    # https://gitlab.gnome.org/GNOME/gnome-online-accounts/-/blob/master/src/examples/list-providers.c
+    (testpath/"test.c").write <<~'C'
+      #define GOA_API_IS_SUBJECT_TO_CHANGE
+      #define GOA_BACKEND_API_IS_SUBJECT_TO_CHANGE
+      #include <goabackend/goabackend.h>
+
+      typedef struct {
+        GMainLoop *loop;
+        GList *providers;
+        GError *error;
+      } GetAllData;
+
+      static void get_all_cb (GObject *source, GAsyncResult *res, gpointer user_data) {
+        GetAllData *data = user_data;
+        goa_provider_get_all_finish (&data->providers, res, &data->error);
+        g_main_loop_quit (data->loop);
+      }
+
+      int main (int argc, char **argv) {
+        GetAllData data = {0,};
+        GoaProvider *provider;
+        GList *l;
+
+        data.loop = g_main_loop_new (NULL, FALSE);
+        goa_provider_get_all (get_all_cb, &data);
+        g_main_loop_run (data.loop);
+
+        if (data.error != NULL) {
+          g_printerr ("Failed to list providers: %s (%s, %d)\n",
+              data.error->message,
+              g_quark_to_string (data.error->domain),
+              data.error->code);
+          g_error_free (data.error);
+          goto out;
+        }
+
+        for (l = data.providers; l != NULL; l = l->next) {
+          char *provider_name;
+
+          provider = GOA_PROVIDER (l->data);
+          provider_name = goa_provider_get_provider_name (provider, NULL);
+          g_print ("%s\n", provider_name);
+          g_free (provider_name);
+          provider = NULL;
+        }
+
+      out:
+        g_main_loop_unref (data.loop);
+        g_list_free_full (data.providers, g_object_unref);
+
+        return 0;
+      }
+    C
+
+    providers = ["Google", "WebDAV", "Nextcloud", "Microsoft", "Microsoft Exchange", "IMAP and SMTP"]
+    providers << "Kerberos" unless OS.mac?
+    providers << "Microsoft 365"
+
+    system ENV.cc, "test.c", "-o", "test", *shell_output("pkgconf --cflags --libs goa-backend-1.0").chomp.split
+    assert_equal providers, shell_output("./test").lines(chomp: true)
+  end
+end

--- a/Formula/g/gnome-recipes.rb
+++ b/Formula/g/gnome-recipes.rb
@@ -28,19 +28,15 @@ class GnomeRecipes < Formula
   depends_on "gnome-autoar"
   depends_on "gspell"
   depends_on "gtk+3"
-  depends_on "json-glib" # for goa
+  depends_on "json-glib"
   depends_on "libcanberra"
-  depends_on "librest" # for goa
+  depends_on "libgoa"
+  depends_on "librest"
   depends_on "libsoup"
   depends_on "pango"
 
   on_macos do
     depends_on "gettext"
-  end
-
-  resource "goa" do
-    url "https://download.gnome.org/sources/gnome-online-accounts/3.52/gnome-online-accounts-3.52.3.1.tar.xz"
-    sha256 "49ed727d6fc49474996fa7edf0919b21e4fc856ea37e6e30f17b50b103af9701"
   end
 
   # Apply Debian patch to support newer libsoup and librest
@@ -53,25 +49,6 @@ class GnomeRecipes < Formula
   def install
     # stop meson_post_install.py from doing what needs to be done in the post_install step
     ENV["DESTDIR"] = "/"
-
-    resource("goa").stage do
-      system "meson", "setup", "build", "-Dgoabackend=false",
-                                        "-Ddocumentation=false",
-                                        "-Dintrospection=false",
-                                        "-Dman=false",
-                                        "-Dvapi=false",
-                                        *std_meson_args.map { |s| s.sub prefix, libexec }
-      system "meson", "compile", "-C", "build", "--verbose"
-      system "meson", "install", "-C", "build"
-    end
-
-    ENV.prepend_path "PKG_CONFIG_PATH", libexec/"lib/pkgconfig"
-
-    # Add RPATH to libexec in goa-1.0.pc on Linux.
-    unless OS.mac?
-      inreplace libexec/"lib/pkgconfig/goa-1.0.pc", "-L${libdir}",
-                "-Wl,-rpath,${libdir} -L${libdir}"
-    end
 
     # BSD tar does not support the required options
     inreplace "src/gr-recipe-store.c", "argv[0] = \"tar\";", "argv[0] = \"gtar\";" if OS.mac?

--- a/Formula/g/gnome-recipes.rb
+++ b/Formula/g/gnome-recipes.rb
@@ -7,12 +7,13 @@ class GnomeRecipes < Formula
   revision 3
 
   bottle do
-    sha256 arm64_sequoia: "e6384179a8520296a354b16a713f771ce12005fae15e20b04cad20d70ab78249"
-    sha256 arm64_sonoma:  "26db0d944ceb54fe93dae2eda5d59e8e6d1e42b379d6ace92bc4c8d91c103423"
-    sha256 arm64_ventura: "8d4546ce3489e1abd91c8b8e041e9d45abd62e9544406c2a0d8db793ab4ff845"
-    sha256 sonoma:        "91887470bc686dd30fd50ffda8d7b77fb1c641ce2b82332355c17cd08e363655"
-    sha256 ventura:       "5f5da99ec97f1dc810806d10dab0e7ca7f1efd274acb24964f434908012e3912"
-    sha256 x86_64_linux:  "24c8b3034d9679e5efe8db3197a10de7e3a810d91f5fcc1557d9a2aed3f4a684"
+    rebuild 1
+    sha256 arm64_sequoia: "3bdeeed9601b21231a0681c228ad2c69aeec741c8a03e254927a6563691b8ec3"
+    sha256 arm64_sonoma:  "6747e4b6466b029d7752f666b49efd402420d1f849ba297d1826ead4c3afd357"
+    sha256 arm64_ventura: "f6034dd729fdcb7445b1e41d873d4bf19fad4e8ecd756bef137981ae3337e15c"
+    sha256 sonoma:        "2adb5d5d5318f31ec63b8b76e3d220a2762dcb7ee47e66e64f97099ec10509a0"
+    sha256 ventura:       "80caac371964f0b21498fdc59ffd60b82896b2e8bbb640acb049ec200fd01c39"
+    sha256 x86_64_linux:  "a1dae0cbe0ba46499542cd211ce00a349115b3493b918585813d648509300274"
   end
 
   depends_on "gettext" => :build

--- a/Formula/k/keyutils.rb
+++ b/Formula/k/keyutils.rb
@@ -5,6 +5,10 @@ class Keyutils < Formula
   sha256 "a61d5706136ae4c05bd48f86186bcfdbd88dd8bd5107e3e195c924cfc1b39bb4"
   license all_of: ["GPL-2.0-or-later", "LGPL-2.0-or-later"]
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "d5b06c4e38d2c4b7decb5b7bc0431b3416993231e5fa688950e4df83686a298d"
+  end
+
   depends_on :linux
 
   def install

--- a/Formula/k/keyutils.rb
+++ b/Formula/k/keyutils.rb
@@ -1,0 +1,44 @@
+class Keyutils < Formula
+  desc "Linux key management utilities"
+  homepage "https://git.kernel.org/pub/scm/linux/kernel/git/dhowells/keyutils.git"
+  url "https://git.kernel.org/pub/scm/linux/kernel/git/dhowells/keyutils.git/snapshot/keyutils-1.6.3.tar.gz"
+  sha256 "a61d5706136ae4c05bd48f86186bcfdbd88dd8bd5107e3e195c924cfc1b39bb4"
+  license all_of: ["GPL-2.0-or-later", "LGPL-2.0-or-later"]
+
+  depends_on :linux
+
+  def install
+    inreplace "request-key.conf" do |s|
+      s.gsub! %r{(\s)/bin/key}, "\\1#{opt_bin}/key"
+      s.gsub! %r{(\s)/sbin/key}, "\\1#{opt_sbin}/key"
+      s.gsub! %r{(\s)/usr/share/#{name}/}, "\\1#{opt_pkgshare}/"
+    end
+
+    args = %W[
+      BINDIR=#{bin}
+      ETCDIR=#{etc}
+      INCLUDEDIR=#{include}
+      LIBDIR=#{lib}
+      MANDIR=#{man}
+      SBINDIR=#{sbin}
+      SHAREDIR=#{pkgshare}
+      USRLIBDIR=#{lib}
+    ]
+    system "make", "install", *args
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/keyctl --version")
+    system bin/"keyctl", "supports"
+
+    # CI container doesn't have permissions to modify keys/keyrings
+    return if ENV["HOMEBREW_GITHUB_ACTIONS"]
+
+    (testpath/"test.sh").write <<~SHELL
+      keyring=$(#{bin}/keyctl new_session)
+      key=$(#{bin}/keyctl add user home brew "$keyring")
+      #{bin}/keyctl print "$key"
+    SHELL
+    assert_equal "brew\n", shell_output("bash -e test.sh")
+  end
+end

--- a/Formula/lib/libgoa.rb
+++ b/Formula/lib/libgoa.rb
@@ -1,0 +1,94 @@
+class Libgoa < Formula
+  desc "Single sign-on framework for GNOME - client library"
+  homepage "https://gitlab.gnome.org/GNOME/gnome-online-accounts"
+  url "https://download.gnome.org/sources/gnome-online-accounts/3.52/gnome-online-accounts-3.52.3.1.tar.xz"
+  sha256 "49ed727d6fc49474996fa7edf0919b21e4fc856ea37e6e30f17b50b103af9701"
+  license "LGPL-2.0-or-later"
+  head "https://gitlab.gnome.org/GNOME/gnome-online-accounts.git", branch: "master"
+
+  livecheck do
+    formula "gnome-online-accounts"
+  end
+
+  depends_on "dbus" => [:build, :test]
+  depends_on "gobject-introspection" => :build
+  depends_on "gtk4" => :build # gtk4-update-icon-cache
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+  depends_on "pkgconf" => [:build, :test]
+  depends_on "vala" => :build
+
+  depends_on "glib"
+
+  def install
+    ENV["DESTDIR"] = "/"
+
+    system "meson", "setup", "build", "-Ddocumentation=false", "-Dgoabackend=false", *std_meson_args
+    system "meson", "compile", "-C", "build", "--verbose"
+    system "meson", "install", "-C", "build"
+
+    # Remove directories that are installed in `gnome-online-accounts`
+    rm_r([share/"icons", share/"locale"].select(&:exist?))
+  end
+
+  test do
+    # https://gitlab.gnome.org/GNOME/gnome-online-accounts/-/blob/master/src/examples/list-accounts.c
+    (testpath/"test.c").write <<~'C'
+      #define GOA_API_IS_SUBJECT_TO_CHANGE
+      #include <goa/goa.h>
+
+      int main (int argc, char **argv) {
+        GError *error = NULL;
+        GoaClient *client;
+        GList *accounts, *l;
+        GoaAccount *account;
+
+        client = goa_client_new_sync (NULL, &error);
+        if (!client) {
+          g_critical ("Could not create GoaClient: %s", error->message);
+          return 1;
+        }
+
+        accounts = goa_client_get_accounts (client);
+        for (l = accounts; l != NULL; l = l->next) {
+          GoaOAuth2Based *oauth2 = NULL;
+
+          account = goa_object_get_account (GOA_OBJECT (l->data));
+          g_print ("%s at %s (%s)\n",
+                   goa_account_get_presentation_identity (account),
+                   goa_account_get_provider_name (account),
+                   goa_account_get_provider_type (account));
+          oauth2 = goa_object_get_oauth2_based (GOA_OBJECT (l->data));
+          if (oauth2) {
+            gchar *access_token;
+            if (goa_oauth2_based_call_get_access_token_sync (oauth2,
+                                                             &access_token,
+                                                             NULL,
+                                                             NULL,
+                                                             NULL)) {
+              g_print ("\tAccessToken: %s\n", access_token);
+              g_free (access_token);
+            }
+            g_print ("\tClientId: %s\n\tClientSecret: %s\n",
+                     goa_oauth2_based_get_client_id (oauth2),
+                     goa_oauth2_based_get_client_secret (oauth2));
+          }
+          g_clear_object (&oauth2);
+        }
+
+        g_list_free_full (accounts, (GDestroyNotify) g_object_unref);
+        return 0;
+      }
+    C
+
+    ENV["XDG_DATA_DIRS"] = testpath # avoid loading system dbus services
+    ENV["DBUS_SESSION_BUS_ADDRESS"] = address = "unix:path=#{testpath}/bus"
+    pid = spawn(Formula["dbus"].bin/"dbus-daemon", "--session", "--nofork", "--address=#{address}")
+    sleep 2
+    system ENV.cc, "test.c", "-o", "test", *shell_output("pkgconf --cflags --libs goa-1.0").chomp.split
+    system "./test"
+  ensure
+    Process.kill "TERM", pid
+    Process.wait pid
+  end
+end

--- a/Formula/lib/libgoa.rb
+++ b/Formula/lib/libgoa.rb
@@ -10,6 +10,15 @@ class Libgoa < Formula
     formula "gnome-online-accounts"
   end
 
+  bottle do
+    sha256 cellar: :any, arm64_sequoia: "9dd4a824fec1934b3c2cbbcaf654a2797a54afdb36dc00ba1126093b41529fd3"
+    sha256 cellar: :any, arm64_sonoma:  "1bb59cf37d39e23c46d956bd19d6b629529f10dd9841678619fe85fa365755ce"
+    sha256 cellar: :any, arm64_ventura: "1c0bcf1fee9f98d2fe18175a41d7f19cd30dc19c766ffca09d28b77518a26ef7"
+    sha256 cellar: :any, sonoma:        "3657b52f048664a50626d49ca9e16b15f5817ada32ade77eecc9c731c3b1a331"
+    sha256 cellar: :any, ventura:       "08160332b0c6fffd20cf49c6e627e9a348c16266a143d366eb576f8ed4af80ef"
+    sha256               x86_64_linux:  "c0a81866c3903ff29073cc684e4e4fd86a281dfeffcfe8a0fab4cb5393e4d0be"
+  end
+
   depends_on "dbus" => [:build, :test]
   depends_on "gobject-introspection" => :build
   depends_on "gtk4" => :build # gtk4-update-icon-cache

--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -36,6 +36,7 @@
   ["gcc", "libgccjit"],
   ["gdb", "aarch64-elf-gdb", "arm-none-eabi-gdb", "i386-elf-gdb", "riscv64-elf-gdb", "x86_64-elf-gdb"],
   ["git", "git-credential-libsecret", "git-gui", "git-svn"],
+  ["gnome-online-accounts", "libgoa"],
   ["hdf5", "hdf5-mpi"],
   ["ilmbase", "openexr@2"],
   ["libmediainfo", "media-info"],


### PR DESCRIPTION
Adding formulae for gnome-online-accounts to use as dependency like in `gnome-recipes`.

Done as a split package to avoid excess dependencies for more commonly used files (`libgoa`). `keyutils` also added as a dependency for the SSO backend.

Both are commonly provided as seen on repology (though more popular on Linux side as one is Linux kernel related and other is built on D-Bus):
- `keyutils` - https://repology.org/project/keyutils/versions
- `gnome-online-accounts` - https://repology.org/project/gnome-online-accounts/versions