### PR TITLE
seexpr: update test for arm64 linux

### DIFF
--- a/Formula/s/seexpr.rb
+++ b/Formula/s/seexpr.rb
@@ -52,7 +52,7 @@ class Seexpr < Formula
 
   test do
     actual_output = shell_output("#{bin}/asciiGraph2 'x^3-8*x'").lines.map(&:rstrip).join("\n")
-    roundoff = "#" if Hardware::CPU.arm? && OS.mac? && MacOS.version >= :ventura
+    roundoff = "#" if Hardware::CPU.arm? && (!OS.mac? || MacOS.version >= :ventura)
     expected_output = <<~EOS
                                     |        #
                               ##    |        #
@@ -86,6 +86,6 @@ class Seexpr < Formula
                           #         |
     EOS
 
-    assert_equal actual_output, expected_output.rstrip
+    assert_equal expected_output.rstrip, actual_output
   end
 end


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-core/actions/runs/14234192576/job/39890467735#step:5:73

```
 ==> /home/linuxbrew/.linuxbrew/Cellar/seexpr/3.0.1/bin/asciiGraph2 'x^3-8*x'
  Error: seexpr: failed
  An exception occurred within a child process:
    Minitest::Assertion: --- expected
  +++ actual
  @@ -25,6 +25,6 @@
                       #         | #   #
                       #         | ##  #
                       #         |  #  #
  -                              |  ####
  +                              |  ###
                       #         |   ##
                       #         |"
  ```