### PR TITLE
rmds 1.0.1 (new formula)

### DIFF
--- a/Formula/r/rmds.rb
+++ b/Formula/r/rmds.rb
@@ -1,0 +1,22 @@
+class Rmds < Formula
+  desc "Remove all .DS_Store files recursively from current directory"
+  homepage "https://github.com/fitchmultz/rmds"
+  url "https://github.com/fitchmultz/rmds/archive/refs/tags/v1.0.1.tar.gz"
+  sha256 "e59532a7a1cfecd37fdd1f9698606b111d43eb7ad1aac36bc5a34b154f8f6cdc"
+  license "MIT"
+
+  def install
+    bin.install "rmds"
+    man1.install "rmds.1"
+  end
+
+  test do
+    # Create a test .DS_Store file
+    touch "#{testpath}/.DS_Store"
+    system bin/"rmds"
+    refute_path_exists "#{testpath}/.DS_Store"
+
+    # Test help flag
+    assert_match "Usage: rmds", shell_output(bin/"rmds --help")
+  end
+end


### PR DESCRIPTION
  Adds a new formula `rmds` for removing .DS_Store files recursively
  - Simple command-line utility for common macOS maintenance task
  - Helpful for cleaning up .DS_Store files before creating archives, submitting files, or in automated
  workflows
  - Currently no active tool in Homebrew core for this specific purpose

  Features:
  - Removes .DS_Store files recursively from current directory
  - Shows count of files removed
  - Optional verbose mode to show each file as it's deleted
  - Man page documentation
  - Lightweight bash script with no dependencies