### PR TITLE
asciitex: fix multiple definition build issue with gcc 10+

### DIFF
--- a/Formula/a/asciitex.rb
+++ b/Formula/a/asciitex.rb
@@ -24,6 +24,10 @@ class Asciitex < Formula
   end
 
   def install
+    # Work around failure from GCC 10+ using default of `-fno-common`
+    # multiple definition of `SYNTAX_ERR_FLAG'; array.o:(.bss+0x0): first defined here
+    ENV.append_to_cflags "-fcommon" if OS.linux?
+
     system "./configure", "--prefix=#{prefix}", "--disable-gtk"
     inreplace "Makefile", "man/asciiTeX_gui.1", ""
     system "make", "install"


### PR DESCRIPTION
asciitex: fix multiple definition build issue with gcc 10+

```
  gcc-11  -g -O2   -o asciiTeX array.o brace.o draw.o main.o sqrt.o symbols.o asciiTeX.o dim.o frac.o limit.o ouline.o sscript.o utils.o  
  /usr/bin/ld: brace.o:(.bss+0x0): multiple definition of `SYNTAX_ERR_FLAG'; array.o:(.bss+0x0): first defined here
  /usr/bin/ld: draw.o:(.bss+0x0): multiple definition of `SYNTAX_ERR_FLAG'; array.o:(.bss+0x0): first defined here
  /usr/bin/ld: sqrt.o:(.bss+0x0): multiple definition of `SYNTAX_ERR_FLAG'; array.o:(.bss+0x0): first defined here
  /usr/bin/ld: symbols.o:(.bss+0x0): multiple definition of `SYNTAX_ERR_FLAG'; array.o:(.bss+0x0): first defined here
  /usr/bin/ld: asciiTeX.o:(.bss+0x0): multiple definition of `SYNTAX_ERR_FLAG'; array.o:(.bss+0x0): first defined here
  /usr/bin/ld: dim.o:(.bss+0x0): multiple definition of `SYNTAX_ERR_FLAG'; array.o:(.bss+0x0): first defined here
  /usr/bin/ld: frac.o:(.bss+0x0): multiple definition of `SYNTAX_ERR_FLAG'; array.o:(.bss+0x0): first defined here
  /usr/bin/ld: limit.o:(.bss+0x0): multiple definition of `SYNTAX_ERR_FLAG'; array.o:(.bss+0x0): first defined here
  /usr/bin/ld: ouline.o:(.bss+0x0): multiple definition of `SYNTAX_ERR_FLAG'; array.o:(.bss+0x0): first defined here
  /usr/bin/ld: sscript.o:(.bss+0x0): multiple definition of `SYNTAX_ERR_FLAG'; array.o:(.bss+0x0): first defined here
  /usr/bin/ld: utils.o:(.bss+0x0): multiple definition of `SYNTAX_ERR_FLAG'; array.o:(.bss+0x0): first defined here
  collect2: error: ld returned 1 exit status
  make[1]: *** [Makefile:316: asciiTeX] Error 1
  make[1]: Leaving directory '/tmp/asciitex-20250321-2937-r2y4af/asciiTeX-0.21/src'
  make: *** [Makefile:303: install-recursive] Error 1
```

---

- #211761 