### PR TITLE
opendbx: add explicit `--build` flag and cxx11 env for linux arm build

### DIFF
--- a/Formula/o/opendbx.rb
+++ b/Formula/o/opendbx.rb
@@ -34,13 +34,16 @@ class Opendbx < Formula
   depends_on "sqlite"
 
   def install
+    ENV.cxx11
+
     # Reported upstream: http://bugs.linuxnetworks.de/index.php?do=details&id=40
     inreplace "utils/Makefile.in", "$(LIBSUFFIX)", ".dylib" if OS.mac?
 
-    system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}",
-                          "--with-backends=sqlite3"
-    system "make"
+    args = []
+    # Help old config scripts identify arm64 linux
+    args << "--build=aarch64-unknown-linux-gnu" if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+
+    system "./configure", "--with-backends=sqlite3", *args, *std_configure_args
     system "make", "install"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
libtool: link: gcc-14 -shared  .libs/libopendbx_la-odbxlib.o .libs/libopendbx_la-odbx.o      -Wl,-soname -Wl,libopendbx.so.1 -o .libs/libopendbx.so.1.2.0
odbx_impl.cpp:32:72: error: ISO C++17 does not allow dynamic exception specifications
   32 |         Lob_Impl::Lob_Impl( odbx_result_t* result, const char* value ) throw( std::exception )
      |                                                                        ^~~~~
odbx_impl.cpp:55:32: error: ISO C++17 does not allow dynamic exception specifications
   55 |         void Lob_Impl::close() throw( std::exception )
      |                                ^~~~~
odbx_impl.cpp:69:63: error: ISO C++17 does not allow dynamic exception specifications
   69 |         ssize_t Lob_Impl::read( void* buffer, size_t buflen ) throw( std::exception )
      |                                                               ^~~~~
odbx_impl.cpp:83:64: error: ISO C++17 does not allow dynamic exception specifications
   83 |         ssize_t Lob_Impl::write( void* buffer, size_t buflen ) throw( std::exception )
      |                                                                ^~~~~
odbx_impl.cpp:105:52: error: ISO C++17 does not allow dynamic exception specifications
  105 |         Result_Impl::Result_Impl( odbx_t* handle ) throw( std::exception )
      |                                                    ^~~~~
odbx_impl.cpp:124:36: error: ISO C++17 does not allow dynamic exception specifications
  124 |         void Result_Impl::finish() throw( std::exception )
      |                                    ^~~~~
odbx_impl.cpp:140:88: error: ISO C++17 does not allow dynamic exception specifications
  140 |         odbxres Result_Impl::getResult( struct timeval* timeout, unsigned long chunk ) throw( std::exception )
      |                                                                                        ^~~~~
odbx_impl.cpp:165:39: error: ISO C++17 does not allow dynamic exception specifications
  165 |         odbxrow Result_Impl::getRow() throw( std::exception )
      |                                       ^~~~~
odbx_impl.cpp:179:46: error: ISO C++17 does not allow dynamic exception specifications
  179 |         uint64_t Result_Impl::rowsAffected() throw( std::exception )
      |                                              ^~~~~
odbx_impl.cpp:186:50: error: ISO C++17 does not allow dynamic exception specifications
  186 |         unsigned long Result_Impl::columnCount() throw( std::exception )
      |                                                  ^~~~~
odbx_impl.cpp:193:68: error: ISO C++17 does not allow dynamic exception specifications
  193 |         unsigned long Result_Impl::columnPos( const string& name ) throw( std::exception )
      |                                                                    ^~~~~
odbx_impl.cpp:216:67: error: ISO C++17 does not allow dynamic exception specifications
  216 |         const string Result_Impl::columnName( unsigned long pos ) throw( std::exception )
      |                                                                   ^~~~~
odbx_impl.cpp:233:63: error: ISO C++17 does not allow dynamic exception specifications
  233 |         odbxtype Result_Impl::columnType( unsigned long pos ) throw( std::exception )
      |                                                               ^~~~~
odbx_impl.cpp:245:69: error: ISO C++17 does not allow dynamic exception specifications
  245 |         unsigned long Result_Impl::fieldLength( unsigned long pos ) throw( std::exception )
      |                                                                     ^~~~~
odbx_impl.cpp:257:66: error: ISO C++17 does not allow dynamic exception specifications
  257 |         const char* Result_Impl::fieldValue( unsigned long pos ) throw( std::exception )
      |                                                                  ^~~~~
odbx_impl.cpp:268:61: error: ISO C++17 does not allow dynamic exception specifications
  268 |         Lob_Iface* Result_Impl::getLob( const char* value ) throw( std::exception )
      |                                                             ^~~~~
odbx_impl.cpp:283:48: error: ISO C++17 does not allow dynamic exception specifications
  283 |         Stmt_Impl::Stmt_Impl( odbx_t* handle ) throw( std::exception )
      |                                                ^~~~~
odbx_impl.cpp:304:79: error: ISO C++17 does not allow dynamic exception specifications
  304 |         StmtSimple_Impl::StmtSimple_Impl( odbx_t* handle, const string& sql ) throw( std::exception ) : Stmt_Impl( handle )
      |                                                                               ^~~~~
odbx_impl.cpp:329:44: error: ISO C++17 does not allow dynamic exception specifications
  329 |         StmtSimple_Impl::StmtSimple_Impl() throw( std::exception ) : Stmt_Impl( NULL )
      |                                            ^~~~~
odbx_impl.cpp:368:50: error: ISO C++17 does not allow dynamic exception specifications
  368 |         Result_Iface* StmtSimple_Impl::execute() throw( std::exception )
      |                                                  ^~~~~
odbx_impl.cpp:380:55: error: ISO C++17 does not allow dynamic exception specifications
  380 |         inline void StmtSimple_Impl::_exec_noparams() throw( std::exception )
      |                                                       ^~~~~
odbx_impl.cpp:455:89: error: ISO C++17 does not allow dynamic exception specifications
  455 |         Conn_Impl::Conn_Impl( const char* backend, const char* host, const char* port ) throw( std::exception )
      |                                                                                         ^~~~~
odbx_impl.cpp:483:106: error: ISO C++17 does not allow dynamic exception specifications
  483 |         void Conn_Impl::bind( const char* database, const char* who, const char* cred, odbxbind method ) throw( std::exception )
      |                                                                                                          ^~~~~
odbx_impl.cpp:497:34: error: ISO C++17 does not allow dynamic exception specifications
  497 |         void Conn_Impl::unbind() throw( std::exception )
      |                                  ^~~~~
odbx_impl.cpp:511:34: error: ISO C++17 does not allow dynamic exception specifications
  511 |         void Conn_Impl::finish() throw( std::exception )
      |                                  ^~~~~
odbx_impl.cpp:531:54: error: ISO C++17 does not allow dynamic exception specifications
  531 |         bool Conn_Impl::getCapability( odbxcap cap ) throw( std::exception )
      |                                                      ^~~~~
odbx_impl.cpp:548:66: error: ISO C++17 does not allow dynamic exception specifications
  548 |         void Conn_Impl::getOption( odbxopt option, void* value ) throw( std::exception )
      |                                                                  ^~~~~
odbx_impl.cpp:560:66: error: ISO C++17 does not allow dynamic exception specifications
  560 |         void Conn_Impl::setOption( odbxopt option, void* value ) throw( std::exception )
      |                                                                  ^~~~~
odbx_impl.cpp:572:90: error: ISO C++17 does not allow dynamic exception specifications
  572 |         string& Conn_Impl::escape( const char* from, unsigned long fromlen, string& to ) throw( std::exception )
      |                                                                                          ^~~~~
odbx_impl.cpp:597:77: error: ISO C++17 does not allow dynamic exception specifications
  597 |         Stmt_Iface* Conn_Impl::create( const string& sql, Stmt::Type type ) throw( std::exception )
      |                                                                             ^~~~~
odbx_impl.cpp:610:70: error: ISO C++17 does not allow dynamic exception specifications
  610 |         inline char* Conn_Impl::_resize( char* buffer, size_t size ) throw( std::exception )
      |                                                                      ^~~~~
libtool: link: (cd ".libs" && rm -f "libopendbx.so.1" && ln -s "libopendbx.so.1.2.0" "libopendbx.so.1")
libtool: link: (cd ".libs" && rm -f "libopendbx.so" && ln -s "libopendbx.so.1.2.0" "libopendbx.so")
libtool: link: ar cru .libs/libopendbx.a  libopendbx_la-odbxlib.o libopendbx_la-odbx.o
```

#211761 