### PR TITLE
hyper-mcp 0.1.3 (new formula)

### DIFF
--- a/Formula/h/hyper-mcp.rb
+++ b/Formula/h/hyper-mcp.rb
@@ -1,0 +1,61 @@
+class HyperMcp < Formula
+  desc "MCP server that extends its capabilities through WebAssembly plugins"
+  homepage "https://github.com/tuananh/hyper-mcp"
+  url "https://github.com/tuananh/hyper-mcp/archive/refs/tags/v0.1.3.tar.gz"
+  sha256 "32a7515748856f2564006dec54b3ad822dee90187ce88c384c18f4e5cacc0066"
+  license "Apache-2.0"
+  head "https://github.com/tuananh/hyper-mcp.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  on_linux do
+    depends_on "pkgconf" => :build
+    depends_on "openssl@3"
+  end
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    (testpath/"config.json").write <<~JSON
+      {
+        "plugins": []
+      }
+    JSON
+
+    init_json = <<~JSON
+      {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+          "protocolVersion": "2024-11-05",
+          "capabilities": {
+            "roots": {},
+            "sampling": {},
+            "experimental": {}
+          },
+          "clientInfo": {
+            "name": "hyper-mcp",
+            "version": "#{version}"
+          }
+        }
+      }
+    JSON
+
+    require "open3"
+    Open3.popen3(bin/"hyper-mcp", "--config-file", testpath/"config.json") do |stdin, stdout, _, w|
+      sleep 2
+      stdin.puts JSON.generate(JSON.parse(init_json))
+      Timeout.timeout(10) do
+        stdout.each do |line|
+          break if line.include? "\"version\":\"#{version}\""
+        end
+      end
+      stdin.close
+    ensure
+      Process.kill "TERM", w.pid
+    end
+  end
+end

--- a/Formula/h/hyper-mcp.rb
+++ b/Formula/h/hyper-mcp.rb
@@ -6,6 +6,15 @@ class HyperMcp < Formula
   license "Apache-2.0"
   head "https://github.com/tuananh/hyper-mcp.git", branch: "main"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "2a47ba9534141b16a9f7599a0ae988a98c6d12c21d57655be20330833a1b9324"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "68f718a26b90661c85b10b330128bc2176c5eddbc2e7f762057f212b8c34c330"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "d1cae9171ecf44e4af0685fb6b33300bf4be6aa66392903e83672d84578a7315"
+    sha256 cellar: :any_skip_relocation, sonoma:        "54ab3644c4c208c07084484366629734e2eea3fc969bbe840b92213571a0675c"
+    sha256 cellar: :any_skip_relocation, ventura:       "10086f91485d4a86d7688d8b77a8c2145a2ac67fb799c3d45d4d365852989268"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e6bece954e8e2edbe6cd19a2a8817dc3776c1d3db12157f7d1dce12998daace8"
+  end
+
   depends_on "rust" => :build
 
   on_linux do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Adds `hyper-mcp` v0.1.1
MCP server that extends its capabilities through WebAssembly plugins
https://github.com/tuananh/hyper-mcp