### PR TITLE
open-feature-cli 0.3.3 (new formula)

### DIFF
--- a/Formula/o/open-feature-cli.rb
+++ b/Formula/o/open-feature-cli.rb
@@ -1,0 +1,37 @@
+class OpenFeatureCli < Formula
+  desc "Command-line tool for managing feature flags across environments"
+  homepage "https://openfeature.dev"
+  url "https://github.com/open-feature/cli/archive/refs/tags/v0.3.3.tar.gz"
+  sha256 "3a1c398d022006ac90223679e4fc7dd5b277e5302fe6aec466fca8ad1a692ee4"
+  license "Apache-2.0"
+  head "https://github.com/open-feature/cli.git", branch: "main"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = %W[
+      -s -w
+      -X main.version=#{version}
+      -X main.commit=unknown
+      -X main.date=#{Time.now.utc.iso8601}
+    ]
+    system "go", "build", *std_go_args(ldflags:)
+
+    # The CLI doesn't currently support shell completions
+    # Will need to be updated when/if it adds this feature
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/openfeature version")
+    
+    # Create a basic flag manifest
+    system bin/"openfeature", "init", "--no-input", "--name", "test-flags"
+    assert_predicate testpath/"flag-manifest.yaml", :exist?
+    assert_match "name: test-flags", (testpath/"flag-manifest.yaml").read
+  end
+end


### PR DESCRIPTION
Adds a Homebrew formula for the open-feature-cli, a command-line tool for managing feature flags across environments.

This allows users to easily install the CLI using Homebrew. It also includes a test to verify the installation and basic functionality.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
