### PR TITLE
hexcurse: fix multiple definition build issue with gcc 10+

### DIFF
--- a/Formula/h/hexcurse.rb
+++ b/Formula/h/hexcurse.rb
@@ -26,9 +26,11 @@ class Hexcurse < Formula
   uses_from_macos "ncurses"
 
   def install
-    system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}",
-                          "--mandir=#{man}"
+    # Work around failure from GCC 10+ using default of `-fno-common`
+    # multiple definition of `fpIN'; file.o:(.bss+0x0): first defined here
+    ENV.append_to_cflags "-fcommon" if OS.linux?
+
+    system "./configure", "--mandir=#{man}", *std_configure_args
     system "make", "install"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
  /usr/bin/ld: llist.o:(.bss+0x0): multiple definition of `fpIN'; file.o:(.bss+0x0): first defined here
  /usr/bin/ld: screen.o:(.bss+0x0): multiple definition of `fpIN'; file.o:(.bss+0x0): first defined here
  /usr/bin/ld: hexcurse.o:(.bss+0x20): multiple definition of `fpIN'; file.o:(.bss+0x0): first defined here
  /usr/bin/ld: stack.o:(.bss+0x0): multiple definition of `fpIN'; file.o:(.bss+0x0): first defined here
  /usr/bin/ld: acceptch.o:(.bss+0x10): multiple definition of `fpIN'; file.o:(.bss+0x0): first defined here
  /usr/bin/ld: color.o:(.bss+0x8): multiple definition of `fpIN'; file.o:(.bss+0x0): first defined here
```

#211761 
