### PR TITLE
strongswan: workaround patchelf.rb bug on Linux

### DIFF
--- a/Formula/s/strongswan.rb
+++ b/Formula/s/strongswan.rb
@@ -34,6 +34,10 @@ class Strongswan < Formula
   uses_from_macos "curl"
 
   def install
+    # Work around RPATH modifications corrupting binary. Upstream patchelf fixed this issue
+    # https://github.com/NixOS/patchelf/issues/315 but it may be missing in patchelf.rb
+    ENV.append_path "HOMEBREW_RPATH_PATHS", libexec if OS.linux?
+
     args = %W[
       --sbindir=#{bin}
       --sysconfdir=#{etc}


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
