### PR TITLE
excalidraw-converter: fix backwards compatibility

### DIFF
--- a/Formula/e/excalidraw-converter.rb
+++ b/Formula/e/excalidraw-converter.rb
@@ -19,11 +19,12 @@ class ExcalidrawConverter < Formula
 
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w")
+    bin.install_symlink "excalidraw-converter" => "exconv"
   end
 
   test do
     resource "test_input.excalidraw" do
-      url "https://raw.githubusercontent.com/sindrel/excalidraw-converter/refs/heads/master/test/data/test_input.excalidraw"
+      url "https://raw.githubusercontent.com/sindrel/excalidraw-converter/refs/tags/v1.4.3/test/data/test_input.excalidraw"
       sha256 "46fd108ab73f6ba70610cb2a79326e453246d58399b65ffc95e0de41dd2f12e8"
     end
 
@@ -31,5 +32,6 @@ class ExcalidrawConverter < Formula
     system bin/"excalidraw-converter", "gliffy", "-i", testpath/"test_input.excalidraw", "-o",
 testpath/"test_output.gliffy"
     assert_path_exists testpath/"test_output.gliffy"
+    system bin/"exconv", "version"
   end
 end

--- a/Formula/e/excalidraw-converter.rb
+++ b/Formula/e/excalidraw-converter.rb
@@ -7,12 +7,13 @@ class ExcalidrawConverter < Formula
   head "https://github.com/sindrel/excalidraw-converter.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "763dc4bb5ee943e4410d0e62ce974df086fb30c9880aad434931d5ec7ee315b9"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "763dc4bb5ee943e4410d0e62ce974df086fb30c9880aad434931d5ec7ee315b9"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "763dc4bb5ee943e4410d0e62ce974df086fb30c9880aad434931d5ec7ee315b9"
-    sha256 cellar: :any_skip_relocation, sonoma:        "922fa0d2076dab8305a8b3272be219dca5b5df39f1fe1fac65399406bfe000bb"
-    sha256 cellar: :any_skip_relocation, ventura:       "922fa0d2076dab8305a8b3272be219dca5b5df39f1fe1fac65399406bfe000bb"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "dd5c567b5a6222f47ad7af9c470e806c5518d85dd37bdd614859217a0b6b7ad6"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "dc23c5e752693645418f3c42a98a66579e54c32f8355145e96cc671a36b0516a"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "dc23c5e752693645418f3c42a98a66579e54c32f8355145e96cc671a36b0516a"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "dc23c5e752693645418f3c42a98a66579e54c32f8355145e96cc671a36b0516a"
+    sha256 cellar: :any_skip_relocation, sonoma:        "549b36612acb600e5dfdffae4597a2973cb063600ac61f153349c35f1557666a"
+    sha256 cellar: :any_skip_relocation, ventura:       "549b36612acb600e5dfdffae4597a2973cb063600ac61f153349c35f1557666a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a2d69479c2407d3ef1e1773ceab68642d2e5962a9c870589e2ffca50ff49ee6b"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Adds a symlink to ensure backwards compatibility for users that previously installed from the [sindrel/homebrew-tap](https://github.com/sindrel/homebrew-tap/blob/master/Formula/excalidraw-converter.rb) tap, expecting `exconv`.

Also simplifies verification post-install to make future version updates easier.