### PR TITLE
gor: backport for arm64 linux

### DIFF
--- a/Formula/g/gor.rb
+++ b/Formula/g/gor.rb
@@ -1,10 +1,17 @@
 class Gor < Formula
   desc "Real-time HTTP traffic replay tool written in Go"
   homepage "https://goreplay.org"
-  url "https://github.com/buger/goreplay/archive/refs/tags/1.3.3.tar.gz"
-  sha256 "d8487e4d677546f9533b930e1d5f604628cd904f7e31a260552dfbf7b440876e"
   license "LGPL-3.0-only"
   head "https://github.com/buger/goreplay.git", branch: "master"
+
+  stable do
+    url "https://github.com/buger/goreplay/archive/refs/tags/1.3.3.tar.gz"
+    sha256 "d8487e4d677546f9533b930e1d5f604628cd904f7e31a260552dfbf7b440876e"
+
+    # Backport part of commit needed for arm64 linux support
+    # https://github.com/buger/goreplay/commit/d440b3dc8f2800b8147cd968f68aa10ec8b72e3b
+    patch :DATA
+  end
 
   livecheck do
     url :stable
@@ -44,3 +51,27 @@ class Gor < Formula
     Process.kill "TERM", server_pid
   end
 end
+
+__END__
+diff --git a/capture/sock_linux.go b/capture/sock_linux.go
+index 1ff5cb6a..9d149fe2 100644
+--- a/capture/sock_linux.go
++++ b/capture/sock_linux.go
+@@ -1,4 +1,5 @@
+-// +build linux
++//go:build linux && !arm64
++// +build linux,!arm64
+ 
+ package capture
+ 
+diff --git a/capture/sock_others.go b/capture/sock_others.go
+index 0d8559b5..1e297bed 100644
+--- a/capture/sock_others.go
++++ b/capture/sock_others.go
+@@ -1,4 +1,5 @@
+-// +build !linux
++//go:build (!linux && ignore) || arm64 || darwin
++// +build !linux,ignore arm64 darwin
+ 
+ package capture
+ 


### PR DESCRIPTION
Fixes build but bottling is still blocked by patchelf issue.
