### PR TITLE
hbase: remove `netcat` test dependency

### DIFF
--- a/Formula/h/hbase.rb
+++ b/Formula/h/hbase.rb
@@ -20,8 +20,6 @@ class Hbase < Formula
   depends_on "lzo"
   depends_on "openjdk@11"
 
-  uses_from_macos "netcat" => :test
-
   resource "hadoop-lzo" do
     url "https://github.com/cloudera/hadoop-lzo/archive/refs/tags/0.4.14.tar.gz"
     sha256 "aa8ddbb8b3f9e1c4b8cc3523486acdb7841cd97c002a9f2959c5b320c7bb0e6c"
@@ -91,7 +89,7 @@ class Hbase < Formula
     # https://issues.apache.org/jira/browse/HBASE-15426
     inreplace "#{libexec}/conf/hbase-site.xml",
       /<configuration>/,
-      <<~EOS
+      <<~XML
         <configuration>
           <property>
             <name>hbase.rootdir</name>
@@ -117,7 +115,7 @@ class Hbase < Formula
             <name>hbase.master.dns.interface</name>
             <value>#{loopback}</value>
           </property>
-      EOS
+      XML
   end
 
   def post_install
@@ -161,9 +159,14 @@ class Hbase < Formula
     ENV["HBASE_PID_DIR"]  = testpath/"pid"
 
     system bin/"start-hbase.sh"
-    sleep 15
     begin
-      assert_match "Zookeeper", pipe_output("nc 127.0.0.1 #{port} 2>&1", "stats")
+      sleep 15
+      TCPSocket.open("127.0.0.1", port) do |sock|
+        sock.puts("stats")
+        assert_match "Zookeeper", sock.gets
+      ensure
+        sock.close
+      end
     ensure
       system bin/"stop-hbase.sh"
     end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
