### PR TITLE
iccmax 2.1.26 (new formula)

### DIFF
--- a/Formula/i/iccmax.rb
+++ b/Formula/i/iccmax.rb
@@ -5,6 +5,15 @@ class Iccmax < Formula
   sha256 "e3bff2e0e7876faebe4a2097eefa2a190325bcc04c152ef470449f0c01b41fa7"
   license "MIT"
 
+  bottle do
+    sha256 cellar: :any,                 arm64_sequoia: "1c199d5cf09f566e818d2049fb093faf85d4db8d5523e1434291fa2c9472410b"
+    sha256 cellar: :any,                 arm64_sonoma:  "1b74500262109e0e702597ed2342f488c4517b8f44800534e33c55c88b89bdaf"
+    sha256 cellar: :any,                 arm64_ventura: "47bc9ddae076560477d5dcb2aba20a1f1ee6a1bfd7abf427bf70aec37c7b911d"
+    sha256 cellar: :any,                 sonoma:        "7fb47953f25262626476ffa53e8b9a1062ac2f8dfd1a3c492c4cabb8159da326"
+    sha256 cellar: :any,                 ventura:       "0c77e5b40278033497bdf99dd0f667a06b3e8ceb5ec47ee4c32802da98d8e930"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0923ecf885cebd5ad8dc4438ca1d594faa37f9139c1a2606494aca2f2a023a1b"
+  end
+
   depends_on "cmake" => :build
   depends_on "jpeg"
   depends_on "libpng"

--- a/Formula/i/iccmax.rb
+++ b/Formula/i/iccmax.rb
@@ -1,0 +1,40 @@
+class Iccmax < Formula
+  desc "Demonstration Implementation for iccMAX color profiles"
+  homepage "https://github.com/InternationalColorConsortium/DemoIccMAX"
+  url "https://github.com/InternationalColorConsortium/DemoIccMAX/archive/refs/tags/v2.1.26.tar.gz"
+  sha256 "e3bff2e0e7876faebe4a2097eefa2a190325bcc04c152ef470449f0c01b41fa7"
+  license "MIT"
+
+  depends_on "cmake" => :build
+  depends_on "jpeg"
+  depends_on "libpng"
+  depends_on "libtiff"
+  depends_on "nlohmann-json"
+  depends_on "wxwidgets"
+
+  uses_from_macos "libxml2"
+
+  def install
+    args = %W[
+      -DCMAKE_INSTALL_RPATH=#{opt_lib}
+      -DENABLE_TOOLS=ON
+      -DENABLE_SHARED_LIBS=ON
+      -DENABLE_INSTALL_RIM=ON
+      -DENABLE_ICCXML=ON
+    ]
+
+    system "cmake", "-S", "Build/Cmake", "-B", "build", *args, *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+
+    pkgshare.install "Testing/Calc/CameraModel.xml"
+  end
+
+  test do
+    system bin/"iccFromXml", pkgshare/"CameraModel.xml", "output.icc"
+    assert_path_exists testpath/"output.icc"
+
+    system bin/"iccToXml", "output.icc", "output.xml"
+    assert_path_exists testpath/"output.xml"
+  end
+end


### PR DESCRIPTION
Fix: Change License Type back to MIT
Fix: Update correct Dependency Order and Uses

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
