### PR TITLE
adaptivecpp 24.10.0 (new formula)

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -15,6 +15,7 @@ activemq
 ad
 ada-url
 adapterremoval
+adaptivecpp
 adb-enhanced
 adios2
 adns

--- a/Formula/a/adaptivecpp.rb
+++ b/Formula/a/adaptivecpp.rb
@@ -6,6 +6,15 @@ class Adaptivecpp < Formula
   license "BSD-2-Clause"
   head "https://github.com/AdaptiveCpp/AdaptiveCpp.git", branch: "develop"
 
+  bottle do
+    sha256 arm64_sequoia: "6af7a60866ba36c0ba11868fc6e297770759edd2a27cc0a5b0b367710e86b6bb"
+    sha256 arm64_sonoma:  "f9c9b8747b3683f0867fd1a5fa9003c79021eb0e348f4dff8151be1df7489edd"
+    sha256 arm64_ventura: "6712a76c4d5506b9cd9c687bbc6e70897753b976597ee2f92461efe818261dab"
+    sha256 sonoma:        "4d6a4b0814bf29cd7c1c42fe56f5c6fe35bbf92616c3aefd40f54f97069cfe9a"
+    sha256 ventura:       "a3d0b58605759af86b67a17f88ffdf7bb34219f8ca45a6b4886e142ed8301a9c"
+    sha256 x86_64_linux:  "8fbf35c1a2f4dfec80ed3d99d03908d8fcfcf8ad85f8fb7c587414b9b1be5859"
+  end
+
   depends_on "cmake" => :build
   depends_on "boost"
   depends_on "llvm"

--- a/Formula/a/adaptivecpp.rb
+++ b/Formula/a/adaptivecpp.rb
@@ -1,0 +1,46 @@
+class Adaptivecpp < Formula
+  desc "SYCL and C++ standard parallelism for CPUs and GPUs"
+  homepage "https://github.com/AdaptiveCpp/AdaptiveCpp"
+  url "https://github.com/AdaptiveCpp/AdaptiveCpp/archive/refs/tags/v24.10.0.tar.gz"
+  sha256 "3bcd94eee41adea3ccc58390498ec9fd30e1548af5330a319be8ce3e034a6a0b"
+  license "BSD-2-Clause"
+  head "https://github.com/AdaptiveCpp/AdaptiveCpp.git", branch: "develop"
+
+  depends_on "cmake" => :build
+  depends_on "boost"
+  depends_on "llvm"
+  uses_from_macos "python"
+
+  on_macos do
+    depends_on "libomp"
+  end
+
+  def install
+    libomp_root = Formula["libomp"].opt_prefix
+
+    system "cmake", "-S", ".", "-B", "build", "-DOpenMP_ROOT=#{libomp_root}", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+
+    # Avoid references to Homebrew shims directory
+    shim_references = [prefix/"etc/AdaptiveCpp/acpp-core.json"]
+    inreplace shim_references, Superenv.shims_path/ENV.cxx, ENV.cxx
+
+    # we add -I#{libomp_root}/include to default-omp-cxx-flags
+    inreplace prefix/"etc/AdaptiveCpp/acpp-core.json",
+      "\"default-omp-cxx-flags\" : \"", "\"default-omp-cxx-flags\" : \"-I#{libomp_root}/include "
+  end
+
+  test do
+    system bin/"acpp", "--version"
+
+    (testpath/"hellosycl.cpp").write <<~C
+      #include <sycl/sycl.hpp>
+      int main(){
+          sycl::queue q{};
+      }
+    C
+    system bin/"acpp", "hellosycl.cpp", "-o", "hello"
+    system "./hello"
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Contributes adaptivecpp package from https://github.com/tdavidcl/homebrew-adaptivecpp to homebrew-core.
This was tested using brew test-bot in the tap and on multiple end users.