### PR TITLE
freeimage: apply Debian patches to unbundle libraries

### DIFF
--- a/Formula/c/colmap.rb
+++ b/Formula/c/colmap.rb
@@ -4,7 +4,7 @@ class Colmap < Formula
   url "https://github.com/colmap/colmap/archive/refs/tags/3.11.1.tar.gz"
   sha256 "d2c20729ab5b1198e17725b720128f304f4cfae5c0a8c20d75c0e9c5bdee5860"
   license "BSD-3-Clause"
-  revision 2
+  revision 3
 
   bottle do
     sha256 cellar: :any, arm64_sequoia: "a10d84ff5e6e26782f2043ea71657f741f6ad2a84870b15126d52dd75216fab8"
@@ -42,6 +42,12 @@ class Colmap < Formula
 
   on_linux do
     depends_on "mesa"
+  end
+
+  # Backport build fix. Remove in the next release
+  patch do
+    url "https://github.com/colmap/colmap/commit/a586e7cb223cc86c609105246ecd3a10e0c55131.patch?full_index=1"
+    sha256 "9d8a1699c87d7989a78820ba82717a7222761f329639e45ace23e6f84df973c4"
   end
 
   def install

--- a/Formula/f/forge.rb
+++ b/Formula/f/forge.rb
@@ -4,6 +4,7 @@ class Forge < Formula
   url "https://github.com/arrayfire/forge/archive/refs/tags/v1.0.8.tar.gz"
   sha256 "77d2581414d6392aa51748454b505a747cd63404f63d3e1ddeafae6a0664419c"
   license "BSD-3-Clause"
+  revision 1
 
   livecheck do
     url :stable

--- a/Formula/o/opencascade.rb
+++ b/Formula/o/opencascade.rb
@@ -5,6 +5,7 @@ class Opencascade < Formula
   version "7.9.0"
   sha256 "ff118a524ec451867e8f0ac3b631522c98f2b4353c7dbf2786bf239589909ec6"
   license "LGPL-2.1-only"
+  revision 1
 
   # The first-party download page (https://dev.opencascade.org/release)
   # references version 7.5.0 and hasn't been updated for later maintenance

--- a/Formula/p/perceptualdiff.rb
+++ b/Formula/p/perceptualdiff.rb
@@ -1,9 +1,11 @@
 class Perceptualdiff < Formula
   desc "Perceptual image comparison tool"
   homepage "https://pdiff.sourceforge.net/"
+  # TODO: Remove CMAKE_POLICY_VERSION_MINIMUM in next release
   url "https://github.com/myint/perceptualdiff/archive/refs/tags/v2.1.tar.gz"
   sha256 "0dea51046601e4d23dc45a3ec342f1a305baf3bf3328e9ccdae115fe1942f041"
   license "GPL-2.0-or-later"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "69f5e86989148e15fdca126111c1070bb23777eabadd346f8e735b6cedc86f5a"
@@ -17,8 +19,15 @@ class Perceptualdiff < Formula
   depends_on "cmake" => :build
   depends_on "freeimage"
 
+  on_macos do
+    depends_on "libomp"
+  end
+
   def install
-    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    args = ["-DCMAKE_POLICY_VERSION_MINIMUM=3.5"]
+    args << "-DCMAKE_EXE_LINKER_FLAGS=-lomp" if OS.mac?
+
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
   end


### PR DESCRIPTION
Similar patches are also applied in pretty much all Linux distros. Went with Debian's as easiest to apply multiple patches. The original source of unbundle patches is from Fedora but they are on a SVN revision so their latest patches won't apply.

For now just doing this on Linux as macOS will need additional work, i.e. requires updating our dylib patch and will need another OpenEXR patch.

EDIT: bundled libraries had issues on newer macOS so trying to unbundle now.