### PR TITLE
zig: fix CPU target for arm64 Linux

### DIFF
--- a/Formula/z/zig.rb
+++ b/Formula/z/zig.rb
@@ -55,8 +55,11 @@ class Zig < Formula
                                                       .join(" ")
     end
 
-    cpu = case Hardware.oldest_cpu
-    when :arm_vortex_tempest then "apple_m1" # See `zig targets`.
+    cpu = case Hardware.oldest_cpu # See `zig targets`.
+    # Cortex A-53 seems to be the oldest available ARMv8-A processor.
+    # https://en.wikipedia.org/wiki/ARM_Cortex-A53
+    when :armv8 then "cortex_a53"
+    when :arm_vortex_tempest then "apple_m1"
     else Hardware.oldest_cpu
     end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Zig doesn't seem to recognise `armv8`.[^1]

[^1]: https://github.com/Homebrew/homebrew-core/actions/runs/13989608958/job/39170464877#step:5:199
