### PR TITLE
bash-git-prompt: fix test for linux

### DIFF
--- a/Formula/b/bash-git-prompt.rb
+++ b/Formula/b/bash-git-prompt.rb
@@ -30,7 +30,7 @@ class BashGitPrompt < Formula
   end
 
   test do
-    output = shell_output("/bin/sh #{share}/gitstatus.sh 2>&1")
+    output = shell_output("/bin/bash #{share}/gitstatus.sh 2>&1")
     assert_match "not a git repository", output
   end
 end

--- a/Formula/b/bash-git-prompt.rb
+++ b/Formula/b/bash-git-prompt.rb
@@ -7,7 +7,8 @@ class BashGitPrompt < Formula
   head "https://github.com/magicmonty/bash-git-prompt.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "aba8fdb7276afbd19020d92a907102912674172b4ff9d4883e349fd73fd69995"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "5049efb01e5ceb83df920dfe1c5dd23595401e3c700064fee74afbf9949d4f8f"
   end
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

On linux, `bash-git-prompt` test currently return
```
bash-git-prompt/2.7.1/share/gitstatus.sh: 9: Bad substitution
```
