### PR TITLE
greed: use FreeBSD tarball

### DIFF
--- a/Formula/g/greed.rb
+++ b/Formula/g/greed.rb
@@ -1,7 +1,8 @@
 class Greed < Formula
   desc "Game of consumption"
   homepage "http://www.catb.org/~esr/greed/"
-  url "http://www.catb.org/~esr/greed/greed-4.3.tar.gz"
+  url "https://pkg.freebsd.org/ports-distfiles/greed-4.3.tar.gz"
+  mirror "http://www.catb.org/~esr/greed/greed-4.3.tar.gz"
   sha256 "60433afaef3eb8e20e4aa33d4b5538f6ea661b1880c98cd9d7c6df86c91d4baa"
   license "BSD-2-Clause"
   head "https://gitlab.com/esr/greed.git", branch: "master"


### PR DESCRIPTION
Already deprecated but just add the FreeBSD copy of tarball so formula can still build before removal.

```
❯ curl -sL https://pkg.freebsd.org/ports-distfiles/greed-4.3.tar.gz | sha256
60433afaef3eb8e20e4aa33d4b5538f6ea661b1880c98cd9d7c6df86c91d4baa
```

Still no response upstream though diff is mainly some fix for homepage url in doc files, i.e. https://gitlab.com/esr/greed/-/commit/c9e7ce6f5b5d0c40bd84023287a2cf4b95388487
```
│ ├── file list
│ │ @@ -1,9 +1,9 @@
│ │  -rw-rw-r--   0 esr       (1000) esr       (1000)      738 2024-01-29 16:50:59.000000 greed-4.3/control
│ │  -rw-rw-r--   0 esr       (1000) esr       (1000)     1310 2015-10-17 17:26:44.000000 greed-4.3/COPYING
│ │ --rw-rw-r--   0 esr       (1000) esr       (1000)     2942 2024-02-06 12:47:26.000000 greed-4.3/greed.6
│ │ --rw-rw-r--   0 esr       (1000) esr       (1000)     2254 2024-02-01 21:42:59.000000 greed-4.3/greed.adoc
│ │ +-rw-rw-r--   0 esr       (1000) esr       (1000)     2913 2024-02-08 01:27:11.000000 greed-4.3/greed.6
│ │ +-rw-rw-r--   0 esr       (1000) esr       (1000)     2227 2024-02-08 01:25:29.000000 greed-4.3/greed.adoc
│ │  -rw-rw-r--   0 esr       (1000) esr       (1000)    19570 2024-02-06 12:44:02.000000 greed-4.3/greed.c
│ │  -rw-rw-r--   0 esr       (1000) esr       (1000)     2216 2015-06-15 01:21:37.000000 greed-4.3/greed-logo.png
│ │ --rw-rw-r--   0 esr       (1000) esr       (1000)     1570 2024-02-06 12:44:33.000000 greed-4.3/Makefile
│ │ --rw-rw-r--   0 esr       (1000) esr       (1000)      965 2024-02-06 12:44:02.000000 greed-4.3/NEWS.adoc
│ │ +-rw-rw-r--   0 esr       (1000) esr       (1000)     1570 2024-02-08 01:25:29.000000 greed-4.3/Makefile
│ │ +-rw-rw-r--   0 esr       (1000) esr       (1000)      965 2024-02-08 01:27:02.000000 greed-4.3/NEWS.adoc
│ │  -rw-rw-r--   0 esr       (1000) esr       (1000)     2918 2024-02-06 12:44:02.000000 greed-4.3/README
│ ├── greed-4.3/greed.6
│ │ @@ -1,17 +1,17 @@
│ │  '\" t
│ │  .\"     Title: galaxixs
│ │  .\"    Author: [see the "AUTHOR(S)" section]
│ │  .\" Generator: Asciidoctor 2.0.16
│ │ -.\"      Date: 2024-02-01
│ │ +.\"      Date: 2024-02-07
│ │  .\"    Manual: \ \&
│ │  .\"    Source: \ \&
│ │  .\"  Language: English
│ │  .\"
│ │ -.TH "GREED" "6" "2024-02-01" "\ \&" "\ \&"
│ │ +.TH "GREED" "6" "2024-02-07" "\ \&" "\ \&"
│ │  .ie \n(.g .ds Aq \(aq
│ │  .el       .ds Aq '
│ │  .ss \n[.ss] 0
│ │  .nh
│ │  .ad l
│ │  .de URL
│ │  \fI\\$2\fP <\\$1>\\$3
│ │ @@ -115,14 +115,14 @@
│ │  .RE
│ │  .SH "AUTHORS == ORIGINALLY WRITTEN"
│ │  .sp
│ │  Written by Matt Day.  Maintained by \c
│ │  .MTO "esr\(atsnark.thyrsus.com" "" "."
│ │  See ESR\(cqs home
│ │  page at \c
│ │ -.URL "http://www.catb.org/esr/\*(Aq>http://www.catb.org/esr/" "" ""
│ │ +.URL "http://www.catb.org/~esr/" "" ""
│ │  for
│ │  updates and other resources.
│ │  .SH "BUGS"
│ │  .sp
│ │  This really ought to be an X game, but that would have been too much
│ │  like work.
│ ├── greed-4.3/greed.adoc
│ │ @@ -75,15 +75,15 @@
│ │     Default location of Greed high scores.
│ │  ~/.greedscores::
│ │     Where they're put if the default location cannot be written to..
│ │
│ │  [[authors]]
│ │  == AUTHORS == Originally written
│ │  Written by Matt Day.  Maintained by <esr@snark.thyrsus.com>. See ESR's home
│ │ -page at http://www.catb.org/~esr/'>http://www.catb.org/~esr/ for
│ │ +page at http://www.catb.org/~esr/ for
│ │  updates and other resources.
│ │
│ │  [[bugs]]
│ │  == BUGS ==
│ │  This really ought to be an X game, but that would have been too much
│ │  like work.
│ ├── greed-4.3/NEWS.adoc
│ │ @@ -1,10 +1,10 @@
│ │  = greed project news
│ │
│ │ -4.3: 2024-02-06::
│ │ +4.3: 2024-02-07::
│ │    Code cleanup for moden C. Add validation.
│ │    Make the @ for the player's position more visible
│ │
│ │  4.2: 2017-03-16::
│ │    Document the basic movement keys better on the manual page.
│ │    Change from BSD 3-clause to 2-clause and use SPDX tagging.
```