### PR TITLE
readosm: add explicit `--build` flag for linux arm build

### DIFF
--- a/Formula/r/readosm.rb
+++ b/Formula/r/readosm.rb
@@ -29,27 +29,17 @@ class Readosm < Formula
   uses_from_macos "zlib"
 
   def install
-    system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
+    args = []
+    # Help old config scripts identify arm64 linux
+    args << "--build=aarch64-unknown-linux-gnu" if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+
+    system "./configure", *args, *std_configure_args
     system "make", "install"
 
     # Install examples but don't include Makefiles or objects
     doc.install "examples"
     rm doc.glob("examples/Makefile*")
     rm doc.glob("examples/*.o")
-
-    if OS.linux?
-      # Remove shim references
-      shim_files = [
-        doc/"examples/test_osm1",
-        doc/"examples/test_osm2",
-        doc/"examples/test_osm3",
-      ]
-
-      shim_files.each do |f|
-        inreplace f, Superenv.shims_path, HOMEBREW_PREFIX/bin
-      end
-    end
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----


#211761 