### PR TITLE
monero: update homepage for Repology detection

### DIFF
--- a/Formula/m/monero.rb
+++ b/Formula/m/monero.rb
@@ -1,6 +1,6 @@
 class Monero < Formula
   desc "Official Monero wallet and CPU miner"
-  homepage "https://www.getmonero.org/"
+  homepage "https://www.getmonero.org/downloads/#cli"
   license "BSD-3-Clause"
   revision 1
 


### PR DESCRIPTION
Repology needs some help categorizing our `monero` formula as there is an overlap in multiple Monero packages (with need to differentiate GUI from CLI) - https://repology.org/project/monero-unclassified/versions

I think the homepage used by Debian (https://packages.debian.org/sid/source/monero) should work.

Alternative is the GitHub repo. Or rename to `monero-cli` but not worth hassle.