### PR TITLE
github-keygen: add dependency for linux

### DIFF
--- a/Formula/g/github-keygen.rb
+++ b/Formula/g/github-keygen.rb
@@ -10,6 +10,8 @@ class GithubKeygen < Formula
     sha256 cellar: :any_skip_relocation, all: "ce4d2d363e88f82852998fb401ac8bdbcffae2c1028c521bb3e99dc9e1fc598f"
   end
 
+  uses_from_macos "perl"
+
   def install
     bin.install "github-keygen"
   end


### PR DESCRIPTION
Adds `perl` as a dependency for Linux systems. Perl might be available on distros (such as Bazzite) without having all the modules bundled. The github-keygen tool has expectations about available modules. By making Homebrew’s Perl a dependency, this is addressed.

Fixes #219910.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
