### PR TITLE
yamdi: deprecate as adobe flash player EOL 12/31/2020

### DIFF
--- a/Formula/y/yamdi.rb
+++ b/Formula/y/yamdi.rb
@@ -23,6 +23,9 @@ class Yamdi < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "b4a7cf29beb52e599c9d245d550d00848b935a8d8e5c0b9f3d46fd362e28a32b"
   end
 
+  # adobe flash player EOL 12/31/2020, https://www.adobe.com/products/flashplayer/end-of-life-alternative.html
+  deprecate! date: "2025-03-21", because: :unmaintained
+
   def install
     system ENV.cc, "yamdi.c", "-o", "yamdi", *ENV.cflags.to_s.split
     bin.install "yamdi"


### PR DESCRIPTION
yamdi: deprecate as adobe flash player EOL 12/31/2020

---

<img width="696" alt="image" src="https://github.com/user-attachments/assets/e18e456c-6503-45ca-9c95-027d0e71180b" />
