### PR TITLE
pipgrip: update resources, harden test

### DIFF
--- a/Formula/p/pipgrip.rb
+++ b/Formula/p/pipgrip.rb
@@ -21,19 +21,13 @@ class Pipgrip < Formula
   depends_on "python@3.13"
 
   resource "anytree" do
-    url "https://files.pythonhosted.org/packages/f9/44/2dd9c5d0c3befe899738b930aa056e003b1441bfbf34aab8fce90b2b7dea/anytree-2.12.1.tar.gz"
-    sha256 "244def434ccf31b668ed282954e5d315b4e066c4940b94aff4a7962d85947830"
-
-    # poetry build patch, upstream pr ref, https://github.com/c0fec0de/anytree/pull/271
-    patch do
-      url "https://github.com/c0fec0de/anytree/commit/aa20d31631403f9650f3b4090d5c8579f9abaf5b.patch?full_index=1"
-      sha256 "05b9b5ecf80986fcecb195d798e1277c9e7c69ed5fd44fea9898e20a44828587"
-    end
+    url "https://files.pythonhosted.org/packages/bc/a8/eb55fab589c56f9b6be2b3fd6997aa04bb6f3da93b01154ce6fc8e799db2/anytree-2.13.0.tar.gz"
+    sha256 "c9d3aa6825fdd06af7ebb05b4ef291d2db63e62bb1f9b7d9b71354be9d362714"
   end
 
   resource "click" do
-    url "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz"
-    sha256 "ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"
+    url "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz"
+    sha256 "ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"
   end
 
   resource "packaging" do
@@ -42,13 +36,8 @@ class Pipgrip < Formula
   end
 
   resource "setuptools" do
-    url "https://files.pythonhosted.org/packages/43/54/292f26c208734e9a7f067aea4a7e282c080750c4546559b58e2e45413ca0/setuptools-75.6.0.tar.gz"
-    sha256 "8199222558df7c86216af4f84c30e9b34a61d8ba19366cc914424cdbd28252f6"
-  end
-
-  resource "six" do
-    url "https://files.pythonhosted.org/packages/71/39/171f1c67cd00715f190ba0b100d606d440a28c93c7714febeca8b79af85e/six-1.16.0.tar.gz"
-    sha256 "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+    url "https://files.pythonhosted.org/packages/a9/5a/0db4da3bc908df06e5efae42b44e75c81dd52716e10192ff36d0c1c8e379/setuptools-78.1.0.tar.gz"
+    sha256 "18fd474d4a82a5f83dac888df697af65afa82dec7323d09c3e37d1f14288da54"
   end
 
   resource "wheel" do
@@ -63,8 +52,8 @@ class Pipgrip < Formula
   end
 
   test do
-    assert_match "pipgrip==#{version}", shell_output("#{bin}/pipgrip pipgrip --no-cache-dir")
+    assert_match "pip==25.0.1", shell_output("#{bin}/pipgrip --no-cache-dir pip==25.0.1")
     # Test gcc dependency
-    assert_match "dxpy==", shell_output("#{bin}/pipgrip dxpy --no-cache-dir")
+    assert_match "dxpy==", shell_output("#{bin}/pipgrip --no-cache-dir dxpy==0.394.0")
   end
 end

--- a/Formula/p/pipgrip.rb
+++ b/Formula/p/pipgrip.rb
@@ -9,13 +9,14 @@ class Pipgrip < Formula
   head "https://github.com/ddelange/pipgrip.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "8200545764bb23a787a49b0fc005dde71dcf392ea6768e4b35882928be00c753"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "8200545764bb23a787a49b0fc005dde71dcf392ea6768e4b35882928be00c753"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "8200545764bb23a787a49b0fc005dde71dcf392ea6768e4b35882928be00c753"
-    sha256 cellar: :any_skip_relocation, sonoma:        "6765b9fc84ef8911ea27ca8b1d4585cda50a6c582ac32bce062e7fe5a813d2ea"
-    sha256 cellar: :any_skip_relocation, ventura:       "6765b9fc84ef8911ea27ca8b1d4585cda50a6c582ac32bce062e7fe5a813d2ea"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "a9845a02f039857039cd822de651efab04a91e70fe02cc07699a8dacbb0cdcdf"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8ccdc85fb3e71bcbd61b7c62fe7f213f8cdc11461b440792c881a155ab03e582"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "158d120e374774c7e6a9c613a19cee2e29ef587030627b7425eb86532342c2cf"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "158d120e374774c7e6a9c613a19cee2e29ef587030627b7425eb86532342c2cf"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "158d120e374774c7e6a9c613a19cee2e29ef587030627b7425eb86532342c2cf"
+    sha256 cellar: :any_skip_relocation, sonoma:        "955d231bc75581deb2be9fb31e6f6997a510784c929bd5bf1616e24c20e716fe"
+    sha256 cellar: :any_skip_relocation, ventura:       "955d231bc75581deb2be9fb31e6f6997a510784c929bd5bf1616e24c20e716fe"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "9d77cf7e45e6a83a1624774b8f55dd8544ba98d037a0d3b0e82a0254aabd1b47"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "9d77cf7e45e6a83a1624774b8f55dd8544ba98d037a0d3b0e82a0254aabd1b47"
   end
 
   depends_on "python@3.13"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Like #219058, this test isn't reproducible and will fail when a new `pipgrip` is released to PyPI but we haven't updated yet
