### PR TITLE
clojure-lsp: align version scheme to match official

### DIFF
--- a/Formula/c/clojure-lsp.rb
+++ b/Formula/c/clojure-lsp.rb
@@ -2,18 +2,15 @@ class ClojureLsp < Formula
   desc "Language Server (LSP) for Clojure"
   homepage "https://github.com/clojure-lsp/clojure-lsp"
   url "https://github.com/clojure-lsp/clojure-lsp/releases/download/2025.03.07-17.42.36/clojure-lsp-standalone.jar"
-  version "20250307T174236"
+  version "2025.03.07-17.42.36"
   sha256 "671512207513256d93b516621122809ee04e4bbb36530ceaa534e00318e447b4"
   license "MIT"
+  version_scheme 1
   head "https://github.com/clojure-lsp/clojure-lsp.git", branch: "master"
 
   livecheck do
     url :stable
-    regex(%r{^(?:release[._-])?v?(\d+(?:[T/.-]\d+)+)$}i)
-    strategy :git do |tags, regex|
-      # Convert tags like `2021.03.01-19.18.54` to `20210301T191854` format
-      tags.filter_map { |tag| tag[regex, 1]&.delete(".")&.gsub(%r{[/-]}, "T") }
-    end
+    regex(/^v?(\d{4}(?:[.-]\d+)+)$/i)
   end
 
   bottle do

--- a/Formula/c/clojure-lsp.rb
+++ b/Formula/c/clojure-lsp.rb
@@ -14,7 +14,7 @@ class ClojureLsp < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "8dc7a71f5c566a6ded2c9fc88cac0508e7d1db7103b55ab96f32f849d7444027"
+    sha256 cellar: :any_skip_relocation, all: "a60374232f92726c43b6b564a229dc577a18c62a883249c8b7549dacb014d939"
   end
 
   depends_on "openjdk"


### PR DESCRIPTION
It has been over 4 years that upstream has kept the new version scheme.

We have been using the old version scheme from the `release-yyyymmddThhmmss` tag format (from 2020)

This change allows us to be in line with everyone else, i.e.
* match official upstream version scheme (https://github.com/clojure-lsp/clojure-lsp/blob/master/CHANGELOG.md) 
* and avoid being the odd one out in Repology (https://repology.org/project/clojure-lsp/versions)