### PR TITLE
java-service-wrapper: optimize test shell_output for assert_match

### DIFF
--- a/Formula/j/java-service-wrapper.rb
+++ b/Formula/j/java-service-wrapper.rb
@@ -75,10 +75,7 @@ class JavaServiceWrapper < Formula
     JAVA
 
     system "#{java_home}/bin/javac", "HelloWorld.java"
-    assert_match <<~EOS, shell_output("bin/helloworld console")
-      jvm 1    | WrapperManager: Initializing...
-      jvm 1    | Hello, world!
-      wrapper  | <-- Wrapper Stopped
-    EOS
+    console_output = shell_output("bin/helloworld console")
+    assert_match "Hello, world!", console_output
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
This is to support openjdk 24 (#212057), and the output log running on it is as follows:
```
Running Hello World...
wrapper  | --> Wrapper Started as Console
wrapper  | Java Service Wrapper Community Edition 64-bit 3.6.0
wrapper  |   Copyright (C) 1999-2025 Tanuki Software, Ltd. All Rights Reserved.
wrapper  |     https://wrapper.tanukisoftware.com
wrapper  | 
wrapper  | Launching a JVM...
jvm 1    | Picked up _JAVA_OPTIONS: -Duser.home=/home/linuxbrew/.cache/Homebrew/java_cache -Djava.io.tmpdir=/var/tmp
jvm 1    | WrapperManager: Initializing...
jvm 1    | WARNING: A restricted method in java.lang.System has been called
jvm 1    | WARNING: java.lang.System::loadLibrary has been called by org.tanukisoftware.wrapper.WrapperManager in an unnamed module (file:/home/linuxbrew/.linuxbrew/Cellar/java-service-wrapper/3.6.0/libexec/lib/wrapper.jar)
jvm 1    | WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
jvm 1    | WARNING: Restricted methods will be blocked in a future release unless native access is enabled
jvm 1    | 
jvm 1    | Hello, world!
wrapper  | <-- Wrapper Stopped

```