### PR TITLE
openliberty-jakartaee9 openliberty-webprofile9: update livecheck

### DIFF
--- a/Formula/o/openliberty-jakartaee9.rb
+++ b/Formula/o/openliberty-jakartaee9.rb
@@ -7,7 +7,7 @@ class OpenlibertyJakartaee9 < Formula
 
   livecheck do
     url "https://openliberty.io/api/builds/data"
-    regex(/openliberty[._-]v?(\d+(?:\.\d+)+)\.zip/i)
+    regex(/openliberty[._-]jakartaee9[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 
   bottle do

--- a/Formula/o/openliberty-webprofile9.rb
+++ b/Formula/o/openliberty-webprofile9.rb
@@ -7,7 +7,7 @@ class OpenlibertyWebprofile9 < Formula
 
   livecheck do
     url "https://openliberty.io/api/builds/data"
-    regex(/openliberty[._-]v?(\d+(?:\.\d+)+)\.zip/i)
+    regex(/openliberty[._-]webProfile9[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 
   bottle do


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Current livecheck detects version of `openliberty-*10` instead of `openliberty-*9` (maybe it worth adding them as new formulae?)