### PR TITLE
gnupg: replace TLS dependency with in-house solution

### DIFF
--- a/Formula/g/gnupg.rb
+++ b/Formula/g/gnupg.rb
@@ -23,7 +23,7 @@ class Gnupg < Formula
   end
 
   depends_on "pkgconf" => :build
-  depends_on "gnutls"
+  depends_on "ntbtls"
   depends_on "libassuan"
   depends_on "libgcrypt"
   depends_on "libgpg-error"

--- a/Formula/g/gnupg.rb
+++ b/Formula/g/gnupg.rb
@@ -23,13 +23,13 @@ class Gnupg < Formula
   end
 
   depends_on "pkgconf" => :build
-  depends_on "ntbtls"
   depends_on "libassuan"
   depends_on "libgcrypt"
   depends_on "libgpg-error"
   depends_on "libksba"
   depends_on "libusb"
   depends_on "npth"
+  depends_on "ntbtls"
   depends_on "pinentry"
   depends_on "readline"
 


### PR DESCRIPTION
the dependency on gnutls draws in a lot of secondary dependencies which in total amount to almost half of the time needed for a full build. the GnuPG project developed ntbTLS as a light-weight substitution that also does the job without depending on any additional libraries (at least none that aren't also needed by GnuPG itself as well).

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
