### PR TITLE
jsontoolkit: deprecate

### DIFF
--- a/Formula/j/jsontoolkit.rb
+++ b/Formula/j/jsontoolkit.rb
@@ -16,6 +16,9 @@ class Jsontoolkit < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "7201211ab61aa4766b12221174fd6fa7215e99571a2f898395d1fedbe19432c7"
   end
 
+  # Original source is no longer available after repo change
+  deprecate! date: "2025-04-17", because: :does_not_build
+
   depends_on "cmake" => :build
 
   def install


### PR DESCRIPTION
We may still consider new repo even though they don't version/tag; however, this will need further discussion and perhaps a documented Homebrew policy.

For now, will mark deprecation and maybe someone interested can open a PR before removal.

---

`:does_not_build` to avoid tracking as part of mass bottling.