### PR TITLE
solr: rebuild using openjdk 21

### DIFF
--- a/Formula/s/solr.rb
+++ b/Formula/s/solr.rb
@@ -10,7 +10,8 @@ class Solr < Formula
     sha256 cellar: :any_skip_relocation, all: "7c95f8f53dcd8074d27a4822d11f0f8c3184902b426931aa6c764f862bd5ecf4"
   end
 
-  depends_on "openjdk"
+  # Can be updated after https://github.com/apache/solr/pull/3153
+  depends_on "openjdk@21"
 
   def install
     pkgshare.install "bin/solr.in.sh"

--- a/Formula/s/solr.rb
+++ b/Formula/s/solr.rb
@@ -7,7 +7,8 @@ class Solr < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "7c95f8f53dcd8074d27a4822d11f0f8c3184902b426931aa6c764f862bd5ecf4"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "1b1b9d9f35f77d275fa2686314998b9a97036b69ecd18fa2e562da1c317150d7"
   end
 
   # Can be updated after https://github.com/apache/solr/pull/3153


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Before Solr is updated to support openjdk 24, we will temporarily downgrade the dependency to openjdk 21 LTS to ensure the normal release and update of [openjdk 24](https://github.com/Homebrew/homebrew-core/pull/212057) are not affected.

The reason for this PR is explained as follows:

Starting with openjdk 24, the Security Manager has been permanently disabled. It is no longer possible to enable the Security Manager or install a custom Security Manager at startup. Any attempt to do so will cause the JVM to report an error and exit. As a temporary measure, we are downgrading the dependency to openjdk 21 LTS while waiting for the next Solr release, which could be 9.8.2, 9.9.x, or even 10.0.

References:
- Java SE 24 Doc: [The Security Manager Is Permanently Disabled](https://docs.oracle.com/en/java/javase/24/security/security-manager-is-permanently-disabled.html)
- https://github.com/apache/solr/pull/3153
- https://issues.apache.org/jira/browse/SOLR-17641