### PR TITLE
cargo-outdated: update to use libgit2 1.9

### DIFF
--- a/Formula/c/cargo-outdated.rb
+++ b/Formula/c/cargo-outdated.rb
@@ -8,13 +8,13 @@ class CargoOutdated < Formula
   head "https://github.com/kbknapp/cargo-outdated.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "2f07c8770e65c22709f66c88803d731f49dae9701d0cdb09e7a03ad5f20975b5"
-    sha256 cellar: :any,                 arm64_sonoma:  "70fa28d6d29ed7ffc72e9af5d542b2667ccddc786df36bed40fa97f5cfe12481"
-    sha256 cellar: :any,                 arm64_ventura: "b0b0f15665c9067c04f268639baef2476eef8f699cb47aa39e63d543186cf072"
-    sha256 cellar: :any,                 sonoma:        "30888f6e8ae69512bf0486d81336aded2f20af9593cc52311fc1ef7f41788e2f"
-    sha256 cellar: :any,                 ventura:       "1d6290123b277fcf587e45778af8bdc5a5fc3c8426c416a67c633c9f3fb931d5"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "a20abb07d2ff9f3e38e12f6b27bb14a4e0de856d7330c1519a97193ea7f85761"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3987240911e43c2dc506aa9d1ca75e41867554e89e40536da5825aa060495059"
+    sha256 cellar: :any,                 arm64_sequoia: "acdcb7ecd3db5e0b5a0d279d33f3f308d9180a9f434ff4f01f2ad2dd075db7d0"
+    sha256 cellar: :any,                 arm64_sonoma:  "d54403dea4e7474a13d95f37c4df3cf620391e920c72ddc814b614abc15e31d3"
+    sha256 cellar: :any,                 arm64_ventura: "63f180c145002e1906a6cb979b706167b51ad49d1a5d04aa4e9b47722a2ca306"
+    sha256 cellar: :any,                 sonoma:        "fe719091f6604bb307a67e5dc40a1834a2c6c00be1d709d0b39e608e34eb62f9"
+    sha256 cellar: :any,                 ventura:       "9969c6842f7ada5d69bbd34cf5922b4ae2b5d43814234b0b9c6c29401977bed8"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "394f86740d2621697b1bcf853741e7d35f37934dbec121896e139fe5ca1a897b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "16e44c82524d478341c722f1837ebb9d82807fb556e2074a0675e44bfff7b79f"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/c/cargo-outdated.rb
+++ b/Formula/c/cargo-outdated.rb
@@ -4,6 +4,7 @@ class CargoOutdated < Formula
   url "https://github.com/kbknapp/cargo-outdated/archive/refs/tags/v0.17.0.tar.gz"
   sha256 "6c1c6914f34d3c0d9ebf26b74224fa6744a374e876b35f9836193c2b03858fa4"
   license "MIT"
+  revision 1
   head "https://github.com/kbknapp/cargo-outdated.git", branch: "master"
 
   bottle do
@@ -19,10 +20,21 @@ class CargoOutdated < Formula
   depends_on "pkgconf" => :build
   depends_on "rust" => :build
   depends_on "rustup" => :test
-  depends_on "libgit2@1.8" # needs https://github.com/rust-lang/git2-rs/issues/1109 to support libgit2 1.9
+  depends_on "libgit2"
   depends_on "openssl@3"
 
   uses_from_macos "zlib"
+
+  # libgit2 1.9 patch, upstream pr ref, https://github.com/kbknapp/cargo-outdated/pull/417
+  patch do
+    url "https://github.com/kbknapp/cargo-outdated/commit/67213eb08b60f402d543d4b2aeb79f813f1ade5e.patch?full_index=1"
+    sha256 "712df30c8293327848e5156df8524f60fb425c9d397f954d88c5d31c36189a79"
+  end
+  # cargo 0.87 update
+  patch do
+    url "https://github.com/kbknapp/cargo-outdated/commit/9c766bf49d37fc2d3fc19ee6b06c4b022c7138a1.patch?full_index=1"
+    sha256 "5d3d1361804eb64272eb8d88110eeafbf998eff4262687989164b0d32e0c2225"
+  end
 
   def install
     ENV["LIBGIT2_NO_VENDOR"] = "1"
@@ -63,7 +75,7 @@ class CargoOutdated < Formula
     end
 
     [
-      Formula["libgit2@1.8"].opt_lib/shared_library("libgit2"),
+      Formula["libgit2"].opt_lib/shared_library("libgit2"),
       Formula["openssl@3"].opt_lib/shared_library("libssl"),
       Formula["openssl@3"].opt_lib/shared_library("libcrypto"),
     ].each do |library|


### PR DESCRIPTION


```
==> Pouring cargo-outdated--0.17.0.arm64_sequoia.bottle.tar.gz
Broken dependencies:
  /opt/homebrew/opt/libgit2@1.8/lib/libgit2.1.8.dylib (libgit2@1.8)
```

---

- #218030 