### PR TITLE
xsv: deprecate

### DIFF
--- a/Formula/x/xsv.rb
+++ b/Formula/x/xsv.rb
@@ -22,6 +22,8 @@ class Xsv < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "b2e6982514f6800be13fbbe4d1e2512023baa2f3bb2dc9e4bad87c0699bb911f"
   end
 
+  deprecate! date: "2025-04-27", because: :repo_archived
+
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The upstream GitHub repository for `xsv` was archived on 2025-04-24. The `README` was updated before archiving to say, "`xsv` is now unmaintained" and to recommend [qsv](https://github.com/dathere/qsv) or [xan](https://github.com/medialab/xan) instead. This deprecates the formula accordingly.