### PR TITLE
msdl: fix multiple definition build issue with gcc 10+

### DIFF
--- a/Formula/m/msdl.rb
+++ b/Formula/m/msdl.rb
@@ -34,9 +34,19 @@ class Msdl < Formula
   patch :DATA
 
   def install
+    # Work around failure from GCC 10+ using default of `-fno-common`
+    # multiple definition of `display_flags'; asf.o:(.bss+0x0): first defined here
+    # multiple definition of `colors_available'; asf.o:(.bss+0x4): first defined here
+    ENV.append_to_cflags "-fcommon" if OS.linux?
+
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"
+  end
+
+  test do
+    system bin/"msdl", "http://example.org/index.html"
+    assert_path_exists "index.html"
   end
 end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
