### PR TITLE
percona-server: allow building without `-march=armv8.1-a+crypto`

### DIFF
--- a/Formula/p/percona-server.rb
+++ b/Formula/p/percona-server.rb
@@ -66,6 +66,13 @@ class PerconaServer < Formula
     cause "Requires GCC 10 or newer"
   end
 
+  # Backport fix for CMake 4.0
+  patch do
+    url "https://github.com/Percona-Lab/coredumper/commit/715fa9da1d7958e39d69e9b959c7a23fec8650ab.patch?full_index=1"
+    sha256 "632a6aff4091d9cbe010ed600eeb548ae7762ac7e822113f9c93e3fef9aafb4f"
+    directory "extra/coredumper"
+  end
+
   # Patch out check for Homebrew `boost`.
   # This should not be necessary when building inside `brew`.
   # https://github.com/Homebrew/homebrew-test-bot/pull/820
@@ -121,9 +128,10 @@ class PerconaServer < Formula
       -DWITH_ZSTD=system
       -DWITH_UNIT_TESTS=OFF
       -DROCKSDB_BUILD_ARCH=#{ENV.effective_arch}
+      -DALLOW_NO_ARMV81A_CRYPTO=ON
+      -DALLOW_NO_SSE42=ON
     ]
     args << "-DROCKSDB_DISABLE_AVX2=ON" if build.bottle?
-    args << "-DALLOW_NO_SSE42=ON" if Hardware::CPU.intel? && (!OS.mac? || !MacOS.version.requires_sse42?)
     args << "-DWITH_KERBEROS=system" unless OS.mac?
 
     system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args

--- a/Formula/p/percona-server@8.0.rb
+++ b/Formula/p/percona-server@8.0.rb
@@ -87,6 +87,13 @@ class PerconaServerAT80 < Formula
     sha256 "d4afcdfb0dd8dcb7c0f7e380a88605b515874628107295ab5b892e8f1e019604"
   end
 
+  # Backport fix for CMake 4.0
+  patch do
+    url "https://github.com/Percona-Lab/coredumper/commit/715fa9da1d7958e39d69e9b959c7a23fec8650ab.patch?full_index=1"
+    sha256 "632a6aff4091d9cbe010ed600eeb548ae7762ac7e822113f9c93e3fef9aafb4f"
+    directory "extra/coredumper"
+  end
+
   def datadir
     var/"mysql"
   end
@@ -141,9 +148,10 @@ class PerconaServerAT80 < Formula
       -DWITH_UNIT_TESTS=OFF
       -DWITH_INNODB_MEMCACHED=ON
       -DROCKSDB_BUILD_ARCH=#{ENV.effective_arch}
+      -DALLOW_NO_ARMV81A_CRYPTO=ON
+      -DALLOW_NO_SSE42=ON
     ]
     args << "-DROCKSDB_DISABLE_AVX2=ON" if build.bottle?
-    args << "-DALLOW_NO_SSE42=ON" if Hardware::CPU.intel? && (!OS.mac? || !MacOS.version.requires_sse42?)
     args << "-DWITH_KERBEROS=system" unless OS.mac?
 
     ENV.append "CXXFLAGS", "-std=c++17"


### PR DESCRIPTION
The `ALLOW_NO_*` arguments just control whether to make CMake error message into a non-blocking warning so can be applied everywhere.

---

RocksDB does support runtime detection but the way Percona Server builds is by using `-march=` on all files - https://github.com/percona/percona-server/blob/Percona-Server-8.4.4-4/cmake/compiler_features.cmake#L266

This seems less safe than the way MariaDB handles it by only changing `-march=` or using `-msse4.2` on the specific file - https://github.com/MariaDB/server/blob/main/storage/rocksdb/build_rocksdb.cmake#L477-L478