### PR TITLE
autobump.txt: remove `asyncapi`

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -144,7 +144,6 @@ astroterm
 astyle
 asuka
 asymptote
-asyncapi
 asyncplusplus
 at-spi2-core
 atac


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR removes `asyncapi` from `autobump.txt`. Upstream has their own workflow for this and they've put some thought into making sure they don't spam us with multiple releases per day (cf. https://github.com/asyncapi/cli/issues/503, https://github.com/asyncapi/cli/pull/532). Perhaps we should defer to their workflow in this case, especially to avoid multiple PRs for the same `asyncapi` version (e.g. https://github.com/Homebrew/homebrew-core/pull/212744 & https://github.com/Homebrew/homebrew-core/pull/212724).