### PR TITLE
driftwood: deprecate and replaced by `trufflehog`

### DIFF
--- a/Formula/d/driftwood.rb
+++ b/Formula/d/driftwood.rb
@@ -19,6 +19,8 @@ class Driftwood < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "f23e0f3345fb5ee170a3572e9c02243b531c471ff5691ca9e6121454f93594b2"
   end
 
+  deprecate! date: "2025-04-27", because: :repo_archived, replacement_formula: "trufflehog"
+
   depends_on "go" => :build
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The upstream GitHub repository for `driftwood` was archived on 2025-04-04. The `README` was updated before archiving to state:

> ⚠️ The Driftwood CLI tool is no longer supported. Please use [TruffleHog](https://github.com/trufflesecurity/trufflehog) instead! ⚠️

This deprecates the formula accordingly.