### PR TITLE
Added a `service` block for managing `tika-rest-server`

### DIFF
--- a/Formula/t/tika.rb
+++ b/Formula/t/tika.rb
@@ -7,7 +7,8 @@ class Tika < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "92bd1bfdc17fa792f3094c3045c399f0fa94070e754b22b68c5113ee1568a6ce"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "6b8514dd76bbf0d80792b06d878ab6aacf44c2be4dad3149477ead5742fe0736"
   end
 
   depends_on "openjdk"

--- a/Formula/t/tika.rb
+++ b/Formula/t/tika.rb
@@ -26,6 +26,11 @@ class Tika < Formula
     bin.write_jar_script libexec/"tika-server-standard-#{version}.jar", "tika-rest-server"
   end
 
+  service do
+    run [opt_bin/"tika-rest-server"]
+    working_dir HOMEBREW_PREFIX
+  end
+
   test do
     assert_match version.to_s, resource("server").version.to_s, "server resource out of sync with formula"
     pdf = test_fixtures("test.pdf")


### PR DESCRIPTION
… enabling the Tika server to run under `launchd` per Homebrew’s integration.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
