### PR TITLE
mhonarc 2.6.24

### DIFF
--- a/Formula/m/mhonarc.rb
+++ b/Formula/m/mhonarc.rb
@@ -1,27 +1,16 @@
 class Mhonarc < Formula
   desc "Mail-to-HTML converter"
   homepage "https://www.mhonarc.org/"
-  url "https://www.mhonarc.org/release/MHonArc/tar/MHonArc-2.6.19.tar.bz2"
-  sha256 "08912eae8323997b940b94817c83149d2ee3ed11d44f29b3ef4ed2a39de7f480"
+  url "https://cpan.metacpan.org/authors/id/L/LD/LDIDRY/MHonArc-2.6.24.tar.gz"
+  sha256 "457dc7374ee59cb75a0729e51cef2f2c52b48180f739d8fd956ea19882815f33"
   license "GPL-2.0-or-later"
-  revision 6
-
-  livecheck do
-    url :homepage
-    regex(/href=.*?MHonArc[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
+  head "https://github.com/sympa-community/mhonarc.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "e4d56bb7e4a40a68b0a23faf8d4df159142e6e4f1f55ebd457fffd64e478a6d9"
   end
 
   depends_on "perl"
-
-  # Apply a bugfix for syntax. https://savannah.nongnu.org/bugs/?49997
-  patch do
-    url "https://file.savannah.gnu.org/file/monharc.patch?file_id=39391"
-    sha256 "723ef1779474c6728fbc88b1f6e9a4ca2c22d76a8adc4d3bd8838793852e60c4"
-  end
 
   def install
     # Using Perl's `installprefix` rather than `prefix` allows install.me to use

--- a/Formula/m/mhonarc.rb
+++ b/Formula/m/mhonarc.rb
@@ -7,7 +7,7 @@ class Mhonarc < Formula
   head "https://github.com/sympa-community/mhonarc.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "e4d56bb7e4a40a68b0a23faf8d4df159142e6e4f1f55ebd457fffd64e478a6d9"
+    sha256 cellar: :any_skip_relocation, all: "c6d3c93cbdca1f8cfba7471ad031646541f79d166e2a560006c6f445d748fa33"
   end
 
   depends_on "perl"


### PR DESCRIPTION
Switching to different upstream based on wide adoption.

This has been accepted by both Debian and Fedora along with others like FreeBSD, GNU Guix, MacPorts, NixOS (https://repology.org/project/mhonarc/versions).

Also the default installation via CPAN https://metacpan.org/dist/MHonArc