### PR TITLE
gnupg@1.4: fix multiple definition build issue with gcc 10+

### DIFF
--- a/Formula/g/gnupg@1.4.rb
+++ b/Formula/g/gnupg@1.4.rb
@@ -33,16 +33,21 @@ class GnupgAT14 < Formula
   uses_from_macos "zlib"
 
   def install
-    args = %W[
-      --disable-dependency-tracking
+    # Work around failure from GCC 10+ using default of `-fno-common`
+    # multiple definition of `mpi_debug_mode'; mpicalc.o:(.bss+0x344): first defined here
+    # multiple definition of `memory_stat_debug_mode'; mpicalc.o:(.bss+0x348): first defined here
+    # multiple definition of `memory_debug_mode'; mpicalc.o:(.bss+0x34c): first defined here
+    # multiple definition of `iobuf_debug_mode'; mpicalc.o:(.bss+0x350): first defined here
+    ENV.append_to_cflags "-fcommon" if OS.linux?
+
+    args = %w[
       --disable-silent-rules
-      --prefix=#{prefix}
       --disable-asm
       --program-suffix=1
       --with-libusb=no
     ]
 
-    system "./configure", *args
+    system "./configure", *args, *std_configure_args
     system "make"
     system "make", "check"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
  gcc-11  -g -O2 -Wall -Wno-pointer-sign   -o mpicalc mpicalc.o ../cipher/libcipher.a ../mpi/libmpi.a ../util/libutil.a      
  /usr/bin/ld: ../mpi/libmpi.a(mpi-add.o):(.bss+0x0): multiple definition of `mpi_debug_mode'; mpicalc.o:(.bss+0x344): first defined here
  /usr/bin/ld: ../mpi/libmpi.a(mpi-add.o):(.bss+0x4): multiple definition of `memory_stat_debug_mode'; mpicalc.o:(.bss+0x348): first defined here
  /usr/bin/ld: ../mpi/libmpi.a(mpi-add.o):(.bss+0x8): multiple definition of `memory_debug_mode'; mpicalc.o:(.bss+0x34c): first defined here
  /usr/bin/ld: ../mpi/libmpi.a(mpi-add.o):(.bss+0xc): multiple definition of `iobuf_debug_mode'; mpicalc.o:(.bss+0x350): first defined here
  /usr/bin/ld: ../mpi/libmpi.a(mpi-bit.o):(.bss+0x0): multiple definition of `mpi_debug_mode'; mpicalc.o:(.bss+0x344): first defined here
  /usr/bin/ld: ../mpi/libmpi.a(mpi-bit.o):(.bss+0x4): multiple definition of `memory_stat_debug_mode'; mpicalc.o:(.bss+0x348): first defined here
  /usr/bin/ld: ../mpi/libmpi.a(mpi-bit.o):(.bss+0x8): multiple definition of `memory_debug_mode'; mpicalc.o:(.bss+0x34c): first defined here
  /usr/bin/ld: ../mpi/libmpi.a(mpi-bit.o):(.bss+0xc): multiple definition of `iobuf_debug_mode'; mpicalc.o:(.bss+0x350): first defined here
  /usr/bin/ld: ../mpi/libmpi.a(mpi-div.o):(.bss+0x0): multiple definition of `mpi_debug_mode'; mpicalc.o:(.bss+0x344): first defined here
  /usr/bin/ld: ../mpi/libmpi.a(mpi-div.o):(.bss+0x4): multiple definition of `memory_stat_debug_mode'; mpicalc.o:(.bss+0x348): first defined here
  /usr/bin/ld: ../mpi/libmpi.a(mpi-div.o):(.bss+0x8): multiple definition of `memory_debug_mode'; mpicalc.o:(.bss+0x34c): first defined here
  /usr/bin/ld: ../mpi/libmpi.a(mpi-div.o):(.bss+0xc): multiple definition of `iobuf_debug_mode'; mpicalc.o:(.bss+0x350): first defined here
  /usr/bin/ld: ../mpi/libmpi.a(mpi-gcd.o):(.bss+0x0): multiple definition of `mpi_debug_mode'; mpicalc.o:(.bss+0x344): first defined here
  /usr/bin/ld: ../mpi/libmpi.a(mpi-gcd.o):(.bss+0x4): multiple definition of `memory_stat_debug_mode'; mpicalc.o:(.bss+0x348): first defined here
  /usr/bin/ld: ../mpi/libmpi.a(mpi-gcd.o):(.bss+0x8): multiple definition of `memory_debug_mode'; mpicalc.o:(.bss+0x34c): first defined here
  /usr/bin/ld: ../mpi/libmpi.a(mpi-gcd.o):(.bss+0xc): multiple definition of `iobuf_debug_mode'; mpicalc.o:(.bss+0x350): first defined here
  /usr/bin/ld: ../mpi/libmpi.a(mpi-inv.o):(.bss+0x0): multiple definition of `mpi_debug_mode'; mpicalc.o:(.bss+0x344): first defined here
  /usr/bin/ld: ../mpi/libmpi.a(mpi-inv.o):(.bss+0x4): multiple definition of `memory_stat_debug_mode'; mpicalc.o:(.bss+0x348): first defined here
  /usr/bin/ld: ../mpi/libmpi.a(mpi-inv.o):(.bss+0x8): multiple definition of `memory_debug_mode'; mpicalc.o:(.bss+0x34c): first defined here
  /usr/bin/ld: ../mpi/libmpi.a(mpi-inv.o):(.bss+0xc): multiple definition of `iobuf_debug_mode'; mpicalc.o:(.bss+0x350): first defined here
  /usr/bin/ld: ../mpi/libmpi.a(mpi-mul.o):(.bss+0x0): multiple definition of `mpi_debug_mode'; mpicalc.o:(.bss+0x344): first defined here
  /usr/bin/ld: ../mpi/libmpi.a(mpi-mul.o):(.bss+0x4): multiple definition of `memory_stat_debug_mode'; mpicalc.o:(.bss+0x348): first defined here
  /usr/bin/ld: ../mpi/libmpi.a(mpi-mul.o):(.bss+0x8): multiple definition of `memory_debug_mode'; mpicalc.o:(.bss+0x34c): first defined here
  /usr/bin/ld: ../mpi/libmpi.a(mpi-mul.o):(.bss+0xc): multiple definition of `iobuf_debug_mode'; mpicalc.o:(.bss+0x350): first defined here
  /usr/bin/ld: ../mpi/libmpi.a(mpi-pow.o):(.bss+0x0): multiple definition of `mpi_debug_mode'; mpicalc.o:(.bss+0x344): first defined here
  /usr/bin/ld: ../mpi/libmpi.a(mpi-pow.o):(.bss+0x4): multiple definition of `memory_stat_debug_mode'; mpicalc.o:(.bss+0x348): first defined here
  /usr/bin/ld: ../mpi/libmpi.a(mpi-pow.o):(.bss+0x8): multiple definition of `memory_debug_mode'; mpicalc.o:(.bss+0x34c): first defined here
  /usr/bin/ld: ../mpi/libmpi.a(mpi-pow.o):(.bss+0xc): multiple definition of `iobuf_debug_mode'; mpicalc.o:(.bss+0x350): first defined here
  /usr/bin/ld: ../mpi/libmpi.a(mpicoder.o):(.bss+0x0): multiple definition of `mpi_debug_mode'; mpicalc.o:(.bss+0x344): first defined here
  /usr/bin/ld: ../mpi/libmpi.a(mpicoder.o):(.bss+0x4): multiple definition of `memory_stat_debug_mode'; mpicalc.o:(.bss+0x348): first defined here
  /usr/bin/ld: ../mpi/libmpi.a(mpicoder.o):(.bss+0x8): multiple definition of `memory_debug_mode'; mpicalc.o:(.bss+0x34c): first defined here
  /usr/bin/ld: ../mpi/libmpi.a(mpicoder.o):(.bss+0xc): multiple definition of `iobuf_debug_mode'; mpicalc.o:(.bss+0x350): first defined here
  /usr/bin/ld: ../mpi/libmpi.a(mpih-cmp.o):(.bss+0x0): multiple definition of `mpi_debug_mode'; mpicalc.o:(.bss+0x344): first defined here
  /usr/bin/ld: ../mpi/libmpi.a(mpih-cmp.o):(.bss+0x4): multiple definition of `memory_stat_debug_mode'; mpicalc.o:(.bss+0x348): first defined here
  /usr/bin/ld: ../mpi/libmpi.a(mpih-cmp.o):(.bss+0x8): multiple definition of `memory_debug_mode'; mpicalc.o:(.bss+0x34c): first defined here
  /usr/bin/ld: ../mpi/libmpi.a(mpih-cmp.o):(.bss+0xc): multiple definition of `iobuf_debug_mode'; mpicalc.o:(.bss+0x350): first defined here
  /usr/bin/ld: ../mpi/libmpi.a(mpih-div.o):(.bss+0x0): multiple definition of `mpi_debug_mode'; mpicalc.o:(.bss+0x344): first defined here
  /usr/bin/ld: ../mpi/libmpi.a(mpih-div.o):(.bss+0x4): multiple definition of `memory_stat_debug_mode'; mpicalc.o:(.bss+0x348): first defined here
  /usr/bin/ld: ../util/libutil.a(memory.o):(.bss+0x0): multiple definition of `mpi_debug_mode'; mpicalc.o:(.bss+0x344): first defined here
  /usr/bin/ld: ../util/libutil.a(memory.o):(.bss+0x4): multiple definition of `iobuf_debug_mode'; mpicalc.o:(.bss+0x350): first defined here
  /usr/bin/ld: ../util/libutil.a(memory.o):(.bss+0x8): multiple definition of `memory_stat_debug_mode'; mpicalc.o:(.bss+0x348): first defined here
  /usr/bin/ld: ../util/libutil.a(memory.o):(.bss+0xc): multiple definition of `memory_debug_mode'; mpicalc.o:(.bss+0x34c): first defined here
  /usr/bin/ld: ../util/libutil.a(secmem.o):(.bss+0x50): multiple definition of `mpi_debug_mode'; mpicalc.o:(.bss+0x344): first defined here
  /usr/bin/ld: ../util/libutil.a(secmem.o):(.bss+0x54): multiple definition of `iobuf_debug_mode'; mpicalc.o:(.bss+0x350): first defined here
  /usr/bin/ld: ../util/libutil.a(secmem.o):(.bss+0x58): multiple definition of `memory_stat_debug_mode'; mpicalc.o:(.bss+0x348): first defined here
  /usr/bin/ld: ../util/libutil.a(secmem.o):(.bss+0x5c): multiple definition of `memory_debug_mode'; mpicalc.o:(.bss+0x34c): first defined here
  /usr/bin/ld: ../util/libutil.a(iobuf.o):(.bss+0x14): multiple definition of `mpi_debug_mode'; mpicalc.o:(.bss+0x344): first defined here
  /usr/bin/ld: ../util/libutil.a(iobuf.o):(.bss+0x4): multiple definition of `iobuf_debug_mode'; mpicalc.o:(.bss+0x350): first defined here
  /usr/bin/ld: ../util/libutil.a(iobuf.o):(.bss+0x18): multiple definition of `memory_stat_debug_mode'; mpicalc.o:(.bss+0x348): first defined here
  /usr/bin/ld: ../util/libutil.a(iobuf.o):(.bss+0x1c): multiple definition of `memory_debug_mode'; mpicalc.o:(.bss+0x34c): first defined here
  /usr/bin/ld: ../util/libutil.a(strgutil.o):(.bss+0x24): multiple definition of `mpi_debug_mode'; mpicalc.o:(.bss+0x344): first defined here
  /usr/bin/ld: ../util/libutil.a(strgutil.o):(.bss+0x28): multiple definition of `memory_stat_debug_mode'; mpicalc.o:(.bss+0x348): first defined here
  /usr/bin/ld: ../util/libutil.a(strgutil.o):(.bss+0x2c): multiple definition of `memory_debug_mode'; mpicalc.o:(.bss+0x34c): first defined here
  /usr/bin/ld: ../util/libutil.a(strgutil.o):(.bss+0x30): multiple definition of `iobuf_debug_mode'; mpicalc.o:(.bss+0x350): first defined here
  /usr/bin/ld: ../util/libutil.a(estream-printf.o):(.bss+0x0): multiple definition of `memory_stat_debug_mode'; mpicalc.o:(.bss+0x348): first defined here
  /usr/bin/ld: ../util/libutil.a(estream-printf.o):(.bss+0x4): multiple definition of `memory_debug_mode'; mpicalc.o:(.bss+0x34c): first defined here
  collect2: error: ld returned 1 exit status
  make[2]: *** [Makefile:562: mpicalc] Error 1
```

#211761 