### PR TITLE
morpheus: make `libomp` macOS-only

### DIFF
--- a/Formula/m/morpheus.rb
+++ b/Formula/m/morpheus.rb
@@ -26,7 +26,6 @@ class Morpheus < Formula
   depends_on "ninja" => :build
   depends_on "ffmpeg"
   depends_on "graphviz"
-  depends_on "libomp"
   depends_on "libtiff"
   depends_on "qt@5"
 
@@ -34,9 +33,13 @@ class Morpheus < Formula
   uses_from_macos "libxml2"
   uses_from_macos "zlib"
 
+  on_macos do
+    depends_on "libomp"
+  end
+
   def install
     # has to build with Ninja until: https://gitlab.kitware.com/cmake/cmake/-/issues/25142
-    args = ["-G Ninja"]
+    args = ["-G", "Ninja"]
 
     if OS.mac?
       args << "-DMORPHEUS_RELEASE_BUNDLE=ON"
@@ -58,10 +61,8 @@ class Morpheus < Formula
   end
 
   def post_install
-    return unless OS.mac?
-
     # Sign to ensure proper execution of the app bundle
-    system "/usr/bin/codesign", "-f", "-s", "-", "#{prefix}/Morpheus.app" if Hardware::CPU.arm?
+    system "/usr/bin/codesign", "-f", "-s", "-", "#{prefix}/Morpheus.app" if OS.mac? && Hardware::CPU.arm?
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
