### PR TITLE
tinfoil 0.0.8 (new formula)

### DIFF
--- a/Formula/t/tinfoil.rb
+++ b/Formula/t/tinfoil.rb
@@ -1,0 +1,23 @@
+class Tinfoil < Formula
+  desc "CLI tool for secrets management"
+  homepage "https://github.com/tinfoilsh/tinfoil-cli"
+  version "0.0.8"
+  license "GPL-3.0-or-later"
+
+  if Hardware::CPU.intel?
+    url "https://github.com/tinfoilsh/tinfoil-cli/releases/download/v0.0.8/tinfoil-cli_0.0.8_darwin_amd64.tar.gz"
+    sha256 "2a1b6fcc311571374bd6fb1bd0fffaa856cc68234688d4d98c03c9b1cef74be8"
+  else
+    url "https://github.com/tinfoilsh/tinfoil-cli/releases/download/v0.0.8/tinfoil-cli_0.0.8_darwin_arm64.tar.gz"
+    sha256 "b2837a13ed34e78f69130c35047e5b261ae3bd003815065d3737ec0cc849b37a"
+  end
+
+  def install
+    bin.install "tinfoil"
+  end
+
+  test do
+    output = shell_output("#{bin}/tinfoil --help")
+    assert_match "Usage", output
+  end
+end


### PR DESCRIPTION
Add `tinfoil` CLI version 0.0.8 as a new formula.

`tinfoil` is a command-line tool for secure secrets management, encrypted AI prompting, and enclave-based attestation workflows. It ships with prebuilt binaries for macOS (Intel and Apple Silicon) and includes a single CLI binary.

Repo: https://github.com/tinfoilsh/tinfoil-cli  
license "GPL-3.0-or-later"
Latest release: https://github.com/tinfoilsh/tinfoil-cli/releases/tag/v0.0.8

✅ Formula uses architecture-specific tarballs with verified SHA256 hashes  
✅ `test do` block confirms binary returns help text  
✅ Verified locally using Homebrew’s contribution guide

---

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source tinfoil`?
- [x] Is your test running fine `brew test tinfoil`?
- [x] Does your build pass `brew audit --strict --online tinfoil`?

Thanks for reviewing!
