### PR TITLE
workflow/triage: add `long dependent tests` label for SQLite

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -316,6 +316,7 @@ jobs:
                 rust|\
                 sdl2|\
                 shared-mime-info|\
+                sqlite|\
                 suite-sparse|\
                 qt|\
                 readline|\
@@ -337,6 +338,7 @@ jobs:
             - label: CI-skip-recursive-dependents
               path: Formula/.+/(ca-certificates|curl|gettext|openssl@3|sqlite|systemd).rb
               keep_if_no_match: true
+              allow_any_match: true
 
             - label: CI-linux-self-hosted
               path: "Formula/.+/(\


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
