### PR TITLE
webkit2png: deprecate

### DIFF
--- a/Formula/w/webkit2png.rb
+++ b/Formula/w/webkit2png.rb
@@ -9,6 +9,9 @@ class Webkit2png < Formula
     sha256 cellar: :any_skip_relocation, all: "ad209d841f88f9b5d3a969e2493d853237c89234bd09dfc3d1aa2106832d2d7d"
   end
 
+  # requires Python 2, see https://github.com/paulhammond/webkit2png/issues/108
+  deprecate! date: "2025-03-21", because: :unsupported
+
   # Requires Quartz, as well as other potentially Mac-only libraries
   depends_on :macos
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`webkit2png` requires Python 2 and upstream has two issues pointing out that it doesn't work with Catalina and after:
* https://github.com/paulhammond/webkit2png/issues/108
* https://github.com/paulhammond/webkit2png/issues/120
