### PR TITLE
mysql-search-replace: depend on php

### DIFF
--- a/Formula/m/mysql-search-replace.rb
+++ b/Formula/m/mysql-search-replace.rb
@@ -1,4 +1,8 @@
+require "language/php"
+
 class MysqlSearchReplace < Formula
+  include Language::PHP::Shebang
+
   desc "Database search and replace script in PHP"
   homepage "https://interconnectit.com/products/search-and-replace-for-wordpress-databases/"
   url "https://github.com/interconnectit/Search-Replace-DB/archive/refs/tags/4.1.2.tar.gz"
@@ -9,11 +13,13 @@ class MysqlSearchReplace < Formula
     sha256 cellar: :any_skip_relocation, all: "08b03d69eae7a4b2f89ead89f79ac09cd0bd093da29e0255329c308fd559ff43"
   end
 
+  depends_on "php"
+
   def install
     libexec.install "srdb.class.php"
     libexec.install "srdb.cli.php" => "srdb"
-    chmod 0755, libexec/"srdb"
-    bin.install_symlink libexec/"srdb"
+    rewrite_shebang detected_php_shebang, libexec/"srdb" if OS.linux?
+    bin.write_exec_script libexec/"srdb"
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`brew test mysql-search-replace` currently fails because it depends on `php`.