### PR TITLE
octobuild: fix build on arm64 linux

### DIFF
--- a/Formula/o/octobuild.rb
+++ b/Formula/o/octobuild.rb
@@ -22,7 +22,29 @@ class Octobuild < Formula
     depends_on "openssl@3"
   end
 
+  resource "ipc-rs" do
+    on_linux do
+      on_arm do
+        url "https://github.com/octobuild/ipc-rs/archive/e8d76ee36146d4548d18ba8480bf5b5a2f116eac.tar.gz"
+        sha256 "aaa5418086f55df5bea924848671df365e85aa57102abd0751366e1237abcff5"
+
+        # Apply commit from open PR https://github.com/octobuild/ipc-rs/pull/12
+        patch do
+          url "https://github.com/octobuild/ipc-rs/commit/1eabde12d785ceda197588490abeb15615a00dad.patch?full_index=1"
+          sha256 "521d8161be9695480f5b578034166c8e7e15b078733d3571cd5db2a00951cdd8"
+        end
+      end
+    end
+  end
+
   def install
+    if OS.linux? && Hardware::CPU.arm?
+      (buildpath/"ipc-rs").install resource("ipc-rs")
+      (buildpath/"Cargo.toml").append_lines <<~TOML
+        [patch."https://github.com/octobuild/ipc-rs"]
+        ipc = { path = "./ipc-rs" }
+      TOML
+    end
     system "cargo", "install", *std_cargo_args
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
