### PR TITLE
formulae: revision bump to migrate to `icu4c@77`

### DIFF
--- a/Formula/b/boost@1.85.rb
+++ b/Formula/b/boost@1.85.rb
@@ -4,7 +4,7 @@ class BoostAT185 < Formula
   url "https://github.com/boostorg/boost/releases/download/boost-1.85.0/boost-1.85.0-b2-nodocs.tar.xz"
   sha256 "09f0628bded81d20b0145b30925d7d7492fd99583671586525d5d66d4c28266a"
   license "BSL-1.0"
-  revision 2
+  revision 3
 
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "663d20076d5f0eca3aeaaad6e8b3dfb7face08b889e7aaf534205bb06c599d84"
@@ -17,7 +17,7 @@ class BoostAT185 < Formula
 
   keg_only :versioned_formula
 
-  depends_on "icu4c@76"
+  depends_on "icu4c@77"
   depends_on "xz"
   depends_on "zstd"
 

--- a/Formula/b/boost@1.85.rb
+++ b/Formula/b/boost@1.85.rb
@@ -7,12 +7,12 @@ class BoostAT185 < Formula
   revision 3
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "663d20076d5f0eca3aeaaad6e8b3dfb7face08b889e7aaf534205bb06c599d84"
-    sha256 cellar: :any,                 arm64_sonoma:  "349ee1eab75de938bf98b797b56062aedff7f007817dd13e6196176454e24c4f"
-    sha256 cellar: :any,                 arm64_ventura: "32994c90a2429d6ffbdeb5f504d266bf044e6e3c0048d8b4056bc77de0ed5b8c"
-    sha256 cellar: :any,                 sonoma:        "6d6e43ab14638792e56d3e5b1ebce85ac3e6fce5910a4067e0aeef6be095c492"
-    sha256 cellar: :any,                 ventura:       "9a408e7ff44e78626c2408df18fa9a006ee9095d8ad8b7f5faebb61173a6ab0a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "78218534456473132b31b8e7918bdcc65c094452096a3be240c06c83e0c9724b"
+    sha256                               arm64_sequoia: "0d57280eb03360e23f3693d33604711f5912a47c6400fbcf7a78ce4829d35db6"
+    sha256                               arm64_sonoma:  "a4d8d3af279e68a17a5d177dfbb716757d59b91448ba82dc8c015bc8749b6e0c"
+    sha256                               arm64_ventura: "c60cdfef891f2f447509c8a460db5fd1b16e07111c7169457044eaa46674c9f3"
+    sha256 cellar: :any,                 sonoma:        "21d45293e2b2ded9f5ac1c8bfa04867fd0e5d02f15911aa24e73a69665968d69"
+    sha256 cellar: :any,                 ventura:       "834cb3ac5b69ae8a4768e2e1773798d7a1ae01aadb761a9e737ff84b8d07a837"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1afa1ddd0506aa3991d3e6b86941fb066fae250feecc9adeaad82780efac55da"
   end
 
   keg_only :versioned_formula

--- a/Formula/g/gnustep-base.rb
+++ b/Formula/g/gnustep-base.rb
@@ -18,12 +18,12 @@ class GnustepBase < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "ede50b79bcb8a6c0a47339bfcdf39f048962d1514015c5cbdd6c9a4760aee69b"
-    sha256 cellar: :any,                 arm64_sonoma:  "3b2e44ee9247c8d63b84912e4a4726820d5d8bc9092ae5566853d9b119aada50"
-    sha256 cellar: :any,                 arm64_ventura: "f218b318c4b8835c31c1bcb6eeac58cdfa0894a2021d7e26c1cdf5bdce6a80f2"
-    sha256 cellar: :any,                 sonoma:        "812aa8fae123bd2799b8b1841d4b01bcff9b2b8e25f9b897659d89d962c28420"
-    sha256 cellar: :any,                 ventura:       "fe4f0cc328ef0dc600196af6c7b1796bf4b7f2a05f0ff418b63f723c8a08be9f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a906c5120ed08dc88fe2de568fbd905cf90beedc1151c5f1d2238a6a0b4b46d0"
+    sha256 cellar: :any,                 arm64_sequoia: "022cbc646ea0a05743c51cb7d804549b78d53bd2b9900113421ba9b37853e515"
+    sha256 cellar: :any,                 arm64_sonoma:  "c87551242fea4d1739d7c651a590113ef97ec2f25a7e5ed3067ef4d5d382d62b"
+    sha256 cellar: :any,                 arm64_ventura: "32af6ef0e1a74f765fb361e8012b32a0f8b0d47d8d0ccd3f37eb616992c554e0"
+    sha256 cellar: :any,                 sonoma:        "7ca4a56508b6eaa4fb8ba7d3f111795bf180588709537e3dda6657a86925b328"
+    sha256 cellar: :any,                 ventura:       "c396d40c48b47283351eff5a976ad62cb4d11a3456e9d96abd4364d2fd457c39"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "6fa791efd053cb237f8194a380d86325b69ed5a65fcc7ba442265f89bcb9c5ad"
   end
 
   depends_on "gnustep-make" => :build

--- a/Formula/g/gnustep-base.rb
+++ b/Formula/g/gnustep-base.rb
@@ -4,6 +4,7 @@ class GnustepBase < Formula
   url "https://github.com/gnustep/libs-base/releases/download/base-1_31_1/gnustep-base-1.31.1.tar.gz"
   sha256 "e7546f1c978a7c75b676953a360194a61e921cb45a4804497b4f346a460545cd"
   license "GPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url :stable
@@ -37,7 +38,7 @@ class GnustepBase < Formula
   uses_from_macos "zlib"
 
   on_system :linux, macos: :big_sur_or_older do
-    depends_on "icu4c@76"
+    depends_on "icu4c@77"
   end
 
   on_linux do

--- a/Formula/h/hfstospell.rb
+++ b/Formula/h/hfstospell.rb
@@ -4,7 +4,7 @@ class Hfstospell < Formula
   url "https://github.com/hfst/hfst-ospell/releases/download/v0.5.4/hfst-ospell-0.5.4.tar.bz2"
   sha256 "ab644c802f813a06a406656c3a873d31f6a999e13cafc9df68b03e76714eae0e"
   license "Apache-2.0"
-  revision 3
+  revision 4
 
   livecheck do
     url :stable
@@ -24,7 +24,7 @@ class Hfstospell < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkgconf" => :build
-  depends_on "icu4c@76"
+  depends_on "icu4c@77"
   depends_on "libarchive"
 
   def install

--- a/Formula/h/hfstospell.rb
+++ b/Formula/h/hfstospell.rb
@@ -12,12 +12,12 @@ class Hfstospell < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "1a5abc098f35bafed06807e2a6fcb5d9628ec031082e574752c6b94b897d93ca"
-    sha256 cellar: :any,                 arm64_sonoma:  "f4f59fbdc8ac56b4a9875ecae70904099b5e6967cab2353d01faee5e14b2278b"
-    sha256 cellar: :any,                 arm64_ventura: "54090c096a5b65d691da0b9eeae97761fe51a65e5d667189309e0987ab429ea8"
-    sha256 cellar: :any,                 sonoma:        "4afb0aec6411f6d48112f5150c18a996f32421f6f989b1f26f8be7d1a37593eb"
-    sha256 cellar: :any,                 ventura:       "caac1fea5a7b3fe47e8cafd75347fe19838af7f23535d9dfe67aedffb20c21a7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "9fc01d70da2bb94ee86ae40f49fe5f2d49649b3d2f0e697f184442569d63569e"
+    sha256 cellar: :any,                 arm64_sequoia: "512a7ec1987a6ea4ba00e0e97744fe569cf086f8599fc1116d3a286430e51b82"
+    sha256 cellar: :any,                 arm64_sonoma:  "b9620e78ab2a3afaa6dbfeeb225da7e9f1e5da55a0bf82e8bff66bf51a1c6bdb"
+    sha256 cellar: :any,                 arm64_ventura: "68701bdb5dbcfc7e2874ed38329b15851fac68b5ffd6a9b4cd52017d63490f20"
+    sha256 cellar: :any,                 sonoma:        "fd2830d383ff448efa33c3061360e7f95226c985a50cb01780f2220de2e1d1f5"
+    sha256 cellar: :any,                 ventura:       "1f4cc82befe7f5e77bb255468434d980c15baa8b9eca1fd7a67003dcbdb17e8c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "87395934d55bf05dbd13fa44c20c36d417a883bfb1080ca2fdb5b03be5237e8d"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/lib/libspelling@0.2.rb
+++ b/Formula/lib/libspelling@0.2.rb
@@ -7,12 +7,12 @@ class LibspellingAT02 < Formula
   revision 2
 
   bottle do
-    sha256 cellar: :any, arm64_sequoia: "2cd2a76ecb4d0c55efe4f3ad8f58bc8a6a8c077bc453ef004f0285aa071a24a2"
-    sha256 cellar: :any, arm64_sonoma:  "b652f34c8392f88a799e5285224b9af15781c556b4badd43b93d0689e55e91cb"
-    sha256 cellar: :any, arm64_ventura: "9bac22470da786b43ab4cee4811ec97315593e6ca65a845cb50ceab4cbcdae2e"
-    sha256 cellar: :any, sonoma:        "b9696d798a8832c3ecf34dd3cac5f7213b830e6f37ce80bb2013a44449673b3d"
-    sha256 cellar: :any, ventura:       "6d90b748623f6bca87717ef60777ac623a3a12478c234af42acb24c44b116ed7"
-    sha256               x86_64_linux:  "524fb06ad25e8e6a8ca34c3cdde8a9089557b17bac93039aeefb3f357cd0c5fa"
+    sha256 cellar: :any, arm64_sequoia: "2743f798c8a8ab3afa19842bdddb996e868736ec1d95b324e18994b987625773"
+    sha256 cellar: :any, arm64_sonoma:  "87bcb552532a3c890664a0b16a858ff766f49fc595ced5b8a5c387da2e3c4ce3"
+    sha256 cellar: :any, arm64_ventura: "3fd146874edb16cefef9b8b2288fdcfbe0ef6811ee8e2d87635e6eb13acb2eb2"
+    sha256 cellar: :any, sonoma:        "00d924b8e7f5cd27fbbe087e60a343c5a10617ac99d3605340eac21d0e31c171"
+    sha256 cellar: :any, ventura:       "611812775575e4302a6612301a51d6036dc14dbbd4c031d848446e89219f08c5"
+    sha256               x86_64_linux:  "624143b2d621071b4239dbdf74b9adde6f7da4a8cbc42742bdee7435fd187749"
   end
 
   keg_only :versioned_formula

--- a/Formula/lib/libspelling@0.2.rb
+++ b/Formula/lib/libspelling@0.2.rb
@@ -4,7 +4,7 @@ class LibspellingAT02 < Formula
   url "https://gitlab.gnome.org/GNOME/libspelling/-/archive/0.2.1/libspelling-0.2.1.tar.bz2"
   sha256 "5393a9b93fda445598348a47c42d1ad13586c0bcf35dfd257afd613fd31812c1"
   license "LGPL-2.1-or-later"
-  revision 1
+  revision 2
 
   bottle do
     sha256 cellar: :any, arm64_sequoia: "2cd2a76ecb4d0c55efe4f3ad8f58bc8a6a8c077bc453ef004f0285aa071a24a2"
@@ -29,7 +29,7 @@ class LibspellingAT02 < Formula
   depends_on "glib"
   depends_on "gtk4"
   depends_on "gtksourceview5"
-  depends_on "icu4c@76"
+  depends_on "icu4c@77"
   depends_on "pango"
 
   on_macos do

--- a/Formula/n/neovide.rb
+++ b/Formula/n/neovide.rb
@@ -4,6 +4,7 @@ class Neovide < Formula
   url "https://github.com/neovide/neovide/archive/refs/tags/0.14.1.tar.gz"
   sha256 "ca89ddd63b2a321ff0b7fb2afbaa33d125c207ed6b8663e5fb6d6f665329b899"
   license "MIT"
+  revision 1
   head "https://github.com/neovide/neovide.git", branch: "main"
 
   bottle do
@@ -31,7 +32,7 @@ class Neovide < Formula
     depends_on "fontconfig"
     depends_on "freetype"
     depends_on "harfbuzz"
-    depends_on "icu4c@76"
+    depends_on "icu4c@77"
     depends_on "jpeg-turbo"
     depends_on "libpng"
     # `libxcursor` is loaded when using X11 (DISPLAY) instead of Wayland (WAYLAND_DISPLAY).

--- a/Formula/n/neovide.rb
+++ b/Formula/n/neovide.rb
@@ -8,12 +8,12 @@ class Neovide < Formula
   head "https://github.com/neovide/neovide.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "a42ebb37b45dcda42c98a5420699936cbb51a26613ebc70c89b893ea8ba1c650"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "b22958ff06b5237e06d249085fea2a1ff8d16fc0d64a49315621c8118139956d"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "93955570f9ab9c32a29452a2463239e623cfedc4a75d05e4a9a17dddddbf36f2"
-    sha256 cellar: :any_skip_relocation, sonoma:        "972c0ed2bc64aec9f43db835e9409068ac5a633dbc162beaf710267ff9bf3879"
-    sha256 cellar: :any_skip_relocation, ventura:       "c1b294340ac56aea0e228306e283577d7b1e624e6f77330275051afeb7d34a1b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4052904691427ea9f23916b19ee1a52020324e7e326edd5f7fe939cae2767816"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "f6fe6421436c0452f8fada6d8d27b8cdf8035bcca3369949d0573cef8cd377ce"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "d809b5451c96327c4c574097ed0432d37307733fa816ce2ae821341be29744d4"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "b125091a42af4296ee697e7286f692a0181aca313a05aff63206109582953a01"
+    sha256 cellar: :any_skip_relocation, sonoma:        "1176698a9e5736a4b687eda38e0428d61441fd443fbf1963bd5eedf5109416b9"
+    sha256 cellar: :any_skip_relocation, ventura:       "f03febcf44a281ebd18b93d6bc8b1805f9ae0adfaa3eefe49418ad22d538d90a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d615931f3e1f8c12fb29257c41e349d6fd08cf5bb701178d023986a14ae7f2d7"
   end
 
   depends_on "ninja" => :build

--- a/Formula/n/nuspell.rb
+++ b/Formula/n/nuspell.rb
@@ -7,12 +7,12 @@ class Nuspell < Formula
   revision 3
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "36f7270654e68ddfc9778b1e8e44d50b84e2f3af1d9da22e7ef904352665ee1e"
-    sha256 cellar: :any,                 arm64_sonoma:  "fdef7d9831fbc25f5d118a8588614fe70cb274c26746d20fbedb1d4e820e3aad"
-    sha256 cellar: :any,                 arm64_ventura: "25326f25f21894062a81c8f854d2d2c0fbcd4fa42e36178e67ab10badb99aade"
-    sha256 cellar: :any,                 sonoma:        "0133410cf4271b33aae4c074884a8e5c6cd4eea1f02c7c4bb6ccb9caa845dafe"
-    sha256 cellar: :any,                 ventura:       "5a22de305a727f7a0b1b7bba8712fc5a6dece9c3e7df3c0c23798cd93009dbbd"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4e4173a44483183ed87307a0880afcaa4c8504c10186da722dc5893edaaeac0b"
+    sha256 cellar: :any,                 arm64_sequoia: "14ba0bb0f17a8fc5967e48e18fde6cab3bb3b8b001bc9bc35faef3aa59c5ced8"
+    sha256 cellar: :any,                 arm64_sonoma:  "f4bd583376d69180bec744cdcd0c8d2ab7a9bb0b4677460d6ffc7e824c59ff3f"
+    sha256 cellar: :any,                 arm64_ventura: "02756d92662cd21767555be0978764212c94bf7be5a9194fa6635e49239f1de5"
+    sha256 cellar: :any,                 sonoma:        "23775d359fef306735dc2afd3042a386f22ec7de882bea316685d1822942e3a5"
+    sha256 cellar: :any,                 ventura:       "90574b2385853fd7d0894a9c06e10385f371a63e56c5299eacf0f96783547ed0"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "108063c1f0d81a9da12e8f82a98b942a80245bba5458415d76e6cd2f760ac678"
   end
 
   depends_on "cmake" => :build

--- a/Formula/n/nuspell.rb
+++ b/Formula/n/nuspell.rb
@@ -4,7 +4,7 @@ class Nuspell < Formula
   url "https://github.com/nuspell/nuspell/archive/refs/tags/v5.1.6.tar.gz"
   sha256 "5d4baa1daf833a18dc06ae0af0571d9574cc849d47daff6b9ce11dac0a5ded6a"
   license "LGPL-3.0-or-later"
-  revision 2
+  revision 3
 
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "36f7270654e68ddfc9778b1e8e44d50b84e2f3af1d9da22e7ef904352665ee1e"
@@ -18,7 +18,7 @@ class Nuspell < Formula
   depends_on "cmake" => :build
   depends_on "pandoc" => :build
   depends_on "pkgconf" => :test
-  depends_on "icu4c@76"
+  depends_on "icu4c@77"
 
   def install
     system "cmake", "-S", ".", "-B", "build", "-DCMAKE_INSTALL_RPATH=#{rpath}", *std_cmake_args

--- a/Formula/o/openrct2.rb
+++ b/Formula/o/openrct2.rb
@@ -5,6 +5,7 @@ class Openrct2 < Formula
       tag:      "v0.4.20",
       revision: "1c1b6d4b26e0f7d564b00a4d10e1770b93bfbda7"
   license "GPL-3.0-only"
+  revision 1
   head "https://github.com/OpenRCT2/OpenRCT2.git", branch: "develop"
 
   bottle do
@@ -23,7 +24,7 @@ class Openrct2 < Formula
   depends_on "duktape"
   depends_on "flac"
   depends_on "freetype"
-  depends_on "icu4c@76"
+  depends_on "icu4c@77"
   depends_on "libogg"
   depends_on "libpng"
   depends_on "libvorbis"

--- a/Formula/o/openrct2.rb
+++ b/Formula/o/openrct2.rb
@@ -9,12 +9,12 @@ class Openrct2 < Formula
   head "https://github.com/OpenRCT2/OpenRCT2.git", branch: "develop"
 
   bottle do
-    sha256 cellar: :any, arm64_sequoia: "85e91290d31164f934e3146a99f5d01bb24c52bf5f2bd737a3e55caf29b23ccb"
-    sha256 cellar: :any, arm64_sonoma:  "5fe8f61a9562e91ed19c9919661ef69a0900d7b506bc86ca56bc5bb38b566b4d"
-    sha256 cellar: :any, arm64_ventura: "90045bf9b69c66f139baa09a59dd6f3953af8d7808d7cf234090647b9f93538c"
-    sha256 cellar: :any, sonoma:        "5132f90ba139709b05545942c6a95218a26af98f1bf8083257c7e1e187be653e"
-    sha256 cellar: :any, ventura:       "25f781765024485f834d64bb271a3a0d75bbf38b210bc15a4a3b8a063584e959"
-    sha256               x86_64_linux:  "484e6392a840c93bb3a5c954d09377e477d6d0952d5b789b7a723a960e908320"
+    sha256 cellar: :any, arm64_sequoia: "3d7be0481dc7f68bf48cadc426910773ef6358819654ee8976b48007f76969c1"
+    sha256 cellar: :any, arm64_sonoma:  "407dd50764631d508a4fec2f22894b3d6837496498680e80f6a4c92b2fec5deb"
+    sha256 cellar: :any, arm64_ventura: "4f80d98a1b7a40ddb3289e70b9d70b56caf52a6a05c20b903444d2865eb1ff5a"
+    sha256 cellar: :any, sonoma:        "52e99cca0287d7e88696fe5209d5272d2b16f187cd8bf729c3a133e210b5c87a"
+    sha256 cellar: :any, ventura:       "018561814658f374c1f423df99168abe8762f3c406195c7d6ae78a775d35077b"
+    sha256               x86_64_linux:  "16d529dd1728164ba6be80b31b7ee896a4daba7bae646e67b563bfdf511eff72"
   end
 
   depends_on "cmake" => :build

--- a/Formula/p/planck.rb
+++ b/Formula/p/planck.rb
@@ -4,7 +4,7 @@ class Planck < Formula
   url "https://github.com/planck-repl/planck/archive/refs/tags/2.28.0.tar.gz"
   sha256 "44f52e170d9a319ec89d3f7a67a7bb8082354f3da385a83bd3c7ac15b70b9825"
   license "EPL-1.0"
-  revision 2
+  revision 3
   head "https://github.com/planck-repl/planck.git", branch: "master"
 
   bottle do
@@ -20,7 +20,7 @@ class Planck < Formula
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
   depends_on xcode: :build
-  depends_on "icu4c@76"
+  depends_on "icu4c@77"
   depends_on "libzip"
 
   uses_from_macos "vim" => :build # for xxd

--- a/Formula/p/planck.rb
+++ b/Formula/p/planck.rb
@@ -8,12 +8,12 @@ class Planck < Formula
   head "https://github.com/planck-repl/planck.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "ab34e0ef0e2e78aa190ca2ba821bd8e4ccfc7f4ba3b79fc1d7a74c697095512e"
-    sha256 cellar: :any,                 arm64_sonoma:  "96f747019fe7702ddf88fa4d7d2267b6031436df2417073f3bbcabb8c6b5d66d"
-    sha256 cellar: :any,                 arm64_ventura: "342f71f4a83296fa7754cc6244c4979a8976f0a4a5a6ea1ebad661ad6d6e329e"
-    sha256 cellar: :any,                 sonoma:        "d8d0fd48c44530bc3ef14f7eaa733c596356a686c6acba27da55224a936d0172"
-    sha256 cellar: :any,                 ventura:       "0ed48e120f059d43836251a16464488a85e46826a428838317bdef1bda516bea"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3f73054a3ff20c391c8f63196e146ff267143c1c3f72a4177d205f63bd2a1aa6"
+    sha256 cellar: :any,                 arm64_sequoia: "94dbee8e25f82b3d6af4c0f5aa768b072b5f42c37c17a6ee55820a6c3e9a9210"
+    sha256 cellar: :any,                 arm64_sonoma:  "9b48ec0e76cc42f5a7bcee1704e043b6ee37cecbcc65acc9f9926367cb99b54a"
+    sha256 cellar: :any,                 arm64_ventura: "698191a3c5a7d477a3d21bd0f7638b67fbc34c8d71b69fa44d5814dcc842ac2b"
+    sha256 cellar: :any,                 sonoma:        "1569b2fbd7b63d35aa7a8c86df20494825214a1b66e5f789cbf4c72c3a595560"
+    sha256 cellar: :any,                 ventura:       "bc7daa8d9acfdf57759f78bacf47c2f5d03843bfb9885e29f87c288dfeee2c44"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f833bad418d1787df2686c970188abd9dfad3657707a309827773253dfa5487b"
   end
 
   depends_on "clojure" => :build

--- a/Formula/r/r.rb
+++ b/Formula/r/r.rb
@@ -12,12 +12,12 @@ class R < Formula
   end
 
   bottle do
-    sha256 arm64_sequoia: "8c299fdd43bd0ecf898be9533bbc9dad1b094cba9c36b1dac9ab1c8ea441915a"
-    sha256 arm64_sonoma:  "e714bd693c7e12d005805d6c4f4d37792a9eaa5a2664f295323cdad631208bc8"
-    sha256 arm64_ventura: "75a14f6cd7317b624441ddac64109d318a25741877ad7680cb696cde67199eed"
-    sha256 sonoma:        "c9ffdf7e569a2d38afde8f0983778289379dd033bea7310c71377d0a59598b0e"
-    sha256 ventura:       "54904547d81ec81b1155eaaae98f063f85720089717e6234e079117ff07297d4"
-    sha256 x86_64_linux:  "d6210ff0aa663c98c80fdf9c58a2ac8750ec76e4e9d473e3d73d2d2cb8218f85"
+    sha256 arm64_sequoia: "6db06adb8cef11de86401d3426e54f89037676b48432aa072cb03cf3ef7ea109"
+    sha256 arm64_sonoma:  "76eb6fb50dab28a414ce6fdbf54b620b105298f0692b81d75c62f106bf56cd4e"
+    sha256 arm64_ventura: "fbcc2d7f8151c50f43124504b2e5e51f741311f785581184eeccb28f9e4cfe45"
+    sha256 sonoma:        "85a90fa83e598a0a061401e7ddbe1a78d2a141fd14543c5e6bf85650f979ef02"
+    sha256 ventura:       "80b5bc276df4be9daedb8b9723dceb8c182bfdbfc8f963f88f5f984ca9605ba2"
+    sha256 x86_64_linux:  "c4a1fdfccdd2aa0a3b0e888326f8a0e7bc60930632ef98b7973808321d7b4fc8"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/r/r.rb
+++ b/Formula/r/r.rb
@@ -4,6 +4,7 @@ class R < Formula
   url "https://cran.r-project.org/src/base/R-4/R-4.4.3.tar.gz"
   sha256 "0d93d224442dea253c2b086f088db6d0d3cfd9b592cd5496e8cb2143e90fc9e8"
   license "GPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url "https://cran.rstudio.com/banner.shtml"
@@ -51,7 +52,7 @@ class R < Formula
   on_linux do
     depends_on "glib"
     depends_on "harfbuzz"
-    depends_on "icu4c@76"
+    depends_on "icu4c@77"
     depends_on "libice"
     depends_on "libsm"
     depends_on "libtirpc"

--- a/Formula/s/samba.rb
+++ b/Formula/s/samba.rb
@@ -7,6 +7,7 @@ class Samba < Formula
   url "https://download.samba.org/pub/samba/stable/samba-4.22.0.tar.gz"
   sha256 "b39242e1ac1f5469e634c94b2e472045e5060975c2dd6c4cdcdfce0c5586cd76"
   license "GPL-3.0-or-later"
+  revision 1
 
   livecheck do
     url "https://www.samba.org/samba/download/"
@@ -28,7 +29,7 @@ class Samba < Formula
   depends_on "gnutls"
   # icu4c can get linked if detected by pkg-config and there isn't a way to force disable
   # without disabling spotlight support. So we just enable the feature for all systems.
-  depends_on "icu4c@76"
+  depends_on "icu4c@77"
   depends_on "krb5"
   depends_on "libtasn1"
   depends_on "libxcrypt"

--- a/Formula/s/samba.rb
+++ b/Formula/s/samba.rb
@@ -15,12 +15,12 @@ class Samba < Formula
   end
 
   bottle do
-    sha256 arm64_sequoia: "0782bf543bab66eecffb9868f4af27a71e1b26b135a137863318e3c06861e176"
-    sha256 arm64_sonoma:  "0c8e1e21052bb44dfef98e7cbf09d0c3820a46d12a005b07ab963cf0f9b6a78c"
-    sha256 arm64_ventura: "ffa1e53c2b8d7b453657fc1a9d6d10f2fd6b48212f38e1b9dd102dd3b0541239"
-    sha256 sonoma:        "f44510831a28a77e4149ddff1772af2cb97a0886c4f4f8ece5b059da8a082df2"
-    sha256 ventura:       "19802793869b056af4b5e93a4673ac606e76645957f445a576bedb1133a53f95"
-    sha256 x86_64_linux:  "560e07b104a7c16ea30aa2fd27a9c7d0527a3f010f8bbba95c38f00a188f00ce"
+    sha256 arm64_sequoia: "5ffc039c1b45616abf0ea947d64b3f5abfb6bb6ee8b204e41f1b63c386e38975"
+    sha256 arm64_sonoma:  "dc59fd54f2a9be982d43a2e82928f915c83c5040982b5fce45ba35988288f18b"
+    sha256 arm64_ventura: "d4aedb5733a1533ccfbf3b225ca70d499b60e51ef3f77930b11083c353beaad8"
+    sha256 sonoma:        "1f9e859a09adfc3e6323712953fa4a7cd865227471aad03a4820679284b721a7"
+    sha256 ventura:       "7bcc54821d340ca1e2ea0caad4dd549dd32b0f1f4ce1f459fae4ee26d03313e0"
+    sha256 x86_64_linux:  "660cc22baa8f195ea9aae7eb517356ac3ea864896b50ca34072048aeb1c29895"
   end
 
   depends_on "bison" => :build

--- a/Formula/s/simdutf.rb
+++ b/Formula/s/simdutf.rb
@@ -13,11 +13,11 @@ class Simdutf < Formula
   end
 
   bottle do
-    sha256 cellar: :any, arm64_sequoia: "0f586847bb4805352cce379a1281cd5db74234401c7da1c8cecfee72bab74dc3"
-    sha256 cellar: :any, arm64_sonoma:  "87ff0c541577c57409af96c9a6c038f46f866a55d1966695cebe5c592e2362d0"
-    sha256 cellar: :any, arm64_ventura: "fdb1aff026057d23566714333b88a50bc29f356d7564cd107b87c584bfae31db"
-    sha256 cellar: :any, sonoma:        "098ae3f6a3096c74d3325178604f766b0733127fe08c5f60a41150056d8ccf27"
-    sha256 cellar: :any, ventura:       "5ba3158352985ecce7e3059b541010dee830550adfd213a8e1c14bc6d4909ea4"
+    sha256 cellar: :any, arm64_sequoia: "09bb9c7ffc1534a37f37d0e43b879f511a54866a1d5f11a7293dfb47a754c0df"
+    sha256 cellar: :any, arm64_sonoma:  "433d755550a96990888a435c88cb67c8a73555fa53b593fafb3784c35cf6ee38"
+    sha256 cellar: :any, arm64_ventura: "97d8a756e2bb40b470d5dd5c577f0f5afad22f2da1aae28dc9da04c2fa60690c"
+    sha256 cellar: :any, sonoma:        "110d9452f4b8c821f34ee81dd10751e755ef515cefa6e4105c249198038e788d"
+    sha256 cellar: :any, ventura:       "e01ebce713a4d76bdf6eebe3d298bd6c636b67e548418049b8d03e51fbb9f2fb"
   end
 
   depends_on "cmake" => :build

--- a/Formula/s/simdutf.rb
+++ b/Formula/s/simdutf.rb
@@ -4,6 +4,7 @@ class Simdutf < Formula
   url "https://github.com/simdutf/simdutf/archive/refs/tags/v6.3.1.tar.gz"
   sha256 "7a36c37db8f6dd36e03b1e894075c15f54dac6d0fe45026090eb56b941fcadca"
   license any_of: ["Apache-2.0", "MIT"]
+  revision 1
   head "https://github.com/simdutf/simdutf.git", branch: "master"
 
   livecheck do
@@ -20,7 +21,7 @@ class Simdutf < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "icu4c@76"
+  depends_on "icu4c@77"
 
   uses_from_macos "python" => :build
 

--- a/Formula/s/spidermonkey@115.rb
+++ b/Formula/s/spidermonkey@115.rb
@@ -15,12 +15,12 @@ class SpidermonkeyAT115 < Formula
   end
 
   bottle do
-    sha256 cellar: :any, arm64_sequoia: "79c292c235d28ccca95422e38e8a3bb11ed17679317181238cffa071c50868bb"
-    sha256 cellar: :any, arm64_sonoma:  "84811a850e6e15e66ed67ae1320fe4e15245eba812db65c271c73528388f902c"
-    sha256 cellar: :any, arm64_ventura: "97a40a74ef64335ebe21243b7ab85a8ba854744e392537295fa33cfc21ef51f8"
-    sha256 cellar: :any, sonoma:        "17d17df8dfd81ff1770fc07dfa26d7fedc0a18f65fc796c6034c1d6e7fa9fe36"
-    sha256 cellar: :any, ventura:       "96e59d8369db111c6a8b23246db3ee300c04ceb60725aa312cab0c6b3008d708"
-    sha256               x86_64_linux:  "7728fbaf5bf6f373925398791504801841204a496ac84e1b7addbc0cd004bfc4"
+    sha256 cellar: :any, arm64_sequoia: "edf502b1dc33265137abe3ed2363700e2ec0d5cdd9a26d4a72f363b911f46ea1"
+    sha256 cellar: :any, arm64_sonoma:  "a569d72fd4c611fa3e5e0f7ea085e665dbb7345bd5e574a596aa9bc476dc4ccc"
+    sha256 cellar: :any, arm64_ventura: "9545a3797e37bead09a4d8fac19b94a288b25d58a037bea78aaaece74ae25d22"
+    sha256 cellar: :any, sonoma:        "661ebc84360d1d729ae27c61dc32a1a444abd51206ffbe76a09fd143544955f5"
+    sha256 cellar: :any, ventura:       "ad4a8f9f92f2f2f0a4a3369defe4de6875acb4fe36a6e1a4914cd15931670a76"
+    sha256               x86_64_linux:  "860166d69b32fb34418ea53dc42b42a07ac1cbbce0af86ec232b28f4cd280d82"
   end
 
   disable! date: "2025-07-01", because: :versioned_formula

--- a/Formula/s/spidermonkey@115.rb
+++ b/Formula/s/spidermonkey@115.rb
@@ -5,6 +5,7 @@ class SpidermonkeyAT115 < Formula
   version "115.21.0"
   sha256 "ff118b1d6d17cefe8eef08bba74ae0d47939010d21afdbaadd8859fd4016b674"
   license "MPL-2.0"
+  revision 1
 
   # Spidermonkey versions use the same versions as Firefox, so we simply check
   # Firefox ESR release versions.
@@ -27,7 +28,7 @@ class SpidermonkeyAT115 < Formula
   depends_on "pkgconf" => :build
   depends_on "python@3.11" => :build # https://bugzilla.mozilla.org/show_bug.cgi?id=1857515
   depends_on "rust" => :build
-  depends_on "icu4c@76"
+  depends_on "icu4c@77"
   depends_on "nspr"
   depends_on "readline"
 

--- a/Formula/t/tarantool.rb
+++ b/Formula/t/tarantool.rb
@@ -16,12 +16,12 @@ class Tarantool < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "f03e8db8b668fe87a24439a71f3bbc52c3226fadf791b83061f1926a5c3e8352"
-    sha256 cellar: :any,                 arm64_sonoma:  "4b98a50aca0c19485215f3e9c5c461e5870e72370bb7459a84d7fc5d9ea9824e"
-    sha256 cellar: :any,                 arm64_ventura: "b8ba71cd9c98e584949bf3e19f27a1f4346951911b6e45f2367cb7fd40f09be2"
-    sha256 cellar: :any,                 sonoma:        "5eaad296be43d3ef6bda96f740ed7eeddf66ec2c60b5922ae441991974bdde45"
-    sha256 cellar: :any,                 ventura:       "9d64cfee36b26abedbf58ab12296fcb6045ee58c14ac0cc2dbb2dc417e1f84ec"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5e98ef1935e7ceee4a5e0a816207decec98c2e984ecb6062b79a27c3d46f81b9"
+    sha256 cellar: :any,                 arm64_sequoia: "5298f8fd26ac5cca02095bed524f471102e6e732477d7417e451ac2dfecae86b"
+    sha256 cellar: :any,                 arm64_sonoma:  "7b71b83056da025a166c42b201cb34fbb2dd759d15530aad69eb5f3c3d6c6f68"
+    sha256 cellar: :any,                 arm64_ventura: "48c9a273d79164f5058427033540616bd4dda795507860149725a46a2ffc5cda"
+    sha256 cellar: :any,                 sonoma:        "114182d89ca1081c142002c70e52e62048fd5c012fc43860ef11ebab24a8af2e"
+    sha256 cellar: :any,                 ventura:       "e680a57e44b09e2aeac0d1e3753849ede9bda9bf646b45bd9d257a44b72b76f7"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c16a9f89d4e515a874b56577571ddf3b568a742dbeb06a9184241c578d6fc8ce"
   end
 
   depends_on "cmake" => :build

--- a/Formula/t/tarantool.rb
+++ b/Formula/t/tarantool.rb
@@ -4,6 +4,7 @@ class Tarantool < Formula
   url "https://download.tarantool.org/tarantool/src/tarantool-3.3.1.tar.gz"
   sha256 "c0f9d2160da2fa73a7dfb7e87d064d35554bf90358464e4c4ab9cced4695264e"
   license "BSD-2-Clause"
+  revision 1
   version_scheme 1
   head "https://github.com/tarantool/tarantool.git", branch: "master"
 
@@ -25,7 +26,7 @@ class Tarantool < Formula
 
   depends_on "cmake" => :build
   depends_on "curl" # curl 8.4.0+
-  depends_on "icu4c@76"
+  depends_on "icu4c@77"
   depends_on "libyaml"
   depends_on "openssl@3"
   depends_on "readline"

--- a/Formula/t/tracker.rb
+++ b/Formula/t/tracker.rb
@@ -6,7 +6,7 @@ class Tracker < Formula
       tag:      "3.6.0",
       revision: "624ef729966f2d9cf748321bd7bac822489fa8ed"
   license all_of: ["LGPL-2.1-or-later", "GPL-2.0-or-later"]
-  revision 3
+  revision 4
 
   bottle do
     sha256 arm64_sequoia: "7bc9ae43638dc877591fddf360e63423faca1c263a80eaec7016c56c526c7891"
@@ -26,7 +26,7 @@ class Tracker < Formula
 
   depends_on "dbus"
   depends_on "glib"
-  depends_on "icu4c@76"
+  depends_on "icu4c@77"
   depends_on "json-glib"
   depends_on "libsoup"
   depends_on "sqlite"

--- a/Formula/t/tracker.rb
+++ b/Formula/t/tracker.rb
@@ -9,12 +9,12 @@ class Tracker < Formula
   revision 4
 
   bottle do
-    sha256 arm64_sequoia: "7bc9ae43638dc877591fddf360e63423faca1c263a80eaec7016c56c526c7891"
-    sha256 arm64_sonoma:  "97c7afc9f1177586a46d70761edd999dfb89db9e824750894dbc357dceb26a53"
-    sha256 arm64_ventura: "49f5ca10fcc3bb45bb6c82a20b5c112fefd5e8c94b81e0f1abdbe1aa80b1810c"
-    sha256 sonoma:        "85b6515fcef419b02070410794f79047fb646aa1fa12693d94b7a1b349f6cdda"
-    sha256 ventura:       "17e2d6239703864d719f29322f28d0e17b588a99b3b40dead296242c4857642d"
-    sha256 x86_64_linux:  "83e5feea79a2bc65e893cd9dd6cbc7204d30f9dd51f857ce49c6e02aa67ae89e"
+    sha256 arm64_sequoia: "34218a3697312858347f19f7b687ad25626b65dd8f78c10efd462df9327eb078"
+    sha256 arm64_sonoma:  "cb0d4881cc33a9e7a2d68c2c02f1011840ed28a4a1c3333bad6d4a254861a3e7"
+    sha256 arm64_ventura: "3d7d3a10c25bbc2c3161945c5eee127b3b6a0adb40db702cd5a13bed35602ec4"
+    sha256 sonoma:        "5d7a0c796901eb167fb888acabff2a609ecf161dba2e8bf8df1066e9a7360cf3"
+    sha256 ventura:       "d2f1ea7776a2aeb58a5c9adafe33bfa75c405cbd47059c6c8b86700118006514"
+    sha256 x86_64_linux:  "11ce63277d3d02cf375c31b84744a10cccac59b65b8227c8c7f08c9dbe377528"
   end
 
   depends_on "gobject-introspection" => :build

--- a/Formula/u/unar.rb
+++ b/Formula/u/unar.rb
@@ -8,12 +8,12 @@ class Unar < Formula
   head "https://github.com/MacPaw/XADMaster.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "88b011e1e61a3422988ca90b01e71fac6d7883db613c3291fba1b35046090c22"
-    sha256 cellar: :any,                 arm64_sonoma:  "e3914d0d21ef96d413f94bc0d3bcdb2dd4bba6e17b1e5543940297f6747ff3bd"
-    sha256 cellar: :any,                 arm64_ventura: "11743466c012f30198def083984fb8c4b0d31447012df6109c3a04f8445f13b9"
-    sha256 cellar: :any,                 sonoma:        "cae1803e4689f0ed4c392408bd22b602c9c4ec4ed24d16f52b239e01cf286ae7"
-    sha256 cellar: :any,                 ventura:       "fad1370b6b0fafde0cf8ccf525754ef6bb1d736df80968f3ca44073605407984"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "df779ffa5a0db66776069dfce6b15428c565360f7664bc19309144f8b180f8e0"
+    sha256 cellar: :any,                 arm64_sequoia: "3c3885c3e70e7e37ad4d2d2a4a3d8840cf53e9f675a6642f57ad93d4da4fa8a8"
+    sha256 cellar: :any,                 arm64_sonoma:  "456de86a2a8cf4b63c7b598f9b4740a4598af1b8dcfe066724601075da938739"
+    sha256 cellar: :any,                 arm64_ventura: "b9d20ecd5c6627f96ff7554775a5944848ff89ffc666e4b841bb67ab51782950"
+    sha256 cellar: :any,                 sonoma:        "e398cb80ec4fe5195312ecef6986e96858c7a172bf0aa5fb310d7a5738ba4bd8"
+    sha256 cellar: :any,                 ventura:       "ff08a4c92f3b66fc3bbd8f8e6ddfab7c4f82a7cad165c116a773402054131a74"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "19ffbed9a0f8c86c8b688e347e6b4bcb4f63aeaee730d511aa90b9e553a3060e"
   end
 
   depends_on xcode: :build

--- a/Formula/u/unar.rb
+++ b/Formula/u/unar.rb
@@ -4,7 +4,7 @@ class Unar < Formula
   url "https://github.com/MacPaw/XADMaster/archive/refs/tags/v1.10.8.tar.gz"
   sha256 "652953d7988b3c33f4f52b61c357afd1a7c2fc170e5e6e2219f4432b0c4cd39f"
   license "LGPL-2.1-or-later"
-  revision 5
+  revision 6
   head "https://github.com/MacPaw/XADMaster.git", branch: "master"
 
   bottle do
@@ -24,7 +24,7 @@ class Unar < Formula
 
   on_linux do
     depends_on "gnustep-base"
-    depends_on "icu4c@76"
+    depends_on "icu4c@77"
     depends_on "libobjc2"
     depends_on "wavpack"
   end

--- a/Formula/u/urweb.rb
+++ b/Formula/u/urweb.rb
@@ -7,12 +7,12 @@ class Urweb < Formula
   revision 12
 
   bottle do
-    sha256 arm64_sequoia: "e1fc49213a5c984c84898202dd078b55bf3cf6baf72a9f7ede2e28b6ffd2fb81"
-    sha256 arm64_sonoma:  "ee1d643f45eb35714ec50820311651b322651f892526a4bc7a0f362e3eecb720"
-    sha256 arm64_ventura: "2054bc84d32c0a2dce1b55c13e765dfef2543f47bb8558c632da848bc4669fb5"
-    sha256 sonoma:        "4d5a47544891ae36a6726b43fabfa525db32450f6e40fa2bbb258ca7c3d1cd39"
-    sha256 ventura:       "80869fade6a1b20b7003666b42a1951330b1ea7d5ee073c150e96f0bc5780c86"
-    sha256 x86_64_linux:  "7556e09718c5a0e4ad6fd6b3e30ba6ad6db1632b572659d7f6bcfa5184bfe117"
+    sha256 arm64_sequoia: "6b9b4b19d55dd9fa56d0e848f3730131b1d9942e7752af3c4d4cbe9e7865cac5"
+    sha256 arm64_sonoma:  "5ae2a880693f266d5a4c97a701f6c275be9af42c6a5001285df1fd5943cf9020"
+    sha256 arm64_ventura: "22c6a1384b9b1eceff5db2458d95a6fd4204e7db2073bae3b4b790cf3f3e0fa3"
+    sha256 sonoma:        "99566a5188759af116d5a8f53f8250d0b41d81d790712536a17647c98ff7e063"
+    sha256 ventura:       "7c0dcc4ba08622d7a5c46e5d71c946c1327adda0c3024a6fa6e2927c7544e5d6"
+    sha256 x86_64_linux:  "85193d19fd4b3065379dce5a2123a7838157f229e84fa71a14fd6e6cc298e62c"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/u/urweb.rb
+++ b/Formula/u/urweb.rb
@@ -4,7 +4,7 @@ class Urweb < Formula
   url "https://github.com/urweb/urweb/releases/download/20200209/urweb-20200209.tar.gz"
   sha256 "ac3010c57f8d90f09f49dfcd6b2dc4d5da1cdbb41cbf12cb386e96e93ae30662"
   license "BSD-3-Clause"
-  revision 11
+  revision 12
 
   bottle do
     sha256 arm64_sequoia: "e1fc49213a5c984c84898202dd078b55bf3cf6baf72a9f7ede2e28b6ffd2fb81"
@@ -20,7 +20,7 @@ class Urweb < Formula
   depends_on "libtool" => :build
   depends_on "mlton" => :build
   depends_on "gmp"
-  depends_on "icu4c@76"
+  depends_on "icu4c@77"
   depends_on "openssl@3"
 
   # Patch to fix build for icu4c 68.2

--- a/Formula/z/zk.rb
+++ b/Formula/z/zk.rb
@@ -4,6 +4,7 @@ class Zk < Formula
   url "https://github.com/zk-org/zk/archive/refs/tags/v0.14.2.tar.gz"
   sha256 "51956ab37595f2c95d97594e1a825d35de9be0c31af2f32f2e2d4468b7b88e0c"
   license "GPL-3.0-only"
+  revision 1
   head "https://github.com/zk-org/zk.git", branch: "main"
 
   livecheck do
@@ -22,7 +23,7 @@ class Zk < Formula
 
   depends_on "go" => :build
 
-  depends_on "icu4c@76"
+  depends_on "icu4c@77"
   uses_from_macos "sqlite"
 
   def install

--- a/Formula/z/zk.rb
+++ b/Formula/z/zk.rb
@@ -13,12 +13,12 @@ class Zk < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "f16805068eb80ed2f67a4b54e2b17d5d627e2a2a70fd19b6c3289e122c1e0a76"
-    sha256 cellar: :any,                 arm64_sonoma:  "f5ae5d324c4ffd2e402091ce39737cb757e99bff7f42ad711160d5183dce93df"
-    sha256 cellar: :any,                 arm64_ventura: "8884aa15091691a698705dfb01cdb9ab586516014c822fab80447b9a5fa5d89f"
-    sha256 cellar: :any,                 sonoma:        "78027aae1bc427c8ab5b0657d455cbfb670b998137eaf492a2a09699323ef620"
-    sha256 cellar: :any,                 ventura:       "5a66bc9ec38fa76978bddcd9acde239373131293cabbbe07bdc2f1eddc7be4a6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e5662aa1334225f191db6adf80d805094bf489cfff6a58fb623a09820eb02e8c"
+    sha256 cellar: :any,                 arm64_sequoia: "79a8bf894b660fc6434833710a2545e1a01477bd52365c7f56696bc2d66d7ea2"
+    sha256 cellar: :any,                 arm64_sonoma:  "12ba68014a20014e794c864399165ef2b1cecf2c5a12ca131b32671b09b4632f"
+    sha256 cellar: :any,                 arm64_ventura: "7218edc02ca8d75ff11da7899546b8514dfe686b969f53e8ea5e46bd85f28f50"
+    sha256 cellar: :any,                 sonoma:        "a4d1dc245f7a61d8ab8add359eed41230868ab9e8e8296eb22d7de4a3670e1e9"
+    sha256 cellar: :any,                 ventura:       "e7dff217adae10898bc1345bbf4ecae9c5f517a97ae2c250e2b97099f4cd7438"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b71f2405deeda4fd3894cdd7dd101e0995fcf77eb3e2139ae075d8b0b9fb0c3a"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
- boost@1.85: revision bump to migrate to `icu4c@77`
- gnustep-base: revision bump to migrate to `icu4c@77`
- hfstospell: revision bump to migrate to `icu4c@77`
- libspelling@0.2: revision bump to migrate to `icu4c@77`
- neovide: revision bump to migrate to `icu4c@77`
- nuspell: revision bump to migrate to `icu4c@77`
- openrct2: revision bump to migrate to `icu4c@77`
- planck: revision bump to migrate to `icu4c@77`
- r: revision bump to migrate to `icu4c@77`
- samba: revision bump to migrate to `icu4c@77`
- simdutf: revision bump to migrate to `icu4c@77`
- spidermonkey@115: revision bump to migrate to `icu4c@77`
- tarantool: revision bump to migrate to `icu4c@77`
- tracker: revision bump to migrate to `icu4c@77`
- unar: revision bump to migrate to `icu4c@77`
- urweb: revision bump to migrate to `icu4c@77`
- zk: revision bump to migrate to `icu4c@77`
