### PR TITLE
go@1.23: remove `src/debug/dwarf/testdata`, `GOROOT_FINAL` and `go install std cmd`

### DIFF
--- a/Formula/g/go@1.23.rb
+++ b/Formula/g/go@1.23.rb
@@ -33,22 +33,22 @@ class GoAT123 < Formula
   depends_on "go" => :build
 
   def install
-    cd "src" do
-      ENV["GOROOT_FINAL"] = libexec
+    libexec.install Dir["*"]
+
+    cd libexec/"src" do
       # Set portable defaults for CC/CXX to be used by cgo
       with_env(CC: "cc", CXX: "c++") { system "./make.bash" }
     end
 
-    libexec.install Dir["*"]
     bin.install_symlink Dir[libexec/"bin/go*"]
-
-    system bin/"go", "install", "std", "cmd"
 
     # Remove useless files.
     # Breaks patchelf because folder contains weird debug/test files
     rm_r(libexec/"src/debug/elf/testdata")
     # Binaries built for an incompatible architecture
     rm_r(libexec/"src/runtime/pprof/testdata")
+    # Remove testdata with binaries for non-native architectures.
+    rm_r(libexec/"src/debug/dwarf/testdata")
   end
 
   test do


### PR DESCRIPTION
Remove `src/debug/dwarf/testdata`, `GOROOT_FINAL` and `go install std cmd`.

Ref:
* porting https://github.com/Homebrew/homebrew-core/pull/214955 to go@1.23
* porting https://github.com/Homebrew/homebrew-core/pull/219303 to go@1.23
* https://github.com/Homebrew/homebrew-core/issues/211761

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
