### PR TITLE
go: remove `src/debug/dwarf/testdata`

### DIFF
--- a/Formula/g/go.rb
+++ b/Formula/g/go.rb
@@ -83,6 +83,8 @@ class Go < Formula
     rm_r(libexec/"src/debug/elf/testdata")
     # Binaries built for an incompatible architecture
     rm_r(libexec/"src/runtime/pprof/testdata")
+    # Remove testdata with binaries for non-native architectures.
+    rm_r(libexec/"src/debug/dwarf/testdata")
   end
 
   test do


### PR DESCRIPTION
go: remove `src/debug/dwarf/testdata`

```
go
  * Binaries built for a non-native architecture were installed into go's prefix.
    The offending files are:
      /home/runner/.linuxbrew/Cellar/go/1.24.1/libexec/src/debug/dwarf/testdata/line-clang-dwarf5.elf   (x86_64)
      /home/runner/.linuxbrew/Cellar/go/1.24.1/libexec/src/debug/dwarf/testdata/line-clang.elf  (x86_64)
      /home/runner/.linuxbrew/Cellar/go/1.24.1/libexec/src/debug/dwarf/testdata/line-gcc-dwarf5.elf     (x86_64)
      /home/runner/.linuxbrew/Cellar/go/1.24.1/libexec/src/debug/dwarf/testdata/line-gcc-zstd.elf       (x86_64)
      /home/runner/.linuxbrew/Cellar/go/1.24.1/libexec/src/debug/dwarf/testdata/line-gcc.elf    (x86_64)
      /home/runner/.linuxbrew/Cellar/go/1.24.1/libexec/src/debug/dwarf/testdata/ranges.elf      (x86_64)
      /home/runner/.linuxbrew/Cellar/go/1.24.1/libexec/src/debug/dwarf/testdata/rnglistx.elf    (x86_64)
      /home/runner/.linuxbrew/Cellar/go/1.24.1/libexec/src/debug/dwarf/testdata/split.elf       (x86_64)
      /home/runner/.linuxbrew/Cellar/go/1.24.1/libexec/src/debug/dwarf/testdata/typedef.elf     (x86_64)
```

---

- #211761 