### PR TITLE
fb303: add `:build` dependency on `mvfst`

### DIFF
--- a/Formula/f/fb303.rb
+++ b/Formula/f/fb303.rb
@@ -16,6 +16,7 @@ class Fb303 < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "mvfst" => :build
   depends_on "fbthrift"
   depends_on "fizz"
   depends_on "fmt"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fixes

    CMake Error at /home/linuxbrew/.linuxbrew/lib/cmake/fbthrift/FBThriftConfig.cmake:57 (find_package):
      Could not find a package configuration file provided by "mvfst" with any of
      the following names:

        mvfstConfig.cmake
        mvfst-config.cmake

https://github.com/Homebrew/homebrew-core/actions/runs/13986029785/job/39159812468#step:5:100

This probably builds fine on version bumps because it's typically built
along with `mvfst`.
