### PR TITLE
texi2html: add explicit `--build` flag for linux arm build

### DIFF
--- a/Formula/t/texi2html.rb
+++ b/Formula/t/texi2html.rb
@@ -29,8 +29,11 @@ class Texi2html < Formula
   depends_on "gettext"
 
   def install
-    system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}",
-                          "--mandir=#{man}", "--infodir=#{info}"
+    args = []
+    # Help old config scripts identify arm64 linux
+    args << "--build=aarch64-unknown-linux-gnu" if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+
+    system "./configure", "--mandir=#{man}", "--infodir=#{info}", *args, *std_configure_args
     chmod 0755, "./install-sh"
     system "make", "install"
   end


### PR DESCRIPTION
```
  config.guess timestamp = 2006-07-02
  
  uname -m = aarch64
  uname -r = 6.8.0-1021-azure
  uname -s = Linux
  uname -v = #25~22.04.1-Ubuntu SMP Thu Jan 16 21:09:47 UTC 2025
  
  /usr/bin/uname -p = aarch64
  /bin/uname -X     = 
  
  hostinfo               = 
  /bin/universe          = 
  /usr/bin/arch -k       = 
  /bin/arch              = aarch64
  /usr/bin/oslevel       = 
  /usr/convex/getsysinfo = 
  
  UNAME_MACHINE = aarch64
  UNAME_RELEASE = 6.8.0-1021-azure
  UNAME_SYSTEM  = Linux
  UNAME_VERSION = #25~22.04.1-Ubuntu SMP Thu Jan 16 21:09:47 UTC 2025
  configure: error: cannot guess build type; you must specify one
```

---

https://github.com/Homebrew/homebrew-core/issues/211761