### PR TITLE
imagemagick: drop ghostscript dependency

### DIFF
--- a/Formula/i/imagemagick.rb
+++ b/Formula/i/imagemagick.rb
@@ -12,13 +12,14 @@ class Imagemagick < Formula
   end
 
   bottle do
-    sha256 arm64_sequoia: "17dc01edff23efc0180b38e0cc567778216240eb9b57f321894022abecd44a2f"
-    sha256 arm64_sonoma:  "bce3619782675469ef11edc6b2f40a8529a72edffd090decb6fb87df1a23e1ca"
-    sha256 arm64_ventura: "341a5112100873c7298ae95dd869251cc489663d311009b34c7adca4ef64791f"
-    sha256 sonoma:        "6a4bece70e04010ea0c8cd3a79b5550805417ec8ef806bbf3aafac9c2eb7c378"
-    sha256 ventura:       "c217d0c45807dc5fc76bafe90966ff981240b754545f6cdf8ffc26d9daa390bf"
-    sha256 arm64_linux:   "0a40588706b93670e4a5e1a0512534ef8056d4b675004647299a5c62cce3f7e8"
-    sha256 x86_64_linux:  "3215ff618340ad769fc4b2a164636cc8767c0d0bab37a05fdac74e5908fedf1c"
+    rebuild 1
+    sha256 arm64_sequoia: "3d7b63545a505aa12f4b9919c03499765b9ae91bb22c171503e00ef1403d447a"
+    sha256 arm64_sonoma:  "34e1150a01678d185c30df5f2274d07c4f06236f92b3fb707c3027e346f83610"
+    sha256 arm64_ventura: "81ba67cc61546e29607ff63e792dcaa078453c66300e62c48dd805c76b2b469e"
+    sha256 sonoma:        "4392321a4b1027b2b005046cc4da9695daabcf10fd7855f438757525a937dadb"
+    sha256 ventura:       "a4d5765e945c356571764b833bd1b884d93f4befe9dcc1b62c4213daa8f687b1"
+    sha256 arm64_linux:   "adfcf4acb6cb5c630fa7ed04cde51b2567bee8bced1bd9694c3f9e25df6f9721"
+    sha256 x86_64_linux:  "cd94eab74e5550506589f0b8b8f1e401e38f1a57d714c1005cdd61095c2cb6fd"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/i/imagemagick.rb
+++ b/Formula/i/imagemagick.rb
@@ -24,7 +24,6 @@ class Imagemagick < Formula
   depends_on "pkgconf" => :build
   depends_on "fontconfig"
   depends_on "freetype"
-  depends_on "ghostscript"
   depends_on "jpeg-turbo"
   depends_on "jpeg-xl"
   depends_on "libheif"
@@ -77,7 +76,7 @@ class Imagemagick < Formula
       "--with-webp=yes",
       "--with-heic=yes",
       "--with-raw=yes",
-      "--with-gslib",
+      "--without-gslib",
       "--with-gs-font-dir=#{HOMEBREW_PREFIX}/share/ghostscript/fonts",
       "--with-lqr",
       "--without-djvu",
@@ -100,6 +99,13 @@ class Imagemagick < Formula
     system "make", "install"
   end
 
+  def caveats
+    <<~EOS
+      Ghostscript is not installed by default as a dependency.
+      If you need PS or PDF support, ImageMagick will still use the ghostscript formula if installed directly.
+    EOS
+  end
+
   test do
     assert_match "PNG", shell_output("#{bin}/identify #{test_fixtures("test.png")}")
 
@@ -114,6 +120,5 @@ class Imagemagick < Formula
     ["AVIF  HEIC      rw+", "ARW  DNG       r--", "DNG  DNG       r--"].each do |format|
       assert_match format, formats
     end
-    assert_match "Helvetica", shell_output("#{bin}/magick -list font")
   end
 end

--- a/Formula/i/imagemagick@6.rb
+++ b/Formula/i/imagemagick@6.rb
@@ -12,13 +12,14 @@ class ImagemagickAT6 < Formula
   end
 
   bottle do
-    sha256 arm64_sequoia: "a884a93b2af4d61c53146f4059c6631862698370699f1b0e72440a63aa004c7c"
-    sha256 arm64_sonoma:  "15eb0b4a426cc33f2cd99baf57017f9537d6251d29b8d09cfd7291fa6be85ea2"
-    sha256 arm64_ventura: "561e5419e3167dba6d08dd98f4aca808124d54f101d290e01699972211bb85ec"
-    sha256 sonoma:        "5c9d716152df5bff058f68b827de0ec536038302b9511b4a6b81eef630dac1d6"
-    sha256 ventura:       "56d2bad5fe40d06ef7211974b8203bdf1b5d95758afb3c21b6cb6d78648f75f5"
-    sha256 arm64_linux:   "4b17eeaa7ccab403f1cb8960e95b28aad76115aebba989edf44033345c3d5f8e"
-    sha256 x86_64_linux:  "d9cf6be91ea016b35b0115117fb216f111f8ed69ca3132ff0078ae99dce207fe"
+    rebuild 1
+    sha256 arm64_sequoia: "09cae28da4c71a6004c02518ffea95ef4df07fcc7f211eab10d6eac87eb48fb5"
+    sha256 arm64_sonoma:  "3f7492a6a7040334c307e36e780a4e34a9148c2d644713c939ab8ccd4c82bf6e"
+    sha256 arm64_ventura: "0736732b7c46c6fcbbf5106695758e428ef862d2a03414bd97c9986f0e1f96c7"
+    sha256 sonoma:        "57a9fb490b1378cc28e1df03706e8d3c937c1d0aad8210c18880fc186069a6ec"
+    sha256 ventura:       "68eeb42ec14914a27303bb7748bce2ced67135dd6824fba1a138f1967b67e8dd"
+    sha256 arm64_linux:   "4d83ead3cbb27e2c7aff3f58e5796c07691a16c2574aede0ce4aa35f99bbc057"
+    sha256 x86_64_linux:  "5487c6a697e5ec21472cadd645e053b289700c75c169a1ae9e0eaf52b482f090"
   end
 
   keg_only :versioned_formula

--- a/Formula/i/imagemagick@6.rb
+++ b/Formula/i/imagemagick@6.rb
@@ -27,7 +27,6 @@ class ImagemagickAT6 < Formula
 
   depends_on "fontconfig"
   depends_on "freetype"
-  depends_on "ghostscript"
   depends_on "jpeg-turbo"
   depends_on "libpng"
   depends_on "libtiff"
@@ -60,7 +59,7 @@ class ImagemagickAT6 < Formula
       --with-modules
       --with-webp=yes
       --with-openjp2
-      --with-gslib
+      --without-gslib
       --with-gs-font-dir=#{HOMEBREW_PREFIX}/share/ghostscript/fonts
       --without-djvu
       --without-fftw
@@ -71,6 +70,13 @@ class ImagemagickAT6 < Formula
 
     system "./configure", *args, *std_configure_args
     system "make", "install"
+  end
+
+  def caveats
+    <<~EOS
+      Ghostscript is not installed by default as a dependency.
+      If you need PS or PDF support, ImageMagick will still use the ghostscript formula if installed directly.
+    EOS
   end
 
   test do


### PR DESCRIPTION
Ghostscript is fairly large and is AGPL 3.0. Looking at dependencies, it seems like it might be ok legally (I think x265 should actually be `GPL-2.0-or-later` rather than `only`) but I don't think it's really worth it when you consider that when ImageMagick doesn't have libgs it will defer to the `gs` executable anyway.

This means we can make the Ghostscript dependency completely down to the user. If they need `PS`/`PDF` support then they can do `brew install ghostscript`. If they don't, then they don't need to have it installed.

This also allows people with `HOMEBREW_FORBIDDEN_LICENSES=AGPL-3.0` to install ImageMagick again.