### PR TITLE
c2rust: revision bump (switch to `llvm@19`)

### DIFF
--- a/Formula/c/c2rust.rb
+++ b/Formula/c/c2rust.rb
@@ -4,6 +4,7 @@ class C2rust < Formula
   url "https://github.com/immunant/c2rust/archive/refs/tags/v0.20.0.tar.gz"
   sha256 "482330d3f27cfe85deea207e490bebbbe9c709b4bc054e3135498b3bbb585bec"
   license "BSD-3-Clause"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "dacd5b36647696ad2e1863cb2f12fa8c6063c242f691d371b808a1b0310f0911"
@@ -17,7 +18,7 @@ class C2rust < Formula
 
   depends_on "cmake" => [:build, :test]
   depends_on "rust" => :build
-  depends_on "llvm"
+  depends_on "llvm@19"
 
   def install
     system "cargo", "install", *std_cargo_args(path: "c2rust")

--- a/Formula/c/c2rust.rb
+++ b/Formula/c/c2rust.rb
@@ -7,13 +7,13 @@ class C2rust < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "dacd5b36647696ad2e1863cb2f12fa8c6063c242f691d371b808a1b0310f0911"
-    sha256 cellar: :any,                 arm64_sonoma:  "b97d3c3bfc6ef351f11d6c354429883673846f68fd5f4358b8f6d6bbf57355c0"
-    sha256 cellar: :any,                 arm64_ventura: "0b0a702e795b476ee814afb2baae0ada272969df641eeb73de82ca4c730688fa"
-    sha256 cellar: :any,                 sonoma:        "77ed97b9636ca5992fa5b445d951976d696c2d4aa50e321d60d046601ecf832f"
-    sha256 cellar: :any,                 ventura:       "dea354ab6e4c104f14001b5005589ffbfc617e7c3af9c52b8333016edf6236ec"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "a5745c2e86ff939bbfe5b41eeb785a0f6609ce2ecc76f1f4f1d785fd71ed33ca"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "fffe661d012d1c8957c55d107c6c85438f2a3c8199d2d298744ad5964626da33"
+    sha256 cellar: :any,                 arm64_sequoia: "905499716b48b54ad1eea09ff40e229e2056536e72098b7605dc2ddb145117c4"
+    sha256 cellar: :any,                 arm64_sonoma:  "7ad4256baed5d1869cce80b57a863c9ef20c7b73632b574a8b4d40d35f4c6fd4"
+    sha256 cellar: :any,                 arm64_ventura: "60df9dd74e927f4dcbd82409a1e09036602b5de922e53b1cf8377cf6b199d069"
+    sha256 cellar: :any,                 sonoma:        "8575b649a3f0faa7ee46b1f1bc38435f284973ef02b8ad24afcea5477eb60e40"
+    sha256 cellar: :any,                 ventura:       "dd757588e38c35414c4a47feb0d0b40b2aeb39bd4f94f001c2479253fd433ce6"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "20c31538b457c35efdf00988833dcd68df79d82e6ddabe188fe479b1f4fc2376"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8150aa61370a613f5df88413c96cafc937fe817e0f80cff2134132270323feb7"
   end
 
   depends_on "cmake" => [:build, :test]


### PR DESCRIPTION
After LLVM PR is merged

```
==> brew linkage --test c2rust
==> FAILED
Full linkage --test c2rust output
  Missing libraries:
    libLLVM.so.19.1
    libclang-cpp.so.19.1
```