### PR TITLE
zig: fix linkage with libc++

### DIFF
--- a/Formula/z/zig.rb
+++ b/Formula/z/zig.rb
@@ -12,12 +12,12 @@ class Zig < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "a17b92f1104e62390a01a8e31e295c71dd52d79508499708b4b5b799082f245d"
-    sha256 cellar: :any,                 arm64_sonoma:  "c1f2f16abedca60a68a1bc74276637584977c6247437a9e06a0ac2a8c9192dd3"
-    sha256 cellar: :any,                 arm64_ventura: "1acb25e4cd4a8a64370fde167a782a12b45a2e1a88f75956a8eba92ca28e60f7"
-    sha256 cellar: :any,                 sonoma:        "baa5432cfb71ed4753567a363aaacbbf8abf21ce0b4d073ba8fee26b871096db"
-    sha256 cellar: :any,                 ventura:       "76cdb82a0f756ad875823349f092d16ace69b42d7f1c0a28b5b43997729d4c55"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e3bec4d81efadf0922823ec4b711abc304b844941551427261d1f47080106405"
+    sha256 cellar: :any,                 arm64_sequoia: "582c6da9e4c1d916fc318c8d25ee4981941d5c1e89f2e9dac1981173337390b6"
+    sha256 cellar: :any,                 arm64_sonoma:  "3ff0ad19dc0d0ed496395844745da89a89d021b7611d28b96fb5f4c208941e9f"
+    sha256 cellar: :any,                 arm64_ventura: "b7cadbfbaea540925472f28df0e119c4e26233335cb8886b755ceb1663b5e00a"
+    sha256 cellar: :any,                 sonoma:        "1b9125a527782269930c27e0d67a62c3c36656e01906725f080ac972f6bbf3a7"
+    sha256 cellar: :any,                 ventura:       "537e3e061b77ad9ca512aa866b9aae06fee5d1e2faa85128cf903aa3d18dc9ca"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a71266139b1fe7f17638b0ad92b36a424295db899797bcef6fd9a6e64d68d6bc"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Closes #210173
Fixes #210073
