### PR TITLE
sops: change head branch to main

### DIFF
--- a/Formula/s/sops.rb
+++ b/Formula/s/sops.rb
@@ -4,7 +4,7 @@ class Sops < Formula
   url "https://github.com/getsops/sops/archive/refs/tags/v3.9.4.tar.gz"
   sha256 "3e0fc9a43885e849eba3b099d3440c3147ad0a0cd5dd77a9ef87c266a8488249"
   license "MPL-2.0"
-  head "https://github.com/getsops/sops.git", branch: "master"
+  head "https://github.com/getsops/sops.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "47fb0da48816583bb499374230d9a1eb3d568dbfb3e5dad262b2b416f13c71c6"

--- a/Formula/s/sops.rb
+++ b/Formula/s/sops.rb
@@ -7,12 +7,13 @@ class Sops < Formula
   head "https://github.com/getsops/sops.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "47fb0da48816583bb499374230d9a1eb3d568dbfb3e5dad262b2b416f13c71c6"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "47fb0da48816583bb499374230d9a1eb3d568dbfb3e5dad262b2b416f13c71c6"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "47fb0da48816583bb499374230d9a1eb3d568dbfb3e5dad262b2b416f13c71c6"
-    sha256 cellar: :any_skip_relocation, sonoma:        "b6714897154831757549504869480fdd212b3ff6249f547b1c321e8173fa4750"
-    sha256 cellar: :any_skip_relocation, ventura:       "b6714897154831757549504869480fdd212b3ff6249f547b1c321e8173fa4750"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b8787fc174766bbf18e0014ae7b80438e12db9a5db76d0b9645842c867135d10"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "37e076fb5868d03a09f4d1dc0362985f6287277f2f6e52071319d909c5ee572a"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "37e076fb5868d03a09f4d1dc0362985f6287277f2f6e52071319d909c5ee572a"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "37e076fb5868d03a09f4d1dc0362985f6287277f2f6e52071319d909c5ee572a"
+    sha256 cellar: :any_skip_relocation, sonoma:        "7044f03ea020947e1e855ca703de6044fbd778f06d892652da35725ff6db2100"
+    sha256 cellar: :any_skip_relocation, ventura:       "7044f03ea020947e1e855ca703de6044fbd778f06d892652da35725ff6db2100"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "6f5356d7cc9fb4b00f111872dfe2a6d06a60f11cf083d993c74de2ca3f821f07"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Hey,

I would want to use [some unreleased features from sops 3.10](https://github.com/getsops/sops/issues/1803#issuecomment-2734717724) and this requires building from source.

It fails because sops is using `main` branch as the default instead of `master`.

```
$ brew install --HEAD --build-from-source sops
==> Fetching dependencies for sops: go
==> Fetching go
==> Downloading https://ghcr.io/v2/homebrew/core/go/manifests/1.24.1
Already downloaded: /Users/onnimonni/Library/Caches/Homebrew/downloads/c429f880dd8fd02f79c56590e458180716ef21784fb09e304b865b6011bb9c9c--go-1.24.1.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/go/blobs/sha256:b19cbfcaf4a76ce2cd2bfd22538d6a019f75e25f274f9d2f92f5ba1850906942
Already downloaded: /Users/onnimonni/Library/Caches/Homebrew/downloads/e08425ba19478e36a0b4cc718cab3046ddc522cf66e8e0a293be9a87555935b8--go--1.24.1.arm64_sequoia.bottle.tar.gz
==> Fetching sops
==> Downloading https://raw.githubusercontent.com/Homebrew/homebrew-core/83a9a9932069859d0ab798add393da38b1370052/Formula/s/sops.rb
Already downloaded: /Users/onnimonni/Library/Caches/Homebrew/downloads/bd3b931e12685e250a232abca736219baa4893f7535bfddee806c6f01d1f1d9e--sops.rb
==> Cloning https://github.com/getsops/sops.git
Cloning into '/Users/onnimonni/Library/Caches/Homebrew/sops--git'...
fatal: Remote branch master not found in upstream origin
Error: sops: Failed to download resource "sops"
Failure while executing; `/usr/bin/env git clone --branch master --config advice.detachedHead=false --config core.fsmonitor=false https://github.com/getsops/sops.git /Users/onnimonni/Library/Caches/Homebrew/sops--git` exited with 128. Here's the output:
Cloning into '/Users/onnimonni/Library/Caches/Homebrew/sops--git'...
fatal: Remote branch master not found in upstream origin
```