### PR TITLE
tadabor 2.6.0 (new formula)

### DIFF
--- a/Formula/t/tadabor.rb
+++ b/Formula/t/tadabor.rb
@@ -1,19 +1,22 @@
 cask "tadabor" do
     version "2.6.0"
-    sha256 "aa3de07efa30508b1c849da6aa1f3b5f589ff06f10fdc2531b412cd93a2270cc"  # For ARM version
-  
+    
+    # SHA256 for ARM and Intel versions
+    sha256 arm: "aa3de07efa30508b1c849da6aa1f3b5f589ff06f10fdc2531b412cd93a2270cc", # ARM version
+           intel: "e3a693f9b2ebc8f1ce61e76f167e1c8093f49b67a5c8721c5b1570c3a16f9c53" # Intel version
+    
+    # Define the URL based on architecture
     if Hardware::CPU.arm?
       url "https://github.com/mohammed-ashrf/MediSync_Release/releases/download/V2/Tadabor_2.6.0_aarch64.dmg"
     else
       url "https://github.com/mohammed-ashrf/MediSync_Release/releases/download/V2/Tadabor_2.6.0_x64.dmg"
-      sha256 "e3a693f9b2ebc8f1ce61e76f167e1c8093f49b67a5c8721c5b1570c3a16f9c53"  # For Intel version
     end
   
     name "Tadabor"
     homepage "https://tadabor.vercel.app"
-    desc "A comprehensive study companion designed for meaningful engagement By Mohammed Younis"
-
-    # Check if the app already exists in /Applications
+    desc "A comprehensive study companion designed for meaningful engagement by Mohammed Younis"
+  
+    # Preflight: Ensure the app is not already installed
     preflight do
       if File.exist?("/Applications/Tadabor.app")
         raise "Error: Tadabor.app is already installed in /Applications. Please uninstall it first or use --force to overwrite."
@@ -32,13 +35,13 @@ cask "tadabor" do
       end
     end
   
-    # Handle errors during the mounting of the DMG
+    # Trash files during uninstall
     zap trash: [
       "~/Library/Application Support/Tadabor",
       "~/Library/Preferences/com.Tadabor.plist"
     ]
   
-    # After app install, check if everything is set up correctly
+    # After app install, verify successful installation
     uninstall_postflight do
       unless File.exist?("#{appdir}/Tadabor.app")
         raise "Error: Tadabor.app was not found after installation. Installation might have failed."

--- a/Formula/t/tadabor.rb
+++ b/Formula/t/tadabor.rb
@@ -1,0 +1,47 @@
+cask "tadabor" do
+    version "2.6.0"
+    sha256 "aa3de07efa30508b1c849da6aa1f3b5f589ff06f10fdc2531b412cd93a2270cc"  # For ARM version
+  
+    if Hardware::CPU.arm?
+      url "https://github.com/mohammed-ashrf/MediSync_Release/releases/download/V2/Tadabor_2.6.0_aarch64.dmg"
+    else
+      url "https://github.com/mohammed-ashrf/MediSync_Release/releases/download/V2/Tadabor_2.6.0_x64.dmg"
+      sha256 "e3a693f9b2ebc8f1ce61e76f167e1c8093f49b67a5c8721c5b1570c3a16f9c53"  # For Intel version
+    end
+  
+    name "Tadabor"
+    homepage "https://tadabor.vercel.app"
+    desc "A comprehensive study companion designed for meaningful engagement By Mohammed Younis"
+
+    # Check if the app already exists in /Applications
+    preflight do
+      if File.exist?("/Applications/Tadabor.app")
+        raise "Error: Tadabor.app is already installed in /Applications. Please uninstall it first or use --force to overwrite."
+      end
+    end
+  
+    # Install the app
+    app "Tadabor.app"
+  
+    # Post-install: Remove quarantine flag and handle errors
+    postflight do
+      begin
+        system_command "/usr/bin/xattr", args: ["-d", "com.apple.quarantine", "#{appdir}/Tadabor.app"]
+      rescue StandardError => e
+        raise "Error: Failed to remove quarantine flag from Tadabor.app. Please try manually running 'xattr -d com.apple.quarantine #{appdir}/Tadabor.app'."
+      end
+    end
+  
+    # Handle errors during the mounting of the DMG
+    zap trash: [
+      "~/Library/Application Support/Tadabor",
+      "~/Library/Preferences/com.Tadabor.plist"
+    ]
+  
+    # After app install, check if everything is set up correctly
+    uninstall_postflight do
+      unless File.exist?("#{appdir}/Tadabor.app")
+        raise "Error: Tadabor.app was not found after installation. Installation might have failed."
+      end
+    end
+end  


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
### Summary:
This pull request adds the `Tadabor` app to Homebrew Cask. `Tadabor` is more than just a Quran app—it is a comprehensive study companion designed for meaningful engagement, whether you're memorizing, reflecting, or studying. The app is available for both ARM (Apple Silicon) and Intel architectures and includes an easy-to-install `.dmg` file.

### Key Features:
- Cross-platform app for Apple Silicon (ARM) and Intel-based Macs.
- Easy-to-install `.dmg` for both architectures.
- App focused on Quran study and engagement.

This PR includes the Cask formula for installing the app, as well as post-installation steps to ensure the app runs smoothly without any quarantine issues.

### Checklist:
- [x] I have followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md).
- [x] My commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit).
- [x] I have checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change.
- [x] I have built my formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source tadabor`.
- [x] The test for `tadabor` runs fine with `brew test tadabor`.
- [x] The formula passes `brew audit --strict tadabor` after building from source.