### PR TITLE
nsuds: fix multiple definition build issue with gcc 10+

### DIFF
--- a/Formula/n/nsuds.rb
+++ b/Formula/n/nsuds.rb
@@ -38,6 +38,10 @@ class Nsuds < Formula
   uses_from_macos "ncurses"
 
   def install
+    # Work around failure from GCC 10+ using default of `-fno-common`
+    # multiple definition of `showmarks'; nsuds-grid.o:(.bss+0x60): first defined here
+    ENV.append_to_cflags "-fcommon" if OS.linux?
+
     # Temporary Homebrew-specific work around for linker flag ordering problem in Ubuntu 16.04.
     # Remove after migration to 18.04.
     ENV["LDADD"] = "-lncurses -lm" unless OS.mac?


### PR DESCRIPTION
nsuds: fix multiple definition build issue with gcc 10+

```
  gcc-11 -pedantic -ansi -Wall -W -DHELPDIR='"/home/linuxbrew/.linuxbrew/Cellar/nsuds/0.7B/share/doc/nsuds-0.7B/"' -DSCOREDIR='"/home/linuxbrew/.linuxbrew/Cellar/nsuds/0.7B/var/games/nsuds/"' -g -O2 -lncurses -lm  -o nsuds nsuds-dialog.o nsuds-gen.o nsuds-grid.o nsuds-highscores.o nsuds-marks.o nsuds-menu.o nsuds-nsuds.o nsuds-score.o nsuds-scroller.o nsuds-timer.o nsuds-util.o -lncurses -lm 
  /usr/bin/ld: nsuds-marks.o:(.bss+0x2e0): multiple definition of `showmarks'; nsuds-grid.o:(.bss+0x60): first defined here
  /usr/bin/ld: nsuds-nsuds.o:(.bss+0x60): multiple definition of `showmarks'; nsuds-grid.o:(.bss+0x60): first defined here
  /usr/bin/ld: nsuds-score.o:(.bss+0x10): multiple definition of `level_data'; nsuds-nsuds.o:(.bss+0x80): first defined here
```

---

- #211761 