### PR TITLE
csound: fix building with Ableton Link

### DIFF
--- a/Formula/c/csound.rb
+++ b/Formula/c/csound.rb
@@ -21,6 +21,23 @@ class Csound < Formula
       url "https://github.com/csound/csound/commit/2a071ae8ca89bc21b5c80037f8c95a01bb670ac9.patch?full_index=1"
       sha256 "c7026330b5c89ab399e74aff17019067705011b7e35b9c75f9ed1a5878f53b4b"
     end
+
+    # Fix build failure due to incorrect member name on macOS 15+
+    patch <<~DIFF
+      diff --git a/include/plugin.h b/include/plugin.h
+      index dcf011e6b..55e8055bf 100644
+      --- a/include/plugin.h
+      +++ b/include/plugin.h
+      @@ -1002,7 +1002,7 @@ template <std::size_t N> struct InPlug : OPDS {
+         /** check if this opcode runs at perf time
+         */
+         bool is_perf() {
+      -      return this->opaddr ? true : false;
+      +      return this->opadr ? true : false;
+         }
+
+       };
+    DIFF
   end
 
   livecheck do

--- a/Formula/c/csound.rb
+++ b/Formula/c/csound.rb
@@ -3,7 +3,7 @@ class Csound < Formula
   homepage "https://csound.com"
   license "LGPL-2.1-or-later"
   revision 11
-  head "https://github.com/csound/csound.git", branch: "master"
+  head "https://github.com/csound/csound.git", branch: "develop"
 
   # Remove `stable` block when patches are no longer needed
   stable do
@@ -76,8 +76,8 @@ class Csound < Formula
   conflicts_with "libextractor", because: "both install `extract` binaries"
 
   resource "ableton-link" do
-    url "https://github.com/Ableton/link/archive/refs/tags/Link-3.1.2.tar.gz"
-    sha256 "2673dfad75b1484e8388deb8393673c3304b3ab5662dd5828e08e029ca8797aa"
+    url "https://github.com/Ableton/link/archive/bdcda7474114b39dea5a371cdc802536dda00d03.tar.gz"
+    sha256 "61f93d9b26b3f518bb37b0f0c27bf21f2594b79d5dd6b2948c40d3550479aa96"
   end
 
   resource "csound-plugins" do
@@ -242,6 +242,7 @@ class Csound < Formula
     assert_path_exists testpath/"test.mp3"
 
     (testpath/"opcode-existence.orc").write <<~ORC
+      gi_programHandle faustcompile "process = _;", "--vectorize --loop-variant 1"
       JackoInfo
       instr 1
           i_ websocket 8888, 0

--- a/Formula/c/csound.rb
+++ b/Formula/c/csound.rb
@@ -23,21 +23,10 @@ class Csound < Formula
     end
 
     # Fix build failure due to incorrect member name on macOS 15+
-    patch <<~DIFF
-      diff --git a/include/plugin.h b/include/plugin.h
-      index dcf011e6b..55e8055bf 100644
-      --- a/include/plugin.h
-      +++ b/include/plugin.h
-      @@ -1002,7 +1002,7 @@ template <std::size_t N> struct InPlug : OPDS {
-         /** check if this opcode runs at perf time
-         */
-         bool is_perf() {
-      -      return this->opaddr ? true : false;
-      +      return this->opadr ? true : false;
-         }
-
-       };
-    DIFF
+    patch do
+      url "https://github.com/csound/csound/commit/bb9bafcfa17a87d3733eda1e25a812fd0be08ac6.patch?full_index=1"
+      sha256 "b1492e344a7cc067989ef600a08319d388bebb344fee616d83dce969f3afe8cb"
+    end
   end
 
   livecheck do

--- a/Formula/c/csound.rb
+++ b/Formula/c/csound.rb
@@ -82,8 +82,8 @@ class Csound < Formula
   conflicts_with "libextractor", because: "both install `extract` binaries"
 
   resource "ableton-link" do
-    url "https://github.com/Ableton/link/archive/bdcda7474114b39dea5a371cdc802536dda00d03.tar.gz"
-    sha256 "61f93d9b26b3f518bb37b0f0c27bf21f2594b79d5dd6b2948c40d3550479aa96"
+    url "https://github.com/Ableton/link/archive/refs/tags/Link-3.1.3.tar.gz"
+    sha256 "b0eba86d40a46b01ab821cdfb53041bfc693f0266538ea8163f1cea7ac42f476"
   end
 
   resource "csound-plugins" do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR updates the [Ableton Link](https://github.com/Ableton/link) resource to the [latest commit](https://github.com/Ableton/link/commit/bdcda7474114b39dea5a371cdc802536dda00d03), which doesn’t use functions that were [removed in ASIO v1.33](https://github.com/chriskohlhoff/asio/commit/352394454e2f631d9eb9933db6f566e8788c4de4). (I tried to apply that commit as a patch, but the patch didn’t apply cleanly.)

While we’re at it, also
* Restore a test of the existence of [Faust](https://faust.grame.fr) features. This test was removed in https://github.com/Homebrew/homebrew-core/commit/c1413ac5e280d37be6cf8e78c88e50ae99297d86 because [Faust features are causing a segmentation fault when used with FluidSynth](https://github.com/csound/plugins/issues/28), but it’s possible to check that Faust is present without running it.
* Change the `HEAD` branch to `develop` (so that the formula passes `brew audit --strict --online`).