### PR TITLE
evince: add caveats

### DIFF
--- a/Formula/e/evince.rb
+++ b/Formula/e/evince.rb
@@ -76,6 +76,17 @@ class Evince < Formula
     system "#{Formula["gtk+3"].opt_bin}/gtk3-update-icon-cache", "-f", "-t", "#{HOMEBREW_PREFIX}/share/icons/hicolor"
   end
 
+  def caveats
+    <<~EOS
+      Before using Evince ensure the path to GSettings schemas is exported.
+      It should be exported on most Linux distributions but it might not be the case
+      on your computer or macOS.
+      It can be done by adding the following to your shell profile e.g. ~/.profile
+      or ~/.zshrc:
+        export GSETTINGS_SCHEMA_DIR="#{HOMEBREW_PREFIX}/share/glib-2.0/schemas"
+    EOS
+  end
+
   test do
     assert_match version.to_s, shell_output("#{bin}/evince --version")
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
At least on macOS (and Linux distros without pre-installed GSettings) this program doesn't work out of the box, user has to define path to the schemas in `GSETTINGS_SCHEMA_DIR` variable.

There is another issue with `hicolor` theme but I didn't find a way to fix this issue (changing `XDG_DATA_DIRS`, `GTK_DATA_PREFIX`, `GTK_ICON_THEME`, and `GTK_THEME` didn't help):
```
Gtk-WARNING **: 21:49:41.698: Could not find the icon 'view-sidebar-symbolic-ltr'. The 'hicolor' theme
was not found either, perhaps you need to install it.
```