### PR TITLE
keychain: update livecheck

### DIFF
--- a/Formula/k/keychain.rb
+++ b/Formula/k/keychain.rb
@@ -7,6 +7,7 @@ class Keychain < Formula
 
   livecheck do
     url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
     strategy :github_latest
   end
 


### PR DESCRIPTION
keychain: update livecheck to ignore beta releases (https://github.com/funtoo/keychain/releases/tag/2.9.0_beta2)