### PR TITLE
micro_inetd: remove `netcat` test dependency

### DIFF
--- a/Formula/m/micro_inetd.rb
+++ b/Formula/m/micro_inetd.rb
@@ -23,8 +23,6 @@ class MicroInetd < Formula
   # Original URLs are dead and last release from 2014-08-14
   deprecate! date: "2025-03-18", because: :unmaintained
 
-  uses_from_macos "netcat" => :test
-
   def install
     bin.mkpath
     man1.mkpath
@@ -33,14 +31,14 @@ class MicroInetd < Formula
 
   test do
     port = free_port
-    pid = fork do
-      exec bin/"micro_inetd", port.to_s, "/bin/echo", "OK"
-    end
+    pid = spawn bin/"micro_inetd", port.to_s, "/bin/echo", "OK"
 
     # wait for server to be running
     sleep 1
 
-    assert_equal "OK", shell_output("nc localhost #{port}").strip
+    TCPSocket.open("localhost", port) do |sock|
+      assert_equal "OK", sock.gets.strip
+    end
   ensure
     Process.kill "TERM", pid
     Process.wait pid


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
