### PR TITLE
kea: use latest `boost`

### DIFF
--- a/Formula/k/kea.rb
+++ b/Formula/k/kea.rb
@@ -1,12 +1,21 @@
 class Kea < Formula
   desc "DHCP server"
   homepage "https://www.isc.org/kea/"
-  # NOTE: the livecheck block is a best guess at excluding development versions.
-  #       Check https://www.isc.org/download/#Kea to make sure we're using a stable version.
-  url "https://ftp.isc.org/isc/kea/2.6.2/kea-2.6.2.tar.gz"
-  mirror "https://dl.cloudsmith.io/public/isc/kea-2-6/raw/versions/2.6.2/kea-2.6.2.tar.gz"
-  sha256 "8a50b63103734b59c3b8619ccd6766d2dfee3f02e3a5f9f3abc1cd55f70fa424"
   license "MPL-2.0"
+
+  stable do
+    # NOTE: the livecheck block is a best guess at excluding development versions.
+    #       Check https://www.isc.org/download/#Kea to make sure we're using a stable version.
+    url "https://ftp.isc.org/isc/kea/2.6.2/kea-2.6.2.tar.gz"
+    mirror "https://dl.cloudsmith.io/public/isc/kea-2-6/raw/versions/2.6.2/kea-2.6.2.tar.gz"
+    sha256 "8a50b63103734b59c3b8619ccd6766d2dfee3f02e3a5f9f3abc1cd55f70fa424"
+
+    # Backport support for Boost 1.87.0
+    patch do
+      url "https://gitlab.isc.org/isc-projects/kea/-/commit/81edc181f85395c39964104ef049a195bafb9737.diff"
+      sha256 "17fd38148482e61be2192b19f7d05628492397d3f7c54e9097a89aeacf030072"
+    end
+  end
 
   livecheck do
     url "ftp://ftp.isc.org/isc/kea/"
@@ -33,12 +42,14 @@ class Kea < Formula
   end
 
   depends_on "pkgconf" => :build
-  # boost@1.87 deprecates ip::address::from_string which is used by kea
-  depends_on "boost@1.85"
+  depends_on "boost"
   depends_on "log4cplus"
   depends_on "openssl@3"
 
   def install
+    # Workaround to build with Boost 1.87.0+
+    ENV.append "CXXFLAGS", "-std=gnu++14"
+
     system "autoreconf", "--force", "--install", "--verbose" if build.head?
     system "./configure", "--disable-silent-rules",
                           "--with-openssl=#{Formula["openssl@3"].opt_prefix}",

--- a/Formula/k/kea.rb
+++ b/Formula/k/kea.rb
@@ -25,12 +25,13 @@ class Kea < Formula
   end
 
   bottle do
-    sha256 arm64_sequoia: "ea6fb38b3daee77b1049f0833bb2acffc9546b19aa5d8fb0c096fff2bdc209e9"
-    sha256 arm64_sonoma:  "0d09a65ad289a9209feca86df4cdbb62144e7583bec1897099401d9a1cd3619a"
-    sha256 arm64_ventura: "d14266bef57406a13dc79defec164b5e1f21e4315539f234593b8c2495d44600"
-    sha256 sonoma:        "3cae18d12ace2e3c9d22bf1e5e7b0abc2c5051d6aa083d629850cf0548ee73d0"
-    sha256 ventura:       "0de8f2810f380300a418cb9dbd17c4b74916532cb698b37bd82b10947e81ff2f"
-    sha256 x86_64_linux:  "662a312f7d4a72ab9c7f000a21dd21f37b6136ec1b0931786b6a5dcf197a2b70"
+    rebuild 1
+    sha256 arm64_sequoia: "0140ea7c9ede2d94efc51caadaf12c062c853d7d3d5cc68a26221b7a37226e83"
+    sha256 arm64_sonoma:  "59d717d80b87a2e491e1107105e04f9ef4caaf4d269f458558808777cfceed2e"
+    sha256 arm64_ventura: "e6a283e858cc2f08b3db91c7941f2eb0cacda7be81e58b00b8520356fe35e394"
+    sha256 sonoma:        "058ce5aeb4d71d54ebf0f6ff98ce7732c8e14d9d509588d48a05d23d488fe8bd"
+    sha256 ventura:       "a9bb4722c39d136fcc2641e78ffacdd58cbe1f3e3fb0fe1120e3141a046242a9"
+    sha256 x86_64_linux:  "3db7bc8bbb9a06006c008c199d5412c1e76a771b5d96a769d8014fc65c9ebf4a"
   end
 
   head do


### PR DESCRIPTION
Backporting support to reduce older Boost usage.

May end up deprecating anything on older Boost 1.85.0 when Boost 1.88.0 is released.

Remaining Boost 1.85.0 usage:
- `monero` - new release planned for Friday
- `cpprestsdk` - in maintenance mode so may not be fixed. To avoid deprecation, will need Vcpkg patch  - https://github.com/microsoft/vcpkg/blob/master/ports/cpprestsdk/fix-asio-error.patch
- `vineyard` - no support yet