### PR TITLE
runme: update build and `head` to use correct org

### DIFF
--- a/Formula/r/runme.rb
+++ b/Formula/r/runme.rb
@@ -7,12 +7,13 @@ class Runme < Formula
   head "https://github.com/runmedev/runme.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "d9077a299edd0efa813c60bc0828d6040f79ab4517c35445b96cff919e5f8bcf"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "d9077a299edd0efa813c60bc0828d6040f79ab4517c35445b96cff919e5f8bcf"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "d9077a299edd0efa813c60bc0828d6040f79ab4517c35445b96cff919e5f8bcf"
-    sha256 cellar: :any_skip_relocation, sonoma:        "85d78447f39d4715ef2687e0240d99fbe12495532afc94e3ddb8f8a3ed4f2768"
-    sha256 cellar: :any_skip_relocation, ventura:       "85d78447f39d4715ef2687e0240d99fbe12495532afc94e3ddb8f8a3ed4f2768"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "65684ce59bb44cf7a74ac1097f8e5ae90681ecb2789538a6db7bd2996548bdd5"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "87b33b519cd52117f0d32ce19bb0cbc6cd978df4c0c641ba08b56afa504772db"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "87b33b519cd52117f0d32ce19bb0cbc6cd978df4c0c641ba08b56afa504772db"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "87b33b519cd52117f0d32ce19bb0cbc6cd978df4c0c641ba08b56afa504772db"
+    sha256 cellar: :any_skip_relocation, sonoma:        "cedba62de9f9bf7570ea77c27a12d626f1dcaef689fbe96929efbdc3a2a5c3da"
+    sha256 cellar: :any_skip_relocation, ventura:       "cedba62de9f9bf7570ea77c27a12d626f1dcaef689fbe96929efbdc3a2a5c3da"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0859c8177de3d4c97ec11e87ac0be649dbf74cd64c8079c1b70c8555e7c9b610"
   end
 
   depends_on "go" => :build

--- a/Formula/r/runme.rb
+++ b/Formula/r/runme.rb
@@ -4,7 +4,7 @@ class Runme < Formula
   url "https://github.com/runmedev/runme/archive/refs/tags/v3.12.7.tar.gz"
   sha256 "26fa831b2848d75de42f9f48cfbe3c15ee6624336dc747cd3c52763bb76d3f35"
   license "Apache-2.0"
-  head "https://github.com/stateful/runme.git", branch: "main"
+  head "https://github.com/runmedev/runme.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "d9077a299edd0efa813c60bc0828d6040f79ab4517c35445b96cff919e5f8bcf"
@@ -20,9 +20,9 @@ class Runme < Formula
   def install
     ldflags = %W[
       -s -w
-      -X github.com/stateful/runme/v3/internal/version.BuildDate=#{time.iso8601}
-      -X github.com/stateful/runme/v3/internal/version.BuildVersion=#{version}
-      -X github.com/stateful/runme/v3/internal/version.Commit=#{tap.user}
+      -X github.com/runmedev/runme/v3/internal/version.BuildDate=#{time.iso8601}
+      -X github.com/runmedev/runme/v3/internal/version.BuildVersion=#{version}
+      -X github.com/runmedev/runme/v3/internal/version.Commit=#{tap.user}
     ]
 
     system "go", "build", *std_go_args(ldflags:)
@@ -30,7 +30,7 @@ class Runme < Formula
   end
 
   test do
-    system bin/"runme", "--version"
+    assert_match version.to_s, shell_output("#{bin}/runme --version")
     markdown = (testpath/"README.md")
     markdown.write <<~MARKDOWN
       # Some Markdown


### PR DESCRIPTION
Using the `runmedev` org in the build instructions will make sure that commit hash and version numbers will be properly included in `runme` builds.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
