### PR TITLE
chkrootkit 0.58b

### DIFF
--- a/Formula/c/chkrootkit.rb
+++ b/Formula/c/chkrootkit.rb
@@ -1,14 +1,14 @@
 class Chkrootkit < Formula
   desc "Rootkit detector"
   homepage "https://www.chkrootkit.org/"
-  url "ftp://ftp.chkrootkit.org/pub/seg/pac/chkrootkit-0.58.tar.gz"
-  mirror "https://fossies.org/linux/misc/chkrootkit-0.58.tar.gz"
-  sha256 "0325cd19ace8928ca036aa956ec8cd9a3d9fe02965e30a4720e9baf34ed56a42"
+  url "ftp://ftp.chkrootkit.org/pub/seg/pac/chkrootkit-0.58b.tar.gz"
+  mirror "https://fossies.org/linux/misc/chkrootkit-0.58b.tar.gz"
+  sha256 "75ed2ace81f0fa3e9c3fb64dab0e8857ed59247ea755f5898416feb2c66807b9"
   license "GPL-2.0-or-later"
 
   livecheck do
     url :homepage
-    regex(/href=.*?download[^>]*>chkrootkit v?(\d+(?:\.\d+)+)/i)
+    regex(/href=.*?download[^>]*>chkrootkit v?(\d+(?:\.\d+)+[a-z]?)/i)
   end
 
   bottle do

--- a/Formula/c/chkrootkit.rb
+++ b/Formula/c/chkrootkit.rb
@@ -12,16 +12,12 @@ class Chkrootkit < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "fe29a10c285df79b49a35471df0da20208774ec8436932cddc09e4bc2099a215"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "7c24f28d8f90e8f0aa3eea0978e1f518dce8a288919927b24ebb5d77a6aa9121"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "bbd2dd4ac20e747293eedd01d9ccc8c9bfbd56d75b4cc269f33c9e3cd793ceda"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "d7d9ddf16ed810c46ebc3aa73063bb35887722d115a317b5c4ab9d099c12bb82"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "7cc2ca082dcb083a06732f58d51ce7ed9f3a4ee3eccd2aea4e3b7d8fd14861c7"
-    sha256 cellar: :any_skip_relocation, sonoma:         "9e8632f9ef69b72066519be738516b81e15485b41d03d5cc6c89ac40b0b59089"
-    sha256 cellar: :any_skip_relocation, ventura:        "d4fb446dedba887717246dabc02a955b435fddb76d3d24f227e3048b02cc5d03"
-    sha256 cellar: :any_skip_relocation, monterey:       "792f77c1f50ff0cd9c93974d1729e65cccceb9c89acb102ad3d86d8a6ffe8241"
-    sha256 cellar: :any_skip_relocation, big_sur:        "7c891dc0f3d653c9e072cef412a9ffe697dccc170a2c28fbc5710a6b61249072"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "69c27f598f7f53881f961c3b9db7b9f637cbe05c83f0264b678dee6911d01e0b"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "9b2e02512815e0752d64b43908190240ac58c5f3895200c876b5328f78ce9345"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "81fe5bf8ee342b99e6048b3908f49c0c6cb21edd0374cebf439808986106c7e2"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "5533e32cc63a4c5de2e644afa929f5d55dc87999f6dfdab84bc5cc943a85c527"
+    sha256 cellar: :any_skip_relocation, sonoma:        "27f7982730e34a76130cbc1d775845f17480053cd8fb46a76bf8317d36f57771"
+    sha256 cellar: :any_skip_relocation, ventura:       "3845af7aac3b4114fbf0eac4fb38c79afc0fd2a6a3eb8063f2598cc697e79221"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "93aec292d7e8a289ffccd9cd35591ee1ea2dd6ad8e11b3b9320171afc9710e6b"
   end
 
   def install


### PR DESCRIPTION
Upstream appends letter for quick patch fixes to tarball, e.g.
* ftp://ftp.chkrootkit.org/pub/seg/pac/chkrootkit-0.58.tar.gz
* ftp://ftp.chkrootkit.org/pub/seg/pac/chkrootkit-0.58a.tar.gz
* ftp://ftp.chkrootkit.org/pub/seg/pac/chkrootkit-0.58b.tar.gz

Not much difference other than metadata (e.g. permission changes) but should at least allow mirror to work correctly as Fossies only has latest version 0.58b

Matches official homepage https://www.chkrootkit.org/
> [chkrootkit 0.58b is now available!](https://www.chkrootkit.org/download/) (Release Date: Jul 05 2023)

And what you get when you click on unversioned download link at https://www.chkrootkit.org/download/
```
❯ curl -sL ftp://ftp.chkrootkit.org/pub/seg/pac/chkrootkit.tar.gz | sha256
75ed2ace81f0fa3e9c3fb64dab0e8857ed59247ea755f5898416feb2c66807b9
```