### PR TITLE
async-profiler 4.0 (new formula)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -238,7 +238,7 @@ jobs:
 #        include: ${{fromJson(needs.setup_runners.outputs.runners)}}
 #      fail-fast: ${{fromJson(needs.setup_tests.outputs.fail-fast)}}
     name: "macOS 15-arm64"
-    runs-on: "15-arm64-14833693346"
+    runs-on: "15-arm64-15539075192"
     # container: ${{matrix.container}}
     timeout-minutes: 60
     defaults:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -204,34 +204,43 @@ jobs:
         id: determine-runners
         run: brew determine-test-runners "$TESTING_FORMULAE" "$DELETED_FORMULAE"
 
+
+#  {
+#    "name": "macOS 13-arm64",
+#    "runner": "13-arm64-14841654080",
+#    "timeout": 60,
+#    "cleanup": false,
+#    "testing_formulae": "async-profiler"
+#  },
+
   tests:
     needs: [tap_syntax, formulae_detect, setup_tests, setup_runners]
     if: >
       github.event_name == 'pull_request' &&
       !fromJson(needs.setup_tests.outputs.syntax-only) &&
       fromJson(needs.setup_runners.outputs.runners_present)
-    strategy:
-      matrix:
-        include: ${{fromJson(needs.setup_runners.outputs.runners)}}
-      fail-fast: ${{fromJson(needs.setup_tests.outputs.fail-fast)}}
-    name: ${{matrix.name}}
-    runs-on: ${{matrix.runner}}
-    container: ${{matrix.container}}
-    timeout-minutes: ${{ matrix.timeout }}
+#    strategy:
+#      matrix:
+#        include: ${{fromJson(needs.setup_runners.outputs.runners)}}
+#      fail-fast: ${{fromJson(needs.setup_tests.outputs.fail-fast)}}
+    name: "macOS 13-arm64"
+    runs-on: "13-arm64-14841654080"
+    # container: ${{matrix.container}}
+    timeout-minutes: 60
     defaults:
       run:
         shell: /bin/bash -xeuo pipefail {0}
-        working-directory: ${{matrix.workdir || github.workspace}}
+        working-directory: ${{github.workspace}}
     env:
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       HOMEBREW_GITHUB_API_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      BOTTLES_DIR: ${{matrix.workdir || github.workspace}}/bottles
+      BOTTLES_DIR: ${{github.workspace}}/bottles
     steps:
       - name: Pre-test steps
         uses: Homebrew/actions/pre-build@master
         with:
           bottles-directory: ${{ env.BOTTLES_DIR }}
-          cleanup: ${{ matrix.cleanup }}
+          cleanup: false
 
       - name: Test formulae
         id: brew-test-bot-formulae
@@ -252,8 +261,8 @@ jobs:
         if: always()
         uses: Homebrew/actions/post-build@master
         with:
-          runner: ${{ matrix.runner }}
-          cleanup: ${{ matrix.cleanup }}
+          runner: "13-arm64-14841654080"
+          cleanup: false
           bottles-directory: ${{ env.BOTTLES_DIR }}
           logs-directory: ${{ format('{0}/logs', env.BOTTLES_DIR) }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -242,10 +242,10 @@ jobs:
           bottles-directory: ${{ env.BOTTLES_DIR }}
           cleanup: false
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        with:
-          detached: true
+#      - name: Setup tmate session
+#        uses: mxschmitt/action-tmate@v3
+#        with:
+#          detached: true
 
       - name: Test formulae
         id: brew-test-bot-formulae

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -206,6 +206,20 @@ jobs:
 
 
 #  {
+#    "name": "macOS 15-arm64",
+#    "runner": "15-arm64-14833693346",
+#    "timeout": 60,
+#    "cleanup": false,
+#    "testing_formulae": "async-profiler"
+#  },
+#  {
+#    "name": "macOS 14-arm64",
+#    "runner": "14-arm64-14833693346",
+#    "timeout": 60,
+#    "cleanup": false,
+#    "testing_formulae": "async-profiler"
+#  },
+#  {
 #    "name": "macOS 13-arm64",
 #    "runner": "13-arm64-14841654080",
 #    "timeout": 60,
@@ -223,8 +237,8 @@ jobs:
 #      matrix:
 #        include: ${{fromJson(needs.setup_runners.outputs.runners)}}
 #      fail-fast: ${{fromJson(needs.setup_tests.outputs.fail-fast)}}
-    name: "macOS 13-arm64"
-    runs-on: "13-arm64-14841654080"
+    name: "macOS 15-arm64"
+    runs-on: "15-arm64-14833693346"
     # container: ${{matrix.container}}
     timeout-minutes: 60
     defaults:
@@ -241,11 +255,6 @@ jobs:
         with:
           bottles-directory: ${{ env.BOTTLES_DIR }}
           cleanup: false
-
-#      - name: Setup tmate session
-#        uses: mxschmitt/action-tmate@v3
-#        with:
-#          detached: true
 
       - name: Test formulae
         id: brew-test-bot-formulae

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -242,6 +242,11 @@ jobs:
           bottles-directory: ${{ env.BOTTLES_DIR }}
           cleanup: false
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        with:
+          detached: true
+
       - name: Test formulae
         id: brew-test-bot-formulae
         run: |

--- a/Formula/a/async-profiler.rb
+++ b/Formula/a/async-profiler.rb
@@ -42,7 +42,7 @@ class AsyncProfiler < Formula
       "System.out.println(System.getProperty(\"java.io.tmpdir\"))",
     )
 
-    pid = spawn Formula["openjdk"].bin/"java", "-XX:+StartAttachListener", testpath/"Main.java", "8"
+    pid = spawn Formula["openjdk"].bin/"java", "-XX:+StartAttachListener", testpath/"Main.java", "100"
     begin
       ohai shell_output("bash -c 'lsof -p #{pid}'")
       sleep 1

--- a/Formula/a/async-profiler.rb
+++ b/Formula/a/async-profiler.rb
@@ -2,30 +2,33 @@ class AsyncProfiler < Formula
     desc "Sampling CPU & HEAP profiler for Java featuring AsyncGetCallTrace + perf_events"
     homepage "https://github.com/jvm-profiling-tools/async-profiler"
     license "Apache-2.0"
-    if OS.linux?
-      if Hardware::CPU.intel?
-        url "https://github.com/async-profiler/async-profiler/releases/download/v4.0/async-profiler-4.0-linux-x64.tar.gz"
-        sha256 "ba32bd69cc2906f6251cd5aa8ae72c3abc12267ba858d38733f7751cc4d3e05b"
-      elsif Hardware::CPU.arm?
-        url "https://github.com/async-profiler/async-profiler/releases/download/v4.0/async-profiler-4.0-linux-arm64.tar.gz"
-        sha256 "482c142075dd8eeb762627087dd663725631e2747822f4480753e3b5507b3a62"
-      end
-    else
-      # The macOs distribution works for intel and arm64
-      url "https://github.com/async-profiler/async-profiler/releases/download/v4.0/async-profiler-4.0-macos.zip"
-      sha256 "1f27e5f5952ec40126a22addad6989bcbeb0509da8a2714ec489953abd698360"
+    on_linux do
+        on_intel do
+            url "https://github.com/async-profiler/async-profiler/releases/download/v4.0/async-profiler-4.0-linux-x64.tar.gz"
+            sha256 "ba32bd69cc2906f6251cd5aa8ae72c3abc12267ba858d38733f7751cc4d3e05b"
+        end
+
+        on_arm do
+            url "https://github.com/async-profiler/async-profiler/releases/download/v4.0/async-profiler-4.0-linux-arm64.tar.gz"
+            sha256 "482c142075dd8eeb762627087dd663725631e2747822f4480753e3b5507b3a62"
+        end
     end
-  
+
+    on_macos do
+        # The macOs distribution works for intel and arm64
+        url "https://github.com/async-profiler/async-profiler/releases/download/v4.0/async-profiler-4.0-macos.zip"
+        sha256 "1f27e5f5952ec40126a22addad6989bcbeb0509da8a2714ec489953abd698360"
+    end
+
     def install
-      ohai "Installing #{HOMEBREW_PREFIX}/bin/asprof"
-      bin.install Dir["bin/*"]
-      ohai "Installing #{HOMEBREW_PREFIX}/lib/#{shared_library("libasyncProfiler")}"
-      lib.install Dir["lib/*"]
+        ohai "Installing #{HOMEBREW_PREFIX}/bin/asprof"
+        bin.install Dir["bin/*"]
+        ohai "Installing #{HOMEBREW_PREFIX}/lib/#{shared_library("libasyncProfiler")}"
+        lib.install Dir["lib/*"]
     end
-  
+
     test do
-      output = shell_output("#{bin}/asprof --version")
-      assert_match(/Async-profiler 4.0.+/, output.strip)
+        output = shell_output("#{bin}/asprof --version")
+        assert_match(/Async-profiler 4.0.+/, output.strip)
     end
-  end
-  
+end

--- a/Formula/a/async-profiler.rb
+++ b/Formula/a/async-profiler.rb
@@ -1,50 +1,56 @@
 class AsyncProfiler < Formula
-    desc "Sampling CPU and HEAP profiler for Java featuring AsyncGetCallTrace + perf_events"
-    homepage "https://github.com/async-profiler/async-profiler"
-    url "https://github.com/async-profiler/async-profiler/archive/refs/tags/v4.0.tar.gz"
-    version "4.0"
-    sha256 "7beb736868af485d6b0b624e42141f78df0ca8403188adc17965b7153261aa55"
-    license "Apache-2.0"
-    head "https://github.com/async-profiler/async-profiler.git", branch: "master"
-  
-    depends_on "cmake" => :build
-    depends_on "openjdk" => :test
-  
-    def install
-      args = []
-      args << "COMMIT_TAG=#{Utils.git_head}" if build.head?
-      args << "FAT_BINARY=true" if OS.mac?
-      # args << "CC=/usr/local/musl/bin/musl-gcc" if OS.linux?
-  
-      system "make", *args, "all"
-  
-      bin.install Dir["build/bin/*"]
-      lib.install Dir["build/lib/*"]
-      libexec.install Dir["build/jar/*"]
-    end
-  
-    test do
-      assert_match "Async-profiler #{version}", shell_output("#{bin}/asprof --version")
-  
-      (testpath/"Main.java").write <<~JAVA
-        public class Main {
-          public static void main(String[] args) throws Exception {
-            Thread.sleep(8_000);
-          }
-        }
-      JAVA
-  
-      pid = spawn Formula["openjdk"].bin/"java", testpath/"Main.java"
-      system bin/"asprof", "-d", "2", "-f", testpath/"test-profile-via-attach.html", "jps"
-      assert_predicate testpath/"test-profile-via-attach.html", :exist?
-  
-      system Formula["openjdk"].bin/"java", "-agentpath:#{lib}/libasyncProfiler.dylib=start,event=cpu,lock=10ms,file=test-profile-via-lib.jfr", testpath/"Main.java"
-      assert_predicate testpath/"test-profile-via-lib.jfr", :exist?
-  
-      system bin/"jfrconv", "-o", "pprof", testpath/"test-profile-via-lib.jfr", testpath/"test-profile-via-lib.pprof"
-      assert_predicate testpath/"test-profile-via-lib.pprof", :exist?
-    ensure
-      Process.kill("TERM", pid)
-    end
+  desc "Sampling CPU & HEAP profiler for Java using AsyncGetCallTrace + perf_events"
+  homepage "https://github.com/async-profiler/async-profiler"
+  url "https://github.com/async-profiler/async-profiler/archive/refs/tags/v4.0.tar.gz"
+  sha256 "7beb736868af485d6b0b624e42141f78df0ca8403188adc17965b7153261aa55"
+  license "Apache-2.0"
+  head "https://github.com/async-profiler/async-profiler.git", branch: "master"
+
+  depends_on "cmake" => :build
+  depends_on "openjdk" => :test
+
+  def install
+    args = []
+    args << "COMMIT_TAG=#{Utils.git_head}" if build.head?
+    args << "FAT_BINARY=true" if OS.mac?
+    # args << "CC=/usr/local/musl/bin/musl-gcc" if OS.linux?
+
+    system "make", *args, "all"
+
+    bin.install Dir["build/bin/*"]
+    lib.install Dir["build/lib/*"]
+    libexec.install Dir["build/jar/*"]
   end
-  
+
+  test do
+    assert_match "Async-profiler #{version}", shell_output("#{bin}/asprof --version")
+
+    (testpath/"Main.java").write <<~JAVA
+      public class Main {
+        public static void main(String[] args) throws Exception {
+          Thread.sleep(8_000);
+        }
+      }
+    JAVA
+
+    pid = spawn Formula["openjdk"].bin/"java", testpath/"Main.java"
+    system bin/"asprof",
+           "-d", "2",
+           "-f", testpath/"test-profile-via-attach.html",
+           "jps"
+    assert_path_exists testpath/"test-profile-via-attach.html"
+
+    system Formula["openjdk"].bin/"java",
+           "-agentpath:#{lib}/libasyncProfiler.dylib=start,event=cpu,lock=10ms,file=test-profile-via-lib.jfr",
+           testpath/"Main.java"
+    assert_path_exists testpath/"test-profile-via-lib.jfr"
+
+    system bin/"jfrconv",
+           "-o", "pprof",
+           testpath/"test-profile-via-lib.jfr",
+           testpath/"test-profile-via-lib.pprof"
+    assert_path_exists testpath/"test-profile-via-lib.pprof"
+  ensure
+    Process.kill("TERM", pid)
+  end
+end

--- a/Formula/a/async-profiler.rb
+++ b/Formula/a/async-profiler.rb
@@ -37,8 +37,14 @@ class AsyncProfiler < Formula
       }
     JAVA
 
-    pid = spawn Formula["openjdk"].bin/"java", testpath/"Main.java", "8"
+    ohai pipe_output(
+      "#{Formula["openjdk"].bin}/jshell -q -",
+      "System.out.println(System.getProperty(\"java.io.tmpdir\"))",
+    )
+
+    pid = spawn Formula["openjdk"].bin/"java", "-XX:+StartAttachListener", testpath/"Main.java", "8"
     begin
+      ohai shell_output("bash -c 'lsof -p #{pid}'")
       sleep 1
       system bin/"asprof",
              "-d", "2",

--- a/Formula/a/async-profiler.rb
+++ b/Formula/a/async-profiler.rb
@@ -5,17 +5,18 @@ class AsyncProfiler < Formula
     version "4.0"
     sha256 "7beb736868af485d6b0b624e42141f78df0ca8403188adc17965b7153261aa55"
     license "Apache-2.0"
+    head "https://github.com/async-profiler/async-profiler.git", branch: "master"
   
     depends_on "cmake" => :build
     depends_on "openjdk" => :test
   
     def install
-      on_macos do
-        system "make", "FAT_BINARY=true"
-      end
-  #     on_linux do
-  #       system "make", "CC=/usr/local/musl/bin/musl-gcc"
-  #     end
+      args = []
+      args << "COMMIT_TAG=#{Utils.git_head}" if build.head?
+      args << "FAT_BINARY=true" if OS.mac?
+      # args << "CC=/usr/local/musl/bin/musl-gcc" if OS.linux?
+  
+      system "make", *args, "all"
   
       bin.install Dir["build/bin/*"]
       lib.install Dir["build/lib/*"]
@@ -28,7 +29,7 @@ class AsyncProfiler < Formula
       (testpath/"Main.java").write <<~JAVA
         public class Main {
           public static void main(String[] args) throws Exception {
-            Thread.sleep(10_000);
+            Thread.sleep(8_000);
           }
         }
       JAVA
@@ -39,6 +40,9 @@ class AsyncProfiler < Formula
   
       system Formula["openjdk"].bin/"java", "-agentpath:#{lib}/libasyncProfiler.dylib=start,event=cpu,lock=10ms,file=test-profile-via-lib.jfr", testpath/"Main.java"
       assert_predicate testpath/"test-profile-via-lib.jfr", :exist?
+  
+      system bin/"jfrconv", "-o", "pprof", testpath/"test-profile-via-lib.jfr", testpath/"test-profile-via-lib.pprof"
+      assert_predicate testpath/"test-profile-via-lib.pprof", :exist?
     ensure
       Process.kill("TERM", pid)
     end

--- a/Formula/a/async-profiler.rb
+++ b/Formula/a/async-profiler.rb
@@ -1,34 +1,49 @@
+# Documentation: https://docs.brew.sh/Formula-Cookbook
+#                https://rubydoc.brew.sh/Formula
+# PLEASE REMOVE ALL GENERATED COMMENTS BEFORE SUBMITTING YOUR PULL REQUEST!
 class AsyncProfiler < Formula
-    desc "Sampling CPU & HEAP profiler for Java featuring AsyncGetCallTrace + perf_events"
-    homepage "https://github.com/jvm-profiling-tools/async-profiler"
+    desc "Sampling CPU and HEAP profiler for Java featuring AsyncGetCallTrace + perf_events"
+    homepage "https://github.com/async-profiler/async-profiler"
+    url "https://github.com/async-profiler/async-profiler/archive/refs/tags/v4.0.tar.gz"
+    version "4.0"
+    sha256 "7beb736868af485d6b0b624e42141f78df0ca8403188adc17965b7153261aa55"
     license "Apache-2.0"
-    on_linux do
-        on_intel do
-            url "https://github.com/async-profiler/async-profiler/releases/download/v4.0/async-profiler-4.0-linux-x64.tar.gz"
-            sha256 "ba32bd69cc2906f6251cd5aa8ae72c3abc12267ba858d38733f7751cc4d3e05b"
-        end
-
-        on_arm do
-            url "https://github.com/async-profiler/async-profiler/releases/download/v4.0/async-profiler-4.0-linux-arm64.tar.gz"
-            sha256 "482c142075dd8eeb762627087dd663725631e2747822f4480753e3b5507b3a62"
-        end
-    end
-
-    on_macos do
-        # The macOs distribution works for intel and arm64
-        url "https://github.com/async-profiler/async-profiler/releases/download/v4.0/async-profiler-4.0-macos.zip"
-        sha256 "1f27e5f5952ec40126a22addad6989bcbeb0509da8a2714ec489953abd698360"
-    end
-
+  
+    depends_on "cmake" => :build
+    depends_on "openjdk" => :test
+  
     def install
-        ohai "Installing #{HOMEBREW_PREFIX}/bin/asprof"
-        bin.install Dir["bin/*"]
-        ohai "Installing #{HOMEBREW_PREFIX}/lib/#{shared_library("libasyncProfiler")}"
-        lib.install Dir["lib/*"]
+      on_macos do
+        system "make", "FAT_BINARY=true"
+      end
+  #     on_linux do
+  #       system "make", "CC=/usr/local/musl/bin/musl-gcc"
+  #     end
+  
+      bin.install Dir["build/bin/*"]
+      lib.install Dir["build/lib/*"]
+      libexec.install Dir["build/jar/*"]
     end
-
+  
     test do
-        output = shell_output("#{bin}/asprof --version")
-        assert_match(/Async-profiler 4.0.+/, output.strip)
+      assert_match "Async-profiler #{version}", shell_output("#{bin}/asprof --version")
+  
+      (testpath/"Main.java").write <<~JAVA
+        public class Main {
+          public static void main(String[] args) throws Exception {
+            Thread.sleep(10_000);
+          }
+        }
+      JAVA
+  
+      pid = spawn Formula["openjdk"].bin/"java", testpath/"Main.java"
+      system bin/"asprof", "-d", "2", "-f", testpath/"test-profile-via-attach.html", "jps"
+      assert_predicate testpath/"test-profile-via-attach.html", :exist?
+  
+      system Formula["openjdk"].bin/"java", "-agentpath:#{lib}/libasyncProfiler.dylib=start,event=cpu,lock=10ms,file=test-profile-via-lib.jfr", testpath/"Main.java"
+      assert_predicate testpath/"test-profile-via-lib.jfr", :exist?
+    ensure
+      Process.kill("TERM", pid)
     end
-end
+  end
+  

--- a/Formula/a/async-profiler.rb
+++ b/Formula/a/async-profiler.rb
@@ -7,13 +7,12 @@ class AsyncProfiler < Formula
   head "https://github.com/async-profiler/async-profiler.git", branch: "master"
 
   depends_on "cmake" => :build
-  depends_on "openjdk" => :test
+  depends_on "openjdk" => [:build, :test]
 
   def install
     args = []
     args << "COMMIT_TAG=#{Utils.git_head}" if build.head?
-    args << "FAT_BINARY=true" if OS.mac?
-    # args << "CC=/usr/local/musl/bin/musl-gcc" if OS.linux?
+    args << "CC=#{ENV.cc}" if OS.linux?
 
     system "make", *args, "all"
 

--- a/Formula/a/async-profiler.rb
+++ b/Formula/a/async-profiler.rb
@@ -12,7 +12,6 @@ class AsyncProfiler < Formula
   def install
     args = []
     args << "COMMIT_TAG=#{Utils.git_head}" if build.head?
-    args << "CC=#{ENV.cc}" if OS.linux?
 
     system "make", *args, "all"
 

--- a/Formula/a/async-profiler.rb
+++ b/Formula/a/async-profiler.rb
@@ -1,0 +1,31 @@
+class AsyncProfiler < Formula
+    desc "Sampling CPU & HEAP profiler for Java featuring AsyncGetCallTrace + perf_events"
+    homepage "https://github.com/jvm-profiling-tools/async-profiler"
+    license "Apache-2.0"
+    if OS.linux?
+      if Hardware::CPU.intel?
+        url "https://github.com/async-profiler/async-profiler/releases/download/v4.0/async-profiler-4.0-linux-x64.tar.gz"
+        sha256 "ba32bd69cc2906f6251cd5aa8ae72c3abc12267ba858d38733f7751cc4d3e05b"
+      elsif Hardware::CPU.arm?
+        url "https://github.com/async-profiler/async-profiler/releases/download/v4.0/async-profiler-4.0-linux-arm64.tar.gz"
+        sha256 "482c142075dd8eeb762627087dd663725631e2747822f4480753e3b5507b3a62"
+      end
+    else
+      # The macOs distribution works for intel and arm64
+      url "https://github.com/async-profiler/async-profiler/releases/download/v4.0/async-profiler-4.0-macos.zip"
+      sha256 "1f27e5f5952ec40126a22addad6989bcbeb0509da8a2714ec489953abd698360"
+    end
+  
+    def install
+      ohai "Installing #{HOMEBREW_PREFIX}/bin/asprof"
+      bin.install Dir["bin/*"]
+      ohai "Installing #{HOMEBREW_PREFIX}/lib/#{shared_library("libasyncProfiler")}"
+      lib.install Dir["lib/*"]
+    end
+  
+    test do
+      output = shell_output("#{bin}/asprof --version")
+      assert_match(/Async-profiler 4.0.+/, output.strip)
+    end
+  end
+  

--- a/Formula/a/async-profiler.rb
+++ b/Formula/a/async-profiler.rb
@@ -1,6 +1,3 @@
-# Documentation: https://docs.brew.sh/Formula-Cookbook
-#                https://rubydoc.brew.sh/Formula
-# PLEASE REMOVE ALL GENERATED COMMENTS BEFORE SUBMITTING YOUR PULL REQUEST!
 class AsyncProfiler < Formula
     desc "Sampling CPU and HEAP profiler for Java featuring AsyncGetCallTrace + perf_events"
     homepage "https://github.com/async-profiler/async-profiler"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

Also : `brew style --formula async-profiler`

-----

Contributing my [formula](https://github.com/bric3/homebrew-tap/blob/main/async-profiler.rb) for [async-profiler/async-profiler](https://github.com/async-profiler/async-profiler) (8.1 K stars).

Note this formula is only for version 4.0, however my original formulas started with 2.8 (which was mostly a script and and lib until 3.0).

