### PR TITLE
workflow: revert condition to prevent getting falsy value

### DIFF
--- a/.github/workflows/create-replacement-pr.yml
+++ b/.github/workflows/create-replacement-pr.yml
@@ -124,9 +124,9 @@ jobs:
 
       - name: Checkout PR branch
         if: ${{ !inputs.autosquash }}
-        working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
+        working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}
         env:
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr checkout "$PR" --repo "$GITHUB_REPOSITORY"
 
       - name: Checkout replacement PR branch
@@ -162,8 +162,8 @@ jobs:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_CORE_PUBLIC_REPO_EMAIL_TOKEN }}
           MESSAGE: ${{ inputs.message }}
           AUTOSQUASH_FLAG: ${{ inputs.autosquash && '--autosquash' || '' }}
-          CLEAN_FLAG: ${{ inputs.autosquash && '' || '--clean' }}
-          NO_CHERRY_PICK_FLAG: ${{ inputs.autosquash && '' || '--no-cherry-pick' }}
+          CLEAN_FLAG: ${{ !inputs.autosquash && '--clean' || '' }}
+          NO_CHERRY_PICK_FLAG: ${{ !inputs.autosquash && '--no-cherry-pick' || '' }}
         run: |
           # Don't quote arguments that might be empty; this causes errors.
           brew pr-pull \
@@ -183,18 +183,18 @@ jobs:
       - name: Generate build provenance
         uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0
         with:
-          subject-path: '${{steps.pr-pull.outputs.bottle_path}}/*.tar.gz'
+          subject-path: '${{ steps.pr-pull.outputs.bottle_path }}/*.tar.gz'
         if: inputs.upload
 
       - name: Upload bottles to GitHub Packages
         id: pr-upload
         if: inputs.upload
-        working-directory: ${{steps.pr-pull.outputs.bottle_path}}
+        working-directory: ${{ steps.pr-pull.outputs.bottle_path }}
         env:
           BREWTESTBOT_NAME_EMAIL: "BrewTestBot <1589480+BrewTestBot@users.noreply.github.com>"
           HOMEBREW_GITHUB_PACKAGES_USER: brewtestbot
-          HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{secrets.HOMEBREW_CORE_GITHUB_PACKAGES_TOKEN}}
-          WARN_ON_UPLOAD_FAILURE_FLAG: ${{inputs.warn_on_upload_failure && '--warn-on-upload-failure' || ''}}
+          HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{ secrets.HOMEBREW_CORE_GITHUB_PACKAGES_TOKEN }}
+          WARN_ON_UPLOAD_FAILURE_FLAG: ${{ inputs.warn_on_upload_failure && '--warn-on-upload-failure' || '' }}
         run: |
           # Don't quote arguments that might be empty; this causes errors when `brew`
           # interprets them as empty arguments when we want `brew` to ignore them instead.


### PR DESCRIPTION
It seems that the ternary operation is return the false value when the condition is even true only if the true value is empty.

---

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
