### PR TITLE
intercal: backport fix for GCC 10+

### DIFF
--- a/Formula/i/intercal.rb
+++ b/Formula/i/intercal.rb
@@ -1,9 +1,18 @@
 class Intercal < Formula
   desc "Esoteric, parody programming language"
   homepage "http://catb.org/~esr/intercal/"
-  url "http://catb.org/~esr/intercal/intercal-0.31.tar.gz"
-  sha256 "93d842b81ecdc82b352beb463fbf688749b0c04445388a999667e1958bba4ffc"
   license "GPL-2.0-or-later"
+
+  stable do
+    url "http://catb.org/~esr/intercal/intercal-0.31.tar.gz"
+    sha256 "93d842b81ecdc82b352beb463fbf688749b0c04445388a999667e1958bba4ffc"
+
+    # Backport fix for GCC 10 and newer
+    patch do
+      url "https://gitlab.com/esr/intercal/-/commit/f33a8f3a96e955a6eb3e8db850d0edac44c22176.diff"
+      sha256 "2cd1be13f779a0fd93aa3c50e1dbf62596b81727c539674d872b4e912ad62a55"
+    end
+  end
 
   # The latest version tags in the Git repository are `0.31` (2019-06-12) and
   # `0.30` (2015-04-02) but there are older versions like `1.27` (2010-08-25)


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
