### PR TITLE
workflows/publish-commit-bottles: update workflow comment

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -53,6 +53,9 @@ env:
   ORG_FORK_MESSAGE: >-
     :no_entry: It looks like @BrewTestBot cannot push to your PR branch. Please open
     future pull requests from a non-organization fork to simplify the merge process.
+  BOTTLE_COMMIT_PUSH_MESSAGE: >-
+    Please **do not** push to this PR branch before the bottle commits have been pushed, as this results in a state that is difficult to recover from.
+    If you need to resolve a merge conflict, please use a merge commit. Do not force-push to this PR branch.
 
 jobs:
   check:
@@ -279,8 +282,14 @@ jobs:
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           issue: ${{inputs.pull_request}}
-          body: ":shipit: @${{github.actor}} has [requested bottles to be published to this PR](${{env.RUN_URL}})."
-          bot_body: ":robot: An automated task has [requested bottles to be published to this PR](${{env.RUN_URL}})."
+          body: |
+            :shipit: @${{github.actor}} has [requested bottles to be published to this PR](${{env.RUN_URL}}).
+
+            ${{env.BOTTLE_COMMIT_PUSH_MESSAGE}}
+          bot_body: |
+            :robot: An automated task has [requested bottles to be published to this PR](${{env.RUN_URL}}).
+
+            ${{env.BOTTLE_COMMIT_PUSH_MESSAGE}}
           bot: github-actions[bot]
 
       - name: Set up Homebrew


### PR DESCRIPTION
Let's try to discourage users from pushing to PRs once the publish
workflow has started, as this can be awkward to recover from.
