### PR TITLE
seven-kingdoms: fix build on arm64 linux

### DIFF
--- a/Formula/s/seven-kingdoms.rb
+++ b/Formula/s/seven-kingdoms.rb
@@ -51,7 +51,10 @@ class SevenKingdoms < Formula
   end
 
   def install
-    system "./configure", "--disable-silent-rules", *std_configure_args
+    args = ["--disable-silent-rules"]
+    args += ["--disable-curl", "--disable-enet", "--disable-multiplayer"] unless Hardware::CPU.intel?
+
+    system "./configure", *args, *std_configure_args
     system "make"
     system "make", "install"
   end


### PR DESCRIPTION
These are auto-disabled features. Making them explicitly disabled seems to help fix build. 