### PR TITLE
swiftformat: Update HEAD to develop branch

### DIFF
--- a/Formula/s/swiftformat.rb
+++ b/Formula/s/swiftformat.rb
@@ -4,7 +4,7 @@ class Swiftformat < Formula
   url "https://github.com/nicklockwood/SwiftFormat/archive/refs/tags/0.55.6.tar.gz"
   sha256 "3914c84ccd1e03a7dd3a518f90b1987c4b7c5dcb7f81b86aad23a3fed53a7b0f"
   license "MIT"
-  head "https://github.com/nicklockwood/SwiftFormat.git", branch: "master"
+  head "https://github.com/nicklockwood/SwiftFormat.git", branch: "develop"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "7617fbec05965e628176ee52fd4f329801eaa31d58ef28d719df0e88ec2a75b1"


### PR DESCRIPTION
This PR updates the HEAD of the SwiftFormat formula from the `master` branch to the `develop` branch:
 1. SwiftFormat doesn't have a `master` branch: https://github.com/nicklockwood/SwiftFormat/branches
 2. Active SwiftFormat development happens on the `develop` branch ([documentation](https://github.com/nicklockwood/SwiftFormat/blob/main/CONTRIBUTING.md#branches-and-versioning))

This will make it so that `brew install SwiftFormat --HEAD`:
 1. Actually succeeds (it currently fails with `fatal: couldn't find remote ref refs/heads/master`).
 2. Includes the latest unreleased / unstable changes, enabling contributors to more easily install builds with their changes before those changes are officially released.

cc @nicklockwood 

------

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
