### PR TITLE
zig: update test

### DIFF
--- a/Formula/z/zig.rb
+++ b/Formula/z/zig.rb
@@ -97,6 +97,10 @@ class Zig < Formula
       end
     end
 
+    native_os = OS.mac? ? "macos" : OS.kernel_name.downcase
+    native_arch = Hardware::CPU.arm? ? "aarch64" : Hardware::CPU.arch
+    assert_equal "Hello, world!", shell_output("./hello-#{native_arch}-#{native_os}")
+
     # error: 'TARGET_OS_IPHONE' is not defined, evaluates to 0
     # https://github.com/ziglang/zig/issues/10377
     ENV.delete "CPATH"
@@ -107,8 +111,13 @@ class Zig < Formula
         return 0;
       }
     C
-    system bin/"zig", "cc", "hello.c", "-o", "hello"
-    assert_equal "Hello, world!", shell_output("./hello")
+    system bin/"zig", "cc", "hello.c", "-o", "hello-c"
+    assert_equal "Hello, world!", shell_output("./hello-c")
+
+    return unless OS.mac?
+
+    # See https://github.com/Homebrew/homebrew-core/pull/211129
+    assert_includes (bin/"zig").dynamically_linked_libraries, "/usr/lib/libc++.1.dylib"
   end
 end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Let's update the tests to:
- make sure that #210073 doesn't regress
- improve check from #209552 to ensure we can execute native executables
- ensure that the C code compilation test doesn't accidentally re-use a
  test executable compiled earlier in the test
