### PR TITLE
wayland 1.23.1

### DIFF
--- a/Formula/w/wayland.rb
+++ b/Formula/w/wayland.rb
@@ -1,8 +1,8 @@
 class Wayland < Formula
   desc "Protocol for a compositor to talk to its clients"
   homepage "https://wayland.freedesktop.org"
-  url "https://gitlab.freedesktop.org/wayland/wayland/-/releases/1.23.0/downloads/wayland-1.23.0.tar.xz"
-  sha256 "05b3e1574d3e67626b5974f862f36b5b427c7ceeb965cb36a4e6c2d342e45ab2"
+  url "https://gitlab.freedesktop.org/wayland/wayland/-/releases/1.23.1/downloads/wayland-1.23.1.tar.xz"
+  sha256 "864fb2a8399e2d0ec39d56e9d9b753c093775beadc6022ce81f441929a81e5ed"
   license "MIT"
 
   # Versions with a 90+ patch are unstable (e.g., 1.21.91 is an alpha release)

--- a/Formula/w/wayland.rb
+++ b/Formula/w/wayland.rb
@@ -13,8 +13,8 @@ class Wayland < Formula
   end
 
   bottle do
-    sha256 arm64_linux:  "b796850dbd4cdb487d3a1ed75d2e0a16cd7df3299636262fe11b1be50de006dc"
-    sha256 x86_64_linux: "7579271ba889ad24f0be1099df176f7c9789c5b40acefacdd51bd86cb3184c0b"
+    sha256 arm64_linux:  "82fbcf11a962ee831af7822eb2dc00a7adbc8139b65d34ec7bad9c1641e29d88"
+    sha256 x86_64_linux: "fa8a51b1ec926a84aab9b92585613a17bb6c8bcd7e8c56941db5e4b3c3f62a25"
   end
 
   depends_on "meson" => :build


### PR DESCRIPTION
Looks like a valid release but upstream didn't update their site so doesn't show up on livecheck.

Announced on their mailer - https://lists.freedesktop.org/archives/wayland-devel/2024-August/043760.html

Enough distros have been providing it so I think it should be okay to update to https://repology.org/project/wayland/versions (e.g. Alpine, Arch Linux, Debian, Gentoo)