### PR TITLE
openstackclient: fix error for some with readline

### DIFF
--- a/Formula/o/openstackclient.rb
+++ b/Formula/o/openstackclient.rb
@@ -23,6 +23,13 @@ class Openstackclient < Formula
   depends_on "libyaml"
   depends_on "python@3.13"
 
+  resource "gnureadline" do
+    on_macos do
+      url "https://files.pythonhosted.org/packages/cb/92/20723aa239b9a8024e6f8358c789df8859ab1085a1ae106e5071727ad20f/gnureadline-8.2.13.tar.gz"
+      sha256 "c9b9e1e7ba99a80bb50c12027d6ce692574f77a65bf57bc97041cf81c0f49bd1"
+    end
+  end
+
   resource "pyinotify" do
     on_linux do
       url "https://files.pythonhosted.org/packages/e3/c0/fd5b18dde17c1249658521f69598f3252f11d9d7a980c5be8619970646e1/pyinotify-0.9.6.tar.gz"
@@ -391,7 +398,17 @@ class Openstackclient < Formula
   end
 
   def install
-    virtualenv_install_with_resources
+    if OS.mac?
+      ENV["CC"] = ENV.cc
+      python3 = "python3.13"
+      # pip install does not build readline from it's source, so we need to install it manually
+      resource("gnureadline").stage do
+        system python3, "-m", "pip", "install", *std_pip_args(prefix: libexec, build_isolation: true), "."
+      end
+      virtualenv_install_with_resources without: "gnureadline"
+    else
+      virtualenv_install_with_resources
+    end
   end
 
   test do

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -613,7 +613,7 @@
   },
   "openstackclient": {
     "extra_packages": [
-      "keystoneauth-websso", "osc-placement", "python-barbicanclient",
+      "gnureadline", "keystoneauth-websso", "osc-placement", "python-barbicanclient",
       "python-cloudkittyclient", "python-designateclient",
       "python-glanceclient", "python-heatclient", "python-ironicclient",
       "python-magnumclient", "python-manilaclient", "python-mistralclient",


### PR DESCRIPTION
When using the openstack CLI on some macOS machines users will get the following:

Readline features including tab completion have been disabled because no supported version of readline was found. To resolve this, install pyreadline3 on Windows or gnureadline on Linux/Mac.

This adds installing gnureadline.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
