### PR TITLE
prestodb: restore `:all` bottle

### DIFF
--- a/Formula/p/prestodb.rb
+++ b/Formula/p/prestodb.rb
@@ -16,13 +16,8 @@ class Prestodb < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "c72cbf63fde263aa303b17aacacd37c48f2b7e553cfde06d2950ff5084cdfb94"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "c72cbf63fde263aa303b17aacacd37c48f2b7e553cfde06d2950ff5084cdfb94"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "c72cbf63fde263aa303b17aacacd37c48f2b7e553cfde06d2950ff5084cdfb94"
-    sha256 cellar: :any_skip_relocation, sonoma:        "c72cbf63fde263aa303b17aacacd37c48f2b7e553cfde06d2950ff5084cdfb94"
-    sha256 cellar: :any_skip_relocation, ventura:       "c72cbf63fde263aa303b17aacacd37c48f2b7e553cfde06d2950ff5084cdfb94"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "c72cbf63fde263aa303b17aacacd37c48f2b7e553cfde06d2950ff5084cdfb94"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1a4ca5d90974d99af3c5567f52f818425aab5cc3539c52647d1e1727b99d16db"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "4eddb6530bd68a0cdcbfc9ffa891dcbef3a359110881db51d89af58fce4629bb"
   end
 
   depends_on "openjdk@17"

--- a/Formula/p/prestodb.rb
+++ b/Formula/p/prestodb.rb
@@ -88,6 +88,8 @@ class Prestodb < Formula
 
     # Remove incompatible pre-built binaries
     libprocname_dirs = (libexec/"bin/procname").children
+    # Keep the Linux-x86_64 directory to make bottles identical
+    libprocname_dirs.reject! { |dir| dir.basename.to_s == "Linux-x86_64" }
     libprocname_dirs.reject! { |dir| dir.basename.to_s == "#{OS.kernel_name}-#{Hardware::CPU.arch}" }
     rm_r libprocname_dirs
   end

--- a/audit_exceptions/mismatched_binary_allowlist.json
+++ b/audit_exceptions/mismatched_binary_allowlist.json
@@ -6,6 +6,7 @@
   "i686-elf-grub": "lib/i686-elf/grub/i386-pc/*",
   "lima": "share/lima/lima-guestagent.Linux-*",
   "picotool": "share/picotool/xip_ram_perms.elf",
+  "prestodb": "libexec/bin/procname/Linux-*/libprocname.so",
   "qemu": "share/qemu/*",
   "x86_64-elf-grub": "lib/x86_64-elf/grub/i386-pc/*"
 }


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We can keep the `:all`  bottle if we allow the mismatched binaries in
`libexec/bin/procname/*`.
