### PR TITLE
cargo-bundle: fix test for arm64 Linux

### DIFF
--- a/Formula/c/cargo-bundle.rb
+++ b/Formula/c/cargo-bundle.rb
@@ -57,7 +57,8 @@ class CargoBundle < Formula
     bundle_subdir = if OS.mac?
       "osx/#{testproject}.app"
     else
-      "deb/#{testproject}_#{version}_amd64.deb"
+      arch = Hardware::CPU.intel? ? "amd64" : Hardware::CPU.arch
+      "deb/#{testproject}_#{version}_#{arch}.deb"
     end
     bundle_path = testpath/testproject/"target/release/bundle"/bundle_subdir
     assert_path_exists bundle_path


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing test assumes that Linux runs on amd64/x86_64.
