### PR TITLE
unoconv: deprecate

### DIFF
--- a/Formula/u/unoconv.rb
+++ b/Formula/u/unoconv.rb
@@ -20,6 +20,8 @@ class Unoconv < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "98d229d5206a98c1b525a0fd707041b499c6dd9cf3a2c9ccbc92f3a18fb36e1b"
   end
 
+  deprecate! date: "2025-04-27", because: :repo_archived
+
   depends_on "python@3.13"
 
   resource "setuptools" do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The upstream GitHub repository for `unoconv` was archived on 2025-03-31. The `README` was updated on 2021-11-12 with a message saying that Unoconv is deprecated in favor of [Unoserver](https://github.com/unoconv/unoserver/) (a rewrite) and that Unoconv will become unsupported once Unoserver has the major features of Unoconv. The Unoconv repository hasn't been updated since then and the most recent release was on 2019-10-21, so archiving the repository presumably means that the project is now unsupported. This deprecates the formula accordingly.