### PR TITLE
docker docker-completion 28.0.4

### DIFF
--- a/Formula/d/docker-completion.rb
+++ b/Formula/d/docker-completion.rb
@@ -11,7 +11,7 @@ class DockerCompletion < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "404a8406c026634db0a625b5daeef5a4d873e2362f612b09c6cee39f988d4833"
+    sha256 cellar: :any_skip_relocation, all: "ab2d16d72a1a2b17b8149581cc8fbc7d6b4dcd65451a8d8a28ba32024248c4ce"
   end
 
   # These used to also be provided by the `docker` formula.

--- a/Formula/d/docker-completion.rb
+++ b/Formula/d/docker-completion.rb
@@ -1,8 +1,8 @@
 class DockerCompletion < Formula
   desc "Bash, Zsh and Fish completion for Docker"
   homepage "https://www.docker.com/"
-  url "https://github.com/docker/cli/archive/refs/tags/v28.0.2.tar.gz"
-  sha256 "70ded7462897bab0b7d7e5716ffc787391ff5f2b483d7eb590a37bf6512bd3e4"
+  url "https://github.com/docker/cli/archive/refs/tags/v28.0.4.tar.gz"
+  sha256 "09b41aa5ff656bc135feb80cb9b73c70aeba099ef9756c3cef7bcb2eb3c98ba6"
   license "Apache-2.0"
   head "https://github.com/docker/cli.git", branch: "master"
 

--- a/Formula/d/docker.rb
+++ b/Formula/d/docker.rb
@@ -13,12 +13,12 @@ class Docker < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "84c6869be2b3f5023734b148c0a7365005935f634ade9f66f55e899bd44ea5bd"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "84c6869be2b3f5023734b148c0a7365005935f634ade9f66f55e899bd44ea5bd"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "84c6869be2b3f5023734b148c0a7365005935f634ade9f66f55e899bd44ea5bd"
-    sha256 cellar: :any_skip_relocation, sonoma:        "aae29dc6349692cc4ada0dabd8d551b29679eea4e9e78e427d438f9f918c909f"
-    sha256 cellar: :any_skip_relocation, ventura:       "aae29dc6349692cc4ada0dabd8d551b29679eea4e9e78e427d438f9f918c909f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "297ceee7ef10f39eff38dab187ba82f3e360f878c7473fd783e334a9b5383f4f"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "5d179df1d2e67d317743aaf177397c73570e84e14ac6b2d3b7d5e39a5cf8c0a1"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "5d179df1d2e67d317743aaf177397c73570e84e14ac6b2d3b7d5e39a5cf8c0a1"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "5d179df1d2e67d317743aaf177397c73570e84e14ac6b2d3b7d5e39a5cf8c0a1"
+    sha256 cellar: :any_skip_relocation, sonoma:        "881876f98098a12ec8af810401738be89d1d65aecc8766d269e2f40f2fd821c7"
+    sha256 cellar: :any_skip_relocation, ventura:       "881876f98098a12ec8af810401738be89d1d65aecc8766d269e2f40f2fd821c7"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1d6bcefd31a370efcda1817742be32f0cf21cd1ae650946a3ac3e55a2670730f"
   end
 
   depends_on "go" => :build

--- a/Formula/d/docker.rb
+++ b/Formula/d/docker.rb
@@ -2,8 +2,8 @@ class Docker < Formula
   desc "Pack, ship and run any application as a lightweight container"
   homepage "https://www.docker.com/"
   url "https://github.com/docker/cli.git",
-      tag:      "v28.0.2",
-      revision: "0442a7378f37ef9482ade1c8addf618cb8becb00"
+      tag:      "v28.0.4",
+      revision: "b8034c0ed70494a90c133461d145cd072d920d7c"
   license "Apache-2.0"
   head "https://github.com/docker/cli.git", branch: "master"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Docker has released two new versions, **[v28.0.3](https://github.com/docker/cli/releases/tag/v28.0.3)** and **[v28.0.4](https://github.com/docker/cli/releases/tag/v28.0.4)**, within the past **more than ten hours**. The release time between these two versions is only **4 hours** apart. Should we consider submitting a PR for **[v28.0.3](https://github.com/docker/cli/releases/tag/v28.0.3)** first?