### PR TITLE
claude-code 0.2.99 (new formula)

### DIFF
--- a/Formula/c/claude-code.rb
+++ b/Formula/c/claude-code.rb
@@ -1,0 +1,19 @@
+class ClaudeCode < Formula
+  desc "Agentic coding tool - use 'claude' as the command"
+  homepage "https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview"
+  url "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-0.2.99.tgz"
+  sha256 "37ec931cb48ea8fc021060a8c640372b3c6e18fde635bfc166a5da10b13ecb6f"
+  license :cannot_represent # See https://github.com/anthropics/claude-code/blob/main/LICENSE.md
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    # add a meaningful test here, version isn't usually meaningful
+    assert_match version.to_s, shell_output("#{bin}/claude --version")
+  end
+end


### PR DESCRIPTION
Adding the claude-code cli, full documentation available at https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview

While published to npm, it has a proprietary license available at https://github.com/anthropics/claude-code/blob/main/LICENSE.md

When installed, claude code will be available as `claude`

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
   - No, because of the following error on macos (arm) even though it works fine

```  * Formulae in homebrew/core must specify a license.
  * Binaries built for a non-native architecture were installed into claude-code's prefix.
    The offending files are:
      /opt/homebrew/Cellar/claude-code/0.2.99/libexec/lib/node_modules/@anthropic-ai/claude-code/vendor/ripgrep/x64-darwin/rg   (x86_64)
Error: 2 problems in 1 formula detected.``` 

-----
