### PR TITLE
cargo-shuttle: fix test

### DIFF
--- a/Formula/c/cargo-shuttle.rb
+++ b/Formula/c/cargo-shuttle.rb
@@ -38,7 +38,7 @@ class CargoShuttle < Formula
 
   test do
     assert_match version.to_s, shell_output("#{bin}/shuttle --version")
-    assert_match "Forbidden", shell_output("#{bin}/shuttle account 2>&1", 1)
+    assert_match "Unauthorized", shell_output("#{bin}/shuttle account 2>&1", 1)
     output = shell_output("#{bin}/shuttle deployment status 2>&1", 1)
     assert_match "ailed to find a Rust project in this directory.", output
   end


### PR DESCRIPTION
It seems that the api response is changed, so have to fix the test.

- https://github.com/Homebrew/homebrew-core/pull/218820

---

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
