### PR TITLE
regula: deprecate

### DIFF
--- a/Formula/r/regula.rb
+++ b/Formula/r/regula.rb
@@ -20,6 +20,8 @@ class Regula < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "abbb2a4a62e5c18d4a2ecfb9c34fa98ff7d93b5275d0b288482fa65379978cd7"
   end
 
+  deprecate! date: "2025-04-27", because: :repo_archived
+
   depends_on "go" => :build
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----


The upstream GitHub repository for `regula` was archived on 2024-09-03. The `README` was updated before archiving to state:

> Regula is no longer actively maintained.  Most of the relevant code has been moved to [snyk/policy-engine](https://github.com/snyk/policy-engine/) which is the engine powering the new [Snyk IaC](https://snyk.io/product/infrastructure-as-code-security/).

This deprecates the formula accordingly.