### PR TITLE
procmail 3.24

### DIFF
--- a/Formula/p/procmail.rb
+++ b/Formula/p/procmail.rb
@@ -7,21 +7,12 @@ class Procmail < Formula
   version_scheme 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "3797ccaf0b1d12c6b04012265e1cbad538769cad66d9175e6fb0e8a7e0cfc54d"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "791a9a4eb68e2bc3e190dc7ab66efa1c1516abe9457c7a6e00bfca199ae3564a"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "0ebd812ae059d9cfcdc313028d1a967093b2fcb54745308f3ac900f17f850822"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "f36e2740c6191a3cc46063e606fa3bf9bd5f5da712e7ef191722ee1ef5c85810"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "e39fb3a7e1b24091190e1348b3a0cecf28f189828c5b5b126e3de0bfedaa02ac"
-    sha256 cellar: :any_skip_relocation, sonoma:         "4702908a7f5fb3ce9fc5e08ad9d3978c69b2a5cafd5706672550eaf05fd78b8e"
-    sha256 cellar: :any_skip_relocation, ventura:        "7b6228407ed3b8ad685845095e0d0ef126cefe4994a2ac87db15c4abc8b6bb23"
-    sha256 cellar: :any_skip_relocation, monterey:       "68edea089a8cac07fe73a92c5c31ab7f8a17e4f57affad9acd8cc1d71e2bc8bf"
-    sha256 cellar: :any_skip_relocation, big_sur:        "c29ed505600498218a3733d68ebff1eb29c259ac3789da32dc2c76d9aaa33527"
-    sha256 cellar: :any_skip_relocation, catalina:       "a7f6ee9550f27ea88322a4c4c88b04421e6d2c676248a914571a2fbffd6d425f"
-    sha256 cellar: :any_skip_relocation, mojave:         "48be3e5215b4ac296ef1f9150b313964112e5c7d04fe20489f336342548656e0"
-    sha256 cellar: :any_skip_relocation, high_sierra:    "c64920b1989d941d9aa4de7c275cf2e80306cb8bd2ee5d8263e883ddab7ef2e3"
-    sha256 cellar: :any_skip_relocation, sierra:         "c64ccf998d9c71d1b73004abe4c96a8c35993cf4c1a899cd6d92bfab82b9272a"
-    sha256 cellar: :any_skip_relocation, el_capitan:     "3328bcda4649612afba606950e59f4cb0c22e10fe97a4f1e38f190e3e4115800"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "72b9fa811e78c4bbda5b5d1c85493954afacc8382c0e7ce69af5197f4c739279"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "4a2dee1f884a35fe10236bd86b12bd6bc507aa720f764be04e75fdc042c75fd8"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "a9daf01dcf08b8b98d376cc6a99f1e8404db58f51ee2d62305ec604ddbcf3d7f"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "09fcc2d016f1f67c3f69caa887411eab4e0b44c0c1e465841604bf6210522e8c"
+    sha256 cellar: :any_skip_relocation, sonoma:        "d075ce7ac129209d21b5eeb25f2c5431f7921bb42d36140913855c27ee1aa53d"
+    sha256 cellar: :any_skip_relocation, ventura:       "f3b010bf2fb93f2dea465f19d898358e75f0fce1bfca7e31cb6298b607426f8e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "09534e911a38143ef58d749661b6359585308a1f42cb842b425f3fa6f803ff70"
   end
 
   # Apply open PR to fix build on modern Clang/GCC rather than disabling errors.


### PR DESCRIPTION
Switch from Apple's unmaintained copy (Apple's v14 is a patched official v3.22 which has CVEs) to the original author's active git repo.

Same source used by Fedora, Gentoo and MacPorts - https://repology.org/project/procmail/versions

