### PR TITLE
you-get: adjust test

### DIFF
--- a/Formula/y/you-get.rb
+++ b/Formula/y/you-get.rb
@@ -39,10 +39,6 @@ class YouGet < Formula
 
   test do
     assert_match version.to_s, shell_output("#{bin}/you-get --version 2>&1")
-
-    # Tests fail with bot detection
-    return if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"]
-
-    system bin/"you-get", "--info", "https://youtu.be/he2a4xK8ctk"
+    assert_match "82 bytes", shell_output("#{bin}/you-get --info https://imgur.com/ZTZ6Xy1")
   end
 end


### PR DESCRIPTION
YouTube breaks scrapers a lot and it's not our responsibility to test for upstream problems.

Imgur breaks a bit less so use that.