### PR TITLE
conan@1: fix test with latest cmake

### DIFF
--- a/Formula/c/conan@1.rb
+++ b/Formula/c/conan@1.rb
@@ -133,7 +133,7 @@ class ConanAT1 < Formula
   test do
     system bin/"conan", "search", "zlib", "--remote", "conancenter"
 
-    system bin/"conan", "install", "zlib/1.2.11@", "--build"
-    assert_path_exists testpath/".conan/data/zlib/1.2.11"
+    system bin/"conan", "install", "zlib/1.3.1@", "--build"
+    assert_path_exists testpath/".conan/data/zlib/1.3.1"
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Failed in #218829

Also, can't find a support policy but this currently logs a [deprecation warning](https://github.com/conan-io/conan/commit/b8d375f382c15ca4ece8e79c10151798c6222430) so may be time to deprecate on our side too
