### PR TITLE
libgudev: update test as `systemd` is now keg-only

### DIFF
--- a/Formula/lib/libgudev.rb
+++ b/Formula/lib/libgudev.rb
@@ -42,6 +42,7 @@ class Libgudev < Formula
         return 0;
       }
     C
+    ENV.append_path "PKG_CONFIG_PATH", Formula["systemd"].lib/"pkgconfig"
     system ENV.cc, "test.c", "-o", "test", *shell_output("pkgconf --cflags --libs gudev-1.0").chomp.split
     system "./test"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
