### PR TITLE
textidote: install (and then test/run) supports openjdk 24

### DIFF
--- a/Formula/t/textidote.rb
+++ b/Formula/t/textidote.rb
@@ -32,19 +32,15 @@ class Textidote < Formula
 
     # Install the JAR + a wrapper script
     libexec.install "textidote.jar"
-    bin.write_jar_script libexec/"textidote.jar", "textidote"
+    # Fix run with `openjdk` 24.
+    # Reported upstream at https://github.com/sylvainhalle/textidote/issues/265.
+    bin.write_jar_script libexec/"textidote.jar", "textidote", "-Djdk.xml.totalEntitySizeLimit=50000000"
 
     bash_completion.install "Completions/textidote.bash" => "textidote"
     zsh_completion.install "Completions/textidote.zsh" => "_textidote"
   end
 
   test do
-    # After openjdk 24, "jdk.xml.totalEntitySizeLimit" was modified to 100000 (and before that was 50000000),
-    # which would cause a JAXP00010004 error.
-    # See: https://docs.oracle.com/en/java/javase/23/docs/api/java.xml/module-summary.html#jdk.xml.totalEntitySizeLimit
-    # See: https://docs.oracle.com/en/java/javase/24/docs/api/java.xml/module-summary.html#jdk.xml.totalEntitySizeLimit
-    ENV["JAVA_OPTS"] = "-Djdk.xml.totalEntitySizeLimit=50000000"
-
     output = shell_output("#{bin}/textidote --version")
     assert_match "TeXtidote", output
 

--- a/Formula/t/textidote.rb
+++ b/Formula/t/textidote.rb
@@ -12,14 +12,14 @@ class Textidote < Formula
   end
 
   bottle do
-    rebuild 2
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "233ce6f6a6e226e5f00f7fada39dd51587afdb332e4c87f1ec9424e394d80743"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "14b7818a01928aeda595a8a77e91004a75e587a95c0e02110e48980ec6afea0e"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "d99486e4a64f499d54fc3ceb04e025c93c437ab84bccd09ea18924c0ed536265"
-    sha256 cellar: :any_skip_relocation, sonoma:        "918182a20520b96b5dd635a1d0cb4d373b5368cc1776f1645786c06554e1f50d"
-    sha256 cellar: :any_skip_relocation, ventura:       "14ef73a0bfd65f87b129c5ca365608322a019ce74f2717ed152169b692b2c5c7"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "3b8b47f1a6865eedba83b190e10721c013c31e1bedaca84b319aa4acc1c865d6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "820b5da9880ca2ce2b4c9251236314ef10be053b64c27b7a927325a8daf2591b"
+    rebuild 3
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "3bc15a1fbb32e89fa3aa4f01a348336f1032974eca44c74789719e8e3ee9f391"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "5c7874766d3f1f514f1b32435f160c92a0622a19ca8d2b0f7a8f653bfec05445"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "4bf516adb25ff61f3453f6825819e6353e2045619e46c7168ee250a782dc538d"
+    sha256 cellar: :any_skip_relocation, sonoma:        "39c5742e46605837bfb719356ba9aeb9811afa145ef5bdaabe0982704a270a30"
+    sha256 cellar: :any_skip_relocation, ventura:       "e50f6561b290ac98eec57706a01c5a6e644a66b5d12e2c289d81c785d05f6ce4"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "1bf9049a7149770b7e587a8a0fd0437750306a7ab810b7f6d878aeca523a54e3"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "73b3a785959a0992e981b78f47a4c39932c59f158a3d4c3281fb5ccc5926abc5"
   end
 
   depends_on "ant" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

It appears that #221584 doesn’t fully cover [openjdk 24](https://github.com/Homebrew/homebrew-core/pull/212057) support in this formula. Specifically, `bin.write_jar_script` does not pass through `JAVA_OPTS` from the environment to the wrapper script `textidote` - it only respects `JAVA_HOME`.

The relevant implementation is shown below:
```ruby
# Copied from Homebrew/brew@master
# Library/Homebrew/extend/pathname.rb#L428-L435
def write_jar_script(target_jar, script_name, java_opts = "", java_version: nil)
  mkpath
  (self/script_name).write <<~EOS
    #!/bin/bash
    export JAVA_HOME="#{Language::Java.overridable_java_home_env(java_version)[:JAVA_HOME]}"
    exec "${JAVA_HOME}/bin/java" #{java_opts} -jar "#{target_jar}" "$@"
  EOS
end
```

This behavior means that even if users set `JAVA_OPTS` globally, the JVM options won’t be picked up when launching `textidote`. As a workaround, we can follow the pattern in #221709 by explicitly adding the necessary JVM options to the final `exec` call within the generated wrapper script.

Additionally, to avoid errors like `JAXP00010004` caused by changes in openjdk 24 (where `jdk.xml.totalEntitySizeLimit` was set to 100,000), adding the JVM option to override the default size limit may be necessary.

To provide better flexibility and avoid similar issues in the future, I believe that `bin.write_jar_script` should include logic similar to `bin.env_script_all_files`, which reads the `JAVA_OPTS` environment variable. This would allow users to have more control over their JVM options, helping them manage such configurations based on their specific needs.