### PR TITLE
pax: update URLs

### DIFF
--- a/Formula/p/pax.rb
+++ b/Formula/p/pax.rb
@@ -1,7 +1,7 @@
 class Pax < Formula
   desc "Portable Archive Interchange archive tool"
-  homepage "https://www.mirbsd.org/pax.htm"
-  url "https://www.mirbsd.org/MirOS/dist/mir/cpio/paxmirabilis-20201030.tgz"
+  homepage "https://mbsd.evolvis.org/pax.htm"
+  url "https://mbsd.evolvis.org/MirOS/dist/mir/cpio/paxmirabilis-20201030.tgz"
   sha256 "1cc892c9c8ce265d28457bab4225eda71490d93def0a1d2271430c2863b728dc"
   license "MirOS"
 


### PR DESCRIPTION
The original URLs now only supports HTTP, e.g. http://www.mirbsd.org/pax.htm

New URLs were mentioned upstream at http://www.mirbsd.org/permalinks/wlog2021_e20230905.htm#e20230905_wlog2021
> [TLSv1.2+-capable mirror](http://www.mirbsd.org/permalinks/wlog2021_e20230905.htm#e20230905_wlog2021) 2023-09-05
> ...
> tl;dr: https://mbsd.evolvis.org/ with the usual URL paths.
