### PR TITLE
oscats: add explicit `--build` flag for linux arm build

### DIFF
--- a/Formula/o/oscats.rb
+++ b/Formula/o/oscats.rb
@@ -40,7 +40,11 @@ class Oscats < Formula
   end
 
   def install
-    system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
+    args = []
+    # Help old config scripts identify arm64 linux
+    args << "--build=aarch64-unknown-linux-gnu" if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+
+    system "./configure", *args, *std_configure_args
     system "make", "install"
     pkgshare.install "examples"
     # Fix shim references in examples Makefile.
@@ -55,7 +59,7 @@ class Oscats < Formula
 
   test do
     pkgconf_flags = shell_output("pkgconf --cflags --libs oscats glib-2.0").chomp.split
-    system ENV.cc, pkgshare/"examples/ex01.c", *pkgconf_flags, "-o", "ex01"
+    system ENV.cc, "-Wno-incompatible-pointer-types", pkgshare/"examples/ex01.c", *pkgconf_flags, "-o", "ex01"
     assert_match "Done", shell_output("#{testpath}/ex01")
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
/home/linuxbrew/.linuxbrew/Cellar/oscats/0.6_7/share/oscats/examples/ex01.c:132:17: error: assignment to ‘OscatsAlgExposureCounter *’ {aka ‘struct _OscatsAlgExposureCounter *’} from incompatible pointer type ‘OscatsAlgorithm *’ {aka ‘struct _OscatsAlgorithm *’} [-Wincompatible-pointer-types]
  132 |     exposure[j] = oscats_algorithm_register(g_object_new(OSCATS_TYPE_ALG_EXPOSURE_COUNTER, NULL), test[j]);
      |                 ^
```

#211761 