### PR TITLE
workflows/dispatch-rebottle: support formulae with arm64 Linux bottles

### DIFF
--- a/.github/workflows/dispatch-rebottle.yml
+++ b/.github/workflows/dispatch-rebottle.yml
@@ -47,6 +47,7 @@ env:
   HOMEBREW_NO_AUTO_UPDATE: 1
   HOMEBREW_NO_INSTALL_FROM_API: 1
   HOMEBREW_NO_BUILD_ERROR_ISSUES: 1
+  HOMEBREW_ARM64_TESTING: 1
   RUN_URL: ${{github.event.repository.html_url}}/actions/runs/${{github.run_id}}
   DISPATCH_REBOTTLE_SENDER: ${{ github.event.sender.login }}
   DISPATCH_REBOTTLE_FORMULA: ${{ inputs.formula }}


### PR DESCRIPTION
This will allow the `dispatch-rebottle.yml` workflow to just work for
formulae with `:arm64_linux` bottles.
