### PR TITLE
crystal: depend on `:x86_64` on Linux

### DIFF
--- a/Formula/c/crystal.rb
+++ b/Formula/c/crystal.rb
@@ -46,6 +46,11 @@ class Crystal < Formula
 
   uses_from_macos "libffi" # for the interpreter
 
+  on_linux do
+    # There is no bootstrap compiler for arm64 Linux
+    depends_on arch: :x86_64
+  end
+
   # It used to be the case that every new crystal release was built from a
   # previous release, except patches. Crystal is updating its policy to
   # allow 4 minor releases of compatibility unless otherwise specified.


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This needs a bootstrap compiler to build, but there is none available
for arm64 Linux.
