### PR TITLE
sdl2: build with OpenGL support on Linux

### DIFF
--- a/Formula/s/sdl2.rb
+++ b/Formula/s/sdl2.rb
@@ -11,13 +11,14 @@ class Sdl2 < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "b942fa2153404b4ddb138153432d57a09715f1a66e5ce76b05d838e1980b6e98"
-    sha256 cellar: :any,                 arm64_sonoma:  "bd16f10d59f32856cc2a39f82752f988300efa56a0b0f836f1c18bad4715781b"
-    sha256 cellar: :any,                 arm64_ventura: "a64929baa62d649a79c64107a942c48ef659d8504c59d896137f8758abfa28e4"
-    sha256 cellar: :any,                 sonoma:        "61f9b4812e65459c46e3b16694afdc85352b4d4352e006f76c7aa2c3e2278720"
-    sha256 cellar: :any,                 ventura:       "1f3d11654b35815f560b1d6dd515b2776c2a23ab8a11b30ccac8a12bac602c12"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "6948b8e27ab47ce22a27133198c1fb37847361bbc7225ef745b28350b69f650a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "6a6b8538e6e4bbf03fd2b9117424fc1ebb444ece7cdcf02d3bc8afa30ec12af9"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "7aa4224b56ceddc46eedc4cf805ac236fe2d5a5b5b33a93a69b5471dfa43d691"
+    sha256 cellar: :any,                 arm64_sonoma:  "b61af37727abc55b55dbe2baf1b8ec02c3cd85e66afa98f6db440343a21cd4b0"
+    sha256 cellar: :any,                 arm64_ventura: "aa9658eed3e2e5634d2ce24f544684d13b8059aa2c5bd99a9f02f043c96ea6c4"
+    sha256 cellar: :any,                 sonoma:        "f7e2133875018fdfa8221bc9084b3043b4149cdae850a1c731409f6cf8f3f5bb"
+    sha256 cellar: :any,                 ventura:       "8ad8dff987ec56ff7633cb1dccd8c57fecd1e2450ea01ba711f4f49f24d629ca"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "bccbecc2057a6d8cddc312150a6988b980fb7579f74b4f7cc233fa2909b3b8fb"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "68c49d05f60cafbe2c9f4a75901a5c2513c43327f0a3b8921ec44008249b66e2"
   end
 
   head do

--- a/Formula/s/sdl2.rb
+++ b/Formula/s/sdl2.rb
@@ -29,13 +29,17 @@ class Sdl2 < Formula
   end
 
   on_linux do
+    depends_on "mesa" => :build
     depends_on "pkgconf" => :build
-    depends_on "libice"
+    depends_on "alsa-lib"
+    depends_on "libx11"
     depends_on "libxcursor"
+    depends_on "libxext"
+    depends_on "libxfixes"
+    depends_on "libxi"
+    depends_on "libxrandr"
     depends_on "libxscrnsaver"
-    depends_on "libxxf86vm"
     depends_on "pulseaudio"
-    depends_on "xinput"
   end
 
   def install
@@ -60,7 +64,6 @@ class Sdl2 < Formula
         --enable-video-x11
         --enable-video-x11-scrnsaver
         --enable-video-x11-xcursor
-        --enable-video-x11-xinerama
         --enable-video-x11-xinput
         --enable-video-x11-xrandr
         --enable-video-x11-xshape


### PR DESCRIPTION
Needed by some dependents like PPSSPP.

Features are dynamically loaded so can avoid runtime dependency to reduce dependency trees. 

Also remove unsupported `--enable-video-x11-xinerama` - https://github.com/libsdl-org/SDL/commit/7d7ec9c95146c44d4b4643ed552796bf07937057

---

EDIT: added all the indirect but linked dependencies, which were seen in prior PRs.

Dropped some dependencies:
* `xinput` - I think we want `libxi` instead as the former is an executable/CLI while latter is the library
* `libxxf86vm` - didn't see anything related to this upstream or in Linux distros
* `libice` - mainly seems to be detected along with `libSM` which we don't have as dependency. Didn't find any Linux distro using this.