### PR TITLE
pciutils: update test

### DIFF
--- a/Formula/p/pciutils.rb
+++ b/Formula/p/pciutils.rb
@@ -21,6 +21,6 @@ class Pciutils < Formula
 
   test do
     assert_match "lspci version", shell_output("#{bin}/lspci --version")
-    assert_match "Host bridge:", shell_output("#{bin}/lspci")
+    assert_match(/Host bridge:|controller:/, shell_output("#{bin}/lspci"))
   end
 end


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-core/actions/runs/14296556901/job/40064490073#step:5:76
```
    Minitest::Assertion: Expected /Host\ bridge:/ to match "4563:00:00.0 Non-Volatile memory controller: Microsoft Corporation Device b111 (rev 01)\n7c07:00:02.0 Ethernet controller: Mellanox Technologies MT28800 Family [ConnectX-5 Ex Virtual Function] (rev 80)\n".
```

https://github.com/Homebrew/homebrew-core/actions/runs/14000589459/job/39205922171#step:5:77
```
    Minitest::Assertion: Expected /Host\ bridge:/ to match "d00e:00:02.0 Ethernet controller: Mellanox Technologies MT27800 Family [ConnectX-5 Virtual Function] (rev 80)\n".
```