### PR TITLE
gitmux 0.11.2 (new formula)

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -1327,6 +1327,7 @@ gitlab-gem
 gitlab-runner
 gitleaks
 gitmoji
+gitmux
 gitoxide
 gitql
 gitsign

--- a/Formula/g/gitmux.rb
+++ b/Formula/g/gitmux.rb
@@ -5,6 +5,15 @@ class Gitmux < Formula
   sha256 "c62b180415c272743d01531b911091b9c35911be4ec4aae3e7bfceddf5094f6c"
   license "MIT"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "94802a69e31ec9c017fb332eef1427d91c17e87b657db245817a83f5362b3b21"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "94802a69e31ec9c017fb332eef1427d91c17e87b657db245817a83f5362b3b21"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "94802a69e31ec9c017fb332eef1427d91c17e87b657db245817a83f5362b3b21"
+    sha256 cellar: :any_skip_relocation, sonoma:        "47f6304b35b33a7c5ffd896df4879fe25fba51b51b9701170f63b31d1f420bff"
+    sha256 cellar: :any_skip_relocation, ventura:       "47f6304b35b33a7c5ffd896df4879fe25fba51b51b9701170f63b31d1f420bff"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "40b685c802a8ccbb422f1e60541c12236b8be7c2c28f275247f2a41d4425e29f"
+  end
+
   depends_on "go" => :build
   depends_on "git" => :test
   depends_on "tmux"

--- a/Formula/g/gitmux.rb
+++ b/Formula/g/gitmux.rb
@@ -1,0 +1,27 @@
+class Gitmux < Formula
+  desc "Git status in tmux status bar"
+  homepage "https://github.com/arl/gitmux"
+  url "https://github.com/arl/gitmux/archive/refs/tags/v0.11.2.tar.gz"
+  sha256 "c62b180415c272743d01531b911091b9c35911be4ec4aae3e7bfceddf5094f6c"
+  license "MIT"
+
+  depends_on "go" => :build
+  depends_on "git" => :test
+  depends_on "tmux"
+
+  def install
+    ldflags = "-s -w -X main.version=#{version}"
+
+    system "go", "build", *std_go_args(ldflags:)
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/gitmux -V")
+
+    system "git", "init", "--initial-branch=gitmux"
+
+    # `gitmux` breaks our git shim by clearing the environment.
+    ENV.prepend_path "PATH", Formula["git"].opt_bin
+    assert_match '"LocalBranch": "gitmux"', shell_output("#{bin}/gitmux -dbg")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
