### PR TITLE
formulae(rust): Run `rustup set profile minimal` before installing the toolchain

### DIFF
--- a/Formula/b/bacon.rb
+++ b/Formula/b/bacon.rb
@@ -32,8 +32,8 @@ class Bacon < Formula
     # Show that we can use a different toolchain than the one provided by the `rust` formula.
     # https://github.com/Homebrew/homebrew-core/pull/134074#pullrequestreview-1484979359
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "beta"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "beta"
 
     crate = testpath/"demo-crate"
     mkdir crate do

--- a/Formula/c/cargo-about.rb
+++ b/Formula/c/cargo-about.rb
@@ -27,8 +27,8 @@ class CargoAbout < Formula
     # Show that we can use a different toolchain than the one provided by the `rust` formula.
     # https://github.com/Homebrew/homebrew-core/pull/134074#pullrequestreview-1484979359
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "beta"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "beta"
 
     crate = testpath/"demo-crate"
     mkdir crate do

--- a/Formula/c/cargo-all-features.rb
+++ b/Formula/c/cargo-all-features.rb
@@ -31,8 +31,8 @@ class CargoAllFeatures < Formula
     # Show that we can use a different toolchain than the one provided by the `rust` formula.
     # https://github.com/Homebrew/homebrew-core/pull/134074#pullrequestreview-1484979359
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "beta"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "beta"
 
     crate = testpath/"demo-crate"
     mkdir crate do

--- a/Formula/c/cargo-auditable.rb
+++ b/Formula/c/cargo-auditable.rb
@@ -28,8 +28,8 @@ class CargoAuditable < Formula
     # Show that we can use a different toolchain than the one provided by the `rust` formula.
     # https://github.com/Homebrew/homebrew-core/pull/134074#pullrequestreview-1484979359
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "beta"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "beta"
 
     crate = testpath/"demo-crate"
     mkdir crate do

--- a/Formula/c/cargo-binutils.rb
+++ b/Formula/c/cargo-binutils.rb
@@ -31,8 +31,8 @@ class CargoBinutils < Formula
     # Show that we can use a different toolchain than the one provided by the `rust` formula.
     # https://github.com/Homebrew/homebrew-core/pull/134074#pullrequestreview-1484979359
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "beta"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "beta"
     system "rustup", "component", "add", "llvm-tools-preview"
 
     crate = testpath/"demo-crate"

--- a/Formula/c/cargo-bloat.rb
+++ b/Formula/c/cargo-bloat.rb
@@ -29,8 +29,8 @@ class CargoBloat < Formula
     # Show that we can use a different toolchain than the one provided by the `rust` formula.
     # https://github.com/Homebrew/homebrew-core/pull/134074#pullrequestreview-1484979359
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "beta"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "beta"
 
     system "cargo", "new", "hello_world", "--bin"
     cd "hello_world" do

--- a/Formula/c/cargo-bundle.rb
+++ b/Formula/c/cargo-bundle.rb
@@ -29,8 +29,8 @@ class CargoBundle < Formula
     # Show that we can use a different toolchain than the one provided by the `rust` formula.
     # https://github.com/Homebrew/homebrew-core/pull/134074#pullrequestreview-1484979359
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "beta"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "beta"
 
     # `cargo-bundle` does not like `TERM=dumb`.
     # https://github.com/burtonageo/cargo-bundle/issues/118

--- a/Formula/c/cargo-cache.rb
+++ b/Formula/c/cargo-cache.rb
@@ -29,8 +29,8 @@ class CargoCache < Formula
     # Show that we can use a different toolchain than the one provided by the `rust` formula.
     # https://github.com/Homebrew/homebrew-core/pull/134074#pullrequestreview-1484979359
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "beta"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "beta"
 
     output = shell_output(bin/"cargo-cache")
     assert_match "0 installed binaries:", output

--- a/Formula/c/cargo-chef.rb
+++ b/Formula/c/cargo-chef.rb
@@ -26,8 +26,8 @@ class CargoChef < Formula
     # Show that we can use a different toolchain than the one provided by the `rust` formula.
     # https://github.com/Homebrew/homebrew-core/pull/134074#pullrequestreview-1484979359
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "beta"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "beta"
 
     (testpath/"Cargo.toml").write <<~TOML
       [package]

--- a/Formula/c/cargo-crev.rb
+++ b/Formula/c/cargo-crev.rb
@@ -38,8 +38,8 @@ class CargoCrev < Formula
     # Show that we can use a different toolchain than the one provided by the `rust` formula.
     # https://github.com/Homebrew/homebrew-core/pull/134074#pullrequestreview-1484979359
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "beta"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "beta"
 
     system "cargo", "crev", "config", "dir"
 

--- a/Formula/c/cargo-cyclonedx.rb
+++ b/Formula/c/cargo-cyclonedx.rb
@@ -32,8 +32,8 @@ class CargoCyclonedx < Formula
     # Show that we can use a different toolchain than the one provided by the `rust` formula.
     # https://github.com/Homebrew/homebrew-core/pull/134074#pullrequestreview-1484979359
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "beta"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "beta"
 
     (testpath/"Cargo.toml").write <<~TOML
       [package]

--- a/Formula/c/cargo-deny.rb
+++ b/Formula/c/cargo-deny.rb
@@ -28,8 +28,8 @@ class CargoDeny < Formula
     # Show that we can use a different toolchain than the one provided by the `rust` formula.
     # https://github.com/Homebrew/homebrew-core/pull/134074#pullrequestreview-1484979359
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "beta"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "beta"
 
     crate = testpath/"demo-crate"
     mkdir crate do

--- a/Formula/c/cargo-depgraph.rb
+++ b/Formula/c/cargo-depgraph.rb
@@ -33,8 +33,8 @@ class CargoDepgraph < Formula
     # Show that we can use a different toolchain than the one provided by the `rust` formula.
     # https://github.com/Homebrew/homebrew-core/pull/134074#pullrequestreview-1484979359
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "beta"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "beta"
 
     crate = testpath/"demo-crate"
     mkdir crate do

--- a/Formula/c/cargo-deps.rb
+++ b/Formula/c/cargo-deps.rb
@@ -31,8 +31,8 @@ class CargoDeps < Formula
     # Show that we can use a different toolchain than the one provided by the `rust` formula.
     # https://github.com/Homebrew/homebrew-core/pull/134074#pullrequestreview-1484979359
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "beta"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "beta"
 
     crate = testpath/"demo-crate"
     mkdir crate do

--- a/Formula/c/cargo-dist.rb
+++ b/Formula/c/cargo-dist.rb
@@ -29,8 +29,8 @@ class CargoDist < Formula
     # Show that we can use a different toolchain than the one provided by the `rust` formula.
     # https://github.com/Homebrew/homebrew-core/pull/134074#pullrequestreview-1484979359
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "beta"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "beta"
 
     assert_match version.to_s, shell_output("#{bin}/dist --version")
 

--- a/Formula/c/cargo-docset.rb
+++ b/Formula/c/cargo-docset.rb
@@ -32,8 +32,8 @@ class CargoDocset < Formula
     # Show that we can use a different toolchain than the one provided by the `rust` formula.
     # https://github.com/Homebrew/homebrew-core/pull/134074#pullrequestreview-1484979359
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "beta"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "beta"
 
     crate = testpath/"demo-crate"
     mkdir crate do

--- a/Formula/c/cargo-edit.rb
+++ b/Formula/c/cargo-edit.rb
@@ -27,8 +27,8 @@ class CargoEdit < Formula
     # Show that we can use a different toolchain than the one provided by the `rust` formula.
     # https://github.com/Homebrew/homebrew-core/pull/134074#pullrequestreview-1484979359
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "beta"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "beta"
 
     crate = testpath/"demo-crate"
     mkdir crate do

--- a/Formula/c/cargo-expand.rb
+++ b/Formula/c/cargo-expand.rb
@@ -25,8 +25,8 @@ class CargoExpand < Formula
 
   test do
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "stable"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "stable"
 
     system "cargo", "new", "hello_world", "--lib"
     cd "hello_world" do

--- a/Formula/c/cargo-flamegraph.rb
+++ b/Formula/c/cargo-flamegraph.rb
@@ -29,8 +29,8 @@ class CargoFlamegraph < Formula
     # Show that we can use a different toolchain than the one provided by the `rust` formula.
     # https://github.com/Homebrew/homebrew-core/pull/134074#pullrequestreview-1484979359
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "beta"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "beta"
 
     assert_match version.to_s, shell_output("#{bin}/flamegraph --version")
 

--- a/Formula/c/cargo-fuzz.rb
+++ b/Formula/c/cargo-fuzz.rb
@@ -28,8 +28,8 @@ class CargoFuzz < Formula
     # Show that we can use a different toolchain than the one provided by the `rust` formula.
     # https://github.com/Homebrew/homebrew-core/pull/134074#pullrequestreview-1484979359
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "beta"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "beta"
 
     system "cargo", "init"
     system bin/"cargo-fuzz", "init"

--- a/Formula/c/cargo-hack.rb
+++ b/Formula/c/cargo-hack.rb
@@ -27,8 +27,8 @@ class CargoHack < Formula
     # Show that we can use a different toolchain than the one provided by the `rust` formula.
     # https://github.com/Homebrew/homebrew-core/pull/134074#pullrequestreview-1484979359
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "beta"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "beta"
 
     system "cargo", "new", "hello_world"
     cd "hello_world" do

--- a/Formula/c/cargo-llvm-cov.rb
+++ b/Formula/c/cargo-llvm-cov.rb
@@ -28,8 +28,8 @@ class CargoLlvmCov < Formula
     # Show that we can use a different toolchain than the one provided by the `rust` formula.
     # https://github.com/Homebrew/homebrew-core/pull/134074#pullrequestreview-1484979359
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "beta"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "beta"
 
     system "cargo", "new", "hello_world", "--lib"
     cd "hello_world" do

--- a/Formula/c/cargo-llvm-lines.rb
+++ b/Formula/c/cargo-llvm-lines.rb
@@ -27,8 +27,8 @@ class CargoLlvmLines < Formula
     # Show that we can use a different toolchain than the one provided by the `rust` formula.
     # https://github.com/Homebrew/homebrew-core/pull/134074#pullrequestreview-1484979359
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "beta"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "beta"
 
     system "cargo", "new", "hello_world", "--bin"
     cd "hello_world" do

--- a/Formula/c/cargo-make.rb
+++ b/Formula/c/cargo-make.rb
@@ -26,8 +26,8 @@ class CargoMake < Formula
     # Show that we can use a different toolchain than the one provided by the `rust` formula.
     # https://github.com/Homebrew/homebrew-core/pull/134074#pullrequestreview-1484979359
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "beta"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "beta"
 
     text = "it's working!"
     (testpath/"Makefile.toml").write <<~TOML

--- a/Formula/c/cargo-msrv.rb
+++ b/Formula/c/cargo-msrv.rb
@@ -29,8 +29,8 @@ class CargoMsrv < Formula
     # Show that we can use a different toolchain than the one provided by the `rust` formula.
     # https://github.com/Homebrew/homebrew-core/pull/134074#pullrequestreview-1484979359
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "beta"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "beta"
 
     assert_match version.to_s, shell_output("#{bin}/cargo-msrv --version")
 

--- a/Formula/c/cargo-nextest.rb
+++ b/Formula/c/cargo-nextest.rb
@@ -32,8 +32,8 @@ class CargoNextest < Formula
     # Show that we can use a different toolchain than the one provided by the `rust` formula.
     # https://github.com/Homebrew/homebrew-core/pull/134074#pullrequestreview-1484979359
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "beta"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "beta"
 
     crate = testpath/"demo-crate"
     mkdir crate do

--- a/Formula/c/cargo-outdated.rb
+++ b/Formula/c/cargo-outdated.rb
@@ -50,8 +50,8 @@ class CargoOutdated < Formula
     # Show that we can use a different toolchain than the one provided by the `rust` formula.
     # https://github.com/Homebrew/homebrew-core/pull/134074#pullrequestreview-1484979359
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "beta"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "beta"
 
     crate = testpath/"demo-crate"
     mkdir crate do

--- a/Formula/c/cargo-public-api.rb
+++ b/Formula/c/cargo-public-api.rb
@@ -36,8 +36,8 @@ class CargoPublicApi < Formula
     # Show that we can use a different toolchain than the one provided by the `rust` formula.
     # https://github.com/Homebrew/homebrew-core/pull/134074#pullrequestreview-1484979359
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "beta"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "beta"
     system "rustup", "toolchain", "install", "nightly"
 
     (testpath/"Cargo.toml").write <<~TOML

--- a/Formula/c/cargo-release.rb
+++ b/Formula/c/cargo-release.rb
@@ -33,8 +33,8 @@ class CargoRelease < Formula
     # Show that we can use a different toolchain than the one provided by the `rust` formula.
     # https://github.com/Homebrew/homebrew-core/pull/134074#pullrequestreview-1484979359
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "beta"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "beta"
 
     system "cargo", "new", "hello_world", "--bin"
     cd "hello_world" do

--- a/Formula/c/cargo-run-bin.rb
+++ b/Formula/c/cargo-run-bin.rb
@@ -28,8 +28,8 @@ class CargoRunBin < Formula
     # Show that we can use a different toolchain than the one provided by the `rust` formula.
     # https://github.com/Homebrew/homebrew-core/pull/134074#pullrequestreview-1484979359
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "beta"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "beta"
 
     (testpath/"Cargo.toml").write <<~TOML
       [package]

--- a/Formula/c/cargo-sort.rb
+++ b/Formula/c/cargo-sort.rb
@@ -27,8 +27,8 @@ class CargoSort < Formula
     # Show that we can use a different toolchain than the one provided by the `rust` formula.
     # https://github.com/Homebrew/homebrew-core/pull/134074#pullrequestreview-1484979359
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "beta"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "beta"
 
     assert_match version.to_s, shell_output("#{bin}/cargo-sort --version")
 

--- a/Formula/c/cargo-spellcheck.rb
+++ b/Formula/c/cargo-spellcheck.rb
@@ -31,8 +31,8 @@ class CargoSpellcheck < Formula
     # Show that we can use a different toolchain than the one provided by the `rust` formula.
     # https://github.com/Homebrew/homebrew-core/pull/134074#pullrequestreview-1484979359
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "beta"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "beta"
 
     assert_match version.to_s, shell_output("#{bin}/cargo-spellcheck --version")
 

--- a/Formula/c/cargo-sweep.rb
+++ b/Formula/c/cargo-sweep.rb
@@ -28,8 +28,8 @@ class CargoSweep < Formula
   test do
     assert_equal "cargo-sweep #{version}", shell_output(bin/"cargo-sweep -V").strip
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "beta"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "beta"
 
     crate = testpath/"demo-crate"
     mkdir crate do

--- a/Formula/c/cargo-udeps.rb
+++ b/Formula/c/cargo-udeps.rb
@@ -51,8 +51,8 @@ class CargoUdeps < Formula
     # Show that we can use a different toolchain than the one provided by the `rust` formula.
     # https://github.com/Homebrew/homebrew-core/pull/134074#pullrequestreview-1484979359
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "beta"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "beta"
 
     crate = testpath/"demo-crate"
     mkdir crate do

--- a/Formula/c/cargo-update.rb
+++ b/Formula/c/cargo-update.rb
@@ -41,8 +41,8 @@ class CargoUpdate < Formula
     # Show that we can use a different toolchain than the one provided by the `rust` formula.
     # https://github.com/Homebrew/homebrew-core/pull/134074#pullrequestreview-1484979359
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "beta"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "beta"
 
     assert_match version.to_s, shell_output("cargo install-update --version")
 

--- a/Formula/c/cargo-watch.rb
+++ b/Formula/c/cargo-watch.rb
@@ -32,8 +32,8 @@ class CargoWatch < Formula
     # Show that we can use a different toolchain than the one provided by the `rust` formula.
     # https://github.com/Homebrew/homebrew-core/pull/134074#pullrequestreview-1484979359
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "beta"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "beta"
 
     output = shell_output("#{bin}/cargo-watch -x build 2>&1", 1)
     assert_match "error: project root does not exist", output

--- a/Formula/c/cargo-zigbuild.rb
+++ b/Formula/c/cargo-zigbuild.rb
@@ -31,8 +31,8 @@ class CargoZigbuild < Formula
     ENV.delete "RUSTFLAGS"
 
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "beta"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "beta"
     system "rustup", "target", "add", "aarch64-unknown-linux-gnu"
 
     system "cargo", "new", "hello_world", "--bin"

--- a/Formula/p/pgrx.rb
+++ b/Formula/p/pgrx.rb
@@ -30,8 +30,8 @@ class Pgrx < Formula
     # Show that we can use a different toolchain than the one provided by the `rust` formula.
     # https://github.com/Homebrew/homebrew-core/pull/134074#pullrequestreview-1484979359
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "beta"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "beta"
 
     system "cargo", "pgrx", "new", "my_extension"
     assert_path_exists testpath/"my_extension/my_extension.control"

--- a/Formula/t/teleport.rb
+++ b/Formula/t/teleport.rb
@@ -56,8 +56,8 @@ class Teleport < Formula
     YAML
 
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "stable"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "stable"
 
     ENV.deparallelize { system "make", "full", "FIDO2=dynamic" }
     bin.install Dir["build/*"]

--- a/Formula/t/tinysearch.rb
+++ b/Formula/t/tinysearch.rb
@@ -32,8 +32,8 @@ class Tinysearch < Formula
 
   test do
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "stable"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "stable"
 
     system bin/"tinysearch", pkgshare/"fixtures/index.json"
     assert_path_exists testpath/"wasm_output/tinysearch_engine_bg.wasm"

--- a/Formula/w/wasm-pack.rb
+++ b/Formula/w/wasm-pack.rb
@@ -37,8 +37,8 @@ class WasmPack < Formula
     assert_match "wasm-pack #{version}", shell_output("#{bin}/wasm-pack --version")
 
     ENV.prepend_path "PATH", Formula["rustup"].bin
-    system "rustup", "default", "stable"
     system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "stable"
 
     system bin/"wasm-pack", "new", "hello-wasm"
     system bin/"wasm-pack", "build", "hello-wasm"


### PR DESCRIPTION
Running `rustup set profile minimal` after installing the toolchain is a no-op. It only has an effect if executed before toolchain installation.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?