### PR TITLE
triage: remove limit-pull-requests

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -65,31 +65,6 @@ jobs:
           PR: ${{ github.event.number }}
         run: gh pr edit --add-label workflows "$PR" --repo "$GITHUB_REPOSITORY"
 
-  limit-pull-requests:
-    if: >
-      always() && github.repository_owner == 'Homebrew' &&
-      (github.event_name == 'pull_request_target' &&
-       github.event.action == 'opened')
-    permissions:
-      contents: read
-      issues: read
-      pull-requests: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: Homebrew/actions/limit-pull-requests@master
-        with:
-          except-users: |
-            BrewTestBot
-          comment-limit: 15
-          comment: |
-            Hi, thanks for your contribution to Homebrew! :heart:
-
-            You already have >=15 open pull requests, so please get them ready to be merged or close them before you open more. If CI fails on any of them, please fix it or ask for help doing so.
-
-            If you are performing simple version bumps, @BrewTestBot automatically bumps [a list of formulae](https://github.com/${{ github.repository }}/blob/HEAD/.github/autobump.txt) so you don't need to. Please take a look at issues and pull requests labelled https://github.com/${{ github.repository }}/labels/help%20wanted and see if you can help to fix any of them. Thanks!
-          close-limit: 30
-          close: true
-
   triage:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
This hasn't been useful for quite some time, and now that we prevent opening bumps for autobumped formulae, I think we can remove this. It just dumps comments on maintainer PR's and then they're deleted or hidden.