### PR TITLE
vineyard 0.24.2

### DIFF
--- a/Formula/e/etcd-cpp-apiv3.rb
+++ b/Formula/e/etcd-cpp-apiv3.rb
@@ -7,12 +7,12 @@ class EtcdCppApiv3 < Formula
   revision 25
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "fb70880120dba7fdaa981c78fc124ac714006081213214cb2383262110c4a0b9"
-    sha256 cellar: :any,                 arm64_sonoma:  "4aad0e8502b8487eca9f486aa6b802b2abe326fe154a0e12defe6aae0d3b6654"
-    sha256 cellar: :any,                 arm64_ventura: "d5f51bd1228d709df4e063a404136eaca40cf507a1914485a48144777e37407f"
-    sha256 cellar: :any,                 sonoma:        "d6386990008636db46d6aaeb7199e97c575f96e93fb8b481f3036cf230c78a3f"
-    sha256 cellar: :any,                 ventura:       "6b249b9862118363a608df12a6b64e86d324d4c95a4b8d5d39503663bbd82998"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "6b3dc7e7a8c14e6119807397926a1af9651877973f6c766278b649478fda94de"
+    sha256 cellar: :any,                 arm64_sequoia: "41bea044776b9876a036125b174c010a180eda1dc5d2c8b8ef27202f107afb91"
+    sha256 cellar: :any,                 arm64_sonoma:  "017ec471a86ff1ce0206bd602f1f75dc36f2a5b0b96f7925e739d72b2c24bee5"
+    sha256 cellar: :any,                 arm64_ventura: "65ac21eebf66881b10441e8fc9cbf00ae71ae411a2554a42dcc415352b6127b1"
+    sha256 cellar: :any,                 sonoma:        "11ffc458f2406c8b5dcb36a5e1c5d235a176f1571b4c5fabca6f48c4dedbf5d9"
+    sha256 cellar: :any,                 ventura:       "ecad4f87f7f67fbc551ecf2e436c951967664c0c320a9f28140d7b6aa785d768"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0e5da2baab218285b9338bf8b6939350563ffe6441496eb0572453094ae2a866"
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/e/etcd-cpp-apiv3.rb
+++ b/Formula/e/etcd-cpp-apiv3.rb
@@ -4,7 +4,7 @@ class EtcdCppApiv3 < Formula
   url "https://github.com/etcd-cpp-apiv3/etcd-cpp-apiv3/archive/refs/tags/v0.15.4.tar.gz"
   sha256 "4516ecfa420826088c187efd42dad249367ca94ea6cdfc24e3030c3cf47af7b4"
   license "BSD-3-Clause"
-  revision 24
+  revision 25
 
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "fb70880120dba7fdaa981c78fc124ac714006081213214cb2383262110c4a0b9"
@@ -31,6 +31,20 @@ class EtcdCppApiv3 < Formula
   patch do
     url "https://github.com/etcd-cpp-apiv3/etcd-cpp-apiv3/commit/ece56adf4d01658a5f0668a3618c97153665581c.patch?full_index=1"
     sha256 "f3686647436045a9a53b05f81fae02d5a5a2025d5ce78a66aca0ade85c1a99c6"
+  end
+
+  # Backport cluster manager api needed for newer `vineyard`
+  patch do
+    url "https://github.com/etcd-cpp-apiv3/etcd-cpp-apiv3/commit/17d7b60194e5b6d9005bb10947905a393f432624.patch?full_index=1"
+    sha256 "b0d1bce10cf2f03124af744f2a184162b6b555b09d162b8633ed8ab9b613f8f8"
+  end
+  patch do
+    url "https://github.com/etcd-cpp-apiv3/etcd-cpp-apiv3/commit/3ad17314d6e8c26beb88501f8e74e506ccaf26b8.patch?full_index=1"
+    sha256 "52dd6132b03c4c1210bb1c0b8a32ff952f84b198d612903c10a53b7a4f5ce2b9"
+  end
+  patch do
+    url "https://github.com/etcd-cpp-apiv3/etcd-cpp-apiv3/commit/ea56cee80f441973a0149b57604e7a7874c61b65.patch?full_index=1"
+    sha256 "bce8ef02bc56f2ac430d580191217ff78210cc6e261d29c7031a22e65cd05693"
   end
 
   def install

--- a/Formula/v/vineyard.rb
+++ b/Formula/v/vineyard.rb
@@ -6,12 +6,12 @@ class Vineyard < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256                               arm64_sequoia: "b6dc11e4e502840985f86d45b4107f81025805784e7f65694cd528c096acb737"
-    sha256                               arm64_sonoma:  "8f0240b97cb7be288e52bd6a3f0004bae5c14491062447e98d583b059e00b66c"
-    sha256                               arm64_ventura: "45e20492b2ff3ce178518b95f0d8a1c0b7e3dc1ae083bb45b0bfebdaddac566d"
-    sha256                               sonoma:        "f016f3e8d63b65b2f30a775357c3f0e4f6aba2ff8d62df4d3c523ab845a11410"
-    sha256                               ventura:       "1c22a5e1e3fe00ec81653af2bd21de6aa862e732ec3c731fa00e59ef3589775c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2e427ead7197ad2b3664740369ca0ccac1264df4702cad61ac39d4489a9c7d22"
+    sha256                               arm64_sequoia: "1e523a56e12c147bf7169720737ed422f8bc6092c295557c0e3d7daaa6799b28"
+    sha256                               arm64_sonoma:  "f3d6060bf786fe16cd5f2885eee5428e45dc4655cb061a1a90873f33ba596769"
+    sha256                               arm64_ventura: "bd04f41327ff13207caa720dfc459585336e4572c843d7a28babe77ffd52b78c"
+    sha256                               sonoma:        "cb25f9308b95310edf63637abf5a5e26dc61fd4a4680b649ab12c645e6ee7d30"
+    sha256                               ventura:       "932d86751cc8df0045186b5fa15a7b9ced9313214a294a5b002629d71de5e72a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e94664da0a8f82686aaec91f5db75543bb11d9b430c47fc63040495e1b5507db"
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/v/vineyard.rb
+++ b/Formula/v/vineyard.rb
@@ -1,12 +1,9 @@
 class Vineyard < Formula
-  include Language::Python::Virtualenv
-
   desc "In-memory immutable data manager. (Project under CNCF)"
   homepage "https://v6d.io"
-  url "https://github.com/v6d-io/v6d/releases/download/v0.23.2/v6d-0.23.2.tar.gz"
-  sha256 "2a2788ed77b9459477b3e90767a910e77e2035a34f33c29c25b9876568683fd4"
+  url "https://github.com/v6d-io/v6d/releases/download/v0.24.2/v6d-0.24.2.tar.gz"
+  sha256 "a3acf9a9332bf5cce99712f9fd00a271b4330add302a5a8bbfd388e696a795c8"
   license "Apache-2.0"
-  revision 11
 
   bottle do
     sha256                               arm64_sequoia: "b6dc11e4e502840985f86d45b4107f81025805784e7f65694cd528c096acb737"
@@ -20,6 +17,7 @@ class Vineyard < Formula
   depends_on "cmake" => [:build, :test]
   depends_on "llvm" => :build # for clang Python bindings
   depends_on "openssl@3" => :build # indirect (not linked) but CMakeLists.txt checks for it
+  depends_on "python-setuptools" => :build
   depends_on "python@3.13" => :build
   depends_on "apache-arrow"
   depends_on "boost@1.85"
@@ -31,15 +29,14 @@ class Vineyard < Formula
   depends_on "libgrape-lite"
   depends_on "open-mpi"
 
-  resource "setuptools" do
-    url "https://files.pythonhosted.org/packages/27/b8/f21073fde99492b33ca357876430822e4800cdf522011f18041351dfa74b/setuptools-75.1.0.tar.gz"
-    sha256 "d59a21b17a275fb872a9c3dae73963160ae079f1049ed956880cd7c09b120538"
+  on_linux do
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
   end
 
   def install
     python3 = "python3.13"
-    venv = virtualenv_create(buildpath/"venv", python3)
-    venv.pip_install resources
     # LLVM is keg-only.
     llvm = deps.map(&:to_formula).find { |f| f.name.match?(/^llvm(@\d+)?$/) }
     ENV.prepend_path "PYTHONPATH", llvm.opt_prefix/Language::Python.site_packages(python3)
@@ -52,7 +49,7 @@ class Vineyard < Formula
       "-DCMAKE_FIND_PACKAGE_PREFER_CONFIG=ON", # for newer protobuf
       "-DLIBGRAPELITE_INCLUDE_DIRS=#{Formula["libgrape-lite"].opt_include}",
       "-DOPENSSL_ROOT_DIR=#{Formula["openssl@3"].opt_prefix}",
-      "-DPYTHON_EXECUTABLE=#{venv.root}/bin/python",
+      "-DPYTHON_EXECUTABLE=#{which(python3)}",
       "-DUSE_EXTERNAL_ETCD_LIBS=ON",
       "-DUSE_EXTERNAL_HIREDIS_LIBS=ON",
       "-DUSE_EXTERNAL_REDIS_LIBS=ON",


### PR DESCRIPTION
vineyard 0.24.2

---

etcd-cpp-apiv3: backport cluster manager api for vineyard

Applied commits include:
* https://github.com/etcd-cpp-apiv3/etcd-cpp-apiv3/commit/17d7b60194e5b6d9005bb10947905a393f432624
  Needed to cleanly apply next commit. Minor impact header include.
* https://github.com/etcd-cpp-apiv3/etcd-cpp-apiv3/commit/3ad17314d6e8c26beb88501f8e74e506ccaf26b8
  Required feature for Vineyard. Changes are for new APIs
* https://github.com/etcd-cpp-apiv3/etcd-cpp-apiv3/commit/ea56cee80f441973a0149b57604e7a7874c61b65
  Fix to install header after prior commit.

---

Vineyard is the only dependent of etcd-cpp-apiv3 so just patching it rather than using the bundled copy.