### PR TITLE
fio: enable runtime CPU detection

### DIFF
--- a/Formula/f/fio.rb
+++ b/Formula/f/fio.rb
@@ -24,6 +24,7 @@ class Fio < Formula
   conflicts_with "fiona", because: "both install `fio` binaries"
 
   def install
+    ENV.runtime_cpu_detection
     system "./configure"
     # fio's CFLAGS passes vital stuff around, and crushing it will break the build
     system "make", "prefix=#{prefix}",

--- a/style_exceptions/runtime_cpu_detection_allowlist.json
+++ b/style_exceptions/runtime_cpu_detection_allowlist.json
@@ -9,6 +9,7 @@
   "coreutils",
   "cryptopp",
   "fftw",
+  "fio",
   "groestlcoin",
   "handbrake",
   "highway",


### PR DESCRIPTION
At least for CRC32c there is CPU detection:
- https://github.com/axboe/fio/commit/e0ab5f977075ec2f8ad42378c95eb800a611f0ef
- https://github.com/axboe/fio/commit/58828d0759642a8d438c94ee96a3e9848f89102a