### PR TITLE
garnet: test with `valkey`

### DIFF
--- a/Formula/g/garnet.rb
+++ b/Formula/g/garnet.rb
@@ -13,7 +13,7 @@ class Garnet < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "99420a3aeb83129340b5bab671176be4a7068f9fbde657f3730a0fd8320e7ff2"
   end
 
-  depends_on "redis" => :test
+  depends_on "valkey" => :test
   depends_on "dotnet"
 
   on_linux do
@@ -57,7 +57,7 @@ class Garnet < Formula
     end
     sleep 3
 
-    output = shell_output("#{Formula["redis"].opt_bin}/redis-cli -h 127.0.0.1 -p #{port} ping")
+    output = shell_output("#{Formula["valkey"].opt_bin}/valkey-cli -h 127.0.0.1 -p #{port} ping")
     assert_equal "PONG", output.strip
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Trying to keep `redis` usage low in preparation for future deprecation/removal.