### PR TITLE
perceptualdiff 2.1

### DIFF
--- a/Formula/p/perceptualdiff.rb
+++ b/Formula/p/perceptualdiff.rb
@@ -6,21 +6,12 @@ class Perceptualdiff < Formula
   license "GPL-2.0-or-later"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia:  "7cd37c8a0a9d07ae428f4ddb5d749b2c073ce9639605794495ba57889b59d171"
-    sha256 cellar: :any,                 arm64_sonoma:   "b114f4c6c43b2282782ad2195f3e05c7177d8369c1526d4bc092d3c3ace87e51"
-    sha256 cellar: :any,                 arm64_ventura:  "cd7694959ea2d1c45f69101b17974cad283ad5075ff3adb0b5efed3a23549f47"
-    sha256 cellar: :any,                 arm64_monterey: "aada4032f19de165252aa13e584609103b36cb3c62e17ef5519122409cb7a0a4"
-    sha256 cellar: :any,                 arm64_big_sur:  "6260c155e96ef17bdaf4ba1032986371db4748e3de145c5354e936fd0f854875"
-    sha256 cellar: :any,                 sonoma:         "6da21d373d2b55f336f8e19a2eab16843b58288790a78b9e8ab301e079e628d8"
-    sha256 cellar: :any,                 ventura:        "c329dd1cd469f9e1a4efdee715c8aa3722dd35633ebd984f90f1e54638332aee"
-    sha256 cellar: :any,                 monterey:       "fd75a857ebc139216c5edc6c671c60ca9d3862a5f7702bfe33fb5293c2ba6a30"
-    sha256 cellar: :any,                 big_sur:        "fdc7e444e4d48802ce4a7c671260ec1a51ebb100248d4cb90622ce3cb2dfce82"
-    sha256 cellar: :any,                 catalina:       "9edad00fd4470f908e5f9e1eb8c96c364b94c504dab46d1f38a45036871a10a0"
-    sha256 cellar: :any,                 mojave:         "1d3d02c27772801105fe9cf3e3ad697bcbeb4db9b260f134bd3e342344455481"
-    sha256 cellar: :any,                 high_sierra:    "683d05fc64186ee518180b56345d446be90ff2c42666c80adb86bc185d20d283"
-    sha256 cellar: :any,                 sierra:         "eb2da458eda1cebc7872b2621c96e5aa627d9711f8d31fb792cb092d92d060db"
-    sha256 cellar: :any,                 el_capitan:     "d47d680df91ee88897f95123e6b9f972351a603a5f4921726b2877cc2e67924f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "17bf61ff6c7342680902d574cc000bedecbcc409f292891754b804aacab9216a"
+    sha256 cellar: :any,                 arm64_sequoia: "69f5e86989148e15fdca126111c1070bb23777eabadd346f8e735b6cedc86f5a"
+    sha256 cellar: :any,                 arm64_sonoma:  "da4677947b68eca55af42a10d556324578763cb94a71cc14afaccdc3ddf99bf3"
+    sha256 cellar: :any,                 arm64_ventura: "0499b71de1b661a7c68f28c343c1fe1175dfb2cfe28b70d6fb6b27393a8613a6"
+    sha256 cellar: :any,                 sonoma:        "35f5e8523401d29ed1728df2d4e23c477e441418023d52b7ab03023e81faeeb2"
+    sha256 cellar: :any,                 ventura:       "1d88590df41a1619ce9c7f4b29a534179b0bd6d18d7aa296d50da6c4e0101e44"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2d9a1e10f07e3467e60a855f18c75a07fee4c238d746dc0b91652c147733e9c8"
   end
 
   depends_on "cmake" => :build

--- a/Formula/p/perceptualdiff.rb
+++ b/Formula/p/perceptualdiff.rb
@@ -1,8 +1,8 @@
 class Perceptualdiff < Formula
   desc "Perceptual image comparison tool"
   homepage "https://pdiff.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/pdiff/pdiff/perceptualdiff-1.1.1/perceptualdiff-1.1.1-src.tar.gz"
-  sha256 "ab349279a63018663930133b04852bde2f6a373cc175184b615944a10c1c7c6a"
+  url "https://github.com/myint/perceptualdiff/archive/refs/tags/v2.1.tar.gz"
+  sha256 "0dea51046601e4d23dc45a3ec342f1a305baf3bf3328e9ccdae115fe1942f041"
   license "GPL-2.0-or-later"
 
   bottle do
@@ -27,11 +27,6 @@ class Perceptualdiff < Formula
   depends_on "freeimage"
 
   def install
-    # cstdio header should be included explicitly to placate older compilers
-    # Included upstream in https://sourceforge.net/p/pdiff/code/53/, remove on next release
-    inreplace "Metric.cpp", "#include \"Metric.h\"\n",
-              "#include <cstdio>\n#include \"Metric.h\"\n"
-
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"


### PR DESCRIPTION
Original v1.1.1 is from 2009-05-28.

v2.1 is from a fork that meets our policy[^1] as Debian (Trixie) and Fedora (34) switched.

Looking at other repositories https://repology.org/project/perceptualdiff/versions
* FreeBSD and nixpkgs started at v2.1
* Ignoring LTS of Debian/Fedora/etc, only ALT and T2 are still on SourceForge release (i.e. 1.1.1 or older)

[^1]: https://docs.brew.sh/Acceptable-Formulae#not-a-fork-usually