### PR TITLE
geomview: remove ARM macOS

### DIFF
--- a/Formula/g/geomview.rb
+++ b/Formula/g/geomview.rb
@@ -13,11 +13,6 @@ class Geomview < Formula
   end
 
   bottle do
-    sha256                               arm64_sequoia:  "43cff98337cb7c17de62b442639a7dbb9715c7eb28e32cdcc6eb853ec73d9545"
-    sha256                               arm64_sonoma:   "c043de83033a9cfc8c98d746347c395612ddef4aaaeb810296306cd4abe03941"
-    sha256                               arm64_ventura:  "a427349c7f4ab1b887d3c3370a85b8c2bd01a1c38ed40ac4a8a90b7521339f98"
-    sha256                               arm64_monterey: "171b71c0d54b089d996a04f0a0febeea6d0cfdadc25d96c83cc30824db5c36ce"
-    sha256                               arm64_big_sur:  "d425aa4b27f1d1ba8b02c8b5b907b9d7fd5f2bbef8d8e67d1d616a51913a9b70"
     sha256                               sonoma:         "9d20121d9c889670a2aac8f7a72d917b7da522ed4c81cde78d634cfd40538ec3"
     sha256                               ventura:        "95e6d434f3176020ae4d59a74d514df63f1bb361dfb092396c16aba2bccaa492"
     sha256                               monterey:       "16501f149c43a7875f49f90b1c419c982d927a74e06a2624e31b12d91cd45dd8"
@@ -40,6 +35,10 @@ class Geomview < Formula
 
   uses_from_macos "zlib"
 
+  on_macos do
+    depends_on arch: :x86_64 # https://github.com/orgs/Homebrew/discussions/6025
+  end
+
   conflicts_with "clip", because: "both install `clip` binaries"
 
   # Fix -flat_namespace being used on Big Sur and later.
@@ -49,12 +48,7 @@ class Geomview < Formula
   end
 
   def install
-    # Work around for build error due to `finite`/`isfinite` detection on macOS.
-    # ../../../../include/porting.h:68:19: error: expected identifier or '('
-    # static inline int finite(double v)
-    ENV["ac_cv_func_finite"] = "yes" if OS.mac? && Hardware::CPU.arm?
-
-    system "./configure", *std_configure_args, "--disable-silent-rules"
+    system "./configure", "--disable-silent-rules", *std_configure_args
     system "make", "install"
     (bin/"hvectext").unlink
   end


### PR DESCRIPTION
Removing ARM macOS bottles based as user report that they don't work. I have confirmed on ARM Sequoia that the latest (arm64_sequoia) and oldest (arm64_big_sur) bottles segfault.

No issues when tested on ARM Linux VM so just restricting to arch on macOS.