### PR TITLE
apm-bash-completion: deprecate

### DIFF
--- a/Formula/a/apm-bash-completion.rb
+++ b/Formula/a/apm-bash-completion.rb
@@ -10,6 +10,8 @@ class ApmBashCompletion < Formula
     sha256 cellar: :any_skip_relocation, all: "f86348dd9abdb4b7a8c6353f29374d7432375920a0281e806f14d50b8673bc1f"
   end
 
+  deprecate! date: "2025-04-27", because: :repo_archived
+
   def install
     bash_completion.install "apm"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The upstream GitHub repository for `apm-bash-completion` was archived on 2025-03-18. The most recent commit is from 2021-06-11 and the `README` was not updated to explain the situation before the repository was archived but presumably this means that the project is discontinued, so this deprecates the formula accordingly.