### PR TITLE
deno: reduce linux workaround

### DIFF
--- a/Formula/d/deno.rb
+++ b/Formula/d/deno.rb
@@ -61,13 +61,7 @@ class Deno < Formula
 
     # use our clang version, and disable lld because the build assumes the lld
     # supports features from newer clang versions (>=20)
-    ENV["GN_ARGS"] = "clang_version=#{llvm.version.major}"
-    if OS.mac?
-      ENV.append "GN_ARGS", "use_lld=false"
-    else
-      ENV.append "GN_ARGS", "use_lld=true"
-      ENV.delete "RUSTFLAGS"
-    end
+    ENV["GN_ARGS"] = "clang_version=#{llvm.version.major} use_lld=#{OS.linux?}"
 
     system "cargo", "install", "--no-default-features", "-vv", *std_cargo_args(path: "cli")
     generate_completions_from_executable(bin/"deno", "completions")


### PR DESCRIPTION
Following up on bump PR to try to see which change fixed build.

Trying out LLD first as original issue was from LD.

RUSTFLAGS change should only set an optimization target (core2) and change loading behavior of config.toml:
```toml
[target.'cfg(all())']
rustflags = [
  "-D",
  "clippy::all",
  "-D",
  "clippy::await_holding_refcell_ref",
  "-D",
  "clippy::missing_safety_doc",
  "-D",
  "clippy::undocumented_unsafe_blocks",
  "--cfg",
  "tokio_unstable",
]
```