### PR TITLE
px: Fix the build

### DIFF
--- a/Formula/p/px.rb
+++ b/Formula/p/px.rb
@@ -26,6 +26,8 @@ class Px < Formula
   conflicts_with "pixie", because: "both install `px` binaries"
 
   def install
+    system "python3", "devbin/update_version_py.py"
+
     virtualenv_install_with_resources
 
     man1.install Dir["doc/*.1"]


### PR DESCRIPTION
This change ensures that `px/version.py` is created before the build starts.

Previously, `virtualenv_install_with_resources` called `setup.py`, which called `devbin/update_version_py.py`, creating `px/version.py` and the build worked.

Nowadays however, `virtualenv_install_with_resources` seems not to be calling `setup.py`, so we need to call `devbin/update_version_py.py` manually.

The point is to fix the build for https://github.com/Homebrew/homebrew-core/pull/210943.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
