### PR TITLE
apache-flink 2.0.0, apache-flink@1 (new formula)

### DIFF
--- a/Aliases/apache-flink@2
+++ b/Aliases/apache-flink@2
@@ -1,0 +1,1 @@
+../Formula/a/apache-flink.rb

--- a/Formula/a/apache-flink-cdc.rb
+++ b/Formula/a/apache-flink-cdc.rb
@@ -9,7 +9,7 @@ class ApacheFlinkCdc < Formula
   head "https://github.com/apache/flink-cdc.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "68208a88aaed1d60d35718e6c47548d1f4939b4a18ea008d857b76c931de0745"
+    sha256 cellar: :any_skip_relocation, all: "1cef7a93c789288ae90f0be233b2891a553f12bdee58bdd2e7ccaedf38da477e"
   end
 
   depends_on "apache-flink@1" => :test

--- a/Formula/a/apache-flink-cdc.rb
+++ b/Formula/a/apache-flink-cdc.rb
@@ -5,17 +5,23 @@ class ApacheFlinkCdc < Formula
   mirror "https://archive.apache.org/dist/flink/flink-cdc-3.3.0/flink-cdc-3.3.0-bin.tar.gz"
   sha256 "efb6a5e36bcb85550c367cb39104ee7fcbacfd8124190a2fc3e547ca19446719"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/apache/flink-cdc.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "68208a88aaed1d60d35718e6c47548d1f4939b4a18ea008d857b76c931de0745"
   end
 
-  depends_on "apache-flink" => :test
+  depends_on "apache-flink@1" => :test
 
+  # See: https://github.com/apache/flink-cdc/blob/master/docs/content/docs/connectors/pipeline-connectors/overview.md#supported-connectors
   resource "mysql-connector" do
     url "https://search.maven.org/remotecontent?filepath=org/apache/flink/flink-cdc-pipeline-connector-mysql/3.3.0/flink-cdc-pipeline-connector-mysql-3.3.0.jar"
     sha256 "6e1af3675279e11c3e0240ca0475910c13bf75ecfd1ab23c0077a5fabc65c44a"
+  end
+  resource "oceanbase-connector" do
+    url "https://search.maven.org/remotecontent?filepath=org/apache/flink/flink-cdc-pipeline-connector-oceanbase/3.3.0/flink-cdc-pipeline-connector-oceanbase-3.3.0.jar"
+    sha256 "1de0ca47dc3f495b585e5f8f63c182f9e2f6c5bb6ed895392a65b2255d7c3c8f"
   end
   resource "paimon-connector" do
     url "https://search.maven.org/remotecontent?filepath=org/apache/flink/flink-cdc-pipeline-connector-paimon/3.3.0/flink-cdc-pipeline-connector-paimon-3.3.0.jar"
@@ -25,9 +31,17 @@ class ApacheFlinkCdc < Formula
     url "https://search.maven.org/remotecontent?filepath=org/apache/flink/flink-cdc-pipeline-connector-kafka/3.3.0/flink-cdc-pipeline-connector-kafka-3.3.0.jar"
     sha256 "988af808ba3c2b1bc2ac7c4e79388615ecd2d0614b5ccba48362b526ae1b98e9"
   end
+  resource "maxcompute-connector" do
+    url "https://search.maven.org/remotecontent?filepath=org/apache/flink/flink-cdc-pipeline-connector-maxcompute/3.3.0/flink-cdc-pipeline-connector-maxcompute-3.3.0.jar"
+    sha256 "f2388915ace24911cb56f32c31e5cc387d968283cfb06333c8e43651108e35a6"
+  end
   resource "doris-connector" do
     url "https://search.maven.org/remotecontent?filepath=org/apache/flink/flink-cdc-pipeline-connector-doris/3.3.0/flink-cdc-pipeline-connector-doris-3.3.0.jar"
     sha256 "112981b8bb216fa08928c12abc0a7ce3d2772f22c06d417e2426884e4f880304"
+  end
+  resource "elasticsearch-connector" do
+    url "https://search.maven.org/remotecontent?filepath=org/apache/flink/flink-cdc-pipeline-connector-elasticsearch/3.3.0/flink-cdc-pipeline-connector-elasticsearch-3.3.0.jar"
+    sha256 "41ca15269df57a57576740fb75e3a00a62bc7e0733b021f3844c50a05bf9610c"
   end
   resource "starrocks-connector" do
     url "https://search.maven.org/remotecontent?filepath=org/apache/flink/flink-cdc-pipeline-connector-starrocks/3.3.0/flink-cdc-pipeline-connector-starrocks-3.3.0.jar"
@@ -78,7 +92,7 @@ class ApacheFlinkCdc < Formula
     YAML
     (testpath/"log").mkpath
     ENV["FLINK_LOG_DIR"] = testpath/"log"
-    flink_home = Formula["apache-flink"].libexec
+    flink_home = Formula["apache-flink@1"].libexec
     system flink_home/"bin/start-cluster.sh"
     output = shell_output "#{bin}/flink-cdc --flink-home #{flink_home} #{testpath}/test-pipeline.yaml"
     assert_match "Pipeline has been submitted to cluster.", output

--- a/Formula/a/apache-flink.rb
+++ b/Formula/a/apache-flink.rb
@@ -1,10 +1,10 @@
 class ApacheFlink < Formula
   desc "Scalable batch and stream data processing"
   homepage "https://flink.apache.org/"
-  url "https://www.apache.org/dyn/closer.lua?path=flink/flink-1.20.1/flink-1.20.1-bin-scala_2.12.tgz"
-  mirror "https://archive.apache.org/dist/flink/flink-1.20.1/flink-1.20.1-bin-scala_2.12.tgz"
-  version "1.20.1"
-  sha256 "5fc4551cd11aee83a9569392339c43fb32a60847db456e1cb4fa64c8daae0186"
+  url "https://www.apache.org/dyn/closer.lua?path=flink/flink-2.0.0/flink-2.0.0-bin-scala_2.12.tgz"
+  mirror "https://archive.apache.org/dist/flink/flink-2.0.0/flink-2.0.0-bin-scala_2.12.tgz"
+  version "2.0.0"
+  sha256 "04fe5be9841a10d30e0e1cd682ec4d015a86603f710f2f857c43c75beae97aad"
   license "Apache-2.0"
   head "https://github.com/apache/flink.git", branch: "master"
 
@@ -17,11 +17,13 @@ class ApacheFlink < Formula
     sha256 cellar: :any_skip_relocation, all: "fbe2fb53fc2f5ac4138833d16af72d80e6ee2f8a3ba38b5fa41cf993d5710ea0"
   end
 
-  depends_on "openjdk@11"
+  # Java 11, 17 (Default), and 21 are supported.
+  # See: https://github.com/apache/flink?tab=readme-ov-file#building-apache-flink-from-source
+  depends_on "openjdk@21"
 
   def install
     inreplace "conf/config.yaml" do |s|
-      s.sub!(/^env:/, "env.java.home: #{Language::Java.java_home("11")}\n\\0")
+      s.sub!(/^env:/, "env.java.home: #{Language::Java.java_home("21")}\n\\0")
     end
     libexec.install Dir["*"]
     bin.write_exec_script libexec/"bin/flink"

--- a/Formula/a/apache-flink.rb
+++ b/Formula/a/apache-flink.rb
@@ -14,7 +14,7 @@ class ApacheFlink < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "fbe2fb53fc2f5ac4138833d16af72d80e6ee2f8a3ba38b5fa41cf993d5710ea0"
+    sha256 cellar: :any_skip_relocation, all: "ab20a5e33f83e6aa4d71d256529eefcc5345def0b8c8a1a7de77b177511c1afc"
   end
 
   # Java 11, 17 (Default), and 21 are supported.

--- a/Formula/a/apache-flink@1.rb
+++ b/Formula/a/apache-flink@1.rb
@@ -1,0 +1,42 @@
+class ApacheFlinkAT1 < Formula
+  desc "Scalable batch and stream data processing"
+  homepage "https://flink.apache.org/"
+  url "https://www.apache.org/dyn/closer.lua?path=flink/flink-1.20.1/flink-1.20.1-bin-scala_2.12.tgz"
+  mirror "https://archive.apache.org/dist/flink/flink-1.20.1/flink-1.20.1-bin-scala_2.12.tgz"
+  version "1.20.1"
+  sha256 "5fc4551cd11aee83a9569392339c43fb32a60847db456e1cb4fa64c8daae0186"
+  license "Apache-2.0"
+
+  keg_only :versioned_formula
+
+  depends_on "openjdk@11"
+
+  def install
+    inreplace "conf/config.yaml" do |s|
+      s.sub!(/^env:/, "env.java.home: #{Language::Java.java_home("11")}\n\\0")
+    end
+    libexec.install Dir["*"]
+    bin.write_exec_script libexec/"bin/flink"
+  end
+
+  test do
+    (testpath/"log").mkpath
+    (testpath/"input").write "foo bar foobar"
+    expected = <<~EOS
+      (foo,1)
+      (bar,1)
+      (foobar,1)
+    EOS
+    ENV.prepend "_JAVA_OPTIONS", "-Djava.io.tmpdir=#{testpath}"
+    ENV.prepend "FLINK_LOG_DIR", testpath/"log"
+    system libexec/"bin/start-cluster.sh"
+    system bin/"flink", "run", "-p", "1",
+           libexec/"examples/streaming/WordCount.jar", "--input", testpath/"input",
+           "--output", testpath/"result"
+    system libexec/"bin/stop-cluster.sh"
+    assert_path_exists testpath/"result"
+    result_files = Dir[testpath/"result/*/*"]
+    assert_equal 1, result_files.length
+    assert_equal expected, (testpath/result_files.first).read
+  end
+end

--- a/Formula/a/apache-flink@1.rb
+++ b/Formula/a/apache-flink@1.rb
@@ -7,6 +7,10 @@ class ApacheFlinkAT1 < Formula
   sha256 "5fc4551cd11aee83a9569392339c43fb32a60847db456e1cb4fa64c8daae0186"
   license "Apache-2.0"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, all: "99384bed6ba14959e8215e2eb0ca41df3597021c0b5f1bdac4a952b4d7f74ecb"
+  end
+
   keg_only :versioned_formula
 
   depends_on "openjdk@11"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
[Apache Flink](https://flink.apache.org/) [2.0.0](https://github.com/apache/flink/releases/tag/release-2.0.0) is a major release, and compared to [1.20.1](https://github.com/apache/flink/releases/tag/release-1.20.1), there will be some [breaking changes](https://flink.apache.org/2025/03/24/apache-flink-2.0.0-a-new-era-of-real-time-data-processing/#breaking-changes). The 1.x version will still be widely used in business for the foreseeable future, as both 1.x and 2.x major versions should coexist to provide users with a choice.

#216302