### PR TITLE
liquid-dsp: backport fix for arm64 linux

### DIFF
--- a/Formula/l/liquid-dsp.rb
+++ b/Formula/l/liquid-dsp.rb
@@ -18,6 +18,12 @@ class LiquidDsp < Formula
   depends_on "automake" => :build
   depends_on "fftw"
 
+  # Backport fix for ARM64 Linux
+  patch do
+    url "https://github.com/jgaeddert/liquid-dsp/commit/3a5e1f578ad5e73d7665e71781e764765608c2a2.patch?full_index=1"
+    sha256 "8dcece1e5e612b5dad77030dfd453f0f47755fdb41e6201c0c8b6b7123f053b9"
+  end
+
   def install
     system "./bootstrap.sh"
     system "./configure", "--prefix=#{prefix}"


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-core/actions/runs/14003016706/job/39212796765
```
  gcc-11 -g -O2  -ffast-math -mcpu=cortex-a7 -mfloat-abi=hard -mfpu=neon-vfpv4  -Wall -fPIC -Wno-deprecated -Wno-deprecated-declarations -I. -I./include  -c -o src/audio/src/cvsd.o src/audio/src/cvsd.c
  gcc-11: error: unrecognized command-line option ‘-mfloat-abi=hard’
  gcc-11: error: unrecognized command-line option ‘-mfloat-abi=hard’
  gcc-11: error: unrecognized command-line option ‘-mfloat-abi=hard’
  gcc-11: error: unrecognized command-line option ‘-mfloat-abi=hard’
  gcc-11: error: unrecognized command-line option ‘-mfpu=neon-vfpv4’
  gcc-11: error: unrecognized command-line option ‘-mfpu=neon-vfpv4’
  gcc-11: error: unrecognized command-line option ‘-mfpu=neon-vfpv4’
  gcc-11: error: unrecognized command-line option ‘-mfpu=neon-vfpv4’
```