### PR TITLE
cdpr: fix multiple definition build issue with gcc 10+

### DIFF
--- a/Formula/c/cdpr.rb
+++ b/Formula/c/cdpr.rb
@@ -26,8 +26,15 @@ class Cdpr < Formula
   uses_from_macos "libpcap"
 
   def install
+    # Work around failure from GCC 10+ using default of `-fno-common`
+    # multiple definition of `timeout'; /tmp/ccw1Bjcf.o:(.bss+0x0): first defined here
+    # multiple definition of `cdprs'; /tmp/ccw1Bjcf.o:(.bss+0x4): first defined here
+    # multiple definition of `handle'; /tmp/ccw1Bjcf.o:(.bss+0x8): first defined here
+    cflags = []
+    cflags << "-fcommon" if OS.linux?
+
     # Makefile hardcodes gcc and other atrocities
-    system ENV.cc, "cdpr.c", "cdprs.c", "conffile.c", "-lpcap", "-o", "cdpr"
+    system ENV.cc, *cflags, "cdpr.c", "cdprs.c", "conffile.c", "-lpcap", "-o", "cdpr"
     bin.install "cdpr"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
  ==> gcc-11 cdpr.c cdprs.c conffile.c -lpcap -o cdpr
  /usr/bin/ld: /tmp/ccQppc2g.o:(.bss+0x0): multiple definition of `timeout'; /tmp/ccw1Bjcf.o:(.bss+0x0): first defined here
  /usr/bin/ld: /tmp/ccQppc2g.o:(.bss+0x4): multiple definition of `cdprs'; /tmp/ccw1Bjcf.o:(.bss+0x4): first defined here
  /usr/bin/ld: /tmp/ccQppc2g.o:(.bss+0x8): multiple definition of `handle'; /tmp/ccw1Bjcf.o:(.bss+0x8): first defined here
  /usr/bin/ld: /tmp/ccb8nr4o.o:(.bss+0x0): multiple definition of `timeout'; /tmp/ccw1Bjcf.o:(.bss+0x0): first defined here
  /usr/bin/ld: /tmp/ccb8nr4o.o:(.bss+0x4): multiple definition of `cdprs'; /tmp/ccw1Bjcf.o:(.bss+0x4): first defined here
  /usr/bin/ld: /tmp/ccb8nr4o.o:(.bss+0x8): multiple definition of `handle'; /tmp/ccw1Bjcf.o:(.bss+0x8): first defined here
  collect2: error: ld returned 1 exit status
```

#211761 