### PR TITLE
kitchen-sync: add workaround for CMake 4, add missing include

### DIFF
--- a/Formula/k/kitchen-sync.rb
+++ b/Formula/k/kitchen-sync.rb
@@ -1,6 +1,7 @@
 class KitchenSync < Formula
   desc "Fast efficiently sync database without dumping & reloading"
   homepage "https://github.com/willbryant/kitchen_sync"
+  # TODO: Remove CMAKE_POLICY_VERSION_MINIMUM after https://github.com/willbryant/kitchen_sync/pull/120
   url "https://github.com/willbryant/kitchen_sync/archive/refs/tags/v2.20.tar.gz"
   sha256 "e79e5dfad48b8345b1d80444a0e992b2f9b9c53f29f6f607647e567292a7d0f2"
   license "MIT"
@@ -25,8 +26,15 @@ class KitchenSync < Formula
   depends_on "libpq"
   depends_on "mariadb-connector-c"
 
+  # Apply PR for missing include https://github.com/willbryant/kitchen_sync/pull/121
+  patch do
+    url "https://github.com/willbryant/kitchen_sync/commit/f5b423aa2fb3680055e0c7f2eb5ee7bec9e032a0.patch?full_index=1"
+    sha256 "334768cc830db059e2e9dd0d43ccaeb3efb4a74e695e9933bc2fbf21b036ead5"
+  end
+
   def install
     system "cmake", "-S", ".", "-B", "build",
+                    "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
                     "-DMySQL_INCLUDE_DIR=#{Formula["mariadb-connector-c"].opt_include}/mariadb",
                     "-DMySQL_LIBRARY_DIR=#{Formula["mariadb-connector-c"].opt_lib}",
                     "-DPostgreSQL_INCLUDE_DIR=#{Formula["libpq"].opt_include}",


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
