### PR TITLE
go: bump revision to build arm64 linux bottle

### DIFF
--- a/Formula/g/go.rb
+++ b/Formula/g/go.rb
@@ -5,6 +5,7 @@ class Go < Formula
   mirror "https://fossies.org/linux/misc/go1.24.1.src.tar.gz"
   sha256 "8244ebf46c65607db10222b5806aeb31c1fcf8979c1b6b12f60c677e9a3c0656"
   license "BSD-3-Clause"
+  revision 1
   head "https://go.googlesource.com/go.git", branch: "master"
 
   livecheck do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Ref
* tracked in https://github.com/Homebrew/homebrew-core/issues/211761
* https://github.com/Homebrew/homebrew-core/actions/runs/13986807469/job/39161905439#step:5:61 and
* https://github.com/Homebrew/homebrew-core/actions/runs/13996802088/job/39195144630#step:5:61 both report
````
Full audit --formula go --git --skip-style output
  go
    * Binaries built for a non-native architecture were installed into go's prefix.
      The offending files are:
        /home/linuxbrew/.linuxbrew/Cellar/go/1.24.1/libexec/src/debug/dwarf/testdata/line-clang-dwarf5.elf	(x86_64)
        /home/linuxbrew/.linuxbrew/Cellar/go/1.24.1/libexec/src/debug/dwarf/testdata/line-clang.elf	(x86_[64](https://github.com/Homebrew/homebrew-core/actions/runs/13996802088/job/39195144630#step:5:65))
        /home/linuxbrew/.linuxbrew/Cellar/go/1.24.1/libexec/src/debug/dwarf/testdata/line-gcc-dwarf5.elf	(x86_64)
        /home/linuxbrew/.linuxbrew/Cellar/go/1.24.1/libexec/src/debug/dwarf/testdata/line-gcc-zstd.elf	(x86_64)
        /home/linuxbrew/.linuxbrew/Cellar/go/1.24.1/libexec/src/debug/dwarf/testdata/line-gcc.elf	(x86_64)
        /home/linuxbrew/.linuxbrew/Cellar/go/1.24.1/libexec/src/debug/dwarf/testdata/ranges.elf	(x86_64)
        /home/linuxbrew/.linuxbrew/Cellar/go/1.24.1/libexec/src/debug/dwarf/testdata/rnglistx.elf	(x86_64)
        /home/linuxbrew/.linuxbrew/Cellar/go/1.24.1/libexec/src/debug/dwarf/testdata/split.elf	(x86_64)
        /home/linuxbrew/.linuxbrew/Cellar/go/1.24.1/libexec/src/debug/dwarf/testdata/typedef.elf	(x86_64)
  Error: 1 problem in 1 formula detected.
````
* these test binaries come from upstream source repo: https://github.com/golang/go/tree/master/src/debug/dwarf/testdata