### PR TITLE
vrpn: disable python wrapper

### DIFF
--- a/Formula/v/vrpn.rb
+++ b/Formula/v/vrpn.rb
@@ -7,17 +7,13 @@ class Vrpn < Formula
   head "https://github.com/vrpn/vrpn.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia:  "75a13c37fad4a005e8308fadcc7a98f75e9147f73fafe7c2f73709e4c3156b48"
-    sha256 cellar: :any,                 arm64_sonoma:   "761817673c366cc4107359c8da2ad4d98c0b0baba8a804ac58f30d56a5ed81bc"
-    sha256 cellar: :any,                 arm64_ventura:  "30798e598e05078f5ce75ca7451df08ccef3810848f61f6870a440c802c2008f"
-    sha256 cellar: :any,                 arm64_monterey: "e16ae039e897123feecad339bba4ebdb34773a30924ac0046e5785c86c37e243"
-    sha256 cellar: :any,                 arm64_big_sur:  "7937578e438051b79f3270c6fbcd9025d1f4cf42785aa04d72d2c4d245733fa3"
-    sha256 cellar: :any,                 sonoma:         "bcbf18043a42516374d9c6aedb11ea725bf7f8338cfb99cecb554191588e3fa0"
-    sha256 cellar: :any,                 ventura:        "7ad5e83677486dc1cee37c5a2a80c599f9065780af1a7c0660ecbac0fa000bd4"
-    sha256 cellar: :any,                 monterey:       "2b172896f3d3c3103643f4d7ded96c1302730677741ee3db5b2cd1d94a65d4b0"
-    sha256 cellar: :any,                 big_sur:        "994b39680e7cb653839053a76ad471e29b1fefbce14a9bbf5434d9de8625732d"
-    sha256 cellar: :any,                 catalina:       "c3fb15bbfbde5f246e3776cde0489227836a695bef07a7a25cc928f2e28a935b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c9f1717e1d29898fb06c95d84c99c1beee02403f6e64f9617569e08e358abbbb"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "462a889a4d51338c58f99862c0812246a5277b9d2e234cfdf860d48c4be65220"
+    sha256 cellar: :any,                 arm64_sonoma:  "91159cd014e31a07bb587ef84b34fc15356a33f9530395556e1c53698ff67b17"
+    sha256 cellar: :any,                 arm64_ventura: "0966014087dbd6557936ebcd2c06a7ad2d93f82b8bf692efabf8f374f2d3706e"
+    sha256 cellar: :any,                 sonoma:        "4d230ea0614872eb9f765d5ad75cebfe4a940794b84306abf87bf77c48ce52b6"
+    sha256 cellar: :any,                 ventura:       "0b00fe78bd9847767966b12aadb1f66789edb318baa67b5a78fe1485fc2d01fb"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "9e62daba2f3721ca392c8e47767987b5b865bd12d1100e63ca22baedcf037e73"
   end
 
   depends_on "cmake" => :build

--- a/Formula/v/vrpn.rb
+++ b/Formula/v/vrpn.rb
@@ -28,6 +28,8 @@ class Vrpn < Formula
       -DVRPN_BUILD_CLIENTS=OFF
       -DVRPN_BUILD_JAVA=OFF
       -DVRPN_USE_WIIUSE=OFF
+      -DVRPN_BUILD_PYTHON=OFF
+      -DVRPN_BUILD_PYTHON_HANDCODED_3X=OFF
     ]
 
     args << "-DCMAKE_OSX_SYSROOT=#{MacOS.sdk_path}" if OS.mac?


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
  /tmp/vrpn-20250323-6062-udewjb/vrpn/python/include/handlers.hpp: In function ‘void vrpn_python::handlers::change_handler(void*, vrpn_info_type)’:
  /tmp/vrpn-20250323-6062-udewjb/vrpn/python/include/handlers.hpp:24:26: error: there are no arguments to ‘PyEval_CallObject’ that depend on a template parameter, so a declaration of ‘PyEval_CallObject’ must be available [-fpermissive]
     24 |       PyObject *result = PyEval_CallObject(callback,arglist);
        |                          ^~~~~~~~~~~~~~~~~
```

#211761 
- https://github.com/vrpn/vrpn/pull/299