### PR TITLE
wasm-pack: workaround for arm64 linux

### DIFF
--- a/Formula/w/wasm-pack.rb
+++ b/Formula/w/wasm-pack.rb
@@ -20,6 +20,15 @@ class WasmPack < Formula
   depends_on "rustup"
 
   def install
+    # We hit a segfault in test using pre-built cargo-generate < 0.21.2 on arm64 linux.
+    # The logic to use a global copy from PATH is broken[^1] and a PR[^2] to fix stalled.
+    # There is another PR[^3] to provide an environment variable to bypass version check.
+    #
+    # [^1]: https://github.com/rustwasm/wasm-pack/issues/1457
+    # [^2]: https://github.com/rustwasm/wasm-pack/pull/1330
+    # [^3]: https://github.com/rustwasm/wasm-pack/pull/1482
+    inreplace "src/install/mod.rs", '"0.18.2"', '"0.21.3"' if OS.linux? && Hardware::CPU.arm?
+
     system "cargo", "install", *std_cargo_args
   end
 


### PR DESCRIPTION
Scoped to arm64 linux in case some behavior changes cause unexpected breakage. Homebrew ARM Linux support is still alpha/beta so can at least experiment more here.

Went with the lowest major/minor that fixed `brew test` for me and then picked highest patch.