### PR TITLE
go: remove GOROOT_FINAL and `go install std cmd`

### DIFF
--- a/Formula/g/go.rb
+++ b/Formula/g/go.rb
@@ -63,20 +63,16 @@ class Go < Formula
   end
 
   def install
+    libexec.install Dir["*"]
     (buildpath/"gobootstrap").install resource("gobootstrap")
     ENV["GOROOT_BOOTSTRAP"] = buildpath/"gobootstrap"
 
-    cd "src" do
-      ENV["GOROOT_FINAL"] = libexec
+    cd libexec/"src" do
       # Set portable defaults for CC/CXX to be used by cgo
       with_env(CC: "cc", CXX: "c++") { system "./make.bash" }
     end
 
-    rm_r("gobootstrap") # Bootstrap not required beyond compile.
-    libexec.install Dir["*"]
     bin.install_symlink Dir[libexec/"bin/go*"]
-
-    system bin/"go", "install", "std", "cmd"
 
     # Remove useless files.
     # Breaks patchelf because folder contains weird debug/test files


### PR DESCRIPTION
GOROOT_FINAL was dropped by Go 1.23
https://github.com/golang/go/commit/507d1b22f4b58ac68841582d0c2c0ab6b20e5a98

We can also just perform build in `libexec` and let brew automatically clean up the bootstrap.

Remove `go install std cmd` to align with other repositories.

---

Can go without bottles to experiment on ARM Linux side before it gets applied to all OS.