### PR TITLE
mesa-glu: update urls

### DIFF
--- a/Formula/m/mesa-glu.rb
+++ b/Formula/m/mesa-glu.rb
@@ -1,15 +1,10 @@
 class MesaGlu < Formula
   desc "Mesa OpenGL Utility library"
-  homepage "https://cgit.freedesktop.org/mesa/glu"
-  url "ftp://ftp.freedesktop.org/pub/mesa/glu/glu-9.0.3.tar.xz"
+  homepage "https://gitlab.freedesktop.org/mesa/glu"
+  url "https://archive.mesa3d.org/glu/glu-9.0.3.tar.xz"
   sha256 "bd43fe12f374b1192eb15fe20e45ff456b9bc26ab57f0eee919f96ca0f8a330f"
   license any_of: ["GPL-3.0-or-later", "GPL-2.0-or-later", "MIT", "SGI-B-2.0"]
   head "https://gitlab.freedesktop.org/mesa/glu.git", branch: "master"
-
-  livecheck do
-    url :head
-    regex(/^(?:glu[._-])?v?(\d+(?:\.\d+)+)$/i)
-  end
 
   bottle do
     sha256 cellar: :any,                 arm64_sequoia:  "20ebc8dee6088f6f72e85c115535d7ae2d91af99b06dfa347bb9fb159d1e593c"


### PR DESCRIPTION
https://cgit.freedesktop.org/mesa/glu is a mirror of https://gitlab.freedesktop.org/mesa/glu so should just use latter (alternatively could use `mesa` homepage)
> Unnamed repository; edit this file to name it for gitweb. (mirrored from https://gitlab.freedesktop.org/mesa/glu)

---

Let's also use the HTTPS url which is officially documented at https://docs.mesa3d.org/download.html#demos-glut-and-glu
> A package of SGI’s GLU library is available [here](https://archive.mesa3d.org/glu/)

And also use our default livecheck:
```
URL:              https://archive.mesa3d.org/glu/glu-9.0.3.tar.xz
Strategy:         Xorg
/usr/bin/env /opt/homebrew/Library/Homebrew/shims/shared/curl --disable --cookie /dev/null --globoff --show-error --user-agent Homebrew/4.4.26-76-gc68682a-dirty\ \(Macintosh\;\ arm64\ Mac\ OS\ X\ 15.3.1\)\ curl/8.7.1 --header Accept-Language:\ en --retry 3 -V
URL (strategy):   https://archive.mesa3d.org/glu/
Regex (strategy): /href=.*?glu[._-]v?(\d+(?:\.\d+)+)\.t/i

Matched Versions:
9.0.0, 9.0.1, 9.0.2, 9.0.3

mesa-glu: 9.0.3 ==> 9.0.3
```

---

Confirmed checksum is same so just running syntax only
```
❯ curl -sL https://archive.mesa3d.org/glu/glu-9.0.3.tar.xz | sha256
bd43fe12f374b1192eb15fe20e45ff456b9bc26ab57f0eee919f96ca0f8a330f
```