### PR TITLE
go 1.24.3

### DIFF
--- a/Formula/g/garble.rb
+++ b/Formula/g/garble.rb
@@ -4,6 +4,7 @@ class Garble < Formula
   url "https://github.com/burrowers/garble/archive/refs/tags/v0.14.2.tar.gz"
   sha256 "aea6e0a172296b50e3671a9b753aeb2eb7080a3103575cdf5e4d1aeccfe14ede"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/burrowers/garble.git", branch: "master"
 
   bottle do

--- a/Formula/g/garble.rb
+++ b/Formula/g/garble.rb
@@ -8,12 +8,12 @@ class Garble < Formula
   head "https://github.com/burrowers/garble.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "b5715a8ccc015d8152d67195f34d15a4095b4f9468ae466553935a3d2c759a47"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "b5715a8ccc015d8152d67195f34d15a4095b4f9468ae466553935a3d2c759a47"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "b5715a8ccc015d8152d67195f34d15a4095b4f9468ae466553935a3d2c759a47"
-    sha256 cellar: :any_skip_relocation, sonoma:        "824f09b76e9b67cf156efb2921ee6b41bb5797dad8f1b21832eedf337ed84b6a"
-    sha256 cellar: :any_skip_relocation, ventura:       "824f09b76e9b67cf156efb2921ee6b41bb5797dad8f1b21832eedf337ed84b6a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2c375abc7794717bb46c545ddef748afa6fc7ce49ce28de8148219a4d855eeba"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "5ec2f692cb8fa1413dd70e4adb73a9379c177ad67d83c5edc6223022116420f7"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "5ec2f692cb8fa1413dd70e4adb73a9379c177ad67d83c5edc6223022116420f7"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "5ec2f692cb8fa1413dd70e4adb73a9379c177ad67d83c5edc6223022116420f7"
+    sha256 cellar: :any_skip_relocation, sonoma:        "932cad6102367a29f5092455a7859df9f69251ddc1f82c5af7ae9f37f830835f"
+    sha256 cellar: :any_skip_relocation, ventura:       "932cad6102367a29f5092455a7859df9f69251ddc1f82c5af7ae9f37f830835f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "202e90501c53fe9f6f324a7175d2087d0113e69d012219acaed1a4dcdac26498"
   end
 
   depends_on "go" => [:build, :test]

--- a/Formula/g/go.rb
+++ b/Formula/g/go.rb
@@ -1,9 +1,9 @@
 class Go < Formula
   desc "Open source programming language to build simple/reliable/efficient software"
   homepage "https://go.dev/"
-  url "https://go.dev/dl/go1.24.2.src.tar.gz"
-  mirror "https://fossies.org/linux/misc/go1.24.2.src.tar.gz"
-  sha256 "9dc77ffadc16d837a1bf32d99c624cb4df0647cee7b119edd9e7b1bcc05f2e00"
+  url "https://go.dev/dl/go1.24.3.src.tar.gz"
+  mirror "https://fossies.org/linux/misc/go1.24.3.src.tar.gz"
+  sha256 "229c08b600b1446798109fae1f569228102c8473caba8104b6418cb5bc032878"
   license "BSD-3-Clause"
   head "https://go.googlesource.com/go.git", branch: "master"
 

--- a/Formula/g/go.rb
+++ b/Formula/g/go.rb
@@ -21,13 +21,13 @@ class Go < Formula
   end
 
   bottle do
-    sha256                               arm64_sequoia: "af3b7e49c04ba9c7c5da1f18ad09ca9282388507ac0455d6a7d67ad3a634b403"
-    sha256                               arm64_sonoma:  "af3b7e49c04ba9c7c5da1f18ad09ca9282388507ac0455d6a7d67ad3a634b403"
-    sha256                               arm64_ventura: "af3b7e49c04ba9c7c5da1f18ad09ca9282388507ac0455d6a7d67ad3a634b403"
-    sha256                               sonoma:        "f34bd91a7f803e9bd4a15c66fec9e08a7c5d47cde9afd9ca1f10d35ac31a0cef"
-    sha256                               ventura:       "f34bd91a7f803e9bd4a15c66fec9e08a7c5d47cde9afd9ca1f10d35ac31a0cef"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "0eae1c913860d8682a7e7594cf53f28862de3e64b13b5b66b443c518560f0668"
-    sha256                               x86_64_linux:  "33ab89c5b736bc433a2118050bfcc09a238f72f821ea8e5add409928579806a2"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "7333b18cd1ba62bb1bcc7b7e24fc1084fa1bbb77003d4ed647d539f530bcc2cf"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "7333b18cd1ba62bb1bcc7b7e24fc1084fa1bbb77003d4ed647d539f530bcc2cf"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "7333b18cd1ba62bb1bcc7b7e24fc1084fa1bbb77003d4ed647d539f530bcc2cf"
+    sha256 cellar: :any_skip_relocation, sonoma:        "20ade196c57038f73f5ba7d29dcf4abcbe4bc56e238929a0efa0068de335a129"
+    sha256 cellar: :any_skip_relocation, ventura:       "20ade196c57038f73f5ba7d29dcf4abcbe4bc56e238929a0efa0068de335a129"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "503115ac69ffbcef21dff5d62154c8a505a164e9b821a1be4052e02bb9ce4bc7"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "885e20364acb6df6c86e437a853ad0d649945e50542fd5bb914e2d8989e5fc27"
   end
 
   # Don't update this unless this version cannot bootstrap the new version.

--- a/Formula/s/staticcheck.rb
+++ b/Formula/s/staticcheck.rb
@@ -8,12 +8,12 @@ class Staticcheck < Formula
   head "https://github.com/dominikh/go-tools.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "fdfccf0daef098c323090f84334bb145b6c48da9587cd40cee6fd4d71db3bfeb"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "fdfccf0daef098c323090f84334bb145b6c48da9587cd40cee6fd4d71db3bfeb"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "fdfccf0daef098c323090f84334bb145b6c48da9587cd40cee6fd4d71db3bfeb"
-    sha256 cellar: :any_skip_relocation, sonoma:        "bc21362b5a7567bdf9041359ff6661df40e3e793cb0a1bf120efffb219d3f17c"
-    sha256 cellar: :any_skip_relocation, ventura:       "bc21362b5a7567bdf9041359ff6661df40e3e793cb0a1bf120efffb219d3f17c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "347107bbe8efbff2565326aae4e0f5f05fb8637dee773a8a9667710de54bc319"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "fa358b34210b2a62d257ebe2e788f197cd55656c18acf72c8f783208ef7353aa"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "fa358b34210b2a62d257ebe2e788f197cd55656c18acf72c8f783208ef7353aa"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "fa358b34210b2a62d257ebe2e788f197cd55656c18acf72c8f783208ef7353aa"
+    sha256 cellar: :any_skip_relocation, sonoma:        "c22f781e614f17c4836a4a3df8a2744fb764a2bc49efa3530e01d8f46ba87453"
+    sha256 cellar: :any_skip_relocation, ventura:       "c22f781e614f17c4836a4a3df8a2744fb764a2bc49efa3530e01d8f46ba87453"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "fcd84b6cdd36306e9403869f94850b25b5a05561fe2740dbba895115ad06974a"
   end
 
   depends_on "go"

--- a/Formula/s/staticcheck.rb
+++ b/Formula/s/staticcheck.rb
@@ -4,7 +4,7 @@ class Staticcheck < Formula
   url "https://github.com/dominikh/go-tools/archive/refs/tags/2025.1.1.tar.gz"
   sha256 "259aaf528e4d98e7d3652e283e8551cfdb98cd033a7c01003cd377c2444dd6de"
   license "MIT"
-  revision 1
+  revision 2
   head "https://github.com/dominikh/go-tools.git", branch: "master"
 
   bottle do


### PR DESCRIPTION
Security release for CVE-2025-22873: 
* https://github.com/golang/go/issues/73556
* https://github.com/golang/go/issues/73555

https://go.dev/doc/devel/release#go1.24.3
> go1.24.3 (released 2025-05-06) includes security fixes to the os package, as well as bug fixes to the runtime, the compiler, the linker, the go command, and the crypto/tls and os packages. See the [Go 1.24.3 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.24.3+label%3ACherryPickApproved) on our issue tracker for details.

---

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
