### PR TITLE
mold: fix linux arm audit failure

### DIFF
--- a/Formula/m/mold.rb
+++ b/Formula/m/mold.rb
@@ -67,6 +67,9 @@ class Mold < Formula
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
 
+    # remove non-native artifact
+    rm "test/out/test/x86_64/repro/exe" if OS.linux? && Hardware::CPU.arm?
+
     pkgshare.install "test"
   end
 


### PR DESCRIPTION
```
      The offending files are:
        /home/linuxbrew/.linuxbrew/Cellar/mold/2.37.1/share/mold/test/out/test/x86_64/repro/exe	(x86_64)
```

relates to https://github.com/Homebrew/homebrew-core/actions/runs/13977952869/job/39136312152#step:5:64

relates to #211761