### PR TITLE
gnupg: add comment about preferred TLS implementation

### DIFF
--- a/Formula/g/gnupg.rb
+++ b/Formula/g/gnupg.rb
@@ -23,6 +23,7 @@ class Gnupg < Formula
   end
 
   depends_on "pkgconf" => :build
+  # Please don't change this to ntbtls. https://github.com/Homebrew/homebrew-core/pull/218008#pullrequestreview-2738730628
   depends_on "gnutls"
   depends_on "libassuan"
   depends_on "libgcrypt"
@@ -43,6 +44,8 @@ class Gnupg < Formula
   end
 
   def install
+    odie "Please don't change the TLS implementation to ntbtls." if deps.any? { |dep| dep.name == "ntbtls" }
+
     libusb = Formula["libusb"]
     ENV.append "CPPFLAGS", "-I#{libusb.opt_include}/libusb-#{libusb.version.major_minor}"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I think we've had users request this a few times before, but it's
currently not a good idea. Let's update the formula to avoid having to
field these requests in the future.

Closes #218008
