### PR TITLE
sonic: remove `netcat` test dependency

### DIFF
--- a/Formula/s/sonic.rb
+++ b/Formula/s/sonic.rb
@@ -19,7 +19,6 @@ class Sonic < Formula
   depends_on "rust" => :build
 
   uses_from_macos "llvm" => :build
-  uses_from_macos "netcat" => :test
 
   def install
     system "cargo", "install", *std_cargo_args
@@ -42,8 +41,19 @@ class Sonic < Formula
     inreplace "config.cfg", "[::1]:1491", "0.0.0.0:#{port}"
     inreplace "config.cfg", "#{var}/sonic", "."
 
-    fork { exec bin/"sonic" }
+    pid = spawn bin/"sonic"
     sleep 10
-    system "nc", "-z", "localhost", port
+    TCPSocket.open("localhost", port) do |sock|
+      assert_match "CONNECTED", sock.gets
+      sock.puts "START ingest SecretPassword"
+      assert_match "STARTED ingest protocol(1)", sock.gets
+      sock.puts 'PUSH messages user:0dcde3a6 conversation:71f3d63b "Hello world!"'
+      assert_match "OK", sock.gets
+      sock.puts "QUIT"
+      assert_match "ENDED", sock.gets
+    end
+  ensure
+    Process.kill "TERM", pid
+    Process.wait pid
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
