### PR TITLE
or-tools: revision bump to test Linux failure

### DIFF
--- a/Formula/o/or-tools.rb
+++ b/Formula/o/or-tools.rb
@@ -57,6 +57,16 @@ class OrTools < Formula
     pkgshare.install "ortools/linear_solver/samples/simple_lp_program.cc"
     pkgshare.install "ortools/constraint_solver/samples/simple_routing_program.cc"
     pkgshare.install "ortools/sat/samples/simple_sat_program.cc"
+
+    cd prefix do
+      system "tar", "zcf", "lib.tar.gz", "lib/"
+    end
+  end
+
+  def post_install
+    cd prefix do
+      system "tar", "zxf", "lib.tar.gz"
+    end
   end
 
   test do


### PR DESCRIPTION
Testing only. Checking on problems seen in Protobuf PR for Linux. Preventing brew's binary patching avoids issue.

Previous successful runs:
- `openvino` - Feb 6, OpenVINO 2025.0.0 PR
- `opencv` - Feb 6, OpenVINO 2025.0.0 PR
- `ola` -  Jan 8, Protobuf 29.3 PR (if no failure, may be from rebuild in large PR)
- `or-tools` - Jan 8, Protobuf 29.3 PR (if no failure, may be from 9.12)

First time I've seen an issue was on Feb 17 (e.g. #208051 and #207988)

Dependency updates don't seem related as they do not match timeframe:
* Protobuf update on Jan 8
* Abseil update on Jan 23
* CMake updates on Jan 24 and Feb 24

No new https://github.com/david942j/patchelf.rb updates.