### PR TITLE
ldc: downgrade bootstrap for macOS 15.4

### DIFF
--- a/Formula/d/dpp.rb
+++ b/Formula/d/dpp.rb
@@ -5,6 +5,7 @@ class Dpp < Formula
       tag:      "v0.6.0",
       revision: "9c2b175b32cc46581a94a7ee1c0026f0cda045fc"
   license "BSL-1.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "b9bac32440464a7d775ef641fff284d5de50ab7ecf6c1ad37e3a137898435504"

--- a/Formula/d/dpp.rb
+++ b/Formula/d/dpp.rb
@@ -8,15 +8,13 @@ class Dpp < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "b9bac32440464a7d775ef641fff284d5de50ab7ecf6c1ad37e3a137898435504"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "2476590c375c79bc2b694bf10a2edd7721d3603f7738b8d6c935d487ac9655f9"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "a55479222fdfcb5350b7a06f509ce37a7af58d6b2f0c36807a3250b0a3169618"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "56f17de3bca828d4d844a811f40ed824827876530e8c4f3bef427c1f1c934678"
-    sha256 cellar: :any_skip_relocation, sonoma:         "a342da9f8b506999916e8ab83b6a0b7ca1574852e5daa106d4eb5308b1f4e588"
-    sha256 cellar: :any_skip_relocation, ventura:        "cff6526644d8ebdf667ad74b1ef8c420bf76014f0dd57b05bf9706f45efba495"
-    sha256 cellar: :any_skip_relocation, monterey:       "0dea447606ae46a62481252ea7cd16c2a6545be69918abea6949c787b55c39b7"
-    sha256 cellar: :any_skip_relocation, arm64_linux:    "b5d7706120bcdd68aa87702e23cd5b1057af2ffb1f1c55a2a978f26ff79df070"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ac1f792f0814d1b5b07b10b751308dd7efc34f7105f93fc27946d3a649857db4"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e5f0fc9c62c460aba1532c7389e42c9bb85da0bcfa38607b76a361cb66c0d396"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "49bf533852469130afaf24027a2d88f6825d35cd90515e041bdddccff3620640"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "443e5a65e5f70dc1c1af23f374c94cb1c6ff26836a4b23c9c6e4597502dbd060"
+    sha256 cellar: :any_skip_relocation, sonoma:        "aebc8ca08df57de8624e9fb1a324872bb5883b207bb2a650a59125efc54e823b"
+    sha256 cellar: :any_skip_relocation, ventura:       "8acb22136bec153dd078adc4ad53441ce33e65a1ad96c25161a13cc19ca9e1e0"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "5115fc9b696c79b4acaa885bf0476915c91993d8a0ecfe393fd85cbd2b5af56d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2831967224ea98d7b494448db999203aead8f24183bb33319315f5af8d271185"
   end
 
   depends_on "dtools" => :build

--- a/Formula/d/dtools.rb
+++ b/Formula/d/dtools.rb
@@ -8,13 +8,13 @@ class Dtools < Formula
   head "https://github.com/dlang/tools.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "6778d202df0d520c381dc2673255dad0f918731e4bf342cb4ec2c6496fd434a7"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "0f878981e244a35df18c4e96672b15cef4fed2b6078972201adbb2736891b3d8"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "f98206ff041de733df29b77e9dc282ac33fed0442a086c42f6d90047e7aa24cf"
-    sha256 cellar: :any_skip_relocation, sonoma:        "5ef13d4318457fd18617cc7908faf31cca88cb390bbe03b8f12ba1e2e5fba427"
-    sha256 cellar: :any_skip_relocation, ventura:       "0ee01bf2167c23fb9735c8cd59a1d4da4e9c8510929b50246dc3921932575515"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "30acf8b3f1796a504cd7e9cb7d635913c3bcc37c58f48def9799784d7c30c653"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "6584c89d375ae71783b3317e953db07a4bc0a72f48c68b86eff1dc02b91c8a38"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e0f6645e51b5da22628b3b64b43acafc4ac335b98afbe8cbee3d10ef88fdaec9"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "2e3f2aed17e75ef0632e0ec36b9dfb3db9566af400d3e2ec027aa89bf1699234"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "4ffb209a7cc7a4e05c90771030c6c91941be35dd9884fe58f9dd14ef82c5fce1"
+    sha256 cellar: :any_skip_relocation, sonoma:        "6b01da4e8af6781c0a9333fc0e27fbcd2b758e0e9a99fc49a6a3123f0a1725d2"
+    sha256 cellar: :any_skip_relocation, ventura:       "7fbe7a851ed67642ac50e8a196ac216278eb7528f4c150360c9d4a219be3d30f"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "9d8fd7789bb36d3a8577f925224336d7bc6cd2b891b9065a81d91b6e97b7b73b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "6eb2ded59c5d481a4ef6d450a65ac15bdf527b9d56ab89bc293fbd68f9c6a180"
   end
 
   depends_on "dub" => :build

--- a/Formula/d/dtools.rb
+++ b/Formula/d/dtools.rb
@@ -4,6 +4,7 @@ class Dtools < Formula
   url "https://github.com/dlang/tools/archive/refs/tags/v2.111.0.tar.gz"
   sha256 "4c391349e929f73b7ffe97da7b98fbbdb04effda3e6389d9d46dc9d9938ece3b"
   license "BSL-1.0"
+  revision 1
   head "https://github.com/dlang/tools.git", branch: "master"
 
   bottle do

--- a/Formula/l/ldc.rb
+++ b/Formula/l/ldc.rb
@@ -49,13 +49,15 @@ class Ldc < Formula
 
   resource "ldc-bootstrap" do
     on_macos do
+      # Do not use 1.29 - 1.40 to bootstrap as it segfaults on macOS 15.4.
+      # Ref: https://github.com/dlang/dmd/issues/21126#issuecomment-2775948553
       on_arm do
-        url "https://github.com/ldc-developers/ldc/releases/download/v1.40.0/ldc2-1.40.0-osx-arm64.tar.xz"
-        sha256 "04ebaaddfadf5b62486914eee511a8cb9e6802a7b413e7a8799d5a7fa1ca5cb4"
+        url "https://github.com/ldc-developers/ldc/releases/download/v1.28.1/ldc2-1.28.1-osx-arm64.tar.xz"
+        sha256 "9bddeb1b2c277019cf116b2572b5ee1819d9f99fe63602c869ebe42ffb813aed"
       end
       on_intel do
-        url "https://github.com/ldc-developers/ldc/releases/download/v1.40.0/ldc2-1.40.0-osx-x86_64.tar.xz"
-        sha256 "90802f92801b700804b8ba48d8c12128d3724c9dbb6a88811d6c9204fce9e036"
+        url "https://github.com/ldc-developers/ldc/releases/download/v1.28.1/ldc2-1.28.1-osx-x86_64.tar.xz"
+        sha256 "9aa43e84d94378f3865f69b08041331c688e031dd2c5f340eb1f3e30bdea626c"
       end
     end
     on_linux do

--- a/Formula/l/ldc.rb
+++ b/Formula/l/ldc.rb
@@ -28,14 +28,14 @@ class Ldc < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256                               arm64_sequoia: "36449ae414e34231fc2e2efeb52dfd1440fb8f85661f6e1949a549f26629ed63"
-    sha256                               arm64_sonoma:  "8428db33b0d7a88ef5b528a00dd1fad1f33ca1fdb36b3149a281fbfb8cc9f2c2"
-    sha256                               arm64_ventura: "1c1cbed780079891dd07f15f77021200b58502baad0595c59721d577f81d222d"
-    sha256                               sonoma:        "fb203819c3456a88e723d0d7958e010eeca90db38406b3a2cb100ba12f2476b9"
-    sha256                               ventura:       "192c24c114b06e3d7c7dddbec28f029cf22df142e11983421d31d4d865a218dc"
-    sha256                               arm64_linux:   "979f2477a03297565bda42f05e52ae9abe85b9f4cac0d88b042b3f5e9e2c1cff"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "88375463fd83a64305e0cd725d6c552852bd53c2a317895bf918861e4d5325e4"
+    rebuild 2
+    sha256                               arm64_sequoia: "9384ccb16954cc0bd4cdc10cbff3b88f7c4198376adca1180d96f7f7ebd2ba43"
+    sha256                               arm64_sonoma:  "97f6afa4dab17754196e9b29885721d61ce6244cdc2c627ac2d2e4a2ab9f62bc"
+    sha256                               arm64_ventura: "284c606878e28375d5a6bd4dcba1ab090be8022d5fee5e974942c29a383a8e2b"
+    sha256                               sonoma:        "46bb2adaf6f60942728c169eb3ab1c3951133ecdd6816c5ac3ba4aa32b7c7f02"
+    sha256                               ventura:       "212beef9d9dd8f73794f2ca9a6c1786a1920d4f5c21f5800d2b17b09297e8417"
+    sha256                               arm64_linux:   "eccf24bbebc2f4960b38f37612e16316b5cc1941d97930d27418eda01ae38240"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e9d640a656f11e1f2e421a1d093a7d8bb183e0052aeca6101176b7b7c14adbed"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
So the backport from #219909 helps produce non-segfaulting binaries but doesn't fix `ldc` itself as original bootstrap had the bug.

Easiest workaround for now is to downgrade bootstrap to working version.