### PR TITLE
slumber: update checksum (slumber 3.1.1)

### DIFF
--- a/Formula/s/slumber.rb
+++ b/Formula/s/slumber.rb
@@ -2,7 +2,7 @@ class Slumber < Formula
   desc "Terminal-based HTTP/REST client"
   homepage "https://slumber.lucaspickering.me/"
   url "https://github.com/LucasPickering/slumber/archive/refs/tags/v3.1.1.tar.gz"
-  sha256 "9d3a7ef79c04175ce6b69cfe5b4b5aac761aee41e0d9fd5cbbad5a038f059092"
+  sha256 "b7e6bdaae2ba181d5cb213cd1b8bb6e5e1341728bd26e74ca4b692537d4a7ead"
   license "MIT"
   head "https://github.com/LucasPickering/slumber.git", branch: "master"
 

--- a/Formula/s/slumber.rb
+++ b/Formula/s/slumber.rb
@@ -7,13 +7,14 @@ class Slumber < Formula
   head "https://github.com/LucasPickering/slumber.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "4acf5df08883a77829743182e5993f3a20a1b5505158f7f15424a8697b335494"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "ebd1dde7678cd9b91a58eb84a3f5dd64d152599f98aa480f9df08966472336ca"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "489a5a74c72d3d8c0f35cbc343a5820a7c1962c4cdd4235b9c3b782ffe2cf92c"
-    sha256 cellar: :any_skip_relocation, sonoma:        "78fd4463d86642b1a382048983b272a2d4f699bb881631b70e27d294d75db0e6"
-    sha256 cellar: :any_skip_relocation, ventura:       "90cbc3f21ec6f05b7c03a2af4ad7f965abc5ac4fea5eb71b4d73204d069322ca"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "50072a67d65a4c07716263c000de4d066ae0db8b3b117840ce5c9b7bcf364e38"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "00d4dedeca58b7d0d97eb518513ac5fc98d73dd916ed5f14e696eef01c1ac6e2"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "ad7bc8e3e46c086a4c93d814795f928cb0418ad45f55b0c4e1ca4214f5846cb3"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "e1e060c547138ec5e31af522468cd29436bea9cfde5d8e5c15204fa49f279046"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "768f586f80d8ab02c5bf47e936c137c858603a4db27ce80ee639c97bee96fa86"
+    sha256 cellar: :any_skip_relocation, sonoma:        "0ef040f0e33616c051a6f7d19981829beb1747f4a55fb992157bebe3272076fc"
+    sha256 cellar: :any_skip_relocation, ventura:       "6f44f9edc62c191099861448a54b88272fa186af63f5b69970dafbf57633a030"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "27721677aa58690109c4a1987c1b4307d4bc664562c76532e4591b40ffcbc7e5"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a4872dd735264feecacf8bc029d273dc2776987613d9b672478b2521d1581f48"
   end
 
   depends_on "rust" => :build


### PR DESCRIPTION
update checksum (3.1.1 got re-tagged multiple times)

<img width="1430" alt="image" src="https://github.com/user-attachments/assets/35584f0f-86ab-442c-b9ed-7196a083d3bc" />

relates to https://github.com/Homebrew/homebrew-core/pull/223613