### PR TITLE
mono-libgdiplus: update livecheck

### DIFF
--- a/Formula/m/mono-libgdiplus.rb
+++ b/Formula/m/mono-libgdiplus.rb
@@ -6,8 +6,11 @@ class MonoLibgdiplus < Formula
   license "MIT"
 
   livecheck do
-    url "https://dl.winehq.org/mono/sources/libgdiplus/"
-    regex(/href=.*?libgdiplus[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url "https://gitlab.winehq.org/api/v4/projects/1906/releases"
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :json do |json, regex|
+      json.map { |item| item["tag_name"]&.[](regex, 1) }
+    end
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `mono-libgdiplus` presumably checks the directory listing page where the `stable` tarball is found but that URL is no longer accessible, so the check returns an `Unable to get versions` error. The `stable` tarball is still accessible, it's just that we can't fetch a listing of the files anymore.

This updates the `livecheck` block to check WineHQ GitLab releases, which link to the related tarball from dl.winehq.org.