### PR TITLE
adb-enhanced: mention adb requirement

### DIFF
--- a/Formula/a/adb-enhanced.rb
+++ b/Formula/a/adb-enhanced.rb
@@ -33,6 +33,15 @@ class AdbEnhanced < Formula
     virtualenv_install_with_resources
   end
 
+  def caveats
+    <<~EOS
+      At runtime, adb must be accessible from your PATH.
+
+      You can install adb from Homebrew Cask:
+        brew install --cask android-platform-tools
+    EOS
+  end
+
   test do
     assert_match version.to_s, shell_output("#{bin}/adbe --version")
     # ADB is not intentionally supplied


### PR DESCRIPTION
Add mention of `adb` binary requirement for `adb-enhanced`, matching what's already done for `gnirehtet`, `purr`, `rogcat`, `scrcpy`, `spytrap-adb`. Solves #222097.