### PR TITLE
ext2fuse: x86_64-only

### DIFF
--- a/Formula/e/ext2fuse.rb
+++ b/Formula/e/ext2fuse.rb
@@ -14,6 +14,7 @@ class Ext2fuse < Formula
   # Last release on 2008-06-26. Needs `libfuse@2` and patches to build
   deprecate! date: "2025-03-06", because: :unmaintained
 
+  depends_on arch: :x86_64
   depends_on "e2fsprogs"
   depends_on "libfuse@2"
   depends_on :linux # on macOS, requires closed-source macFUSE


### PR DESCRIPTION
I tried removing `ENV.append "CFLAGS", "-D__i386__"` (to avoid assembly) but compilation fails.
