### PR TITLE
libva: update drivers path, update test

### DIFF
--- a/Formula/lib/libva.rb
+++ b/Formula/lib/libva.rb
@@ -31,6 +31,7 @@ class Libva < Formula
                           "--enable-x11",
                           "--disable-glx",
                           "--enable-wayland",
+                          "--with-drivers-path=#{HOMEBREW_PREFIX}/lib/dri",
                           *std_configure_args
     system "make"
     system "make", "install"
@@ -40,10 +41,14 @@ class Libva < Formula
     %w[libva libva-drm libva-wayland libva-x11].each do |name|
       assert_match "-I#{include}", shell_output("pkgconf --cflags #{name}")
     end
+
+    # We cannot run a functional test without a VA-API driver; however, the
+    # drivers have a dependency on `libva` which results in a dependency loop
     (testpath/"test.c").write <<~C
+      #include <stddef.h>
       #include <va/va.h>
       int main(int argc, char *argv[]) {
-        VADisplay display;
+        VADisplay display = NULL;
         vaDisplayIsValid(display);
         return 0;
       }

--- a/Formula/lib/libva.rb
+++ b/Formula/lib/libva.rb
@@ -11,7 +11,8 @@ class Libva < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "f09fc392caac089c8689d89ccbfd9bea27689afd747313e84ff59ca21f339b78"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "159b556ea708ad404ef2716f18c3e135e285b3f55be0ca01905fc4205b48cc24"
   end
 
   depends_on "pkgconf" => [:build, :test]


### PR DESCRIPTION
Default drivers path is `#{lib}/dri` which will never have drivers - https://github.com/intel/libva/blob/master/configure.ac#L171
```
    [], [with_drivers_path="$libdir/dri"])
```

Within Homebrew/core, we mainly use Mesa drivers which will be linked at the updated path.

Could consider adding path to (potentially more optimal) system drivers. Main downside is it requires taking into account multiple different distro paths, e.g.
* Debian is multiarch so `/usr/lib/$(uname -m)-linux-gnu/dri`
* Arch Linux is not so `/usr/lib/dri`

There is an easy environment variable override via `LIBVA_DRIVERS_PATH` so may just ignore for now and reconsider if enough users prefer system drivers automatically detected.

---

Also checking if test relies on UB, i.e. is it assuming the default pointer is NULL. 