### PR TITLE
rtptools: add `libnsl` dependency on Linux

### DIFF
--- a/Formula/r/rtptools.rb
+++ b/Formula/r/rtptools.rb
@@ -1,6 +1,6 @@
 class Rtptools < Formula
   desc "Set of tools for processing RTP data"
-  homepage "https://www.cs.columbia.edu/irt/software/rtptools/"
+  homepage "https://github.com/irtlab/rtptools"
   url "https://github.com/irtlab/rtptools/archive/refs/tags/1.22.tar.gz"
   sha256 "ac6641558200f5689234989e28ed3c44ead23757ccf2381c8878933f9c2523e0"
   license "BSD-3-Clause"
@@ -29,6 +29,10 @@ class Rtptools < Formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
+
+  on_linux do
+    depends_on "libnsl"
+  end
 
   def install
     system "autoreconf", "--verbose", "--install", "--force"


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-core/actions/runs/14296870916/job/40065155946#step:5:65
```
==> brew linkage --test rtptools
==> FAILED
Full linkage --test rtptools output
  Unwanted system libraries:
    /lib/aarch64-linux-gnu/libnsl.so.2
```