### PR TITLE
cmake: fix compilation on macOS 10.13

### DIFF
--- a/Formula/c/cmake.rb
+++ b/Formula/c/cmake.rb
@@ -42,6 +42,9 @@ class Cmake < Formula
   # For the GUI application please instead use `brew install --cask cmake`.
 
   def install
+    # Work around "error: no member named 'signbit' in the global namespace"
+    ENV["SDKROOT"] = MacOS.sdk_path if OS.mac? && MacOS.version == :high_sierra
+
     args = %W[
       --prefix=#{prefix}
       --no-system-libs


### PR DESCRIPTION
Workaround for [SDK issue](https://github.com/Homebrew/homebrew-core/pull/51949#issuecomment-601943075) that only affects macOS High Sierra.