### PR TITLE
gnu-typist: update sha for 2.10.1 release

### DIFF
--- a/Formula/g/gnu-typist.rb
+++ b/Formula/g/gnu-typist.rb
@@ -3,7 +3,7 @@ class GnuTypist < Formula
   homepage "https://www.gnu.org/software/gtypist/"
   url "https://ftp.gnu.org/gnu/gtypist/gtypist-2.10.1.tar.xz"
   mirror "https://ftpmirror.gnu.org/gtypist/gtypist-2.10.1.tar.xz"
-  sha256 "6b734c307e6d0a69af1d3b1ca3c97282ddbce7359b6b816f0f120460c6795ffb"
+  sha256 "ca618054e91f1ed5ef043fcc43500bbad701c959c31844d4688ff22849ac252d"
   license "GPL-3.0-or-later"
 
   bottle do

--- a/Formula/g/gnu-typist.rb
+++ b/Formula/g/gnu-typist.rb
@@ -7,12 +7,13 @@ class GnuTypist < Formula
   license "GPL-3.0-or-later"
 
   bottle do
-    sha256 arm64_sequoia: "244d2aeb4b8d7c3f510812a347ea94d6bfdcc83c26ac5bbe4257306ad002d33b"
-    sha256 arm64_sonoma:  "cbf0d47fb143b0f938e989c9067053b207433a71e93a2faa48088b38c52c66d2"
-    sha256 arm64_ventura: "f58083be0b713eeefb687b211e5504e1afa45f309279535807324aa6d09a71a2"
-    sha256 sonoma:        "52a5ba01a1811bd23dfae3300f545e480ec1a22e19aebebc5c09f7deade9b81f"
-    sha256 ventura:       "ea26b88799d31db4328f08e9fe8b630c9b649d48de36aa68e551a8afc0300939"
-    sha256 x86_64_linux:  "47df2b292debdcf816185d968d4ec8ef2affea9a3554c9098d883a0b8e0bfe24"
+    rebuild 1
+    sha256 arm64_sequoia: "15ba375ec67355fe2043282cd1de4a229fd8d29b4857f73e22b05c8d702fe9e2"
+    sha256 arm64_sonoma:  "df74aca9130820bcdbc021116652a23122835e14016003aac9ef0f0d8bdab972"
+    sha256 arm64_ventura: "790643311a056fa38bc014e51107bf0984f25d77506f86e60f3843ac8ee5b3cc"
+    sha256 sonoma:        "7d10079dae92ce4490e710e6fb6ebe12c6d0703ae8d8a0f31b48c4759a8325d4"
+    sha256 ventura:       "7cc31cf6f3f5cd325c69d8b61fe0a75e0f1fd0ab0be47649ca06423a14fed6cf"
+    sha256 x86_64_linux:  "15b3985018e2cb520b709f0cf8c0b41307c49caf6756255638a1ddc9f37f3ac6"
   end
 
   depends_on "gettext"


### PR DESCRIPTION
see in linux arm bottle build, https://github.com/Homebrew/homebrew-core/actions/runs/13996801999/job/39195126247

---

- #211761 

---

<img width="673" alt="image" src="https://github.com/user-attachments/assets/f1a7fd9b-d47d-4ed9-92d3-f434b69223b2" />

https://lists.gnu.org/archive/html/info-gnu/2025-02/msg00002.html