### PR TITLE
fastfec: remove from autobump list

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -992,7 +992,6 @@ fanyi
 fast_float
 fastapi
 fastd
-fastfec
 fastfetch
 fastlane
 fastly


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `fastfec` formula is in the autobump list but it has a future disable date due to some build issues, so livecheck skips it as deprecated. The project is [reportedly unmaintained](https://github.com/Homebrew/homebrew-core/pull/211267#discussion_r1999583314), so this removes `fastfec` from the autobump list.