### PR TITLE
various: remove livecheck, update autobump

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -432,7 +432,6 @@ cargo-sort
 cargo-spellcheck
 cargo-udeps
 cargo-update
-cargo-watch
 cargo-zigbuild
 cariddi
 carla
@@ -1317,7 +1316,6 @@ gnumeric
 gnunet
 gnupg
 gnupg-pkcs11-scd
-gnupg@2.2
 gnuplot
 gnuradio
 gnutls
@@ -1704,7 +1702,6 @@ jsoncpp
 jsonnet
 jsonnet-bundler
 jsonrpc-glib
-jsontoolkit
 jsrepo
 jsvc
 jtbl
@@ -1808,7 +1805,6 @@ kubent
 kubeone
 kubergrunt
 kubernetes-cli
-kubernetes-cli@1.29
 kubernetes-cli@1.30
 kubernetes-cli@1.31
 kubescape
@@ -2256,7 +2252,6 @@ mavsdk
 mawk
 maxwell
 mbedtls
-mbedtls@2
 mbt
 mcap
 mcfly
@@ -3047,7 +3042,6 @@ recode
 recoverpy
 redict
 redis
-redis@6.2
 redka
 redocly-cli
 redress
@@ -3056,7 +3050,6 @@ regal
 regclient
 regina-rexx
 regipy
-regula
 rekor-cli
 release-it
 remarshal
@@ -3134,7 +3127,6 @@ rubberband
 ruby
 ruby-install
 ruby-lsp
-ruby@3.1
 ruby@3.2
 ruby@3.3
 ruff
@@ -3345,7 +3337,6 @@ socat
 soci
 socket_vmnet
 soft-serve
-solana
 solargraph
 solarus
 solc-select
@@ -3802,7 +3793,6 @@ vile
 vim
 vineyard
 vips
-virgil
 virtctl
 virtualenv
 virtualenvwrapper

--- a/Formula/a/alure.rb
+++ b/Formula/a/alure.rb
@@ -6,11 +6,6 @@ class Alure < Formula
   license "MIT"
   revision 1
 
-  livecheck do
-    url "https://kcat.tomasu.net/alure-releases/"
-    regex(/href=.*?alure[._-]v?(\d+(?:\.\d+)+)(?:[._-]src)?\.t/i)
-  end
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_sequoia:  "5a83dde3ee767c2d722500d07ed8868c671c2d560b932953cfd52fdcf835eef1"

--- a/Formula/f/flvstreamer.rb
+++ b/Formula/f/flvstreamer.rb
@@ -5,11 +5,6 @@ class Flvstreamer < Formula
   sha256 "e90e24e13a48c57b1be01e41c9a7ec41f59953cdb862b50cf3e667429394d1ee"
   license "GPL-2.0-or-later"
 
-  livecheck do
-    url "https://download.savannah.gnu.org/releases/flvstreamer/source/"
-    regex(/href=.*?flvstreamer[._-]v?(\d+(?:\.\d+)+(?:[a-z]\d*)?)\.t/i)
-  end
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "dcbbbb87db99f0140c73453fd12af2023b37d44c42302d99156335b0cd69891d"

--- a/Formula/g/gnupg@2.2.rb
+++ b/Formula/g/gnupg@2.2.rb
@@ -5,11 +5,6 @@ class GnupgAT22 < Formula
   sha256 "d1abecd2b6c052749fd5748ba9de7021567e06b573dc6becac8df25cb87500e8"
   license "GPL-3.0-or-later"
 
-  livecheck do
-    url "https://gnupg.org/ftp/gcrypt/gnupg/"
-    regex(/href=.*?gnupg[._-]v?(2\.2(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     sha256 arm64_sequoia: "8d5d196f730de5750668c544a89072f9b49f4c1e50b789febfef6dfa45737732"
     sha256 arm64_sonoma:  "95e6b4de9833631f8edabe5e884f361064868fdd53cedc77270c44c5cff92fb9"

--- a/Formula/k/kubernetes-cli@1.29.rb
+++ b/Formula/k/kubernetes-cli@1.29.rb
@@ -6,11 +6,6 @@ class KubernetesCliAT129 < Formula
       revision: "4f359b2e16764ab5e175195ee6992dfb53b36acf"
   license "Apache-2.0"
 
-  livecheck do
-    url :stable
-    regex(/^v?(1\.29(?:\.\d+)+)$/i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "087825baacb21eea7f0ba0d335a06cbaa73d20bfd0009e2b3081a5accf173017"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "987a7f47b50c4f231a6de7e4065166f0798691f5f2e2181eaba0f30f73528706"

--- a/Formula/l/lean.rb
+++ b/Formula/l/lean.rb
@@ -6,19 +6,6 @@ class Lean < Formula
   license "Apache-2.0"
   head "https://github.com/leanprover-community/lean.git", branch: "master"
 
-  livecheck do
-    url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
-    strategy :git do |tags, regex|
-      tags.map do |tag|
-        version = tag[regex, 1]
-        next if version == "9.9.9" # Omit a problematic version tag
-
-        version
-      end
-    end
-  end
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_sonoma:   "a5568b994d186b0a5e50a10dcfaa7e7ada0106308a8f80412eea4e71662729cf"

--- a/Formula/m/mariadb@11.2.rb
+++ b/Formula/m/mariadb@11.2.rb
@@ -5,18 +5,6 @@ class MariadbAT112 < Formula
   sha256 "1cd0a7cfd5f9e25d8526aa70b1130743f9e551d8d03fe7ccdd2107b4e172d579"
   license "GPL-2.0-only"
 
-  livecheck do
-    url "https://downloads.mariadb.org/rest-api/mariadb/all-releases/?olderReleases=false"
-    strategy :json do |json|
-      json["releases"]&.map do |release|
-        next unless release["release_number"]&.start_with?(version.major_minor)
-        next if release["status"] != "stable"
-
-        release["release_number"]
-      end
-    end
-  end
-
   bottle do
     sha256 arm64_sequoia: "951ac2e9c45f3ff6510824fe7cfdcbb5f33252230b71487859444fb192c6ef87"
     sha256 arm64_sonoma:  "a7bacbd1b817fd5d0a81a7f386e844326b8851c36e766b06dad96d8d0d297bf3"

--- a/Formula/m/mbedtls@2.rb
+++ b/Formula/m/mbedtls@2.rb
@@ -6,11 +6,6 @@ class MbedtlsAT2 < Formula
   license "Apache-2.0"
   head "https://github.com/Mbed-TLS/mbedtls.git", branch: "mbedtls-2.28"
 
-  livecheck do
-    url :stable
-    regex(/^v?(2(?:\.\d+)+)$/i)
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "1ac6bd9c970e98200758af383b9e8295387bd7b4c247dcdcb16cb05521b39607"
     sha256 cellar: :any,                 arm64_sonoma:  "194e03a15d26c9c866962875b2d1e5ccedab9e10f7ad9d60e01a155c88fdc2b6"

--- a/Formula/p/putmail-queue.rb
+++ b/Formula/p/putmail-queue.rb
@@ -4,11 +4,6 @@ class PutmailQueue < Formula
   url "https://downloads.sourceforge.net/project/putmail/putmail-queue/0.2/putmail-queue-0.2.tar.bz2"
   sha256 "09349ad26345783e061bfe4ad7586fbbbc5d1cc48e45faa9ba9f667104f9447c"
 
-  livecheck do
-    url :stable
-    regex(%r{url=.*?/putmail-queue[._-]v?(\d+(?:\.\d+)+)\.t}i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, all: "6fc472e77db929384f6f9e436b6a3433df05d86cc583e499f92bd69373d332c3"
   end

--- a/Formula/p/python@3.8.rb
+++ b/Formula/p/python@3.8.rb
@@ -5,11 +5,6 @@ class PythonAT38 < Formula
   sha256 "6fb89a7124201c61125c0ab4cf7f6894df339a40c02833bfd28ab4d7691fafb4"
   license "Python-2.0"
 
-  livecheck do
-    url "https://www.python.org/ftp/python/"
-    regex(%r{href=.*?v?(3\.8(?:\.\d+)*)/?["' >]}i)
-  end
-
   bottle do
     sha256 arm64_sequoia:  "1fa19eccb400ea5724d9cd6077ef473ecb1d506b8f515034b3565222f0cd8cb6"
     sha256 arm64_sonoma:   "49082bc289bc3547b509f24e962cc8cbefad015345c0675631e42b3b23d2ecc7"

--- a/Formula/r/redis@6.2.rb
+++ b/Formula/r/redis@6.2.rb
@@ -11,11 +11,6 @@ class RedisAT62 < Formula
     any_of: ["CC0-1.0", "BSD-2-Clause"], # deps/hdr_histogram
   ]
 
-  livecheck do
-    url "https://download.redis.io/releases/"
-    regex(/href=.*?redis[._-]v?(6\.2(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "bd4e8b149de304f96ca737de9dbbfa4a3055dd93df5a0bf42d25dec056bc81d3"
     sha256 cellar: :any,                 arm64_sonoma:  "097a41d0f9e5c0a68981de1230d7d7d9cda8454aed0ac9ff038e8f48e2a5214e"

--- a/Formula/r/ruby@3.1.rb
+++ b/Formula/r/ruby@3.1.rb
@@ -5,11 +5,6 @@ class RubyAT31 < Formula
   sha256 "0556acd69f141ddace03fa5dd8d76e7ea0d8f5232edf012429579bcdaab30e7b"
   license "Ruby"
 
-  livecheck do
-    url "https://www.ruby-lang.org/en/downloads/releases/"
-    regex(/href=.*?ruby[._-]v?(3\.1(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     rebuild 1
     sha256 arm64_sequoia: "0b2c994b56cc016e46c5897105ec0c68ce7a84dc755e2ffab9fbcbca55997998"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This removes `livecheck` blocks from formulae that are deprecated or disabled and there isn't any reason to check for new versions (e.g., EOL, etc.).

* alure: disabled because the upstream website is just a parked page now
* flvstreamer: deprecated; most recent version is from 2010-02-15
* gnupg@2.2: disabled; 2.2 is EOL as of 2024-12-31
* kubernetes-cli@1.29: disabled; 1.29 is EOL as of 2025-02-28
* lean: disabled because Lean 3 is no longer actively maintained (deprecated upstream)
* mariadb@11.2: disabled because MariaDB 11.2 is EOL
* mbedtls@2: deprecated because Mbed TLS 2.28 is EOL
* putmail-queue: disabled; doesn't support Python 3 and no new versions since at least 2005
* python@3.8: disabled; 3.8 is EOL as of 2024-10-07
* redis@6.2: deprecated; 6.2 is EOL as of 2025-02-28
* ruby@3.1: deprecated; 3.1 is EOL as of 2025-03-26

Besides the above, this also removes some related formulae from the autobump list that livecheck skips (I deprecated some of these recently and forgot to remove them from the autobump list).