### PR TITLE
wxpython: backport build fix

### DIFF
--- a/Formula/w/wxpython.rb
+++ b/Formula/w/wxpython.rb
@@ -29,6 +29,12 @@ class Wxpython < Formula
     depends_on "gtk+3"
   end
 
+  # Backport increase of SIP ABI to fix build
+  patch do
+    url "https://github.com/wxWidgets/Phoenix/commit/de9aa4be5bb49adf82991c7582ea3c42ed505bf7.patch?full_index=1"
+    sha256 "bf752fa850459d963cf8a7678dd0463934888d9867a9ac80d58ca51d19cb9f93"
+  end
+
   # build patch to build with doxygen 1.11.0+, remove in next release
   # upstream commit ref, https://github.com/wxWidgets/wxWidgets/commit/2d79dfc7a2a8dd42021ff0ea3dcc8ed05f7c23ef
   patch :DATA


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
