### PR TITLE
primer3: remove unneeded workaround

### DIFF
--- a/Formula/p/primer3.rb
+++ b/Formula/p/primer3.rb
@@ -23,9 +23,6 @@ class Primer3 < Formula
   end
 
   def install
-    # workaround for `thal.c:429:13: error: ISO C++ forbids comparison between pointer and integer`
-    ENV.append_to_cflags "-fpermissive" if OS.linux?
-
     system "make", "-C", "src", "install", "PREFIX=#{prefix}"
     pkgshare.install "src/primer3_config"
     prefix.install "src/LICENSE_GPL3_for_Amplicon3"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This shouldn't be needed any more as of version 2.6.1 (previous ARM64 bottling failure was with 2.4.0).
