### PR TITLE
ninvaders: fix multiple definition build issue with gcc 10+

### DIFF
--- a/Formula/n/ninvaders.rb
+++ b/Formula/n/ninvaders.rb
@@ -26,6 +26,10 @@ class Ninvaders < Formula
   uses_from_macos "ncurses"
 
   def install
+    # Work around failure from GCC 10+ using default of `-fno-common`
+    # multiple definition of `skill_level'; aliens.o:(.bss+0x67c): first defined here
+    inreplace "Makefile", "-Wall", "-Wall -fcommon" if OS.linux?
+
     ENV.deparallelize # this formula's build system can't parallelize
     inreplace "Makefile" do |s|
       s.change_make_var! "CC", ENV.cc


### PR DESCRIPTION
ninvaders: fix multiple definition build issue with gcc 10+

```
gcc-11  -o nInvaders globals.o view.o aliens.o ufo.o player.o nInvaders.o -lncurses
  /usr/bin/ld: ufo.o:(.bss+0x28): multiple definition of `skill_level'; aliens.o:(.bss+0x67c): first defined here
  /usr/bin/ld: ufo.o:(.bss+0x2c): multiple definition of `level'; aliens.o:(.bss+0x678): first defined here
  /usr/bin/ld: ufo.o:(.bss+0x30): multiple definition of `weite'; aliens.o:(.bss+0x684): first defined here
  /usr/bin/ld: ufo.o:(.bss+0x38): multiple definition of `bunker'; aliens.o:(.bss+0x138): first defined here
  /usr/bin/ld: ufo.o:(.bss+0x548): multiple definition of `alienBlock'; aliens.o:(.bss+0x18): first defined here
  /usr/bin/ld: ufo.o:(.bss+0x610): multiple definition of `alienshotnum'; aliens.o:(.bss+0x130): first defined here
  /usr/bin/ld: ufo.o:(.bss+0x618): multiple definition of `alienshoty'; aliens.o:(.bss+0x108): first defined here
  /usr/bin/ld: ufo.o:(.bss+0x640): multiple definition of `alienshotx'; aliens.o:(.bss+0xe0): first defined here
  /usr/bin/ld: ufo.o:(.bss+0x668): multiple definition of `lowest_ship'; aliens.o:(.bss+0x650): first defined here
  /usr/bin/ld: ufo.o:(.bss+0x6[90](https://github.com/Homebrew/homebrew-core/actions/runs/13994819068/job/39187279029#step:5:91)): multiple definition of `shipnum'; aliens.o:(.bss+0x648): first defined here
  /usr/bin/ld: ufo.o:(.bss+0x10): multiple definition of `aliens'; aliens.o:(.bss+0x0): first defined here
  /usr/bin/ld: player.o:(.bss+0x34): multiple definition of `skill_level'; aliens.o:(.bss+0x67c): first defined here
  /usr/bin/ld: player.o:(.bss+0x38): multiple definition of `level'; aliens.o:(.bss+0x678): first defined here
  /usr/bin/ld: player.o:(.bss+0x3c): multiple definition of `weite'; aliens.o:(.bss+0x684): first defined here
  /usr/bin/ld: player.o:(.bss+0x40): multiple definition of `ufo'; ufo.o:(.bss+0x0): first defined here
  /usr/bin/ld: player.o:(.bss+0x48): multiple definition of `bunker'; aliens.o:(.bss+0x138): first defined here
  /usr/bin/ld: player.o:(.bss+0x558): multiple definition of `alienBlock'; aliens.o:(.bss+0x18): first defined here
  /usr/bin/ld: player.o:(.bss+0x620): multiple definition of `alienshotnum'; aliens.o:(.bss+0x130): first defined here
  /usr/bin/ld: player.o:(.bss+0x628): multiple definition of `alienshoty'; aliens.o:(.bss+0x108): first defined here
  /usr/bin/ld: player.o:(.bss+0x650): multiple definition of `alienshotx'; aliens.o:(.bss+0xe0): first defined here
  /usr/bin/ld: player.o:(.bss+0x678): multiple definition of `lowest_ship'; aliens.o:(.bss+0x650): first defined here
  /usr/bin/ld: player.o:(.bss+0x30): multiple definition of `shipnum'; aliens.o:(.bss+0x648): first defined here
  /usr/bin/ld: player.o:(.bss+0x18): multiple definition of `aliens'; aliens.o:(.bss+0x0): first defined here
  /usr/bin/ld: nInvaders.o:(.bss+0x40): multiple definition of `ufo'; ufo.o:(.bss+0x0): first defined here
  /usr/bin/ld: nInvaders.o:(.bss+0x48): multiple definition of `bunker'; aliens.o:(.bss+0x138): first defined here
  /usr/bin/ld: nInvaders.o:(.bss+0x558): multiple definition of `alienBlock'; aliens.o:(.bss+0x18): first defined here
  /usr/bin/ld: nInvaders.o:(.bss+0x620): multiple definition of `alienshotnum'; aliens.o:(.bss+0x130): first defined here
  /usr/bin/ld: nInvaders.o:(.bss+0x628): multiple definition of `alienshoty'; aliens.o:(.bss+0x[108](https://github.com/Homebrew/homebrew-core/actions/runs/13994819068/job/39187279029#step:5:109)): first defined here
  /usr/bin/ld: nInvaders.o:(.bss+0x650): multiple definition of `alienshotx'; aliens.o:(.bss+0xe0): first defined here
  /usr/bin/ld: nInvaders.o:(.bss+0x678): multiple definition of `lowest_ship'; aliens.o:(.bss+0x650): first defined here
  /usr/bin/ld: nInvaders.o:(.bss+0x2c): multiple definition of `shipnum'; aliens.o:(.bss+0x648): first defined here
  /usr/bin/ld: nInvaders.o:(.bss+0x6a0): multiple definition of `aliens'; aliens.o:(.bss+0x0): first defined here
  /usr/bin/ld: nInvaders.o:(.bss+0x28): multiple definition of `skill_level'; aliens.o:(.bss+0x67c): first defined here
  /usr/bin/ld: nInvaders.o:(.bss+0x4): multiple definition of `level'; aliens.o:(.bss+0x678): first defined here
  /usr/bin/ld: nInvaders.o:(.bss+0x30): multiple definition of `weite'; aliens.o:(.bss+0x684): first defined here
```

---

- #211761 