### PR TITLE
various: cmake 4 compatibility

### DIFF
--- a/Formula/d/double-conversion.rb
+++ b/Formula/d/double-conversion.rb
@@ -18,6 +18,13 @@ class DoubleConversion < Formula
 
   depends_on "cmake" => :build
 
+  # Fix to cmake 4 compatibility
+  # PR ref: https://github.com/google/double-conversion/pull/240
+  patch do
+    url "https://github.com/google/double-conversion/commit/69880f0e68d6ddcb760285709195d63c5fd193c4.patch?full_index=1"
+    sha256 "9895afd264e304368d78d83d4bedf85fbd282f79fe99f70cd7384cde2baab329"
+  end
+
   def install
     system "cmake", "-S", ".", "-B", "shared", "-DBUILD_SHARED_LIBS=ON", *std_cmake_args
     system "cmake", "--build", "shared"

--- a/Formula/lib/libcbor.rb
+++ b/Formula/lib/libcbor.rb
@@ -17,6 +17,13 @@ class Libcbor < Formula
 
   depends_on "cmake" => :build
 
+  # Fix to cmake 4 compatibility
+  # PR ref: https://github.com/PJK/libcbor/pull/355
+  patch do
+    url "https://github.com/PJK/libcbor/commit/1183292d4695300785b272532c1e02d68840e4b8.patch?full_index=1"
+    sha256 "54c1984fa401a4bf85e9d9cfd1500bfd1f3106cf39e1f72cfdf762dd30643098"
+  end
+
   def install
     args = %w[
       -DWITH_EXAMPLES=OFF

--- a/Formula/lib/libsamplerate.rb
+++ b/Formula/lib/libsamplerate.rb
@@ -19,6 +19,19 @@ class Libsamplerate < Formula
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
 
+  # Fix CMake deprecation warning CMP0091 (prereq for cmake 4 compatibility fix below)
+  # PR ref: https://github.com/libsndfile/libsamplerate/pull/180
+  patch do
+    url "https://github.com/libsndfile/libsamplerate/commit/e4a0ab46887029e0f65f145ba3987cc592f18200.patch?full_index=1"
+    sha256 "0826fb59d733188645f3dc207c938580970700381b9bc87058b137723cb30bba"
+  end
+  # Fix to cmake 4 compatibility
+  # PR ref: https://github.com/libsndfile/libsamplerate/pull/225
+  patch do
+    url "https://github.com/libsndfile/libsamplerate/commit/1abc639420b2df8b9ff2e0bdcc28cf6613c7c0d0.patch?full_index=1"
+    sha256 "b6fb61c763a0f072ef2ebb3a311037d2429a5e294141f6d5e552ccd25efabdc0"
+  end
+
   def install
     args = ["-DLIBSAMPLERATE_EXAMPLES=OFF"]
 

--- a/Formula/s/snappy.rb
+++ b/Formula/s/snappy.rb
@@ -35,6 +35,13 @@ class Snappy < Formula
   # `folly` issue ref: https://github.com/facebook/folly/issues/1583
   patch :DATA
 
+  # Fix to cmake 4 compatibility
+  # PR ref: https://github.com/google/snappy/pull/200
+  patch do
+    url "https://github.com/google/snappy/commit/a688be4b77b954c403db805c8351ff62770f1044.patch?full_index=1"
+    sha256 "d7ce00be23a95bc438ec00a287de1c52a2b7d9c261a365a4a2b458e29b486fd8"
+  end
+
   def install
     ENV.llvm_clang if OS.mac? && (DevelopmentTools.clang_build_version <= 1100)
 

--- a/Formula/s/srt.rb
+++ b/Formula/s/srt.rb
@@ -20,6 +20,13 @@ class Srt < Formula
   depends_on "pkgconf" => :build
   depends_on "openssl@3"
 
+  # Fix to cmake 4 compatibility
+  # PR ref: https://github.com/Haivision/srt/pull/3167
+  patch do
+    url "https://github.com/Haivision/srt/commit/7962936829e016295e5c570539eb2520b326da4c.patch?full_index=1"
+    sha256 "e4489630886bf8b26f63a23c8b1aec549f7280f07713ded07fce281e542725f7"
+  end
+
   def install
     openssl = Formula["openssl@3"]
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Applying a similar fix to #223050 to additional formulae with CMake 4.x compatibility issues.

See also:

- #223050 / #223019 (libsndfile)
- #221904 (mono)
- #222944 (grokj2k)

The current PR potentially conflicts with the snappy version update #222288 / #216761 (though I will follow up separately there).