### PR TITLE
liblcf: backport fix to use macOS expat

### DIFF
--- a/Formula/e/easyrpg-player.rb
+++ b/Formula/e/easyrpg-player.rb
@@ -12,12 +12,12 @@ class EasyrpgPlayer < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "a32ab95798e512a5e7aedbf1ed9427fa5b7f61c26e7b9eca46b8ec5309fa52b5"
-    sha256 cellar: :any,                 arm64_sonoma:  "a235adad11b54f8cff2742248e2feb77553091870043fbac8f86376c4396df2c"
-    sha256 cellar: :any,                 arm64_ventura: "0647aaa793ff98d38f4ab33a51739fd4a38e38b115f3a88c63e9cd750b32e653"
-    sha256 cellar: :any,                 sonoma:        "3a0abcf7abbdf8843d99e2a41d29f53b09117d26ca081a5dee9aed20dbd9a7ae"
-    sha256 cellar: :any,                 ventura:       "aa01edc79c1b3c6ac0b0ff91e292f5b0e47cbc42149419318a1204b13ea0edc4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5dd92702f1a18aded2ddebeb9bda83e8f08f46aa78bcb956205bad2315403efc"
+    sha256 cellar: :any,                 arm64_sequoia: "91a3f17478db7d87e435ede9a774f9aaa60efd9d1643bd40a1b46d41b6cb583f"
+    sha256 cellar: :any,                 arm64_sonoma:  "ee017d61080f9d8f939b265c48baa3a951c639539d7e60fc630a8ea59d75ceef"
+    sha256 cellar: :any,                 arm64_ventura: "07a6d81fc75427bb8844e9bd79b6b457def126c37ad2db8e386cf4eb979f5b37"
+    sha256 cellar: :any,                 sonoma:        "96816388fdb23de41c554995d0d4b52aa348c50430495d1e6248e425934f3c9f"
+    sha256 cellar: :any,                 ventura:       "7d669fe4965e4a7739897bd749ed5f184778d9493eb6e9938135ba23a9058f12"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "900ef138e0241d3b323307182d08e38ae55d1e7f99ca82ec7cbf9e3bbc1c4124"
   end
 
   depends_on "cmake" => :build

--- a/Formula/e/easyrpg-player.rb
+++ b/Formula/e/easyrpg-player.rb
@@ -4,7 +4,7 @@ class EasyrpgPlayer < Formula
   url "https://easyrpg.org/downloads/player/0.8/easyrpg-player-0.8.tar.xz"
   sha256 "06e6d034348d1c52993d0be6b88fc3502a6c7718e366f691401539d5a2195c79"
   license "GPL-3.0-or-later"
-  revision 7
+  revision 8
 
   livecheck do
     url "https://easyrpg.org/player/downloads/"
@@ -21,7 +21,6 @@ class EasyrpgPlayer < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "expat"
   depends_on "fmt"
   depends_on "freetype"
   depends_on "harfbuzz"
@@ -36,6 +35,7 @@ class EasyrpgPlayer < Formula
   depends_on "sdl2"
   depends_on "speexdsp"
 
+  uses_from_macos "expat"
   uses_from_macos "zlib"
 
   on_macos do

--- a/Formula/lib/liblcf.rb
+++ b/Formula/lib/liblcf.rb
@@ -2,7 +2,7 @@ class Liblcf < Formula
   desc "Library for RPG Maker 2000/2003 games data"
   homepage "https://easyrpg.org/"
   license "MIT"
-  revision 5
+  revision 6
   head "https://github.com/EasyRPG/liblcf.git", branch: "master"
 
   stable do
@@ -13,6 +13,12 @@ class Liblcf < Formula
     patch do
       url "https://github.com/EasyRPG/liblcf/commit/8c782e54ba244981141d91e7d44922952563677c.patch?full_index=1"
       sha256 "593f729e7f9a5411e6d8548aaac0039e09eee437f525409a9ca8513a0ee15cd0"
+    end
+
+    # Backport CMake fix when using FindEXPAT
+    patch do
+      url "https://github.com/EasyRPG/liblcf/commit/a759e18d39cd73c0d2934896ed5c9520a9e1ca94.patch?full_index=1"
+      sha256 "4b34c80fbb80f388a3c08cf9e810a13c58e79c11671fc5064a54c1b6c0d5956d"
     end
   end
 
@@ -26,8 +32,9 @@ class Liblcf < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "expat" # Building against `liblcf` fails with `uses_from_macos`
   depends_on "icu4c@77"
+
+  uses_from_macos "expat"
 
   def install
     system "cmake", "-S", ".", "-B", "build",

--- a/Formula/lib/liblcf.rb
+++ b/Formula/lib/liblcf.rb
@@ -23,12 +23,12 @@ class Liblcf < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "0ce1d52bf550672b277c189f92aa81e25b40a8b9342c31974a8da8d037311565"
-    sha256 cellar: :any,                 arm64_sonoma:  "3eb59771db72f108f7e2345aaf4095f55e621ace5b95a7af03f374ac34784b27"
-    sha256 cellar: :any,                 arm64_ventura: "d159fe2f340bf3ad58f1e730ce8b739e4e38deeeb5e87702d235754cc158b409"
-    sha256 cellar: :any,                 sonoma:        "deb6d3ce9b1ff44726207ba6754a80ba56f541e73c0332f4543d388caf3e0f6d"
-    sha256 cellar: :any,                 ventura:       "26b9bedec364a4e139c5db09ebdac6979b36581c29387994083a3e502fcb8df6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "743579b1d4cd94e49240f8ed6f432c146123764f5692cab39b477de090055a1a"
+    sha256 cellar: :any,                 arm64_sequoia: "e1151274ab64086b4a8aaa60158ec06b5ae873a01f509938b2f04ab61101195f"
+    sha256 cellar: :any,                 arm64_sonoma:  "d978147a8f8c7dbcfd7162ac2b42082fccc315f74f7e64f5f78a3271df73f77d"
+    sha256 cellar: :any,                 arm64_ventura: "88b64f5e02c66eba7184bfbecdda6dfb6f331c3ad113b89f7400e51cad4a90da"
+    sha256 cellar: :any,                 sonoma:        "ab362e5a999bd3210a26c2c2e431135a51ae43cc7a6dd6371a3ab07a93438795"
+    sha256 cellar: :any,                 ventura:       "dc447f1a04732969f18f1d32f1fd6ecce02c4115f9b1031f71f0008843618bfb"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5415f715fd1e60c8e1cb80a633588d4afd743b309d760c12f483e0881746e646"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
