### PR TITLE
bigquery-emulator: remove `netcat` test dependency

### DIFF
--- a/Formula/b/bigquery-emulator.rb
+++ b/Formula/b/bigquery-emulator.rb
@@ -18,7 +18,6 @@ class BigqueryEmulator < Formula
   depends_on "go" => :build
 
   uses_from_macos "llvm" => :build
-  uses_from_macos "netcat" => :test
 
   fails_with :gcc
 
@@ -30,15 +29,46 @@ class BigqueryEmulator < Formula
   end
 
   test do
+    # https://github.com/goccy/bigquery-emulator/blob/main/_examples/python/data.yaml
+    (testpath/"data.yaml").write <<~YAML
+      projects:
+      - id: test
+        datasets:
+          - id: dataset1
+            tables:
+              - id: table_a
+                columns:
+                  - name: id
+                    type: INTEGER
+                  - name: name
+                    type: STRING
+                  - name: createdAt
+                    type: TIMESTAMP
+                data:
+                  - id: 1
+                    name: alice
+                    createdAt: "2022-10-21T00:00:00"
+                  - id: 2
+                    name: bob
+                    createdAt: "2022-10-21T00:00:00"
+    YAML
+
     port = free_port
-
-    fork do
-      exec bin/"bigquery-emulator", "--project=test", "--port=#{port}"
-    end
-
+    grpc_port = free_port
+    pid = spawn bin/"bigquery-emulator", "--project=test",
+                                         "--data-from-yaml=./data.yaml",
+                                         "--port=#{port}",
+                                         "--grpc-port=#{grpc_port}"
     sleep 5
-    system "nc", "-z", "localhost", port.to_s
+
+    query = '{"query": "SELECT name FROM dataset1.table_a WHERE id = 2"}'
+    query_url = "http://localhost:#{port}/bigquery/v2/projects/test/queries"
+    response = JSON.parse(shell_output("curl -s -X POST -d '#{query}' #{query_url}"))
+    assert_equal [{ "f" => [{ "v" => "bob" }] }], response["rows"]
 
     assert_match "version: #{version} (Homebrew)", shell_output("#{bin}/bigquery-emulator --version")
+  ensure
+    Process.kill "TERM", pid
+    Process.wait pid
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
