### PR TITLE
dspdfviewer: workaround for CMake 4

### DIFF
--- a/Formula/d/dspdfviewer.rb
+++ b/Formula/d/dspdfviewer.rb
@@ -40,6 +40,7 @@ class Dspdfviewer < Formula
     # Allow setting CMAKE_CXX_STANDARD in args
     inreplace "cmake/compiler_clang.cmake", 'add_definitions("-std=c++11")', ""
     inreplace "cmake/compiler_gnu_gcc.cmake", "add_definitions(-std=c++11)", ""
+    inreplace "cmake/compiler_unknown.cmake", "add_definitions(-std=c++11)", ""
 
     args = %w[
       -DRunDualScreenTests=OFF
@@ -47,6 +48,7 @@ class Dspdfviewer < Formula
       -DUseQtFive=ON
       -DCMAKE_CXX_STANDARD=14
       -DCMAKE_CXX_FLAGS=-Wno-deprecated-declaration
+      -DCMAKE_POLICY_VERSION_MINIMUM=3.5
     ]
 
     system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args


### PR DESCRIPTION
Also update workaround for C++14 which is needed as newer CMake policy detects Apple Clang separately.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
