### PR TITLE
nylon: add explicit `--build` flag for linux arm build

### DIFF
--- a/Formula/n/nylon.rb
+++ b/Formula/n/nylon.rb
@@ -30,11 +30,11 @@ class Nylon < Formula
   depends_on "libevent"
 
   def install
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
-                          "--prefix=#{prefix}",
-                          "--mandir=#{man}",
-                          "--with-libevent=#{HOMEBREW_PREFIX}"
+    args = []
+    # Help old config scripts identify arm64 linux
+    args << "--build=aarch64-unknown-linux-gnu" if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+
+    system "./configure", "--mandir=#{man}", "--with-libevent=#{HOMEBREW_PREFIX}", *args, *std_configure_args
     system "make", "install"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
   config.guess timestamp = 2002-07-23
  
  uname -m = aarch64
  uname -r = 6.8.0-1021-azure
  uname -s = Linux
  uname -v = #25~22.04.1-Ubuntu SMP Thu Jan 16 21:09:47 UTC 2025
  
  /usr/bin/uname -p = aarch64
  /bin/uname -X     = 
  
  hostinfo               = 
  /bin/universe          = 
  /usr/bin/arch -k       = 
  /bin/arch              = aarch64
  /usr/bin/oslevel       = 
  /usr/convex/getsysinfo = 
  
  UNAME_MACHINE = aarch64
  UNAME_RELEASE = 6.8.0-1021-azure
  UNAME_SYSTEM  = Linux
  UNAME_VERSION = #25~22.04.1-Ubuntu SMP Thu Jan 16 21:09:47 UTC 2025
  configure: error: cannot guess build type; you must specify one
  
```

#211761 