### PR TITLE
guichan 0.8.3 (new formula)

### DIFF
--- a/Formula/g/guichan.rb
+++ b/Formula/g/guichan.rb
@@ -1,0 +1,42 @@
+class Guichan < Formula
+  desc "Small, efficient C++ GUI library designed for games"
+  homepage "https://github.com/darkbitsorg/guichan"
+  url "https://github.com/darkbitsorg/guichan/releases/download/v0.8.3/guichan-0.8.3.tar.gz"
+  sha256 "2f3b265d1b243e30af9d87e918c71da6c67947978dcaa82a93cb838dbf93529b"
+  license "BSD-3-Clause"
+
+  on_linux do
+    depends_on "mesa"
+    depends_on "mesa-glu"
+  end
+
+  def install
+    system "./configure", *std_configure_args
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"helloworld.cpp").write <<~EOS
+      #include <guichan.hpp>
+
+      int main(int argc, char **argv)
+      {
+          gcn::Gui gui;
+          gcn::Container container;
+          gui.setTop(&container);
+
+          gui.logic();
+
+          return 0;
+      }
+    EOS
+
+    flags = [
+      "-L#{lib}", "-lguichan"
+    ]
+    flags << (OS.mac? ? "-lc++" : "-lstdc++")
+    system ENV.cxx, "helloworld.cpp", ENV.cppflags,
+                   *flags, "-o", "helloworld"
+    system "./helloworld"
+  end
+end

--- a/Formula/g/guichan.rb
+++ b/Formula/g/guichan.rb
@@ -5,6 +5,15 @@ class Guichan < Formula
   sha256 "2f3b265d1b243e30af9d87e918c71da6c67947978dcaa82a93cb838dbf93529b"
   license "BSD-3-Clause"
 
+  bottle do
+    sha256 cellar: :any,                 arm64_sequoia: "a0d1e15669f361e19d404bdbb8b311443da4c4a775fdcb1d8d17a4fe03034e5f"
+    sha256 cellar: :any,                 arm64_sonoma:  "b9f1f1aba6da5d653df4d082c3048724e14d221ef5fa9f3c1368413b5e703fcf"
+    sha256 cellar: :any,                 arm64_ventura: "6b923b087914799d905e9fc2676231bc115dc5dca4dbc446e72fc7cabb943f21"
+    sha256 cellar: :any,                 sonoma:        "642fc80010772295bbc9c393340137b0afaf4f51f3df6079a46103701ddde137"
+    sha256 cellar: :any,                 ventura:       "8d8a76daa74d299ef906b105b25c98b62b5fbb3f6a7efa37ba7af5bba316f916"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "41d93c438a1966464eb85c1bc4f9d9743e9015502a06d90105e2f5b438c2df56"
+  end
+
   on_linux do
     depends_on "mesa"
     depends_on "mesa-glu"


### PR DESCRIPTION
This re-introduces the previously deprecated, disabled and removed formula for Guichan and updates it to the new official location and recent 0.8.3 release.

It also removes the dependencies on `sdl_image`. The Guichan core library is generic and still useful to games not based on SDL 1. The test was replaced with an example using Guichan without any of its extension libraries.

This reverts commit 9045538339885234729d50324c5dc6036cfc568f (#194698). "guichan: remove formula"

This reverts commit 54732ff7981bbf6e2b055370967cc5027eabefee (#151272). "guichan: disable"

This reverts commit b3b42951b6368306b9e9748581000f1aeaa1f3a2 (#122334). "guichan: deprecate"

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
