### PR TITLE
cargo-watch: deprecate

### DIFF
--- a/Formula/c/cargo-watch.rb
+++ b/Formula/c/cargo-watch.rb
@@ -6,11 +6,6 @@ class CargoWatch < Formula
   license "CC0-1.0"
   head "https://github.com/watchexec/cargo-watch.git", branch: "main"
 
-  livecheck do
-    url :stable
-    strategy :github_latest
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "3e89525ad4d4dcff0e84930435fafab04934a7ed2cf2701e5747a9d953c9e9b3"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "d767cc28d20886e772e0ba5ea5b32be862b609d79ddaf8f8dd7dfde4e1cbb8a6"
@@ -20,6 +15,8 @@ class CargoWatch < Formula
     sha256 cellar: :any_skip_relocation, arm64_linux:   "1e1f3420f8e56134c4c42400399b67ea3e3389490ed5fd6d5fbce8b3b93289f4"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "9bc56bac3a510bfeb102997b3bdba25b01f83dddf771b116c46ef101dc8df988"
   end
+
+  deprecate! date: "2025-04-27", because: :repo_archived
 
   depends_on "rust" => :build
   depends_on "rustup" => :test


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The upstream GitHub repository for `cargo-watch` was archived on 2025-01-18. The `README` was updated on 2024-09-30 and 2024-10-02 to explain that the project won't receive further updates. This deprecates the formula accordingly.