### PR TITLE
Scala does not need openjdk anymore

### DIFF
--- a/Formula/s/scala.rb
+++ b/Formula/s/scala.rb
@@ -14,9 +14,6 @@ class Scala < Formula
     sha256 cellar: :any_skip_relocation, all: "766187b4b8b191e3df5cccc2697ffd55e01c6234f02d9598dc40cb837fa29ad8"
   end
 
-  # JDK Compatibility: https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
-  depends_on "openjdk"
-
   conflicts_with "pwntools", because: "both install `common` binaries"
 
   def install
@@ -24,7 +21,7 @@ class Scala < Formula
 
     libexec.install "lib", "maven2", "VERSION", "libexec"
     prefix.install "bin"
-    bin.env_script_all_files libexec/"bin", Language::Java.overridable_java_home_env
+    bin.env_script_all_files libexec/"bin"
 
     # Set up an IntelliJ compatible symlink farm in 'idea'
     idea = prefix/"idea"


### PR DESCRIPTION
Since Scala 3.5.0, Scala will download the Java version needed, if targeting the JVM (could be JS or Native), depending on the project config and what's already installed on the machine.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
