### PR TITLE
simdutf: change test for Linux

### DIFF
--- a/Formula/s/simdutf.rb
+++ b/Formula/s/simdutf.rb
@@ -48,6 +48,6 @@ class Simdutf < Formula
   end
 
   test do
-    system bin/"sutf-benchmark", "--random-utf8", "1024", "-I", "20"
+    system bin/"sutf-benchmark", "--random-utf8", "10240", "-I", "100"
   end
 end


### PR DESCRIPTION
Not sure why other run gets stuck but this example is shown in `--help` output
```
Examples:

    # test all known UTF8 procedures against 10k random input (in 100 iterations)
    $ benchmark --random-utf8 10240 -I 100
```