### PR TITLE
jcal v0.5.1

### DIFF
--- a/Formula/j/jcal.rb
+++ b/Formula/j/jcal.rb
@@ -1,13 +1,14 @@
 class Jcal < Formula
   desc "UNIX-cal-like tool to display Jalali calendar"
-  homepage "https://savannah.nongnu.org/projects/jcal/"
-  url "https://download.savannah.gnu.org/releases/jcal/jcal-0.4.1.tar.gz"
-  sha256 "e8983ecad029b1007edc98458ad13cd9aa263d4d1cf44a97e0a69ff778900caa"
+  homepage "https://github.com/persiancal/jcal"
+  url "https://github.com/persiancal/jcal/archive/refs/tags/v0.5.1.tar.gz"
+  sha256 "6cc477c668962de9250b7aebfdf0eee979ab94ec4f393dc04782024ef68fff45"
   license "GPL-3.0-or-later"
+  head "https://github.com/persiancal/jcal.git", branch: "master"
 
   livecheck do
-    url "https://download.savannah.gnu.org/releases/jcal/"
-    regex(/href=.*?jcal[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do
@@ -32,15 +33,18 @@ class Jcal < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
+  depends_on "readline"
 
   def install
     shell_name = OS.mac? ? "/bin/sh" : "/bin/bash"
-    system shell_name, "autogen.sh"
-    system "./configure", "--prefix=#{prefix}",
-                          "--disable-debug",
-                          "--disable-dependency-tracking"
-    system "make"
-    system "make", "install"
+    cd "sources" do
+      system shell_name, "autogen.sh"
+      system "./configure", "--prefix=#{prefix}",
+                            "--disable-debug",
+                            "--disable-dependency-tracking"
+      system "make"
+      system "make", "install"
+    end
   end
 
   test do


### PR DESCRIPTION
Disclaimer: I am not a brew user, so I manually created this pr, not using brew 
The original author of the tool, jcal, passed away a few years ago and we forked it to keep it alive. 
This PR's goal is to use the new github repository as the source and switch to latest tag, which is v0.5.1
