### PR TITLE
qemu: fix segfault on macOS 15.0-15.3

### DIFF
--- a/Formula/q/qemu.rb
+++ b/Formula/q/qemu.rb
@@ -72,6 +72,12 @@ class Qemu < Formula
   end
 
   def install
+    # Fix segfault on macOS 15.0-15.3
+    # https://github.com/Homebrew/homebrew-core/issues/221154
+    if OS.mac? && MacOS.version == :sequoia && build.bottle?
+      inreplace "meson.build", "config_host_data.set('HAVE_STRCHRNUL', cc.has_function('strchrnul'))\n", ""
+    end
+
     ENV["LIBTOOL"] = "glibtool"
 
     # Remove wheels unless explicitly permitted. Currently this:


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Closes #221154