### PR TITLE
pyoxidizer: update test as brew `rust` no longer works

### DIFF
--- a/Formula/p/pyoxidizer.rb
+++ b/Formula/p/pyoxidizer.rb
@@ -24,15 +24,22 @@ class Pyoxidizer < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "0648492b46bc163e396b0e6e2ca99350a937476050c158dd5d8a32b9b0fc102d"
   end
 
-  depends_on "rust" => [:build, :test]
+  depends_on "rust" => :build
 
   def install
     system "cargo", "install", *std_cargo_args(path: "pyoxidizer")
   end
 
   test do
-    system bin/"pyoxidizer", "init-rust-project", "--system-rust", "hello_world"
+    assert_match version.to_s, shell_output("#{bin}/pyoxidizer --version")
+
+    # FIXME: restore brew `rust` usage if support is added for newer Rust
+    # system bin/"pyoxidizer", "init-rust-project", "--system-rust", "hello_world"
+    system bin/"pyoxidizer", "init-rust-project", "hello_world"
     assert_path_exists testpath/"hello_world/Cargo.toml"
+
+    # Intel macOS runners are slow enough that extra time from fetching Rust causes timeout
+    return if OS.mac? && Hardware::CPU.intel?
 
     cd "hello_world" do
       if Hardware::CPU.arm? && OS.mac? && MacOS.version < :ventura
@@ -42,9 +49,7 @@ class Pyoxidizer < Formula
                   "dist = default_python_distribution()",
                   "dist = default_python_distribution(python_version='3.8')"
       end
-      system bin/"pyoxidizer", "build", "--system-rust"
+      system bin/"pyoxidizer", "build" # FIXME: , "--system-rust"
     end
-
-    assert_match version.to_s, shell_output("#{bin}/pyoxidizer --version")
   end
 end


### PR DESCRIPTION
Looks like one of the Rust updates broke the test. 

For now just let pyoxidizer fetch Rust.

Can consider if we should deprecate in the future. There is a pinned issue on project being potentially dead (https://github.com/indygreg/PyOxidizer/issues/741) but there have been some commits after that post. 