### PR TITLE
t1lib: add explicit `--build` flag for linux arm build

### DIFF
--- a/Formula/t/t1lib.rb
+++ b/Formula/t/t1lib.rb
@@ -34,7 +34,11 @@ class T1lib < Formula
     # Workaround for newer Clang
     ENV.append_to_cflags "-Wno-implicit-int" if DevelopmentTools.clang_build_version >= 1403
 
-    system "./configure", "--prefix=#{prefix}"
+    args = []
+    # Help old config scripts identify arm64 linux
+    args << "--build=aarch64-unknown-linux-gnu" if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+
+    system "./configure", *args, *std_configure_args
     system "make", "without_doc"
     system "make", "install"
     share.install "Fonts" => "fonts"


### PR DESCRIPTION
```
  config.guess timestamp = 2004-09-07
  
  uname -m = aarch64
  uname -r = 6.8.0-1021-azure
  uname -s = Linux
  uname -v = #25~22.04.1-Ubuntu SMP Thu Jan 16 21:09:47 UTC 2025
  
  /usr/bin/uname -p = aarch64
  /bin/uname -X     = 
  
  hostinfo               = 
  /bin/universe          = 
  /usr/bin/arch -k       = 
  /bin/arch              = aarch64
  /usr/bin/oslevel       = 
  /usr/convex/getsysinfo = 
  
  UNAME_MACHINE = aarch64
  UNAME_RELEASE = 6.8.0-1021-azure
  UNAME_SYSTEM  = Linux
  UNAME_VERSION = #25~22.04.1-Ubuntu SMP Thu Jan 16 21:09:47 UTC 2025
  configure: error: cannot guess build type; you must specify one
```

---

#211761 