### PR TITLE
xorriso 1.5.6.pl02

### DIFF
--- a/Formula/x/xorriso.rb
+++ b/Formula/x/xorriso.rb
@@ -1,10 +1,16 @@
 class Xorriso < Formula
   desc "ISO9660+RR manipulation tool"
   homepage "https://www.gnu.org/software/xorriso/"
-  url "https://ftp.gnu.org/gnu/xorriso/xorriso-1.5.6.tar.gz"
-  mirror "https://ftpmirror.gnu.org/xorriso/xorriso-1.5.6.tar.gz"
-  sha256 "d4b6b66bd04c49c6b358ee66475d806d6f6d7486e801106a47d331df1f2f8feb"
+  url "https://ftp.gnu.org/gnu/xorriso/xorriso-1.5.6.pl02.tar.gz"
+  mirror "https://ftpmirror.gnu.org/xorriso/xorriso-1.5.6.pl02.tar.gz"
+  version "1.5.6.pl02"
+  sha256 "786f9f5df9865cc5b0c1fecee3d2c0f5e04cab8c9a859bd1c9c7ccd4964fdae1"
   license "GPL-2.0-or-later"
+
+  livecheck do
+    url :stable
+    regex(/href=.*?xorriso[._-]v?(\d+(?:\.\d+)+(?:\.pl\d+)?)\.t/i)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "9b8deb74524ee426ccfed55983d41f621de69ba1ffea7c574496b1bec72ef3ae"
@@ -21,13 +27,8 @@ class Xorriso < Formula
 
   uses_from_macos "zlib"
 
-  # Submit the patch into the upstream, see:
-  # https://lists.gnu.org/archive/html/bug-xorriso/2023-06/msg00000.html
-  patch :DATA
-
   def install
-    system "./configure", "--disable-debug", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
+    system "./configure", "--disable-silent-rules", *std_configure_args
     system "make"
 
     # `make install` has to be deparallelized due to the following error:
@@ -42,17 +43,3 @@ class Xorriso < Formula
     assert_match version.to_s, shell_output("#{bin}/xorriso -version")
   end
 end
-
-__END__
-diff --git a/libisofs/rockridge.h b/libisofs/rockridge.h
-index 5649eb7..01c4224 100644
---- a/libisofs/rockridge.h
-+++ b/libisofs/rockridge.h
-@@ -41,6 +41,8 @@
-
- #include "ecma119.h"
-
-+/* For ssize_t */
-+#include <unistd.h>
-
- #define SUSP_SIG(entry, a, b) ((entry->sig[0] == a) && (entry->sig[1] == b))

--- a/Formula/x/xorriso.rb
+++ b/Formula/x/xorriso.rb
@@ -13,16 +13,12 @@ class Xorriso < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "9b8deb74524ee426ccfed55983d41f621de69ba1ffea7c574496b1bec72ef3ae"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "4231bedc678f7cbb7151e5dd846ade6123811b472b7a378164b29d0edaaf8680"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "3e64ea078ab6659f5892db71cf6d2c72825cbefb80956ee88a8aaf5d0080594d"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "0c7004800a9d909e5cbe3373dbb2d8fb71a943d022901f8a5b950c34c52215b5"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "b6a4f6c99d783a4c6c7b32438aae079f7d769b34ad831310868309fe275ff585"
-    sha256 cellar: :any_skip_relocation, sonoma:         "f9020ad45bcbf572393a1a95377c38fb8aaf861aaa09510d379fdd19e0f9a598"
-    sha256 cellar: :any_skip_relocation, ventura:        "3865faab160986fdaa7e94f37056a15a1b790a32501118e4d6ab91abeb9543ce"
-    sha256 cellar: :any_skip_relocation, monterey:       "b0d7600730ba18eab8cdc658ddeb80f849906fbd505694a7603e57650568b392"
-    sha256 cellar: :any_skip_relocation, big_sur:        "b69459a4b5cbf28b29730e7b79ee89f1fd916d2c7f05c4de83826296c576a79f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "af398fe111c552f7c70837d0179cd5f42784a79444fb9dc913c4fdf4b0eb8da6"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "4ce9aa17c62698d61ba30175e05e730cdbfb45c00f414728e344912d8f533e50"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "1c0d17d1c03669586c4d7f5e10c915ff46e0448b65838ad8f4b4b9cda589f0b9"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "cb072e208fba6a3d7e100b173dabba79aad125900499366ae5c876223d51589e"
+    sha256 cellar: :any_skip_relocation, sonoma:        "d4c500ee979adcd61b5f7fd5790992ebd1209d7d778244d39e5b070ad317b62e"
+    sha256 cellar: :any_skip_relocation, ventura:       "6d06e4c85a3b819c1b0f6209de9ff66be94464f5f7ffc6e54987c1a9808417d6"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "db3610de57dbb6a1b2bf32776acc9803efe9a951791101692eb65dc6df1226bd"
   end
 
   uses_from_macos "zlib"


### PR DESCRIPTION
`.pl*` seem to be stable releases

It is the download link on homepage (https://www.gnu.org/software/xorriso/#download) and upstream specifically says previous 1.5.6 is deprecated.

> [xorriso-1.5.6.pl02.tar.gz](https://www.gnu.org/software/xorriso/xorriso-1.5.6.pl02.tar.gz) (2780 KiB).
> (Released 14 Jun 2023)
> ...
> Bug fixes towards deprecated version xorriso-1.5.6:

And also listed as a release on changelog https://dev.lovelyhq.com/libburnia/libisoburn/src/branch/master/xorriso/changelog.txt#L20530