### PR TITLE
opensearch: bump to 2.19.2 and build using openjdk 21

### DIFF
--- a/Formula/o/opensearch.rb
+++ b/Formula/o/opensearch.rb
@@ -6,13 +6,13 @@ class Opensearch < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "d85402ff7c13b214f14f800a5828092fb22b5926dcb68131a45a17f53e00bd06"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "bf85978542db9fbedaf090bfca85800de8ea8a7fe8a08e77c4bba1475e414026"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "8558d7931c85816fd73ef706c60c2db5503802a6aeb432b920e80b69d020224e"
-    sha256 cellar: :any_skip_relocation, sonoma:        "cfd02cbd48e512cb8f5e6d22d4013e404c1204175dae23d6e9ccff74c139d76b"
-    sha256 cellar: :any_skip_relocation, ventura:       "26ae205cc0fdee615e9d8df9b5f5a874cb768cbc6cab66ccfedcaa631a3322d3"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "6ef29cc5d6d64c195fbe329b5ef8a29bf5c0dd9eee7ec9e31b6bfb692e6d5448"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c4da9417e5528f8fd3331ca2eab5348b40e9530bf916da6f37abbfa61d285158"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "2dc6a9a9df5ecb31dc045f765c6fa4a725793d91b70595861ad3f11b3b0064a7"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "88975f6160f4a89fc9493e6c889b8b698dec4028a527bfa68da32214c1ba1bbb"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "ec9dce75fab4820d576da5b88bc86cdc3247824f1bad98f6e9333eadc09c5597"
+    sha256 cellar: :any_skip_relocation, sonoma:        "668204234f0812989aa2e7ffc52661c578e3ac935b952907be2260554cfc3ac9"
+    sha256 cellar: :any_skip_relocation, ventura:       "15d0a18e26c272146a86425d0ce5c2dbf1c5c433aab352db783e46b66ee17795"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "ffd1eddbab1e73489038703ac8ef8c6beadd30b054f830c85d21454adfd3e39e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c24ab6ddd1a235545f34efa48bb75be5e607590bd6929acc9ab6b343fc9e8f32"
   end
 
   depends_on "gradle" => :build

--- a/Formula/o/opensearch.rb
+++ b/Formula/o/opensearch.rb
@@ -1,8 +1,8 @@
 class Opensearch < Formula
   desc "Open source distributed and RESTful search engine"
   homepage "https://github.com/opensearch-project/OpenSearch"
-  url "https://github.com/opensearch-project/OpenSearch/archive/refs/tags/2.19.1.tar.gz"
-  sha256 "99999a392dcf90bafebfa143ed071b45662fb022dcbcfa77df802248338d3a63"
+  url "https://github.com/opensearch-project/OpenSearch/archive/refs/tags/2.19.2.tar.gz"
+  sha256 "660eaf0958e79198c3f5483361b70a1f7618ae965955d25f2ca48ca2d113ed18"
   license "Apache-2.0"
 
   bottle do
@@ -16,12 +16,15 @@ class Opensearch < Formula
   end
 
   depends_on "gradle" => :build
-  depends_on "openjdk"
+  # Can be updated after https://github.com/opensearch-project/OpenSearch/pull/18085 is released.
+  depends_on "openjdk@21"
 
-  # Fix for gradle 8.13, could be removed in the next release
-  # We modify the patch to remove binary changes for linux
-  # PR Ref: https://github.com/opensearch-project/OpenSearch/pull/17345
+  # Remove below patches after https://github.com/opensearch-project/OpenSearch/pull/17942 is released.
   patch :DATA
+  patch do
+    url "https://github.com/opensearch-project/OpenSearch/commit/d3eb8fe5e85f1103d73410703269a0f967ad3ec2.patch?full_index=1"
+    sha256 "f9c91e12cdbcb8625bcc704d34d6d10bdfc94aa86395faa6293bdf41d030cfe8"
+  end
 
   def install
     platform = OS.kernel_name.downcase
@@ -63,7 +66,8 @@ class Opensearch < Formula
                 libexec/"bin/opensearch-keystore",
                 libexec/"bin/opensearch-plugin",
                 libexec/"bin/opensearch-shard"
-    bin.env_script_all_files(libexec/"bin", JAVA_HOME: Formula["openjdk"].opt_prefix)
+    # Can be updated after https://github.com/opensearch-project/OpenSearch/pull/18085 is released.
+    bin.env_script_all_files(libexec/"bin", JAVA_HOME: Formula["openjdk@21"].opt_prefix)
   end
 
   def post_install
@@ -127,17 +131,17 @@ index 679f7b9299248fb0f5173db8fccdfb77965e394b..187574da9e62aec063548871f5dc1a7f
    }
  }
 diff --git a/distribution/packages/build.gradle b/distribution/packages/build.gradle
-index ada19dfa38e785aed9ea01d613226d624856ebbd..d3cecde24a35dade98ed18c2d5f55dba0ee5b5b7 100644
+index 113ab8aced60b29406c60a80ae2097505eb9923b..b94431c63c96467fa75ba7cc607391997dd287fc 100644
 --- a/distribution/packages/build.gradle
 +++ b/distribution/packages/build.gradle
 @@ -63,7 +63,7 @@ import java.util.regex.Pattern
   */
- 
+
  plugins {
 -  id "com.netflix.nebula.ospackage-base" version "11.10.1"
-+  id "com.netflix.nebula.ospackage-base" version "11.11.1"
++  id "com.netflix.nebula.ospackage-base" version "11.11.2"
  }
- 
+
  void addProcessFilesTask(String type, boolean jdk) {
 diff --git a/gradle/code-coverage.gradle b/gradle/code-coverage.gradle
 index eb27dd1a76634251bceafd6fefbafd65eafd5c66..1e41f12e1cc48de3ec9bcd0078f348f3a30af8f3 100644
@@ -157,7 +161,7 @@ index c51246f2815f5294bd8a51b3ac25c19964577ac1..95e1a2f213a063c0f371f4eab8e67ba8
 --- a/gradle/wrapper/gradle-wrapper.properties
 +++ b/gradle/wrapper/gradle-wrapper.properties
 @@ -11,7 +11,7 @@
- 
+
  distributionBase=GRADLE_USER_HOME
  distributionPath=wrapper/dists
 -distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-all.zip
@@ -177,12 +181,12 @@ index f5feea6d6b116baaca5a2642d4d9fa1f47d574a7..faf93008b77e7b52e18c44e4eef257fc
 -APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s
 -' "$PWD" ) || exit
 +APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s\n' "$PWD" ) || exit
- 
+
  # Use the maximum available, or set MAX_FD != -1 to use that value.
  MAX_FD=maximum
 @@ -206,7 +205,7 @@ fi
  DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
- 
+
  # Collect all arguments for the java command:
 -#   * DEFAULT_JVM_OPTS, JAVA_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
 +#   * DEFAULT_JVM_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Before OpenSearch is updated to support openjdk 24, we will temporarily downgrade the dependency to openjdk 21 LTS to ensure the normal release and update of [openjdk 24](https://github.com/Homebrew/homebrew-core/pull/212057) are not affected.

The reason for this PR is explained as follows:

Starting with openjdk 24, the Security Manager has been permanently disabled. It is no longer possible to enable the Security Manager or install a custom Security Manager at startup. Any attempt to do so will cause the JVM to report an error and exit. As a temporary measure, we are downgrading the dependency to to openjdk 21 LTS while waiting for the release of OpenSearch 3.x.

References:
- Java SE 24 Doc: [The Security Manager Is Permanently Disabled](https://docs.oracle.com/en/java/javase/24/security/security-manager-is-permanently-disabled.html)
- https://github.com/opensearch-project/OpenSearch/issues/17661
- https://github.com/opensearch-project/OpenSearch/pull/18085