### PR TITLE
qsoas: remove from autobump list

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -2862,7 +2862,6 @@ qpid-proton
 qrcp
 qrtool
 qshell
-qsoas
 qsv
 qthreads
 qtkeychain

--- a/Formula/q/qsoas.rb
+++ b/Formula/q/qsoas.rb
@@ -6,6 +6,10 @@ class Qsoas < Formula
   license "GPL-2.0-only"
   revision 1
 
+  # The upstream server has an incomplete certificate chain, producing a
+  # curl error on Linux (`(60) SSL certificate problem: unable to get local
+  # issuer certificate`). This check can still work on macOS but we can't add
+  # this formula to the autoump list until this is resolved.
   livecheck do
     url "https://bip.cnrs.fr/groups/bip06/software/downloads/"
     regex(/href=.*?qsoas[._-]v?(\d+(?:\.\d+)+)\.t/i)


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`qsoas` is in the autobump list but the `livecheck` block has been consistently failing in the autobump environment (Ubuntu 22.04). The check works fine on macOS but it produces a curl error on Linux (`curl: (60) SSL certificate problem: unable to get local issuer certificate`), as the server has an incomplete certificate chain.

This removes `qsoas` from the autobump list and adds an explanatory comment before the `livecheck` block (so we won't try to autobump the formula until this is resolved upstream). This check will fail on Linux CI but technical issues stand in the way of only having the `livecheck` block in an `on_macos` block, so we will have to skip livecheck on those PRs for now. [Namely, `brew style` will complain if we wrap the `livecheck` block in an `on_macos` block (`FormulaAudit/ComponentsOrder: Nest on_macos blocks inside livecheck blocks when there is only one inner block`) but if we do that we get an `undefined method 'on_macos' for an instance of Livecheck` runtime error.]