### PR TITLE
technitium-dns, technitium-library 13.5.0 (new formula)

### DIFF
--- a/Formula/t/technitium-dns.rb
+++ b/Formula/t/technitium-dns.rb
@@ -1,0 +1,70 @@
+class TechnitiumDns < Formula
+  desc "Self host a DNS server for privacy & security"
+  homepage "https://technitium.com/dns/"
+  url "https://github.com/TechnitiumSoftware/DnsServer/archive/refs/tags/v13.5.0.tar.gz"
+  sha256 "7a5f47af4c938c5983e415547b777f853ede5ada8837012c8b5e8e36df1a380e"
+  license "GPL-3.0-or-later"
+
+  # TODO: update dotnet version
+  # Issue ref: https://github.com/TechnitiumSoftware/DnsServer/issues/1303
+  depends_on "dotnet@8"
+  depends_on "libmsquic"
+  depends_on "technitium-library"
+
+  on_linux do
+    depends_on "bind" => :test # for `dig`
+  end
+
+  def install
+    ENV["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1"
+
+    dotnet = Formula["dotnet@8"]
+    args = %W[
+      --configuration Release
+      --framework net#{dotnet.version.major_minor}
+      --no-self-contained
+      --output #{libexec}
+      --use-current-runtime
+    ]
+
+    inreplace Dir.glob("**/*.csproj"),
+              "..\\..\\TechnitiumLibrary\\bin",
+              Formula["technitium-library"].libexec.to_s.tr("/", "\\"),
+              audit_result: false
+    system "dotnet", "publish", "DnsServerApp/DnsServerApp.csproj", *args
+
+    (bin/"technitium-dns").write <<~SHELL
+      #!/bin/bash
+      export DYLD_FALLBACK_LIBRARY_PATH=#{Formula["libmsquic"].opt_lib}
+      export DOTNET_ROOT=#{dotnet.opt_libexec}
+      exec #{dotnet.opt_libexec}/dotnet #{libexec}/DnsServerApp.dll #{etc}/technitium-dns
+    SHELL
+  end
+
+  service do
+    run opt_bin/"technitium-dns"
+    keep_alive true
+    error_log_path var/"log/technitium-dns.log"
+    log_path var/"log/technitium-dns.log"
+    working_dir var
+  end
+
+  test do
+    dotnet = Formula["dotnet@8"]
+    tmpdir = Pathname.new(Dir.mktmpdir)
+    # Start the DNS server
+    require "pty"
+    PTY.spawn("#{dotnet.opt_libexec}/dotnet #{libexec}/DnsServerApp.dll #{tmpdir}") do |r, _w, pid|
+      # Give the server time to start
+      sleep 2
+      # Use `dig` to resolve "localhost"
+      assert_match "Server was started successfully", r.gets
+      output = shell_output("dig @127.0.0.1 localhost 2>&1")
+      assert_match "ANSWER SECTION", output
+      assert_match "localhost.", output
+    ensure
+      Process.kill("KILL", pid)
+      Process.wait(pid)
+    end
+  end
+end

--- a/Formula/t/technitium-dns.rb
+++ b/Formula/t/technitium-dns.rb
@@ -5,6 +5,14 @@ class TechnitiumDns < Formula
   sha256 "7a5f47af4c938c5983e415547b777f853ede5ada8837012c8b5e8e36df1a380e"
   license "GPL-3.0-or-later"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "dda28a9edfd838d85510d9663c0a24c3f1c404c072bf30cb8f3cfb21990837e3"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "1cc7e7cad9743fbf3261a1417f03a97d1bbfc37ad544420e4803105c7ec60eff"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "f8ae57540aa984adcf9d21a2e4a30f7be73998036fce3e5ae0d84bc742693051"
+    sha256 cellar: :any_skip_relocation, ventura:       "079e61452c9d175605d9b960b49e24a5237f7da639d0765328c374fda5528da7"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "cda1cc0e7223d0c3b8b7e3f9a13af438e6fb4109e731b690544fd9c162182154"
+  end
+
   # TODO: update dotnet version
   # Issue ref: https://github.com/TechnitiumSoftware/DnsServer/issues/1303
   depends_on "dotnet@8"

--- a/Formula/t/technitium-library.rb
+++ b/Formula/t/technitium-library.rb
@@ -5,6 +5,14 @@ class TechnitiumLibrary < Formula
   sha256 "8e0f3200ad6ee6a1ab346a7224a1bc538f6b3dc1b660cd8bb725d0dc09fa2bf9"
   license "GPL-3.0-only"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "ec851157536a44fd5d308a20ea095be18790f0532973072dc00bbcf34a76c192"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "9e08722a6396e8a695202789ed5db5949594e8386b2b1ac5171a90696bd36a65"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "38d3dbdca7ad114282e27a3b3a7b08bd34ab9e5b1afdba0bfcb0e5d041aa8753"
+    sha256 cellar: :any_skip_relocation, ventura:       "c072c54bbd09d645d0c01864681ab22434bb3b9d27d2d039a2be3fde872a02e4"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "aff4ab8e47c10b2674a6a1af0b698f5016cd5b4cc1aeaba975a1499310266080"
+  end
+
   depends_on "dotnet@8"
 
   def install

--- a/Formula/t/technitium-library.rb
+++ b/Formula/t/technitium-library.rb
@@ -1,0 +1,74 @@
+class TechnitiumLibrary < Formula
+  desc "Library for technitium .net based applications"
+  homepage "https://technitium.com"
+  url "https://github.com/TechnitiumSoftware/TechnitiumLibrary/archive/refs/tags/dns-server-v13.5.0.tar.gz"
+  sha256 "8e0f3200ad6ee6a1ab346a7224a1bc538f6b3dc1b660cd8bb725d0dc09fa2bf9"
+  license "GPL-3.0-only"
+
+  depends_on "dotnet@8"
+
+  def install
+    ENV["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1"
+
+    dotnet = Formula["dotnet@8"]
+    args = %W[
+      --configuration Release
+      --framework net#{dotnet.version.major_minor}
+      --no-self-contained
+      --output #{libexec}
+      --use-current-runtime
+    ]
+
+    system "dotnet", "publish", "TechnitiumLibrary.ByteTree/TechnitiumLibrary.ByteTree.csproj", *args
+    system "dotnet", "publish", "TechnitiumLibrary.Net/TechnitiumLibrary.Net.csproj", *args
+  end
+
+  test do
+    dotnet = Formula["dotnet@8"]
+    target_framework = "net#{dotnet.version.major_minor}"
+
+    (testpath/"test.cs").write <<~CSHARP
+      using System;
+      using TechnitiumLibrary;
+
+      namespace Homebrew
+      {
+        public class TechnitiumLibraryTest
+        {
+          public static void Main(string[] args)
+          {
+            Console.WriteLine(Base32.ToBase32HexString(new byte[] { 1, 2, 3 }));
+          }
+        }
+      }
+    CSHARP
+
+    (testpath/"test.csproj").write <<~XML
+      <Project Sdk="Microsoft.NET.Sdk">
+        <PropertyGroup>
+          <OutputType>Exe</OutputType>
+          <TargetFrameworks>#{target_framework}</TargetFrameworks>
+          <PlatformTarget>AnyCPU</PlatformTarget>
+          <RootNamespace>Homebrew</RootNamespace>
+          <PackageId>Homebrew.Dotnet</PackageId>
+          <Title>Homebrew.Dotnet</Title>
+          <Product>$(AssemblyName)</Product>
+          <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+        </PropertyGroup>
+        <ItemGroup>
+          <Compile Include="test.cs" />
+        </ItemGroup>
+        <ItemGroup>
+          <Reference Include="TechnitiumLibrary">
+            <HintPath>#{libexec}/TechnitiumLibrary.dll</HintPath>
+          </Reference>
+        </ItemGroup>
+      </Project>
+    XML
+
+    system "#{dotnet.opt_libexec}/dotnet", "build", "--framework", target_framework,
+           "--output", testpath, testpath/"test.csproj"
+    output = shell_output("#{dotnet.opt_libexec}/dotnet run --framework #{target_framework} #{testpath}/test.dll")
+    assert_match "04106===", output
+  end
+end

--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -64,6 +64,7 @@
   ["qt", "qt-libiodbc", "qt-mariadb", "qt-mysql", "qt-percona-server", "qt-postgresql", "qt-unixodbc"],
   ["qwt", "qwt-qt5"],
   ["surelog", "uhdm"],
+  ["technitium-dns", "technitium-library"],
   ["tmuxinator", "tmuxinator-completion"],
   ["vulkan-headers", "vulkan-loader", "vulkan-tools", "vulkan-utility-libraries"],
   ["wp-cli", "wp-cli-completion"]


### PR DESCRIPTION
Add a formula for [Technitium DNS](https://github.com/TechnitiumSoftware/DnsServer), a self-hosted DNS server for privacy & security which can also block ads & malware at the DNS level.

The code owner @ShreyasZare approves this contribution: https://github.com/TechnitiumSoftware/DnsServer/discussions/1294

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
