### PR TITLE
net-snmp: deparallelize on Linux

### DIFF
--- a/Formula/n/net-snmp.rb
+++ b/Formula/n/net-snmp.rb
@@ -59,6 +59,8 @@ class NetSnmp < Formula
     system "autoreconf", "-fvi" if Hardware::CPU.arm?
     system "./configure", *args
     system "make"
+    # Work around snmptrapd.c:(.text+0x1e0): undefined reference to `dropauth'
+    ENV.deparallelize if OS.linux?
     system "make", "install"
   end
 


### PR DESCRIPTION
Could apply to only ARM but Gentoo and Alpine deparallelize install so may impact all Linux.

---

Wasn't sure if build should also be deparallelized but I didn't see issues on multiple attempts with this change.