### PR TITLE
go: test skipping `go fmt` on arm64 Linux (do not merge)

### DIFF
--- a/Formula/g/go.rb
+++ b/Formula/g/go.rb
@@ -100,7 +100,7 @@ class Go < Formula
 
     # Run go fmt check for no errors then run the program.
     # This is a a bare minimum of go working as it uses fmt, build, and run.
-    system bin/"go", "fmt", "hello.go"
+    system bin/"go", "fmt", "hello.go" if OS.mac? || Hardware::CPU.intel?
     assert_equal "Hello World\n", shell_output("#{bin}/go run hello.go")
 
     with_env(GOOS: "freebsd", GOARCH: "amd64") do


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Let's see if this is the only thing that's broken on arm64 Linux.
