### PR TITLE
ipv6utils 1.0 (new formula)

### DIFF
--- a/Formula/i/ipv6utils.rb
+++ b/Formula/i/ipv6utils.rb
@@ -1,0 +1,19 @@
+class Ipv6utils < Formula
+  desc "A toolset for IPv6 utilities"
+  homepage "https://github.com/buraglio/ipv6utils"
+  url "https://github.com/buraglio/ipv6utils/archive/refs/tags/v2.tar.gz"
+  sha256 "088f46de98b3f8e906c8f06ca44b17ce10de4da412664f48e5ceacc87667a6b6"  
+  depends_on "go"  #  Ensures Go is installed to build the project
+
+  def install
+    # Build the Go project
+    system "go", "build", "-o", bin/"ipv6utils"
+
+   
+  end
+
+  test do
+    # A simple test to verify the install
+    system "#{bin}/ipv6utils", "-h"
+  end
+end


### PR DESCRIPTION
Create a homebrew install for ipv6utils


This update adds a formula for the ipv6utils tool, a suite of useful translation and subnetting tools for IPv6. 

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
