### PR TITLE
curl: depend on zlib for OS X 10.11, patch test failure

### DIFF
--- a/Formula/c/curl.rb
+++ b/Formula/c/curl.rb
@@ -45,10 +45,22 @@ class Curl < Formula
 
   uses_from_macos "krb5"
   uses_from_macos "openldap"
-  uses_from_macos "zlib"
+  uses_from_macos "zlib", since: :sierra
 
   on_system :linux, macos: :monterey_or_older do
     depends_on "libidn2"
+  end
+
+  # Fixes failure to download certdata.txt due to a redirect
+  patch do
+    url "https://github.com/curl/curl/commit/eeed87f0563d3ca73ff53813418d1f9f03c81fe5.patch?full_index=1"
+    sha256 "f7461a8042ca8ef86492338458ccd79ee286d17773487513928d7ed6ae25818c"
+  end
+
+  # Fixes build on macOS 10.12 and earlier
+  patch do
+    url "https://github.com/curl/curl/commit/d7914f75aa8ecdd68cdbb130c1351a7432597fe4.patch?full_index=1"
+    sha256 "2ba45be5c9238abc914c2a47cd604cbd08972583b310c9079b7b7909b352001b"
   end
 
   def install

--- a/Formula/c/curl.rb
+++ b/Formula/c/curl.rb
@@ -16,13 +16,14 @@ class Curl < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "5629dc2ddfe44e07dc15aa725796a8aad62b5785979b91d19b856060f2bc6e21"
-    sha256 cellar: :any,                 arm64_sonoma:  "acc8f8a0ea285d1f6d664f4cc8c8f598efb3503ba5a7c4ac4bbd71f42425f0d2"
-    sha256 cellar: :any,                 arm64_ventura: "5556e95c7b91201cd03c7b02e4110e4b706ee551038ad4720d6526c3f69c172d"
-    sha256 cellar: :any,                 sonoma:        "bc44f5d463aeb83665feb028968e43fec2aa2731244b79a2c350e01e514a8493"
-    sha256 cellar: :any,                 ventura:       "210a0e1e334cac9c2398c6938f9f8337e4f86e1685c8f604a5c024e6baba7cec"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "18bb0c7ef38940a4c030e8258cce21e0948a7800d208c7e67f125dc4df72fddb"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e29f1bd12fffb9b651022b74f2d1772797093185fb192f051b2a39f549acc469"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "71f23540167a8ab38a56ae1ec35b12f726765d6706602e93efdaad31a99bf01d"
+    sha256 cellar: :any,                 arm64_sonoma:  "e0d632af6097f17ca1d10d2cbe63f43fdf2dd58aa1a36a6e8cad11e7f72159a5"
+    sha256 cellar: :any,                 arm64_ventura: "416ee6d14ce87952b11e325f9e320c068b657e3b5099ba50a34e7f5bbc68d634"
+    sha256 cellar: :any,                 sonoma:        "49161bfb410f5a2f585256b452f9252319064f633789109f7f53941b28816b7b"
+    sha256 cellar: :any,                 ventura:       "d6a522ebfb6b2b64f03911465d16ba15d4ce6b1e68d5cb5820c245c4f6ef8f1f"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "420cec3c2e6f55105664b0074c49119f736621646ca522fae976cbe759667a8b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "9c420f63845b2ed7c29f089cdb84981134173dab3b89b8e6c7b06f22630dcbec"
   end
 
   head do


### PR DESCRIPTION
Recently, curl bumped its [minimum zlib to 1.2.5.2](https://github.com/curl/curl/commit/25f8486f269dfcd8e938ee7ed010a51b848fb36e) and OS X 10.11 shipped with 1.2.5, so depend on brewed zlib in that case. This also adds an HTTP mirror to zlib's test resource so it builds before a modern curl is installed.