### PR TITLE
mill 0.12.9

### DIFF
--- a/Formula/m/mill.rb
+++ b/Formula/m/mill.rb
@@ -11,7 +11,7 @@ class Mill < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "5cc436fd296cf06161609cc7181ab82307d1d4c0d23392d2f0f04cf3b6ddd196"
+    sha256 cellar: :any_skip_relocation, all: "3c560b497e3d0a930261a3a5f9aaf18859458040b951e04fad9a54b5cd3a1da7"
   end
 
   depends_on "openjdk"

--- a/Formula/m/mill.rb
+++ b/Formula/m/mill.rb
@@ -1,16 +1,13 @@
 class Mill < Formula
-  desc "Scala build tool"
-  homepage "https://mill-build.com/mill/Scala_Intro_to_Mill.html"
-  url "https://github.com/com-lihaoyi/mill/releases/download/0.12.5/0.12.5-assembly"
-  sha256 "0c7b25412feecf06d955d013418de9a9080ce755bedbac7601c9109c33d5a057"
+  desc "Fast, scalable JVM build tool"
+  homepage "https://mill-build.org/"
+  url "https://search.maven.org/remotecontent?filepath=com/lihaoyi/mill-dist/0.12.9/mill-dist-0.12.9.jar"
+  sha256 "36dab38afcbc75fb119417253cdb16399e21d5793b0f750957b18b5462047005"
   license "MIT"
 
-  # There can be a notable gap between when a version is tagged and a
-  # corresponding release is created, so we check the "latest" release instead
-  # of the Git tags.
   livecheck do
-    url :stable
-    strategy :github_latest
+    url "https://search.maven.org/remotecontent?filepath=com/lihaoyi/mill-dist/maven-metadata.xml"
+    regex(%r{<version>v?(\d+(?:\.\d+)+)</version>}i)
   end
 
   bottle do


### PR DESCRIPTION
Files are now uploaded on Maven rather than GitHub.

See https://github.com/com-lihaoyi/mill/blob/0.12.9/mill#L214-L231
```sh
      0.5.* | 0.6.* | 0.7.* | 0.8.* | 0.9.* | 0.10.* | 0.11.0-M* )
        DOWNLOAD_SUFFIX="-assembly"
        DOWNLOAD_FROM_MAVEN=0
        ;;
      *)
        DOWNLOAD_SUFFIX="-assembly"
        DOWNLOAD_FROM_MAVEN=1
        ;;
    esac


    DOWNLOAD_FILE=$(mktemp mill.XXXXXX)


    if [ "$DOWNLOAD_FROM_MAVEN" = "1" ] ; then
      DOWNLOAD_URL="https://repo1.maven.org/maven2/com/lihaoyi/mill-dist${ARTIFACT_SUFFIX}/${MILL_VERSION}/mill-dist${ARTIFACT_SUFFIX}-${MILL_VERSION}.jar"
    else
      MILL_VERSION_TAG=$(echo "$MILL_VERSION" | sed -E 's/([^-]+)(-M[0-9]+)?(-.*)?/\1\2/')
      DOWNLOAD_URL="${GITHUB_RELEASE_CDN}${MILL_REPO_URL}/releases/download/${MILL_VERSION_TAG}/${MILL_VERSION}${DOWNLOAD_SUFFIX}"
```

So above URL schemes are:
* 0.12 and newer: `https://repo1.maven.org/maven2/com/lihaoyi/mill-dist/#{version}/mill-dist-${version}.jar`
* 0.11 and older: `https://github.com/com-lihaoyi/mill/releases/download/#{version}/#{version}-assembly`