### PR TITLE
nvi: regenerate configure for linux arm build

### DIFF
--- a/Formula/n/nvi.rb
+++ b/Formula/n/nvi.rb
@@ -25,16 +25,13 @@ class Nvi < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "d8eb6c0c8a8eef36a09bf55e35ced6d2e2afb4d75a70d93d96e88d9cbd5c4b56"
   end
 
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
   depends_on "xz" => :build # Homebrew bug. Shouldn't need declaring explicitly.
   depends_on "berkeley-db@5"
 
   uses_from_macos "ncurses"
-
-  on_macos do
-    depends_on "autoconf" => :build
-    depends_on "automake" => :build
-    depends_on "libtool" => :build
-  end
 
   # Patches per MacPorts
   # The first corrects usage of BDB flags.
@@ -76,17 +73,16 @@ class Nvi < Formula
     cd "dist" do
       # Run autoreconf on macOS to rebuild configure script so that it doesn't try
       # to build with a flat namespace.
-      if OS.mac?
-        # These files must be present for autoreconf to work.
-        %w[AUTHORS ChangeLog NEWS README].each { |f| touch f }
-        system "autoreconf", "--force", "--install", "--verbose"
-      end
+
+      # These files must be present for autoreconf to work.
+      %w[AUTHORS ChangeLog NEWS README].each { |f| touch f }
+      system "autoreconf", "--force", "--install", "--verbose"
 
       # Xcode 12 needs the "-Wno-implicit-function-declaration" to compile successfully
       # The usual trick of setting $CFLAGS in the environment doesn't work for this
       # configure file though, but specifying an explicit CC setting does
       system "./configure", "--program-prefix=n",
-                            "CC=" + ENV.cc + " -Wno-implicit-function-declaration",
+                            "CC=" + ENV.cc + " -Wno-implicit-function-declaration -Wno-incompatible-pointer-types",
                             *std_configure_args
       system "make"
       ENV.deparallelize


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
  config.guess timestamp = 2007-05-17
  
  uname -m = aarch64
  uname -r = 6.8.0-1021-azure
  uname -s = Linux
  uname -v = #25~22.04.1-Ubuntu SMP Thu Jan 16 21:09:47 UTC 2025
  
  /usr/bin/uname -p = aarch64
  /bin/uname -X     = 
  
  hostinfo               = 
  /bin/universe          = 
  /usr/bin/arch -k       = 
  /bin/arch              = aarch64
  /usr/bin/oslevel       = 
  /usr/convex/getsysinfo = 
  
  UNAME_MACHINE = aarch64
  UNAME_RELEASE = 6.8.0-1021-azure
  UNAME_SYSTEM  = Linux
  UNAME_VERSION = #25~22.04.1-Ubuntu SMP Thu Jan 16 21:09:47 UTC 2025
  configure: error: cannot guess build type; you must specify one
```

#211761 