### PR TITLE
ruff-lsp: add livecheck

### DIFF
--- a/Formula/r/ruff-lsp.rb
+++ b/Formula/r/ruff-lsp.rb
@@ -7,6 +7,12 @@ class RuffLsp < Formula
   sha256 "4a1704dc96dc1353557b5edd0733768f3948cfc92042fd332927648e080754bc"
   license "MIT"
 
+  # This minimal `livecheck` block enables us to continue identifying new
+  # versions as long as upstream continues publishing them.
+  livecheck do
+    url :stable
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "9923bd6918b8ee785e265492ded1e3422e9e2f4ea2dfcbed11801acde3a3751c"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `ruff-lsp` formula is deprecated (as the package is deprecated upstream) but it seems that upstream may still be publishing new versions. This adds a minimal `livecheck` block to allow us to continue checking for new versions despite the deprecation, until it's clear that there won't be further versions. At that point, we can remove the `livecheck` block and remove `ruff-lsp` from the autobump list.

There's a newer 0.0.62 version but I'll let autobump handle that after this is merged.