### PR TITLE
flvmeta: deprecate as adobe flash player EOL 12/31/2020

### DIFF
--- a/Formula/f/flvmeta.rb
+++ b/Formula/f/flvmeta.rb
@@ -22,6 +22,9 @@ class Flvmeta < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "9ee08a06c1340135e808d5f305f22d343264c7cd059c250bb0371dab7403a3d9"
   end
 
+  # adobe flash player EOL 12/31/2020, https://www.adobe.com/products/flashplayer/end-of-life-alternative.html
+  deprecate! date: "2025-03-21", because: :unmaintained
+
   depends_on "cmake" => :build
 
   def install


### PR DESCRIPTION
flvmeta: deprecate as adobe flash player has EOL 12/31/2020

---

<img width="683" alt="image" src="https://github.com/user-attachments/assets/39f19778-295a-4db9-b8b1-539959bdfa3e" />
