### PR TITLE
vipsdisp: add livecheck block

### DIFF
--- a/Formula/v/vipsdisp.rb
+++ b/Formula/v/vipsdisp.rb
@@ -5,6 +5,11 @@ class Vipsdisp < Formula
   sha256 "5c40e71c9c60232dcbf2e1c389295a4a102a27603bce994dbb2e35ff4f1844db"
   license "MIT"
 
+  livecheck do
+    url :stable
+    strategy :github_releases
+  end
+
   bottle do
     sha256 cellar: :any, arm64_sequoia: "c730d171fb0ff997048081609c182e91de7c462764255972070153d3f3957fcd"
     sha256 cellar: :any, arm64_sonoma:  "77e6eabacad3268d0fbbf4642b5a9860b7811d79b76223b4ea4a64b671d04191"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`brew livecheck` detects 3.1.1 as the latest version, despite it not being a release