### PR TITLE
librttopo: update to use debian tarball as gitea tarball checksum changes

### DIFF
--- a/Formula/lib/librttopo.rb
+++ b/Formula/lib/librttopo.rb
@@ -1,7 +1,7 @@
 class Librttopo < Formula
   desc "RT Topology Library"
   homepage "https://git.osgeo.org/gitea/rttopo/librttopo"
-  url "https://git.osgeo.org/gitea/rttopo/librttopo/archive/librttopo-1.1.0.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/libr/librttopo/librttopo_1.1.0.orig.tar.gz"
   sha256 "2e2fcabb48193a712a6c76ac9a9be2a53f82e32f91a2bc834d9f1b4fa9cd879f"
   license "GPL-2.0-or-later"
   head "https://git.osgeo.org/gitea/rttopo/librttopo.git", branch: "master"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- it is a known issue, https://github.com/go-gitea/gitea/issues/26620

```
> curl -sL https://git.osgeo.org/gitea/rttopo/librttopo/archive/librttopo-1.1.0.tar.gz | shasum -a 256
60b49acb493c1ab545116fb0b0d223ee115166874902ad8165eb39e9fd98eaa9  -
> curl -sL https://deb.debian.org/debian/pool/main/libr/librttopo/librttopo_1.1.0.orig.tar.gz | shasum -a 256
2e2fcabb48193a712a6c76ac9a9be2a53f82e32f91a2bc834d9f1b4fa9cd879f  -
```