### PR TITLE
ogmtools: use c++11 for build

### DIFF
--- a/Formula/o/ogmtools.rb
+++ b/Formula/o/ogmtools.rb
@@ -38,9 +38,10 @@ class Ogmtools < Formula
   end
 
   def install
+    ENV.cxx11
+
     ENV.append "CPPFLAGS", "-I#{Formula["libvorbis"].opt_include}"
-    system "./configure", "--disable-debug", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}", "--mandir=#{man}"
+    system "./configure", "--mandir=#{man}", *std_configure_args
 
     system "make", "install", "LIBS=-L#{Formula["libvorbis"].opt_lib} -lvorbis -lvorbisenc"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----


```
  In file included from r_ogm.cpp:26:
  queue.h:39:11: error: ISO C++17 does not allow dynamic exception specifications
     39 |     q_c() throw (error_c);
        |           ^~~~~
  In file included from r_ogm.cpp:27:
  r_ogm.h:65:33: error: ISO C++17 does not allow dynamic exception specifications
     65 |                  char *nfourcc) throw (error_c);
        |                                 ^~~~~
```

#211761 