### PR TITLE
rust: add caveats

### DIFF
--- a/Formula/r/rust.rb
+++ b/Formula/r/rust.rb
@@ -222,6 +222,16 @@ class Rust < Formula
     end
   end
 
+  def caveats
+    <<~EOS
+      Link this toolchain with `rustup` under the name `system` with:
+        rustup toolchain link system "$(brew --prefix rust)"
+
+      If you use rustup, avoid PATH conflicts by following instructions in:
+        brew info rustup
+    EOS
+  end
+
   test do
     require "utils/linkage"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Hello, it's me again on behalf of the rustup team here!

We have noticed a common issue with a regular `brew` user developing with Rust:
1. They often start with a perfectly fine `rustup` installation (either installed with or without `brew`).
2. After issuing `brew install rust` (usually implicitly as a build dependency), the binaries provided by that package will __shadow__ existing `rustup`-provided binaries.
3. The existing `rustup`-installed toolchains/components might [seem "gone"](https://users.rust-lang.org/t/solved-feature-gates-not-working-even-when-using-nightly-compiler-error-e0554-feature-may-not-be-used-on-the-stable-release-channel/114718), causing subtle breakages that are essentially out of our control.

We already have warnings when `brew install rust` happens __before__ `rustup` is installed, but unfortunately checking the existence of a `brew`-managed Rust installation will be much more costly afterwards, so I'm making this PR hoping to further inform potential users of this conflict in the **"after"** case.

Hopefully closes https://github.com/rust-lang/rustup/issues/1236.