### PR TITLE
zorba: use `:does_not_build` to hide from bottling tracker

### DIFF
--- a/Formula/z/zorba.rb
+++ b/Formula/z/zorba.rb
@@ -16,7 +16,7 @@ class Zorba < Formula
 
   # https://github.com/28msec/zorba/issues/232
   # no longer build due to `'boost/filesystem/convenience.hpp' file not found`
-  disable! date: "2025-05-01", because: :unmaintained
+  disable! date: "2025-05-01", because: :does_not_build
 
   depends_on "cmake" => :build
   depends_on "openjdk" => :build


### PR DESCRIPTION
We avoid tracking `:does_not_build` formulae in our mass bottling tracker as not possible to bottle these. Zorba is currently in this state after various updates like CMake 4.