### PR TITLE
triage(long dependant build): add `gettext` and `sdl2`

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -278,6 +278,7 @@ jobs:
                 dav1d|\
                 freetype|\
                 gcc|\
+                gettext|\
                 ghc|\
                 glib|\
                 gsettings-desktop-schemas|\
@@ -313,6 +314,7 @@ jobs:
                 python@3.13|\
                 rav1e|\
                 rust|\
+                sdl2|\
                 shared-mime-info|\
                 suite-sparse|\
                 qt|\


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

see:
- https://github.com/Homebrew/homebrew-core/pull/222269
- #222378