### PR TITLE
various: fix build errors on macOS 12 Monterey

### DIFF
--- a/Formula/q/qt.rb
+++ b/Formula/q/qt.rb
@@ -42,6 +42,7 @@ class Qt < Formula
   depends_on xcode: :build
 
   depends_on "assimp"
+  depends_on "at-spi2-core"
   depends_on "brotli"
   depends_on "dbus"
   depends_on "double-conversion"
@@ -77,7 +78,6 @@ class Qt < Formula
 
   on_linux do
     depends_on "alsa-lib"
-    depends_on "at-spi2-core"
     # TODO: depends_on "bluez"
     depends_on "expat"
     depends_on "ffmpeg"
@@ -217,6 +217,8 @@ class Qt < Formula
       # Chromium needs Xcode 15.3+ and using LLVM Clang is not supported on macOS
       # See https://bugreports.qt.io/browse/QTBUG-130922
       cmake_args << "-DBUILD_qtwebengine=OFF" if MacOS::Xcode.version < "15.3"
+
+      cmake_args << "-DQT_FORCE_WARN_APPLE_SDK_AND_XCODE_CHECK=ON" if MacOS.version <= :monterey
 
       %W[
         -DCMAKE_OSX_DEPLOYMENT_TARGET=#{MacOS.version}.0

--- a/Formula/q/qt.rb
+++ b/Formula/q/qt.rb
@@ -137,6 +137,8 @@ class Qt < Formula
     sha256 "b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"
   end
 
+  patch :DATA
+
   def install
     python3 = "python3.13"
 
@@ -412,3 +414,22 @@ class Qt < Formula
     assert_equal HOMEBREW_PREFIX.to_s, shell_output("#{bin}/qmake -query QT_INSTALL_PREFIX").chomp
   end
 end
+__END__
+--- a/qtwebengine/src/3rdparty/chromium/third_party/blink/renderer/build/scripts/gperf.py	2025-05-29 21:23:49.565413007 +0000
++++ b/qtwebengine/src/3rdparty/chromium/third_party/blink/renderer/build/scripts/gperf.py	2025-05-29 21:24:07.164764001 +0000
+@@ -35,8 +35,11 @@
+         # https://savannah.gnu.org/bugs/index.php?53028
+         gperf_output = re.sub(r'\bregister ', '', gperf_output)
+         # -Wimplicit-fallthrough needs an explicit fallthrough statement,
+-        # so replace gperf's /*FALLTHROUGH*/ comment with the statement.
+-        # https://savannah.gnu.org/bugs/index.php?53029
+-        gperf_output = gperf_output.replace('/*FALLTHROUGH*/',
+-                                            '  [[fallthrough]];')
++        # so replace gperf 3.1's /*FALLTHROUGH*/ comment with the statement.
++        # https://savannah.gnu.org/bugs/index.php?53029 (fixed in 3.2)
++        if re.search(
++                r'/\* C\+\+ code produced by gperf version 3\.[01](\.\d+)? \*/',
++                gperf_output):
++            gperf_output = gperf_output.replace('/*FALLTHROUGH*/',
++                                                '  [[fallthrough]];')
+         # -Wpointer-to-int-cast warns about casting pointers to smaller ints

--- a/Formula/v/v8.rb
+++ b/Formula/v/v8.rb
@@ -257,6 +257,7 @@ class V8 < Formula
         gn_args[:fatal_linker_warnings] = false
         inreplace "build/config/mac/BUILD.gn", "[ \"-Wl,-ObjC\" ]",
                                                "[ \"-Wl,-ObjC\", \"-L#{Formula["llvm"].opt_lib}/c++\" ]"
+        inreplace "build/config/compiler/BUILD.gn", /.*\[ "-Wl,-no_warn_duplicate_libraries" \]/, "#\\0"
       end
     end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Build fixes for several formulae that use llvm_clang and had compiler and/or linker errors on macOS 12 Monterey (tested on macOS 12.7.6).