### PR TITLE
nettoe: fix multiple definition build issue with gcc 10+

### DIFF
--- a/Formula/n/nettoe.rb
+++ b/Formula/n/nettoe.rb
@@ -24,8 +24,13 @@ class Nettoe < Formula
   end
 
   def install
-    system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
+    # Work around failure from GCC 10+ using default of `-fno-common`
+    # multiple definition of `addrfamily'; nettoe.o:(.bss+0x68): first defined here
+    # multiple definition of `NO_COLORS'; nettoe.o:(.bss+0x64): first defined here
+    # multiple definition of `NO_BEEP'; nettoe.o:(.bss+0x60): first defined here
+    ENV.append_to_cflags "-fcommon" if OS.linux?
+
+    system "./configure", *std_configure_args
     system "make", "install"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
  gcc-11  -g -O2   -o nettoe ai.o board.o nettoe.o matrices.o terminal.o misc.o network.o  
  /usr/bin/ld: terminal.o:(.bss+0x8): multiple definition of `addrfamily'; nettoe.o:(.bss+0x68): first defined here
  /usr/bin/ld: terminal.o:(.bss+0x0): multiple definition of `NO_COLORS'; nettoe.o:(.bss+0x64): first defined here
  /usr/bin/ld: terminal.o:(.bss+0x4): multiple definition of `NO_BEEP'; nettoe.o:(.bss+0x60): first defined here
  /usr/bin/ld: misc.o:(.bss+0x0): multiple definition of `addrfamily'; nettoe.o:(.bss+0x68): first defined here
  /usr/bin/ld: misc.o:(.bss+0x8): multiple definition of `NO_COLORS'; nettoe.o:(.bss+0x64): first defined here
  /usr/bin/ld: misc.o:(.bss+0x4): multiple definition of `NO_BEEP'; nettoe.o:(.bss+0x60): first defined here
  collect2: error: ld returned 1 exit status
```

#211761 