### PR TITLE
cdk8s: depdend on node@22

### DIFF
--- a/Formula/c/cdk8s.rb
+++ b/Formula/c/cdk8s.rb
@@ -15,7 +15,7 @@ class Cdk8s < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "da5c3a4c5ce3ca69a3cc8cb6dca3ed8767bce370eae556d003063d469d26d8cb"
   end
 
-  depends_on "node"
+  depends_on "node@22"
 
   def install
     system "npm", "install", *std_npm_args


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
With node 23 I was getting the following warning when running `cdk8s synth`:

```text
b'!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n'
b'!!                                                                                                                      !!\n'
b'!!  This software has not been tested with node v23.10.0.                                                               !!\n'
b'!!  Should you encounter odd runtime issues, please try using one of the supported release before filing a bug report.  !!\n'
b'!!                                                                                                                      !!\n'
b'!!  This software is currently running on node v23.10.0.                                                                !!\n'
b'!!  As of the current release of this software, supported node releases are:                                            !!\n'
b'!!  - ^22.0.0 (Planned end-of-life: 2027-04-30)                                                                         !!\n'
b'!!  - ^20.0.0 (Planned end-of-life: 2026-04-30)                                                                         !!\n'
b'!!  - ^18.0.0 (Planned end-of-life: 2025-04-30)                                                                         !!\n'
b'!!                                                                                                                      !!\n'
b'!!  This warning can be silenced by setting the JSII_SILENCE_WARNING_UNTESTED_NODE_VERSION environment variable.        !!\n'
b'!!                                                                                                                      !!\n'
b'!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n'
```

therefore using node@22 now. The issue is that I had to run `brew link --overwrite node@22` to have node in the path. Any recommendations on this?