### PR TITLE
formulae: use `pkgconf` to link openssl for linux build

### DIFF
--- a/Formula/a/authoscope.rb
+++ b/Formula/a/authoscope.rb
@@ -21,6 +21,7 @@ class Authoscope < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "3cf7f5e3bc8dbe57cc22cd6bbdd5b62a7c69c54e1da1cc6ea7e1e19b0166c413"
   end
 
+  depends_on "pkgconf" => :build
   depends_on "rust" => :build
 
   uses_from_macos "zlib"
@@ -30,10 +31,6 @@ class Authoscope < Formula
   end
 
   def install
-    # Ensure that the `openssl` crate picks up the intended library.
-    # https://crates.io/crates/openssl#manual-configuration
-    ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix if OS.linux?
-
     system "cargo", "install", *std_cargo_args
     man1.install "docs/authoscope.1"
 

--- a/Formula/d/drill.rb
+++ b/Formula/d/drill.rb
@@ -20,6 +20,7 @@ class Drill < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "701f7a9ab685f50091ce4c85d09cffde2a6b46ecda5052cdce5a41b06dafffd6"
   end
 
+  depends_on "pkgconf" => :build
   depends_on "rust" => :build
 
   on_linux do
@@ -29,7 +30,6 @@ class Drill < Formula
   conflicts_with "ldns", because: "both install a `drill` binary"
 
   def install
-    ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix if OS.linux?
     system "cargo", "install", *std_cargo_args
   end
 

--- a/Formula/r/rathole.rb
+++ b/Formula/r/rathole.rb
@@ -18,6 +18,7 @@ class Rathole < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "418e67c95c4f95329a0564f4fe78c4c8ff23bda1be98eed056a9ef45fc558b39"
   end
 
+  depends_on "pkgconf" => :build
   depends_on "rust" => :build
 
   on_linux do
@@ -31,10 +32,6 @@ class Rathole < Formula
   end
 
   def install
-    # Ensure that the `openssl` crate picks up the intended library.
-    # https://crates.io/crates/openssl#manual-configuration
-    ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix if OS.linux?
-
     system "cargo", "install", *std_cargo_args
   end
 

--- a/Formula/r/rink.rb
+++ b/Formula/r/rink.rb
@@ -25,10 +25,6 @@ class Rink < Formula
   end
 
   def install
-    # Ensure that the `openssl` crate picks up the intended library.
-    # https://crates.io/crates/openssl#manual-configuration
-    ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix if OS.linux?
-
     system "cargo", "install", *std_cargo_args(path: "cli")
 
     system "make", "man"

--- a/Formula/s/sccache.rb
+++ b/Formula/s/sccache.rb
@@ -21,6 +21,7 @@ class Sccache < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "b53ed3e9f8745cbfa1e5a6b018225f7e30326af3fecd6701887acc580f1254c6"
   end
 
+  depends_on "pkgconf" => :build
   depends_on "rust" => :build
 
   on_linux do
@@ -28,10 +29,6 @@ class Sccache < Formula
   end
 
   def install
-    # Ensure that the `openssl` crate picks up the intended library.
-    # https://crates.io/crates/openssl#manual-configuration
-    ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix if OS.linux?
-
     system "cargo", "install", "--features", "all", *std_cargo_args
   end
 


### PR DESCRIPTION
formulae: use `pkgconf` to link openssl for linux build