### PR TITLE
libdv: regenerate configure for linux arm build

### DIFF
--- a/Formula/lib/libdv.rb
+++ b/Formula/lib/libdv.rb
@@ -24,28 +24,24 @@ class Libdv < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "b4e579189286f35409557243fe450e7509536f831777f37ae2f7519913bddcf8"
   end
 
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "pkgconf" => :build
   depends_on "popt"
-
-  on_macos do
-    depends_on "autoconf" => :build
-    depends_on "automake" => :build
-    depends_on "libtool" => :build
-    depends_on "pkgconf" => :build
-  end
 
   # remove SDL1 dependency by force
   patch :DATA
 
   def install
-    if OS.mac?
-      # This fixes an undefined symbol error on compile.
-      # See the port file for libdv:
-      #   https://trac.macports.org/browser/trunk/dports/multimedia/libdv/Portfile
-      # This flag is the preferred method over what macports uses.
-      # See the apple docs: https://cl.ly/2HeF bottom of the "Finding Imported Symbols" section
-      ENV.append "LDFLAGS", "-undefined dynamic_lookup"
-      system "autoreconf", "--force", "--install", "--verbose"
-    end
+    # This fixes an undefined symbol error on compile.
+    # See the port file for libdv:
+    #   https://trac.macports.org/browser/trunk/dports/multimedia/libdv/Portfile
+    # This flag is the preferred method over what macports uses.
+    # See the apple docs: https://cl.ly/2HeF bottom of the "Finding Imported Symbols" section
+    ENV.append "LDFLAGS", "-undefined dynamic_lookup" if OS.mac?
+
+    system "autoreconf", "--force", "--install", "--verbose"
 
     # Fix compile with newer Clang
     ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
@@ -56,6 +52,11 @@ class Libdv < Formula
                           "--disable-sdltest",
                           *std_configure_args
     system "make", "install"
+  end
+
+  test do
+    system bin/"dubdv", "--version"
+    system bin/"dvconnect", "--version"
   end
 end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
  config.guess timestamp = 2005-12-13
  
  uname -m = aarch64
  uname -r = 6.8.0-1021-azure
  uname -s = Linux
  uname -v = #25~22.04.1-Ubuntu SMP Thu Jan 16 21:09:47 UTC 2025
  
  /usr/bin/uname -p = aarch64
  /bin/uname -X     = 
  
  hostinfo               = 
  /bin/universe          = 
  /usr/bin/arch -k       = 
  /bin/arch              = aarch64
  /usr/bin/oslevel       = 
  /usr/convex/getsysinfo = 
  
  UNAME_MACHINE = aarch64
  UNAME_RELEASE = 6.8.0-1021-azure
  UNAME_SYSTEM  = Linux
  UNAME_VERSION = #25~22.04.1-Ubuntu SMP Thu Jan 16 21:09:47 UTC 2025
  configure: error: cannot guess build type; you must specify one
```

#211761 
