### PR TITLE
cmake@3 3.31.7 (new formula)

### DIFF
--- a/Aliases/cmake@4
+++ b/Aliases/cmake@4
@@ -1,0 +1,1 @@
+../Formula/c/cmake.rb

--- a/Formula/c/cmake@3.rb
+++ b/Formula/c/cmake@3.rb
@@ -1,0 +1,67 @@
+class CmakeAT3 < Formula
+  desc "Cross-platform make"
+  homepage "https://www.cmake.org/"
+  url "https://github.com/Kitware/CMake/releases/download/v3.31.7/cmake-3.31.7.tar.gz"
+  sha256 "a6d2eb1ebeb99130dfe63ef5a340c3fdb11431cce3d7ca148524c125924cea68"
+  license "BSD-3-Clause"
+
+  # The "latest" release on GitHub has been an unstable version before, and
+  # there have been delays between the creation of a tag and the corresponding
+  # release, so we check the website's downloads page instead.
+  livecheck do
+    url "https://cmake.org/download/"
+    regex(/href=.*?cmake[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
+  keg_only :versioned_formula
+
+  uses_from_macos "ncurses"
+
+  on_linux do
+    depends_on "openssl@3"
+  end
+
+  # TODO: add the patch after formula is in repository
+  # https://github.com/Homebrew/homebrew-core/blob/79832b24810b47cc6436a735588f137d0f3bb993/Formula/c/cmake.rb#L87
+
+  # The completions were removed because of problems with system bash
+
+  # The `with-qt` GUI option was removed due to circular dependencies if
+  # CMake is built with Qt support and Qt is built with MySQL support as MySQL uses CMake.
+  # For the GUI application please instead use `brew install --cask cmake`.
+
+  def install
+    args = %W[
+      --prefix=#{prefix}
+      --no-system-libs
+      --parallel=#{ENV.make_jobs}
+      --datadir=/share/cmake
+      --docdir=/share/doc/cmake
+      --mandir=/share/man
+    ]
+    if OS.mac?
+      args += %w[
+        --system-zlib
+        --system-bzip2
+        --system-curl
+      ]
+    end
+
+    system "./bootstrap", *args, "--", *std_cmake_args,
+      "-DCMake_INSTALL_BASH_COMP_DIR=#{bash_completion}",
+      "-DCMake_INSTALL_EMACS_DIR=#{elisp}",
+      "-DCMake_BUILD_LTO=ON"
+
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"CMakeLists.txt").write("find_package(Ruby)")
+    system bin/"cmake", "."
+
+    # These should be supplied in a separate cmake-docs formula.
+    refute_path_exists doc/"html"
+    refute_path_exists man
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
CMake introduced some breaking changes in 4.0.0. In particular new version of Swift doesn't build because `CMP0037` policy cannot be set to `OLD` in this version. Some Homebrew users also want to use legacy version of CMake: https://github.com/orgs/Homebrew/discussions/6058