### PR TITLE
ophcrack: add explicit `--build` flag for linux arm build

### DIFF
--- a/Formula/o/ophcrack.rb
+++ b/Formula/o/ophcrack.rb
@@ -28,13 +28,15 @@ class Ophcrack < Formula
 
   def install
     args = %W[
-      --disable-debug
       --disable-gui
       --with-libssl=#{Formula["openssl@3"].opt_prefix}
-      --prefix=#{prefix}
     ]
     args << "--with-libexpat=#{Formula["expat"].opt_prefix}" if OS.linux?
-    system "./configure", *args
+
+    # Help old config scripts identify arm64 linux
+    args << "--build=aarch64-unknown-linux-gnu" if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+
+    system "./configure", *args, *std_configure_args
     system "make", "install"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

#211761 