### PR TITLE
excalidraw-converter: update test and livecheck, fix version cmd

### DIFF
--- a/Formula/e/excalidraw-converter.rb
+++ b/Formula/e/excalidraw-converter.rb
@@ -7,12 +7,13 @@ class ExcalidrawConverter < Formula
   head "https://github.com/sindrel/excalidraw-converter.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "232799c1eace60fbb1b564d9776886298787f41cd52a2150a58f0317edca51e6"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "232799c1eace60fbb1b564d9776886298787f41cd52a2150a58f0317edca51e6"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "232799c1eace60fbb1b564d9776886298787f41cd52a2150a58f0317edca51e6"
-    sha256 cellar: :any_skip_relocation, sonoma:        "7aa2c9c73b93580c2130fe265b71560226e81851cc52af89afab925e68e487f7"
-    sha256 cellar: :any_skip_relocation, ventura:       "7aa2c9c73b93580c2130fe265b71560226e81851cc52af89afab925e68e487f7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "492b6c807da8de021656772482d817deefac81c1b859d3fd919342b1c26dc134"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "feacb7917a2b592fbef4e2ed7c09b6fc5e6ba0d190b8d6acf6d6a15176147c6d"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "feacb7917a2b592fbef4e2ed7c09b6fc5e6ba0d190b8d6acf6d6a15176147c6d"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "feacb7917a2b592fbef4e2ed7c09b6fc5e6ba0d190b8d6acf6d6a15176147c6d"
+    sha256 cellar: :any_skip_relocation, sonoma:        "6334ab45ea587fbcc8a3ff78c17c9f825e861136332a579bf4d89623df61a23a"
+    sha256 cellar: :any_skip_relocation, ventura:       "6334ab45ea587fbcc8a3ff78c17c9f825e861136332a579bf4d89623df61a23a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "751c2615c2b14ce1d83ab9e837db24aa967d433a939411245aee99efbc4dddd3"
   end
 
   depends_on "go" => :build

--- a/Formula/e/excalidraw-converter.rb
+++ b/Formula/e/excalidraw-converter.rb
@@ -18,18 +18,20 @@ class ExcalidrawConverter < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args(ldflags: "-s -w")
+    system "go", "build", *std_go_args(ldflags: "-s -w -X diagram-converter/cmd.version=#{version}")
     bin.install_symlink "excalidraw-converter" => "exconv"
   end
 
   test do
-    resource "test_input.excalidraw" do
-      url "https://raw.githubusercontent.com/sindrel/excalidraw-converter/refs/tags/v1.4.3/test/data/test_input.excalidraw"
-      sha256 "46fd108ab73f6ba70610cb2a79326e453246d58399b65ffc95e0de41dd2f12e8"
+    test_version = version
+
+    resource "test_homebrew.excalidraw" do
+      url "https://raw.githubusercontent.com/sindrel/excalidraw-converter/refs/tags/v#{test_version}/test/data/test_homebrew.excalidraw"
+      sha256 "87e06e6b89a489fe01ccd06e51b8cc2b73bb51ff02e998d04eaa092a025d64e0"
     end
 
-    resource("test_input.excalidraw").stage testpath
-    system bin/"excalidraw-converter", "gliffy", "-i", testpath/"test_input.excalidraw", "-o",
+    resource("test_homebrew.excalidraw").stage testpath
+    system bin/"excalidraw-converter", "gliffy", "-i", testpath/"test_homebrew.excalidraw", "-o",
 testpath/"test_output.gliffy"
     assert_path_exists testpath/"test_output.gliffy"
     system bin/"exconv", "version"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

* Limits livecheck to stable releases, ignoring release candidates
* Adds passing of the version as a build parameter; fixes the `excalidraw-converter version` command
* Replaces the test input file with one designated for use in this pipeline