### PR TITLE
strace: remove implicit dependencies

### DIFF
--- a/Formula/s/strace.rb
+++ b/Formula/s/strace.rb
@@ -15,9 +15,7 @@ class Strace < Formula
     depends_on "automake" => :build
   end
 
-  depends_on "glibc"
   depends_on :linux
-  depends_on "linux-headers@5.15"
 
   def install
     system "./bootstrap" if build.head?


### PR DESCRIPTION
`glibc` is an implicit dependency that should usually never be installed on a Tier 1 Linux machine.

Also want to check on `linux-headers@5.15` to see if there is something missing in default that we need dependency.

May as well rebuild bottle in case there is something wrong causing addition of dependencies.