### PR TITLE
ospray: workaround for CMake 4 and ISPC linked to newer LLVM

### DIFF
--- a/Formula/o/ospray.rb
+++ b/Formula/o/ospray.rb
@@ -38,17 +38,14 @@ class Ospray < Formula
   end
 
   def install
-    # Work around an Xcode 15 linker issue which causes linkage against LLVM's
-    # libunwind due to it being present in a library search path.
-    if DevelopmentTools.clang_build_version >= 1500
-      ENV.remove "HOMEBREW_LIBRARY_PATHS",
-                 Formula["ispc"].deps.map(&:to_formula).find { |f| f.name.match? "^llvm" }.opt_lib
-    end
+    # Workaround for newer `ispc` + `llvm` until support is added
+    inreplace "cmake/compiler/ispc.cmake", "define_ispc_isa_options(AVX512KNL avx512knl-x16)", ""
 
     resources.each do |r|
       r.stage do
         args = %W[
           -DCMAKE_INSTALL_NAME_DIR=#{lib}
+          -DCMAKE_POLICY_VERSION_MINIMUM=3.5
           -DBUILD_EXAMPLES=OFF
         ]
         system "cmake", "-S", ".", "-B", "build", *std_cmake_args, *args


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
