### PR TITLE
mmctl 10.6.1

### DIFF
--- a/Formula/m/mmctl.rb
+++ b/Formula/m/mmctl.rb
@@ -1,11 +1,15 @@
 class Mmctl < Formula
   desc "Remote CLI tool for Mattermost server"
-  homepage "https://github.com/mattermost/mmctl"
-  url "https://github.com/mattermost/mmctl.git",
-      tag:      "v7.10.5",
-      revision: "ce61514f470b82795eb25d927bbf073b3bd037c6"
-  license "Apache-2.0"
-  head "https://github.com/mattermost/mmctl.git", branch: "master"
+  homepage "https://github.com/mattermost/mattermost"
+  url "https://github.com/mattermost/mattermost/archive/refs/tags/v10.6.1.tar.gz"
+  sha256 "78fc4e398cb63d11141d2915d12fbd900755eeada7ba5f239d13c2cf053a38b8"
+  license all_of: ["AGPL-3.0-only", "Apache-2.0"]
+  head "https://github.com/mattermost/mattermost.git", branch: "master"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "e438f2cd6a51a683e033ce697e7c660888708f59df47ca4777e44bcc4c1f14e8"
@@ -20,13 +24,15 @@ class Mmctl < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "4eb33d2c49c5db76ea8afb3bb3a5b28b8c4234e7161a520c3e934f251407538d"
   end
 
-  deprecate! date: "2024-08-01", because: :repo_archived
-
   depends_on "go" => :build
 
   def install
-    ldflags = "-s -w -X github.com/mattermost/mmctl/commands.BuildHash=#{Utils.git_head}"
-    system "go", "build", *std_go_args(ldflags:), "-mod=vendor"
+    # remove non open source files
+    rm_r("server/enterprise")
+
+    ldflags = "-s -w -X github.com/mattermost/mattermost/server/v8/cmd/mmctl/commands.buildDate=#{time.iso8601}"
+    system "make", "-C", "server", "setup-go-work"
+    system "go", "build", "-C", "server", *std_go_args(ldflags:), "./cmd/mmctl"
 
     # Install shell completions
     generate_completions_from_executable(bin/"mmctl", "completion", shells: [:bash, :zsh])

--- a/Formula/m/mmctl.rb
+++ b/Formula/m/mmctl.rb
@@ -12,16 +12,12 @@ class Mmctl < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "e438f2cd6a51a683e033ce697e7c660888708f59df47ca4777e44bcc4c1f14e8"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "556076fdaa27b44d9cfdbc10cc906d304d1b04907dc631965c727a4818b7fa3f"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "7f9bbd0ee1ba75322fb8a48fa6e3bbe9df725923d15bcd835484af20dfde6497"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "7f9bbd0ee1ba75322fb8a48fa6e3bbe9df725923d15bcd835484af20dfde6497"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "7f9bbd0ee1ba75322fb8a48fa6e3bbe9df725923d15bcd835484af20dfde6497"
-    sha256 cellar: :any_skip_relocation, sonoma:         "9b62b1e5b52d644412d2d2ad01a9cde33c040a73da9e1d952cbcfa75e12cc61b"
-    sha256 cellar: :any_skip_relocation, ventura:        "ce5037a3240ce5a32b1c0f748823c719e221eee469ee116d4a66469f8c6800a2"
-    sha256 cellar: :any_skip_relocation, monterey:       "ce5037a3240ce5a32b1c0f748823c719e221eee469ee116d4a66469f8c6800a2"
-    sha256 cellar: :any_skip_relocation, big_sur:        "ce5037a3240ce5a32b1c0f748823c719e221eee469ee116d4a66469f8c6800a2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4eb33d2c49c5db76ea8afb3bb3a5b28b8c4234e7161a520c3e934f251407538d"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "c8de32b39dc896d0d23bafb17f981dabdcb3c872ba5e93189a91a07b46cccc21"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "c8de32b39dc896d0d23bafb17f981dabdcb3c872ba5e93189a91a07b46cccc21"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "c8de32b39dc896d0d23bafb17f981dabdcb3c872ba5e93189a91a07b46cccc21"
+    sha256 cellar: :any_skip_relocation, sonoma:        "24178840a5aefa6a436b92bbbf1464369b7fc14b40120163c6748ffa1cfe112f"
+    sha256 cellar: :any_skip_relocation, ventura:       "24178840a5aefa6a436b92bbbf1464369b7fc14b40120163c6748ffa1cfe112f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "9dadd79b4de9a5e8955eed7bb66a913b5af71d0930ac9cc5078c68c6a363af4c"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
https://github.com/mattermost/mmctl/blob/master/README.md
> mmctl no longer lives in this repository since we have moved to using a monorepo located in https://github.com/mattermost/mattermost.

Added AGPL-3.0-only to license based on https://github.com/mattermost/mattermost/blob/master/LICENSE.txt
