### PR TITLE
qd: update livecheck

### DIFF
--- a/Formula/q/qd.rb
+++ b/Formula/q/qd.rb
@@ -5,9 +5,11 @@ class Qd < Formula
   sha256 "ad6738e8330928308e10346ff7fd357ed17386408f8fb7a23704cd6f5d52a6c8"
   license "BSD-3-Clause-LBNL"
 
+  # The homepage no longer links to a QD tarball and instead directs users to
+  # the GitHub repository, so we check the Git tags.
   livecheck do
-    url :homepage
-    regex(/href=.*?qd[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url "https://github.com/BL-highprecision/QD.git"
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `qd` is giving an `Unable to get versions` error, as the homepage no longer links to a `qd` tarball and directs users to the GitHub repository instead. This updates the `livecheck` block to check the Git tags accordingly.

We can revisit this with the next version, as it may become clear then whether we need to switch to a GitHub tag tarball going forward (and update the `livecheck` block to use `url :stable`). I did a test build with the current tag tarball and encountered an error about needing latex, so it would require more work than simply swapping the `stable` URL.