### PR TITLE
gopass: disable `-buildmode=pie` on Linux

### DIFF
--- a/Formula/g/gopass.rb
+++ b/Formula/g/gopass.rb
@@ -23,7 +23,11 @@ class Gopass < Formula
   end
 
   def install
-    system "make", "install", "PREFIX=#{prefix}/"
+    args = ["PREFIX=#{prefix}/"]
+    # Build without -buildmode=pie to avoid patchelf.rb corrupting binary
+    args << "BUILDFLAGS=$(BUILDFLAGS_NOPIE)" if OS.linux?
+
+    system "make", "install", *args
 
     bash_completion.install "bash.completion" => "gopass"
     fish_completion.install "fish.completion" => "gopass.fish"


### PR DESCRIPTION
Need to test if this works on x86_64 Linux. I think the resulting binary should be statically linked using pure Go equivalents to C libraries so will bypass the patchelf.rb logic.

Can consider switching to CGO if we ever fix the patchelf issue but this has been a known issue for a while now.