### PR TITLE
mpv: add `wayland-protocols` dependency

### DIFF
--- a/Formula/m/mpv.rb
+++ b/Formula/m/mpv.rb
@@ -61,6 +61,7 @@ class Mpv < Formula
     depends_on "mesa"
     depends_on "pulseaudio"
     depends_on "wayland"
+    depends_on "wayland-protocols" # needed by mpv.pc
   end
 
   def install


### PR DESCRIPTION
Needed after #202409. Could be test-only but we don't really distinguish between general user vs developer usage.