### PR TITLE
psalm: add livecheck

### DIFF
--- a/Formula/p/psalm.rb
+++ b/Formula/p/psalm.rb
@@ -5,6 +5,11 @@ class Psalm < Formula
   sha256 "bb5ac9ba99d6f7562d45c01923ce59196553de68ebc830ae081e1190a68abc38"
   license "MIT"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "c6147b482bdd9a60eebbf2247b78bb1c32fc950bc011ede145e9d3e91d6e9f4c"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "c6147b482bdd9a60eebbf2247b78bb1c32fc950bc011ede145e9d3e91d6e9f4c"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `psalm` but the formula uses a GitHub release asset and there's no release yet for the 6.9.1 tag after a couple of hours. This adds a `GithubLatest` `livecheck` block, as there can be a notable gap between tag and release.