### PR TITLE
redis_exporter 1.71.0 (new formula)

### DIFF
--- a/Formula/r/redis_exporter.rb
+++ b/Formula/r/redis_exporter.rb
@@ -1,0 +1,60 @@
+class RedisExporter < Formula
+  desc "Prometheus Exporter for ValKey & Redis Metrics"
+  homepage "https://github.com/oliver006/redis_exporter"
+  url "https://github.com/oliver006/redis_exporter/archive/refs/tags/v1.71.0.tar.gz"
+  sha256 "5cc761bfe45c5414d21fc06a6a9081285b4811f5ce7be0d030cf135ad731211f"
+  license "MIT"
+
+  depends_on "go" => :build
+  depends_on "valkey" => :test
+
+  def install
+    system "go", "build", *std_go_args(ldflags: "-s -w")
+
+    (bin/"redis_exporter_brew_services").write <<~SHELL
+      #!/bin/bash
+      exec #{bin}/redis_exporter $(<#{etc}/redis_exporter.args)
+    SHELL
+
+    touch etc/"redis_exporter.args"
+  end
+
+  service do
+    run opt_bin/"redis_exporter_brew_services"
+    keep_alive true
+    log_path var/"log/redis_exporter.log"
+    error_log_path var/"log/redis_exporter.log"
+    working_dir var
+  end
+
+  test do
+    valkey_port = free_port
+    valkey_pid = spawn(Formula["valkey"].bin/"valkey-server", "--port", valkey_port.to_s)
+
+    sleep 2
+    # Run redis_exporter
+    exporter_port = free_port
+
+    (testpath/"redis_exporter.args").write <<~EOS
+      --redis.addr=redis://127.0.0.1:#{valkey_port}
+      --web.listen-address=127.0.0.1:#{exporter_port}
+    EOS
+    (testpath/"redis_exporter_brew_services").write <<~SHELL
+      #!/bin/bash
+      exec #{bin}/redis_exporter $(<#{testpath}/redis_exporter.args)
+    SHELL
+
+    chmod "+x", testpath/"redis_exporter_brew_services"
+    exporter_pid = spawn("#{testpath}/redis_exporter_brew_services")
+    begin
+      sleep 2
+      assert_match "redis_up 1", shell_output("curl -s http://127.0.0.1:#{exporter_port}/metrics 2>&1")
+    ensure
+      Process.kill "TERM", exporter_pid
+      Process.wait exporter_pid
+    end
+  ensure
+    Process.kill "TERM", valkey_pid
+    Process.wait valkey_pid
+  end
+end


### PR DESCRIPTION
Prometheus Exporter for ValKey & Redis Metrics. Supports ValKey and Redis 2.x, 3.x, 4.x, 5.x, 6.x, and 7.x.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
