### PR TITLE
add tpchgen-cli 1.0.0 (new formula)

### DIFF
--- a/Formula/t/tpchgen-cli.rb
+++ b/Formula/t/tpchgen-cli.rb
@@ -1,0 +1,19 @@
+class TpchgenCli < Formula
+  desc "TPC-H benchmark data generation in pure Rust"
+  homepage "https://github.com/clflushopt/tpchgen-rs"
+  url "https://github.com/clflushopt/tpchgen-rs/archive/refs/tags/v1.0.0.tar.gz"
+  sha256 "fdb01ec6ffd426de928c4da5e33945095560c78d1b35eaab09f5d4c8c4aa7cb9"
+  license "Apache-2.0"
+  head "https://github.com/clflushopt/tpchgen-rs.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args(path: "tpchgen-cli")
+  end
+
+  test do
+    line_count = shell_output("#{bin}/tpchgen-cli -s 0.01 -T lineitem -p 100 --part 1 --stdout | wc -l").to_i
+    assert line_count.positive?, "Expected some output lines from tpchgen-cli"
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Following example from https://github.com/Homebrew/homebrew-core/blob/master/Formula/d/datafusion.rb

### Commands ran to generate file
```
brew create --rust --verbose https://github.com/clflushopt/tpchgen-rs/archive/refs/tags/v1.0.0.tar.gz
HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source tpchgen-cli
brew test tpchgen-cli
brew audit --new tpchgen-cli
```

TODO:
- [ ] should add `bottle`? 
- [ ] Fix or bypass `brew audit` for `GitHub repository not notable enough`

```
(.venv) ➜  homebrew-core git:(kevinjqliu/add-tpchgen-cli) ✗ brew audit --new tpchgen-cli           

tpchgen-cli
  * GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)
Error: 1 problem in 1 formula detected.
```