### PR TITLE
bunenv 0.2.2 (new formula)

### DIFF
--- a/Formula/b/bunenv.rb
+++ b/Formula/b/bunenv.rb
@@ -1,0 +1,18 @@
+class Bunenv < Formula
+  desc "Version manager for Bun, inspired by rbenv and pyenv"
+  homepage "https://github.com/jonathanphilippou/bunenv"
+  url "https://registry.npmjs.org/bunenv/-/bunenv-0.2.2.tgz"
+  sha256 "365e198e793de7b9f0f2a69ea404e0e3db8e239e3826ae29d64035b8f7846671"
+  license "MIT"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    system bin/"bunenv", "--version"
+  end
+end


### PR DESCRIPTION
## Description\n\nThis PR adds a formula for bunenv, a version manager for Bun JavaScript runtime inspired by rbenv and pyenv. It allows users to easily install and switch between different versions of Bun.\n\n- Project homepage: https://github.com/jonathanphilippou/bunenv\n- npm package: https://www.npmjs.com/package/bunenv\n\n## Checksums\n\nSHA256: 365e198e793de7b9f0f2a69ea404e0e3db8e239e3826ae29d64035b8f7846671