### PR TITLE
get-flash-videos: deprecate as adobe flash player EOL 12/31/2020

### DIFF
--- a/Formula/g/get-flash-videos.rb
+++ b/Formula/g/get-flash-videos.rb
@@ -15,6 +15,9 @@ class GetFlashVideos < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "fc6d8ca49c01ff7cf2af1d97ff3e287ee30617b40bda0db332f794768cdbdca3"
   end
 
+  # adobe flash player EOL 12/31/2020, https://www.adobe.com/products/flashplayer/end-of-life-alternative.html
+  deprecate! date: "2025-03-21", because: :unmaintained
+
   depends_on "rtmpdump"
 
   uses_from_macos "openssl"


### PR DESCRIPTION
get-flash-videos: deprecate as adobe flash player has been deprecated more than  four years ago and upstream has no commit activity in the past five years

<img width="696" alt="image" src="https://github.com/user-attachments/assets/e5a863cc-6f1b-461c-a67c-796bb3c38483" />


----

- https://github.com/Homebrew/homebrew-core/issues/211761