### PR TITLE
libatomic_ops: update urls

### DIFF
--- a/Formula/lib/libatomic_ops.rb
+++ b/Formula/lib/libatomic_ops.rb
@@ -1,10 +1,10 @@
 class LibatomicOps < Formula
   desc "Implementations for atomic memory update operations"
-  homepage "https://github.com/ivmai/libatomic_ops/"
-  url "https://github.com/ivmai/libatomic_ops/releases/download/v7.8.2/libatomic_ops-7.8.2.tar.gz"
+  homepage "https://github.com/bdwgc/libatomic_ops/"
+  url "https://github.com/bdwgc/libatomic_ops/releases/download/v7.8.2/libatomic_ops-7.8.2.tar.gz"
   sha256 "d305207fe207f2b3fb5cb4c019da12b44ce3fcbc593dfd5080d867b1a2419b51"
   license all_of: ["GPL-2.0-or-later", "MIT"]
-  head "https://github.com/ivmai/libatomic_ops.git", branch: "master"
+  head "https://github.com/bdwgc/libatomic_ops.git", branch: "master"
 
   livecheck do
     url :stable


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The upstream GitHub repository for `libatomic_ops` no longer contains any releases, so the existing `stable` URL now returns a 404 (Not Found) response. This updates the `stable` URL to use the latest tag tarball and updates the `livecheck` block to check tags instead of the latest release.