### PR TITLE
wolfssl: disable ARM ASM on Linux as no runtime detection

### DIFF
--- a/Formula/w/wolfssl.rb
+++ b/Formula/w/wolfssl.rb
@@ -45,6 +45,9 @@ class Wolfssl < Formula
       --enable-reproducible-build
     ]
 
+    # https://github.com/wolfSSL/wolfssl/issues/8148
+    args << "--disable-armasm" if OS.linux? && Hardware::CPU.arm?
+
     # Extra flag is stated as a needed for the Mac platform.
     # https://www.wolfssl.com/docs/wolfssl-manual/ch2/
     # Also, only applies if fastmath is enabled.


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
