### PR TITLE
minio-mc: use tag format as version scheme

### DIFF
--- a/Formula/m/minio-mc.rb
+++ b/Formula/m/minio-mc.rb
@@ -16,12 +16,12 @@ class MinioMc < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "d6664bb82d01bcfbd5d05324c19a98c8f200b01f9391baea0ec1274e3f0ff6d5"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "5ba914981ff99303de89027ddac4b3f4ba8b19b01c4f3f2ff6d250ca0c212942"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "49beafdca6f021c62cfb5de7ce485939e5ca896c1b16ded447d39347c678f086"
-    sha256 cellar: :any_skip_relocation, sonoma:        "a3bdd239ec5b14723e6ed399be6adfff6a0f636ffffa12e22b95dfe30f4b6c1d"
-    sha256 cellar: :any_skip_relocation, ventura:       "ec06c6ec4ba770badc942180366bf026b5315e30ce541f69bda0ad5e64f959fd"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3111657b76dd04056c942b718aab8750a0c143235292aeebae97efbcfce5c7a4"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "b0cef88cd24ef1e038c3baba4c255dea2e3155db389965ef5da5ff310604eee8"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "d865d22a208966ebd510e233faba29325cd9a7e210a7ba36be5856a76363c4c6"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "54291fc6fed65a558ef8b54e0cc4c31b36ff73f9e061c1755033231280a937e8"
+    sha256 cellar: :any_skip_relocation, sonoma:        "51db5c1e042363d812f874ecfb318364ef9c9c8fad97b0082a3d1b6fd3508a20"
+    sha256 cellar: :any_skip_relocation, ventura:       "2a791ec089b9a66410828317240eb84c99a4f80577cc64cce40faf33ba1e5f68"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "29a463971735a35dabfaff3f4a917bf8aeec47a3998c909ed6aa21ddba7b7a9c"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
Not sure exact reason we chose original version scheme (maybe we didn't support some characters?).

Just basing version scheme from tag avoids a lot of hassle of transforming it in livecheck.

Upstream uses full git tag (https://github.com/minio/homebrew-stable/blob/master/mc.rb#L3) but we need to strip out "RELEASE." prefix for version parser and it matches others on Repology https://repology.org/project/minio-mc/versions

This also avoids Repology blacklisting our versions: https://github.com/repology/repology-rules/blob/master/900.version-fixes/m.yaml#L151
```yaml
- { name: minio-mc,                    verpat: "[0-9]+",                                   incorrect: true } # must use separators
```

---

Let's fix Copyright year too. Existing bottle shows:
```
Copyright (c) 2015-0000 MinIO, Inc.
```

Used year from tag as that is what upstream build script does (https://github.com/minio/mc/blob/master/buildscripts/gen-ldflags.go#L32-L33). Could alternatively use `time.year`.