### PR TITLE
mysql-client mysql mysql@8.4: remove `no_warn_duplicate_libraries` linker option

### DIFF
--- a/Formula/m/mysql-client.rb
+++ b/Formula/m/mysql-client.rb
@@ -38,6 +38,166 @@ class MysqlClient < Formula
 
   on_ventura :or_older do
     depends_on "llvm" => :build
+    # back out commit: Bug#37065301 Silence warnings on macOS
+    patch <<~EOF
+      diff --git a/cmake/component.cmake b/cmake/component.cmake
+      index a77fa0f..e476381 100644
+      --- a/cmake/component.cmake
+      +++ b/cmake/component.cmake
+      @@ -98,10 +98,6 @@ MACRO(MYSQL_ADD_COMPONENT component_arg)
+           # For APPLE: adjust path dependecy for SSL shared libraries.
+           SET_PATH_TO_CUSTOM_SSL_FOR_APPLE(${target})
+
+      -    IF(APPLE)
+      -      TARGET_LINK_OPTIONS(${target} PRIVATE LINKER:-no_warn_duplicate_libraries)
+      -    ENDIF()
+      -
+           IF(WIN32_CLANG AND WITH_ASAN)
+             TARGET_LINK_LIBRARIES(${target}
+               "${ASAN_LIB_DIR}/clang_rt.asan_dll_thunk-x86_64.lib")
+      diff --git a/cmake/libutils.cmake b/cmake/libutils.cmake
+      index 69adcdb..661171b 100644
+      --- a/cmake/libutils.cmake
+      +++ b/cmake/libutils.cmake
+      @@ -358,7 +358,6 @@ MACRO(MERGE_LIBRARIES_SHARED TARGET_ARG)
+
+         IF(APPLE)
+           SET_TARGET_PROPERTIES(${TARGET} PROPERTIES MACOSX_RPATH ON)
+      -    TARGET_LINK_OPTIONS(${TARGET} PRIVATE LINKER:-no_warn_duplicate_libraries)
+         ENDIF()
+
+         TARGET_LINK_OPTIONS(${TARGET} PRIVATE ${export_link_flags})
+      @@ -703,10 +702,6 @@ FUNCTION(ADD_SHARED_LIBRARY TARGET_ARG)
+           ENDIF()
+         ENDIF()
+
+      -  IF(APPLE)
+      -    TARGET_LINK_OPTIONS(${TARGET} PRIVATE LINKER:-no_warn_duplicate_libraries)
+      -  ENDIF()
+      -
+         ADD_OBJDUMP_TARGET(show_${TARGET} "$<TARGET_FILE:${TARGET}>"
+           DEPENDS ${TARGET})
+
+      diff --git a/cmake/mysql_add_executable.cmake b/cmake/mysql_add_executable.cmake
+      index 2a0548b..232e78a 100644
+      --- a/cmake/mysql_add_executable.cmake
+      +++ b/cmake/mysql_add_executable.cmake
+      @@ -212,10 +212,6 @@ FUNCTION(MYSQL_ADD_EXECUTABLE target_arg)
+           MACOS_ADD_DEVELOPER_ENTITLEMENTS(${target})
+         ENDIF()
+
+      -  IF(APPLE)
+      -    TARGET_LINK_OPTIONS(${target} PRIVATE LINKER:-no_warn_duplicate_libraries)
+      -  ENDIF()
+      -
+         IF(WIN32_CLANG AND WITH_ASAN)
+           TARGET_LINK_LIBRARIES(${target}
+             "${ASAN_LIB_DIR}/clang_rt.asan-x86_64.lib"
+      diff --git a/cmake/plugin.cmake b/cmake/plugin.cmake
+      index a7727ef..eac9d74 100644
+      --- a/cmake/plugin.cmake
+      +++ b/cmake/plugin.cmake
+      @@ -327,10 +327,6 @@ MACRO(MYSQL_ADD_PLUGIN plugin_arg)
+             DEPENDS ${target})
+         ENDIF()
+
+      -  IF(BUILD_PLUGIN AND ARG_MODULE_ONLY AND APPLE)
+      -    TARGET_LINK_OPTIONS(${target} PRIVATE LINKER:-no_warn_duplicate_libraries)
+      -  ENDIF()
+      -
+         IF(BUILD_PLUGIN)
+           ADD_DEPENDENCIES(plugin_all ${target})
+           TARGET_COMPILE_FEATURES(${target} PUBLIC cxx_std_20)
+      diff --git a/extra/libcno/CMakeLists.txt b/extra/libcno/CMakeLists.txt
+      index e2513f4..1577bab 100644
+      --- a/extra/libcno/CMakeLists.txt
+      +++ b/extra/libcno/CMakeLists.txt
+      @@ -16,10 +16,6 @@ SET(LIBCNO_GENERATE_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+
+       DISABLE_MISSING_PROFILE_WARNING()
+
+      -IF(APPLE_XCODE)
+      -  STRING_APPEND(CMAKE_C_FLAGS " -Wno-shorten-64-to-32")
+      -ENDIF()
+      -
+       # Following targets were created to mimic behavior of following
+       # files supplied by libcno:
+       #
+      diff --git a/extra/protobuf/protobuf-24.4/cmake/libprotobuf-lite.cmake b/extra/protobuf/protobuf-24.4/cmake/libprotobuf-lite.cmake
+      index f601e7f..b2826db 100644
+      --- a/extra/protobuf/protobuf-24.4/cmake/libprotobuf-lite.cmake
+      +++ b/extra/protobuf/protobuf-24.4/cmake/libprotobuf-lite.cmake
+      @@ -57,11 +57,6 @@ IF(protobuf_BUILD_SHARED_LIBS)
+           RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/library_output_directory
+           )
+
+      -  IF(APPLE)
+      -    TARGET_LINK_OPTIONS(libprotobuf-lite
+      -      PRIVATE LINKER:-no_warn_duplicate_libraries)
+      -  ENDIF()
+      -
+         IF(WIN32)
+           ADD_CUSTOM_COMMAND(TARGET libprotobuf-lite POST_BUILD
+             COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      diff --git a/extra/protobuf/protobuf-24.4/cmake/libprotobuf.cmake b/extra/protobuf/protobuf-24.4/cmake/libprotobuf.cmake
+      index 81428fb..ceb557f 100644
+      --- a/extra/protobuf/protobuf-24.4/cmake/libprotobuf.cmake
+      +++ b/extra/protobuf/protobuf-24.4/cmake/libprotobuf.cmake
+      @@ -61,10 +61,6 @@ IF(protobuf_BUILD_SHARED_LIBS)
+           RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/library_output_directory
+           )
+
+      -  IF(APPLE)
+      -    TARGET_LINK_OPTIONS(libprotobuf PRIVATE LINKER:-no_warn_duplicate_libraries)
+      -  ENDIF()
+      -
+         IF(WIN32)
+           ADD_CUSTOM_COMMAND(TARGET libprotobuf POST_BUILD
+             COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      diff --git a/extra/protobuf/protobuf-24.4/cmake/libprotoc.cmake b/extra/protobuf/protobuf-24.4/cmake/libprotoc.cmake
+      index ef63037..7ba5394 100644
+      --- a/extra/protobuf/protobuf-24.4/cmake/libprotoc.cmake
+      +++ b/extra/protobuf/protobuf-24.4/cmake/libprotoc.cmake
+      @@ -53,9 +53,6 @@ IF(protobuf_BUILD_SHARED_LIBS)
+           DEBUG_POSTFIX ""
+           LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/library_output_directory
+           RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/library_output_directory)
+      -  IF(APPLE)
+      -    TARGET_LINK_OPTIONS(libprotoc PRIVATE LINKER:-no_warn_duplicate_libraries)
+      -  ENDIF()
+         IF(WIN32)
+           ADD_CUSTOM_COMMAND(TARGET libprotoc POST_BUILD
+             COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      diff --git a/extra/protobuf/protobuf-24.4/cmake/protoc.cmake b/extra/protobuf/protobuf-24.4/cmake/protoc.cmake
+      index 215eb21..70f1b60 100644
+      --- a/extra/protobuf/protobuf-24.4/cmake/protoc.cmake
+      +++ b/extra/protobuf/protobuf-24.4/cmake/protoc.cmake
+      @@ -15,10 +15,6 @@ set_target_properties(protoc PROPERTIES
+
+       ################################################################
+
+      -IF(APPLE)
+      -  TARGET_LINK_OPTIONS(protoc PRIVATE LINKER:-no_warn_duplicate_libraries)
+      -ENDIF()
+      -
+       SET_TARGET_PROPERTIES(protoc PROPERTIES
+         RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/runtime_output_directory)
+
+      diff --git a/router/cmake/Plugin.cmake b/router/cmake/Plugin.cmake
+      index ac6b6b2..9b4afc5 100644
+      --- a/router/cmake/Plugin.cmake
+      +++ b/router/cmake/Plugin.cmake
+      @@ -89,9 +89,6 @@ FUNCTION(add_harness_plugin NAME)
+         # .dylib, which we do not want, so we reset it here.
+         ADD_LIBRARY(${NAME} SHARED ${_option_SOURCES})
+         TARGET_COMPILE_FEATURES(${NAME} PUBLIC cxx_std_20)
+      -  IF(APPLE)
+      -    TARGET_LINK_OPTIONS(${NAME} PRIVATE LINKER:-no_warn_duplicate_libraries)
+      -  ENDIF()
+
+         # add plugin to build-all target
+         ADD_DEPENDENCIES(mysqlrouter_all ${NAME})
+    EOF
     fails_with :clang do
       cause <<~EOS
         std::string_view is not fully compatible with the libc++ shipped
@@ -55,6 +215,11 @@ class MysqlClient < Formula
     version "9"
     cause "Requires C++20"
   end
+
+  # Patch out check for Homebrew `boost`.
+  # This should not be necessary when building inside `brew`.
+  # https://github.com/Homebrew/homebrew-test-bot/pull/820
+  patch :DATA
 
   def install
     if OS.linux?
@@ -91,3 +256,41 @@ class MysqlClient < Formula
     assert_match version.to_s, shell_output("#{bin}/mysql --version")
   end
 end
+
+__END__
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 438dff720c5..47863c17e23 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1948,31 +1948,6 @@ MYSQL_CHECK_RAPIDJSON()
+ MYSQL_CHECK_FIDO()
+ MYSQL_CHECK_FIDO_DLLS()
+
+-IF(APPLE)
+-  GET_FILENAME_COMPONENT(HOMEBREW_BASE ${HOMEBREW_HOME} DIRECTORY)
+-  IF(EXISTS ${HOMEBREW_BASE}/include/boost)
+-    FOREACH(SYSTEM_LIB ICU LZ4 PROTOBUF ZSTD FIDO)
+-      IF(WITH_${SYSTEM_LIB} STREQUAL "system")
+-        MESSAGE(FATAL_ERROR
+-          "WITH_${SYSTEM_LIB}=system is not compatible with Homebrew boost\n"
+-          "MySQL depends on ${BOOST_PACKAGE_NAME} with a set of patches.\n"
+-          "Including headers from ${HOMEBREW_BASE}/include "
+-          "will break the build.\n"
+-          "Please use WITH_${SYSTEM_LIB}=bundled\n"
+-          "or do 'brew uninstall boost' or 'brew unlink boost'"
+-          )
+-      ENDIF()
+-    ENDFOREACH()
+-  ENDIF()
+-  # Ensure that we look in /usr/local/include or /opt/homebrew/include
+-  FOREACH(SYSTEM_LIB ICU LZ4 PROTOBUF ZSTD FIDO)
+-    IF(WITH_${SYSTEM_LIB} STREQUAL "system")
+-      INCLUDE_DIRECTORIES(SYSTEM ${HOMEBREW_BASE}/include)
+-      BREAK()
+-    ENDIF()
+-  ENDFOREACH()
+-ENDIF()
+-
+ IF(WITH_AUTHENTICATION_WEBAUTHN OR
+   WITH_AUTHENTICATION_CLIENT_PLUGINS)
+   IF(WITH_FIDO STREQUAL "system" AND

--- a/Formula/m/mysql-client.rb
+++ b/Formula/m/mysql-client.rb
@@ -38,166 +38,6 @@ class MysqlClient < Formula
 
   on_ventura :or_older do
     depends_on "llvm" => :build
-    # back out commit: Bug#37065301 Silence warnings on macOS
-    patch <<~EOF
-      diff --git a/cmake/component.cmake b/cmake/component.cmake
-      index a77fa0f..e476381 100644
-      --- a/cmake/component.cmake
-      +++ b/cmake/component.cmake
-      @@ -98,10 +98,6 @@ MACRO(MYSQL_ADD_COMPONENT component_arg)
-           # For APPLE: adjust path dependecy for SSL shared libraries.
-           SET_PATH_TO_CUSTOM_SSL_FOR_APPLE(${target})
-
-      -    IF(APPLE)
-      -      TARGET_LINK_OPTIONS(${target} PRIVATE LINKER:-no_warn_duplicate_libraries)
-      -    ENDIF()
-      -
-           IF(WIN32_CLANG AND WITH_ASAN)
-             TARGET_LINK_LIBRARIES(${target}
-               "${ASAN_LIB_DIR}/clang_rt.asan_dll_thunk-x86_64.lib")
-      diff --git a/cmake/libutils.cmake b/cmake/libutils.cmake
-      index 69adcdb..661171b 100644
-      --- a/cmake/libutils.cmake
-      +++ b/cmake/libutils.cmake
-      @@ -358,7 +358,6 @@ MACRO(MERGE_LIBRARIES_SHARED TARGET_ARG)
-
-         IF(APPLE)
-           SET_TARGET_PROPERTIES(${TARGET} PROPERTIES MACOSX_RPATH ON)
-      -    TARGET_LINK_OPTIONS(${TARGET} PRIVATE LINKER:-no_warn_duplicate_libraries)
-         ENDIF()
-
-         TARGET_LINK_OPTIONS(${TARGET} PRIVATE ${export_link_flags})
-      @@ -703,10 +702,6 @@ FUNCTION(ADD_SHARED_LIBRARY TARGET_ARG)
-           ENDIF()
-         ENDIF()
-
-      -  IF(APPLE)
-      -    TARGET_LINK_OPTIONS(${TARGET} PRIVATE LINKER:-no_warn_duplicate_libraries)
-      -  ENDIF()
-      -
-         ADD_OBJDUMP_TARGET(show_${TARGET} "$<TARGET_FILE:${TARGET}>"
-           DEPENDS ${TARGET})
-
-      diff --git a/cmake/mysql_add_executable.cmake b/cmake/mysql_add_executable.cmake
-      index 2a0548b..232e78a 100644
-      --- a/cmake/mysql_add_executable.cmake
-      +++ b/cmake/mysql_add_executable.cmake
-      @@ -212,10 +212,6 @@ FUNCTION(MYSQL_ADD_EXECUTABLE target_arg)
-           MACOS_ADD_DEVELOPER_ENTITLEMENTS(${target})
-         ENDIF()
-
-      -  IF(APPLE)
-      -    TARGET_LINK_OPTIONS(${target} PRIVATE LINKER:-no_warn_duplicate_libraries)
-      -  ENDIF()
-      -
-         IF(WIN32_CLANG AND WITH_ASAN)
-           TARGET_LINK_LIBRARIES(${target}
-             "${ASAN_LIB_DIR}/clang_rt.asan-x86_64.lib"
-      diff --git a/cmake/plugin.cmake b/cmake/plugin.cmake
-      index a7727ef..eac9d74 100644
-      --- a/cmake/plugin.cmake
-      +++ b/cmake/plugin.cmake
-      @@ -327,10 +327,6 @@ MACRO(MYSQL_ADD_PLUGIN plugin_arg)
-             DEPENDS ${target})
-         ENDIF()
-
-      -  IF(BUILD_PLUGIN AND ARG_MODULE_ONLY AND APPLE)
-      -    TARGET_LINK_OPTIONS(${target} PRIVATE LINKER:-no_warn_duplicate_libraries)
-      -  ENDIF()
-      -
-         IF(BUILD_PLUGIN)
-           ADD_DEPENDENCIES(plugin_all ${target})
-           TARGET_COMPILE_FEATURES(${target} PUBLIC cxx_std_20)
-      diff --git a/extra/libcno/CMakeLists.txt b/extra/libcno/CMakeLists.txt
-      index e2513f4..1577bab 100644
-      --- a/extra/libcno/CMakeLists.txt
-      +++ b/extra/libcno/CMakeLists.txt
-      @@ -16,10 +16,6 @@ SET(LIBCNO_GENERATE_DIR "${CMAKE_CURRENT_BINARY_DIR}")
-
-       DISABLE_MISSING_PROFILE_WARNING()
-
-      -IF(APPLE_XCODE)
-      -  STRING_APPEND(CMAKE_C_FLAGS " -Wno-shorten-64-to-32")
-      -ENDIF()
-      -
-       # Following targets were created to mimic behavior of following
-       # files supplied by libcno:
-       #
-      diff --git a/extra/protobuf/protobuf-24.4/cmake/libprotobuf-lite.cmake b/extra/protobuf/protobuf-24.4/cmake/libprotobuf-lite.cmake
-      index f601e7f..b2826db 100644
-      --- a/extra/protobuf/protobuf-24.4/cmake/libprotobuf-lite.cmake
-      +++ b/extra/protobuf/protobuf-24.4/cmake/libprotobuf-lite.cmake
-      @@ -57,11 +57,6 @@ IF(protobuf_BUILD_SHARED_LIBS)
-           RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/library_output_directory
-           )
-
-      -  IF(APPLE)
-      -    TARGET_LINK_OPTIONS(libprotobuf-lite
-      -      PRIVATE LINKER:-no_warn_duplicate_libraries)
-      -  ENDIF()
-      -
-         IF(WIN32)
-           ADD_CUSTOM_COMMAND(TARGET libprotobuf-lite POST_BUILD
-             COMMAND ${CMAKE_COMMAND} -E copy_if_different
-      diff --git a/extra/protobuf/protobuf-24.4/cmake/libprotobuf.cmake b/extra/protobuf/protobuf-24.4/cmake/libprotobuf.cmake
-      index 81428fb..ceb557f 100644
-      --- a/extra/protobuf/protobuf-24.4/cmake/libprotobuf.cmake
-      +++ b/extra/protobuf/protobuf-24.4/cmake/libprotobuf.cmake
-      @@ -61,10 +61,6 @@ IF(protobuf_BUILD_SHARED_LIBS)
-           RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/library_output_directory
-           )
-
-      -  IF(APPLE)
-      -    TARGET_LINK_OPTIONS(libprotobuf PRIVATE LINKER:-no_warn_duplicate_libraries)
-      -  ENDIF()
-      -
-         IF(WIN32)
-           ADD_CUSTOM_COMMAND(TARGET libprotobuf POST_BUILD
-             COMMAND ${CMAKE_COMMAND} -E copy_if_different
-      diff --git a/extra/protobuf/protobuf-24.4/cmake/libprotoc.cmake b/extra/protobuf/protobuf-24.4/cmake/libprotoc.cmake
-      index ef63037..7ba5394 100644
-      --- a/extra/protobuf/protobuf-24.4/cmake/libprotoc.cmake
-      +++ b/extra/protobuf/protobuf-24.4/cmake/libprotoc.cmake
-      @@ -53,9 +53,6 @@ IF(protobuf_BUILD_SHARED_LIBS)
-           DEBUG_POSTFIX ""
-           LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/library_output_directory
-           RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/library_output_directory)
-      -  IF(APPLE)
-      -    TARGET_LINK_OPTIONS(libprotoc PRIVATE LINKER:-no_warn_duplicate_libraries)
-      -  ENDIF()
-         IF(WIN32)
-           ADD_CUSTOM_COMMAND(TARGET libprotoc POST_BUILD
-             COMMAND ${CMAKE_COMMAND} -E copy_if_different
-      diff --git a/extra/protobuf/protobuf-24.4/cmake/protoc.cmake b/extra/protobuf/protobuf-24.4/cmake/protoc.cmake
-      index 215eb21..70f1b60 100644
-      --- a/extra/protobuf/protobuf-24.4/cmake/protoc.cmake
-      +++ b/extra/protobuf/protobuf-24.4/cmake/protoc.cmake
-      @@ -15,10 +15,6 @@ set_target_properties(protoc PROPERTIES
-
-       ################################################################
-
-      -IF(APPLE)
-      -  TARGET_LINK_OPTIONS(protoc PRIVATE LINKER:-no_warn_duplicate_libraries)
-      -ENDIF()
-      -
-       SET_TARGET_PROPERTIES(protoc PROPERTIES
-         RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/runtime_output_directory)
-
-      diff --git a/router/cmake/Plugin.cmake b/router/cmake/Plugin.cmake
-      index ac6b6b2..9b4afc5 100644
-      --- a/router/cmake/Plugin.cmake
-      +++ b/router/cmake/Plugin.cmake
-      @@ -89,9 +89,6 @@ FUNCTION(add_harness_plugin NAME)
-         # .dylib, which we do not want, so we reset it here.
-         ADD_LIBRARY(${NAME} SHARED ${_option_SOURCES})
-         TARGET_COMPILE_FEATURES(${NAME} PUBLIC cxx_std_20)
-      -  IF(APPLE)
-      -    TARGET_LINK_OPTIONS(${NAME} PRIVATE LINKER:-no_warn_duplicate_libraries)
-      -  ENDIF()
-
-         # add plugin to build-all target
-         ADD_DEPENDENCIES(mysqlrouter_all ${NAME})
-    EOF
     fails_with :clang do
       cause <<~EOS
         std::string_view is not fully compatible with the libc++ shipped
@@ -227,6 +67,19 @@ class MysqlClient < Formula
       inreplace "cmake/abi_check.cmake", "RUN_ABI_CHECK 1", "RUN_ABI_CHECK 0"
     elsif MacOS.version <= :ventura
       ENV.llvm_clang
+      # avoid error `ld: unknown option: -no_warn_duplicate_libraries` (see: Bug#37065301 Silence warnings on macOS)
+      cmake_files = %w[
+        cmake/component.cmake
+        cmake/libutils.cmake
+        cmake/mysql_add_executable.cmake
+        cmake/plugin.cmake
+        extra/protobuf/protobuf-*/cmake/libprotobuf-lite.cmake
+        extra/protobuf/protobuf-*/cmake/libprotobuf.cmake
+        extra/protobuf/protobuf-*/cmake/libprotoc.cmake
+        extra/protobuf/protobuf-*/cmake/protoc.cmake
+        router/cmake/Plugin.cmake
+      ].flat_map { |p| buildpath.glob(p) }
+      inreplace cmake_files, /\bTARGET_LINK_OPTIONS *\(.*\bLINKER:-no_warn_duplicate_libraries\)$/i, "#\\0"
     end
 
     # -DINSTALL_* are relative to `CMAKE_INSTALL_PREFIX` (`prefix`)

--- a/Formula/m/mysql-client.rb
+++ b/Formula/m/mysql-client.rb
@@ -79,7 +79,12 @@ class MysqlClient < Formula
         extra/protobuf/protobuf-*/cmake/protoc.cmake
         router/cmake/Plugin.cmake
       ].flat_map { |p| buildpath.glob(p) }
-      inreplace cmake_files, /\bTARGET_LINK_OPTIONS *\(.*\bLINKER:-no_warn_duplicate_libraries\)$/i, "#\\0"
+      inreplace cmake_files do |s|
+        s.gsub!(
+          /\b(TARGET_LINK_OPTIONS\s*)(\(\s*)([^\s]+\s+)([^\s]+\s+)(LINKER:-no_warn_duplicate_libraries\s*)(\)\s*)$/im,
+          '#\1#\2#\3#\4#\5#\6',
+        )
+      end
     end
 
     # -DINSTALL_* are relative to `CMAKE_INSTALL_PREFIX` (`prefix`)

--- a/Formula/m/mysql.rb
+++ b/Formula/m/mysql.rb
@@ -96,7 +96,12 @@ class Mysql < Formula
         extra/protobuf/protobuf-*/cmake/protoc.cmake
         router/cmake/Plugin.cmake
       ].flat_map { |p| buildpath.glob(p) }
-      inreplace cmake_files, /\bTARGET_LINK_OPTIONS *\(.*\bLINKER:-no_warn_duplicate_libraries\)$/i, "#\\0"
+      inreplace cmake_files do |s|
+        s.gsub!(
+          /\b(TARGET_LINK_OPTIONS\s*)(\(\s*)([^\s]+\s+)([^\s]+\s+)(LINKER:-no_warn_duplicate_libraries\s*)(\)\s*)$/im,
+          '#\1#\2#\3#\4#\5#\6',
+        )
+      end
     end
 
     icu4c = deps.find { |dep| dep.name.match?(/^icu4c(@\d+)?$/) }

--- a/Formula/m/mysql.rb
+++ b/Formula/m/mysql.rb
@@ -39,167 +39,6 @@ class Mysql < Formula
 
   on_ventura :or_older do
     depends_on "llvm"
-    # back out commit: Bug#37065301 Silence warnings on macOS
-    patch <<~EOF
-      diff --git a/cmake/component.cmake b/cmake/component.cmake
-      index a77fa0f..e476381 100644
-      --- a/cmake/component.cmake
-      +++ b/cmake/component.cmake
-      @@ -98,10 +98,6 @@ MACRO(MYSQL_ADD_COMPONENT component_arg)
-           # For APPLE: adjust path dependecy for SSL shared libraries.
-           SET_PATH_TO_CUSTOM_SSL_FOR_APPLE(${target})
-
-      -    IF(APPLE)
-      -      TARGET_LINK_OPTIONS(${target} PRIVATE LINKER:-no_warn_duplicate_libraries)
-      -    ENDIF()
-      -
-           IF(WIN32_CLANG AND WITH_ASAN)
-             TARGET_LINK_LIBRARIES(${target}
-               "${ASAN_LIB_DIR}/clang_rt.asan_dll_thunk-x86_64.lib")
-      diff --git a/cmake/libutils.cmake b/cmake/libutils.cmake
-      index 69adcdb..661171b 100644
-      --- a/cmake/libutils.cmake
-      +++ b/cmake/libutils.cmake
-      @@ -358,7 +358,6 @@ MACRO(MERGE_LIBRARIES_SHARED TARGET_ARG)
-
-         IF(APPLE)
-           SET_TARGET_PROPERTIES(${TARGET} PROPERTIES MACOSX_RPATH ON)
-      -    TARGET_LINK_OPTIONS(${TARGET} PRIVATE LINKER:-no_warn_duplicate_libraries)
-         ENDIF()
-
-         TARGET_LINK_OPTIONS(${TARGET} PRIVATE ${export_link_flags})
-      @@ -703,10 +702,6 @@ FUNCTION(ADD_SHARED_LIBRARY TARGET_ARG)
-           ENDIF()
-         ENDIF()
-
-      -  IF(APPLE)
-      -    TARGET_LINK_OPTIONS(${TARGET} PRIVATE LINKER:-no_warn_duplicate_libraries)
-      -  ENDIF()
-      -
-         ADD_OBJDUMP_TARGET(show_${TARGET} "$<TARGET_FILE:${TARGET}>"
-           DEPENDS ${TARGET})
-
-      diff --git a/cmake/mysql_add_executable.cmake b/cmake/mysql_add_executable.cmake
-      index 2a0548b..232e78a 100644
-      --- a/cmake/mysql_add_executable.cmake
-      +++ b/cmake/mysql_add_executable.cmake
-      @@ -212,10 +212,6 @@ FUNCTION(MYSQL_ADD_EXECUTABLE target_arg)
-           MACOS_ADD_DEVELOPER_ENTITLEMENTS(${target})
-         ENDIF()
-
-      -  IF(APPLE)
-      -    TARGET_LINK_OPTIONS(${target} PRIVATE LINKER:-no_warn_duplicate_libraries)
-      -  ENDIF()
-      -
-         IF(WIN32_CLANG AND WITH_ASAN)
-           TARGET_LINK_LIBRARIES(${target}
-             "${ASAN_LIB_DIR}/clang_rt.asan-x86_64.lib"
-      diff --git a/cmake/plugin.cmake b/cmake/plugin.cmake
-      index a7727ef..eac9d74 100644
-      --- a/cmake/plugin.cmake
-      +++ b/cmake/plugin.cmake
-      @@ -327,10 +327,6 @@ MACRO(MYSQL_ADD_PLUGIN plugin_arg)
-             DEPENDS ${target})
-         ENDIF()
-
-      -  IF(BUILD_PLUGIN AND ARG_MODULE_ONLY AND APPLE)
-      -    TARGET_LINK_OPTIONS(${target} PRIVATE LINKER:-no_warn_duplicate_libraries)
-      -  ENDIF()
-      -
-         IF(BUILD_PLUGIN)
-           ADD_DEPENDENCIES(plugin_all ${target})
-           TARGET_COMPILE_FEATURES(${target} PUBLIC cxx_std_20)
-      diff --git a/extra/libcno/CMakeLists.txt b/extra/libcno/CMakeLists.txt
-      index e2513f4..1577bab 100644
-      --- a/extra/libcno/CMakeLists.txt
-      +++ b/extra/libcno/CMakeLists.txt
-      @@ -16,10 +16,6 @@ SET(LIBCNO_GENERATE_DIR "${CMAKE_CURRENT_BINARY_DIR}")
-
-       DISABLE_MISSING_PROFILE_WARNING()
-
-      -IF(APPLE_XCODE)
-      -  STRING_APPEND(CMAKE_C_FLAGS " -Wno-shorten-64-to-32")
-      -ENDIF()
-      -
-       # Following targets were created to mimic behavior of following
-       # files supplied by libcno:
-       #
-      diff --git a/extra/protobuf/protobuf-24.4/cmake/libprotobuf-lite.cmake b/extra/protobuf/protobuf-24.4/cmake/libprotobuf-lite.cmake
-      index f601e7f..b2826db 100644
-      --- a/extra/protobuf/protobuf-24.4/cmake/libprotobuf-lite.cmake
-      +++ b/extra/protobuf/protobuf-24.4/cmake/libprotobuf-lite.cmake
-      @@ -57,11 +57,6 @@ IF(protobuf_BUILD_SHARED_LIBS)
-           RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/library_output_directory
-           )
-
-      -  IF(APPLE)
-      -    TARGET_LINK_OPTIONS(libprotobuf-lite
-      -      PRIVATE LINKER:-no_warn_duplicate_libraries)
-      -  ENDIF()
-      -
-         IF(WIN32)
-           ADD_CUSTOM_COMMAND(TARGET libprotobuf-lite POST_BUILD
-             COMMAND ${CMAKE_COMMAND} -E copy_if_different
-      diff --git a/extra/protobuf/protobuf-24.4/cmake/libprotobuf.cmake b/extra/protobuf/protobuf-24.4/cmake/libprotobuf.cmake
-      index 81428fb..ceb557f 100644
-      --- a/extra/protobuf/protobuf-24.4/cmake/libprotobuf.cmake
-      +++ b/extra/protobuf/protobuf-24.4/cmake/libprotobuf.cmake
-      @@ -61,10 +61,6 @@ IF(protobuf_BUILD_SHARED_LIBS)
-           RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/library_output_directory
-           )
-
-      -  IF(APPLE)
-      -    TARGET_LINK_OPTIONS(libprotobuf PRIVATE LINKER:-no_warn_duplicate_libraries)
-      -  ENDIF()
-      -
-         IF(WIN32)
-           ADD_CUSTOM_COMMAND(TARGET libprotobuf POST_BUILD
-             COMMAND ${CMAKE_COMMAND} -E copy_if_different
-      diff --git a/extra/protobuf/protobuf-24.4/cmake/libprotoc.cmake b/extra/protobuf/protobuf-24.4/cmake/libprotoc.cmake
-      index ef63037..7ba5394 100644
-      --- a/extra/protobuf/protobuf-24.4/cmake/libprotoc.cmake
-      +++ b/extra/protobuf/protobuf-24.4/cmake/libprotoc.cmake
-      @@ -53,9 +53,6 @@ IF(protobuf_BUILD_SHARED_LIBS)
-           DEBUG_POSTFIX ""
-           LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/library_output_directory
-           RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/library_output_directory)
-      -  IF(APPLE)
-      -    TARGET_LINK_OPTIONS(libprotoc PRIVATE LINKER:-no_warn_duplicate_libraries)
-      -  ENDIF()
-         IF(WIN32)
-           ADD_CUSTOM_COMMAND(TARGET libprotoc POST_BUILD
-             COMMAND ${CMAKE_COMMAND} -E copy_if_different
-      diff --git a/extra/protobuf/protobuf-24.4/cmake/protoc.cmake b/extra/protobuf/protobuf-24.4/cmake/protoc.cmake
-      index 215eb21..70f1b60 100644
-      --- a/extra/protobuf/protobuf-24.4/cmake/protoc.cmake
-      +++ b/extra/protobuf/protobuf-24.4/cmake/protoc.cmake
-      @@ -15,10 +15,6 @@ set_target_properties(protoc PROPERTIES
-
-       ################################################################
-
-      -IF(APPLE)
-      -  TARGET_LINK_OPTIONS(protoc PRIVATE LINKER:-no_warn_duplicate_libraries)
-      -ENDIF()
-      -
-       SET_TARGET_PROPERTIES(protoc PROPERTIES
-         RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/runtime_output_directory)
-
-      diff --git a/router/cmake/Plugin.cmake b/router/cmake/Plugin.cmake
-      index ac6b6b2..9b4afc5 100644
-      --- a/router/cmake/Plugin.cmake
-      +++ b/router/cmake/Plugin.cmake
-      @@ -89,9 +89,6 @@ FUNCTION(add_harness_plugin NAME)
-         # .dylib, which we do not want, so we reset it here.
-         ADD_LIBRARY(${NAME} SHARED ${_option_SOURCES})
-         TARGET_COMPILE_FEATURES(${NAME} PUBLIC cxx_std_20)
-      -  IF(APPLE)
-      -    TARGET_LINK_OPTIONS(${NAME} PRIVATE LINKER:-no_warn_duplicate_libraries)
-      -  ENDIF()
-
-         # add plugin to build-all target
-         ADD_DEPENDENCIES(mysqlrouter_all ${NAME})
-    EOF
-
     fails_with :clang do
       cause <<~EOS
         std::string_view is not fully compatible with the libc++ shipped
@@ -245,6 +84,19 @@ class Mysql < Formula
       # When using Homebrew's superenv shims, we need to use HOMEBREW_LIBRARY_PATHS
       # rather than LDFLAGS for libc++ in order to correctly link to LLVM's libc++.
       ENV.prepend_path "HOMEBREW_LIBRARY_PATHS", Formula["llvm"].opt_lib/"c++"
+      # avoid error `ld: unknown option: -no_warn_duplicate_libraries` (see: Bug#37065301 Silence warnings on macOS)
+      cmake_files = %w[
+        cmake/component.cmake
+        cmake/libutils.cmake
+        cmake/mysql_add_executable.cmake
+        cmake/plugin.cmake
+        extra/protobuf/protobuf-*/cmake/libprotobuf-lite.cmake
+        extra/protobuf/protobuf-*/cmake/libprotobuf.cmake
+        extra/protobuf/protobuf-*/cmake/libprotoc.cmake
+        extra/protobuf/protobuf-*/cmake/protoc.cmake
+        router/cmake/Plugin.cmake
+      ].flat_map { |p| buildpath.glob(p) }
+      inreplace cmake_files, /\bTARGET_LINK_OPTIONS *\(.*\bLINKER:-no_warn_duplicate_libraries\)$/i, "#\\0"
     end
 
     icu4c = deps.find { |dep| dep.name.match?(/^icu4c(@\d+)?$/) }

--- a/Formula/m/mysql.rb
+++ b/Formula/m/mysql.rb
@@ -39,6 +39,167 @@ class Mysql < Formula
 
   on_ventura :or_older do
     depends_on "llvm"
+    # back out commit: Bug#37065301 Silence warnings on macOS
+    patch <<~EOF
+      diff --git a/cmake/component.cmake b/cmake/component.cmake
+      index a77fa0f..e476381 100644
+      --- a/cmake/component.cmake
+      +++ b/cmake/component.cmake
+      @@ -98,10 +98,6 @@ MACRO(MYSQL_ADD_COMPONENT component_arg)
+           # For APPLE: adjust path dependecy for SSL shared libraries.
+           SET_PATH_TO_CUSTOM_SSL_FOR_APPLE(${target})
+
+      -    IF(APPLE)
+      -      TARGET_LINK_OPTIONS(${target} PRIVATE LINKER:-no_warn_duplicate_libraries)
+      -    ENDIF()
+      -
+           IF(WIN32_CLANG AND WITH_ASAN)
+             TARGET_LINK_LIBRARIES(${target}
+               "${ASAN_LIB_DIR}/clang_rt.asan_dll_thunk-x86_64.lib")
+      diff --git a/cmake/libutils.cmake b/cmake/libutils.cmake
+      index 69adcdb..661171b 100644
+      --- a/cmake/libutils.cmake
+      +++ b/cmake/libutils.cmake
+      @@ -358,7 +358,6 @@ MACRO(MERGE_LIBRARIES_SHARED TARGET_ARG)
+
+         IF(APPLE)
+           SET_TARGET_PROPERTIES(${TARGET} PROPERTIES MACOSX_RPATH ON)
+      -    TARGET_LINK_OPTIONS(${TARGET} PRIVATE LINKER:-no_warn_duplicate_libraries)
+         ENDIF()
+
+         TARGET_LINK_OPTIONS(${TARGET} PRIVATE ${export_link_flags})
+      @@ -703,10 +702,6 @@ FUNCTION(ADD_SHARED_LIBRARY TARGET_ARG)
+           ENDIF()
+         ENDIF()
+
+      -  IF(APPLE)
+      -    TARGET_LINK_OPTIONS(${TARGET} PRIVATE LINKER:-no_warn_duplicate_libraries)
+      -  ENDIF()
+      -
+         ADD_OBJDUMP_TARGET(show_${TARGET} "$<TARGET_FILE:${TARGET}>"
+           DEPENDS ${TARGET})
+
+      diff --git a/cmake/mysql_add_executable.cmake b/cmake/mysql_add_executable.cmake
+      index 2a0548b..232e78a 100644
+      --- a/cmake/mysql_add_executable.cmake
+      +++ b/cmake/mysql_add_executable.cmake
+      @@ -212,10 +212,6 @@ FUNCTION(MYSQL_ADD_EXECUTABLE target_arg)
+           MACOS_ADD_DEVELOPER_ENTITLEMENTS(${target})
+         ENDIF()
+
+      -  IF(APPLE)
+      -    TARGET_LINK_OPTIONS(${target} PRIVATE LINKER:-no_warn_duplicate_libraries)
+      -  ENDIF()
+      -
+         IF(WIN32_CLANG AND WITH_ASAN)
+           TARGET_LINK_LIBRARIES(${target}
+             "${ASAN_LIB_DIR}/clang_rt.asan-x86_64.lib"
+      diff --git a/cmake/plugin.cmake b/cmake/plugin.cmake
+      index a7727ef..eac9d74 100644
+      --- a/cmake/plugin.cmake
+      +++ b/cmake/plugin.cmake
+      @@ -327,10 +327,6 @@ MACRO(MYSQL_ADD_PLUGIN plugin_arg)
+             DEPENDS ${target})
+         ENDIF()
+
+      -  IF(BUILD_PLUGIN AND ARG_MODULE_ONLY AND APPLE)
+      -    TARGET_LINK_OPTIONS(${target} PRIVATE LINKER:-no_warn_duplicate_libraries)
+      -  ENDIF()
+      -
+         IF(BUILD_PLUGIN)
+           ADD_DEPENDENCIES(plugin_all ${target})
+           TARGET_COMPILE_FEATURES(${target} PUBLIC cxx_std_20)
+      diff --git a/extra/libcno/CMakeLists.txt b/extra/libcno/CMakeLists.txt
+      index e2513f4..1577bab 100644
+      --- a/extra/libcno/CMakeLists.txt
+      +++ b/extra/libcno/CMakeLists.txt
+      @@ -16,10 +16,6 @@ SET(LIBCNO_GENERATE_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+
+       DISABLE_MISSING_PROFILE_WARNING()
+
+      -IF(APPLE_XCODE)
+      -  STRING_APPEND(CMAKE_C_FLAGS " -Wno-shorten-64-to-32")
+      -ENDIF()
+      -
+       # Following targets were created to mimic behavior of following
+       # files supplied by libcno:
+       #
+      diff --git a/extra/protobuf/protobuf-24.4/cmake/libprotobuf-lite.cmake b/extra/protobuf/protobuf-24.4/cmake/libprotobuf-lite.cmake
+      index f601e7f..b2826db 100644
+      --- a/extra/protobuf/protobuf-24.4/cmake/libprotobuf-lite.cmake
+      +++ b/extra/protobuf/protobuf-24.4/cmake/libprotobuf-lite.cmake
+      @@ -57,11 +57,6 @@ IF(protobuf_BUILD_SHARED_LIBS)
+           RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/library_output_directory
+           )
+
+      -  IF(APPLE)
+      -    TARGET_LINK_OPTIONS(libprotobuf-lite
+      -      PRIVATE LINKER:-no_warn_duplicate_libraries)
+      -  ENDIF()
+      -
+         IF(WIN32)
+           ADD_CUSTOM_COMMAND(TARGET libprotobuf-lite POST_BUILD
+             COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      diff --git a/extra/protobuf/protobuf-24.4/cmake/libprotobuf.cmake b/extra/protobuf/protobuf-24.4/cmake/libprotobuf.cmake
+      index 81428fb..ceb557f 100644
+      --- a/extra/protobuf/protobuf-24.4/cmake/libprotobuf.cmake
+      +++ b/extra/protobuf/protobuf-24.4/cmake/libprotobuf.cmake
+      @@ -61,10 +61,6 @@ IF(protobuf_BUILD_SHARED_LIBS)
+           RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/library_output_directory
+           )
+
+      -  IF(APPLE)
+      -    TARGET_LINK_OPTIONS(libprotobuf PRIVATE LINKER:-no_warn_duplicate_libraries)
+      -  ENDIF()
+      -
+         IF(WIN32)
+           ADD_CUSTOM_COMMAND(TARGET libprotobuf POST_BUILD
+             COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      diff --git a/extra/protobuf/protobuf-24.4/cmake/libprotoc.cmake b/extra/protobuf/protobuf-24.4/cmake/libprotoc.cmake
+      index ef63037..7ba5394 100644
+      --- a/extra/protobuf/protobuf-24.4/cmake/libprotoc.cmake
+      +++ b/extra/protobuf/protobuf-24.4/cmake/libprotoc.cmake
+      @@ -53,9 +53,6 @@ IF(protobuf_BUILD_SHARED_LIBS)
+           DEBUG_POSTFIX ""
+           LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/library_output_directory
+           RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/library_output_directory)
+      -  IF(APPLE)
+      -    TARGET_LINK_OPTIONS(libprotoc PRIVATE LINKER:-no_warn_duplicate_libraries)
+      -  ENDIF()
+         IF(WIN32)
+           ADD_CUSTOM_COMMAND(TARGET libprotoc POST_BUILD
+             COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      diff --git a/extra/protobuf/protobuf-24.4/cmake/protoc.cmake b/extra/protobuf/protobuf-24.4/cmake/protoc.cmake
+      index 215eb21..70f1b60 100644
+      --- a/extra/protobuf/protobuf-24.4/cmake/protoc.cmake
+      +++ b/extra/protobuf/protobuf-24.4/cmake/protoc.cmake
+      @@ -15,10 +15,6 @@ set_target_properties(protoc PROPERTIES
+
+       ################################################################
+
+      -IF(APPLE)
+      -  TARGET_LINK_OPTIONS(protoc PRIVATE LINKER:-no_warn_duplicate_libraries)
+      -ENDIF()
+      -
+       SET_TARGET_PROPERTIES(protoc PROPERTIES
+         RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/runtime_output_directory)
+
+      diff --git a/router/cmake/Plugin.cmake b/router/cmake/Plugin.cmake
+      index ac6b6b2..9b4afc5 100644
+      --- a/router/cmake/Plugin.cmake
+      +++ b/router/cmake/Plugin.cmake
+      @@ -89,9 +89,6 @@ FUNCTION(add_harness_plugin NAME)
+         # .dylib, which we do not want, so we reset it here.
+         ADD_LIBRARY(${NAME} SHARED ${_option_SOURCES})
+         TARGET_COMPILE_FEATURES(${NAME} PUBLIC cxx_std_20)
+      -  IF(APPLE)
+      -    TARGET_LINK_OPTIONS(${NAME} PRIVATE LINKER:-no_warn_duplicate_libraries)
+      -  ENDIF()
+
+         # add plugin to build-all target
+         ADD_DEPENDENCIES(mysqlrouter_all ${NAME})
+    EOF
+
     fails_with :clang do
       cause <<~EOS
         std::string_view is not fully compatible with the libc++ shipped

--- a/Formula/m/mysql@8.4.rb
+++ b/Formula/m/mysql@8.4.rb
@@ -40,169 +40,7 @@ class MysqlAT84 < Formula
   uses_from_macos "libedit"
 
   on_macos do
-    if DevelopmentTools.clang_build_version <= 1400
-      depends_on "llvm"
-      # back out commit: Bug#37065301 Silence warnings on macOS
-      patch <<~EOF
-        diff --git a/cmake/component.cmake b/cmake/component.cmake
-        index a77fa0f..e476381 100644
-        --- a/cmake/component.cmake
-        +++ b/cmake/component.cmake
-        @@ -98,10 +98,6 @@ MACRO(MYSQL_ADD_COMPONENT component_arg)
-             # For APPLE: adjust path dependecy for SSL shared libraries.
-             SET_PATH_TO_CUSTOM_SSL_FOR_APPLE(${target})
-
-        -    IF(APPLE)
-        -      TARGET_LINK_OPTIONS(${target} PRIVATE LINKER:-no_warn_duplicate_libraries)
-        -    ENDIF()
-        -
-             IF(WIN32_CLANG AND WITH_ASAN)
-               TARGET_LINK_LIBRARIES(${target}
-                 "${ASAN_LIB_DIR}/clang_rt.asan_dll_thunk-x86_64.lib")
-        diff --git a/cmake/libutils.cmake b/cmake/libutils.cmake
-        index 69adcdb..661171b 100644
-        --- a/cmake/libutils.cmake
-        +++ b/cmake/libutils.cmake
-        @@ -358,7 +358,6 @@ MACRO(MERGE_LIBRARIES_SHARED TARGET_ARG)
-
-           IF(APPLE)
-             SET_TARGET_PROPERTIES(${TARGET} PROPERTIES MACOSX_RPATH ON)
-        -    TARGET_LINK_OPTIONS(${TARGET} PRIVATE LINKER:-no_warn_duplicate_libraries)
-           ENDIF()
-
-           TARGET_LINK_OPTIONS(${TARGET} PRIVATE ${export_link_flags})
-        @@ -703,10 +702,6 @@ FUNCTION(ADD_SHARED_LIBRARY TARGET_ARG)
-             ENDIF()
-           ENDIF()
-
-        -  IF(APPLE)
-        -    TARGET_LINK_OPTIONS(${TARGET} PRIVATE LINKER:-no_warn_duplicate_libraries)
-        -  ENDIF()
-        -
-           ADD_OBJDUMP_TARGET(show_${TARGET} "$<TARGET_FILE:${TARGET}>"
-             DEPENDS ${TARGET})
-
-        diff --git a/cmake/mysql_add_executable.cmake b/cmake/mysql_add_executable.cmake
-        index 2a0548b..232e78a 100644
-        --- a/cmake/mysql_add_executable.cmake
-        +++ b/cmake/mysql_add_executable.cmake
-        @@ -212,10 +212,6 @@ FUNCTION(MYSQL_ADD_EXECUTABLE target_arg)
-             MACOS_ADD_DEVELOPER_ENTITLEMENTS(${target})
-           ENDIF()
-
-        -  IF(APPLE)
-        -    TARGET_LINK_OPTIONS(${target} PRIVATE LINKER:-no_warn_duplicate_libraries)
-        -  ENDIF()
-        -
-           IF(WIN32_CLANG AND WITH_ASAN)
-             TARGET_LINK_LIBRARIES(${target}
-               "${ASAN_LIB_DIR}/clang_rt.asan-x86_64.lib"
-        diff --git a/cmake/plugin.cmake b/cmake/plugin.cmake
-        index a7727ef..eac9d74 100644
-        --- a/cmake/plugin.cmake
-        +++ b/cmake/plugin.cmake
-        @@ -327,10 +327,6 @@ MACRO(MYSQL_ADD_PLUGIN plugin_arg)
-               DEPENDS ${target})
-           ENDIF()
-
-        -  IF(BUILD_PLUGIN AND ARG_MODULE_ONLY AND APPLE)
-        -    TARGET_LINK_OPTIONS(${target} PRIVATE LINKER:-no_warn_duplicate_libraries)
-        -  ENDIF()
-        -
-           IF(BUILD_PLUGIN)
-             ADD_DEPENDENCIES(plugin_all ${target})
-             TARGET_COMPILE_FEATURES(${target} PUBLIC cxx_std_20)
-        diff --git a/extra/libcno/CMakeLists.txt b/extra/libcno/CMakeLists.txt
-        index e2513f4..1577bab 100644
-        --- a/extra/libcno/CMakeLists.txt
-        +++ b/extra/libcno/CMakeLists.txt
-        @@ -16,10 +16,6 @@ SET(LIBCNO_GENERATE_DIR "${CMAKE_CURRENT_BINARY_DIR}")
-
-         DISABLE_MISSING_PROFILE_WARNING()
-
-        -IF(APPLE_XCODE)
-        -  STRING_APPEND(CMAKE_C_FLAGS " -Wno-shorten-64-to-32")
-        -ENDIF()
-        -
-         # Following targets were created to mimic behavior of following
-         # files supplied by libcno:
-         #
-        diff --git a/extra/protobuf/protobuf-24.4/cmake/libprotobuf-lite.cmake b/extra/protobuf/protobuf-24.4/cmake/libprotobuf-lite.cmake
-        index f601e7f..b2826db 100644
-        --- a/extra/protobuf/protobuf-24.4/cmake/libprotobuf-lite.cmake
-        +++ b/extra/protobuf/protobuf-24.4/cmake/libprotobuf-lite.cmake
-        @@ -57,11 +57,6 @@ IF(protobuf_BUILD_SHARED_LIBS)
-             RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/library_output_directory
-             )
-
-        -  IF(APPLE)
-        -    TARGET_LINK_OPTIONS(libprotobuf-lite
-        -      PRIVATE LINKER:-no_warn_duplicate_libraries)
-        -  ENDIF()
-        -
-           IF(WIN32)
-             ADD_CUSTOM_COMMAND(TARGET libprotobuf-lite POST_BUILD
-               COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        diff --git a/extra/protobuf/protobuf-24.4/cmake/libprotobuf.cmake b/extra/protobuf/protobuf-24.4/cmake/libprotobuf.cmake
-        index 81428fb..ceb557f 100644
-        --- a/extra/protobuf/protobuf-24.4/cmake/libprotobuf.cmake
-        +++ b/extra/protobuf/protobuf-24.4/cmake/libprotobuf.cmake
-        @@ -61,10 +61,6 @@ IF(protobuf_BUILD_SHARED_LIBS)
-             RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/library_output_directory
-             )
-
-        -  IF(APPLE)
-        -    TARGET_LINK_OPTIONS(libprotobuf PRIVATE LINKER:-no_warn_duplicate_libraries)
-        -  ENDIF()
-        -
-           IF(WIN32)
-             ADD_CUSTOM_COMMAND(TARGET libprotobuf POST_BUILD
-               COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        diff --git a/extra/protobuf/protobuf-24.4/cmake/libprotoc.cmake b/extra/protobuf/protobuf-24.4/cmake/libprotoc.cmake
-        index ef63037..7ba5394 100644
-        --- a/extra/protobuf/protobuf-24.4/cmake/libprotoc.cmake
-        +++ b/extra/protobuf/protobuf-24.4/cmake/libprotoc.cmake
-        @@ -53,9 +53,6 @@ IF(protobuf_BUILD_SHARED_LIBS)
-             DEBUG_POSTFIX ""
-             LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/library_output_directory
-             RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/library_output_directory)
-        -  IF(APPLE)
-        -    TARGET_LINK_OPTIONS(libprotoc PRIVATE LINKER:-no_warn_duplicate_libraries)
-        -  ENDIF()
-           IF(WIN32)
-             ADD_CUSTOM_COMMAND(TARGET libprotoc POST_BUILD
-               COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        diff --git a/extra/protobuf/protobuf-24.4/cmake/protoc.cmake b/extra/protobuf/protobuf-24.4/cmake/protoc.cmake
-        index 215eb21..70f1b60 100644
-        --- a/extra/protobuf/protobuf-24.4/cmake/protoc.cmake
-        +++ b/extra/protobuf/protobuf-24.4/cmake/protoc.cmake
-        @@ -15,10 +15,6 @@ set_target_properties(protoc PROPERTIES
-
-         ################################################################
-
-        -IF(APPLE)
-        -  TARGET_LINK_OPTIONS(protoc PRIVATE LINKER:-no_warn_duplicate_libraries)
-        -ENDIF()
-        -
-         SET_TARGET_PROPERTIES(protoc PROPERTIES
-           RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/runtime_output_directory)
-
-        diff --git a/router/cmake/Plugin.cmake b/router/cmake/Plugin.cmake
-        index ac6b6b2..9b4afc5 100644
-        --- a/router/cmake/Plugin.cmake
-        +++ b/router/cmake/Plugin.cmake
-        @@ -89,9 +89,6 @@ FUNCTION(add_harness_plugin NAME)
-           # .dylib, which we do not want, so we reset it here.
-           ADD_LIBRARY(${NAME} SHARED ${_option_SOURCES})
-           TARGET_COMPILE_FEATURES(${NAME} PUBLIC cxx_std_20)
-        -  IF(APPLE)
-        -    TARGET_LINK_OPTIONS(${NAME} PRIVATE LINKER:-no_warn_duplicate_libraries)
-        -  ENDIF()
-
-           # add plugin to build-all target
-           ADD_DEPENDENCIES(mysqlrouter_all ${NAME})
-      EOF
-    end
+    depends_on "llvm" if DevelopmentTools.clang_build_version <= 1400
   end
 
   on_linux do
@@ -246,6 +84,19 @@ class MysqlAT84 < Formula
       #   "std::exception_ptr::__from_native_exception_pointer(void*)", referenced from:
       #       std::exception_ptr std::make_exception_ptr[abi:ne180100]<std::runtime_error>(std::runtime_error) ...
       ENV.prepend_path "HOMEBREW_LIBRARY_PATHS", Formula["llvm"].opt_lib/"c++"
+      # avoid error `ld: unknown option: -no_warn_duplicate_libraries` (see: Bug#37065301 Silence warnings on macOS)
+      cmake_files = %w[
+        cmake/component.cmake
+        cmake/libutils.cmake
+        cmake/mysql_add_executable.cmake
+        cmake/plugin.cmake
+        extra/protobuf/protobuf-*/cmake/libprotobuf-lite.cmake
+        extra/protobuf/protobuf-*/cmake/libprotobuf.cmake
+        extra/protobuf/protobuf-*/cmake/libprotoc.cmake
+        extra/protobuf/protobuf-*/cmake/protoc.cmake
+        router/cmake/Plugin.cmake
+      ].flat_map { |p| buildpath.glob(p) }
+      inreplace cmake_files, /\bTARGET_LINK_OPTIONS *\(.*\bLINKER:-no_warn_duplicate_libraries\)$/i, "#\\0"
     end
 
     icu4c = deps.find { |dep| dep.name.match?(/^icu4c(@\d+)?$/) }

--- a/Formula/m/mysql@8.4.rb
+++ b/Formula/m/mysql@8.4.rb
@@ -40,7 +40,169 @@ class MysqlAT84 < Formula
   uses_from_macos "libedit"
 
   on_macos do
-    depends_on "llvm" if DevelopmentTools.clang_build_version <= 1400
+    if DevelopmentTools.clang_build_version <= 1400
+      depends_on "llvm"
+      # back out commit: Bug#37065301 Silence warnings on macOS
+      patch <<~EOF
+        diff --git a/cmake/component.cmake b/cmake/component.cmake
+        index a77fa0f..e476381 100644
+        --- a/cmake/component.cmake
+        +++ b/cmake/component.cmake
+        @@ -98,10 +98,6 @@ MACRO(MYSQL_ADD_COMPONENT component_arg)
+             # For APPLE: adjust path dependecy for SSL shared libraries.
+             SET_PATH_TO_CUSTOM_SSL_FOR_APPLE(${target})
+
+        -    IF(APPLE)
+        -      TARGET_LINK_OPTIONS(${target} PRIVATE LINKER:-no_warn_duplicate_libraries)
+        -    ENDIF()
+        -
+             IF(WIN32_CLANG AND WITH_ASAN)
+               TARGET_LINK_LIBRARIES(${target}
+                 "${ASAN_LIB_DIR}/clang_rt.asan_dll_thunk-x86_64.lib")
+        diff --git a/cmake/libutils.cmake b/cmake/libutils.cmake
+        index 69adcdb..661171b 100644
+        --- a/cmake/libutils.cmake
+        +++ b/cmake/libutils.cmake
+        @@ -358,7 +358,6 @@ MACRO(MERGE_LIBRARIES_SHARED TARGET_ARG)
+
+           IF(APPLE)
+             SET_TARGET_PROPERTIES(${TARGET} PROPERTIES MACOSX_RPATH ON)
+        -    TARGET_LINK_OPTIONS(${TARGET} PRIVATE LINKER:-no_warn_duplicate_libraries)
+           ENDIF()
+
+           TARGET_LINK_OPTIONS(${TARGET} PRIVATE ${export_link_flags})
+        @@ -703,10 +702,6 @@ FUNCTION(ADD_SHARED_LIBRARY TARGET_ARG)
+             ENDIF()
+           ENDIF()
+
+        -  IF(APPLE)
+        -    TARGET_LINK_OPTIONS(${TARGET} PRIVATE LINKER:-no_warn_duplicate_libraries)
+        -  ENDIF()
+        -
+           ADD_OBJDUMP_TARGET(show_${TARGET} "$<TARGET_FILE:${TARGET}>"
+             DEPENDS ${TARGET})
+
+        diff --git a/cmake/mysql_add_executable.cmake b/cmake/mysql_add_executable.cmake
+        index 2a0548b..232e78a 100644
+        --- a/cmake/mysql_add_executable.cmake
+        +++ b/cmake/mysql_add_executable.cmake
+        @@ -212,10 +212,6 @@ FUNCTION(MYSQL_ADD_EXECUTABLE target_arg)
+             MACOS_ADD_DEVELOPER_ENTITLEMENTS(${target})
+           ENDIF()
+
+        -  IF(APPLE)
+        -    TARGET_LINK_OPTIONS(${target} PRIVATE LINKER:-no_warn_duplicate_libraries)
+        -  ENDIF()
+        -
+           IF(WIN32_CLANG AND WITH_ASAN)
+             TARGET_LINK_LIBRARIES(${target}
+               "${ASAN_LIB_DIR}/clang_rt.asan-x86_64.lib"
+        diff --git a/cmake/plugin.cmake b/cmake/plugin.cmake
+        index a7727ef..eac9d74 100644
+        --- a/cmake/plugin.cmake
+        +++ b/cmake/plugin.cmake
+        @@ -327,10 +327,6 @@ MACRO(MYSQL_ADD_PLUGIN plugin_arg)
+               DEPENDS ${target})
+           ENDIF()
+
+        -  IF(BUILD_PLUGIN AND ARG_MODULE_ONLY AND APPLE)
+        -    TARGET_LINK_OPTIONS(${target} PRIVATE LINKER:-no_warn_duplicate_libraries)
+        -  ENDIF()
+        -
+           IF(BUILD_PLUGIN)
+             ADD_DEPENDENCIES(plugin_all ${target})
+             TARGET_COMPILE_FEATURES(${target} PUBLIC cxx_std_20)
+        diff --git a/extra/libcno/CMakeLists.txt b/extra/libcno/CMakeLists.txt
+        index e2513f4..1577bab 100644
+        --- a/extra/libcno/CMakeLists.txt
+        +++ b/extra/libcno/CMakeLists.txt
+        @@ -16,10 +16,6 @@ SET(LIBCNO_GENERATE_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+
+         DISABLE_MISSING_PROFILE_WARNING()
+
+        -IF(APPLE_XCODE)
+        -  STRING_APPEND(CMAKE_C_FLAGS " -Wno-shorten-64-to-32")
+        -ENDIF()
+        -
+         # Following targets were created to mimic behavior of following
+         # files supplied by libcno:
+         #
+        diff --git a/extra/protobuf/protobuf-24.4/cmake/libprotobuf-lite.cmake b/extra/protobuf/protobuf-24.4/cmake/libprotobuf-lite.cmake
+        index f601e7f..b2826db 100644
+        --- a/extra/protobuf/protobuf-24.4/cmake/libprotobuf-lite.cmake
+        +++ b/extra/protobuf/protobuf-24.4/cmake/libprotobuf-lite.cmake
+        @@ -57,11 +57,6 @@ IF(protobuf_BUILD_SHARED_LIBS)
+             RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/library_output_directory
+             )
+
+        -  IF(APPLE)
+        -    TARGET_LINK_OPTIONS(libprotobuf-lite
+        -      PRIVATE LINKER:-no_warn_duplicate_libraries)
+        -  ENDIF()
+        -
+           IF(WIN32)
+             ADD_CUSTOM_COMMAND(TARGET libprotobuf-lite POST_BUILD
+               COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        diff --git a/extra/protobuf/protobuf-24.4/cmake/libprotobuf.cmake b/extra/protobuf/protobuf-24.4/cmake/libprotobuf.cmake
+        index 81428fb..ceb557f 100644
+        --- a/extra/protobuf/protobuf-24.4/cmake/libprotobuf.cmake
+        +++ b/extra/protobuf/protobuf-24.4/cmake/libprotobuf.cmake
+        @@ -61,10 +61,6 @@ IF(protobuf_BUILD_SHARED_LIBS)
+             RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/library_output_directory
+             )
+
+        -  IF(APPLE)
+        -    TARGET_LINK_OPTIONS(libprotobuf PRIVATE LINKER:-no_warn_duplicate_libraries)
+        -  ENDIF()
+        -
+           IF(WIN32)
+             ADD_CUSTOM_COMMAND(TARGET libprotobuf POST_BUILD
+               COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        diff --git a/extra/protobuf/protobuf-24.4/cmake/libprotoc.cmake b/extra/protobuf/protobuf-24.4/cmake/libprotoc.cmake
+        index ef63037..7ba5394 100644
+        --- a/extra/protobuf/protobuf-24.4/cmake/libprotoc.cmake
+        +++ b/extra/protobuf/protobuf-24.4/cmake/libprotoc.cmake
+        @@ -53,9 +53,6 @@ IF(protobuf_BUILD_SHARED_LIBS)
+             DEBUG_POSTFIX ""
+             LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/library_output_directory
+             RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/library_output_directory)
+        -  IF(APPLE)
+        -    TARGET_LINK_OPTIONS(libprotoc PRIVATE LINKER:-no_warn_duplicate_libraries)
+        -  ENDIF()
+           IF(WIN32)
+             ADD_CUSTOM_COMMAND(TARGET libprotoc POST_BUILD
+               COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        diff --git a/extra/protobuf/protobuf-24.4/cmake/protoc.cmake b/extra/protobuf/protobuf-24.4/cmake/protoc.cmake
+        index 215eb21..70f1b60 100644
+        --- a/extra/protobuf/protobuf-24.4/cmake/protoc.cmake
+        +++ b/extra/protobuf/protobuf-24.4/cmake/protoc.cmake
+        @@ -15,10 +15,6 @@ set_target_properties(protoc PROPERTIES
+
+         ################################################################
+
+        -IF(APPLE)
+        -  TARGET_LINK_OPTIONS(protoc PRIVATE LINKER:-no_warn_duplicate_libraries)
+        -ENDIF()
+        -
+         SET_TARGET_PROPERTIES(protoc PROPERTIES
+           RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/runtime_output_directory)
+
+        diff --git a/router/cmake/Plugin.cmake b/router/cmake/Plugin.cmake
+        index ac6b6b2..9b4afc5 100644
+        --- a/router/cmake/Plugin.cmake
+        +++ b/router/cmake/Plugin.cmake
+        @@ -89,9 +89,6 @@ FUNCTION(add_harness_plugin NAME)
+           # .dylib, which we do not want, so we reset it here.
+           ADD_LIBRARY(${NAME} SHARED ${_option_SOURCES})
+           TARGET_COMPILE_FEATURES(${NAME} PUBLIC cxx_std_20)
+        -  IF(APPLE)
+        -    TARGET_LINK_OPTIONS(${NAME} PRIVATE LINKER:-no_warn_duplicate_libraries)
+        -  ENDIF()
+
+           # add plugin to build-all target
+           ADD_DEPENDENCIES(mysqlrouter_all ${NAME})
+      EOF
+    end
   end
 
   on_linux do

--- a/Formula/m/mysql@8.4.rb
+++ b/Formula/m/mysql@8.4.rb
@@ -96,7 +96,12 @@ class MysqlAT84 < Formula
         extra/protobuf/protobuf-*/cmake/protoc.cmake
         router/cmake/Plugin.cmake
       ].flat_map { |p| buildpath.glob(p) }
-      inreplace cmake_files, /\bTARGET_LINK_OPTIONS *\(.*\bLINKER:-no_warn_duplicate_libraries\)$/i, "#\\0"
+      inreplace cmake_files do |s|
+        s.gsub!(
+          /\b(TARGET_LINK_OPTIONS\s*)(\(\s*)([^\s]+\s+)([^\s]+\s+)(LINKER:-no_warn_duplicate_libraries\s*)(\)\s*)$/im,
+          '#\1#\2#\3#\4#\5#\6',
+        )
+      end
     end
 
     icu4c = deps.find { |dep| dep.name.match?(/^icu4c(@\d+)?$/) }


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
