### PR TITLE
llvm@19 lld@19 19.1.7 (new formula)

### DIFF
--- a/Aliases/llvm@19
+++ b/Aliases/llvm@19
@@ -1,1 +1,0 @@
-../Formula/l/llvm.rb

--- a/Formula/c/clazy.rb
+++ b/Formula/c/clazy.rb
@@ -13,13 +13,12 @@ class Clazy < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_sequoia: "befed9e3e396380d703605d0c951c3906ec5132eaa00e7331913521d168b0683"
-    sha256 cellar: :any,                 arm64_sonoma:  "17c7fddf8588b5eb3036e694e47e0bacb9e1cc4c72cb7e41df27ac7549a8e07b"
-    sha256 cellar: :any,                 arm64_ventura: "2857ba1a5e9e7d03d342acecbce06ad1bc0d9ca74df84960529ae28205f9887b"
-    sha256 cellar: :any,                 sonoma:        "bb07ed1692e2565c9b0c4ee901b0249b335141e8292d3882dd9fc19d54e59cb6"
-    sha256 cellar: :any,                 ventura:       "83f55f60617d1be46cf987cd6c90d8456372fc76a113b497645eafc709d35910"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "82caf7f18cc0624a9772df4c8d4cf219cbb10dc1b46ac040d19dd555bd8876be"
+    sha256 cellar: :any,                 arm64_sequoia: "38da1abaafefe00b8d566a6ecb8aa619834fe325ee4654bba2779ac7e005ec51"
+    sha256 cellar: :any,                 arm64_sonoma:  "481169d2ceba0ae69862e5fac8a6d318feb24989625fb0d2c91212aa420df8f1"
+    sha256 cellar: :any,                 arm64_ventura: "cf1e847bbb0429c4eb955cba0957218823d3b9df9fd3946ef807dc10cd23a467"
+    sha256 cellar: :any,                 sonoma:        "c28c640557ca631975f091153815b15de679819a785c4582c3a5b391bf9f5cfb"
+    sha256 cellar: :any,                 ventura:       "9d26d49ad1194c82c0383f54ec778b88b9747babd74e25cd683b8b44893ac87b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "db982fe89ed2ecb712d65dbb9c5ffe7bbbd21fbb1f9115c8afcbaec48036f3c1"
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/c/clazy.rb
+++ b/Formula/c/clazy.rb
@@ -4,6 +4,7 @@ class Clazy < Formula
   url "https://download.kde.org/stable/clazy/1.13/src/clazy-1.13.tar.xz"
   sha256 "6d36da0c9d4d2f8602fb52910bde34bf27501ff758f6182b1a46fa0a91779ef4"
   license "LGPL-2.0-or-later"
+  revision 1
   head "https://invent.kde.org/sdk/clazy.git", branch: "master"
 
   livecheck do
@@ -24,7 +25,7 @@ class Clazy < Formula
   depends_on "cmake" => [:build, :test]
   depends_on "qt" => :test
   depends_on "coreutils"
-  depends_on "llvm"
+  depends_on "llvm@19" # LLVM 20 issue: https://invent.kde.org/sdk/clazy/-/issues/27
 
   uses_from_macos "libxml2"
   uses_from_macos "ncurses"

--- a/Formula/l/ldc.rb
+++ b/Formula/l/ldc.rb
@@ -13,13 +13,13 @@ class Ldc < Formula
   end
 
   bottle do
-    sha256                               arm64_sequoia: "679a6edb5cf0936eccf07bfb8911c26d94be9a512031ce56d1279403ff58ef1b"
-    sha256                               arm64_sonoma:  "0c413b0142d6a685bc3ce3d2e602fa186c7ccace9fc499da333fab528c55cd6c"
-    sha256                               arm64_ventura: "109a5a8abc99967277d3b843328bb226614fa512e933215319014c9ba58c3541"
-    sha256                               sonoma:        "a1ed0483de3d6acd31100020c3cf2ba3826f09f2e3182c5151ee15b9651beaf4"
-    sha256                               ventura:       "d2b16171d9e8985cff0253cba8c2023bdc8c67a81d9ec7cd48c489e729e58a70"
-    sha256                               arm64_linux:   "1241ce5b60b17a80b64a93c0a5d06a367ab6d2f6556e5e27d9b60f770f7bccb6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "56996dab133b4cfc6997306069b043b4c60ca28554ab4a2e356fd81bd323b7a0"
+    sha256                               arm64_sequoia: "bf62f0e0c7a7eb72db23404decbcb150d0e45b1562db44df733fc7f325c76d44"
+    sha256                               arm64_sonoma:  "4d22f4d7c6623ceea882c608f008218b96deac008d5e2902c34ccc79fb8df50a"
+    sha256                               arm64_ventura: "ef232af8cbe6880220437658f33e946d899f880da8f726d21a23e3d0720ffff5"
+    sha256                               sonoma:        "bc74c7e7324ee29cc9eb33f8c3580ba4185640bc28c0515aa82603657f02d64f"
+    sha256                               ventura:       "aac0761e4cba1a2dbb862cd2f3b4e3899bd76e6738016cb24f33885eef355c73"
+    sha256                               arm64_linux:   "2b685946656c81c99e5a1ce6a2c4b8ef77c320cda2bb0a3f33638dd7e7a5d345"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2b644f70c0fa431945753c3bd4cc59f02febdc4569a17517fca3f0e6e7e9c0ba"
   end
 
   depends_on "cmake" => :build

--- a/Formula/l/ldc.rb
+++ b/Formula/l/ldc.rb
@@ -4,6 +4,7 @@ class Ldc < Formula
   url "https://github.com/ldc-developers/ldc/releases/download/v1.40.1/ldc-1.40.1-src.tar.gz"
   sha256 "b643bee2ee6f9819084ef7468cf739257974a99f3980364d20201bc806a4a454"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/ldc-developers/ldc.git", branch: "master"
 
   livecheck do
@@ -24,8 +25,8 @@ class Ldc < Formula
   depends_on "cmake" => :build
   depends_on "libconfig" => :build
   depends_on "pkgconf" => :build
-  depends_on "lld"
-  depends_on "llvm"
+  depends_on "lld@19" => :test
+  depends_on "llvm@19" # LLVM 20 PR: https://github.com/ldc-developers/ldc/pull/4843
   depends_on "zstd"
 
   uses_from_macos "libxml2" => :build
@@ -94,7 +95,8 @@ class Ldc < Formula
     D
     system bin/"ldc2", "test.d"
     assert_match "Hello, world!", shell_output("./test")
-    with_env(PATH: "#{llvm.opt_bin}:#{ENV["PATH"]}") do
+    lld = deps.map(&:to_formula).find { |f| f.name.match?(/^lld(@\d+(\.\d+)*)?$/) }
+    with_env(PATH: "#{lld.opt_bin}:#{ENV["PATH"]}") do
       system bin/"ldc2", "-flto=thin", "--linker=lld", "test.d"
       assert_match "Hello, world!", shell_output("./test")
       system bin/"ldc2", "-flto=full", "--linker=lld", "test.d"

--- a/Formula/l/lld@19.rb
+++ b/Formula/l/lld@19.rb
@@ -10,6 +10,16 @@ class LldAT19 < Formula
     formula "llvm@19"
   end
 
+  bottle do
+    sha256 cellar: :any,                 arm64_sequoia: "e8e71f728007bf1d4b8941fd08e8f80ba22c4828671145bd59c6358c750cb92f"
+    sha256 cellar: :any,                 arm64_sonoma:  "083f908ec5c6b6d667a5c43cb737d2a826a83be781dda8856640e372ac4c0b2b"
+    sha256 cellar: :any,                 arm64_ventura: "5bc9959a85616afc59418594aae9cae42e907738c2f57beac74332132c791619"
+    sha256 cellar: :any,                 sonoma:        "ed20ffe6301dcc2dc7c2e7e1197cdb4d3b210fe75e9b3f525edf6fe2f29929e0"
+    sha256 cellar: :any,                 ventura:       "d7395e5c60ce34541002e3be335463a81cb168f859dbcdbbaa01d985fb451c5b"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "aae1ed5877dbc2837f9b02547fed455965914eb45bf6d6e40d8ffce97f0ee77f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f8d2ef191e0b229ac246866dc5e017f9e39ce350410ce2e1141c468924314bdb"
+  end
+
   keg_only :versioned_formula
 
   depends_on "cmake" => :build

--- a/Formula/l/lld@19.rb
+++ b/Formula/l/lld@19.rb
@@ -1,0 +1,70 @@
+class LldAT19 < Formula
+  desc "LLVM Project Linker"
+  homepage "https://lld.llvm.org/"
+  url "https://github.com/llvm/llvm-project/releases/download/llvmorg-19.1.7/llvm-project-19.1.7.src.tar.xz"
+  sha256 "82401fea7b79d0078043f7598b835284d6650a75b93e64b6f761ea7b63097501"
+  # The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
+  license "Apache-2.0" => { with: "LLVM-exception" }
+
+  livecheck do
+    formula "llvm@19"
+  end
+
+  keg_only :versioned_formula
+
+  depends_on "cmake" => :build
+  depends_on "llvm@19"
+  depends_on "zstd"
+  uses_from_macos "zlib"
+
+  def install
+    rpaths = [rpath]
+    rpaths << Formula["llvm@19"].opt_lib.to_s if OS.linux?
+
+    system "cmake", "-S", "lld", "-B", "build",
+                    "-DBUILD_SHARED_LIBS=ON",
+                    "-DCMAKE_INSTALL_RPATH=#{rpaths.join(";")}",
+                    "-DLLD_BUILT_STANDALONE=ON",
+                    "-DLLD_VENDOR=#{tap&.user}",
+                    "-DLLVM_ENABLE_LTO=ON",
+                    "-DLLVM_INCLUDE_TESTS=OFF",
+                    "-DLLVM_USE_SYMLINKS=ON",
+                    *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    (testpath/"bin/lld").write <<~BASH
+      #!/bin/bash
+      exit 1
+    BASH
+    chmod "+x", "bin/lld"
+
+    (testpath/"bin").install_symlink "lld" => "ld64.lld"
+    (testpath/"bin").install_symlink "lld" => "ld.lld"
+
+    (testpath/"test.c").write <<~C
+      #include <stdio.h>
+      int main() {
+        printf("hello, world!");
+        return 0;
+      }
+    C
+
+    error_message = case ENV.compiler
+    when /^gcc(-\d+)?$/ then "ld returned 1 exit status"
+    when :clang then "linker command failed"
+    else odie "unexpected compiler"
+    end
+
+    # Check that the `-fuse-ld=lld` flag actually picks up LLD from PATH.
+    ENV.prepend_path "PATH", bin
+    with_env(PATH: "#{testpath}/bin:#{ENV["PATH"]}") do
+      assert_match error_message, shell_output("#{ENV.cc} -v -fuse-ld=lld test.c 2>&1", 1)
+    end
+
+    system ENV.cc, "-v", "-fuse-ld=lld", "test.c", "-o", "test"
+    assert_match "hello, world!", shell_output("./test")
+  end
+end

--- a/Formula/l/llvm@19.rb
+++ b/Formula/l/llvm@19.rb
@@ -11,6 +11,16 @@ class LlvmAT19 < Formula
     regex(/^llvmorg[._-]v?(19(?:\.\d+)+)$/i)
   end
 
+  bottle do
+    sha256 cellar: :any,                 arm64_sequoia: "7b14323528280fe8da37c282cfe3b5b34a9a56f0730c3ce599d165f2c5353a8a"
+    sha256 cellar: :any,                 arm64_sonoma:  "5fdcbc697b42d0559d5d5c76ae2f9a17e3a30014eab679b6b591336ce7072dea"
+    sha256 cellar: :any,                 arm64_ventura: "db184348dbb58b9b9a466664a19747201a36574f9380dfa6158b0ed7cd5b1ca0"
+    sha256 cellar: :any,                 sonoma:        "005ea2af7ececed09684ca0cb19542503edbf849aa9698f3eaa8c0ea5e407fa3"
+    sha256 cellar: :any,                 ventura:       "a4d34e93625d78b8f9766ed561c230dede8302a167e5f6204a6287cc9667149d"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "eb59a5239d343eddc315c28f2860a34405d113b5a8c6db96373e55cf11b14e87"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "371be1cba0e7b3b688e80d9e80d529e30bc8f149ba6492a36cd20233f41b6b16"
+  end
+
   keg_only :versioned_formula
 
   # https://llvm.org/docs/GettingStarted.html#requirement

--- a/Formula/l/llvm@19.rb
+++ b/Formula/l/llvm@19.rb
@@ -1,0 +1,577 @@
+class LlvmAT19 < Formula
+  desc "Next-gen compiler infrastructure"
+  homepage "https://llvm.org/"
+  url "https://github.com/llvm/llvm-project/releases/download/llvmorg-19.1.7/llvm-project-19.1.7.src.tar.xz"
+  sha256 "82401fea7b79d0078043f7598b835284d6650a75b93e64b6f761ea7b63097501"
+  # The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
+  license "Apache-2.0" => { with: "LLVM-exception" }
+
+  livecheck do
+    url :stable
+    regex(/^llvmorg[._-]v?(19(?:\.\d+)+)$/i)
+  end
+
+  keg_only :versioned_formula
+
+  # https://llvm.org/docs/GettingStarted.html#requirement
+  depends_on "cmake" => :build
+  depends_on "ninja" => :build
+  depends_on "python@3.13" => [:build, :test]
+  depends_on "swig" => :build
+  depends_on "xz"
+  depends_on "zstd"
+
+  uses_from_macos "libedit"
+  uses_from_macos "libffi", since: :catalina
+  uses_from_macos "ncurses"
+  uses_from_macos "zlib"
+
+  on_linux do
+    depends_on "pkgconf" => :build
+    depends_on "binutils" # needed for gold
+    depends_on "elfutils" # openmp requires <gelf.h>
+  end
+
+  # Backport relative `CLANG_CONFIG_FILE_SYSTEM_DIR` patch.
+  # https://github.com/llvm/llvm-project/pull/110962
+  patch do
+    url "https://github.com/llvm/llvm-project/commit/1682c99a8877364f1d847395cef501e813804caa.patch?full_index=1"
+    sha256 "2d0a185e27ff2bc46531fc2c18c61ffab521ae8ece2db5b5bed498a15f3f3758"
+  end
+
+  # Support simplified triples in version config files.
+  # https://github.com/llvm/llvm-project/pull/111387
+  patch do
+    url "https://github.com/llvm/llvm-project/commit/88dd0d33147a7f46a3c9df4aed28ad4e47ef597c.patch?full_index=1"
+    sha256 "0acaa80042055ad194306abb9843a94da24f53ee2bb819583d624391a6329b90"
+  end
+
+  # Fix triple config loading for clang-cl
+  # https://github.com/llvm/llvm-project/pull/111397
+  patch do
+    url "https://github.com/llvm/llvm-project/commit/a3e8b860788934d7cc1489f850f00dcfd9d8b595.patch?full_index=1"
+    sha256 "6d8403fec7be55004e94de90b074c2c166811903ad4921fd76274498c5a60a23"
+  end
+
+  def python3
+    "python3.13"
+  end
+
+  def clang_config_file_dir
+    etc/"clang"
+  end
+
+  def install
+    # The clang bindings need a little help finding our libclang.
+    inreplace "clang/bindings/python/clang/cindex.py",
+              /^(\s*library_path\s*=\s*)None$/,
+              "\\1'#{lib}'"
+
+    projects = %w[
+      clang
+      clang-tools-extra
+      mlir
+      polly
+    ]
+    runtimes = %w[
+      compiler-rt
+      libcxx
+      libcxxabi
+      libunwind
+      pstl
+    ]
+
+    python_versions = Formula.names
+                             .select { |name| name.start_with? "python@" }
+                             .map { |py| py.delete_prefix("python@") }
+
+    # Apple's libstdc++ is too old to build LLVM
+    ENV.libcxx if ENV.compiler == :clang
+
+    # compiler-rt has some iOS simulator features that require i386 symbols
+    # I'm assuming the rest of clang needs support too for 32-bit compilation
+    # to work correctly, but if not, perhaps universal binaries could be
+    # limited to compiler-rt. llvm makes this somewhat easier because compiler-rt
+    # can almost be treated as an entirely different build from llvm.
+    ENV.permit_arch_flags
+
+    # we install the lldb Python module into libexec to prevent users from
+    # accidentally importing it with a non-Homebrew Python or a Homebrew Python
+    # in a non-default prefix. See https://lldb.llvm.org/resources/caveats.html
+    args = %W[
+      -DLLVM_ENABLE_PROJECTS=#{projects.join(";")}
+      -DLLVM_ENABLE_RUNTIMES=#{runtimes.join(";")}
+      -DLLVM_POLLY_LINK_INTO_TOOLS=ON
+      -DLLVM_BUILD_EXTERNAL_COMPILER_RT=ON
+      -DLLVM_LINK_LLVM_DYLIB=ON
+      -DLLVM_ENABLE_EH=ON
+      -DLLVM_ENABLE_FFI=ON
+      -DLLVM_ENABLE_RTTI=ON
+      -DLLVM_INCLUDE_DOCS=OFF
+      -DLLVM_INCLUDE_TESTS=OFF
+      -DLLVM_INSTALL_UTILS=ON
+      -DLLVM_ENABLE_Z3_SOLVER=OFF
+      -DLLVM_OPTIMIZED_TABLEGEN=ON
+      -DLLVM_TARGETS_TO_BUILD=all
+      -DLLVM_USE_RELATIVE_PATHS_IN_FILES=ON
+      -DLLVM_SOURCE_PREFIX=.
+      -DLLDB_USE_SYSTEM_DEBUGSERVER=ON
+      -DLLDB_ENABLE_PYTHON=OFF
+      -DLLDB_ENABLE_LUA=OFF
+      -DLLDB_ENABLE_LZMA=ON
+      -DLIBOMP_INSTALL_ALIASES=OFF
+      -DLIBCXX_INSTALL_MODULES=ON
+      -DCLANG_PYTHON_BINDINGS_VERSIONS=#{python_versions.join(";")}
+      -DLLVM_CREATE_XCODE_TOOLCHAIN=OFF
+      -DCLANG_FORCE_MATCHING_LIBCLANG_SOVERSION=OFF
+      -DCLANG_CONFIG_FILE_SYSTEM_DIR=#{clang_config_file_dir.relative_path_from(bin)}
+      -DCLANG_CONFIG_FILE_USER_DIR=~/.config/clang
+    ]
+
+    if tap.present?
+      args += %W[
+        -DPACKAGE_VENDOR=#{tap.user}
+        -DBUG_REPORT_URL=#{tap.issues_url}
+      ]
+      args << "-DCLANG_VENDOR_UTI=sh.brew.clang" if tap.official?
+    end
+
+    runtimes_cmake_args = []
+    builtins_cmake_args = []
+
+    if OS.mac?
+      macos_sdk = MacOS.sdk_path_if_needed
+      if MacOS.version >= :catalina
+        args << "-DFFI_INCLUDE_DIR=#{macos_sdk}/usr/include/ffi"
+        args << "-DFFI_LIBRARY_DIR=#{macos_sdk}/usr/lib"
+      end
+
+      libcxx_install_libdir = lib/"c++"
+      libunwind_install_libdir = lib/"unwind"
+      libcxx_rpaths = [loader_path, rpath(source: libcxx_install_libdir, target: libunwind_install_libdir)]
+
+      args << "-DLLVM_BUILD_LLVM_C_DYLIB=ON"
+      args << "-DLLVM_ENABLE_LIBCXX=ON"
+      args << "-DLIBCXX_PSTL_BACKEND=libdispatch"
+      args << "-DLIBCXX_INSTALL_LIBRARY_DIR=#{libcxx_install_libdir}"
+      args << "-DLIBUNWIND_INSTALL_LIBRARY_DIR=#{libunwind_install_libdir}"
+      args << "-DLIBCXXABI_INSTALL_LIBRARY_DIR=#{libcxx_install_libdir}"
+      runtimes_cmake_args << "-DCMAKE_INSTALL_RPATH=#{libcxx_rpaths.join("|")}"
+
+      # Disable builds for OSes not supported by the CLT SDK.
+      clt_sdk_support_flags = %w[I WATCH TV].map { |os| "-DCOMPILER_RT_ENABLE_#{os}OS=OFF" }
+      builtins_cmake_args += clt_sdk_support_flags
+    else
+      args << "-DFFI_INCLUDE_DIR=#{Formula["libffi"].opt_include}"
+      args << "-DFFI_LIBRARY_DIR=#{Formula["libffi"].opt_lib}"
+
+      # Disable `libxml2` which isn't very useful.
+      args << "-DLLVM_ENABLE_LIBXML2=OFF"
+      args << "-DLLVM_ENABLE_LIBCXX=OFF"
+      args << "-DCLANG_DEFAULT_CXX_STDLIB=libstdc++"
+      # Enable llvm gold plugin for LTO
+      args << "-DLLVM_BINUTILS_INCDIR=#{Formula["binutils"].opt_include}"
+      # Parts of Polly fail to correctly build with PIC when being used for DSOs.
+      args << "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
+      runtimes_cmake_args += %w[
+        -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=OFF
+        -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+
+        -DLIBCXX_ENABLE_STATIC_ABI_LIBRARY=ON
+        -DLIBCXX_STATICALLY_LINK_ABI_IN_SHARED_LIBRARY=OFF
+        -DLIBCXX_STATICALLY_LINK_ABI_IN_STATIC_LIBRARY=ON
+        -DLIBCXX_USE_COMPILER_RT=ON
+        -DLIBCXX_HAS_ATOMIC_LIB=OFF
+
+        -DLIBCXXABI_ENABLE_STATIC_UNWINDER=ON
+        -DLIBCXXABI_STATICALLY_LINK_UNWINDER_IN_SHARED_LIBRARY=OFF
+        -DLIBCXXABI_STATICALLY_LINK_UNWINDER_IN_STATIC_LIBRARY=ON
+        -DLIBCXXABI_USE_COMPILER_RT=ON
+        -DLIBCXXABI_USE_LLVM_UNWINDER=ON
+
+        -DLIBUNWIND_USE_COMPILER_RT=ON
+        -DCOMPILER_RT_USE_BUILTINS_LIBRARY=ON
+        -DCOMPILER_RT_USE_LLVM_UNWINDER=ON
+
+        -DSANITIZER_CXX_ABI=libc++
+        -DSANITIZER_TEST_CXX=libc++
+      ]
+
+      # Prevent compiler-rt from building i386 targets, as this is not portable.
+      builtins_cmake_args << "-DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON"
+    end
+
+    if ENV.cflags.present?
+      args << "-DCMAKE_C_FLAGS=#{ENV.cflags}"
+      runtimes_cmake_args << "-DCMAKE_C_FLAGS=#{ENV.cflags}"
+      builtins_cmake_args << "-DCMAKE_C_FLAGS=#{ENV.cflags}"
+    end
+
+    if ENV.cxxflags.present?
+      args << "-DCMAKE_CXX_FLAGS=#{ENV.cxxflags}"
+      runtimes_cmake_args << "-DCMAKE_CXX_FLAGS=#{ENV.cxxflags}"
+      builtins_cmake_args << "-DCMAKE_CXX_FLAGS=#{ENV.cxxflags}"
+    end
+
+    args << "-DRUNTIMES_CMAKE_ARGS=#{runtimes_cmake_args.join(";")}" if runtimes_cmake_args.present?
+    args << "-DBUILTINS_CMAKE_ARGS=#{builtins_cmake_args.join(";")}" if builtins_cmake_args.present?
+
+    llvmpath = buildpath/"llvm"
+    mkdir llvmpath/"build" do
+      system "cmake", "-G", "Ninja", "..", *(std_cmake_args + args)
+      system "cmake", "--build", "."
+      system "cmake", "--build", ".", "--target", "install"
+    end
+
+    if OS.mac?
+      # Get the version from `llvm-config` to get the correct HEAD or RC version too.
+      llvm_version = Utils.safe_popen_read(bin/"llvm-config", "--version").strip
+      soversion = Version.new(llvm_version).major.to_s
+
+      # Install versioned symlink, or else `llvm-config` doesn't work properly
+      lib.install_symlink "libLLVM.dylib" => "libLLVM-#{soversion}.dylib"
+
+      # Install Xcode toolchain. See:
+      # https://github.com/llvm/llvm-project/blob/main/llvm/tools/xcode-toolchain/CMakeLists.txt
+      # We do this manually in order to avoid:
+      #   1. installing duplicates of files in the prefix
+      #   2. requiring an existing Xcode installation
+      xctoolchain = prefix/"Toolchains/LLVM#{llvm_version}.xctoolchain"
+
+      system "/usr/libexec/PlistBuddy", "-c", "Add:CFBundleIdentifier string org.llvm.#{llvm_version}", "Info.plist"
+      system "/usr/libexec/PlistBuddy", "-c", "Add:CompatibilityVersion integer 2", "Info.plist"
+      xctoolchain.install "Info.plist"
+      (xctoolchain/"usr").install_symlink [bin, include, lib, libexec, share]
+
+      # Install a major-versioned symlink that can be used across minor/patch version upgrades.
+      xctoolchain.parent.install_symlink xctoolchain.basename.to_s => "LLVM#{soversion}.xctoolchain"
+
+      # Write config files for each macOS major version so that this works across OS upgrades.
+      MacOSVersion::SYMBOLS.each_value do |v|
+        macos_version = MacOSVersion.new(v)
+        write_config_files(macos_version, MacOSVersion.kernel_major_version(macos_version), Hardware::CPU.arch)
+      end
+
+      # Also write an unversioned config file as fallback
+      write_config_files("", "", Hardware::CPU.arch)
+    end
+
+    # Install Vim plugins
+    %w[ftdetect ftplugin indent syntax].each do |dir|
+      (share/"vim/vimfiles"/dir).install Pathname.glob("*/utils/vim/#{dir}/*.vim")
+    end
+
+    # Install Emacs modes
+    elisp.install llvmpath.glob("utils/emacs/*.el") + share.glob("clang/*.el")
+  end
+
+  # We use the extra layer of indirection in `arch` because the FormulaAudit/OnSystemConditionals
+  # doesn't want to let us use `Hardware::CPU.arch` outside of `install` or `post_install` blocks.
+  def write_config_files(macos_version, kernel_version, arch)
+    clang_config_file_dir.mkpath
+
+    arches = Set.new([:arm64, :x86_64, :aarch64])
+    arches << arch
+
+    sysroot = if macos_version.blank? || (MacOS.version > macos_version && MacOS::CLT.separate_header_package?)
+      "#{MacOS::CLT::PKG_PATH}/SDKs/MacOSX.sdk"
+    elsif macos_version >= "10.14"
+      "#{MacOS::CLT::PKG_PATH}/SDKs/MacOSX#{macos_version}.sdk"
+    else
+      "/"
+    end
+
+    {
+      darwin: kernel_version,
+      macosx: macos_version,
+    }.each do |system, version|
+      arches.each do |target_arch|
+        config_file = "#{target_arch}-apple-#{system}#{version}.cfg"
+        (clang_config_file_dir/config_file).atomic_write <<~CONFIG
+          -isysroot #{sysroot}
+        CONFIG
+      end
+    end
+  end
+
+  def post_install
+    return unless OS.mac?
+
+    config_files = {
+      darwin: OS.kernel_version.major,
+      macosx: MacOS.version,
+    }.map do |system, version|
+      clang_config_file_dir/"#{Hardware::CPU.arch}-apple-#{system}#{version}.cfg"
+    end
+    return if config_files.all?(&:exist?)
+
+    write_config_files(MacOS.version, OS.kernel_version.major, Hardware::CPU.arch)
+  end
+
+  def caveats
+    s = <<~EOS
+      CLANG_CONFIG_FILE_SYSTEM_DIR: #{clang_config_file_dir}
+      CLANG_CONFIG_FILE_USER_DIR:   ~/.config/clang
+
+      LLD is now provided in a separate formula:
+        brew install lld@19
+    EOS
+
+    on_macos do
+      s += <<~EOS
+
+        Using `clang`, `clang++`, etc., requires a CLT installation at `/Library/Developer/CommandLineTools`.
+        If you don't want to install the CLT, you can write appropriate configuration files pointing to your
+        SDK at ~/.config/clang.
+
+        To use the bundled libunwind please use the following LDFLAGS:
+          LDFLAGS="-L#{opt_lib}/unwind -lunwind"
+
+        To use the bundled libc++ please use the following LDFLAGS:
+          LDFLAGS="-L#{opt_lib}/c++ -L#{opt_lib}/unwind -lunwind"
+
+        NOTE: You probably want to use the libunwind and libc++ provided by macOS unless you know what you're doing.
+      EOS
+    end
+
+    s
+  end
+
+  test do
+    alt_location_libs = [
+      shared_library("libc++", "*"),
+      shared_library("libc++abi", "*"),
+      shared_library("libunwind", "*"),
+    ]
+    assert_empty lib.glob(alt_location_libs) if OS.mac?
+
+    llvm_version = Utils.safe_popen_read(bin/"llvm-config", "--version").strip
+    llvm_version_major = Version.new(llvm_version).major.to_s
+    soversion = llvm_version_major.dup
+    assert_equal version, llvm_version
+
+    assert_equal prefix.to_s, shell_output("#{bin}/llvm-config --prefix").chomp
+    assert_equal "-lLLVM-#{soversion}", shell_output("#{bin}/llvm-config --libs").chomp
+    assert_equal (lib/shared_library("libLLVM-#{soversion}")).to_s,
+                 shell_output("#{bin}/llvm-config --libfiles").chomp
+
+    (testpath/"test.c").write <<~C
+      #include <stdio.h>
+      int main()
+      {
+        printf("Hello World!\\n");
+        return 0;
+      }
+    C
+
+    (testpath/"test.cpp").write <<~CPP
+      #include <iostream>
+      int main()
+      {
+        std::cout << "Hello World!" << std::endl;
+        return 0;
+      }
+    CPP
+
+    system bin/"clang-cpp", "-v", "test.c"
+    system bin/"clang-cpp", "-v", "test.cpp"
+
+    # Testing default toolchain and SDK location.
+    system bin/"clang++", "-v",
+           "-std=c++11", "test.cpp", "-o", "test++"
+    assert_includes MachO::Tools.dylibs("test++"), "/usr/lib/libc++.1.dylib" if OS.mac?
+    assert_equal "Hello World!", shell_output("./test++").chomp
+    system bin/"clang", "-v", "test.c", "-o", "test"
+    assert_equal "Hello World!", shell_output("./test").chomp
+
+    # These tests should ignore the usual SDK includes
+    with_env(CPATH: nil) do
+      # Testing Command Line Tools
+      if OS.mac? && MacOS::CLT.installed?
+        toolchain_path = "/Library/Developer/CommandLineTools"
+        cpp_base = (MacOS.version >= :big_sur) ? MacOS::CLT.sdk_path : toolchain_path
+        system bin/"clang++", "-v",
+               "--no-default-config",
+               "-isysroot", MacOS::CLT.sdk_path,
+               "-isystem", "#{cpp_base}/usr/include/c++/v1",
+               "-isystem", "#{MacOS::CLT.sdk_path}/usr/include",
+               "-isystem", "#{toolchain_path}/usr/include",
+               "-std=c++11", "test.cpp", "-o", "testCLT++"
+        assert_includes MachO::Tools.dylibs("testCLT++"), "/usr/lib/libc++.1.dylib"
+        assert_equal "Hello World!", shell_output("./testCLT++").chomp
+        system bin/"clang", "-v", "test.c", "-o", "testCLT"
+        assert_equal "Hello World!", shell_output("./testCLT").chomp
+
+        targets = ["#{Hardware::CPU.arch}-apple-macosx#{MacOS.full_version}"]
+
+        # The test tends to time out on Intel, so let's do these only for ARM macOS.
+        if Hardware::CPU.arm?
+          old_macos_version = HOMEBREW_MACOS_OLDEST_SUPPORTED.to_i - 1
+          targets << "#{Hardware::CPU.arch}-apple-macosx#{old_macos_version}"
+
+          old_kernel_version = MacOSVersion.kernel_major_version(MacOSVersion.new(old_macos_version.to_s))
+          targets << "#{Hardware::CPU.arch}-apple-darwin#{old_kernel_version}"
+        end
+
+        targets.each do |target|
+          system bin/"clang-cpp", "-v", "--target=#{target}", "test.c"
+          system bin/"clang-cpp", "-v", "--target=#{target}", "test.cpp"
+
+          system bin/"clang", "-v", "--target=#{target}", "test.c", "-o", "test-macosx"
+          assert_equal "Hello World!", shell_output("./test-macosx").chomp
+
+          system bin/"clang++", "-v", "--target=#{target}", "-std=c++11", "test.cpp", "-o", "test++-macosx"
+          assert_equal "Hello World!", shell_output("./test++-macosx").chomp
+        end
+      end
+
+      # Testing Xcode
+      if OS.mac? && MacOS::Xcode.installed?
+        cpp_base = (MacOS::Xcode.version >= "12.5") ? MacOS::Xcode.sdk_path : MacOS::Xcode.toolchain_path
+        system bin/"clang++", "-v",
+               "--no-default-config",
+               "-isysroot", MacOS::Xcode.sdk_path,
+               "-isystem", "#{cpp_base}/usr/include/c++/v1",
+               "-isystem", "#{MacOS::Xcode.sdk_path}/usr/include",
+               "-isystem", "#{MacOS::Xcode.toolchain_path}/usr/include",
+               "-std=c++11", "test.cpp", "-o", "testXC++"
+        assert_includes MachO::Tools.dylibs("testXC++"), "/usr/lib/libc++.1.dylib"
+        assert_equal "Hello World!", shell_output("./testXC++").chomp
+        system bin/"clang", "-v",
+               "-isysroot", MacOS.sdk_path,
+               "test.c", "-o", "testXC"
+        assert_equal "Hello World!", shell_output("./testXC").chomp
+      end
+
+      # link against installed libc++
+      # related to https://github.com/Homebrew/legacy-homebrew/issues/47149
+      cxx_libdir = OS.mac? ? opt_lib/"c++" : opt_lib
+      system bin/"clang++", "-v",
+             "-isystem", "#{opt_include}/c++/v1",
+             "-std=c++11", "-stdlib=libc++", "test.cpp", "-o", "testlibc++",
+             "-rtlib=compiler-rt", "-L#{cxx_libdir}", "-Wl,-rpath,#{cxx_libdir}"
+      assert_includes (testpath/"testlibc++").dynamically_linked_libraries,
+                      (cxx_libdir/shared_library("libc++", "1")).to_s
+      (testpath/"testlibc++").dynamically_linked_libraries.each do |lib|
+        refute_match(/libstdc\+\+/, lib)
+        refute_match(/libgcc/, lib)
+        refute_match(/libatomic/, lib)
+      end
+      assert_equal "Hello World!", shell_output("./testlibc++").chomp
+    end
+
+    if OS.linux?
+      # Link installed libc++, libc++abi, and libunwind archives both into
+      # a position independent executable (PIE), as well as into a fully
+      # position independent (PIC) DSO for things like plugins that export
+      # a C-only API but internally use C++.
+      #
+      # FIXME: It'd be nice to be able to use flags like `-static-libstdc++`
+      # together with `-stdlib=libc++` (the latter one we need anyways for
+      # headers) to achieve this but those flags don't set up the correct
+      # search paths or handle all of the libraries needed by `libc++` when
+      # linking statically.
+
+      system bin/"clang++", "-v", "-o", "test_pie_runtimes",
+                   "-pie", "-fPIC", "test.cpp", "-L#{opt_lib}",
+                   "-stdlib=libc++", "-rtlib=compiler-rt",
+                   "-static-libstdc++", "-lpthread", "-ldl"
+      assert_equal "Hello World!", shell_output("./test_pie_runtimes").chomp
+      (testpath/"test_pie_runtimes").dynamically_linked_libraries.each do |lib|
+        refute_match(/lib(std)?c\+\+/, lib)
+        refute_match(/libgcc/, lib)
+        refute_match(/libatomic/, lib)
+        refute_match(/libunwind/, lib)
+      end
+
+      (testpath/"test_plugin.cpp").write <<~CPP
+        #include <iostream>
+        __attribute__((visibility("default")))
+        extern "C" void run_plugin() {
+          std::cout << "Hello Plugin World!" << std::endl;
+        }
+      CPP
+      (testpath/"test_plugin_main.c").write <<~C
+        extern void run_plugin();
+        int main() {
+          run_plugin();
+        }
+      C
+      system bin/"clang++", "-v", "-o", "test_plugin.so",
+             "-shared", "-fPIC", "test_plugin.cpp", "-L#{opt_lib}",
+             "-stdlib=libc++", "-rtlib=compiler-rt",
+             "-static-libstdc++", "-lpthread", "-ldl"
+      system bin/"clang", "-v",
+             "test_plugin_main.c", "-o", "test_plugin_libc++",
+             "test_plugin.so", "-Wl,-rpath=#{testpath}", "-rtlib=compiler-rt"
+      assert_equal "Hello Plugin World!", shell_output("./test_plugin_libc++").chomp
+      (testpath/"test_plugin.so").dynamically_linked_libraries.each do |lib|
+        refute_match(/lib(std)?c\+\+/, lib)
+        refute_match(/libgcc/, lib)
+        refute_match(/libatomic/, lib)
+        refute_match(/libunwind/, lib)
+      end
+    end
+
+    # Testing mlir
+    (testpath/"test.mlir").write <<~MLIR
+      func.func @main() {return}
+
+      // -----
+
+      // expected-note @+1 {{see existing symbol definition here}}
+      func.func @foo() { return }
+
+      // ----
+
+      // expected-error @+1 {{redefinition of symbol named 'foo'}}
+      func.func @foo() { return }
+    MLIR
+    system bin/"mlir-opt", "--split-input-file", "--verify-diagnostics", "test.mlir"
+
+    (testpath/"scanbuildtest.cpp").write <<~CPP
+      #include <iostream>
+      int main() {
+        int *i = new int;
+        *i = 1;
+        delete i;
+        std::cout << *i << std::endl;
+        return 0;
+      }
+    CPP
+    assert_includes shell_output("#{bin}/scan-build make scanbuildtest 2>&1"),
+                    "warning: Use of memory after it is freed"
+
+    (testpath/"clangformattest.c").write <<~C
+      int    main() {
+          printf("Hello world!"); }
+    C
+    assert_equal "int main() { printf(\"Hello world!\"); }\n",
+      shell_output("#{bin}/clang-format -style=google clangformattest.c")
+
+    # This will fail if the clang bindings cannot find `libclang`.
+    with_env(PYTHONPATH: prefix/Language::Python.site_packages(python3)) do
+      system python3, "-c", <<~PYTHON
+        from clang import cindex
+        cindex.Config().get_cindex_library()
+      PYTHON
+    end
+
+    # Ensure LLVM did not regress output of `llvm-config --system-libs` which for a time
+    # was known to output incorrect linker flags; e.g., `-llibxml2.tbd` instead of `-lxml2`.
+    # On the other hand, note that a fully qualified path to `dylib` or `tbd` is OK, e.g.,
+    # `/usr/local/lib/libxml2.tbd` or `/usr/local/lib/libxml2.dylib`.
+    abs_path_exts = [".tbd", ".dylib"]
+    shell_output("#{bin}/llvm-config --system-libs").chomp.strip.split.each do |lib|
+      if lib.start_with?("-l")
+        assert !lib.end_with?(".tbd"), "expected abs path when lib reported as .tbd"
+        assert !lib.end_with?(".dylib"), "expected abs path when lib reported as .dylib"
+      else
+        p = Pathname.new(lib)
+        if abs_path_exts.include?(p.extname)
+          assert p.absolute?, "expected abs path when lib reported as .tbd or .dylib"
+        end
+      end
+    end
+  end
+end

--- a/Formula/z/zig.rb
+++ b/Formula/z/zig.rb
@@ -12,13 +12,13 @@ class Zig < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "582c6da9e4c1d916fc318c8d25ee4981941d5c1e89f2e9dac1981173337390b6"
-    sha256 cellar: :any,                 arm64_sonoma:  "3ff0ad19dc0d0ed496395844745da89a89d021b7611d28b96fb5f4c208941e9f"
-    sha256 cellar: :any,                 arm64_ventura: "b7cadbfbaea540925472f28df0e119c4e26233335cb8886b755ceb1663b5e00a"
-    sha256 cellar: :any,                 sonoma:        "1b9125a527782269930c27e0d67a62c3c36656e01906725f080ac972f6bbf3a7"
-    sha256 cellar: :any,                 ventura:       "537e3e061b77ad9ca512aa866b9aae06fee5d1e2faa85128cf903aa3d18dc9ca"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "bc74fb16422994ef50087b89eee304931acb3568103fc6688176ffc015eeb2d2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a71266139b1fe7f17638b0ad92b36a424295db899797bcef6fd9a6e64d68d6bc"
+    sha256 cellar: :any,                 arm64_sequoia: "1d93ca443ee4c104e52050f662d67cce83ef90359d3af0002aacfa5c6147cb6b"
+    sha256 cellar: :any,                 arm64_sonoma:  "6c478a26658e289eb7bd6a8c258f8594c505c4fd4252d4e5ab714d3d784d23b7"
+    sha256 cellar: :any,                 arm64_ventura: "ddc4ff42466317700fe5f8dfef706360c74af312be9fdfa33d3f5f177aad3aa9"
+    sha256 cellar: :any,                 sonoma:        "1098717b274fb85082e1321f27b2577695e4c1a244bea6adb7725dfe3d21729a"
+    sha256 cellar: :any,                 ventura:       "b80b9097427d531a0e926bdb885beafff09a4a71132e5f0cda160660b2bd3e73"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "d0527803175f3ffe9f5cf9eeba79e6e339f972c13704b4db6ebae12b01bdd7fc"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "73e30b0d64e6df8d6584b78d6e41110e06f05108988d5f2db49469dcb55614e3"
   end
 
   depends_on "cmake" => :build

--- a/Formula/z/zig.rb
+++ b/Formula/z/zig.rb
@@ -4,7 +4,7 @@ class Zig < Formula
   url "https://ziglang.org/download/0.14.0/zig-0.14.0.tar.xz"
   sha256 "c76638c03eb204c4432ae092f6fa07c208567e110fbd4d862d131a7332584046"
   license "MIT"
-  revision 1
+  revision 2
 
   livecheck do
     url "https://ziglang.org/download/"
@@ -22,13 +22,12 @@ class Zig < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "lld"
-  depends_on "llvm"
+  depends_on "lld@19"
+  depends_on "llvm@19"
   depends_on macos: :big_sur # https://github.com/ziglang/zig/issues/13313
 
   # NOTE: `z3` should be macOS-only dependency whenever we need to re-add
   on_macos do
-    depends_on "z3"
     depends_on "zstd"
   end
 

--- a/audit_exceptions/universal_binary_allowlist.json
+++ b/audit_exceptions/universal_binary_allowlist.json
@@ -7,6 +7,7 @@
   "llvm@16",
   "llvm@17",
   "llvm@18",
+  "llvm@19",
   "logstash",
   "openjdk@11",
   "sourcery",


### PR DESCRIPTION
Splitting out the `llvm@19` portion of #206362 to reduce mixing both in build environment and hopefully simplify other PR.

Also added `lld@19` for `zig` and a cherry-picked a couple formulae to test.

An alternative would be merging LLD into `llvm@19` though this will result in repeatedly switching between shared to static libraries across versions.

---

Changes for `lld@19`, 
* dropped head
* `keg_only :versioned_formula`
* added `ENV.prepend_path "PATH", bin` in test

Changes for `llvm@19` (from cherry-picked commit),
* fixed missing capture in livecheck
* made Python 3.13 build/test-only
* `-DLLDB_ENABLE_PYTHON=OFF` - probably doesn't do anything since `lldb` is removed
* updated caveat to mention `lld@19`

---

Afterward, the remaining formulae that must be downgraded to LLVM 19 can be handled in separate parallel PRs.

There are some that can instead be switched to LLVM 20 either from a prior version bump or by rolling up another commit.