### PR TITLE
openblas: use `cmake` and depend on `libomp`

### DIFF
--- a/Formula/c/cp2k.rb
+++ b/Formula/c/cp2k.rb
@@ -4,6 +4,7 @@ class Cp2k < Formula
   url "https://github.com/cp2k/cp2k/releases/download/v2025.1/cp2k-2025.1.tar.bz2"
   sha256 "65c8ad5488897b0f995919b9fa77f2aba4b61677ba1e3c19bb093d5c08a8ce1d"
   license "GPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url :stable
@@ -33,8 +34,8 @@ class Cp2k < Formula
   depends_on "openblas"
   depends_on "scalapack"
 
-  fails_with :clang do
-    cause "needs OpenMP support for C/C++ and Fortran"
+  on_macos do
+    depends_on "libomp"
   end
 
   resource "libint" do
@@ -59,12 +60,12 @@ class Cp2k < Formula
       ENV.prepend_path "PKG_CONFIG_PATH", libexec/"lib/pkgconfig"
     end
 
-    # TODO: Add workaround to link to LLVM OpenMP (libomp) with gfortran after migrating OpenBLAS
+    # Workaround to link to LLVM OpenMP (libomp) with gfortran
     omp_args = []
-    # if OS.mac?
-    #   omp_args << "-DOpenMP_Fortran_LIB_NAMES=omp"
-    #   omp_args << "-DOpenMP_omp_LIBRARY=#{Formula["libomp"].opt_lib}/libomp.dylib"
-    # end
+    if OS.mac?
+      omp_args << "-DOpenMP_Fortran_LIB_NAMES=omp"
+      omp_args << "-DOpenMP_omp_LIBRARY=#{Formula["libomp"].opt_lib}/libomp.dylib"
+    end
 
     # TODO: Remove dbcsr build along with corresponding CMAKE_PREFIX_PATH
     # and add -DCP2K_BUILD_DBCSR=ON once `cp2k` build supports this option.
@@ -86,9 +87,7 @@ class Cp2k < Formula
     # Avoid trying to access /proc/self/statm on macOS
     ENV.append "FFLAGS", "-D__NO_STATM_ACCESS" if OS.mac?
 
-    # Set -lstdc++ to allow gfortran to link libint
     cp2k_cmake_args = %W[
-      -DCMAKE_SHARED_LINKER_FLAGS=-lstdc++
       -DCMAKE_INSTALL_RPATH=#{rpath};#{rpath(target: libexec/"lib")}
       -DCP2K_BLAS_VENDOR=OpenBLAS
       -DCP2K_USE_LIBINT2=ON

--- a/Formula/f/fftw.rb
+++ b/Formula/f/fftw.rb
@@ -4,7 +4,7 @@ class Fftw < Formula
   url "https://fftw.org/fftw-3.3.10.tar.gz"
   sha256 "56c932549852cddcfafdab3820b0200c7742675be92179e59e6215b340e26467"
   license all_of: ["GPL-2.0-or-later", "BSD-2-Clause"]
-  revision 2
+  revision 3
 
   livecheck do
     url :homepage
@@ -28,10 +28,8 @@ class Fftw < Formula
   depends_on "open-mpi"
 
   on_macos do
-    depends_on "gcc"
+    depends_on "libomp"
   end
-
-  fails_with :clang
 
   # Fix the cmake config file when configured with autotools, upstream pr ref, https://github.com/FFTW/fftw3/pull/338
   patch do
@@ -41,6 +39,11 @@ class Fftw < Formula
 
   def install
     ENV.runtime_cpu_detection
+
+    if OS.mac?
+      ENV["OPENMP_CFLAGS"] = "-Xpreprocessor -fopenmp"
+      ENV.append "LIBS", "-lomp"
+    end
 
     args = [
       "--enable-shared",

--- a/Formula/g/gromacs.rb
+++ b/Formula/g/gromacs.rb
@@ -4,7 +4,7 @@ class Gromacs < Formula
   url "https://ftp.gromacs.org/pub/gromacs/gromacs-2025.3.tar.gz"
   sha256 "8bdfca0268f3f10a7ca3c06e59b62f73ea02420c67211c0ff3912f32d7833c65"
   license "LGPL-2.1-or-later"
-  revision 1
+  revision 2
 
   livecheck do
     url "https://ftp.gromacs.org/pub/gromacs/"
@@ -23,21 +23,15 @@ class Gromacs < Formula
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
   depends_on "fftw"
-  depends_on "gcc" # for OpenMP
   depends_on "lmfit"
+  depends_on "muparser"
   depends_on "openblas"
 
   uses_from_macos "zlib"
 
   on_macos do
-    conflicts_with "muparser", because: "gromacs ships its own copy of muparser"
+    depends_on "libomp"
   end
-
-  on_linux do
-    depends_on "muparser"
-  end
-
-  fails_with :clang
 
   def install
     # Non-executable GMXRC files should be installed in DATADIR
@@ -45,9 +39,9 @@ class Gromacs < Formula
                                         "CMAKE_INSTALL_DATADIR"
 
     # Avoid superenv shim reference
-    gcc = Formula["gcc"]
-    cc = gcc.opt_bin/"gcc-#{gcc.any_installed_version.major}"
-    cxx = gcc.opt_bin/"g++-#{gcc.any_installed_version.major}"
+    cc = DevelopmentTools.locate(ENV.cc)
+    cxx = DevelopmentTools.locate(ENV.cxx)
+
     inreplace "src/gromacs/gromacs-hints.in.cmake" do |s|
       s.gsub! "@CMAKE_LINKER@", "/usr/bin/ld"
       s.gsub! "@CMAKE_C_COMPILER@", cc
@@ -75,15 +69,9 @@ class Gromacs < Formula
       -DGMX_INSTALL_LEGACY_API=ON
       -DGMX_EXTERNAL_ZLIB=ON
       -DGMX_USE_LMFIT=EXTERNAL
+      -DGMX_USE_MUPARSER=EXTERNAL
       -DGMX_SIMD=#{gmx_simd}
     ]
-    args << if OS.mac?
-      # Use bundled `muparser` as brew formula is linked to libc++ on macOS but we need libstdc++.
-      # TODO: Try switching `gromacs` and its dependency tree to use Apple Clang + `libomp`
-      "-DFETCHCONTENT_SOURCE_DIR_MUPARSER=#{buildpath}/src/external/muparser"
-    else
-      "-DGMX_USE_MUPARSER=EXTERNAL"
-    end
 
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args, *args
     system "cmake", "--build", "build"

--- a/Formula/m/muparser.rb
+++ b/Formula/m/muparser.rb
@@ -22,7 +22,6 @@ class Muparser < Formula
 
   on_macos do
     depends_on "libomp"
-    conflicts_with "gromacs", because: "gromacs ships its own copy of muparser"
   end
 
   def install

--- a/Formula/n/nwchem.rb
+++ b/Formula/n/nwchem.rb
@@ -5,7 +5,7 @@ class Nwchem < Formula
   version "7.2.3"
   sha256 "7788e6af9be8681e6384b8df4df5ac57d010b2c7aa50842d735c562d92f94c25"
   license "ECL-2.0"
-  revision 1
+  revision 2
 
   livecheck do
     url :stable
@@ -37,6 +37,10 @@ class Nwchem < Formula
 
   uses_from_macos "libxcrypt"
 
+  on_macos do
+    depends_on "libomp"
+  end
+
   # fix download url in build_dftd3a.sh, upstream pr ref, https://github.com/nwchemgit/nwchem/pull/1054
   patch do
     url "https://github.com/nwchemgit/nwchem/commit/65ce7726d9fa418f7c01665bebfc1e2181f15adf.patch?full_index=1"
@@ -47,6 +51,9 @@ class Nwchem < Formula
     pkgshare.install "QA"
 
     cd "src" do
+      # Workaround to link to LLVM OpenMP (libomp) with gfortran
+      inreplace "config/makefile.h", /(\bLDOPTIONS *\+= *)-fopenmp$/, "\\1-lomp" if OS.mac?
+
       (prefix/"etc").mkdir
       (prefix/"etc/nwchemrc").write <<~EOS
         nwchem_basis_library #{pkgshare}/libraries/

--- a/Formula/p/pytorch.rb
+++ b/Formula/p/pytorch.rb
@@ -6,7 +6,7 @@ class Pytorch < Formula
   url "https://github.com/pytorch/pytorch/releases/download/v2.8.0/pytorch-v2.8.0.tar.gz"
   sha256 "c70a2c9488f6f6e8af5982a10d1cc2c37b7df5e6506d839daa5d5e250953d7b5"
   license "BSD-3-Clause"
-  revision 3
+  revision 4
 
   livecheck do
     url :stable


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Related to #209091, #129648, #129100. Upstream has added support for buiding with `libomp` through https://github.com/OpenMathLib/OpenBLAS/pull/5180, where one can also find multiple issues linked from downstream repositories that are caused by Homebrew's handling of `OpenMP` for `OpenBLAS`.

This change requires dependents of `OpenBLAS` also switched to `libomp`. For `gromacs`, `cp2k` and `fftw`, the switch seems relatively straightforward. However, I am not sure how to go about `dynare`. Currently, `dynare` is directly linked to `libgomp` and it also pulls in `libomp` through `suite-sparse`.