### PR TITLE
qt: split out `qt-webengine`

### DIFF
--- a/Formula/q/qt-webengine.rb
+++ b/Formula/q/qt-webengine.rb
@@ -1,0 +1,230 @@
+class QtWebengine < Formula
+  include Language::Python::Virtualenv
+
+  desc "Provides functionality for rendering regions of dynamic web content"
+  homepage "https://www.qt.io/"
+  url "https://download.qt.io/official_releases/qt/6.9/6.9.0/submodules/qtwebengine-everywhere-src-6.9.0.tar.xz"
+  mirror "https://qt.mirror.constant.com/archive/qt/6.9/6.9.0/submodules/qtwebengine-everywhere-src-6.9.0.tar.xz"
+  mirror "https://mirrors.ukfast.co.uk/sites/qt.io/archive/qt/6.9/6.9.0/submodules/qtwebengine-everywhere-src-6.9.0.tar.xz"
+  sha256 "2b33d1c85e85ed58729db228448f92105ab746ffdc9b98f0c4e3bf00b789789e"
+  license all_of: [
+    "BSD-3-Clause",
+    "GFDL-1.3-no-invariants-only",
+    "GPL-2.0-only",
+    { "GPL-3.0-only" => { with: "Qt-GPL-exception-1.0" } },
+    "LGPL-3.0-only",
+  ]
+  head "https://code.qt.io/qt/qtwebengine.git", branch: "dev"
+
+  livecheck do
+    formula "qt"
+  end
+
+  depends_on "cmake" => [:build, :test]
+  depends_on "ninja" => :build
+  depends_on "node" => :build
+  depends_on "pkgconf" => [:build, :test]
+  depends_on "python@3.13" => :build
+  # Chromium needs Xcode 15.3+ and using LLVM Clang is not supported on macOS
+  # See https://bugreports.qt.io/browse/QTBUG-130922
+  depends_on xcode: ["15.3", :build]
+
+  depends_on "libpng"
+  depends_on "qt"
+
+  uses_from_macos "bison" => :build
+  uses_from_macos "flex" => :build
+  uses_from_macos "gperf" => :build
+
+  uses_from_macos "zlib"
+
+  on_linux do
+    depends_on "pulseaudio" => :build
+    depends_on "alsa-lib"
+    depends_on "dbus"
+    depends_on "expat"
+    depends_on "ffmpeg"
+    depends_on "fontconfig"
+    depends_on "freetype"
+    depends_on "harfbuzz"
+    depends_on "icu4c@77"
+    depends_on "jpeg-turbo"
+    depends_on "libdrm"
+    depends_on "libevent"
+    depends_on "libtiff"
+    depends_on "libx11"
+    depends_on "libxcb"
+    depends_on "libxcomposite"
+    depends_on "libxdamage"
+    depends_on "libxext"
+    depends_on "libxfixes"
+    depends_on "libxkbcommon"
+    depends_on "libxkbfile"
+    depends_on "libxml2"
+    depends_on "libxrandr"
+    depends_on "libxslt"
+    depends_on "libxtst"
+    depends_on "little-cms2"
+    depends_on "mesa"
+    depends_on "minizip"
+    depends_on "nspr"
+    depends_on "nss"
+    depends_on "openjpeg"
+    depends_on "opus"
+    depends_on "snappy"
+    depends_on "systemd"
+    depends_on "webp"
+  end
+
+  resource "html5lib" do
+    url "https://files.pythonhosted.org/packages/ac/b6/b55c3f49042f1df3dcd422b7f224f939892ee94f22abcf503a9b7339eaf2/html5lib-1.1.tar.gz"
+    sha256 "b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f"
+  end
+
+  resource "six" do
+    url "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz"
+    sha256 "ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"
+  end
+
+  resource "webencodings" do
+    url "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz"
+    sha256 "b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"
+  end
+
+  def install
+    venv = virtualenv_create(buildpath/"venv", "python3.13")
+    venv.pip_install resources
+    ENV.prepend_path "PYTHONPATH", venv.site_packages
+
+    # Allow -march options to be passed through, as Qt builds
+    # arch-specific code with runtime detection of capabilities:
+    # https://bugreports.qt.io/browse/QTBUG-113391
+    ENV.runtime_cpu_detection
+
+    # FIXME: GN requires clang in clangBasePath/bin
+    inreplace "src/3rdparty/chromium/build/toolchain/apple/toolchain.gni",
+              'rebase_path("$clang_base_path/bin/", root_build_dir)', '""'
+
+    # FIXME: See https://bugreports.qt.io/browse/QTBUG-89559
+    # and https://codereview.qt-project.org/c/qt/qtbase/+/327393
+    # It is not friendly to Homebrew or macOS
+    # because on macOS `/tmp` -> `/private/tmp`
+    inreplace "src/3rdparty/gn/src/base/files/file_util_posix.cc",
+              "FilePath(full_path)", "FilePath(input)"
+
+    cmake_args = std_cmake_args(install_prefix: HOMEBREW_PREFIX, find_framework: "FIRST") + %W[
+      -DCMAKE_STAGING_PREFIX=#{prefix}
+      -DFEATURE_webengine_proprietary_codecs=ON
+      -DFEATURE_webengine_kerberos=ON
+    ]
+
+    # Chromium always uses bundled libraries on macOS
+    cmake_args += if OS.mac?
+      ENV["SDKROOT"] = MacOS.sdk_for_formula(self).path
+
+      %W[
+        -DCMAKE_OSX_DEPLOYMENT_TARGET=#{MacOS.version}.0
+      ]
+    else
+      # For arguments:
+      # * The vendored copy of `libvpx` is used for VA-API hardware acceleration,
+      #   see https://codereview.qt-project.org/c/qt/qtwebengine/+/454908
+      # * The vendored copy of `re2` is used to avoid rebuilds with `re2` version
+      #   bumps and due to frequent API incompatibilities in Qt's copy of Chromium
+      # * As of Qt 6.6.0, webengine_ozone_x11 feature appears to be mandatory for Linux.
+      %w[
+        -DFEATURE_webengine_ozone_x11=ON
+        -DFEATURE_webengine_system_alsa=ON
+        -DFEATURE_webengine_system_ffmpeg=ON
+        -DFEATURE_webengine_system_freetype=ON
+        -DFEATURE_webengine_system_harfbuzz=ON
+        -DFEATURE_webengine_system_icu=ON
+        -DFEATURE_webengine_system_lcms2=ON
+        -DFEATURE_webengine_system_libevent=ON
+        -DFEATURE_webengine_system_libjpeg=ON
+        -DFEATURE_webengine_system_libpng=ON
+        -DFEATURE_webengine_system_libxml=ON
+        -DFEATURE_webengine_system_libwebp=ON
+        -DFEATURE_webengine_system_minizip=ON
+        -DFEATURE_webengine_system_opus=ON
+        -DFEATURE_webengine_system_pulseaudio=ON
+        -DFEATURE_webengine_system_snappy=ON
+        -DFEATURE_webengine_system_zlib=ON
+      ]
+    end
+
+    system "cmake", "-S", ".", "-B", "build", "-G", "Ninja", *cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+
+    lib.glob("*.framework") do |f|
+      # Some config scripts will only find Qt in a "Frameworks" folder
+      frameworks.install_symlink f
+      # Some dependents' test use include path (e.g. `gecode` and `qwt`)
+      include.install_symlink f/"Headers" => f.stem
+    end
+  end
+
+  test do
+    modules = ["WebEngineWidgets"]
+
+    (testpath/"CMakeLists.txt").write <<~CMAKE
+      cmake_minimum_required(VERSION #{Formula["cmake"].version})
+      project(test VERSION 1.0.0 LANGUAGES CXX)
+
+      set(CMAKE_CXX_STANDARD 17)
+      set(CMAKE_CXX_STANDARD_REQUIRED ON)
+      set(CMAKE_AUTOMOC ON)
+      set(CMAKE_AUTORCC ON)
+      set(CMAKE_AUTOUIC ON)
+
+      find_package(Qt6 REQUIRED COMPONENTS #{modules.join(" ")})
+      add_executable(test main.cpp)
+      target_link_libraries(test PRIVATE Qt6::#{modules.join(" Qt6::")})
+    CMAKE
+
+    (testpath/"test.pro").write <<~QMAKE
+      QT      += #{modules.join(" ").downcase}
+      TARGET   = test
+      CONFIG  += console
+      CONFIG  -= app_bundle
+      TEMPLATE = app
+      SOURCES += main.cpp
+    QMAKE
+
+    (testpath/"main.cpp").write <<~CPP
+      #include <QApplication>
+      #include <QTimer>
+      #include <QWebEngineView>
+
+      int main(int argc, char *argv[])
+      {
+        QApplication app(argc, argv);
+        QWebEngineView view;
+        view.setUrl(QUrl(QStringLiteral("https://brew.sh/")));
+        view.show();
+        QTimer::singleShot(2000, &app, SLOT(quit()));
+        return app.exec();
+      }
+    CPP
+
+    ENV["LC_ALL"] = "en_US.UTF-8"
+    ENV["QT_QPA_PLATFORM"] = "minimal" if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"]
+    ENV["QTWEBENGINE_DISABLE_SANDBOX"] = "1"
+    ENV.delete "CPATH" if OS.mac?
+
+    system "cmake", "-S", ".", "-B", "cmake", "-DCMAKE_BUILD_RPATH=#{lib}"
+    system "cmake", "--build", "cmake"
+    system "./cmake/test"
+
+    mkdir "qmake" do
+      system Formula["qt"].bin/"qmake", testpath/"test.pro"
+      system "make"
+      system "./test"
+    end
+
+    flags = shell_output("pkgconf --cflags --libs Qt6#{modules.join(" Qt6")}").chomp.split
+    system ENV.cxx, "-std=c++17", "main.cpp", "-o", "test", *flags, "-Wl,-rpath,#{lib}"
+    system "./test"
+  end
+end

--- a/Formula/q/qt-webview.rb
+++ b/Formula/q/qt-webview.rb
@@ -1,0 +1,110 @@
+class QtWebview < Formula
+  desc "Light-weight web view"
+  homepage "https://www.qt.io/"
+  url "https://download.qt.io/official_releases/qt/6.9/6.9.0/submodules/qtwebview-everywhere-src-6.9.0.tar.xz"
+  mirror "https://qt.mirror.constant.com/archive/qt/6.9/6.9.0/submodules/qtwebview-everywhere-src-6.9.0.tar.xz"
+  mirror "https://mirrors.ukfast.co.uk/sites/qt.io/archive/qt/6.9/6.9.0/submodules/qtwebview-everywhere-src-6.9.0.tar.xz"
+  sha256 "5b24070e8ceb12c3c4df5a887f3ffc3544193646386e6ce18e41c20d42d7ed6b"
+  license all_of: [
+    "BSD-3-Clause",
+    "GFDL-1.3-no-invariants-only",
+    "GPL-2.0-only",
+    { "GPL-3.0-only" => { with: "Qt-GPL-exception-1.0" } },
+    "LGPL-3.0-only",
+  ]
+  head "https://code.qt.io/qt/qtwebview.git", branch: "dev"
+
+  livecheck do
+    formula "qt"
+  end
+
+  depends_on "cmake" => :build
+  depends_on "ninja" => :build
+
+  depends_on "qt"
+  depends_on "qt-webengine"
+
+  def install
+    plugin_rpath = rpath(source: share/"qt/plugins/webview", target: Formula["qt-webengine"].opt_lib)
+
+    system "cmake", "-S", ".", "-B", "build", "-G", "Ninja",
+                    "-DCMAKE_INSTALL_RPATH=#{plugin_rpath}",
+                    "-DCMAKE_STAGING_PREFIX=#{prefix}",
+                    *std_cmake_args(install_prefix: HOMEBREW_PREFIX, find_framework: "FIRST")
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+
+    lib.glob("*.framework") do |f|
+      # Some config scripts will only find Qt in a "Frameworks" folder
+      frameworks.install_symlink f
+      # Some dependents' test use include path (e.g. `gecode` and `qwt`)
+      include.install_symlink f/"Headers" => f.stem
+    end
+  end
+
+  test do
+    # https://github.com/qt/qtwebview/tree/dev/tests/manual/inquickwidget
+    (testpath/"test.pro").write <<~QMAKE
+      QT        += core gui webview quickwidgets
+      CONFIG    -= app_bundle
+      SOURCES   += main.cpp
+      RESOURCES += qml.qrc
+      DISTFILES += main.qml
+    QMAKE
+
+    (testpath/"main.cpp").write <<~CPP
+      #include <QTimer>
+      #include <QtWidgets/qapplication.h>
+      #include <QtWidgets/QHBoxLayout>
+      #include <QtQuickWidgets/qquickwidget.h>
+
+      int main(int argc, char *argv[])
+      {
+        QQuickWindow::setGraphicsApi(QSGRendererInterface::GraphicsApi::OpenGL);
+        QApplication a(argc, argv);
+        QWidget w;
+        w.setGeometry(0, 0, 800, 600);
+        w.setLayout(new QHBoxLayout);
+        QQuickWidget *qw = new QQuickWidget;
+        qw->setResizeMode(QQuickWidget::ResizeMode::SizeRootObjectToView);
+        qw->setSource(QUrl(QStringLiteral("qrc:/main.qml")));
+        w.layout()->addWidget(qw);
+        w.show();
+        QTimer::singleShot(2000, &a, SLOT(quit()));
+        return a.exec();
+      }
+    CPP
+
+    (testpath/"main.qml").write <<~QML
+      import QtQuick 2.0
+      import QtWebView 1.1
+
+      Rectangle {
+        anchors.fill: parent
+        color: "green"
+
+        WebView {
+          anchors.fill: parent
+          url: "https://qt.io"
+        }
+      }
+    QML
+
+    (testpath/"qml.qrc").write <<~XML
+      <RCC>
+        <qresource prefix="/">
+          <file>main.qml</file>
+        </qresource>
+      </RCC>
+    XML
+
+    ENV["LC_ALL"] = "en_US.UTF-8"
+    ENV["QT_QPA_PLATFORM"] = "minimal" if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"]
+    ENV["QTWEBENGINE_DISABLE_SANDBOX"] = "1"
+    ENV.delete "CPATH" if OS.mac?
+
+    system Formula["qt"].bin/"qmake", testpath/"test.pro"
+    system "make"
+    system "./test"
+  end
+end

--- a/Formula/q/qt.rb
+++ b/Formula/q/qt.rb
@@ -1,6 +1,4 @@
 class Qt < Formula
-  include Language::Python::Virtualenv
-
   desc "Cross-platform application and UI framework"
   homepage "https://www.qt.io/"
   url "https://download.qt.io/official_releases/qt/6.9/6.9.0/single/qt-everywhere-src-6.9.0.tar.xz"
@@ -14,6 +12,7 @@ class Qt < Formula
     { "GPL-3.0-only" => { with: "Qt-GPL-exception-1.0" } },
     "LGPL-3.0-only",
   ]
+  revision 1
   head "https://code.qt.io/qt/qt5.git", branch: "dev"
 
   # The first-party website doesn't make version information readily available,
@@ -28,15 +27,13 @@ class Qt < Formula
     sha256 cellar: :any, arm64_ventura: "f30408e5e2a56aef97597398e4d552da3286b9fb45ba040e405291584009bea8"
     sha256 cellar: :any, sonoma:        "1cb92af62ec86c41bd6901428356fc8908ab98706a1f4b1e7791f09fd6cad498"
     sha256 cellar: :any, ventura:       "3f55e107498966094f5b47f6e729728c7cc97d503f9deed8c59d87ca9f69cfa4"
+    sha256               arm64_linux:   "0f25abc1c0b90ec910b12b3d5c4db85e77e5f0888a2a8446f2d2dc5c973ede78"
     sha256               x86_64_linux:  "0f25abc1c0b90ec910b12b3d5c4db85e77e5f0888a2a8446f2d2dc5c973ede78"
   end
 
   depends_on "cmake" => [:build, :test]
   depends_on maximum_macos: [:sonoma, :build] # https://bugreports.qt.io/browse/QTBUG-128900
-  depends_on "ninja" => :build
-  depends_on "node" => :build
   depends_on "pkgconf" => [:build, :test]
-  depends_on "python@3.13" => :build
   depends_on "vulkan-headers" => [:build, :test]
   depends_on "vulkan-loader" => [:build, :test]
   depends_on xcode: :build
@@ -63,23 +60,17 @@ class Qt < Formula
   depends_on "webp"
   depends_on "zstd"
 
-  uses_from_macos "bison" => :build
-  uses_from_macos "flex" => :build
-  uses_from_macos "gperf" => :build
-
   uses_from_macos "cups"
   uses_from_macos "krb5"
   uses_from_macos "zlib"
 
   on_macos do
     depends_on "molten-vk" => [:build, :test]
+    depends_on "ninja" => :build
   end
 
   on_linux do
-    depends_on "alsa-lib"
-    depends_on "at-spi2-core"
     # TODO: depends_on "bluez"
-    depends_on "expat"
     depends_on "ffmpeg"
     depends_on "fontconfig"
     depends_on "gdk-pixbuf"
@@ -87,79 +78,55 @@ class Qt < Formula
     depends_on "gtk+3"
     # TODO: depends_on "gypsy"
     depends_on "libdrm"
-    depends_on "libevent"
     depends_on "libice"
     depends_on "libsm"
     depends_on "libx11"
     depends_on "libxcb"
-    depends_on "libxcomposite"
-    depends_on "libxdamage"
     depends_on "libxext"
-    depends_on "libxfixes"
     depends_on "libxkbcommon"
-    depends_on "libxkbfile"
-    depends_on "libxml2"
     depends_on "libxrandr"
-    depends_on "libxslt"
-    depends_on "libxtst"
-    depends_on "little-cms2"
     depends_on "mesa"
-    depends_on "minizip"
-    depends_on "nspr"
-    depends_on "nss"
-    depends_on "openjpeg"
-    depends_on "opus"
     depends_on "pango"
     depends_on "pulseaudio"
-    depends_on "snappy"
     depends_on "systemd"
     depends_on "wayland"
-    depends_on "xcb-util"
     depends_on "xcb-util-cursor"
     depends_on "xcb-util-image"
     depends_on "xcb-util-keysyms"
     depends_on "xcb-util-renderutil"
     depends_on "xcb-util-wm"
-  end
 
-  resource "html5lib" do
-    url "https://files.pythonhosted.org/packages/ac/b6/b55c3f49042f1df3dcd422b7f224f939892ee94f22abcf503a9b7339eaf2/html5lib-1.1.tar.gz"
-    sha256 "b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f"
-  end
-
-  resource "six" do
-    url "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz"
-    sha256 "ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"
-  end
-
-  resource "webencodings" do
-    url "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz"
-    sha256 "b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"
+    on_intel do
+      depends_on "ninja" => :build
+    end
   end
 
   def install
-    python3 = "python3.13"
-
-    # Install python dependencies for QtWebEngine
-    venv = virtualenv_create(buildpath/"venv", python3)
-    venv.pip_install resources
-    ENV.prepend_path "PYTHONPATH", venv.site_packages
+    rm_r(%w[
+      qt3d/src/3rdparty/assimp/src
+      qtbase/src/3rdparty/blake2/src
+      qtbase/src/3rdparty/double-conversion
+      qtbase/src/3rdparty/freetype
+      qtbase/src/3rdparty/harfbuzz-ng
+      qtbase/src/3rdparty/libjpeg
+      qtbase/src/3rdparty/libpng
+      qtbase/src/3rdparty/md4c
+      qtbase/src/3rdparty/pcre2
+      qtbase/src/3rdparty/sqlite
+      qtbase/src/3rdparty/xcb
+      qtbase/src/3rdparty/zlib
+      qtimageformats/src/3rdparty/libtiff
+      qtimageformats/src/3rdparty/libwebp
+      qtquick3d/src/3rdparty/assimp
+      qtvirtualkeyboard/src/plugins/hunspell/3rdparty/hunspell
+      qtwebengine
+      qtwebview
+    ])
 
     # Allow -march options to be passed through, as Qt builds
     # arch-specific code with runtime detection of capabilities:
     # https://bugreports.qt.io/browse/QTBUG-113391
     ENV.runtime_cpu_detection
-
-    # FIXME: GN requires clang in clangBasePath/bin
-    inreplace "qtwebengine/src/3rdparty/chromium/build/toolchain/apple/toolchain.gni",
-              'rebase_path("$clang_base_path/bin/", root_build_dir)', '""'
-
-    # FIXME: See https://bugreports.qt.io/browse/QTBUG-89559
-    # and https://codereview.qt-project.org/c/qt/qtbase/+/327393
-    # It is not friendly to Homebrew or macOS
-    # because on macOS `/tmp` -> `/private/tmp`
-    inreplace "qtwebengine/src/3rdparty/gn/src/base/files/file_util_posix.cc",
-              "FilePath(full_path)", "FilePath(input)"
 
     # Modify Assistant path as we manually move `*.app` bundles from `bin` to `libexec`.
     # This fixes invocation of Assistant via the Help menu of apps like Designer and
@@ -170,9 +137,6 @@ class Qt < Formula
     ]
     inreplace assistant_files, '"Assistant.app/Contents/MacOS/Assistant"', '"Assistant"'
 
-    # We prefer CMake `-DQT_FEATURE_system*=ON` arg over configure `-system-*` arg
-    # since the latter may be ignored when auto-detection fails.
-    #
     # We disable clang feature to avoid linkage to `llvm`. This is how we have always
     # built on macOS and it prevents complicating `llvm` version bumps on Linux.
     cmake_args = std_cmake_args(install_prefix: HOMEBREW_PREFIX, find_framework: "FIRST") + %W[
@@ -183,79 +147,45 @@ class Qt < Formula
       -DINSTALL_MKSPECSDIR=share/qt/mkspecs
       -DINSTALL_TESTSDIR=share/qt/tests
 
+      -DBUILD_qtwebengine=OFF
+      -DFEATURE_clang=OFF
+      -DFEATURE_relocatable=OFF
       -DFEATURE_sql_mysql=OFF
       -DFEATURE_sql_odbc=OFF
       -DFEATURE_sql_psql=OFF
-      -DQT_FEATURE_clang=OFF
-      -DQT_FEATURE_relocatable=OFF
 
       -DFEATURE_pkg_config=ON
-      -DQT_FEATURE_system_assimp=ON
-      -DQT_FEATURE_system_doubleconversion=ON
-      -DQT_FEATURE_system_freetype=ON
-      -DQT_FEATURE_system_harfbuzz=ON
-      -DQT_FEATURE_system_hunspell=ON
-      -DQT_FEATURE_system_jpeg=ON
-      -DQT_FEATURE_system_libb2=ON
-      -DQT_FEATURE_system_pcre2=ON
-      -DQT_FEATURE_system_png=ON
-      -DQT_FEATURE_system_sqlite=ON
-      -DQT_FEATURE_system_tiff=ON
-      -DQT_FEATURE_system_webp=ON
-      -DQT_FEATURE_system_zlib=ON
-      -DQT_FEATURE_webengine_proprietary_codecs=ON
-      -DQT_FEATURE_webengine_kerberos=ON
+      -DFEATURE_system_assimp=ON
+      -DFEATURE_system_doubleconversion=ON
+      -DFEATURE_system_freetype=ON
+      -DFEATURE_system_harfbuzz=ON
+      -DFEATURE_system_hunspell=ON
+      -DFEATURE_system_jpeg=ON
+      -DFEATURE_system_libb2=ON
+      -DFEATURE_system_pcre2=ON
+      -DFEATURE_system_png=ON
+      -DFEATURE_system_sqlite=ON
+      -DFEATURE_system_tiff=ON
+      -DFEATURE_system_webp=ON
+      -DFEATURE_system_zlib=ON
       -DQT_ALLOW_SYMLINK_IN_PATHS=ON
     ]
 
     cmake_args += if OS.mac?
-      ENV["SDKROOT"] = MacOS.sdk_for_formula(self).path
-
-      # NOTE: `chromium` should be built with the latest SDK because it uses
-      # `___builtin_available` to ensure compatibility.
-      #
-      # Chromium needs Xcode 15.3+ and using LLVM Clang is not supported on macOS
-      # See https://bugreports.qt.io/browse/QTBUG-130922
-      cmake_args << "-DBUILD_qtwebengine=OFF" if MacOS::Xcode.version < "15.3"
-
       %W[
         -DCMAKE_OSX_DEPLOYMENT_TARGET=#{MacOS.version}.0
-        -DQT_FEATURE_ffmpeg=OFF
+        -DFEATURE_ffmpeg=OFF
       ]
     else
-      # For QtWebEngine arguments:
-      # * The vendored copy of `libvpx` is used for VA-API hardware acceleration,
-      #   see https://codereview.qt-project.org/c/qt/qtwebengine/+/454908
-      # * The vendored copy of `re2` is used to avoid rebuilds with `re2` version
-      #   bumps and due to frequent API incompatibilities in Qt's copy of Chromium
-      # * On macOS Chromium will always use bundled copies and the
-      #   -DQT_FEATURE_webengine_system_*=ON arguments are ignored.
-      # * As of Qt 6.6.0, webengine_ozone_x11 feature appears to be mandatory for Linux.
       %w[
-        -DQT_FEATURE_xcb=ON
-        -DQT_FEATURE_system_xcb_xinput=ON
-        -DQT_FEATURE_webengine_ozone_x11=ON
-        -DQT_FEATURE_webengine_system_alsa=ON
-        -DQT_FEATURE_webengine_system_ffmpeg=ON
-        -DQT_FEATURE_webengine_system_freetype=ON
-        -DQT_FEATURE_webengine_system_harfbuzz=ON
-        -DQT_FEATURE_webengine_system_icu=ON
-        -DQT_FEATURE_webengine_system_lcms2=ON
-        -DQT_FEATURE_webengine_system_libevent=ON
-        -DQT_FEATURE_webengine_system_libjpeg=ON
-        -DQT_FEATURE_webengine_system_libpng=ON
-        -DQT_FEATURE_webengine_system_libxml=ON
-        -DQT_FEATURE_webengine_system_libwebp=ON
-        -DQT_FEATURE_webengine_system_minizip=ON
-        -DQT_FEATURE_webengine_system_opus=ON
-        -DQT_FEATURE_webengine_system_poppler=ON
-        -DQT_FEATURE_webengine_system_pulseaudio=ON
-        -DQT_FEATURE_webengine_system_snappy=ON
-        -DQT_FEATURE_webengine_system_zlib=ON
+        -DFEATURE_xcb=ON
+        -DFEATURE_system_xcb_xinput=ON
       ]
     end
 
-    system "cmake", "-S", ".", "-B", "build", "-G", "Ninja", *cmake_args
+    cmake_args += ["-G", "Ninja"] if OS.mac? || Hardware::CPU.intel?
+
+    system "cmake", "-S", ".", "-B", "build", *cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
 
@@ -313,13 +243,14 @@ class Qt < Formula
         Preferences > Qt Versions > Link with Qt...
       pressing "Choose..." and selecting as the Qt installation path:
         #{HOMEBREW_PREFIX}
+
+      Qt WebEngine is now in the `qt-webengine` formula.
+      Qt WebView is now in the `qt-webview` formula.
     EOS
   end
 
   test do
-    webengine_supported = !OS.mac? || MacOS.version > :ventura
     modules = %w[Core Gui Widgets Sql Concurrent 3DCore Svg Quick3D Network NetworkAuth]
-    modules << "WebEngineCore" if webengine_supported
 
     (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION #{Formula["cmake"].version})
@@ -336,7 +267,7 @@ class Qt < Formula
       target_link_libraries(test PRIVATE Qt6::#{modules.join(" Qt6::")})
     CMAKE
 
-    (testpath/"test.pro").write <<~EOS
+    (testpath/"test.pro").write <<~QMAKE
       QT += #{modules.join(" ").downcase}
       TARGET = test
       CONFIG += console
@@ -344,7 +275,7 @@ class Qt < Formula
       TEMPLATE = app
       SOURCES += main.cpp
       INCLUDEPATH += #{Formula["vulkan-headers"].opt_include}
-    EOS
+    QMAKE
 
     (testpath/"main.cpp").write <<~CPP
       #undef QT_NO_DEBUG
@@ -357,7 +288,6 @@ class Qt < Formula
       #include <QtSvg>
       #include <QDebug>
       #include <QVulkanInstance>
-      #{"#include <QtWebEngineCore>" if webengine_supported}
       #include <iostream>
 
       int main(int argc, char *argv[])
@@ -395,7 +325,7 @@ class Qt < Formula
     system "cmake", "--build", "cmake"
     system "./cmake/test"
 
-    ENV.delete "CPATH" if OS.mac? && MacOS.version > :mojave
+    ENV.delete "CPATH" if OS.mac?
     mkdir "qmake" do
       system bin/"qmake", testpath/"test.pro"
       system "make"

--- a/style_exceptions/runtime_cpu_detection_allowlist.json
+++ b/style_exceptions/runtime_cpu_detection_allowlist.json
@@ -35,6 +35,7 @@
   "postgresql@16",
   "postgresql@17",
   "qt",
+  "qt-webengine",
   "spades",
   "spidermonkey",
   "svt-av1",

--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -61,7 +61,17 @@
   ["python-gdbm@3.12", "python-tk@3.12", "python@3.12"],
   ["python-gdbm@3.13", "python-tk@3.13", "python@3.13", "python-freethreading"],
   ["python-tk@3.9", "python@3.9"],
-  ["qt", "qt-libiodbc", "qt-mariadb", "qt-mysql", "qt-percona-server", "qt-postgresql", "qt-unixodbc"],
+  [
+    "qt",
+    "qt-libiodbc",
+    "qt-mariadb",
+    "qt-mysql",
+    "qt-percona-server",
+    "qt-postgresql",
+    "qt-unixodbc",
+    "qt-webengine",
+    "qt-webview"
+  ],
   ["qwt", "qwt-qt5"],
   ["surelog", "uhdm"],
   ["technitium-dns", "technitium-library"],


### PR DESCRIPTION
WIP.

Related to #209644 but in opposite direction which is easier. WebEngine is particularly the worst part of Qt to build with the largest number of build failures so would be nice to split this out earlier.

---

TODO:
1. First need to prune out dependencies on Linux for `qt` formula (I think most are for WebEngine but not sure).
2. Add `qt-webengine` and `qt-webview` formulae.
4. Update dependents that need WebEngine (e.g. PyQt).
