### PR TITLE
nmh: add `readline` dependency on Linux

### DIFF
--- a/Formula/n/nmh.rb
+++ b/Formula/n/nmh.rb
@@ -40,6 +40,7 @@ class Nmh < Formula
 
   on_linux do
     depends_on "gdbm"
+    depends_on "readline"
   end
 
   conflicts_with "ali", because: "both install `ali` binaries"


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-core/actions/runs/14393679695/job/40366029456?pr=216462#step:4:83
```
==> brew linkage --test nmh
==> FAILED
Full linkage --test nmh output
  Unwanted system libraries:
    /lib/x86_64-linux-gnu/libreadline.so.8
```