### PR TITLE
jjui v0.8.8 (new formula)

### DIFF
--- a/Formula/j/jjui.rb
+++ b/Formula/j/jjui.rb
@@ -1,0 +1,19 @@
+class Jjui < Formula
+  desc "TUI for interacting with the Jujutsu version control system"
+  homepage "https://github.com/idursun/jjui"
+  url "https://github.com/idursun/jjui/archive/refs/tags/v0.8.8.tar.gz"
+  sha256 "66963f2b091855d1e4116bdf45dbbde728ff6b2a65e4adb879e32249a3693242"
+  license "MIT"
+
+  depends_on "go" => :build
+  depends_on "jj"
+
+  def install
+    system "go", "build", *std_go_args(ldflags: "-s -w -X main.Version=#{version}"), "./cmd/jjui"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/jjui -version")
+    assert_match "Error: There is no jj repo in", shell_output("#{bin}/jjui 2>&1", 1)
+  end
+end

--- a/Formula/j/jjui.rb
+++ b/Formula/j/jjui.rb
@@ -5,6 +5,15 @@ class Jjui < Formula
   sha256 "66963f2b091855d1e4116bdf45dbbde728ff6b2a65e4adb879e32249a3693242"
   license "MIT"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "54e7a15721fb267acdaeb43aa73068361593666de8219496e1f19043547662b2"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "54e7a15721fb267acdaeb43aa73068361593666de8219496e1f19043547662b2"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "54e7a15721fb267acdaeb43aa73068361593666de8219496e1f19043547662b2"
+    sha256 cellar: :any_skip_relocation, sonoma:        "60186d9a662096c177aea03a42b2fc7b17045f8f04b6a250d39003d6cd0350b5"
+    sha256 cellar: :any_skip_relocation, ventura:       "60186d9a662096c177aea03a42b2fc7b17045f8f04b6a250d39003d6cd0350b5"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c619c378089dea967033ea1e753b09eed71dd8807e4dd10fb505547fdbeb3327"
+  end
+
   depends_on "go" => :build
   depends_on "jj"
 


### PR DESCRIPTION
Add jjui, a TUI for jujutsu VCS.
See https://github.com/idursun/jjui and https://jj-vcs.github.io/jj/latest.

Being a TUI, I am testing against the output of jjui --version for the lack of a better test


It seemed reasonnable to depend on jj for a functional installation.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
