### PR TITLE
tal: update build and test for Linux

### DIFF
--- a/Formula/t/tal.rb
+++ b/Formula/t/tal.rb
@@ -30,12 +30,25 @@ class Tal < Formula
   end
 
   def install
-    system "make", "linux"
+    system "make", "tal"
     bin.install "tal"
     man1.install "tal.1"
   end
 
   test do
-    system bin/"tal", "/etc/passwd"
+    (testpath/"test.c").write <<~C
+      /***************************************************/
+      /* some text and so on                    */
+      /*       even more text                                   */
+      /*       foo, bar. bar bar.                   */
+      /***************************************************/
+    C
+    assert_equal <<~C, shell_output("#{bin}/tal -p 0 test.c")
+      /***************************************************/
+      /* some text and so on                             */
+      /*       even more text                            */
+      /*       foo, bar. bar bar.                        */
+      /***************************************************/
+    C
   end
 end


### PR DESCRIPTION
Not sure why test is failing in CI as I can't reproduce on VM.

Trying out a different test from https://thomasjensen.com/software/tal/examples.html

---

The linux target just sets: `CC=gcc CFLAGS="-ansi -O"`. Shim handles CC and -O so the problem is `-ansi`.