### PR TITLE
github-mcp-server 0.1.0 (new formula)

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -1240,6 +1240,7 @@ gitbucket
 gitea
 github-keygen
 github-markdown-toc
+github-mcp-server
 gitlab-ci-local
 gitlab-gem
 gitlab-runner

--- a/Formula/g/github-mcp-server.rb
+++ b/Formula/g/github-mcp-server.rb
@@ -6,6 +6,15 @@ class GithubMcpServer < Formula
   license "MIT"
   head "https://github.com/github/github-mcp-server.git", branch: "main"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "b12e2c4b32871e8241c09948c1d0ce05a846c5fe9cafba7c0a40f7304b34a85d"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "b12e2c4b32871e8241c09948c1d0ce05a846c5fe9cafba7c0a40f7304b34a85d"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "b12e2c4b32871e8241c09948c1d0ce05a846c5fe9cafba7c0a40f7304b34a85d"
+    sha256 cellar: :any_skip_relocation, sonoma:        "7cd2b8a16a9e8999dbf8e81336b0d5fcaac2131751b37346552dabd8f45a0a05"
+    sha256 cellar: :any_skip_relocation, ventura:       "7cd2b8a16a9e8999dbf8e81336b0d5fcaac2131751b37346552dabd8f45a0a05"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2d6ad198b094bfa987704270f64036fe3795cee439f863c97fc11c885d84c90f"
+  end
+
   depends_on "go" => :build
 
   def install

--- a/Formula/g/github-mcp-server.rb
+++ b/Formula/g/github-mcp-server.rb
@@ -1,0 +1,36 @@
+class GithubMcpServer < Formula
+  desc "GitHub Model Context Protocol server for AI tools"
+  homepage "https://github.com/github/github-mcp-server"
+  url "https://github.com/github/github-mcp-server/archive/refs/tags/v0.1.0.tar.gz"
+  sha256 "c390bcf344802f8ac81c65e5fcb72b9c47dba4090cec1bb08698311e334d399b"
+  license "MIT"
+  head "https://github.com/github/github-mcp-server.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = "-s -w -X main.version=#{version} -X main.commit=#{tap.user} -X main.date=#{time.iso8601}"
+    system "go", "build", *std_go_args(ldflags:), "./cmd/github-mcp-server"
+
+    generate_completions_from_executable(bin/"github-mcp-server", "completion")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/github-mcp-server --version")
+
+    ENV["GITHUB_PERSONAL_ACCESS_TOKEN"] = "test"
+
+    json = <<~JSON
+      {
+        "jsonrpc": "2.0",
+        "id": 3,
+        "params": {
+          "name": "get_me"
+        },
+        "method": "tools/call"
+      }
+    JSON
+
+    assert_match "GitHub MCP Server running on stdio", pipe_output(bin/"github-mcp-server stdio 2>&1", json, 0)
+  end
+end


### PR DESCRIPTION
This pull request introduces a new formula for the `github-mcp-server` to the Homebrew repository. The formula defines how to install the `github-mcp-server` using Homebrew, including its dependencies, build process, and a basic test to verify the installation.

Key changes include:

* Added a new formula file `Formula/g/github-mcp-server.rb` to define the installation process for `github-mcp-server`, including metadata such as description, homepage, URL, SHA256 checksum, and license.
* Specified `go` as a build dependency for the formula.
* Implemented the `install` method to build the `github-mcp-server` using Go and install it using standard Go arguments.
* Added a test block to verify the installation by running the `--help` command and checking the output.<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
