### PR TITLE
cargo-audit: reduce test files avoiding prebuilts

### DIFF
--- a/Formula/c/cargo-audit.rb
+++ b/Formula/c/cargo-audit.rb
@@ -32,7 +32,7 @@ class CargoAudit < Formula
   def install
     system "cargo", "install", *std_cargo_args(path: "cargo-audit")
     # test cargo-audit
-    pkgshare.install "cargo-audit/tests/support"
+    pkgshare.install "cargo-audit/tests/support/base64_vuln"
   end
 
   test do
@@ -40,7 +40,7 @@ class CargoAudit < Formula
     assert_path_exists HOMEBREW_CACHE/"cargo_cache/advisory-db"
     assert_match "not found: Couldn't load Cargo.lock", output
 
-    cp_r "#{pkgshare}/support/base64_vuln/.", testpath
+    cp_r "#{pkgshare}/base64_vuln/.", testpath
     assert_match "error: 1 vulnerability found!", shell_output("#{bin}/cargo-audit audit 2>&1", 1)
   end
 end


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-core/actions/runs/13996210380/job/39192145712#step:5:59

```
==> brew audit --formula cargo-audit --git --skip-style
==> FAILED
Full audit --formula cargo-audit --git --skip-style output
  cargo-audit
    * Binaries built for a non-native architecture were installed into cargo-audit's prefix.
      The offending files are:
        /home/linuxbrew/.linuxbrew/Cellar/cargo-audit/0.21.2/share/cargo-audit/support/binaries/binary-with-audit-info	(x86_64)
        /home/linuxbrew/.linuxbrew/Cellar/cargo-audit/0.21.2/share/cargo-audit/support/binaries/binary-with-vuln	(x86_64)
        /home/linuxbrew/.linuxbrew/Cellar/cargo-audit/0.21.2/share/cargo-audit/support/binaries/binary-with-vuln-panic	(x86_64)
        /home/linuxbrew/.linuxbrew/Cellar/cargo-audit/0.21.2/share/cargo-audit/support/binaries/binary-without-audit-info	(x86_64)
  Error: 1 problem in 1 formula detected.
```