### PR TITLE
libxml2: added --enable-static to build config

### DIFF
--- a/Formula/lib/libxml2.rb
+++ b/Formula/lib/libxml2.rb
@@ -77,6 +77,7 @@ class Libxml2 < Formula
     system "autoreconf", "--force", "--install", "--verbose" # if build.head?
     system "./configure", "--disable-silent-rules",
                           "--sysconfdir=#{etc}",
+                          "--enable-static",
                           "--with-history",
                           "--with-http",
                           "--with-icu",


### PR DESCRIPTION
This is desired because libxml2 is linked with a number of versioned shared
libraries like libicu which themselves provide static libraries, but
when those formulae update, anything dynamically linked with libxml2 breaks. Statically linking with libxml would avoid this issue altogether.
