### PR TITLE
popt: prioritize HTTPS download url

### DIFF
--- a/Formula/p/popt.rb
+++ b/Formula/p/popt.rb
@@ -1,8 +1,8 @@
 class Popt < Formula
   desc "Library like getopt(3) with a number of enhancements"
   homepage "https://github.com/rpm-software-management/popt"
-  url "http://ftp.rpm.org/popt/releases/popt-1.x/popt-1.19.tar.gz"
-  mirror "https://ftp.osuosl.org/pub/rpm/popt/releases/popt-1.x/popt-1.19.tar.gz"
+  url "https://ftp.osuosl.org/pub/rpm/popt/releases/popt-1.x/popt-1.19.tar.gz"
+  mirror "http://ftp.rpm.org/popt/releases/popt-1.x/popt-1.19.tar.gz"
   sha256 "c25a4838fc8e4c1c8aacb8bd620edb3084a3d63bf8987fdad3ca2758c63240f9"
   license "MIT"
 


### PR DESCRIPTION
Seems better to use HTTPS instead of HTTP. Both are official and are mentioned on GitHub repo

This also matches upstream change in download link on latest release, i.e.
* 1.18: https://github.com/rpm-software-management/popt/releases/tag/popt-1.18-release

    > ## Download
    > 
    > * http://ftp.rpm.org/popt/releases/popt-1.x/popt-1.18.tar.gz
    > * SHA256SUM: 5159bc03a20b28ce363aa96765f37df99ea4d8850b1ece17d1e6ad5c24fdc5d1

* 1.19: https://github.com/rpm-software-management/popt/releases/tag/popt-1.19-release

    > ## Download
    > 
    > * https://ftp.osuosl.org/pub/rpm/popt/releases/popt-1.x/popt-1.19.tar.gz
    > * SHA256SUM: c25a4838fc8e4c1c8aacb8bd620edb3084a3d63bf8987fdad3ca2758c63240f9