### PR TITLE
glib: fix g-ir-scanner PATH precedence.

### DIFF
--- a/Formula/g/glib.rb
+++ b/Formula/g/glib.rb
@@ -99,7 +99,7 @@ class Glib < Formula
     end
     ENV.append_path "PKG_CONFIG_PATH", staging_dir/"lib/pkgconfig"
     ENV.append_path "LD_LIBRARY_PATH", staging_dir/"lib" if OS.linux?
-    ENV.append_path "PATH", staging_dir/"bin"
+    ENV.prepend_path "PATH", staging_dir/"bin"
 
     system "meson", "setup", "build", "--default-library=both", "-Dintrospection=enabled", *args, *std_meson_args
     system "meson", "compile", "-C", "build", "--verbose"


### PR DESCRIPTION
The staging g-ir-scanner must be preferred over the system's g-ir-scanner. A mismatch in the versions, for example, will cause the build to fail.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
