### PR TITLE
htmlcxx: use c++11 for build

### DIFF
--- a/Formula/h/htmlcxx.rb
+++ b/Formula/h/htmlcxx.rb
@@ -29,7 +29,9 @@ class Htmlcxx < Formula
   end
 
   def install
-    system "./configure", "--disable-debug", "--disable-dependency-tracking", "--prefix=#{prefix}"
+    ENV.cxx11
+
+    system "./configure", *std_configure_args
     system "make", "install"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----


```
   In file included from CharsetConverter.cc:5:
  CharsetConverter.h:20:90: error: ISO C++17 does not allow dynamic exception specifications
     20 |                         CharsetConverter(const std::string &from, const std::string &to) throw (Exception);
        |                                                                                          ^~~~~
  CharsetConverter.cc:10:74: error: ISO C++17 does not allow dynamic exception specifications
     10 | CharsetConverter::CharsetConverter(const string &from, const string &to) throw (Exception)
        |                                                                          ^~~~~
  make[1]: *** [Makefile:732: libhtmlcxx_la-CharsetConverter.lo] Error 1
```

#211761 