### PR TITLE
cabal-install allureofthestars bench cgrep: add `gmp` and `libffi` dependencies

### DIFF
--- a/Formula/a/allureofthestars.rb
+++ b/Formula/a/allureofthestars.rb
@@ -21,9 +21,11 @@ class Allureofthestars < Formula
   depends_on "cabal-install" => :build
   depends_on "ghc" => :build
   depends_on "pkgconf" => :build
+  depends_on "gmp"
   depends_on "sdl2"
   depends_on "sdl2_ttf"
 
+  uses_from_macos "libffi"
   uses_from_macos "zlib"
 
   # TODO: Remove resource once new release is available or hackage revision (r2+) with

--- a/Formula/b/bench.rb
+++ b/Formula/b/bench.rb
@@ -32,7 +32,9 @@ class Bench < Formula
 
   depends_on "cabal-install" => :build
   depends_on "ghc" => :build
+  depends_on "gmp"
 
+  uses_from_macos "libffi"
   uses_from_macos "zlib"
 
   def install

--- a/Formula/c/cabal-install.rb
+++ b/Formula/c/cabal-install.rb
@@ -17,6 +17,9 @@ class CabalInstall < Formula
   end
 
   depends_on "ghc"
+  depends_on "gmp"
+
+  uses_from_macos "libffi"
   uses_from_macos "zlib"
 
   resource "bootstrap" do

--- a/Formula/c/cgrep.rb
+++ b/Formula/c/cgrep.rb
@@ -21,7 +21,10 @@ class Cgrep < Formula
   depends_on "cabal-install" => :build
   depends_on "ghc" => :build
   depends_on "pkgconf" => :build
+  depends_on "gmp"
   depends_on "pcre"
+
+  uses_from_macos "libffi"
 
   conflicts_with "aerleon", because: "both install `cgrep` binaries"
 


### PR DESCRIPTION
Decided in #218635 to unbundle these and just dynamically link dependencies.

The linkage is usually expected, e.g. `gmp` is used for some common Haskell types and similar dependencies are seen in Debian and Fedora.

---

Won't update bottles for now. Can be updated whenever new version/revision is needed.