### PR TITLE
faust: remove Android armv8 pre-built

### DIFF
--- a/Formula/f/faust.rb
+++ b/Formula/f/faust.rb
@@ -30,6 +30,12 @@ class Faust < Formula
   depends_on "llvm"
 
   def install
+    # `brew linkage` doesn't like the pre-built Android libsndfile.so for faust2android.
+    # Not an essential feature so just remove it when building arm64 linux in CI.
+    if ENV["HOMEBREW_GITHUB_ACTIONS"].present? && OS.linux? && Hardware::CPU.arm?
+      rm("architecture/android/app/lib/libsndfile/lib/arm64-v8a/libsndfile.so")
+    end
+
     system "cmake", "-S", "build", "-B", "homebrew_build",
                     "-DC_BACKEND=COMPILER DYNAMIC",
                     "-DCODEBOX_BACKEND=COMPILER DYNAMIC",


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-core/actions/runs/13996574256/job/39194095555#step:5:66
```
==> brew linkage --test faust
==> FAILED
Full linkage --test faust output
  Missing libraries:
    libc.so
    libdl.so
    libstdc++.so
  Unwanted system libraries:
    /lib/aarch64-linux-gnu/libm.so
```

Problem being we check all binaries and introduction of arm64 linux means we now overlap with Android hardware.