### PR TITLE
vlang: update `vc` resource and use tarball

### DIFF
--- a/Formula/v/vlang.rb
+++ b/Formula/v/vlang.rb
@@ -22,14 +22,24 @@ class Vlang < Formula
 
   depends_on "bdw-gc"
 
+  on_linux do
+    on_arm do
+      depends_on "llvm" => :build
+
+      fails_with :gcc do
+        cause "compilation failed with errors in vlib/v/ast/scope.v"
+      end
+    end
+  end
+
   conflicts_with "v", because: "both install `v` binaries"
 
   resource "vc" do
     # For every vlang release there is a matching commit of the V compiler in the format
     # "[v:master] {short SHA of the vlang release commit} - {vlang version number}".
     # The sources of this V compiler commit need to be used here
-    url "https://github.com/vlang/vc.git",
-        revision: "7d11c662eaac78bd5195ee5086069b2a65354047"
+    url "https://github.com/vlang/vc/archive/66ea39be2275ac723225b9ca99d51ec1212c640d.tar.gz"
+    sha256 "c3b57600ad8081a525045d9877e245db834655fefdc79d05dcbed385e0ed0a68"
 
     on_big_sur :or_older do
       patch do

--- a/Formula/v/vlang.rb
+++ b/Formula/v/vlang.rb
@@ -12,12 +12,13 @@ class Vlang < Formula
   end
 
   bottle do
-    sha256                               arm64_sequoia: "32aec92a6ac64e9d2dc960ecafbfaa3282bd0eded6db255b9ede6bd571149527"
-    sha256                               arm64_sonoma:  "af87e546e1a6382c3a2ee7ff2cf7b65e2f3270271fc43dbefebde926300c1d4a"
-    sha256                               arm64_ventura: "9c366ca953ffb4b842dd03f76a482ad13f2947d710a310a1a21d9f4ba96a5f50"
-    sha256 cellar: :any,                 sonoma:        "24f58d9baf4cae0aca1927abd2ea628ce05ee7388f71b08073cde56cfc180f12"
-    sha256 cellar: :any,                 ventura:       "282a577155862b49a70bcee58086543e6b6e4fb2bdb1657b4fcfb8150107d89a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "caf700701f2968e5e47851da597f7261f79dcbae2b4be8ac5d126f7c62fdff86"
+    rebuild 1
+    sha256                               arm64_sequoia: "61e324a5cb4f1e5fe36e22feece35f101900884c4ee2e184ed2b560861751a6c"
+    sha256                               arm64_sonoma:  "a781eaf96128ae65326af2541ff60e35ec8cd28d1ec6fdb2ed22484102af95d0"
+    sha256                               arm64_ventura: "14224fb4505f57200c0bd125552913b83fcd1274ca3bfb435fc586036b9d77d3"
+    sha256 cellar: :any,                 sonoma:        "ac31a04a8e221306fad1f9fd4e32bdb11f6788d7d6fbf1bdafc994ae4c79be91"
+    sha256 cellar: :any,                 ventura:       "9d1829750ac5e28f8820dc46b9f9b025ef7a804613026e0b7848b0c153a89e4c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "57484b27ff2dde605916de66bb00e53badeec8f683aa49e81f976b0ceccfee1b"
   end
 
   depends_on "bdw-gc"


### PR DESCRIPTION
Also build with LLVM Clang for arm64 linux to work around build error

---

Old resource: https://github.com/vlang/vc/commit/7d11c662eaac78bd5195ee5086069b2a65354047

New resource: https://github.com/vlang/vc/commit/66ea39be2275ac723225b9ca99d51ec1212c640d

Just off by one commit.