### PR TITLE
abook 0.6.2

### DIFF
--- a/Formula/a/abook.rb
+++ b/Formula/a/abook.rb
@@ -20,19 +20,12 @@ class Abook < Formula
   end
 
   bottle do
-    sha256 arm64_sequoia:  "aecfb31d48ba2a09945e883238d39f657fb3999b2f5419514445686aca65cf11"
-    sha256 arm64_sonoma:   "c0b9ae72d7b4b319def0cc4f65051a392a3cd9318d607d736b6d80eb5eee3210"
-    sha256 arm64_ventura:  "dbcc8ffc1eb5ee674721acec2fc715030ba3c53553f0b419c71994f72925e298"
-    sha256 arm64_monterey: "24854522e2901befeb323be066c744ab4471920495b7a91280e9d05c9bc3b9e7"
-    sha256 arm64_big_sur:  "e062925ce6b559649d5574f2ee4a709611df4a9a54f3396cf706c2a399cc747f"
-    sha256 sonoma:         "ee3e21157d0d6a21e8070e89e102ebeef8b4d7a4a8e72b3440d8638141a35bf5"
-    sha256 ventura:        "82da61749b4896e7e09c2655a372f49a371d660f089c494ca49091a05a2f1993"
-    sha256 monterey:       "923df44c0bbcdcb70df775092fb6aacb3c7c4740a12d40ce6f5ad4a8dd7ea91f"
-    sha256 big_sur:        "0c4b7d1c41dbd920e192711e8ed1200db46c30be141aaaeb606c41718d0c2a79"
-    sha256 catalina:       "09e77aa3db2cf8a702effbebbbf83f7a2f860b0d5db6bcf37549edb7db5438a7"
-    sha256 mojave:         "a6ab99c751a03e11e2ace660ad9325a9fe4262598f284c0fb87626778383e29d"
-    sha256 high_sierra:    "a0461ecc678e5cb65a901bd39dbd7f0f8015a29ed605e6cf28f1315d5c347ecb"
-    sha256 x86_64_linux:   "32ec309e47f9cc195c0bc8c9bccdf1169ff91e211991eeb1fb04d91872c3be51"
+    sha256 arm64_sequoia: "b0113dcc3ee161e37ed8c9fbdab0175486bf04c3a5e802b46dde3b015fe67cac"
+    sha256 arm64_sonoma:  "bbdac04e9da720845e5ee41ba19af9541a62d953c4c9929170400c84dcad3e32"
+    sha256 arm64_ventura: "7ac157f6847b43e07454da28ffefc1911c891c1a7d642d3ad31d7d12166ee42b"
+    sha256 sonoma:        "aaa8b661464c11cc8329a8b9da48ff5088df6b5e556eded5f32970c441858626"
+    sha256 ventura:       "192d1342a247240817e4a4235341eeb440c79d042ec092dbc784015fb346efa4"
+    sha256 x86_64_linux:  "20347763d0c3ac3e729619fcf98b65e72f0931ddd7ca55d51f2c26d62e1f5147"
   end
 
   depends_on "autoconf" => :build


### PR DESCRIPTION
Release info https://sourceforge.net/p/abook/mailman/message/59120713/

> abook 0.6.2 released https://sourceforge.net/p/abook/git/ci/ver_0_6_2/tree/
> 
> Please have a look at RELEASE_NOTES / ChangeLog files.
> 
> XDG and "--mutt-query loose search" features, which have been waiting in the bugtracker for
> a while, were just merged in (and will definitely benefit from some testing).
> Other changes have been in the repository since at least 2023.
> 
> 
> Thanks to everybody

---

Also listed on homepage as git tag only https://abook.sourceforge.io
> * 2025-01-19 - 0.6.2 ([Git tag only](https://sourceforge.net/p/abook/git/ci/ver_0_6_2/tree/))