### PR TITLE
oranda: use `npm` to build as `tailwindcss` 4.x doesn't work

### DIFF
--- a/Formula/o/oranda.rb
+++ b/Formula/o/oranda.rb
@@ -1,6 +1,6 @@
 class Oranda < Formula
   desc "Generate beautiful landing pages for your developer tools"
-  homepage "https://opensource.axo.dev/oranda/"
+  homepage "https://github.com/axodotdev/oranda"
   url "https://github.com/axodotdev/oranda/archive/refs/tags/v0.6.5.tar.gz"
   sha256 "456baf2b8e36ad6492d5d7a6d2b47b48be87c957db9068500dfd82897462d5bd"
   license any_of: ["Apache-2.0", "MIT"]
@@ -15,14 +15,20 @@ class Oranda < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "38453321aae36b4c54631ebaa74ca576f791c4fd5e608bcb5e45088c96a3219c"
   end
 
+  depends_on "node" => :build
   depends_on "pkgconf" => :build
   depends_on "rust" => :build
   depends_on "oniguruma"
-  depends_on "tailwindcss"
 
   def install
     ENV["RUSTONIG_SYSTEM_LIBONIG"] = "1"
-    ENV["ORANDA_USE_TAILWIND_BINARY"] = "1"
+
+    # TODO: Switch back to `ENV["ORANDA_USE_TAILWIND_BINARY"] = "1"`
+    # Issue ref: https://github.com/axodotdev/oranda/issues/719
+    cd "oranda-css" do
+      system "npm", "install", *std_npm_args(prefix: false)
+      system "npm", "run", "build"
+    end
 
     system "cargo", "install", *std_cargo_args
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
