### PR TITLE
fancy-cat ncdu zls: target xgene1 on arm64 Linux as closest to `-march=armv8-a`

### DIFF
--- a/Formula/f/fancy-cat.rb
+++ b/Formula/f/fancy-cat.rb
@@ -21,9 +21,10 @@ class FancyCat < Formula
   def install
     # Fix illegal instruction errors when using bottles on older CPUs.
     # https://github.com/Homebrew/homebrew-core/issues/92282
-    cpu = case Hardware.oldest_cpu
+    cpu = case ENV.effective_arch
     when :arm_vortex_tempest then "apple_m1" # See `zig targets`.
-    else Hardware.oldest_cpu
+    when :armv8 then "xgene1" # Closest to `-march=armv8-a`
+    else ENV.effective_arch
     end
 
     args = []

--- a/Formula/n/ncdu.rb
+++ b/Formula/n/ncdu.rb
@@ -29,9 +29,10 @@ class Ncdu < Formula
   def install
     # Fix illegal instruction errors when using bottles on older CPUs.
     # https://github.com/Homebrew/homebrew-core/issues/92282
-    cpu = case Hardware.oldest_cpu
+    cpu = case ENV.effective_arch
     when :arm_vortex_tempest then "apple_m1" # See `zig targets`.
-    else Hardware.oldest_cpu
+    when :armv8 then "xgene1" # Closest to `-march=armv8-a`
+    else ENV.effective_arch
     end
 
     args = []

--- a/Formula/z/zls.rb
+++ b/Formula/z/zls.rb
@@ -20,9 +20,10 @@ class Zls < Formula
   def install
     # Fix illegal instruction errors when using bottles on older CPUs.
     # https://github.com/Homebrew/homebrew-core/issues/92282
-    cpu = case Hardware.oldest_cpu
+    cpu = case ENV.effective_arch
     when :arm_vortex_tempest then "apple_m1" # See `zig targets`.
-    else Hardware.oldest_cpu
+    when :armv8 then "xgene1" # Closest to `-march=armv8-a`
+    else ENV.effective_arch
     end
 
     args = []


### PR DESCRIPTION
X-Gene 1 is only CPU target that does not enable extra extensions like crc. This does mean it is less optimal for the average user but our official baseline target on ARM64 Linux is armv8-a. The CPU target can be adjusted to cortex_a34 or cortex_a35 if we change our official baseline to require `aes+crc+sha2`, which is available on pretty much all other ARMv8 CPUs other than X-Gene 1.

---

zig targets output shows xgene1 as pretty much `-march=armv8-a`
```
            .xgene1 = .{
                "perfmon",
                "v8a",
            },
```

And cortex_a34/a35 as allowing up to `-march=armv8-a+crc+aes+sha2` (which is more than baseline but not `-march=armv8.1-a`)
```
            .cortex_a34 = .{
                "aes",
                "crc",
                "perfmon",
                "sha2",
                "v8a",
            },
            .cortex_a35 = .{
                "aes",
                "crc",
                "perfmon",
                "sha2",
                "v8a",
            },
```

---

Also use `ENV.effective_cpu` so that `--bottle-arch` works as expected.