### PR TITLE
gnu-shogi: fix multiple definition build issue with gcc 10+

### DIFF
--- a/Formula/g/gnu-shogi.rb
+++ b/Formula/g/gnu-shogi.rb
@@ -25,8 +25,11 @@ class GnuShogi < Formula
   end
 
   def install
-    system "./configure", "--prefix=#{prefix}"
-    system "make"
+    # Work around failure from GCC 10+ using default of `-fno-common`
+    # multiple definition of `DRAW'; globals.o:(.bss+0x0): first defined here
+    ENV.append_to_cflags "-fcommon" if OS.linux?
+
+    system "./configure", *std_configure_args
     system "make", "install", "MANDIR=#{man6}", "INFODIR=#{info}"
   end
 


### PR DESCRIPTION
```
  gcc-11 -g -O2 -DHASHFILE=\"/home/linuxbrew/.linuxbrew/Cellar/gnu-shogi/1.4.2/lib/gnushogi/gnushogi.hsh\" -fsigned-char -funroll-loops -Wall -Wno-implicit-int -Wstrict-prototypes -ansi -pedantic -I. -I.. -I.. -o gnushogi globals.o init-common.o pattern-common.o attacks.o book.o commondsp.o dspwrappers.o eval.o genmove.o init.o pattern.o rawdsp.o search.o tcontrl.o util.o main.o   -lm
  /usr/bin/ld: rawdsp.o:(.bss+0x8): multiple definition of `DRAW'; globals.o:(.bss+0x0): first defined here
```

---

- #211761 