### PR TITLE
libuecc: update repo location

### DIFF
--- a/Formula/lib/libuecc.rb
+++ b/Formula/lib/libuecc.rb
@@ -1,15 +1,10 @@
 class Libuecc < Formula
   desc "Very small Elliptic Curve Cryptography library"
-  homepage "https://git.universe-factory.net/libuecc/"
-  url "https://git.universe-factory.net/libuecc/snapshot/libuecc-7.tar"
-  sha256 "0120aee869f56289204255ba81535369816655264dd018c63969bf35b71fd707"
+  homepage "https://git.universe-factory.net/fastd/libuecc"
+  url "https://git.universe-factory.net/fastd/libuecc/archive/v7.tar.gz"
+  sha256 "80ef381fae912db88a33ebe1b4c7a722b98ed3b1939f75415068b025c5675818"
   license "BSD-2-Clause"
-  head "https://git.universe-factory.net/libuecc", using: :git, branch: "master"
-
-  livecheck do
-    url :head
-    regex(/href=.*?libuecc[._-]v?(\d+(?:\.\d+)*)\.t/i)
-  end
+  head "https://git.universe-factory.net/fastd/libuecc.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_sequoia:  "a94e6f279789d442ddfce719d48af0c5a430e4d255f9c8dd16b7cb691062988f"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Upstream changed their git hosting from CGit to Forgejo, hence repo location/path changed.
- Old git repo: https://web.archive.org/web/20241206012210/https://git.universe-factory.net/libuecc
  - Tag `v7`: https://web.archive.org/web/20211207125149/https://git.universe-factory.net/libuecc/tag/?h=v7
- New git repo: https://git.universe-factory.net/fastd/libuecc
  - Tag v7: https://git.universe-factory.net/fastd/libuecc/releases/tag/v7