### PR TITLE
ipv6toolkit: fix multiple definition build issue with gcc 10+

### DIFF
--- a/Formula/i/ipv6toolkit.rb
+++ b/Formula/i/ipv6toolkit.rb
@@ -30,6 +30,11 @@ class Ipv6toolkit < Formula
   uses_from_macos "libpcap"
 
   def install
+    # Work around failure from GCC 10+ using default of `-fno-common`
+    # multiple definition of `pcap_filter'; /tmp/cck9bqrJ.o:(.bss+0x238): first defined here
+    # multiple definition of `errbuf'; /tmp/cck9bqrJ.o:(.bss+0x12e38): first defined here
+    inreplace "GNUmakefile", "-Wall", "-Wall -fcommon" if OS.linux?
+
     system "make"
     system "make", "install", "DESTDIR=#{prefix}", "PREFIX=", "MANPREFIX=/share"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
  gcc  -Wall -o addr6 tools/addr6.c libipv6.o -lpcap -lm 
  gcc  -Wall -o flow6 tools/flow6.c libipv6.o -lpcap -lm
  gcc  -Wall -o frag6 tools/frag6.c libipv6.o -lpcap -lm 
  gcc  -Wall -o icmp6 tools/icmp6.c libipv6.o -lpcap -lm
  /usr/bin/ld: libipv6.o:(.bss+0x140): multiple definition of `pcap_filter'; /tmp/cck9bqrJ.o:(.bss+0x238): first defined here
  /usr/bin/ld: libipv6.o:(.bss+0x150): multiple definition of `errbuf'; /tmp/cck9bqrJ.o:(.bss+0x12e38): first defined here
  collect2: error: ld returned 1 exit status
  make: *** [GNUmakefile:65: flow6] Error 1
  make: *** Waiting for unfinished jobs....
  /usr/bin/ld: libipv6.o:(.bss+0x140): multiple definition of `pcap_filter'; /tmp/ccRMRk2g.o:(.bss+0x29c0): first defined here
  /usr/bin/ld: libipv6.o:(.bss+0x150): multiple definition of `errbuf'; /tmp/ccRMRk2g.o:(.bss+0x22aa8): first defined here
  collect2: error: ld returned 1 exit status
  make: *** [GNUmakefile:71: icmp6] Error 1
  /usr/bin/ld: libipv6.o:(.bss+0x140): multiple definition of `pcap_filter'; /tmp/ccWOeT3U.o:(.bss+0x2770): first defined here
  /usr/bin/ld: libipv6.o:(.bss+0x150): multiple definition of `errbuf'; /tmp/ccWOeT3U.o:(.bss+0x12e80): first defined here
  collect2: error: ld returned 1 exit status
  make: *** [GNUmakefile:68: frag6] Error 1
```

#211761 