### PR TITLE
projectm-eval (new formula)

### DIFF
--- a/Formula/p/projectm-eval.rb
+++ b/Formula/p/projectm-eval.rb
@@ -16,6 +16,20 @@ class ProjectmEval < Formula
     system "cmake", "-S", ".", "-B", "build", "-DENABLE_PROJECTM_EVAL_INSTALL=ON", *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
+
+     # Create pkgconfig file
+     (lib/"pkgconfig/projectM-Eval.pc").write <<~EOS
+     prefix=#{prefix}
+     exec_prefix=${prefix}
+     libdir=${exec_prefix}/lib
+     includedir=${prefix}/include/projectm-eval
+
+     Name: projectM-Eval
+     Description: Milkdrop-compatible music visualizer preset evaluation library
+     Version: #{version}
+     Libs: -L${libdir} -lprojectM_eval
+     Cflags: -I${includedir}
+   EOS
   end
 
   test do

--- a/Formula/p/projectm-eval.rb
+++ b/Formula/p/projectm-eval.rb
@@ -1,0 +1,25 @@
+class ProjectmEval < Formula
+  desc "Milkdrop-compatible music visualizer preset evaluation library"
+  homepage "https://github.com/projectM-visualizer/projectm-eval"
+  url "https://github.com/projectM-visualizer/projectm-eval.git",
+      branch: "master",
+      revision: "ee180a2473c12856fd25dc754bafdab7e843cc7a"
+  version "HEAD-ee180a"
+  license "LGPL-2.1-or-later"
+
+  depends_on "bison" => :build
+  depends_on "flex" => :build
+  depends_on "cmake" => :build
+  depends_on "pkgconf" => [:build, :test]
+
+  def install
+    system "cmake", "-S", ".", "-B", "build", "-DENABLE_PROJECTM_EVAL_INSTALL=ON", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    assert_predicate lib/"libprojectM_eval.a", :exist?
+    system "pkg-config", "--exists", "projectM-eval"
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ x Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----


I need some help here -

```
❯ HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source --verbose --debug projectm-eval
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading projectm-eval
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading projectm-eval
/opt/homebrew/Library/Homebrew/brew.rb (Cask::CaskLoader::NullLoader): loading projectm-eval
/usr/bin/env PATH=/opt/homebrew/opt/gh/bin:/opt/homebrew/Library/Homebrew/shims/shared:/usr/bin:/bin:/usr/sbin:/sbin HOME=/Users/cyber gh auth token --hostname github.com
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading gh
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading projectm-eval
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading bison
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading flex
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading help2man
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading gettext
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading libunistring
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading perl
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading berkeley-db@5
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading gdbm
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading gettext
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading cmake
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading pkgconf
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading bison
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading libunistring
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading gettext
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading berkeley-db@5
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading gdbm
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading perl
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading help2man
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading flex
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading cmake
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading pkgconf
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading bison
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading libunistring
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading gettext
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading berkeley-db@5
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading gdbm
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading perl
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading help2man
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading flex
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading cmake
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading pkgconf
/usr/bin/env /opt/homebrew/Library/Homebrew/shims/shared/git --version
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading bison
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading bison
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading bison
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading flex
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading flex
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading flex
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading gettext
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading gettext
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading gettext
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading libunistring
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading libunistring
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading libunistring
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading cmake
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading cmake
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading cmake
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading pkgconf
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading pkgconf
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading pkgconf
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading bison
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading bison
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading libunistring
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading libunistring
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading gettext
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading gettext
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading berkeley-db@5
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading berkeley-db@5
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading gdbm
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading gdbm
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading perl
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading perl
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading help2man
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading help2man
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading flex
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading flex
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading cmake
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading cmake
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading pkgconf
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading pkgconf
==> Fetching projectm-eval
==> Cloning https://github.com/projectM-visualizer/projectm-eval.git
/usr/bin/env git --git-dir /Users/cyber/Library/Caches/Homebrew/projectm-eval--git/.git status -s
Updating /Users/cyber/Library/Caches/Homebrew/projectm-eval--git
/usr/bin/env git config remote.origin.url https://github.com/projectM-visualizer/projectm-eval.git
/usr/bin/env git config remote.origin.fetch +refs/heads/master:refs/remotes/origin/master
/usr/bin/env git config remote.origin.tagOpt --no-tags
/usr/bin/env git config advice.detachedHead false
/usr/bin/env git config core.fsmonitor false
/usr/bin/env git fetch origin
==> Checking out branch master
/usr/bin/env git checkout -f master --
Already on 'master'
Your branch is up to date with 'origin/master'.
/usr/bin/env git reset --hard origin/master --
HEAD is now at ee180a2 Fixed some typos in the documentation.
/usr/bin/env git --git-dir /Users/cyber/Library/Caches/Homebrew/projectm-eval--git/.git rev-parse --short=7 HEAD
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading bison
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading libunistring
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading gettext
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading berkeley-db@5
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading gdbm
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading perl
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading help2man
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading flex
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading cmake
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading pkgconf
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading projectm-eval
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading bison
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading libunistring
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading gettext
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading berkeley-db@5
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading gdbm
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading perl
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading help2man
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading flex
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading cmake
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading pkgconf
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading bison
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading libunistring
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading gettext
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading berkeley-db@5
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading gdbm
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading perl
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading help2man
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading flex
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading cmake
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading pkgconf
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading bison
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading bison
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading bison
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading flex
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading flex
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading flex
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading gettext
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading gettext
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading gettext
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading libunistring
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading libunistring
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading libunistring
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading cmake
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading cmake
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading cmake
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading pkgconf
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading pkgconf
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading pkgconf
/opt/homebrew/Library/Homebrew/build.rb (Formulary::FromPathLoader): loading /opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/p/projectm-eval.rb
/usr/bin/env /opt/homebrew/Library/Homebrew/shims/shared/git --version
/opt/homebrew/Library/Homebrew/build.rb (Formulary::FromNameLoader): loading bison
/opt/homebrew/Library/Homebrew/build.rb (Formulary::FromNameLoader): loading flex
/opt/homebrew/Library/Homebrew/build.rb (Formulary::FromNameLoader): loading help2man
/opt/homebrew/Library/Homebrew/build.rb (Formulary::FromNameLoader): loading gettext
/opt/homebrew/Library/Homebrew/build.rb (Formulary::FromNameLoader): loading libunistring
/opt/homebrew/Library/Homebrew/build.rb (Formulary::FromNameLoader): loading perl
/opt/homebrew/Library/Homebrew/build.rb (Formulary::FromNameLoader): loading berkeley-db@5
/opt/homebrew/Library/Homebrew/build.rb (Formulary::FromNameLoader): loading gdbm
/opt/homebrew/Library/Homebrew/build.rb (Formulary::FromNameLoader): loading gettext
/opt/homebrew/Library/Homebrew/build.rb (Formulary::FromNameLoader): loading cmake
/opt/homebrew/Library/Homebrew/build.rb (Formulary::FromNameLoader): loading pkgconf
/opt/homebrew/Library/Homebrew/build.rb (Formulary::FromNameLoader): loading bison
/opt/homebrew/Library/Homebrew/build.rb (Formulary::FromNameLoader): loading libunistring
/opt/homebrew/Library/Homebrew/build.rb (Formulary::FromNameLoader): loading gettext
/opt/homebrew/Library/Homebrew/build.rb (Formulary::FromNameLoader): loading berkeley-db@5
/opt/homebrew/Library/Homebrew/build.rb (Formulary::FromNameLoader): loading gdbm
/opt/homebrew/Library/Homebrew/build.rb (Formulary::FromNameLoader): loading perl
/opt/homebrew/Library/Homebrew/build.rb (Formulary::FromNameLoader): loading help2man
/opt/homebrew/Library/Homebrew/build.rb (Formulary::FromNameLoader): loading flex
/opt/homebrew/Library/Homebrew/build.rb (Formulary::FromNameLoader): loading cmake
/opt/homebrew/Library/Homebrew/build.rb (Formulary::FromNameLoader): loading pkgconf
/opt/homebrew/Library/Homebrew/build.rb (Formulary::FromNameLoader): loading bison
/opt/homebrew/Library/Homebrew/build.rb (Formulary::FromNameLoader): loading flex
/opt/homebrew/Library/Homebrew/build.rb (Formulary::FromNameLoader): loading cmake
/opt/homebrew/Library/Homebrew/build.rb (Formulary::FromNameLoader): loading pkgconf
/usr/bin/env hdiutil imageinfo -format /Users/cyber/Library/Caches/Homebrew/projectm-eval--git
/usr/bin/env cp -pR /Users/cyber/Library/Caches/Homebrew/projectm-eval--git/LICENSE.md /Users/cyber/Library/Caches/Homebrew/projectm-eval--git/CMakeLists.txt /Users/cyber/Library/Caches/Homebrew/projectm-eval--git/cmake /Users/cyber/Library/Caches/Homebrew/projectm-eval--git/ns-eel2-shim /Users/cyber/Library/Caches/Homebrew/projectm-eval--git/tests /Users/cyber/Library/Caches/Homebrew/projectm-eval--git/docs /Users/cyber/Library/Caches/Homebrew/projectm-eval--git/ReadMe.md /Users/cyber/Library/Caches/Homebrew/projectm-eval--git/benchmarks /Users/cyber/Library/Caches/Homebrew/projectm-eval--git/.github /Users/cyber/Library/Caches/Homebrew/projectm-eval--git/projectm-eval /Users/cyber/Library/Caches/Homebrew/projectm-eval--git/.git /private/tmp/homebrew-unpack-20250315-92259-cga7qy
mv /private/tmp/homebrew-unpack-20250315-92259-cga7qy/.git /private/tmp/projectm-eval-20250315-92259-b0fu2q/.git
mv /private/tmp/homebrew-unpack-20250315-92259-cga7qy/.github /private/tmp/projectm-eval-20250315-92259-b0fu2q/.github
mv /private/tmp/homebrew-unpack-20250315-92259-cga7qy/CMakeLists.txt /private/tmp/projectm-eval-20250315-92259-b0fu2q/CMakeLists.txt
mv /private/tmp/homebrew-unpack-20250315-92259-cga7qy/LICENSE.md /private/tmp/projectm-eval-20250315-92259-b0fu2q/LICENSE.md
mv /private/tmp/homebrew-unpack-20250315-92259-cga7qy/ReadMe.md /private/tmp/projectm-eval-20250315-92259-b0fu2q/ReadMe.md
mv /private/tmp/homebrew-unpack-20250315-92259-cga7qy/benchmarks /private/tmp/projectm-eval-20250315-92259-b0fu2q/benchmarks
mv /private/tmp/homebrew-unpack-20250315-92259-cga7qy/cmake /private/tmp/projectm-eval-20250315-92259-b0fu2q/cmake
mv /private/tmp/homebrew-unpack-20250315-92259-cga7qy/docs /private/tmp/projectm-eval-20250315-92259-b0fu2q/docs
mv /private/tmp/homebrew-unpack-20250315-92259-cga7qy/ns-eel2-shim /private/tmp/projectm-eval-20250315-92259-b0fu2q/ns-eel2-shim
mv /private/tmp/homebrew-unpack-20250315-92259-cga7qy/projectm-eval /private/tmp/projectm-eval-20250315-92259-b0fu2q/projectm-eval
mv /private/tmp/homebrew-unpack-20250315-92259-cga7qy/tests /private/tmp/projectm-eval-20250315-92259-b0fu2q/tests
/usr/bin/env git --git-dir /Users/cyber/Library/Caches/Homebrew/projectm-eval--git/.git show -s --format=\%cD
==> cmake -S . -B build -DENABLE_PROJECTM_EVAL_INSTALL=ON -DCMAKE_INSTALL_PREFIX=/opt/homebrew/Cellar/projectm-eval/HEAD-ee180a -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_TYPE=Release -DCMAKE_FIND_FRAMEWORK=LAST -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=/opt/homebrew/Library/Homebrew/cmake/trap_fetchcontent_provider.cmake -Wno-dev -DBUILD_TESTING=OFF -DCMAKE_OSX_SYSROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk
-- The C compiler identification is AppleClang 16.0.0.16000026
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /opt/homebrew/Library/Homebrew/shims/mac/super/clang - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Performing Test FAST_MATH_OPTIMIZATION_SUPPORTED
-- Performing Test FAST_MATH_OPTIMIZATION_SUPPORTED - Success
-- Performing Test NO_MATH_LIB_REQUIRED
-- Performing Test NO_MATH_LIB_REQUIRED - Success
-- Found BISON: /opt/homebrew/opt/bison/bin/bison (found suitable version "3.8.2", minimum required is "3.8")
-- Found FLEX: /opt/homebrew/opt/flex/bin/flex (found suitable version "2.6.4", minimum required is "2.6")
-- Configuring done (0.7s)
-- Generating done (0.0s)
-- Build files have been written to: /tmp/projectm-eval-20250315-92259-b0fu2q/build
==> cmake --build build
Change Dir: '/tmp/projectm-eval-20250315-92259-b0fu2q/build'

Run Build Command(s): /opt/homebrew/opt/cmake/bin/cmake -E env VERBOSE=1 /opt/homebrew/Library/Homebrew/shims/mac/super/gmake -f Makefile
/opt/homebrew/opt/cmake/bin/cmake -S/tmp/projectm-eval-20250315-92259-b0fu2q -B/tmp/projectm-eval-20250315-92259-b0fu2q/build --check-build-system CMakeFiles/Makefile.cmake 0
/opt/homebrew/opt/cmake/bin/cmake -E cmake_progress_start /tmp/projectm-eval-20250315-92259-b0fu2q/build/CMakeFiles /tmp/projectm-eval-20250315-92259-b0fu2q/build//CMakeFiles/progress.marks
/Applications/Xcode.app/Contents/Developer/usr/bin/make  -f CMakeFiles/Makefile2 all
/Applications/Xcode.app/Contents/Developer/usr/bin/make  -f projectm-eval/CMakeFiles/GenerateScanner.dir/build.make projectm-eval/CMakeFiles/GenerateScanner.dir/depend
/Applications/Xcode.app/Contents/Developer/usr/bin/make  -f projectm-eval/CMakeFiles/GenerateCompiler.dir/build.make projectm-eval/CMakeFiles/GenerateCompiler.dir/depend
/Applications/Xcode.app/Contents/Developer/usr/bin/make  -f projectm-eval/CMakeFiles/projectM_eval.dir/build.make projectm-eval/CMakeFiles/projectM_eval.dir/depend
cd /tmp/projectm-eval-20250315-92259-b0fu2q/build && /opt/homebrew/opt/cmake/bin/cmake -E cmake_depends "Unix Makefiles" /tmp/projectm-eval-20250315-92259-b0fu2q /tmp/projectm-eval-20250315-92259-b0fu2q/projectm-eval /tmp/projectm-eval-20250315-92259-b0fu2q/build /tmp/projectm-eval-20250315-92259-b0fu2q/build/projectm-eval /tmp/projectm-eval-20250315-92259-b0fu2q/build/projectm-eval/CMakeFiles/GenerateScanner.dir/DependInfo.cmake "--color="
cd /tmp/projectm-eval-20250315-92259-b0fu2q/build && /opt/homebrew/opt/cmake/bin/cmake -E cmake_depends "Unix Makefiles" /tmp/projectm-eval-20250315-92259-b0fu2q /tmp/projectm-eval-20250315-92259-b0fu2q/projectm-eval /tmp/projectm-eval-20250315-92259-b0fu2q/build /tmp/projectm-eval-20250315-92259-b0fu2q/build/projectm-eval /tmp/projectm-eval-20250315-92259-b0fu2q/build/projectm-eval/CMakeFiles/GenerateCompiler.dir/DependInfo.cmake "--color="
cd /tmp/projectm-eval-20250315-92259-b0fu2q/build && /opt/homebrew/opt/cmake/bin/cmake -E cmake_depends "Unix Makefiles" /tmp/projectm-eval-20250315-92259-b0fu2q /tmp/projectm-eval-20250315-92259-b0fu2q/projectm-eval /tmp/projectm-eval-20250315-92259-b0fu2q/build /tmp/projectm-eval-20250315-92259-b0fu2q/build/projectm-eval /tmp/projectm-eval-20250315-92259-b0fu2q/build/projectm-eval/CMakeFiles/projectM_eval.dir/DependInfo.cmake "--color="
/Applications/Xcode.app/Contents/Developer/usr/bin/make  -f projectm-eval/CMakeFiles/projectM_eval.dir/build.make projectm-eval/CMakeFiles/projectM_eval.dir/build
/Applications/Xcode.app/Contents/Developer/usr/bin/make  -f projectm-eval/CMakeFiles/GenerateCompiler.dir/build.make projectm-eval/CMakeFiles/GenerateCompiler.dir/build
/Applications/Xcode.app/Contents/Developer/usr/bin/make  -f projectm-eval/CMakeFiles/GenerateScanner.dir/build.make projectm-eval/CMakeFiles/GenerateScanner.dir/build
make[2]: Nothing to be done for `projectm-eval/CMakeFiles/GenerateCompiler.dir/build'.
make[2]: Nothing to be done for `projectm-eval/CMakeFiles/GenerateScanner.dir/build'.
[  7%] Building C object projectm-eval/CMakeFiles/projectM_eval.dir/Compiler.c.o
cd /tmp/projectm-eval-20250315-92259-b0fu2q/build/projectm-eval && /opt/homebrew/Library/Homebrew/shims/mac/super/clang  -I/tmp/projectm-eval-20250315-92259-b0fu2q/projectm-eval/.. -I/tmp/projectm-eval-20250315-92259-b0fu2q/projectm-eval/api -O3 -DNDEBUG -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk -fPIC -Ofast -MD -MT projectm-eval/CMakeFiles/projectM_eval.dir/Compiler.c.o -MF CMakeFiles/projectM_eval.dir/Compiler.c.o.d -o CMakeFiles/projectM_eval.dir/Compiler.c.o -c /tmp/projectm-eval-20250315-92259-b0fu2q/projectm-eval/Compiler.c
[ 14%] Building C object projectm-eval/CMakeFiles/projectM_eval.dir/Scanner.c.o
[ 21%] Building C object projectm-eval/CMakeFiles/projectM_eval.dir/ExpressionTree.c.o
[ 28%] Built target GenerateCompiler
cd /tmp/projectm-eval-20250315-92259-b0fu2q/build/projectm-eval && /opt/homebrew/Library/Homebrew/shims/mac/super/clang  -I/tmp/projectm-eval-20250315-92259-b0fu2q/projectm-eval/.. -I/tmp/projectm-eval-20250315-92259-b0fu2q/projectm-eval/api -O3 -DNDEBUG -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk -fPIC -Ofast -MD -MT projectm-eval/CMakeFiles/projectM_eval.dir/Scanner.c.o -MF CMakeFiles/projectM_eval.dir/Scanner.c.o.d -o CMakeFiles/projectM_eval.dir/Scanner.c.o -c /tmp/projectm-eval-20250315-92259-b0fu2q/projectm-eval/Scanner.c
[ 35%] Building C object projectm-eval/CMakeFiles/projectM_eval.dir/CompilerFunctions.c.o
[ 42%] Building C object projectm-eval/CMakeFiles/projectM_eval.dir/CompileContext.c.o
cd /tmp/projectm-eval-20250315-92259-b0fu2q/build/projectm-eval && /opt/homebrew/Library/Homebrew/shims/mac/super/clang  -I/tmp/projectm-eval-20250315-92259-b0fu2q/projectm-eval/.. -I/tmp/projectm-eval-20250315-92259-b0fu2q/projectm-eval/api -O3 -DNDEBUG -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk -fPIC -Ofast -MD -MT projectm-eval/CMakeFiles/projectM_eval.dir/CompilerFunctions.c.o -MF CMakeFiles/projectM_eval.dir/CompilerFunctions.c.o.d -o CMakeFiles/projectM_eval.dir/CompilerFunctions.c.o -c /tmp/projectm-eval-20250315-92259-b0fu2q/projectm-eval/CompilerFunctions.c
[ 50%] Building C object projectm-eval/CMakeFiles/projectM_eval.dir/MemoryBuffer.c.o
[ 57%] Building C object projectm-eval/CMakeFiles/projectM_eval.dir/TreeFunctions.c.o
cd /tmp/projectm-eval-20250315-92259-b0fu2q/build/projectm-eval && /opt/homebrew/Library/Homebrew/shims/mac/super/clang  -I/tmp/projectm-eval-20250315-92259-b0fu2q/projectm-eval/.. -I/tmp/projectm-eval-20250315-92259-b0fu2q/projectm-eval/api -O3 -DNDEBUG -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk -fPIC -Ofast -MD -MT projectm-eval/CMakeFiles/projectM_eval.dir/MemoryBuffer.c.o -MF CMakeFiles/projectM_eval.dir/MemoryBuffer.c.o.d -o CMakeFiles/projectM_eval.dir/MemoryBuffer.c.o -c /tmp/projectm-eval-20250315-92259-b0fu2q/projectm-eval/MemoryBuffer.c
[ 64%] Building C object projectm-eval/CMakeFiles/projectM_eval.dir/TreeVariables.c.o
cd /tmp/projectm-eval-20250315-92259-b0fu2q/build/projectm-eval && /opt/homebrew/Library/Homebrew/shims/mac/super/clang  -I/tmp/projectm-eval-20250315-92259-b0fu2q/projectm-eval/.. -I/tmp/projectm-eval-20250315-92259-b0fu2q/projectm-eval/api -O3 -DNDEBUG -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk -fPIC -Ofast -MD -MT projectm-eval/CMakeFiles/projectM_eval.dir/TreeFunctions.c.o -MF CMakeFiles/projectM_eval.dir/TreeFunctions.c.o.d -o CMakeFiles/projectM_eval.dir/TreeFunctions.c.o -c /tmp/projectm-eval-20250315-92259-b0fu2q/projectm-eval/TreeFunctions.c
[ 71%] Built target GenerateScanner
cd /tmp/projectm-eval-20250315-92259-b0fu2q/build/projectm-eval && /opt/homebrew/Library/Homebrew/shims/mac/super/clang  -I/tmp/projectm-eval-20250315-92259-b0fu2q/projectm-eval/.. -I/tmp/projectm-eval-20250315-92259-b0fu2q/projectm-eval/api -O3 -DNDEBUG -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk -fPIC -Ofast -MD -MT projectm-eval/CMakeFiles/projectM_eval.dir/TreeVariables.c.o -MF CMakeFiles/projectM_eval.dir/TreeVariables.c.o.d -o CMakeFiles/projectM_eval.dir/TreeVariables.c.o -c /tmp/projectm-eval-20250315-92259-b0fu2q/projectm-eval/TreeVariables.c
[ 78%] Building C object projectm-eval/CMakeFiles/projectM_eval.dir/api/projectm-eval.c.o
cd /tmp/projectm-eval-20250315-92259-b0fu2q/build/projectm-eval && /opt/homebrew/Library/Homebrew/shims/mac/super/clang  -I/tmp/projectm-eval-20250315-92259-b0fu2q/projectm-eval/.. -I/tmp/projectm-eval-20250315-92259-b0fu2q/projectm-eval/api -O3 -DNDEBUG -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk -fPIC -Ofast -MD -MT projectm-eval/CMakeFiles/projectM_eval.dir/ExpressionTree.c.o -MF CMakeFiles/projectM_eval.dir/ExpressionTree.c.o.d -o CMakeFiles/projectM_eval.dir/ExpressionTree.c.o -c /tmp/projectm-eval-20250315-92259-b0fu2q/projectm-eval/ExpressionTree.c
cd /tmp/projectm-eval-20250315-92259-b0fu2q/build/projectm-eval && /opt/homebrew/Library/Homebrew/shims/mac/super/clang  -I/tmp/projectm-eval-20250315-92259-b0fu2q/projectm-eval/.. -I/tmp/projectm-eval-20250315-92259-b0fu2q/projectm-eval/api -O3 -DNDEBUG -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk -fPIC -Ofast -MD -MT projectm-eval/CMakeFiles/projectM_eval.dir/api/projectm-eval.c.o -MF CMakeFiles/projectM_eval.dir/api/projectm-eval.c.o.d -o CMakeFiles/projectM_eval.dir/api/projectm-eval.c.o -c /tmp/projectm-eval-20250315-92259-b0fu2q/projectm-eval/api/projectm-eval.c
cd /tmp/projectm-eval-20250315-92259-b0fu2q/build/projectm-eval && /opt/homebrew/Library/Homebrew/shims/mac/super/clang  -I/tmp/projectm-eval-20250315-92259-b0fu2q/projectm-eval/.. -I/tmp/projectm-eval-20250315-92259-b0fu2q/projectm-eval/api -O3 -DNDEBUG -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk -fPIC -Ofast -MD -MT projectm-eval/CMakeFiles/projectM_eval.dir/CompileContext.c.o -MF CMakeFiles/projectM_eval.dir/CompileContext.c.o.d -o CMakeFiles/projectM_eval.dir/CompileContext.c.o -c /tmp/projectm-eval-20250315-92259-b0fu2q/projectm-eval/CompileContext.c
[ 85%] Linking C static library libprojectM_eval.a
cd /tmp/projectm-eval-20250315-92259-b0fu2q/build/projectm-eval && /opt/homebrew/opt/cmake/bin/cmake -P CMakeFiles/projectM_eval.dir/cmake_clean_target.cmake
cd /tmp/projectm-eval-20250315-92259-b0fu2q/build/projectm-eval && /opt/homebrew/opt/cmake/bin/cmake -E cmake_link_script CMakeFiles/projectM_eval.dir/link.txt --verbose=1
/usr/bin/ar qc libprojectM_eval.a CMakeFiles/projectM_eval.dir/Compiler.c.o CMakeFiles/projectM_eval.dir/Scanner.c.o CMakeFiles/projectM_eval.dir/CompileContext.c.o CMakeFiles/projectM_eval.dir/CompilerFunctions.c.o CMakeFiles/projectM_eval.dir/ExpressionTree.c.o CMakeFiles/projectM_eval.dir/MemoryBuffer.c.o CMakeFiles/projectM_eval.dir/TreeFunctions.c.o CMakeFiles/projectM_eval.dir/TreeVariables.c.o "CMakeFiles/projectM_eval.dir/api/projectm-eval.c.o"
/usr/bin/ranlib libprojectM_eval.a
[100%] Built target projectM_eval
/opt/homebrew/opt/cmake/bin/cmake -E cmake_progress_start /tmp/projectm-eval-20250315-92259-b0fu2q/build/CMakeFiles 0

==> cmake --install build
-- Install configuration: "Release"
-- Installing: /opt/homebrew/Cellar/projectm-eval/HEAD-ee180a/lib/libprojectM_eval.a
-- Installing: /opt/homebrew/Cellar/projectm-eval/HEAD-ee180a/include/projectm-eval/projectm-eval.h
-- Installing: /opt/homebrew/Cellar/projectm-eval/HEAD-ee180a/lib/cmake/projectM-Eval/projectM-EvalConfigVersion.cmake
-- Installing: /opt/homebrew/Cellar/projectm-eval/HEAD-ee180a/lib/cmake/projectM-Eval/projectM-EvalConfig.cmake
-- Installing: /opt/homebrew/Cellar/projectm-eval/HEAD-ee180a/lib/cmake/projectM-Eval/projectM-EvalTargets.cmake
-- Installing: /opt/homebrew/Cellar/projectm-eval/HEAD-ee180a/lib/cmake/projectM-Eval/projectM-EvalTargets-release.cmake
Error: Empty installation
/opt/homebrew/Library/Homebrew/formula_installer.rb:1083:in `build'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11933/lib/types/private/methods/call_validation.rb:282:in `bind_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11933/lib/types/private/methods/call_validation.rb:282:in `validate_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11933/lib/types/private/methods/_methods.rb:277:in `block in _on_method_added'
/opt/homebrew/Library/Homebrew/formula_installer.rb:561:in `install'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11933/lib/types/private/methods/call_validation.rb:282:in `bind_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11933/lib/types/private/methods/call_validation.rb:282:in `validate_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11933/lib/types/private/methods/_methods.rb:277:in `block in _on_method_added'
/opt/homebrew/Library/Homebrew/upgrade.rb:213:in `install_formula'
/opt/homebrew/Library/Homebrew/install.rb:380:in `install_formula'
/opt/homebrew/Library/Homebrew/install.rb:316:in `block in install_formulae'
/opt/homebrew/Library/Homebrew/install.rb:315:in `each'
/opt/homebrew/Library/Homebrew/install.rb:315:in `install_formulae'
/opt/homebrew/Library/Homebrew/cmd/install.rb:312:in `run'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11933/lib/types/private/methods/call_validation.rb:282:in `bind_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11933/lib/types/private/methods/call_validation.rb:282:in `validate_call'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.3.0/gems/sorbet-runtime-0.5.11933/lib/types/private/methods/_methods.rb:277:in `block in _on_method_added'
/opt/homebrew/Library/Homebrew/brew.rb:95:in `<main>'
```

I see the files installed properly in `/opt/homebrew/Cellar/projectm-eval/HEAD-ee180a/lib/cmake/projectM-Eval/`
