### PR TITLE
git: Remove default git credential.helper configuration from git formula installation steps

### DIFF
--- a/Formula/g/git.rb
+++ b/Formula/g/git.rb
@@ -170,16 +170,6 @@ class Git < Formula
     # only contains the perllocal.pod installation file.
     perl_dir = prefix/"Library/Perl"
     rm_r perl_dir if perl_dir.exist?
-
-    # Set the macOS keychain credential helper by default
-    # (as Apple's CLT's git also does this).
-    if OS.mac?
-      (buildpath/"gitconfig").write <<~EOS
-        [credential]
-        \thelper = osxkeychain
-      EOS
-      etc.install "gitconfig"
-    end
   end
 
   def caveats


### PR DESCRIPTION
First off thanks to the maintainers of `homebrew` for everything you do! It's been a breeze using `homebrew` for my daily development tasks and I've had basically 0 issues with it since starting to use it a few years ago.

I noticed a small thing that has been a minor annoyance for me personally since starting to use the [`git-credential-oauth`](https://github.com/hickford/git-credential-oauth) credential helper instead of the default `osxkeychain` helper - specifically that the `osxkeychain` helper appears to _always_ be called first, even when I want another one to be used, and I set this in `~/.gitconfig` with:

```gitconfig
[credential]
	helper = cache --timeout 21600 # 6 hours
	helper = oauth
```

This change just removes this default configuration because:
- It is difficult (if not impossible? Please correct me if I'm wrong) to override with user configuration
- It seems like an inconvenient side-effect for those of us that do not want to use the `osxkeychain` credential helper

Apologies if this has already been discussed before - I could not find any related issues when I searched this repo.

My workaround for this is running `sudo rm /opt/homebrew/etc/gitconfig` everytime I install/update this formula, which isn't the nicest dev experience.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?