### PR TITLE
libsigrok*: update livecheck

### DIFF
--- a/Formula/lib/libsigrok.rb
+++ b/Formula/lib/libsigrok.rb
@@ -41,8 +41,11 @@ class Libsigrok < Formula
     end
   end
 
+  # The upstream website has gone down due to a server failure and the previous
+  # download page is not available, so this checks the directory listing page
+  # where the `stable` archive is found until the download page returns.
   livecheck do
-    url "https://sigrok.org/wiki/Downloads"
+    url "https://sigrok.org/download/source/libsigrok/"
     regex(/href=.*?libsigrok[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 

--- a/Formula/lib/libsigrokdecode.rb
+++ b/Formula/lib/libsigrokdecode.rb
@@ -7,8 +7,11 @@ class Libsigrokdecode < Formula
   revision 1
   head "git://sigrok.org/libsigrokdecode", branch: "master"
 
+  # The upstream website has gone down due to a server failure and the previous
+  # download page is not available, so this checks the directory listing page
+  # where the `stable` archive is found until the download page returns.
   livecheck do
-    url "https://sigrok.org/wiki/Downloads"
+    url "https://sigrok.org/download/source/libsigrokdecode/"
     regex(/href=.*?libsigrokdecode[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The upstream website for `libsigrok` and `libsigrokdecode` has gone down due to a server failure and the previous download page is not available. This updates the `livecheck` block to check the directory listing page where the `stable` archive is found until the download page returns.