### PR TITLE
Onnxruntime fix

### DIFF
--- a/Formula/o/onnxnostaticreg.rb
+++ b/Formula/o/onnxnostaticreg.rb
@@ -1,0 +1,98 @@
+class Onnxnostaticreg < Formula
+  desc "Open standard for machine learning interoperability (built for onnxruntime)"
+  homepage "https://onnx.ai/"
+  url "https://github.com/onnx/onnx/archive/refs/tags/v1.17.0.tar.gz"
+  sha256 "8d5e983c36037003615e5a02d36b18fc286541bf52de1a78f6cf9f32005a820e"
+  license "Apache-2.0"
+
+  depends_on "cmake" => [:build, :test]
+  depends_on "abseil"
+  depends_on "protobuf"
+
+  uses_from_macos "python" => :build
+
+  def install
+    args = %W[
+      -DBUILD_SHARED_LIBS=ON
+      -DCMAKE_INSTALL_RPATH=#{rpath}
+      -DONNX_DISABLE_STATIC_REGISTRATION=ON
+      -DONNX_USE_PROTOBUF_SHARED_LIBS=ON
+      -DPYTHON_EXECUTABLE=#{which("python3")}
+    ]
+
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    # https://github.com/onnx/onnx/blob/main/onnx/test/cpp/ir_test.cc
+    (testpath/"test.cpp").write <<~CPP
+      #include <cassert>
+      #include <cctype>
+      #include <memory>
+      #include <string>
+      #include <onnx/common/ir.h>
+      #include <onnx/common/ir_pb_converter.h>
+      using namespace onnx;
+
+      bool IsValidIdentifier(const std::string& name) {
+        if (name.empty()) {
+          return false;
+        }
+        if (!isalpha(name[0]) && name[0] != '_') {
+          return false;
+        }
+        for (size_t i = 1; i < name.size(); ++i) {
+          if (!isalnum(name[i]) && name[i] != '_') {
+            return false;
+          }
+        }
+        return true;
+      }
+
+      int main() {
+        Graph* g = new Graph();
+        g->setName("test");
+        Value* x = g->addInput();
+        x->setUniqueName("x");
+        x->setElemType(TensorProto_DataType_FLOAT);
+        x->setSizes({Dimension("M"), Dimension("N")});
+        Node* node1 = g->create(kNeg, 1);
+        node1->addInput(x);
+        g->appendNode(node1);
+        Value* temp1 = node1->outputs()[0];
+        Node* node2 = g->create(kNeg, 1);
+        node2->addInput(temp1);
+        g->appendNode(node2);
+        Value* y = node2->outputs()[0];
+        g->registerOutput(y);
+
+        ModelProto model;
+        ExportModelProto(&model, std::shared_ptr<Graph>(g));
+
+        for (auto& node : model.graph().node()) {
+          for (auto& name : node.output()) {
+            assert(IsValidIdentifier(name));
+          }
+        }
+        return 0;
+      }
+    CPP
+
+    (testpath/"CMakeLists.txt").write <<~CMAKE
+      cmake_minimum_required(VERSION 3.10)
+      project(test LANGUAGES CXX)
+      find_package(ONNX CONFIG REQUIRED)
+      add_executable(test test.cpp)
+      target_link_libraries(test ONNX::onnx)
+    CMAKE
+
+    ENV.delete "CPATH"
+    args = ["-DCMAKE_FIND_PACKAGE_PREFER_CONFIG=ON"]
+    args << "-DCMAKE_BUILD_RPATH=#{lib};#{HOMEBREW_PREFIX}/lib" if OS.linux?
+    system "cmake", "-S", ".", "-B", "build", *args
+    system "cmake", "--build", "build"
+    system "./build/test"
+  end
+end

--- a/Formula/o/onnxruntime.rb
+++ b/Formula/o/onnxruntime.rb
@@ -30,7 +30,7 @@ class Onnxruntime < Formula
   depends_on "safeint" => :build
   depends_on "abseil"
   depends_on "nsync"
-  depends_on "onnx"
+  depends_on "onnxnostaticreg"
   depends_on "protobuf"
   depends_on "re2"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fixes https://github.com/Homebrew/homebrew-core/issues/215955

When running a program compiled with onnxruntime that creates an `Ort::Env`, we'd get the following schema double registration errors:
```
Schema error: Trying to register schema with name Abs (domain:  version: 1) from file /tmp/onnx-20250108-35339-a6pxcu/onnx-1.17.0/onnx/defs/math/old.cc line 2743, but it is already registered from file /tmp/onnx-20250108-35339-a6pxcu/onnx-1.17.0/onnx/defs/math/old.cc line 2743

Schema error: Trying to register schema with name Add (domain:  version: 1) from file /tmp/onnx-20250108-35339-a6pxcu/onnx-1.17.0/onnx/defs/math/old.cc line 2627, but it is already registered from file /tmp/onnx-20250108-35339-a6pxcu/onnx-1.17.0/onnx/defs/math/old.cc line 2627

Schema error: Trying to register schema with name And (domain:  version: 1) from file /tmp/onnx-20250108-35339-a6pxcu/onnx-1.17.0/onnx/defs/logical/old.cc line 138, but it is already registered from file /tmp/onnx-20250108-35339-a6pxcu/onnx-1.17.0/onnx/defs/logical/old.cc line 138
...
```
As per https://onnxruntime.ai/docs/build/dependencies.html#use-preinstalled-packages
> Each library can be built in different ways. For example, ONNX Runtime expects ONNX is built with “-DONNX_DISABLE_STATIC_REGISTRATION=ON”. If you have got a prebuilt ONNX library from somewhere, most likely it was not built in this way.

This creates a separate onnx build `onnxnostaticreg` (with the correct flags) specifically for `onnxruntime` and updates its dependency.