### PR TITLE
cspice: remove `-m64` to build on arm64 linux

### DIFF
--- a/Formula/c/cspice.rb
+++ b/Formula/c/cspice.rb
@@ -38,8 +38,9 @@ class Cspice < Formula
   def install
     # Use brewed csh on Linux because it is not installed in CI.
     unless OS.mac?
-      Dir["src/*/*.csh"].each do |file|
-        inreplace file, "/bin/csh", Formula["tcsh"].opt_bin/"csh"
+      inreplace Dir["src/*/*.csh"] do |s|
+        s.gsub! "/bin/csh", Formula["tcsh"].opt_bin/"csh"
+        s.gsub! '= "-m64 ', '= "' if Hardware::CPU.arm?
       end
     end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
