### PR TITLE
textidote: test supports openjdk 24

### DIFF
--- a/Formula/t/textidote.rb
+++ b/Formula/t/textidote.rb
@@ -39,6 +39,12 @@ class Textidote < Formula
   end
 
   test do
+    # After openjdk 24, "jdk.xml.totalEntitySizeLimit" was modified to 100000 (and before that was 50000000),
+    # which would cause a JAXP00010004 error.
+    # See: https://docs.oracle.com/en/java/javase/23/docs/api/java.xml/module-summary.html#jdk.xml.totalEntitySizeLimit
+    # See: https://docs.oracle.com/en/java/javase/24/docs/api/java.xml/module-summary.html#jdk.xml.totalEntitySizeLimit
+    ENV["JAVA_OPTS"] = "-Djdk.xml.totalEntitySizeLimit=50000000"
+
     output = shell_output("#{bin}/textidote --version")
     assert_match "TeXtidote", output
 

--- a/Formula/t/textidote.rb
+++ b/Formula/t/textidote.rb
@@ -12,14 +12,14 @@ class Textidote < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "51461cd926b6329d791237ea255458e237710fc6c5eaa0a3067b9bfde03bf533"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "0286fceacded8ff1661117098ea3e864f3e6a9f8d42ba2418eb027578865f5f3"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "e9a83218eb82f98e70fba9d90886ddedc8402f9a664c5578ccb768f013efcee2"
-    sha256 cellar: :any_skip_relocation, sonoma:        "936cca1b103e05e9301cb9442078d417f13169f9726d85e46ba0fe984ece5bd6"
-    sha256 cellar: :any_skip_relocation, ventura:       "2ca10fe4b0d6c75985e19fdfe409db7aa3780bc027f1686d65dbcf295d107862"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "bfb87740c268eb579c4c30a72c79e0ecc9b3b977358f98e2c0f7536edb638f12"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "53bc512af1d05084aef085e8185b29444e3a9a92f515859e06cf7d9860490b31"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "233ce6f6a6e226e5f00f7fada39dd51587afdb332e4c87f1ec9424e394d80743"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "14b7818a01928aeda595a8a77e91004a75e587a95c0e02110e48980ec6afea0e"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "d99486e4a64f499d54fc3ceb04e025c93c437ab84bccd09ea18924c0ed536265"
+    sha256 cellar: :any_skip_relocation, sonoma:        "918182a20520b96b5dd635a1d0cb4d373b5368cc1776f1645786c06554e1f50d"
+    sha256 cellar: :any_skip_relocation, ventura:       "14ef73a0bfd65f87b129c5ca365608322a019ce74f2717ed152169b692b2c5c7"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "3b8b47f1a6865eedba83b190e10721c013c31e1bedaca84b319aa4acc1c865d6"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "820b5da9880ca2ce2b4c9251236314ef10be053b64c27b7a927325a8daf2591b"
   end
 
   depends_on "ant" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
openjdk 24 (#212057) has made some changes to the security policies for the Java API for XML Processing (JAXP), such as reducing the `jdk.xml.totalEntitySizeLimit` from 50,000,000 to 100,000. This causes the formula to throw an error during testing due to exceeding this limit.
```
==> Testing textidote
  ==> /home/linuxbrew/.linuxbrew/Cellar/textidote/0.8.3/bin/textidote --version
  Picked up _JAVA_OPTIONS: -Duser.home=/home/linuxbrew/.cache/Homebrew/java_cache -Djava.io.tmpdir=/var/tmp
  ==> /home/linuxbrew/.linuxbrew/Cellar/textidote/0.8.3/bin/textidote --check en /var/tmp/textidote-test-20250427-312195-jt8o42/test1.tex
  Picked up _JAVA_OPTIONS: -Duser.home=/home/linuxbrew/.cache/Homebrew/java_cache -Djava.io.tmpdir=/var/tmp
  TeXtidote v0.8.3 - A linter for LaTeX documents and others
  (C) 2018-2021 Sylvain Hallé - All rights reserved
  
  WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
  WARNING: sun.misc.Unsafe::objectFieldOffset has been called by com.google.common.util.concurrent.AbstractFuture$UnsafeAtomicHelper (file:/home/linuxbrew/.linuxbrew/Cellar/textidote/0.8.3/libexec/textidote.jar)
  WARNING: Please consider reporting this to the maintainers of class com.google.common.util.concurrent.AbstractFuture$UnsafeAtomicHelper
  WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
  Exception in thread "main" java.lang.RuntimeException: Could not activate rules
  	at org.languagetool.JLanguageTool.<init>(JLanguageTool.java:330)
  	at org.languagetool.JLanguageTool.<init>(JLanguageTool.java:289)
  	at org.languagetool.MultiThreadedJLanguageTool.<init>(MultiThreadedJLanguageTool.java:94)
  	at org.languagetool.MultiThreadedJLanguageTool.<init>(MultiThreadedJLanguageTool.java:84)
  	at org.languagetool.MultiThreadedJLanguageTool.<init>(MultiThreadedJLanguageTool.java:67)
  	at org.languagetool.MultiThreadedJLanguageTool.<init>(MultiThreadedJLanguageTool.java:51)
  	at ca.uqac.lif.textidote.rules.CheckLanguage.<init>(CheckLanguage.java:90)
  	at ca.uqac.lif.textidote.Main.mainLoop(Main.java:624)
  	at ca.uqac.lif.textidote.Main.mainLoop(Main.java:128)
  	at ca.uqac.lif.textidote.Main.main(Main.java:114)
  Caused by: java.io.IOException: Cannot load or parse input stream of '/org/languagetool/rules/en/grammar.xml'
  	at org.languagetool.rules.patterns.PatternRuleLoader.getRules(PatternRuleLoader.java:81)
  	at org.languagetool.Language.getPatternRules(Language.java:635)
  	at org.languagetool.JLanguageTool.activateDefaultPatternRules(JLanguageTool.java:658)
  	at org.languagetool.JLanguageTool.<init>(JLanguageTool.java:323)
  	... 9 more
  Caused by: org.xml.sax.SAXParseException; lineNumber: 55; columnNumber: 41; JAXP00010004: The accumulated size of entities is "100,007" that exceeded the "100,000" limit set by "jdk.xml.totalEntitySizeLimit".
  	at java.xml/com.sun.org.apache.xerces.internal.util.ErrorHandlerWrapper.createSAXParseException(ErrorHandlerWrapper.java:204)
  	at java.xml/com.sun.org.apache.xerces.internal.util.ErrorHandlerWrapper.fatalError(ErrorHandlerWrapper.java:178)
  	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLErrorReporter.reportError(XMLErrorReporter.java:400)
  	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLErrorReporter.reportError(XMLErrorReporter.java:327)
  	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLErrorReporter.reportError(XMLErrorReporter.java:284)
  	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLEntityScanner.checkLimit(XMLEntityScanner.java:1009)
  	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLEntityScanner.checkEntityLimit(XMLEntityScanner.java:968)
  	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLEntityScanner.scanName(XMLEntityScanner.java:753)
  	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl.scanAttribute(XMLDocumentFragmentScannerImpl.java:1508)
  	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl.scanStartElement(XMLDocumentFragmentScannerImpl.java:1372)
  	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl$FragmentContentDriver.next(XMLDocumentFragmentScannerImpl.java:2736)
  	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLDocumentScannerImpl.next(XMLDocumentScannerImpl.java:635)
  	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl.scanDocument(XMLDocumentFragmentScannerImpl.java:551)
  	at java.xml/com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:890)
  	at java.xml/com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:826)
  	at java.xml/com.sun.org.apache.xerces.internal.parsers.XMLParser.parse(XMLParser.java:134)
  	at java.xml/com.sun.org.apache.xerces.internal.parsers.AbstractSAXParser.parse(AbstractSAXParser.java:1225)
  	at java.xml/com.sun.org.apache.xerces.internal.jaxp.SAXParserImpl$JAXPSAXParser.parse(SAXParserImpl.java:643)
  	at java.xml/com.sun.org.apache.xerces.internal.jaxp.SAXParserImpl.parse(SAXParserImpl.java:326)
  	at java.xml/javax.xml.parsers.SAXParser.parse(SAXParser.java:197)
  	at org.languagetool.rules.patterns.PatternRuleLoader.getRules(PatternRuleLoader.java:78)
  	... 12 more
```