### PR TITLE
primer3: add workaround for linux builds

### DIFF
--- a/Formula/p/primer3.rb
+++ b/Formula/p/primer3.rb
@@ -23,6 +23,9 @@ class Primer3 < Formula
   end
 
   def install
+    # workaround for `thal.c:429:13: error: ISO C++ forbids comparison between pointer and integer`
+    ENV.append_to_cflags "-fpermissive" if OS.linux?
+
     system "make", "-C", "src", "install", "PREFIX=#{prefix}"
     pkgshare.install "src/primer3_config"
     prefix.install "src/LICENSE_GPL3_for_Amplicon3"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
   thal.c: In function ‘void thal(const unsigned char*, const unsigned char*, const thal_args*, thal_results*)’:
  thal.c:429:13: error: ISO C++ forbids comparison between pointer and integer [-fpermissive]
    429 |    if ('\0' == oligo_f) {
        |        ~~~~~^~~~~~~~~~
  thal.c:434:13: error: ISO C++ forbids comparison between pointer and integer [-fpermissive]
    434 |    if ('\0' == oligo_r) {
        |        ~~~~~^~~~~~~~~~
```

#211761 