### PR TITLE
subversion: fix test for arm64 Linux

### DIFF
--- a/Formula/s/subversion.rb
+++ b/Formula/s/subversion.rb
@@ -243,7 +243,8 @@ class Subversion < Formula
     platform = if OS.mac?
       "darwin-thread-multi-2level"
     else
-      "#{Hardware::CPU.arch}-#{OS.kernel_name.downcase}-thread-multi"
+      arch = Hardware::CPU.arm? ? :aarch64 : Hardware::CPU.arch
+      "#{arch}-#{OS.kernel_name.downcase}-thread-multi"
     end
 
     perl = DevelopmentTools.locate("perl")


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

It needs to look in `aarch64-linux-thread-multi` and not
`arm64-linux-thread-multi`.
