### PR TITLE
notmuch 0.39

### DIFF
--- a/Formula/n/notmuch-mutt.rb
+++ b/Formula/n/notmuch-mutt.rb
@@ -11,13 +11,13 @@ class NotmuchMutt < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "f8e6267e15ba67f6952b2af6f7b7a544ad07d4464c710b659f93dafcbe91a171"
-    sha256 cellar: :any,                 arm64_sonoma:  "23020e1c1bff402445cdd9099bc0ea7395b6d64c1c5c8dcd25955ac00b9b5a97"
-    sha256 cellar: :any,                 arm64_ventura: "88995f4ddbd5790dd5f4dfdb3fb922bb4c31d1fc0b8ba69c4e80a0c052848d41"
-    sha256 cellar: :any,                 sonoma:        "f63f141a9a62d1245784c09573d7ccd2d19f385c4f1675a657ba75b227e22a2b"
-    sha256 cellar: :any,                 ventura:       "a95b08d75d12c468eeb8c6e256db0e654b1b348ceadfb4475dd53a127c40891f"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "79e57568eec4052b6913e94870ab4512d756251cdef6b5a99430a58c082718a0"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a2bf3fd1b806f84210edbfd26c718506ed9c6c3af7e93bf32c1c15b61856899c"
+    sha256 cellar: :any,                 arm64_sequoia: "7172f1fdbe9794f01c80d042b9052d45fd7d7892cd1f9f4982b6a02b5bfa3680"
+    sha256 cellar: :any,                 arm64_sonoma:  "5ee7a940df309ec27388421162a63c718cfff6f3b16354cf19c61cae3ba61a54"
+    sha256 cellar: :any,                 arm64_ventura: "e45332fb4bdd1c4fd017c43fe8ec0781cbfd0f941a3ceda8c68e6ec5b7d1324d"
+    sha256 cellar: :any,                 sonoma:        "04c812d8705d2fa575c954ca2a5bd01d85183414633f3d69631441e191b16929"
+    sha256 cellar: :any,                 ventura:       "e445cab33c47569706ec82e94db95982c96f5685da6b099ce963ea77f5ad963a"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "2f60737a15a2f386ba14e641f8c7a1820863d2eaf369c1c11228057a44e766b8"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "6dafb17ac7a19666854de6837b3810f8bb5d4804395c07bf7e7af94c60b91eaf"
   end
 
   depends_on "notmuch"

--- a/Formula/n/notmuch-mutt.rb
+++ b/Formula/n/notmuch-mutt.rb
@@ -1,10 +1,9 @@
 class NotmuchMutt < Formula
   desc "Notmuch integration for Mutt"
   homepage "https://notmuchmail.org/"
-  url "https://notmuchmail.org/releases/notmuch-0.38.3.tar.xz"
-  sha256 "9af46cc80da58b4301ca2baefcc25a40d112d0315507e632c0f3f0f08328d054"
+  url "https://notmuchmail.org/releases/notmuch-0.39.tar.xz"
+  sha256 "b88bb02a76c46bad8d313fd2bb4f8e39298b51f66fcbeb304d9f80c3eef704e3"
   license "GPL-3.0-or-later"
-  revision 1
   head "https://git.notmuchmail.org/git/notmuch", using: :git, branch: "master"
 
   livecheck do

--- a/Formula/n/notmuch.rb
+++ b/Formula/n/notmuch.rb
@@ -3,10 +3,9 @@ class Notmuch < Formula
 
   desc "Thread-based email index, search, and tagging"
   homepage "https://notmuchmail.org/"
-  url "https://notmuchmail.org/releases/notmuch-0.38.3.tar.xz"
-  sha256 "9af46cc80da58b4301ca2baefcc25a40d112d0315507e632c0f3f0f08328d054"
+  url "https://notmuchmail.org/releases/notmuch-0.39.tar.xz"
+  sha256 "b88bb02a76c46bad8d313fd2bb4f8e39298b51f66fcbeb304d9f80c3eef704e3"
   license "GPL-3.0-or-later"
-  revision 4
   head "https://git.notmuchmail.org/git/notmuch", using: :git, branch: "master"
 
   livecheck do
@@ -71,9 +70,7 @@ class Notmuch < Formula
     (prefix/"vim/doc").install "vim/notmuch.txt"
     (prefix/"vim").install "vim/syntax"
 
-    ["python", "python-cffi"].each do |subdir|
-      system python3, "-m", "pip", "install", *std_pip_args(build_isolation: true), "./bindings/#{subdir}"
-    end
+    system python3, "-m", "pip", "install", *std_pip_args(build_isolation: true), "./bindings/python-cffi"
   end
 
   test do
@@ -83,8 +80,6 @@ class Notmuch < Formula
     INI
     (testpath/"Mail").mkpath
     assert_match "0 total", shell_output("#{bin}/notmuch new")
-
-    system python3, "-c", "import notmuch"
 
     system python3, "-c", <<~PYTHON
       import notmuch2

--- a/Formula/n/notmuch.rb
+++ b/Formula/n/notmuch.rb
@@ -14,13 +14,13 @@ class Notmuch < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "055eeba042bccbd7a389fe201798c8fc976752481fd1be8b234f14df6d092e9f"
-    sha256 cellar: :any,                 arm64_sonoma:  "f9405e751f351f182de74399d9e9ae9dcc01e87d088c09bdd367af08e7dc8469"
-    sha256 cellar: :any,                 arm64_ventura: "a4532931662794b5fa746ba26e141ddbd92778f3c27e1db56e2f35a350baec91"
-    sha256 cellar: :any,                 sonoma:        "5e63a25c377c0329cc752aa5891b638339bcbf718e4f8a89547c71bac3d047c6"
-    sha256 cellar: :any,                 ventura:       "3cd52d5dd1807606688cfc66be30558e2d9dc952951bd54a051f10ebf05e5a1a"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "ec340caf377ef7b4c1c1e2c4eeaec0e46f427ffead447f73b1422e0a01a0cdf4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d12ea4b3c8b6a052b9784602a0e4ad03b8b99905c0a0f06096a7a0b867c1ac9f"
+    sha256 cellar: :any,                 arm64_sequoia: "d82ad567f35dc86cfe9c3238f211849ec7ebd6a64d39728d1be7979885c19a2d"
+    sha256 cellar: :any,                 arm64_sonoma:  "ff9e440133a39ffb3a01054b5762e0d5ed7ed14b7aa66db9dc3d586540fc0918"
+    sha256 cellar: :any,                 arm64_ventura: "e384a4f762886b8d5e59f6e752574085d2af177c370caab601668eda1725549f"
+    sha256 cellar: :any,                 sonoma:        "f2234ee4ad5abe3603aafdd2a79f838c409b5385b4e57cfc9e9e4a794d87d4bc"
+    sha256 cellar: :any,                 ventura:       "66dc7a1087e43c91d4a4173a1e8f1f84ec30c9ce852be303440d5f8fc735179d"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "8ba411d8183c7e59331dc5bb6df073d8b2b2cbf17ca94c5d61a382a9a2400816"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "66b8788cc35e7be17f259b58f807332e5a18bf444578a33e54b3e4f9162f058f"
   end
 
   depends_on "doxygen" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This release includes the following [commit](https://git.notmuchmail.org/git?p=notmuch;a=commit;h=84e53f70229c42f82ca86b5b1b88a4afeaff7eae):
```
build: remove handling for legacy python bindings version

The legacy python bindings are no longer built.
```
Hence I'm removing the `python` bindings which are not released anymore, and keep only `python-cffi` bindings.