### PR TITLE
chakra icu4c@76: deprecate

### DIFF
--- a/Formula/c/chakra.rb
+++ b/Formula/c/chakra.rb
@@ -42,6 +42,9 @@ class Chakra < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux: "cb090973883ca8832598f8d020bb6c3454567a7a1dd8537325a636be45fb0300"
   end
 
+  # Can be considered for un-deprecation if upstream does a new release
+  deprecate! date: "2025-03-28", because: "fails to run on Linux after rebuild and last release was 2020-12-08"
+
   depends_on "cmake" => :build
   depends_on "icu4c@76"
 

--- a/Formula/i/icu4c@76.rb
+++ b/Formula/i/icu4c@76.rb
@@ -7,14 +7,6 @@ class Icu4cAT76 < Formula
   license "ICU"
   revision 2
 
-  livecheck do
-    url :stable
-    regex(/^release[._-]v?(76(?:[.-]\d+)+)$/i)
-    strategy :git do |tags, regex|
-      tags.filter_map { |tag| tag[regex, 1]&.tr("-", ".") }
-    end
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "36740927f8bdb436e6a4fa4066ac13d32edaaf4125ba3f20ca12e18d7eecbd6f"
     sha256 cellar: :any,                 arm64_sonoma:  "75dc3baf41567d78c356904dd11c66d4a052dc81fc8f06b574d169a10f373b94"
@@ -26,6 +18,9 @@ class Icu4cAT76 < Formula
   end
 
   keg_only :versioned_formula
+
+  # Deprecated with ICU 77.1 release
+  deprecate! date: "2025-03-29", because: :versioned_formula
 
   def install
     args = %w[


### PR DESCRIPTION
~~Trying this again. Dropped from previous PR due to some Linux failure.

If unable to get build working, can consider deprecation.~~

Giving up and just deprecating
```
==> Analytics
install: 15 (30 days), 16 (90 days), 74 (365 days)
install-on-request: 15 (30 days), 17 (90 days), 74 (365 days)
build-error: 2 (30 days)
```

Also deprecating `icu4c@76` now that everything is migrated