### PR TITLE
bpftop: fix build on arm64 linux

### DIFF
--- a/Formula/b/bpftop.rb
+++ b/Formula/b/bpftop.rb
@@ -22,6 +22,11 @@ class Bpftop < Formula
   end
 
   def install
+    # Bypass Homebrew's compiler clang shim which adds incompatible option:
+    # clang: error: unsupported option '-mbranch-protection=' for target 'bpf'
+    clang = Formula["llvm"].opt_bin/"clang"
+    inreplace "build.rs", /^(\s*\.clang)_args/, "\\1(\"#{clang}\")\n\\0", global: false if Hardware::CPU.arm?
+
     system "cargo", "install", *std_cargo_args
   end
 


### PR DESCRIPTION
Seems lower impact to bypass Clang shim for this particular compilation that disabling  hardening everywhere (`ENV.remove "HOMEBREW_CCCFG", "b"`) or bypassing Clang shim everywhere (`ENV.prepend_path "PATH", Formula["llvm"].bin`)

