### PR TITLE
caddy 2.10.0: set HOME when run as a service

### DIFF
--- a/Formula/c/caddy.rb
+++ b/Formula/c/caddy.rb
@@ -7,13 +7,14 @@ class Caddy < Formula
   head "https://github.com/caddyserver/caddy.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "9ec2d892dd02a4b25ce7a0fb81a7d212938de43cdbb48135586e9aefb7dfbe40"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "9ec2d892dd02a4b25ce7a0fb81a7d212938de43cdbb48135586e9aefb7dfbe40"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "9ec2d892dd02a4b25ce7a0fb81a7d212938de43cdbb48135586e9aefb7dfbe40"
-    sha256 cellar: :any_skip_relocation, sonoma:        "591abcce17e69cdc1977ce6a40b088e4d26ce39056eef3b02f47582b0fdb1a86"
-    sha256 cellar: :any_skip_relocation, ventura:       "591abcce17e69cdc1977ce6a40b088e4d26ce39056eef3b02f47582b0fdb1a86"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "b0a9f327848ce83808e0ce71b49481b7310c4fea5f500f6cd1266dbc2728e51a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d751c862bc8581712b570bfffd0cd21197a0071e5318abd4028fa6af4f90d412"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "0a0def155db07e2c3212e3c290b9a675e38935fdfae37e2dbe71f0e0238f5ab4"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "0a0def155db07e2c3212e3c290b9a675e38935fdfae37e2dbe71f0e0238f5ab4"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "0a0def155db07e2c3212e3c290b9a675e38935fdfae37e2dbe71f0e0238f5ab4"
+    sha256 cellar: :any_skip_relocation, sonoma:        "7e2e30ad4694c7cb0f9d4066a45cef177c0a36293526b8e61d58d72fbb1284d5"
+    sha256 cellar: :any_skip_relocation, ventura:       "7e2e30ad4694c7cb0f9d4066a45cef177c0a36293526b8e61d58d72fbb1284d5"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "edfead41ad5b1c16440cfd7a9bb0a600a58d80ca7bffa23466d2510aba4d20cb"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4055b37a0e00a1209288f8e49b72632ee97fd2d80ca8aa195731cff4111c90c3"
   end
 
   depends_on "go" => :build

--- a/Formula/c/caddy.rb
+++ b/Formula/c/caddy.rb
@@ -50,7 +50,10 @@ class Caddy < Formula
     keep_alive true
     error_log_path var/"log/caddy.log"
     log_path var/"log/caddy.log"
-    environment_variables XDG_DATA_HOME: "#{HOMEBREW_PREFIX}/var/lib"
+    environment_variables(
+      XDG_DATA_HOME: "#{HOMEBREW_PREFIX}/var/lib",
+      HOME:          "#{HOMEBREW_PREFIX}/var/lib",
+    )
   end
 
   test do


### PR DESCRIPTION
Set HOME when running caddy as a service. This resolves the following warning:

```
$HOME environment variable is empty - please fix; some assets might be stored in ./caddy
```

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
