### PR TITLE
xfig: disable internationalization on macOS

### DIFF
--- a/Formula/x/xfig.rb
+++ b/Formula/x/xfig.rb
@@ -50,9 +50,19 @@ class Xfig < Formula
                           "--disable-silent-rules",
                           *std_configure_args
     system "make", "install-strip"
+
+    if OS.mac?
+      (etc/"X11/app-defaults/Fig").append_lines <<~X11_DEFAULTS
+        ! Disable internationalization to stop segfaults
+        ! https://github.com/Homebrew/homebrew-core/issues/221146
+        ! https://sourceforge.net/p/mcj/tickets/177/#7c23
+        Fig.international: False
+      X11_DEFAULTS
+    end
   end
 
   test do
     assert_equal "Xfig #{version}", shell_output("#{bin}/xfig -V 2>&1").strip
+    assert_equal "Error: Can't open display:", shell_output("DISPLAY= #{bin}/xfig 2>&1", 1).strip
   end
 end

--- a/Formula/x/xfig.rb
+++ b/Formula/x/xfig.rb
@@ -11,13 +11,14 @@ class Xfig < Formula
   end
 
   bottle do
-    sha256 arm64_sequoia: "15314f47823b47202f5589b9392d3f7240efd9be0550edf3a7708f918f7e11a7"
-    sha256 arm64_sonoma:  "d7bfff29e140007a73340cb17675c39f525904647202c08e9905856c90ed24eb"
-    sha256 arm64_ventura: "e851f86fd326aed56aa0fbef6f266764bc6670ec2fdaa1ba24634babe165898f"
-    sha256 sonoma:        "5465a1183061357a7a8a3a7455488fd8df9182efab574fe6812f256ad881087e"
-    sha256 ventura:       "b8f02cb2ff2cc65c1c64ce3400e7e1ad5fa7e48b4ab09fece650ec6013bc11b8"
-    sha256 arm64_linux:   "be0b497e85f794800724bc4158ea53eff2795d4784fb5e50f135b1ea73459f07"
-    sha256 x86_64_linux:  "421fbe1c1fffddf7545aa6e360430958758b4b2b211f80653ec8854660b864ca"
+    rebuild 1
+    sha256 arm64_sequoia: "161b47e43d5412e6277eff6ba8f2884e0a345c238db8ed1601ece4501f05ee5c"
+    sha256 arm64_sonoma:  "a8acd5f5d17d4bbef98332d6ece0de046b023c8485a1ce713bc183f10110db5e"
+    sha256 arm64_ventura: "e5ae9151e1f3e865317d32e0355445922d46e080e60d583b65df77591322b54b"
+    sha256 sonoma:        "9ed33c2acaeb19e8826d4e82057ffccd949e7de53334d924b3005a02b50baf78"
+    sha256 ventura:       "1cfeb80f07bbdd495c33c152b606f352e2785c421b50ba0816470ae99cc7676a"
+    sha256 arm64_linux:   "ffa26e011fab5d5d529bab92892b47c4911b9126bf1a0d8f7f62de152e6d7c56"
+    sha256 x86_64_linux:  "f4faa9ef548b215a82a5098c94bfcb09ad1acd51eebfa0539818f1a5fd20a112"
   end
 
   depends_on "fig2dev"


### PR DESCRIPTION
Fixes #221146. Also add the standard "run X11 app with no display" test.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
