### PR TITLE
ocaml-num: deparallelize make

### DIFF
--- a/Formula/o/ocaml-num.rb
+++ b/Formula/o/ocaml-num.rb
@@ -34,7 +34,7 @@ class OcamlNum < Formula
       s.change_make_var! "prefix", prefix
     end
 
-    system "make"
+    ENV.deparallelize { system "make" }
     (lib/"ocaml/stublibs").mkpath # `make install` assumes this directory exists
     system "make", "install", "STDLIBDIR=#{lib}/ocaml"
 


### PR DESCRIPTION
Build failure seems related to parallel jobs: https://github.com/Homebrew/homebrew-core/actions/runs/14296400642/job/40064140998#step:5:85
```
  cp: cannot create regular file './num_top_printers.mli': File exists
  cp: cannot create regular file './num_top.mli': File exists
  cp: cannot create regular file './num_top_printers.ml': File exists
  cp: cannot create regular file './num_top.ml': File exists
  make[1]: *** [Makefile:208: num_top_printers.mli] Error 1
```