### PR TITLE
proteinortho: fix OpenMP

### DIFF
--- a/Formula/p/proteinortho.rb
+++ b/Formula/p/proteinortho.rb
@@ -7,14 +7,13 @@ class Proteinortho < Formula
   revision 1
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_sequoia: "2356058c1df4e150a263dbfc0f732c7be1d0554c28962d2c3c1bbbff3234470e"
-    sha256 cellar: :any,                 arm64_sonoma:  "6563d591255724b9b4d51b183ee88e1896a88947cf27711b98c64b808e788e1d"
-    sha256 cellar: :any,                 arm64_ventura: "76bbfd627206c5a346c8b40207cc4c002dbc9a348317032a4eb3dcda98153f46"
-    sha256 cellar: :any,                 sonoma:        "9127cb17cb8e363c879b0ecf81c349f61120ef0e0206366defa07ce11e9cb39d"
-    sha256 cellar: :any,                 ventura:       "1eeab6b4ab460ca0e684f123b1b6e6a293cd005df2209835530d7d08393ac36f"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "ec96e52a4bea6125ac647b78c022e739b7f1f3bc66f33e3cf19349b8e84134dc"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "bde04add25030aed32aac06465de994ca04e4410181a53deac825858df3df18c"
+    sha256 cellar: :any,                 arm64_sequoia: "fb9d08681faf0c8464fa65b131900c097876bac2c1a3c340dfaa85ad3a459702"
+    sha256 cellar: :any,                 arm64_sonoma:  "26e80497cc9d2284466a31dcc6dfd95357ea071ccc733c60eb0e79a086af374d"
+    sha256 cellar: :any,                 arm64_ventura: "8e23bd4abefac07aca474bba3e4e56f469b38cd7e3c9e46f792e573710415009"
+    sha256 cellar: :any,                 sonoma:        "e1862ac62a9b9b594a008d5e50c30faa0388224af3249a0b8f0f4f8ee1666aea"
+    sha256 cellar: :any,                 ventura:       "fc7eddf0b7441b7bcf81cdf6fe97ebb3c53354a4f538569a5334f554338f6c86"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "833760c644e5a42573ff7166c7b1201a925847350deb7a8ff7e35fc7ba97a02c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f93ee04f2ff9dc0c6a526f1567f6410deefaf8b4e340994ecd98734c9c685181"
   end
 
   depends_on "diamond"


### PR DESCRIPTION
Closes https://github.com/Homebrew/homebrew-core/pull/221522

- Uses openmp from the system GCC on Linux
- Uses libomp with the system clang compiler on macOS
- Includes a test provided by @pmjklemm that exercises openmp