### PR TITLE
workflow/autobump: stop relying on `autobump.txt` file

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -49,17 +49,21 @@ jobs:
         with:
           signing_key: ${{ secrets.BREWTESTBOT_SSH_SIGNING_KEY }}
 
+      - name: Bump input formulae
+        uses: Homebrew/actions/bump-packages@master
+        continue-on-error: true
+        if: ${{ github.event.inputs.formulae }}
+        with:
+          token: ${{ secrets.HOMEBREW_CORE_REPO_WORKFLOW_TOKEN }}
+          formulae: ${{ github.event.inputs.formulae }}
+        env:
+          HOMEBREW_TEST_BOT_AUTOBUMP: 1
+
       - name: Bump formulae
+        if: ${{ ! github.event.inputs.formulae }}
         env:
           HOMEBREW_TEST_BOT_AUTOBUMP: 1
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_CORE_REPO_WORKFLOW_TOKEN }}
           HOMEBREW_GIT_COMMITTER_NAME: BrewTestBot
           HOMEBREW_GIT_COMMITTER_EMAIL: 1589480+BrewTestBot@users.noreply.github.com
-          FORMULAE: ${{ inputs.formulae }}
-        run: |
-          BREW_BUMP=(brew bump --no-fork --open-pr --formulae --bump-synced)
-          if [[ -n "${FORMULAE-}" ]]; then
-            xargs "${BREW_BUMP[@]}" <<<"${FORMULAE}"
-          else
-            "${BREW_BUMP[@]}" --auto --tap=Homebrew/core
-          fi
+        run: brew bump --no-fork --open-pr --formulae --bump-synced --auto --tap=Homebrew/core


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
