### PR TITLE
uv: remove `--no-default-features` from formula

### DIFF
--- a/Formula/u/uv.rb
+++ b/Formula/u/uv.rb
@@ -26,7 +26,7 @@ class Uv < Formula
   def install
     ENV["UV_COMMIT_HASH"] = ENV["UV_COMMIT_SHORT_HASH"] = tap.user
     ENV["UV_COMMIT_DATE"] = time.strftime("%F")
-    system "cargo", "install", "--no-default-features", *std_cargo_args(path: "crates/uv")
+    system "cargo", "install", *std_cargo_args(path: "crates/uv")
     generate_completions_from_executable(bin/"uv", "generate-shell-completion")
     generate_completions_from_executable(bin/"uvx", "--generate-shell-completion")
   end


### PR DESCRIPTION
Using this flag disables the `performance` feature, which provides critical performance improvements for production use-cases. I am unsure why it was ever included, it's been there since the formula was added.

See https://github.com/astral-sh/uv/blob/481d05d8dfb8627612dec72840a02c17b926b263/crates/uv/Cargo.toml#L138-L146 for an enumeration of features.

See https://github.com/astral-sh/uv/pull/7686 for the original motivation for splitting performance into a separate feature.
