### PR TITLE
pyp 1.3.0 (new formula)

### DIFF
--- a/Formula/p/pyp.rb
+++ b/Formula/p/pyp.rb
@@ -1,0 +1,20 @@
+class Pyp < Formula
+  include Language::Python::Virtualenv
+
+  desc "Easily run Python at the shell! Magical, but never mysterious"
+  homepage "https://github.com/hauntsaninja/pyp"
+  url "https://files.pythonhosted.org/packages/0c/65/c275ff380e4412438577eab23810dd7a1ba2cf54a6ba558a3d22cf0fb68b/pypyp-1.3.0.tar.gz"
+  sha256 "97c78f8fd6d4550bf67bb5001a4c5c1fa58184d9bd8256abac3e240fa38aa05c"
+  license "MIT"
+
+  depends_on "python@3.13"
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/pyp --version")
+    assert_equal "6", pipe_output("#{bin}/pyp 'sum(map(int, stdin))'", "1\n2\n3\n", 0).strip
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Basically, this tool allows you to use Python instead of awk, grep, `perl -pe`, sed, etc. at the shell.

Not sure what to name it. It's been packaged in nixpkgs, the AUR, and OpenSUSE's repos as pyp. But in Debian and Ubuntu's repos a different package is packaged as pyp. The name on https://pypi.org is pypyp but the upstream repo name is pyp.