### PR TITLE
vcs: deprecate

### DIFF
--- a/Formula/v/vcs.rb
+++ b/Formula/v/vcs.rb
@@ -1,15 +1,10 @@
 class Vcs < Formula
   desc "Creates video contact sheets (previews) of videos"
-  homepage "https://p.outlyer.net/vcs/"
-  url "https://p.outlyer.net/files/vcs/vcs-1.13.4.tar.gz"
+  homepage "https://web.archive.org/web/20240824173847/https://p.outlyer.net/vcs/"
+  url "https://web.archive.org/web/20240824173847/https://p.outlyer.net/files/vcs/vcs-1.13.4.tar.gz"
   sha256 "dc1d6145e10eeed61d16c3591cfe3496a6ac392c9c2f7c2393cbdb0cf248544b"
   license "LGPL-2.0-or-later"
   revision 3
-
-  livecheck do
-    url "https://p.outlyer.net/files/vcs/?C=M&O=D"
-    regex(/href=.*?vcs[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
 
   bottle do
     rebuild 1
@@ -22,6 +17,8 @@ class Vcs < Formula
     sha256 cellar: :any_skip_relocation, monterey:       "c910f7b36e0b796a03ebf4fa4a7b2adb315188db72901920abc95c790c3edd8e"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "f48057f0e485f6e6b20d221f4f036e0708d896e6bb3165837e5a96f193710c1b"
   end
+
+  deprecate! date: "2025-03-22", because: :repo_removed
 
   depends_on "ffmpeg"
   depends_on "ghostscript"


### PR DESCRIPTION
The site is unreachable

```
  ==> Downloading https://p.outlyer.net/files/vcs/vcs-1.13.4.tar.gz
  curl: (7) Failed to connect to p.outlyer.net port 443 after 95 ms: Connection refused
```

---

#211761 