### PR TITLE
workflows/publish-commit-bottles: fix fix for unbound variable

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -424,7 +424,6 @@ jobs:
         run: |
           echo "::notice ::Local repository HEAD: $EXPECTED_SHA"
 
-          success=0
           attempt=0
           max_attempts=10
           timeout=1
@@ -446,7 +445,7 @@ jobs:
           done
 
           # One last check...
-          if [[ -z "$success" ]] && [[ "$EXPECTED_SHA" != "$(git ls-remote origin "pull/$PR/head" | cut -f1)" ]]
+          if [[ -z "${success:-}" ]] && [[ "$EXPECTED_SHA" != "$(git ls-remote origin "pull/$PR/head" | cut -f1)" ]]
           then
             echo "::error ::No attempts remaining. Giving up."
             exit 1


### PR DESCRIPTION
Follow-up to #216882. `-z` tests if the length of a string is zero, so
`-z 0` always succeeds. Instead, we want the final check to be skipped
if a previous check succeeded.
