### PR TITLE
transcrypt: remove optional xxd/vim dependency

### DIFF
--- a/Formula/t/transcrypt.rb
+++ b/Formula/t/transcrypt.rb
@@ -12,7 +12,6 @@ class Transcrypt < Formula
 
   on_linux do
     depends_on "util-linux"
-    depends_on "vim" # needed for xxd
   end
 
   def install


### PR DESCRIPTION
See https://github.com/elasticdog/transcrypt/pull/181 which was released as part of transcrypt 2.3.1

xxd
or printf with %b support
or perl
is required,
making xxd (vim) optional

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
