### PR TITLE
liboping: specify mandir

### DIFF
--- a/Formula/lib/liboping.rb
+++ b/Formula/lib/liboping.rb
@@ -38,10 +38,18 @@ class Liboping < Formula
   end
 
   def install
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
+    system "./configure", "--mandir=#{man}", *std_configure_args
     system "make", "install"
+
+    # move `Net::Oping.3` manpage to man3 dir
+
+    if OS.linux?
+      mv prefix/"man/man3/Net::Oping.3", man3
+      rm_r prefix/"man"
+    else
+      mv prefix/"local/share/man/man3/Net::Oping.3pm", man3
+      rm_r prefix/"local"
+    end
   end
 
   def caveats


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

seeing

```
  liboping
    * A top-level "man" directory was found.
      Homebrew requires that man pages live under "share".
      This can often be fixed by passing `--mandir=#{man}` to `configure`.
```

https://github.com/Homebrew/homebrew-core/actions/runs/14003043203/job/39212875707#step:5:62

#211761 
