### PR TITLE
glm: fix compile with older Clang

### DIFF
--- a/Formula/g/glm.rb
+++ b/Formula/g/glm.rb
@@ -27,6 +27,12 @@ class Glm < Formula
   depends_on "cmake" => :build
   depends_on "doxygen" => :build
 
+  # Fix deprecated attribute handling with older Clang versions
+  patch do
+    url "https://github.com/g-truc/glm/commit/c00e7251e699dfb6ca61935b5a1fb0495093269a.patch?full_index=1"
+    sha256 "fba2d342643c4fcf586ed0da073c36d829a56bd41e04d9f63d9e06d2fc9777db"
+  end
+
   def install
     args = %w[
       -DGLM_BUILD_TESTS=OFF


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
See https://github.com/orgs/Homebrew/discussions/6109.