### PR TITLE
pylint: update deps

### DIFF
--- a/Formula/p/pylint.rb
+++ b/Formula/p/pylint.rb
@@ -19,8 +19,15 @@ class Pylint < Formula
   depends_on "python@3.13"
 
   resource "astroid" do
-    url "https://files.pythonhosted.org/packages/80/c5/5c83c48bbf547f3dd8b587529db7cf5a265a3368b33e85e76af8ff6061d3/astroid-3.3.8.tar.gz"
-    sha256 "a88c7994f914a4ea8572fac479459f4955eeccc877be3f2d959a33273b0cf40b"
+    url "https://files.pythonhosted.org/packages/39/33/536530122a22a7504b159bccaf30a1f76aa19d23028bd8b5009eb9b2efea/astroid-3.3.9.tar.gz"
+    sha256 "622cc8e3048684aa42c820d9d218978021c3c3d174fb03a9f0d615921744f550"
+
+    # fix `setuptools.errors.InvalidConfigError: 'project.license-files' is defined already`
+    # commit ref, https://github.com/pylint-dev/astroid/commit/9faee90fdb66049162834a8bb066c6cb40a0e449
+    patch do
+      url "https://github.com/pylint-dev/astroid/commit/9faee90fdb66049162834a8bb066c6cb40a0e449.patch?full_index=1"
+      sha256 "768c90c11552b7b2c9af3afbf1a17f76855497fa1d10f9ba6c09e50721430c0f"
+    end
   end
 
   resource "dill" do
@@ -39,8 +46,8 @@ class Pylint < Formula
   end
 
   resource "platformdirs" do
-    url "https://files.pythonhosted.org/packages/13/fc/128cc9cb8f03208bdbf93d3aa862e16d376844a14f9a0ce5cf4507372de4/platformdirs-4.3.6.tar.gz"
-    sha256 "357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907"
+    url "https://files.pythonhosted.org/packages/b6/2d/7d512a3913d60623e7eb945c6d1b4f0bddf1d0b7ada5225274c87e5b53d1/platformdirs-4.3.7.tar.gz"
+    sha256 "eb437d586b6a0986388f0d6f74aa0cde27b48d0e3d66843640bfb6bdcdb6e351"
   end
 
   resource "tomlkit" do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/actions/runs/13960780397/job/39081641191#step:5:2544

```
      File "/tmp/pip-build-env-v5x_3f6r/overlay/lib/python3.13/site-packages/setuptools/config/_apply_pyprojecttoml.py", line 94, in _apply_tool_table
        raise InvalidConfigError(
        ...<2 lines>...
        )
    setuptools.errors.InvalidConfigError: 'project.license-files' is defined already. Remove 'tool.setuptools.license-files'.
    error: subprocess-exited-with-error
```

https://github.com/pylint-dev/astroid/pull/2707
https://github.com/Homebrew/homebrew-core/issues/211761