### PR TITLE
snappy 1.2.2

### DIFF
--- a/Formula/s/snappy.rb
+++ b/Formula/s/snappy.rb
@@ -7,15 +7,13 @@ class Snappy < Formula
   head "https://github.com/google/snappy.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia:  "45275e26a466be03a8a2b81ef27afc862038b220cdf7d8cd63f6ff9f47f18e56"
-    sha256 cellar: :any,                 arm64_sonoma:   "2b905dfed7d6c0b44de9c89a79a6aa69824758c2727dcffe95bc6ebef465cf3f"
-    sha256 cellar: :any,                 arm64_ventura:  "ca5b33ef7fd245020808bcb339f5b7799a4d4441b50c430c9bdd4eeca6a7d785"
-    sha256 cellar: :any,                 arm64_monterey: "a3ad18bfdb378542375074f5f3423bb4972147595ee7b3ec38acd04469bff5db"
-    sha256 cellar: :any,                 sonoma:         "4a39b310e4c5a726de262265e14cb0ee219f89c0da0afd19328007d965dba7f8"
-    sha256 cellar: :any,                 ventura:        "80fa828013ffa932262d110a351fc4f28f44524cc783d23c15b61328182170ac"
-    sha256 cellar: :any,                 monterey:       "e31f618776a2346ae18b6aa8bc035e0edc3c1dbf421498ef13f8b5a1e75fd1be"
-    sha256 cellar: :any_skip_relocation, arm64_linux:    "039293445a70911dc94d20f009811e1ae86a0364c2df18f6ff5934586129b4e4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "0c33db20cdc5d828f5f90eb3996f6729a02ebf697bf0a67d28f59feeb24bed42"
+    sha256 cellar: :any,                 arm64_sequoia: "326d8c9a73e0990a43fefe96d2e29355fcd6f42906710017bd1a3baf4401bb33"
+    sha256 cellar: :any,                 arm64_sonoma:  "28b0702ed678a35c6d03cb4d91f975e17b3b5af7480418f3c82f46365e55533d"
+    sha256 cellar: :any,                 arm64_ventura: "9e4594baee5654ab46bf4542d4e1867c6a6700cc11948ee7f496a7a681a1fd28"
+    sha256 cellar: :any,                 sonoma:        "47444cd920b4f3232d1d77f51ead8a18e0a77fb5b154bff7c024bf17d700d273"
+    sha256 cellar: :any,                 ventura:       "026d656d0beaf42781437e7fe70012b18eb73f16db024f7e46f35891e2e8a1b1"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "c2d7ecfa6475c2ad07a45025ad99940c75bf03c7b3772850d830a3dd571ff09c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "462767a5fd6f73305aa7fd232bc5119e96491ad17222092d8b532fe2616ca24e"
   end
 
   depends_on "cmake" => :build

--- a/Formula/s/snappy.rb
+++ b/Formula/s/snappy.rb
@@ -1,8 +1,8 @@
 class Snappy < Formula
   desc "Compression/decompression library aiming for high speed"
   homepage "https://google.github.io/snappy/"
-  url "https://github.com/google/snappy/archive/refs/tags/1.2.1.tar.gz"
-  sha256 "736aeb64d86566d2236ddffa2865ee5d7a82d26c9016b36218fcc27ea4f09f86"
+  url "https://github.com/google/snappy/archive/refs/tags/1.2.2.tar.gz"
+  sha256 "90f74bc1fbf78a6c56b3c4a082a05103b3a56bb17bca1a27e052ea11723292dc"
   license "BSD-3-Clause"
   head "https://github.com/google/snappy.git", branch: "master"
 
@@ -34,13 +34,6 @@ class Snappy < Formula
   # Fix issue where `snappy` setting -fno-rtti causes build issues on `folly`
   # `folly` issue ref: https://github.com/facebook/folly/issues/1583
   patch :DATA
-
-  # Fix to cmake 4 compatibility
-  # PR ref: https://github.com/google/snappy/pull/200
-  patch do
-    url "https://github.com/google/snappy/commit/a688be4b77b954c403db805c8351ff62770f1044.patch?full_index=1"
-    sha256 "d7ce00be23a95bc438ec00a287de1c52a2b7d9c261a365a4a2b458e29b486fd8"
-  end
 
   def install
     ENV.llvm_clang if OS.mac? && (DevelopmentTools.clang_build_version <= 1100)
@@ -88,10 +81,21 @@ end
 
 __END__
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 672561e..2f97b73 100644
+index cd71a47..ef040d1 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -76,10 +76,6 @@ else(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+@@ -51,10 +51,6 @@ if(MSVC)
+   string(REGEX REPLACE "/EH[a-z]+" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHs-c-")
+   add_definitions(-D_HAS_EXCEPTIONS=0)
+-
+-  # Disable RTTI.
+-  string(REGEX REPLACE "/GR" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR-")
+ else(MSVC)
+   # Use -Wall for clang and gcc.
+   if(NOT CMAKE_CXX_FLAGS MATCHES "-Wall")
+@@ -81,10 +77,6 @@ else(MSVC)
    # Disable C++ exceptions.
    string(REGEX REPLACE "-fexceptions" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
@@ -99,6 +103,6 @@ index 672561e..2f97b73 100644
 -  # Disable RTTI.
 -  string(REGEX REPLACE "-frtti" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 -  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
- endif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+ endif(MSVC)
 
  # BUILD_SHARED_LIBS is a standard CMake variable, but we declare it here to make


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Bump snappy version and update the patch to enable RTTI (required by `brew test folly`).

This is a replacement for PR #222288.