### PR TITLE
xml-security-c 3.0.0

### DIFF
--- a/Formula/o/opensaml.rb
+++ b/Formula/o/opensaml.rb
@@ -12,12 +12,12 @@ class Opensaml < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "424750ca3b4b621fc165bd65c1fa43bf8380b1e2edc02e54a69c8c0d0a362848"
-    sha256 cellar: :any,                 arm64_sonoma:  "598d3f098f2019a58c6eb7e0209166386ba5b95aa2c65fbe295efefd1667004b"
-    sha256 cellar: :any,                 arm64_ventura: "8cb5d53e9ce9c54089927ec316df7ffe533fef191704f7f32af88ae09010689e"
-    sha256 cellar: :any,                 sonoma:        "5d4e1be03c528a97e4e4ac17af63b712a61022c8fd26d2abd83f65732dc66b41"
-    sha256 cellar: :any,                 ventura:       "024e4168fb0530e8b68440549a53534c99b0943d5ef1278012c816ec8a766660"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "21dc02829bae8f62f56be0d9c0456fd804ba004bf41c13ad16ca0f534a759e80"
+    sha256 cellar: :any,                 arm64_sequoia: "07a24e559fba8ef6206aa142b47c40d15dd68ec6ecebfcf6ef4e249461a1ebfc"
+    sha256 cellar: :any,                 arm64_sonoma:  "2433e81f6f75b41ace4f4b39a8bc336aad0d07324efe4f5758966ba8db3270be"
+    sha256 cellar: :any,                 arm64_ventura: "30a5d4e496a4053fc99686974cca11d4b8be3d331fe55c0cec552d8171060730"
+    sha256 cellar: :any,                 sonoma:        "11823d44fd8032eb8e3f61827de120b93656107a2e31fbeedc95a78c52e34017"
+    sha256 cellar: :any,                 ventura:       "8045e1d48ada4b5fa6c2a524cda2dd2b31e33014e49d2894b9fdd134597703cc"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "7113cf3ec71403d5a0c60bb4f6e9c358c60f57cf80e203d9cd34cb19f5d1898e"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/o/opensaml.rb
+++ b/Formula/o/opensaml.rb
@@ -4,6 +4,7 @@ class Opensaml < Formula
   url "https://shibboleth.net/downloads/c++-opensaml/3.3.1/opensaml-3.3.1.tar.bz2"
   sha256 "d8e24e070fc6bb80682632ca32c8569a9f3ef170ba57e3b82818322e75b6a37e"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     url "https://shibboleth.net/downloads/c++-opensaml/latest/"

--- a/Formula/s/shibboleth-sp.rb
+++ b/Formula/s/shibboleth-sp.rb
@@ -4,7 +4,7 @@ class ShibbolethSp < Formula
   url "https://shibboleth.net/downloads/service-provider/3.5.0/shibboleth-sp-3.5.0.tar.bz2"
   sha256 "f301604bd17ee4d94a66e6dd7ad1c3f0917949a4a12176d55614483d78fefe58"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   livecheck do
     url "https://shibboleth.net/downloads/service-provider/latest/"

--- a/Formula/s/shibboleth-sp.rb
+++ b/Formula/s/shibboleth-sp.rb
@@ -12,12 +12,12 @@ class ShibbolethSp < Formula
   end
 
   bottle do
-    sha256 arm64_sequoia: "4775f63d70a8545c0b34b3b4f942ad3fc27775c131c0d7b1e7f1fd433060ca96"
-    sha256 arm64_sonoma:  "c5622bcc552c92e4745d9b25dcb3fd57a8e12792fab73061edd4472376440319"
-    sha256 arm64_ventura: "167477db348c5448a0b7dbe9a833d6e0ce44d9dc4dedb2e2d39d68af82000d1f"
-    sha256 sonoma:        "a342bcc063d8ecb1862ffeae5a6f9f17df629c18161193ad39e3e31ae46610cf"
-    sha256 ventura:       "55bce7112b26166fc371d99c249a454b21c55dd537d1eeecb73c2a6d57690c5c"
-    sha256 x86_64_linux:  "69d911cc442e756b45296634942bd2ed5aff3b3d3ec2d930f086c6f6e12325f2"
+    sha256 arm64_sequoia: "0569ff4651fd7d6700c65c25790574f19066174c768959ae2064aea20ad5a99b"
+    sha256 arm64_sonoma:  "0a46e994d409ba22543dc7bc7736238bcce908efc32d987ce0c043ceced97a70"
+    sha256 arm64_ventura: "e5d6b7a4b089ab17ec32cd0808c1d5f0c7de2190df46a0a02bb00c1561d1cfca"
+    sha256 sonoma:        "3266a747920724d2be0e306610ebfc6348cab7d02331702d398dc6fa671c7dfc"
+    sha256 ventura:       "05d2cc8a93f269863e7dee8ce5806dd840b8d8ba6bf0619cb425b8635a1a6dc3"
+    sha256 x86_64_linux:  "5d6bdcc1ac27a3cadcc7e5b0d38d8718ec1e20ee599f2eb2c373af7d24b34d7e"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/x/xml-security-c.rb
+++ b/Formula/x/xml-security-c.rb
@@ -11,12 +11,12 @@ class XmlSecurityC < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "0ef901d1dd62aede4b0a35b64342b969c1895b519dbe5c41dd2b1a5f82d8c7dc"
-    sha256 cellar: :any,                 arm64_sonoma:  "eb8d5c236aae4140590391f48ac857513958496d3e3d6e593201ef72cc321e40"
-    sha256 cellar: :any,                 arm64_ventura: "ce3ae37e20ef8933d995af0447d498c1fa0f244298694e589b998467323851c2"
-    sha256 cellar: :any,                 sonoma:        "9e8f17a36572dcf16e4da2ecc143a77b58647a5c15e4d7a67bd23bb1261907ed"
-    sha256 cellar: :any,                 ventura:       "516a9bcaa920f654420dd343fab87694cf5902a15d17ec5cfa949c007e01b416"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "027db5710abf606d13b530d94cbfd9c9b0f6b619080dd2aff53fcec7a965ed9d"
+    sha256 cellar: :any,                 arm64_sequoia: "7f42a4e63dc531c44888737938b0e97780bb25053f42f5cd35671294251a9f6d"
+    sha256 cellar: :any,                 arm64_sonoma:  "82490b87ef4a44db821acf34f13bffcf99fd52a3ff372886ee1f001f6d22433a"
+    sha256 cellar: :any,                 arm64_ventura: "b4431f1f09c66f1dc9c73eb72cc78c724e0b0a072f93e26917a114b4eae88ccc"
+    sha256 cellar: :any,                 sonoma:        "58c0752a0c3a1aa6b51dd7c48058661c0d5c56e7d336412a47db907b851d6451"
+    sha256 cellar: :any,                 ventura:       "abc08033a4513a659e7938e3708dabc82fd26451d46ea6f400292e4bef28ff98"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2cce7dc9da8984c26b39b9e203162782902841d2ca55b40299c846522ba17407"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/x/xml-security-c.rb
+++ b/Formula/x/xml-security-c.rb
@@ -1,11 +1,14 @@
 class XmlSecurityC < Formula
   desc "Implementation of primary security standards for XML"
   homepage "https://santuario.apache.org/"
-  url "https://www.apache.org/dyn/closer.lua?path=santuario/c-library/xml-security-c-2.0.4.tar.bz2"
-  mirror "https://archive.apache.org/dist/santuario/c-library/xml-security-c-2.0.4.tar.bz2"
-  sha256 "c83ed1b7c0189cce27a49caa81986938e76807bf35597e6056259af30726beca"
+  url "https://shibboleth.net/downloads/xml-security-c/3.0.0/xml-security-c-3.0.0.tar.bz2"
+  sha256 "a4c9e1ae3ed3e8dab5d82f4dbdb8414bcbd0199a562ad66cd7c0cd750804ff32"
   license "Apache-2.0"
-  revision 2
+
+  livecheck do
+    url "https://shibboleth.net/downloads/xml-security-c/"
+    regex(%r{href=["']?v?(\d+(?:\.\d+)+)/?["' >]}i)
+  end
 
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "0ef901d1dd62aede4b0a35b64342b969c1895b519dbe5c41dd2b1a5f82d8c7dc"
@@ -20,15 +23,13 @@ class XmlSecurityC < Formula
   depends_on "openssl@3"
   depends_on "xerces-c"
 
-  # Fix -flat_namespace being used on Big Sur and later.
+  # Apply Debian patch to avoid segfault in test
   patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
-    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+    url "https://sources.debian.org/data/main/x/xml-security-c/3.0.0-2/debian/patches/Provide-the-Xerces-URI-Resolver-for-the-tests.patch"
+    sha256 "585938480165026990e874fecfae42601dde368f345f1e6ee54b189dbcd01734"
   end
 
   def install
-    ENV.cxx11
-
     system "./configure", "--with-openssl=#{Formula["openssl@3"].opt_prefix}", *std_configure_args
     system "make", "install"
   end

--- a/Formula/x/xml-tooling-c.rb
+++ b/Formula/x/xml-tooling-c.rb
@@ -12,12 +12,12 @@ class XmlToolingC < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "e0ef902c27cf8bfa73f4c0f6bee15ec69d9f8a63bfd8b34006b495b9802d7340"
-    sha256 cellar: :any,                 arm64_sonoma:  "ceef02c1031a06a879a79db01b058b32933da2ba8fa64d956844f9bd2fc35cec"
-    sha256 cellar: :any,                 arm64_ventura: "fa0690dbfc52ee1b79aed3b3d3d768470c6a40da769165959d581b644959b540"
-    sha256 cellar: :any,                 sonoma:        "6893f239e822a225d47b76d1fdddb881e1eb9b3ffd5f230fd4c7779f2befd848"
-    sha256 cellar: :any,                 ventura:       "7c31c534202e7ee09a6b43c0a68f75b17bcddc27d6e25df419383419d60a79e0"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2342976e7b86e5826af7d8634ae96c3abc75b1fae9a80436d7e513278887e0e9"
+    sha256 cellar: :any,                 arm64_sequoia: "1b36b66bb9b46fd88ee081350f982c80b786f7badafdf75a741c900be3e1b911"
+    sha256 cellar: :any,                 arm64_sonoma:  "64daef61885d864d71a90bdfaee06917c8c804f16047e57cd7f61e7ea010f2d0"
+    sha256 cellar: :any,                 arm64_ventura: "0e898674f0dff6301c67b43a6f6d2777e8b1f6699db05030c53ad941386e5c88"
+    sha256 cellar: :any,                 sonoma:        "bbb79415f2f27bbecb0695af2c7547f3c08f3caa681564c4f5a10c1732d41f25"
+    sha256 cellar: :any,                 ventura:       "c8d74d8e11b29f17443ceafce0ab9764a22e5cd8dd049929fbc93b11abcfbd7a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "ed7b54bffbe67ec82fa423f304ee36a5877efd2bcc3d163d5bb71f23dc9a7dcd"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/x/xml-tooling-c.rb
+++ b/Formula/x/xml-tooling-c.rb
@@ -4,6 +4,7 @@ class XmlToolingC < Formula
   url "https://shibboleth.net/downloads/c++-opensaml/3.3.0/xmltooling-3.3.0.tar.bz2"
   sha256 "0a2c421be976f3a44b876d6b06ba1f6a2ffbc404f4622f8a65a66c3ba77cb047"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     url "https://shibboleth.net/downloads/c++-opensaml/latest/"


### PR DESCRIPTION
Maintenance was officially transferred from Apache to Shibboleth Project, see https://santuario.apache.org

> As announced early this year, the C++ library has been officially retired. A fork of this code base has been migrated to the Shibboleth Project, which has been the sole maintainer for a number of years now. See [the Shibboleth wiki](https://shibboleth.atlassian.net/wiki/spaces/DEV/pages/3726671873/Santuario) for notable caveats regarding usage of this code.

