### PR TITLE
bind: fix for macOS 15.4+ libxml2

### DIFF
--- a/Formula/b/bind.rb
+++ b/Formula/b/bind.rb
@@ -32,13 +32,13 @@ class Bind < Formula
   end
 
   bottle do
-    sha256 arm64_sequoia: "475a19780d6d715095643e643e29234fc4a8957fdf5fe0771804b90ca2dd5c73"
-    sha256 arm64_sonoma:  "3543326f334022fe41d3ad73c307245b300ac1a1cfe95af00a58035923b4b3f3"
-    sha256 arm64_ventura: "cb80d80f5611f36f33133d685ec183a48157243a81ff5b753f5c95316605e9b2"
-    sha256 sonoma:        "58d1065019d4c9fa3aa6f1cdaa8dc9d0de38a584849319dc765dd2bb057db0f5"
-    sha256 ventura:       "9a4908c982aba2d52f16de4110a1d88fe00cc122694b655dfa02de3983b1d99d"
-    sha256 arm64_linux:   "0e003c29242ddc0b9fdb7180cb6266fb09ce4af72aac1aca0429a560e4c9d1f4"
-    sha256 x86_64_linux:  "eeab5b333e38bf01971fc4597bb4580cd131a78780d77e835a3f92f75abf2859"
+    sha256 arm64_sequoia: "e80ed22d86c4a5fef6c89e8bbfab65269a71032a6a52b6bb103a9685013d9ede"
+    sha256 arm64_sonoma:  "38364bf644834e6a254362c1b5e417ccb0830fc480dcfec917fe595b6bab7ff4"
+    sha256 arm64_ventura: "4c1dbe0b4db181ef597737f90bdee2ee232d5fecef83a1c2a0824d72ae0e60e0"
+    sha256 sonoma:        "ff24146494d636c33df4eb670bc0e28937234bb198653041fefa946daffe3a5d"
+    sha256 ventura:       "1f06f5ec73358e4b89c7b287fad3dfd816a3aea1d913a91c3b8e6bd46205555f"
+    sha256 arm64_linux:   "99756495e4d5931d4d5decbee54f21d256bec8129013fa1e5ce7cdb70db385ed"
+    sha256 x86_64_linux:  "9095b82ecd97dc33b68c941b38f5c18b55d598b4b9becb265ebab304d952263e"
   end
 
   depends_on "pkgconf" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

See
- https://gitlab.isc.org/isc-projects/bind9/-/merge_requests/10374
- https://gitlab.isc.org/isc-projects/bind9/-/issues/5268

Closes #217127
