### PR TITLE
sysprof: add `elfutils` dependency

### DIFF
--- a/Formula/s/sysprof.rb
+++ b/Formula/s/sysprof.rb
@@ -25,6 +25,7 @@ class Sysprof < Formula
   depends_on "ninja" => :build
   depends_on "pkgconf" => [:build, :test]
   depends_on "cairo"
+  depends_on "elfutils"
   depends_on "glib"
   depends_on "graphene"
   depends_on "gtk4"


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-core/actions/runs/13888065859/job/38856022177?pr=211122#step:4:596
```
==> brew linkage --cached --test --strict sysprof
==> FAILED
Full linkage --cached --test --strict sysprof output
  Indirect dependencies with linkage:
    elfutils
```