### PR TITLE
freeglut: workaround for CMake 4, update to renamed org

### DIFF
--- a/Formula/f/freeglut.rb
+++ b/Formula/f/freeglut.rb
@@ -1,7 +1,7 @@
 class Freeglut < Formula
   desc "Open-source alternative to the OpenGL Utility Toolkit (GLUT) library"
   homepage "https://freeglut.sourceforge.net/"
-  url "https://github.com/FreeGLUTProject/freeglut/releases/download/v3.6.0/freeglut-3.6.0.tar.gz"
+  url "https://github.com/freeglut/freeglut/releases/download/v3.6.0/freeglut-3.6.0.tar.gz"
   sha256 "9c3d4d6516fbfa0280edc93c77698fb7303e443c1aaaf37d269e3288a6c3ea52"
   license "MIT"
 
@@ -35,7 +35,10 @@ class Freeglut < Formula
   end
 
   def install
+    # Can remove cmake policy minimum in next release
+    # https://github.com/freeglut/freeglut/commit/2294389397912c9a6505a88221abb7dca0a4fb79
     args = %W[
+      -DCMAKE_POLICY_VERSION_MINIMUM=3.5
       -DFREEGLUT_BUILD_DEMOS=OFF
       -DOPENGL_INCLUDE_DIR=#{Formula["mesa"].include}
       -DOPENGL_gl_LIBRARY=#{Formula["mesa"].lib/shared_library("libGL")}


### PR DESCRIPTION
```
❯ curl -sI https://github.com/FreeGLUTProject/freeglut | grep location
location: https://github.com/freeglut/freeglut
```