### PR TITLE
speech-tools: backport fix for building with `-fno-common`

### DIFF
--- a/Formula/s/speech-tools.rb
+++ b/Formula/s/speech-tools.rb
@@ -14,6 +14,12 @@ class SpeechTools < Formula
       url "https://github.com/festvox/speech_tools/commit/06141f69d21bf507a9becb5405265dc362edb0df.patch?full_index=1"
       sha256 "a42493982af11a914d2cf8b97edd287a54b5cabffe6c8fe0e4a9076c211e85ef"
     end
+
+    # Backport fix for building with -fno-common
+    patch do
+      url "https://github.com/festvox/speech_tools/commit/55bdddcca80906d63090872309c0a7838bf44f44.patch?full_index=1"
+      sha256 "0d0b97ea85550a55d09627d388345b16d467f5cbcbb4ab35aa51479950557048"
+    end
   end
 
   livecheck do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
