### PR TITLE
gnu-go: fix multiple definition build issue with gcc 10+

### DIFF
--- a/Formula/g/gnu-go.rb
+++ b/Formula/g/gnu-go.rb
@@ -29,9 +29,11 @@ class GnuGo < Formula
   end
 
   def install
-    system "./configure", "--disable-debug", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}",
-                          "--with-readline"
+    # Work around failure from GCC 10+ using default of `-fno-common`
+    # multiple definition of `DRAW'; globals.o:(.bss+0x0): first defined here
+    ENV.append_to_cflags "-fcommon" if OS.linux?
+
+    system "./configure", "--with-readline", *std_configure_args
     system "make", "install"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
  gcc-11 -g -O2 -DHASHFILE=\"/home/linuxbrew/.linuxbrew/Cellar/gnu-shogi/1.4.2/lib/gnushogi/gnushogi.hsh\" -fsigned-char -funroll-loops -Wall -Wno-implicit-int -Wstrict-prototypes -ansi -pedantic -I. -I.. -I.. -o gnushogi globals.o init-common.o pattern-common.o attacks.o book.o commondsp.o dspwrappers.o eval.o genmove.o init.o pattern.o rawdsp.o search.o tcontrl.o util.o main.o   -lm
  /usr/bin/ld: rawdsp.o:(.bss+0x8): multiple definition of `DRAW'; globals.o:(.bss+0x0): first defined here
```

#211761 
