### PR TITLE
chore(nvm): update to bring in sync with nvm manual install instructions

### DIFF
--- a/Formula/n/nvm.rb
+++ b/Formula/n/nvm.rb
@@ -19,6 +19,8 @@ class Nvm < Formula
       [ -e "$NVM_DIR" ] || mkdir -p "$NVM_DIR"
       [ -e "$NVM_DIR/nvm.sh" ] || ln -s #{opt_libexec}/nvm.sh "$NVM_DIR/nvm.sh"
       [ -e "$NVM_DIR/nvm-exec" ] || ln -s #{opt_libexec}/nvm-exec "$NVM_DIR/nvm-exec"
+      # Also symlink bash_completion for consistency with manual install instructions https://github.com/nvm-sh/nvm/blob/master/README.md#manual-install
+      [ -e "$NVM_DIR/bash_completion ] || ln -s #{opt_prefix}/etc/bash_completion.d/nvm "$NVM_DIR/bash_completion"
     SH
     libexec.install "nvm.sh", "nvm-exec"
     prefix.install_symlink libexec/"nvm-exec"
@@ -34,10 +36,10 @@ class Nvm < Formula
       You should create NVM's working directory if it doesn't exist:
         mkdir ~/.nvm
 
-      Add the following to your shell profile e.g. ~/.profile or ~/.zshrc:
+      Add the following to your shell profile e.g. ~/.profile, ~/.bashrc, or ~/.zshrc:
         export NVM_DIR="$HOME/.nvm"
-        [ -s "#{opt_prefix}/nvm.sh" ] && \\. "#{opt_prefix}/nvm.sh"  # This loads nvm
-        [ -s "#{opt_prefix}/etc/bash_completion.d/nvm" ] && \\. "#{opt_prefix}/etc/bash_completion.d/nvm"  # This loads nvm bash_completion
+        [ -s "$NVM_DIR/nvm.sh" ] && \\. "$NVM_DIR/nvm.sh"  # This loads nvm
+        [ -s "$NVM_DIR/bash_completion" ] && \\. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
 
       You can set $NVM_DIR to any location, but leaving it unchanged from
       #{prefix} will destroy any nvm-installed Node installations


### PR DESCRIPTION
The [official install instructions](https://github.com/nvm-sh/nvm/blob/master/README.md#manual-install), while they discourage installing from brew, should at least match what's being asked in the caveats, otherwise the bash completion (if it exists from a prior manual install) will compete with the brew install.

This also enables post install scripts to check for the presence of these lines and they'll always be correct (because they match).

Note: does nothing to update existing installs

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
