### PR TITLE
lsd: Add missing Powershell completions to install path

### DIFF
--- a/Formula/l/lsd.rb
+++ b/Formula/l/lsd.rb
@@ -28,6 +28,7 @@ class Lsd < Formula
     bash_completion.install "lsd.bash" => "lsd"
     fish_completion.install "lsd.fish"
     zsh_completion.install "_lsd"
+    pwsh_completion.install "_lsd.ps1"
 
     system "pandoc", "doc/lsd.md", "--standalone", "--to=man", "-o", "doc/lsd.1"
     man1.install "doc/lsd.1"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This adds `_lsd.ps1` to #\{prefix\}/share/pwsh/completions, as it was not included in release builds when completions were first added to the package by https://github.com/Homebrew/homebrew-core/pull/96165

See: https://github.com/lsd-rs/lsd/pull/953

See: https://github.com/lsd-rs/lsd/commit/8937c4720bdeaa931ea6d0878cd913d68b2dd0ef

For an example of build output that proves `_lsd.ps1` is included in macOS aarch64 release builds, see https://github.com/lsd-rs/lsd/actions/runs/13479203210/job/37662299507