### PR TITLE
workflows/publish-commit-bottles: fix unbound var on exhausted attempts

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -424,6 +424,7 @@ jobs:
         run: |
           echo "::notice ::Local repository HEAD: $EXPECTED_SHA"
 
+          success=0
           attempt=0
           max_attempts=10
           timeout=1


### PR DESCRIPTION
Only noticed now because `git ls-remote` usually doesn't take over 10 minutes to update.