### PR TITLE
oniguruma: update livecheck

### DIFF
--- a/Formula/o/oniguruma.rb
+++ b/Formula/o/oniguruma.rb
@@ -7,8 +7,7 @@ class Oniguruma < Formula
   head "https://github.com/kkos/oniguruma.git", branch: "master"
 
   livecheck do
-    url :stable
-    regex(/^v?(\d+(?:\.\d+)+(?:[._-](?:mark|rev)\d+)?)$/i)
+    skip "No longer developed or maintained"
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The upstream GitHub repository for `oniguruma` was archived on 2025-04-24. The `README` was updated before archiving to include a message at the top saying, "This project ended on April 24, 2025." A number of formulae depend on `oniguruma`, so this updates the `livecheck` block to skip it until it can be deprecated.