### PR TITLE
neko: fix caveats for Ruby 3.4

### DIFF
--- a/Formula/n/neko.rb
+++ b/Formula/n/neko.rb
@@ -53,14 +53,12 @@ class Neko < Formula
   end
 
   def caveats
-    s = ""
     if HOMEBREW_PREFIX.to_s != "/usr/local"
-      s << <<~EOS
+      <<~EOS
         You must add the following line to your .bashrc or equivalent:
           export NEKOPATH="#{HOMEBREW_PREFIX}/lib/neko"
       EOS
     end
-    s
   end
 
   test do


### PR DESCRIPTION
Fixes warning with `brew generate-formula-api`:
> /opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/n/neko.rb:58: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)