### PR TITLE
zig dependents: fix CPU target for arm64 Linux

### DIFF
--- a/Formula/b/bold.rb
+++ b/Formula/b/bold.rb
@@ -19,8 +19,11 @@ class Bold < Formula
   def install
     # Fix illegal instruction errors when using bottles on older CPUs.
     # https://github.com/Homebrew/homebrew-core/issues/92282
-    cpu = case Hardware.oldest_cpu
-    when :arm_vortex_tempest then "apple_m1" # See `zig targets`.
+    cpu = case Hardware.oldest_cpu # See `zig targets`.
+    # Cortex A-53 seems to be the oldest available ARMv8-A processor.
+    # https://en.wikipedia.org/wiki/ARM_Cortex-A53
+    when :armv8 then "cortex_a53"
+    when :arm_vortex_tempest then "apple_m1"
     else Hardware.oldest_cpu
     end
 

--- a/Formula/f/fancy-cat.rb
+++ b/Formula/f/fancy-cat.rb
@@ -21,8 +21,11 @@ class FancyCat < Formula
   def install
     # Fix illegal instruction errors when using bottles on older CPUs.
     # https://github.com/Homebrew/homebrew-core/issues/92282
-    cpu = case Hardware.oldest_cpu
-    when :arm_vortex_tempest then "apple_m1" # See `zig targets`.
+    cpu = case Hardware.oldest_cpu # See `zig targets`.
+    # Cortex A-53 seems to be the oldest available ARMv8-A processor.
+    # https://en.wikipedia.org/wiki/ARM_Cortex-A53
+    when :armv8 then "cortex_a53"
+    when :arm_vortex_tempest then "apple_m1"
     else Hardware.oldest_cpu
     end
 

--- a/Formula/f/flow-control.rb
+++ b/Formula/f/flow-control.rb
@@ -22,8 +22,11 @@ class FlowControl < Formula
   def install
     # Fix illegal instruction errors when using bottles on older CPUs.
     # https://github.com/Homebrew/homebrew-core/issues/92282
-    cpu = case Hardware.oldest_cpu
-    when :arm_vortex_tempest then "apple_m1" # See `zig targets`.
+    cpu = case Hardware.oldest_cpu # See `zig targets`.
+    # Cortex A-53 seems to be the oldest available ARMv8-A processor.
+    # https://en.wikipedia.org/wiki/ARM_Cortex-A53
+    when :armv8 then "cortex_a53"
+    when :arm_vortex_tempest then "apple_m1"
     else Hardware.oldest_cpu
     end
 

--- a/Formula/g/glyph.rb
+++ b/Formula/g/glyph.rb
@@ -21,8 +21,11 @@ class Glyph < Formula
   def install
     # Fix illegal instruction errors when using bottles on older CPUs.
     # https://github.com/Homebrew/homebrew-core/issues/92282
-    cpu = case Hardware.oldest_cpu
-    when :arm_vortex_tempest then "apple_m1" # See `zig targets`.
+    cpu = case Hardware.oldest_cpu # See `zig targets`.
+    # Cortex A-53 seems to be the oldest available ARMv8-A processor.
+    # https://en.wikipedia.org/wiki/ARM_Cortex-A53
+    when :armv8 then "cortex_a53"
+    when :arm_vortex_tempest then "apple_m1"
     else Hardware.oldest_cpu
     end
 

--- a/Formula/h/hevi.rb
+++ b/Formula/h/hevi.rb
@@ -19,8 +19,11 @@ class Hevi < Formula
   def install
     # Fix illegal instruction errors when using bottles on older CPUs.
     # https://github.com/Homebrew/homebrew-core/issues/92282
-    cpu = case Hardware.oldest_cpu
-    when :arm_vortex_tempest then "apple_m1" # See `zig targets`.
+    cpu = case Hardware.oldest_cpu # See `zig targets`.
+    # Cortex A-53 seems to be the oldest available ARMv8-A processor.
+    # https://en.wikipedia.org/wiki/ARM_Cortex-A53
+    when :armv8 then "cortex_a53"
+    when :arm_vortex_tempest then "apple_m1"
     else Hardware.oldest_cpu
     end
 

--- a/Formula/n/ncdu.rb
+++ b/Formula/n/ncdu.rb
@@ -29,8 +29,11 @@ class Ncdu < Formula
   def install
     # Fix illegal instruction errors when using bottles on older CPUs.
     # https://github.com/Homebrew/homebrew-core/issues/92282
-    cpu = case Hardware.oldest_cpu
-    when :arm_vortex_tempest then "apple_m1" # See `zig targets`.
+    cpu = case Hardware.oldest_cpu # See `zig targets`.
+    # Cortex A-53 seems to be the oldest available ARMv8-A processor.
+    # https://en.wikipedia.org/wiki/ARM_Cortex-A53
+    when :armv8 then "cortex_a53"
+    when :arm_vortex_tempest then "apple_m1"
     else Hardware.oldest_cpu
     end
 

--- a/Formula/s/superhtml.rb
+++ b/Formula/s/superhtml.rb
@@ -19,8 +19,11 @@ class Superhtml < Formula
   def install
     # Fix illegal instruction errors when using bottles on older CPUs.
     # https://github.com/Homebrew/homebrew-core/issues/92282
-    cpu = case Hardware.oldest_cpu
-    when :arm_vortex_tempest then "apple_m1" # See `zig targets`.
+    cpu = case Hardware.oldest_cpu # See `zig targets`.
+    # Cortex A-53 seems to be the oldest available ARMv8-A processor.
+    # https://en.wikipedia.org/wiki/ARM_Cortex-A53
+    when :armv8 then "cortex_a53"
+    when :arm_vortex_tempest then "apple_m1"
     else Hardware.oldest_cpu
     end
 

--- a/Formula/z/zigmod.rb
+++ b/Formula/z/zigmod.rb
@@ -25,8 +25,11 @@ class Zigmod < Formula
   def install
     # Fix illegal instruction errors when using bottles on older CPUs.
     # https://github.com/Homebrew/homebrew-core/issues/92282
-    cpu = case Hardware.oldest_cpu
-    when :arm_vortex_tempest then "apple_m1" # See `zig targets`.
+    cpu = case Hardware.oldest_cpu # See `zig targets`.
+    # Cortex A-53 seems to be the oldest available ARMv8-A processor.
+    # https://en.wikipedia.org/wiki/ARM_Cortex-A53
+    when :armv8 then "cortex_a53"
+    when :arm_vortex_tempest then "apple_m1"
     else Hardware.oldest_cpu
     end
 

--- a/Formula/z/zigup.rb
+++ b/Formula/z/zigup.rb
@@ -19,8 +19,11 @@ class Zigup < Formula
   def install
     # Fix illegal instruction errors when using bottles on older CPUs.
     # https://github.com/Homebrew/homebrew-core/issues/92282
-    cpu = case Hardware.oldest_cpu
-    when :arm_vortex_tempest then "apple_m1" # See `zig targets`.
+    cpu = case Hardware.oldest_cpu # See `zig targets`.
+    # Cortex A-53 seems to be the oldest available ARMv8-A processor.
+    # https://en.wikipedia.org/wiki/ARM_Cortex-A53
+    when :armv8 then "cortex_a53"
+    when :arm_vortex_tempest then "apple_m1"
     else Hardware.oldest_cpu
     end
 

--- a/Formula/z/zls.rb
+++ b/Formula/z/zls.rb
@@ -20,8 +20,11 @@ class Zls < Formula
   def install
     # Fix illegal instruction errors when using bottles on older CPUs.
     # https://github.com/Homebrew/homebrew-core/issues/92282
-    cpu = case Hardware.oldest_cpu
-    when :arm_vortex_tempest then "apple_m1" # See `zig targets`.
+    cpu = case Hardware.oldest_cpu # See `zig targets`.
+    # Cortex A-53 seems to be the oldest available ARMv8-A processor.
+    # https://en.wikipedia.org/wiki/ARM_Cortex-A53
+    when :armv8 then "cortex_a53"
+    when :arm_vortex_tempest then "apple_m1"
     else Hardware.oldest_cpu
     end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

See #213501.

- **bold: fix CPU target for arm64 Linux**
- **fancy-cat: fix CPU target for arm64 Linux**
- **flow-control: fix CPU target for arm64 Linux**
- **glyph: fix CPU target for arm64 Linux**
- **hevi: fix CPU target for arm64 Linux**
- **ncdu: fix CPU target for arm64 Linux**
- **superhtml: fix CPU target for arm64 Linux**
- **zigmod: fix CPU target for arm64 Linux**
- **zigup: fix CPU target for arm64 Linux**
- **zls: fix CPU target for arm64 Linux**
