### PR TITLE
gor: remove `netcat` test dependency

### DIFF
--- a/Formula/g/gor.rb
+++ b/Formula/g/gor.rb
@@ -28,7 +28,6 @@ class Gor < Formula
 
   depends_on "go" => :build
 
-  uses_from_macos "netcat" => :test
   uses_from_macos "libpcap"
 
   def install
@@ -36,10 +35,12 @@ class Gor < Formula
   end
 
   test do
+    (testpath/"test").write "Hello"
     test_port = free_port
-    spawn bin/"gor", "file-server", ":#{test_port}"
-
+    server_pid = spawn bin/"gor", "file-server", ":#{test_port}"
     sleep 2
-    system "nc", "-z", "localhost", test_port
+    assert_equal "Hello", shell_output("curl -s http://localhost:#{test_port}/test")
+  ensure
+    Process.kill "TERM", server_pid
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
