### PR TITLE
vineyard: add workaround to support newer Boost

### DIFF
--- a/Formula/c/cpprestsdk.rb
+++ b/Formula/c/cpprestsdk.rb
@@ -9,12 +9,12 @@ class Cpprestsdk < Formula
   head "https://github.com/microsoft/cpprestsdk.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "e414a002007eba0a4606f30cc11817338e1287f720d623a616f7e46524717479"
-    sha256 cellar: :any,                 arm64_sonoma:  "ca0b2b79e8165896f68903d6307ad3aa3f01116f952ce0c36074840852cb2ded"
-    sha256 cellar: :any,                 arm64_ventura: "52897f579904d7bd14996e47e0344d779939936dc96b6ff066d76bbd972b90bc"
-    sha256 cellar: :any,                 sonoma:        "5b13e9fd406f3807679d8e193ca8ae4b9bb183a536e3c6add15fe7be7e4806a0"
-    sha256 cellar: :any,                 ventura:       "1c7a0ec58aefff285cc161f38fa77b1b7f5c1a62b4c36c85f1bd6d037c932fbf"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "06c8025f11aa65e2d9f0694d5a6d530b292d4eb77bec724105c3849dd1254e45"
+    sha256 cellar: :any,                 arm64_sequoia: "9640d605200200ae3d237d25c4331dbba2966b4581caff255f36a6ee4afe342b"
+    sha256 cellar: :any,                 arm64_sonoma:  "7be58510e079c21e8521cbd6d8abcc72aa21e6253050b60b47cc4796b7a80ed5"
+    sha256 cellar: :any,                 arm64_ventura: "18cca4c9e3e5beb9e777729aab6b8f0bada951a3e4ea7605137c810e248b9a1e"
+    sha256 cellar: :any,                 sonoma:        "fe4b73f785105a59749145114cba254a60729d80cb018e949fb1c2e1b32e84ff"
+    sha256 cellar: :any,                 ventura:       "e644df4a3ff8db4487036eafbdd520bcf9479b6fe120845c6aaf400a81938d43"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1703233871c829af74138257f48fa690602ea45f7d7084a0acbd163a4c6db494"
   end
 
   depends_on "cmake" => :build

--- a/Formula/v/vineyard.rb
+++ b/Formula/v/vineyard.rb
@@ -7,12 +7,12 @@ class Vineyard < Formula
   revision 1
 
   bottle do
-    sha256                               arm64_sequoia: "1e523a56e12c147bf7169720737ed422f8bc6092c295557c0e3d7daaa6799b28"
-    sha256                               arm64_sonoma:  "f3d6060bf786fe16cd5f2885eee5428e45dc4655cb061a1a90873f33ba596769"
-    sha256                               arm64_ventura: "bd04f41327ff13207caa720dfc459585336e4572c843d7a28babe77ffd52b78c"
-    sha256                               sonoma:        "cb25f9308b95310edf63637abf5a5e26dc61fd4a4680b649ab12c645e6ee7d30"
-    sha256                               ventura:       "932d86751cc8df0045186b5fa15a7b9ced9313214a294a5b002629d71de5e72a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e94664da0a8f82686aaec91f5db75543bb11d9b430c47fc63040495e1b5507db"
+    sha256                               arm64_sequoia: "561165ad084f00d50a006cbc129d2f680d09fc0ad125d2f3984a95bcbcc72321"
+    sha256                               arm64_sonoma:  "1a7a921549ba270da4d7d328e3473f110c67ffddd96204e3d65baedf198e8da8"
+    sha256                               arm64_ventura: "f1480e5c08cd4bbaed23bb7ac94129c39197f16b3b42fa2a2324ccd4aad2224c"
+    sha256                               sonoma:        "a8c536a70c4aa56fb7e47c3a2d730908e091f20c37ecd46fb1fb468aab9012a8"
+    sha256                               ventura:       "e4d5f00c8254923e4808411e904e5b57466cdb6959f5dee7b27d9fcea4e79245"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "033e633eb759b964d7881b6d3354e43517058fa3fff32a8a75235b931332a474"
   end
 
   depends_on "cmake" => [:build, :test]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
