### PR TITLE
cdecl 18.4.1 (switch to fork)

### DIFF
--- a/Formula/c/cdecl.rb
+++ b/Formula/c/cdecl.rb
@@ -10,22 +10,13 @@ class Cdecl < Formula
   ]
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "14019e0b790a1321d87a8885ed9ed415a6ecfc4a74929cb567d393137389f65f"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "846241c80519b5d11e202535582176b22077b1460e53e14347ccdbca61abdc93"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "36acc58f38ee551b35a2c531d9bdfb8113aee61cbb4bdb9d43646ddcfeba9053"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "8dcff021c0d0078666c5a4781d738e8958fc52222bb2062b447f581d1b398971"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "6ffb24daa6ca1e12ddfbc0cf77ef3461dfdc7eec3ba8149e0f5dbacabeefce2b"
-    sha256 cellar: :any_skip_relocation, sonoma:         "9927708e1d28894af1d6ff2b06d5ef00ec7650be6facea6eee5aee2644461f0a"
-    sha256 cellar: :any_skip_relocation, ventura:        "172450bfee9de34b028b40568fbd21662fb6fbf5149343eee624b0cd03766f02"
-    sha256 cellar: :any_skip_relocation, monterey:       "484c974a4e2c954bd4c5dc321de2ca4a778be9d55db712cd9913ec2fd67b41ad"
-    sha256 cellar: :any_skip_relocation, big_sur:        "ac04af015afd9bc8d756f4220c53d484de0fba6f0c8a0976f99b63e2bdfccf3e"
-    sha256 cellar: :any_skip_relocation, catalina:       "bba9953b96f037148b23ecf85030ed505bf1e6712f21099d494084c26cd52f1c"
-    sha256 cellar: :any_skip_relocation, mojave:         "beed8e3f4c2de0b75bd12bd65e6d9ce4a7cb626fac5cd8c5e20426d2b9325840"
-    sha256 cellar: :any_skip_relocation, high_sierra:    "a2469d514723e35850b252b97d3bf90f9311c276455b218383d276ccb0c88ee4"
-    sha256 cellar: :any_skip_relocation, sierra:         "1d424613881cf9109d824664fc77fc947f2968b9850d448db4b02c6f0a562b5c"
-    sha256 cellar: :any_skip_relocation, el_capitan:     "4f0e990d88823aa9f3d1dcea71ffa442c13640ce82cc9da41f90a1be5ef457dc"
-    sha256 cellar: :any_skip_relocation, arm64_linux:    "76dcaf8ba94fa0014a2f9e13546f00d0a17a3e2960ee3a7e1c6026583ce9d038"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "1ce7e2b34d87649b10f5cd29b4df13c565f518936b42f029b7d1b592984d237e"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "363c05b8547ead28209b9d14ed12e7765359ae4e5a2d28b18ef4b488400950b0"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "7d56b56d1c525678f844e3dd83e89dbca5e4d8db5ad57daf11ea08d1bfc9453c"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "98a53d5cd3b85690103a4901e59296ee3a6f8fa94aaa2702e42e29c6267b9ffc"
+    sha256 cellar: :any_skip_relocation, sonoma:        "8a6be79e61b3bbf3ed748d8df383ae50bf4b33978484a79f876b9e176d577ef7"
+    sha256 cellar: :any_skip_relocation, ventura:       "9971729c1580ea4e25bc41e60830397586c19181ba073adb5579a264ef022072"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "3393652d469f42d4bc1b998275ba05d60b88975366d30bea5a6d2ebe761da8e3"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "ced2523c93fde88e64b437a8db68c5f28d60353dafa872258fd290280897592a"
   end
 
   uses_from_macos "bison" => :build

--- a/Formula/c/cdecl.rb
+++ b/Formula/c/cdecl.rb
@@ -1,13 +1,13 @@
 class Cdecl < Formula
   desc "Turn English phrases to C or C++ declarations"
-  homepage "https://cdecl.org/"
-  url "https://cdecl.org/files/cdecl-blocks-2.5.tar.gz"
-  sha256 "9ee6402be7e4f5bb5e6ee60c6b9ea3862935bf070e6cecd0ab0842305406f3ac"
-  license :public_domain
-
-  livecheck do
-    skip "No version information available"
-  end
+  homepage "https://github.com/paul-j-lucas/cdecl"
+  url "https://github.com/paul-j-lucas/cdecl/releases/download/cdecl-18.4.1/cdecl-18.4.1.tar.gz"
+  sha256 "5b7899fb44b30e67a0375223368a7b342c2047ffa9f268b90f7c6eaa9db2a474"
+  license all_of: [
+    "GPL-3.0-or-later",
+    "LGPL-2.1-or-later", # gnulib
+    :public_domain, # original cdecl
+  ]
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "14019e0b790a1321d87a8885ed9ed415a6ecfc4a74929cb567d393137389f65f"
@@ -30,33 +30,19 @@ class Cdecl < Formula
 
   uses_from_macos "bison" => :build
   uses_from_macos "flex" => :build
+  uses_from_macos "ncurses"
 
   on_linux do
     depends_on "readline"
   end
 
   def install
-    # Workaround for newer Clang
-    ENV.append_to_cflags "-Wno-incompatible-function-pointer-types" if DevelopmentTools.clang_build_version >= 1500
-
-    # Fix namespace clash with Lion's getline
-    inreplace "cdecl.c", "getline", "cdecl_getline"
-
-    bin.mkpath
-    man1.mkpath
-
-    ENV.append "CFLAGS", "-DBSD -DUSE_READLINE -std=gnu89"
-
-    system "make", "CC=#{ENV.cc}",
-                   "CFLAGS=#{ENV.cflags}",
-                   "LIBS=-lreadline",
-                   "BINDIR=#{bin}",
-                   "MANDIR=#{man1}",
-                   "install"
+    system "./configure", "--disable-silent-rules", *std_configure_args
+    system "make", "install"
   end
 
   test do
-    assert_equal "declare a as pointer to int",
+    assert_equal "declare a as pointer to integer",
                  shell_output("#{bin}/cdecl explain int *a").strip
   end
 end


### PR DESCRIPTION
The prior upstream's last release tarball has modification date of 2009-10-20 and was a fork of the original cdecl 2.5 with added support for Apple blocks. Since then, there haven't been any updates and instead we've mainly dealt with missing tarball in 2017 and 2023:

* `https://github.com/ridiculousfish/cdecl-blocks/issues/3`
* `https://github.com/ridiculousfish/cdecl-blocks/issues/37`

The new fork was originally submitted back in 2017-04-25 (#12871). At time of submission, it did not meet our requirements.

Now, it meets our notability requirement and also meets our fork requirements[^1] as it was used at:

* Fedora[^2]
* Gentoo[^3] - 2.5 was removed and then 11.11 was added

Also accepted at:

* FreeBSD[^4]
* nixpkgs[^5] - prior upstream still available as `cdecl-blocks`

[^1]: https://docs.brew.sh/Acceptable-Formulae#not-a-fork-usually
[^2]: https://src.fedoraproject.org/rpms/cdecl/blob/rawhide/f/cdecl.spec#_130
[^3]: https://gitweb.gentoo.org/repo/gentoo.git/log/dev-util/cdecl
[^4]: https://github.com/freebsd/freebsd-ports/commit/adc67685a4208e8fa2af09d11902d0d6a071a40d
[^5]: https://github.com/NixOS/nixpkgs/commit/ce95595c1f3f848692908639edc922c7daacba9c
