### PR TITLE
cargo-shear 1.2.4 (new formula)

### DIFF
--- a/Formula/c/cargo-shear.rb
+++ b/Formula/c/cargo-shear.rb
@@ -6,6 +6,15 @@ class CargoShear < Formula
   license "MIT"
   head "https://github.com/Boshen/cargo-shear.git", branch: "main"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "9d1cef5fc862e8c26115a6cab56da98de553dd37ad01e10aee076d24b1ebabce"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "9794da55825255345537b9905e1c9196dd45e2b9f90e0bb55aa8205e19563028"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "2ef55a63a6eb49f771f8ee9b48b7076e0c178d3776635482bea3add593a9c438"
+    sha256 cellar: :any_skip_relocation, sonoma:        "5bd2f417d96e67a653772ab833a303f75bef2f92a0bd8fd2b93912ea5728604e"
+    sha256 cellar: :any_skip_relocation, ventura:       "d64bc681a19dfd38da4901612a456c9995d9eabecce5da192709c6dda77258ff"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a2453871d1d71575e462f91dfb9033db055055bf9ab3653ca5accf171da3d3a7"
+  end
+
   depends_on "rust" => :build
   depends_on "rustup" => :test
 

--- a/Formula/c/cargo-shear.rb
+++ b/Formula/c/cargo-shear.rb
@@ -1,0 +1,48 @@
+class CargoShear < Formula
+  desc "Detect and remove unused dependencies from `Cargo.toml` in Rust projects"
+  homepage "https://github.com/Boshen/cargo-shear"
+  url "https://github.com/Boshen/cargo-shear/archive/refs/tags/v1.2.4.tar.gz"
+  sha256 "18d5ae6f2c1f85d0604e764eb1d1802c82c5657176bf54388ee7d65e2ee904c4"
+  license "MIT"
+  head "https://github.com/Boshen/cargo-shear.git", branch: "main"
+
+  depends_on "rust" => :build
+  depends_on "rustup" => :test
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    # Show that we can use a different toolchain than the one provided by the `rust` formula.
+    # https://github.com/Homebrew/homebrew-core/pull/134074#pullrequestreview-1484979359
+    ENV.prepend_path "PATH", Formula["rustup"].bin
+    system "rustup", "set", "profile", "minimal"
+    system "rustup", "default", "beta"
+
+    crate = testpath/"demo-crate"
+    mkdir crate do
+      (crate/"Cargo.toml").write <<~TOML
+        [package]
+        name = "demo-crate"
+        version = "0.1.0"
+
+        [lib]
+        path = "lib.rs"
+
+        [dependencies]
+        libc = "0.1"
+        bear = "0.2"
+      TOML
+
+      (crate/"lib.rs").write "use libc;"
+
+      output = shell_output("cargo shear", 1)
+      # bear is unused
+      assert_match <<~OUTPUT, output
+        demo-crate -- Cargo.toml:
+          bear
+      OUTPUT
+    end
+  end
+end


### PR DESCRIPTION
cargo-shear detects and removes unused dependencies from Cargo.toml in Rust projects.

It recenlty removed 1089 unused dependencies in Discord's internal Rust codebase. And according to the official documentation, there are multiple cases where cargo-shear helped remove unnecessary dependencies. I hope adding it to homebrew-core helps it gain more reputation and usage.

###### References
- https://github.com/Boshen/cargo-shear/tree/88f73f986#trophy-cases
- https://x.com/boshen_c/status/1913977016992612799
- https://github.com/Boshen/cargo-shear/pull/168

&nbsp;

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?