### PR TITLE
Compile schemas in package share folder

### DIFF
--- a/Formula/v/virt-manager.rb
+++ b/Formula/v/virt-manager.rb
@@ -73,7 +73,8 @@ class VirtManager < Formula
 
   def post_install
     # manual schema compile step
-    system Formula["glib"].opt_bin/"glib-compile-schemas", HOMEBREW_PREFIX/"share/glib-2.0/schemas"
+    # note: virt-manager seems to be looking for schemas relative to where its installed and not in the shared folder
+    system Formula["glib"].opt_bin/"glib-compile-schemas", "#{share}/glib-2.0/schemas"
     # manual icon cache update step
     system Formula["gtk+3"].opt_bin/"gtk3-update-icon-cache", HOMEBREW_PREFIX/"share/icons/hicolor"
   end


### PR DESCRIPTION
Fixes `(virt-manager:17853): GLib-GIO-ERROR **: 00:01:20.851: No GSettings schemas are installed on the system` 

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
