### PR TITLE
ghc: workaround for arm64 linux

### DIFF
--- a/Formula/g/ghc.rb
+++ b/Formula/g/ghc.rb
@@ -37,6 +37,23 @@ class Ghc < Formula
     depends_on "gnu-sed" => :build
   end
 
+  on_linux do
+    on_arm do
+      depends_on "gcc" => :build if DevelopmentTools.gcc_version("gcc") < 12
+
+      fails_with :gcc do
+        version "11"
+        cause <<~CAUSE
+          _build/stage1/compiler/build/GHC.p_dyn_o:(.text..LsO3B_info+0x198):
+          relocation truncated to fit: R_AARCH64_JUMP26 against symbol
+          `ghczm9zi12zi2zminplace_GHCziUtilsziPanic_showGhcException_info'
+          defined in .text.ghczm9zi12zi2zminplace_GHCziUtilsziPanic_showGhcException_info
+          section in _build/stage1/compiler/build/GHC/Utils/Panic.p_dyn_o
+        CAUSE
+      end
+    end
+  end
+
   # A binary of ghc is needed to bootstrap ghc
   resource "binary" do
     on_macos do


### PR DESCRIPTION
Just triggering arm64 linux CI to try to debug issue.

---

Currently, LLVM at least works - https://github.com/Homebrew/homebrew-core/actions/runs/14585433386/job/40910115645?pr=220914#step:4:51

Could be a difference in code model defaults or implementation.

Also trying out newer GCC before merge. EDIT: GCC 14 also works