### PR TITLE
Use LLVM libunwind from `lib/"unwind"/` dir

### DIFF
--- a/Formula/b/botan.rb
+++ b/Formula/b/botan.rb
@@ -58,7 +58,7 @@ class Botan < Formula
     if OS.mac? && DevelopmentTools.clang_build_version <= 1400
       ENV.llvm_clang
 
-      ldflags = %W[-L#{Formula["llvm"].opt_lib}/c++ -L#{Formula["llvm"].opt_lib} -lunwind]
+      ldflags = %W[-L#{Formula["llvm"].opt_lib}/c++ -L#{Formula["llvm"].opt_lib}/unwind -lunwind]
       args << "--ldflags=#{ldflags.join(" ")}"
     end
 

--- a/Formula/b/botan.rb
+++ b/Formula/b/botan.rb
@@ -12,13 +12,14 @@ class Botan < Formula
   end
 
   bottle do
-    sha256 arm64_sequoia: "0d1f589f900dc679b34940bf606a016e015ed922a5f759b9daadbd9b8969c1ae"
-    sha256 arm64_sonoma:  "751910a74fe11ed9d3b8b3abf79aae11036b92f9875fd0475d13294d92dcf49c"
-    sha256 arm64_ventura: "466dbfcd5eaff897ea903b82d6ecf680f1159c28087e6621760f0f29c96805cf"
-    sha256 sonoma:        "1d91396c3dd3462bd6c770c75e65add1b924f97c21d66d8448abbe24906588a9"
-    sha256 ventura:       "38149c11397d68a6e7671dd3efd73922357105e29f8a68ef7d6652e293293d80"
-    sha256 arm64_linux:   "0a7614e14b1aaa075695bc05185c789f48b8deec3d431288fd547f10f53f4fa1"
-    sha256 x86_64_linux:  "2b8a84de394ad2ecc64249091c0f4ccc23521a4b33ff70b693480a5731271454"
+    rebuild 1
+    sha256 arm64_sequoia: "a967bbee75aacedb40abbea69a039efeb6d3747f60f78d7df3c990389f4bb4ee"
+    sha256 arm64_sonoma:  "363aac39d5a069ded0ffad86a0d924fdeba5da34b541c47de8a91a2b8ff37a55"
+    sha256 arm64_ventura: "d8bcc4c1e2fe8db29e38d6fc6420b03b9addba885332dcf37ecbde13dd1dad00"
+    sha256 sonoma:        "fb26ebacd465ecc8efe8978a8b0a7a7b2b1fa9b19f5838c71e1c0b02488610f8"
+    sha256 ventura:       "54669a30e929a073ae91d196a9a0929b9a4b77a05da4e026fb97f58da9ece15b"
+    sha256 arm64_linux:   "13c3d6c959ea7e723868b616eddbbafe0d9d705d015e975e7e53f2dca18bc50b"
+    sha256 x86_64_linux:  "3fb558f2f23a738424a0b1593e1541bf02ff454be11a1ceafadc05f30215a772"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/q/qca.rb
+++ b/Formula/q/qca.rb
@@ -13,11 +13,12 @@ class Qca < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:  "7d36a3c7300b55b416b3ecc78c83652e607e08f5cf9e16237dd958c3986f4940"
-    sha256 cellar: :any,                 arm64_ventura: "ae332ff406dea6f7ec23a4bc6f3c00533b753a8a07de5bfaf8486a0da379b9c3"
-    sha256 cellar: :any,                 sonoma:        "8f7cc19fb5287ca7840c1723d8bdee5270841dd375913ae3c70c415725f1b8c4"
-    sha256 cellar: :any,                 ventura:       "e93c6f830c94b94dc72bacc2a1a6664aaa0ce313b624b6d9151a47182d89a867"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "ce993e1748bf8e89e8963a8c745daa2ce149ca37f0158a2e7ebc4fac7c1e731d"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sonoma:  "5d1185d69deda47364a7d2e279f27d68ece2a39fcf519e431fd356467a6b3b82"
+    sha256 cellar: :any,                 arm64_ventura: "ba134c852c174798c1e3591150a1b8c2b13eab89c164ad64784f46ee7fed1d6b"
+    sha256 cellar: :any,                 sonoma:        "413848dff121c2d4b2e48decf5e79e06d448be120d62e82f55a2dc8d7a6f45ff"
+    sha256 cellar: :any,                 ventura:       "0f7e5193b934d41a0d581f613f76317c0a600263859f11da094216fca2c8b39e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2eea9797f98480d589b8f4561ed35a0d306254692490c626ee2aeadb6546877d"
   end
 
   depends_on "cmake" => :build

--- a/Formula/q/qca.rb
+++ b/Formula/q/qca.rb
@@ -46,7 +46,7 @@ class Qca < Formula
   def install
     if OS.mac? && DevelopmentTools.clang_build_version <= 1400
       ENV.llvm_clang
-      ENV.append "LDFLAGS", "-L#{Formula["llvm"].opt_lib}/c++ -L#{Formula["llvm"].opt_lib} -lunwind"
+      ENV.append "LDFLAGS", "-L#{Formula["llvm"].opt_lib}/c++ -L#{Formula["llvm"].opt_lib}/unwind -lunwind"
     end
 
     ENV["QC_CERTSTORE_PATH"] = Formula["ca-certificates"].pkgetc/"cert.pem"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I suspect the botan and qca formula builds have been failing on older macOS releases since #191829 when libunwind was moved to the `lib/unwind/` subdirectory.

(Tested on macOS Monterey 12.7.6)