### PR TITLE
autobump: remove some deprecated formulae

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -170,7 +170,6 @@ avfs
 avrdude
 awk
 aws-amplify
-aws-auth
 aws-c-auth
 aws-c-cal
 aws-c-common
@@ -2167,7 +2166,6 @@ md2pdf
 md4c
 mdbook
 mdbtools
-mdcat
 mdds
 mdformat
 mdless


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This removes some deprecated formulae from the autobump list:

* aws-auth: The npm package an GitHub repository have been removed.
* mdcat: The GitHub repository has been archived and the `README` describes the project as unmaintained.