### PR TITLE
python@3.13: fold post install into build

### DIFF
--- a/Formula/p/python@3.13.rb
+++ b/Formula/p/python@3.13.rb
@@ -50,6 +50,8 @@ class PythonAT313 < Formula
   link_overwrite "lib/libpython3.so"
   link_overwrite "lib/pkgconfig/python3.pc"
   link_overwrite "lib/pkgconfig/python3-embed.pc"
+  link_overwrite "lib/python3.13/site-packages/pip*"
+  link_overwrite "lib/python3.13/site-packages/wheel*"
   link_overwrite "Frameworks/Python.framework/Headers"
   link_overwrite "Frameworks/Python.framework/Python"
   link_overwrite "Frameworks/Python.framework/Resources"
@@ -237,7 +239,7 @@ class PythonAT313 < Formula
     end
 
     # Remove the site-packages that Python created in its Cellar.
-    rm_r(site_packages_cellar)
+    rm_r site_packages_cellar.children
 
     # Prepare a wheel of wheel to install later.
     common_pip_args = %w[
@@ -262,21 +264,16 @@ class PythonAT313 < Formula
 
     # Replace bundled pip with our own.
     rm lib_cellar.glob("ensurepip/_bundled/pip-*.whl")
-    %w[pip].each do |r|
-      resource(r).stage do
-        system whl_build/"bin/pip3", "wheel", *common_pip_args,
-                                              "--wheel-dir=#{lib_cellar}/ensurepip/_bundled",
-                                              "."
-      end
+    resource("pip").stage do
+      system whl_build/"bin/pip3", "wheel", *common_pip_args,
+                                            "--wheel-dir=#{lib_cellar}/ensurepip/_bundled",
+                                            "."
     end
 
     # Patch ensurepip to bootstrap our updated version of pip
     inreplace lib_cellar/"ensurepip/__init__.py" do |s|
       s.gsub!(/_PIP_VERSION = .*/, "_PIP_VERSION = \"#{resource("pip").version}\"")
     end
-
-    # Write out sitecustomize.py
-    (lib_cellar/"sitecustomize.py").atomic_write(sitecustomize)
 
     # Install unversioned symlinks in libexec/bin.
     {
@@ -287,33 +284,8 @@ class PythonAT313 < Formula
     }.each do |short_name, long_name|
       (libexec/"bin").install_symlink (bin/long_name).realpath => short_name
     end
-  end
 
-  def post_install
-    ENV.delete "PYTHONPATH"
-
-    # Fix up the site-packages so that user-installed Python software survives
-    # minor updates, such as going from 3.3.2 to 3.3.3:
-
-    # Create a site-packages in HOMEBREW_PREFIX/lib/python#{version.major_minor}/site-packages
-    site_packages.mkpath
-
-    # Symlink the prefix site-packages into the cellar.
-    site_packages_cellar.unlink if site_packages_cellar.exist?
-    site_packages_cellar.parent.install_symlink site_packages
-
-    # Remove old sitecustomize.py. Now stored in the cellar.
-    rm_r(Dir["#{site_packages}/sitecustomize.py[co]"])
-
-    # Remove old setuptools installations that may still fly around and be
-    # listed in the easy_install.pth. This can break setuptools build with
-    # zipimport.ZipImportError: bad local file header
-    # setuptools-0.9.8-py3.3.egg
-    rm_r(Dir["#{site_packages}/distribute[-_.][0-9]*", "#{site_packages}/distribute"])
-    rm_r(Dir["#{site_packages}/pip[-_.][0-9]*", "#{site_packages}/pip"])
-    rm_r(Dir["#{site_packages}/wheel[-_.][0-9]*", "#{site_packages}/wheel"])
-
-    (lib_cellar/"EXTERNALLY-MANAGED").unlink if (lib_cellar/"EXTERNALLY-MANAGED").exist?
+    # Bootstrap initial install of pip.
     system python3, "-Im", "ensurepip"
 
     # Install desired versions of pip, wheel using the version of
@@ -321,22 +293,23 @@ class PythonAT313 < Formula
     # Note that while we replaced the ensurepip wheels, there's no guarantee
     # ensurepip actually used them, since other existing installations could
     # have been picked up (and we can't pass --ignore-installed).
+    root_site_packages = lib/"python#{version.major_minor}/site-packages"
     bundled = lib_cellar/"ensurepip/_bundled"
     system python3, "-Im", "pip", "install", "-v",
            "--no-deps",
            "--no-index",
            "--upgrade",
            "--isolated",
-           "--target=#{site_packages}",
+           "--target=#{root_site_packages}",
            bundled/"pip-#{resource("pip").version}-py3-none-any.whl",
            libexec/"wheel-#{resource("wheel").version}-py3-none-any.whl"
 
     # pip install with --target flag will just place the bin folder into the
     # target, so move its contents into the appropriate location
-    mv (site_packages/"bin").children, bin
-    rmdir site_packages/"bin"
+    mv (root_site_packages/"bin").children, bin
+    rmdir root_site_packages/"bin"
 
-    rm_r(bin/"pip")
+    rm bin/"pip"
     mv bin/"wheel", bin/"wheel#{version.major_minor}"
     bin.install_symlink "wheel#{version.major_minor}" => "wheel3"
 
@@ -348,10 +321,14 @@ class PythonAT313 < Formula
       (libexec/"bin").install_symlink (bin/long_name).realpath => short_name
     end
 
-    # post_install happens after link
-    %W[wheel3 pip3 wheel#{version.major_minor} pip#{version.major_minor}].each do |e|
-      (HOMEBREW_PREFIX/"bin").install_symlink bin/e
+    if OS.mac?
+      # Replace framework site-packages with a symlink to the real one.
+      rm_r site_packages_cellar
+      site_packages_cellar.parent.install_symlink root_site_packages
     end
+
+    # Write out sitecustomize.py
+    (lib_cellar/"sitecustomize.py").atomic_write(sitecustomize)
 
     # Mark Homebrew python as externally managed: https://peps.python.org/pep-0668/#marking-an-interpreter-as-using-an-external-package-manager
     # Placed after ensurepip since it invokes pip in isolated mode, meaning
@@ -417,7 +394,7 @@ class PythonAT313 < Formula
           sys.path.extend(library_packages)
           # the Cellar site-packages is a symlink to the HOMEBREW_PREFIX
           # site_packages; prefer the shorter paths
-          long_prefix = re.compile(r'#{rack}/[0-9\\._abrc]+/Frameworks/Python\\.framework/Versions/#{version.major_minor}/lib/python#{version.major_minor}/site-packages')
+          long_prefix = re.compile(r'#{rack}/(?:[0-9\\._abrc]+/Frameworks/Python\\.framework/Versions/#{version.major_minor}/)?lib/python#{version.major_minor}/site-packages')
           sys.path = [long_prefix.sub('#{site_packages}', p) for p in sys.path]
           # Set the sys.executable to use the opt_prefix. Only do this if PYTHONEXECUTABLE is not
           # explicitly set and we are not in a virtualenv:
@@ -427,16 +404,21 @@ class PythonAT313 < Formula
           cellar_prefix = re.compile(r'#{rack}/[0-9\\._abrc]+/')
           if os.path.realpath(sys.base_prefix).startswith('#{rack}'):
               new_prefix = cellar_prefix.sub('#{opt_prefix}/', sys.base_prefix)
+              site.PREFIXES[:] = [new_prefix if x == sys.base_prefix else x for x in site.PREFIXES]
               if sys.prefix == sys.base_prefix:
-                  site.PREFIXES[:] = [new_prefix if x == sys.prefix else x for x in site.PREFIXES]
                   sys.prefix = new_prefix
               sys.base_prefix = new_prefix
           if os.path.realpath(sys.base_exec_prefix).startswith('#{rack}'):
               new_exec_prefix = cellar_prefix.sub('#{opt_prefix}/', sys.base_exec_prefix)
+              site.PREFIXES[:] = [new_exec_prefix if x == sys.base_exec_prefix else x for x in site.PREFIXES]
               if sys.exec_prefix == sys.base_exec_prefix:
-                  site.PREFIXES[:] = [new_exec_prefix if x == sys.exec_prefix else x for x in site.PREFIXES]
                   sys.exec_prefix = new_exec_prefix
               sys.base_exec_prefix = new_exec_prefix
+      # Make site.getsitepackages() return the HOMEBREW_PREFIX site-packages,
+      # but only if we are outside a venv or in one with include-system-site-packages.
+      if sys.base_prefix in site.PREFIXES:
+          site.PREFIXES.insert(site.PREFIXES.index(sys.base_prefix), '#{HOMEBREW_PREFIX}')
+          site.addsitedir('#{site_packages}')
       # Check for and add the prefix of split Python formulae.
       for split_module in ["tk", "gdbm"]:
           split_prefix = f"#{HOMEBREW_PREFIX}/opt/python-{split_module}@#{version.major_minor}/libexec"

--- a/Formula/p/python@3.13.rb
+++ b/Formula/p/python@3.13.rb
@@ -11,14 +11,15 @@ class PythonAT313 < Formula
   end
 
   bottle do
-    sha256 arm64_sequoia: "fad806ba37f980ddf343e13a5e89ecf31e631b4559fec7a1773f012af1eabedd"
-    sha256 arm64_sonoma:  "3b6fd0ef841dd084bb323ed682aeea96c5c95be69e28a662ce5841e2f1c1ad65"
-    sha256 arm64_ventura: "583b1331aa861999323df5da093c70d5c6a6c879103ace0dc97d80d9ebe2d85a"
-    sha256 sequoia:       "6994e690285c2a0f0323f60e2e6ab630292c43dd9310b306f2397e38945c00bf"
-    sha256 sonoma:        "5c912abab190d5046e62e321ca7b17a0bcc35dea627b3cb7ff7f35b89620d0fe"
-    sha256 ventura:       "f800067c349bb25b650fb30a2fd937f76ad166b696d69a1d19d9ba40f91577f0"
-    sha256 arm64_linux:   "3b658547705afcb2e5f9b7074d0c4792c4302e17b2316da08b004e6a08e5dcf1"
-    sha256 x86_64_linux:  "31e051bd6749a977f61010e1d7be4ca4168717d3386dc55af5fd74c74b7c3082"
+    rebuild 1
+    sha256 arm64_sequoia: "243ab8eec20fbc33c7d6760af6097842a400a9e67c07316cbc9b8de4c2762df7"
+    sha256 arm64_sonoma:  "7db8454a41dc2260025320248f7509a993a6a5c2ae031ad7c0d680655556e032"
+    sha256 arm64_ventura: "ea46d6b11e664d1c703bffc6e4d5cda138b9272374eab1b9ef51dc79ab430893"
+    sha256 sequoia:       "06226a6baaacbf231e768abbc089467adda132991735b8884f0fcc4ee570a2ee"
+    sha256 sonoma:        "5a9d812e4c3d6c01dff3fba709c3b3ee3575be47fb869b54f236ff6e1dc9bee8"
+    sha256 ventura:       "6d656bdabcedee8aff8a05c38cbf2b7be69c8adae884b4bd1624e81643d398db"
+    sha256 arm64_linux:   "b9b2ce016403eba77b0d7280951986648d1c344f14fc0a325fb382e42e507b9a"
+    sha256 x86_64_linux:  "fbca800b2b6c5b7ffbf00167ae9375990ab2a747ed038b0410bc3dee41816e50"
   end
 
   depends_on "pkgconf" => :build


### PR DESCRIPTION
Now that the site-packages directory is marked as externally managed, it may now be possible to remove post install entirely.

If successful, we could backport this to `python@3.12` and `python-freethreading`. Backporting to 3.11 and earlier is riskier since they do not mark site-packages as externally managed (for backwards compatibility reasons) - it's unclear yet if this works well with a common user request of `pip3 install -U pip`.

There's a few cons here:

1. This is significant change with moderate risk, albeit hopefully doesn't break any workflows. Our restriction of systemwide packages however reduces this risk.
2. Old `.dist-info` directories from prior to this migration are not cleaned up properly. Unclear if this is a problem or not.
3. The first upgrade after this migration is very noisy and gives unnecessarily scary warnings that fill the entire terminal window, which will almost certainly attract questions from users. It may be worth first addressing whether we want to silence this in brew (I've marked this PR as a draft pending the answer to this). Posted the entire output below to show how large it is:
```
Warning: These files were overwritten during the `brew link` step:
/opt/homebrew/lib/python3.13/site-packages/pip/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/__main__.py
/opt/homebrew/lib/python3.13/site-packages/pip/__pip-runner__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/build_env.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/cache.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/cli/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/cli/autocompletion.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/cli/base_command.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/cli/cmdoptions.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/cli/command_context.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/cli/index_command.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/cli/main.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/cli/main_parser.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/cli/parser.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/cli/progress_bars.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/cli/req_command.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/cli/spinners.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/cli/status_codes.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/commands/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/commands/cache.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/commands/check.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/commands/completion.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/commands/configuration.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/commands/debug.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/commands/download.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/commands/freeze.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/commands/hash.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/commands/help.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/commands/index.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/commands/inspect.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/commands/install.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/commands/list.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/commands/search.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/commands/show.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/commands/uninstall.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/commands/wheel.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/configuration.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/distributions/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/distributions/base.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/distributions/installed.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/distributions/sdist.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/distributions/wheel.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/exceptions.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/index/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/index/collector.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/index/package_finder.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/index/sources.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/locations/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/locations/_distutils.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/locations/_sysconfig.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/locations/base.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/main.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/metadata/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/metadata/_json.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/metadata/base.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/metadata/importlib/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/metadata/importlib/_compat.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/metadata/importlib/_dists.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/metadata/importlib/_envs.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/metadata/pkg_resources.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/models/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/models/candidate.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/models/direct_url.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/models/format_control.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/models/index.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/models/installation_report.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/models/link.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/models/scheme.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/models/search_scope.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/models/selection_prefs.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/models/target_python.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/models/wheel.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/network/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/network/auth.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/network/cache.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/network/download.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/network/lazy_wheel.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/network/session.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/network/utils.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/network/xmlrpc.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/operations/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/operations/build/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/operations/build/build_tracker.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/operations/build/metadata.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/operations/build/metadata_editable.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/operations/build/metadata_legacy.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/operations/build/wheel.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/operations/build/wheel_editable.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/operations/build/wheel_legacy.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/operations/check.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/operations/freeze.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/operations/install/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/operations/install/editable_legacy.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/operations/install/wheel.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/operations/prepare.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/pyproject.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/req/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/req/constructors.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/req/req_file.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/req/req_install.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/req/req_set.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/req/req_uninstall.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/resolution/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/resolution/base.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/resolution/legacy/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/resolution/legacy/resolver.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/resolution/resolvelib/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/resolution/resolvelib/base.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/resolution/resolvelib/candidates.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/resolution/resolvelib/factory.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/resolution/resolvelib/found_candidates.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/resolution/resolvelib/provider.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/resolution/resolvelib/reporter.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/resolution/resolvelib/requirements.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/resolution/resolvelib/resolver.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/self_outdated_check.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/utils/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/utils/_jaraco_text.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/utils/_log.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/utils/appdirs.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/utils/compat.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/utils/compatibility_tags.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/utils/datetime.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/utils/deprecation.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/utils/direct_url_helpers.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/utils/egg_link.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/utils/entrypoints.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/utils/filesystem.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/utils/filetypes.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/utils/glibc.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/utils/hashes.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/utils/logging.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/utils/misc.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/utils/packaging.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/utils/retry.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/utils/setuptools_build.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/utils/subprocess.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/utils/temp_dir.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/utils/unpacking.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/utils/urls.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/utils/virtualenv.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/utils/wheel.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/vcs/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/vcs/bazaar.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/vcs/git.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/vcs/mercurial.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/vcs/subversion.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/vcs/versioncontrol.py
/opt/homebrew/lib/python3.13/site-packages/pip/_internal/wheel_builder.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/cachecontrol/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/cachecontrol/_cmd.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/cachecontrol/adapter.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/cachecontrol/cache.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/cachecontrol/caches/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/cachecontrol/caches/file_cache.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/cachecontrol/caches/redis_cache.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/cachecontrol/controller.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/cachecontrol/filewrapper.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/cachecontrol/heuristics.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/cachecontrol/py.typed
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/cachecontrol/serialize.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/cachecontrol/wrapper.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/certifi/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/certifi/__main__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/certifi/cacert.pem
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/certifi/core.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/certifi/py.typed
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/distlib/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/distlib/compat.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/distlib/database.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/distlib/index.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/distlib/locators.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/distlib/manifest.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/distlib/markers.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/distlib/metadata.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/distlib/resources.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/distlib/scripts.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/distlib/t32.exe
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/distlib/t64-arm.exe
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/distlib/t64.exe
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/distlib/util.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/distlib/version.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/distlib/w32.exe
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/distlib/w64-arm.exe
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/distlib/w64.exe
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/distlib/wheel.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/distro/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/distro/__main__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/distro/distro.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/distro/py.typed
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/idna/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/idna/codec.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/idna/compat.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/idna/core.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/idna/idnadata.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/idna/intranges.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/idna/package_data.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/idna/py.typed
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/idna/uts46data.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/msgpack/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/msgpack/exceptions.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/msgpack/ext.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/msgpack/fallback.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/packaging/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/packaging/_elffile.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/packaging/_manylinux.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/packaging/_musllinux.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/packaging/_parser.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/packaging/_structures.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/packaging/_tokenizer.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/packaging/licenses/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/packaging/licenses/_spdx.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/packaging/markers.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/packaging/metadata.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/packaging/py.typed
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/packaging/requirements.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/packaging/specifiers.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/packaging/tags.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/packaging/utils.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/packaging/version.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pkg_resources/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/platformdirs/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/platformdirs/__main__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/platformdirs/android.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/platformdirs/api.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/platformdirs/macos.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/platformdirs/py.typed
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/platformdirs/unix.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/platformdirs/version.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/platformdirs/windows.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pygments/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pygments/__main__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pygments/cmdline.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pygments/console.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pygments/filter.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pygments/filters/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pygments/formatter.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pygments/formatters/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pygments/formatters/_mapping.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pygments/formatters/bbcode.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pygments/formatters/groff.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pygments/formatters/html.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pygments/formatters/img.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pygments/formatters/irc.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pygments/formatters/latex.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pygments/formatters/other.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pygments/formatters/pangomarkup.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pygments/formatters/rtf.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pygments/formatters/svg.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pygments/formatters/terminal.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pygments/formatters/terminal256.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pygments/lexer.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pygments/lexers/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pygments/lexers/_mapping.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pygments/lexers/python.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pygments/modeline.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pygments/plugin.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pygments/regexopt.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pygments/scanner.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pygments/sphinxext.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pygments/style.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pygments/styles/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pygments/styles/_mapping.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pygments/token.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pygments/unistring.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pygments/util.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pyproject_hooks/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pyproject_hooks/_impl.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pyproject_hooks/_in_process/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/pyproject_hooks/py.typed
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/requests/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/requests/__version__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/requests/_internal_utils.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/requests/adapters.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/requests/api.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/requests/auth.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/requests/certs.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/requests/compat.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/requests/cookies.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/requests/exceptions.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/requests/help.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/requests/hooks.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/requests/models.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/requests/packages.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/requests/sessions.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/requests/status_codes.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/requests/structures.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/requests/utils.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/resolvelib/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/resolvelib/compat/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/resolvelib/compat/collections_abc.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/resolvelib/providers.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/resolvelib/py.typed
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/resolvelib/reporters.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/resolvelib/resolvers.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/resolvelib/structs.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/__main__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/_cell_widths.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/_emoji_codes.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/_emoji_replace.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/_export_format.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/_extension.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/_fileno.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/_inspect.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/_log_render.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/_loop.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/_null_file.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/_palettes.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/_pick.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/_ratio.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/_spinners.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/_stack.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/_timer.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/_win32_console.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/_windows.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/_windows_renderer.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/_wrap.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/abc.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/align.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/ansi.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/bar.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/box.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/cells.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/color.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/color_triplet.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/columns.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/console.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/constrain.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/containers.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/control.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/default_styles.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/diagnose.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/emoji.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/errors.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/file_proxy.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/filesize.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/highlighter.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/json.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/jupyter.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/layout.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/live.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/live_render.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/logging.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/markup.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/measure.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/padding.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/pager.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/palette.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/panel.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/pretty.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/progress.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/progress_bar.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/prompt.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/protocol.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/py.typed
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/region.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/repr.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/rule.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/scope.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/screen.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/segment.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/spinner.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/status.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/style.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/styled.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/syntax.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/table.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/terminal_theme.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/text.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/theme.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/themes.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/traceback.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/rich/tree.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/tomli/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/tomli/_parser.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/tomli/_re.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/tomli/_types.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/tomli/py.typed
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/truststore/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/truststore/_api.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/truststore/_macos.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/truststore/_openssl.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/truststore/_ssl_constants.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/truststore/_windows.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/truststore/py.typed
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/typing_extensions.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/urllib3/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/urllib3/_collections.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/urllib3/_version.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/urllib3/connection.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/urllib3/connectionpool.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/urllib3/contrib/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/urllib3/contrib/_appengine_environ.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/urllib3/contrib/_securetransport/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/urllib3/contrib/_securetransport/bindings.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/urllib3/contrib/_securetransport/low_level.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/urllib3/contrib/appengine.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/urllib3/contrib/ntlmpool.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/urllib3/contrib/pyopenssl.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/urllib3/contrib/securetransport.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/urllib3/contrib/socks.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/urllib3/exceptions.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/urllib3/fields.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/urllib3/filepost.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/urllib3/packages/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/urllib3/packages/backports/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/urllib3/packages/backports/makefile.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/urllib3/packages/backports/weakref_finalize.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/urllib3/packages/six.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/urllib3/poolmanager.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/urllib3/request.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/urllib3/response.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/urllib3/util/__init__.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/urllib3/util/connection.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/urllib3/util/proxy.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/urllib3/util/queue.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/urllib3/util/request.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/urllib3/util/response.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/urllib3/util/retry.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/urllib3/util/ssl_.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/urllib3/util/ssl_match_hostname.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/urllib3/util/ssltransport.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/urllib3/util/timeout.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/urllib3/util/url.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/urllib3/util/wait.py
/opt/homebrew/lib/python3.13/site-packages/pip/_vendor/vendor.txt
/opt/homebrew/lib/python3.13/site-packages/pip/py.typed
/opt/homebrew/lib/python3.13/site-packages/pip-25.0.dist-info/AUTHORS.txt
/opt/homebrew/lib/python3.13/site-packages/pip-25.0.dist-info/INSTALLER
/opt/homebrew/lib/python3.13/site-packages/pip-25.0.dist-info/LICENSE.txt
/opt/homebrew/lib/python3.13/site-packages/pip-25.0.dist-info/METADATA
/opt/homebrew/lib/python3.13/site-packages/pip-25.0.dist-info/REQUESTED
/opt/homebrew/lib/python3.13/site-packages/pip-25.0.dist-info/WHEEL
/opt/homebrew/lib/python3.13/site-packages/pip-25.0.dist-info/entry_points.txt
/opt/homebrew/lib/python3.13/site-packages/pip-25.0.dist-info/top_level.txt
/opt/homebrew/lib/python3.13/site-packages/wheel/__init__.py
/opt/homebrew/lib/python3.13/site-packages/wheel/__main__.py
/opt/homebrew/lib/python3.13/site-packages/wheel/_bdist_wheel.py
/opt/homebrew/lib/python3.13/site-packages/wheel/_setuptools_logging.py
/opt/homebrew/lib/python3.13/site-packages/wheel/bdist_wheel.py
/opt/homebrew/lib/python3.13/site-packages/wheel/cli/__init__.py
/opt/homebrew/lib/python3.13/site-packages/wheel/cli/convert.py
/opt/homebrew/lib/python3.13/site-packages/wheel/cli/pack.py
/opt/homebrew/lib/python3.13/site-packages/wheel/cli/tags.py
/opt/homebrew/lib/python3.13/site-packages/wheel/cli/unpack.py
/opt/homebrew/lib/python3.13/site-packages/wheel/macosx_libfile.py
/opt/homebrew/lib/python3.13/site-packages/wheel/metadata.py
/opt/homebrew/lib/python3.13/site-packages/wheel/util.py
/opt/homebrew/lib/python3.13/site-packages/wheel/vendored/__init__.py
/opt/homebrew/lib/python3.13/site-packages/wheel/vendored/packaging/LICENSE
/opt/homebrew/lib/python3.13/site-packages/wheel/vendored/packaging/LICENSE.APACHE
/opt/homebrew/lib/python3.13/site-packages/wheel/vendored/packaging/LICENSE.BSD
/opt/homebrew/lib/python3.13/site-packages/wheel/vendored/packaging/__init__.py
/opt/homebrew/lib/python3.13/site-packages/wheel/vendored/packaging/_elffile.py
/opt/homebrew/lib/python3.13/site-packages/wheel/vendored/packaging/_manylinux.py
/opt/homebrew/lib/python3.13/site-packages/wheel/vendored/packaging/_musllinux.py
/opt/homebrew/lib/python3.13/site-packages/wheel/vendored/packaging/_parser.py
/opt/homebrew/lib/python3.13/site-packages/wheel/vendored/packaging/_structures.py
/opt/homebrew/lib/python3.13/site-packages/wheel/vendored/packaging/_tokenizer.py
/opt/homebrew/lib/python3.13/site-packages/wheel/vendored/packaging/markers.py
/opt/homebrew/lib/python3.13/site-packages/wheel/vendored/packaging/requirements.py
/opt/homebrew/lib/python3.13/site-packages/wheel/vendored/packaging/specifiers.py
/opt/homebrew/lib/python3.13/site-packages/wheel/vendored/packaging/tags.py
/opt/homebrew/lib/python3.13/site-packages/wheel/vendored/packaging/utils.py
/opt/homebrew/lib/python3.13/site-packages/wheel/vendored/packaging/version.py
/opt/homebrew/lib/python3.13/site-packages/wheel/vendored/vendor.txt
/opt/homebrew/lib/python3.13/site-packages/wheel/wheelfile.py
/opt/homebrew/lib/python3.13/site-packages/wheel-0.45.1.dist-info/INSTALLER
/opt/homebrew/lib/python3.13/site-packages/wheel-0.45.1.dist-info/LICENSE.txt
/opt/homebrew/lib/python3.13/site-packages/wheel-0.45.1.dist-info/METADATA
/opt/homebrew/lib/python3.13/site-packages/wheel-0.45.1.dist-info/REQUESTED
/opt/homebrew/lib/python3.13/site-packages/wheel-0.45.1.dist-info/WHEEL
/opt/homebrew/lib/python3.13/site-packages/wheel-0.45.1.dist-info/entry_points.txt

They have been backed up to: ~/Library/Caches/Homebrew/Backup
```