### PR TITLE
advancescan: use c++11 for build

### DIFF
--- a/Formula/a/advancescan.rb
+++ b/Formula/a/advancescan.rb
@@ -26,8 +26,9 @@ class Advancescan < Formula
   uses_from_macos "zlib"
 
   def install
-    system "./configure", "--disable-silent-rules",
-                          "--prefix=#{prefix}"
+    ENV.cxx11
+
+    system "./configure", "--disable-silent-rules", *std_configure_args
     system "make", "install"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
  ==> make install
  g++-11 -DHAVE_CONFIG_H -I.     -g -O2 -DUSE_LSB -DUSE_ERROR_SILENT -c -o scan.o scan.cc
  g++-11 -DHAVE_CONFIG_H -I.     -g -O2 -DUSE_LSB -DUSE_ERROR_SILENT -c -o rom.o rom.cc
  g++-11 -DHAVE_CONFIG_H -I.     -g -O2 -DUSE_LSB -DUSE_ERROR_SILENT -c -o disk.o disk.cc
  g++-11 -DHAVE_CONFIG_H -I.     -g -O2 -DUSE_LSB -DUSE_ERROR_SILENT -c -o sample.o sample.cc
  In file included from sample.h:24,
                   from sample.cc:23:
  file.h:70:43: error: ISO C++17 does not allow dynamic exception specifications
     70 | bool file_exists(const std::string& file) throw (error);
        |                                           ^~~~~
  file.h:71:75: error: ISO C++17 does not allow dynamic exception specifications
     71 | void file_write(const std::string& path, const char* data, unsigned size) throw (error);
        |                                                                           ^~~~~
  file.h:72:68: error: ISO C++17 does not allow dynamic exception specifications
     72 | void file_read(const std::string& path, char* data, unsigned size) throw (error);
        |                                                                    ^~~~~
  file.h:73:85: error: ISO C++17 does not allow dynamic exception specifications
     73 | void file_read(const std::string& path, char* data, unsigned offset, unsigned size) throw (error);
        |                                                                                     ^~~~~
  file.h:74:43: error: ISO C++17 does not allow dynamic exception specifications
     74 | time_t file_time(const std::string& path) throw (error);
        |                                           ^~~~~
  file.h:75:54: error: ISO C++17 does not allow dynamic exception specifications
     75 | void file_utime(const std::string& path, time_t tod) throw (error);
        |                                                      ^~~~~
  file.h:76:45: error: ISO C++17 does not allow dynamic exception specifications
     76 | unsigned file_size(const std::string& path) throw (error);
        |                                             ^~~~~
  file.h:77:41: error: ISO C++17 does not allow dynamic exception specifications
     77 | crc_t file_crc(const std::string& path) throw (error);
        |                                         ^~~~~
  file.h:78:68: error: ISO C++17 does not allow dynamic exception specifications
     78 | void file_copy(const std::string& path1, const std::string& path2) throw (error);
        |                                                                    ^~~~~
  file.h:79:68: error: ISO C++17 does not allow dynamic exception specifications
     79 | void file_move(const std::string& path1, const std::string& path2) throw (error);
        |                                                                    ^~~~~
  file.h:80:44: error: ISO C++17 does not allow dynamic exception specifications
     80 | void file_remove(const std::string& path1) throw (error);
        |                                            ^~~~~
  file.h:81:44: error: ISO C++17 does not allow dynamic exception specifications
     81 | void file_mktree(const std::string& path1) throw (error);
        |                                            ^~~~~
  In file included from rom.h:24,
                   from rom.cc:23:
  file.h:70:43: error: ISO C++17 does not allow dynamic exception specifications
     74 | time_t file_time(const std::string& path) throw (error);
        |                                           ^~~~~
  file.h:75:54: error: ISO C++17 does not allow dynamic exception specifications
     75 | void file_utime(const std::string& path, time_t tod) throw (error);
        |                                                      ^~~~~
  file.h:76:45: error: ISO C++17 does not allow dynamic exception specifications
     76 | unsigned file_size(const std::string& path) throw (error);
        |                                             ^~~~~
  file.h:77:41: error: ISO C++17 does not allow dynamic exception specifications
     77 | crc_t file_crc(const std::string& path) throw (error);
        |                                         ^~~~~
  file.h:78:68: error: ISO C++17 does not allow dynamic exception specifications
     78 | void file_copy(const std::string& path1, const std::string& path2) throw (error);
        |                                                                    ^~~~~
  file.h:79:68: error: ISO C++17 does not allow dynamic exception specifications
     79 | void file_move(const std::string& path1, const std::string& path2) throw (error);
        |                                                                    ^~~~~
  file.h:80:44: error: ISO C++17 does not allow dynamic exception specifications
     80 | void file_remove(const std::string& path1) throw (error);
        |                                            ^~~~~
  file.h:81:44: error: ISO C++17 does not allow dynamic exception specifications
     81 | void file_mktree(const std::string& path1) throw (error);
        |                                            ^~~~~
  In file included from rom.h:24,
                   from game.h:24,
                   from scan.cc:23:
  file.h:70:43: error: ISO C++17 does not allow dynamic exception specifications
     70 | bool file_exists(const std::string& file) throw (error);
        |                                           ^~~~~
  file.h:71:75: error: ISO C++17 does not allow dynamic exception specifications
     71 | void file_write(const std::string& path, const char* data, unsigned size) throw (error);
        |                                                                           ^~~~~
  file.h:72:68: error: ISO C++17 does not allow dynamic exception specifications
     72 | void file_read(const std::string& path, char* data, unsigned size) throw (error);
        |                                                                    ^~~~~
  file.h:73:85: error: ISO C++17 does not allow dynamic exception specifications
     73 | void file_read(const std::string& path, char* data, unsigned offset, unsigned size) throw (error);
        |                                                                                     ^~~~~
  file.h:74:43: error: ISO C++17 does not allow dynamic exception specifications
     74 | time_t file_time(const std::string& path) throw (error);
        |                                           ^~~~~
  file.h:75:54: error: ISO C++17 does not allow dynamic exception specifications
     75 | void file_utime(const std::string& path, time_t tod) throw (error);
        |                                                      ^~~~~
  file.h:76:45: error: ISO C++17 does not allow dynamic exception specifications
     76 | unsigned file_size(const std::string& path) throw (error);
        |                                             ^~~~~
  file.h:77:41: error: ISO C++17 does not allow dynamic exception specifications
     77 | crc_t file_crc(const std::string& path) throw (error);
        |                                         ^~~~~
  file.h:78:68: error: ISO C++17 does not allow dynamic exception specifications
     78 | void file_copy(const std::string& path1, const std::string& path2) throw (error);
        |                                                                    ^~~~~
  file.h:79:68: error: ISO C++17 does not allow dynamic exception specifications
     79 | void file_move(const std::string& path1, const std::string& path2) throw (error);
        |                                                                    ^~~~~
  file.h:80:44: error: ISO C++17 does not allow dynamic exception specifications
     80 | void file_remove(const std::string& path1) throw (error);
        |                                            ^~~~~
  file.h:81:44: error: ISO C++17 does not allow dynamic exception specifications
     81 | void file_mktree(const std::string& path1) throw (error);
        |                                            ^~~~~
  make: *** [Makefile:584: sample.o] Error 1
  make: *** Waiting for unfinished jobs....
  make: *** [Makefile:584: disk.o] Error 1
  make: *** [Makefile:584: rom.o] Error 1
  make: *** [Makefile:584: scan.o] Error 1
```


#211761 