### PR TITLE
f2: downgrade to 2.0.3, add livecheck

### DIFF
--- a/Formula/f/f2.rb
+++ b/Formula/f/f2.rb
@@ -1,18 +1,26 @@
 class F2 < Formula
   desc "Command-line batch renaming tool"
   homepage "https://github.com/ayoisaiah/f2"
-  url "https://github.com/ayoisaiah/f2/archive/refs/tags/v2.1.0.tar.gz"
-  sha256 "0c0e22f2f19cbaae5746f09cd42c9178b338f21314fdc8067fafa163e85cb4de"
+  url "https://github.com/ayoisaiah/f2/archive/refs/tags/v2.0.3.tar.gz"
+  sha256 "164e1282ae1f2ea6a8af93c785d7bb214b09919ad8537b8fbab5b5bc8ee1a396"
   license "MIT"
   head "https://github.com/ayoisaiah/f2.git", branch: "master"
 
+  # Upstream may add/remove tags before releasing a version, so we check
+  # GitHub releases instead of the Git tags.
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "18a61e35ab3ee4be8e68c6e56029ebc77311030a951de7cca1b6185465e41a0e"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "18a61e35ab3ee4be8e68c6e56029ebc77311030a951de7cca1b6185465e41a0e"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "18a61e35ab3ee4be8e68c6e56029ebc77311030a951de7cca1b6185465e41a0e"
-    sha256 cellar: :any_skip_relocation, sonoma:        "a90e79eca9c15448a6ba1e6b6d5ac489e16431d3018d4bd34a9f4f87d5ef7300"
-    sha256 cellar: :any_skip_relocation, ventura:       "a90e79eca9c15448a6ba1e6b6d5ac489e16431d3018d4bd34a9f4f87d5ef7300"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "ce3b9d2b37b38ebc202648823ed78536f7c64ed8acfff4336651e4398f71e6bc"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "8302833ac2fb9359a9219c8157f0f2b89cfc0a1c77878d333def7a43386aa33b"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "8302833ac2fb9359a9219c8157f0f2b89cfc0a1c77878d333def7a43386aa33b"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "8302833ac2fb9359a9219c8157f0f2b89cfc0a1c77878d333def7a43386aa33b"
+    sha256 cellar: :any_skip_relocation, sonoma:        "8bd506a72e01572496aec534f019ba39752b8f8c9974cdae26c0aad3c2f9b247"
+    sha256 cellar: :any_skip_relocation, ventura:       "8bd506a72e01572496aec534f019ba39752b8f8c9974cdae26c0aad3c2f9b247"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "42b70125dde40f56f721d1f02904018d5ce9bfaf048a5c0cd4d22465a2a25851"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

An upstream v2.1.0 tag for `f2` existed yesterday and [autobump picked it up](https://github.com/Homebrew/homebrew-core/pull/215948) but it has since been removed. I'm not sure if there was a 2.1.0 release on GitHub at the time but there isn't one now. Either upstream created the v2.1.0 tag and removed it without creating a release or they yanked the version.

Either way, 2.1.0 doesn't exist right now, so this downgrades the formula to 2.0.3. This also adds a `livecheck` block that uses the `GithubLatest` strategy, so hopefully we will avoid this situation in the future.