### PR TITLE
netcat: fix build/test on arm64 linux

### DIFF
--- a/Formula/n/netcat.rb
+++ b/Formula/n/netcat.rb
@@ -27,6 +27,15 @@ class Netcat < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
 
+  # Fix running on Linux ARM64, using patch from Arch Linux ARM.
+  # https://sourceforge.net/p/netcat/bugs/51/
+  patch do
+    on_arm do
+      url "https://raw.githubusercontent.com/archlinuxarm/PKGBUILDs/05ebc1439262e7622ba4ab0c15c2a3bad1ac64c4/extra/gnu-netcat/gnu-netcat-flagcount.patch"
+      sha256 "63ffd690c586b164ec2f80723f5bcc46d009ffd5e0dd78bbe56fd1b770fd0788"
+    end
+  end
+
   def install
     # Regenerate configure script for arm64/Apple Silicon support.
     system "autoreconf", "--force", "--install", "--verbose"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- #211761