### PR TITLE
cloudflared: add build UUID

### DIFF
--- a/Formula/c/cloudflared.rb
+++ b/Formula/c/cloudflared.rb
@@ -18,11 +18,17 @@ class Cloudflared < Formula
   depends_on "go" => :build
 
   def install
+    # https://github.com/cloudflare/cloudflared/issues/1460
+    # build with newer Go version to pick up the backported "-B gobuildid" flag
+    inreplace ".teamcity/install-cloudflare-go.sh",
+      "af19da5605ca11f85776ef7af3384a02a315a52b",
+      "37bc41c6ff79507200a315b72834fce6ca427a7e"
     system "make", "install",
       "VERSION=#{version}",
       "DATE=#{time.iso8601}",
       "PACKAGE_MANAGER=#{tap.user}",
-      "PREFIX=#{prefix}"
+      "PREFIX=#{prefix}",
+      "LDFLAGS=-ldflags='-B gobuildid -X \"main.Version=#{version}\" -X \"main.BuildTime=#{time.iso8601}\" -X \"github.com/cloudflare/cloudflared/cmd/cloudflared/updater.BuiltForPackageManager=#{tap.user}\"'"
   end
 
   service do


### PR DESCRIPTION
Recent macOS versions require user permissions to access the local network. This can only be granted for binaries which have a `LC_UUID` load command. Go 1.24 adds the UUID by default, but the fix was backported to Go 1.22.9 and 1.23 where it requires passing `-B gobuildid` to the linker.

`cloudflared` uses Cloudflare's Go fork which is based on Go 1.22.5 and doesn't have the backport. Because of this, `cloudflared` can't talk to any machine on the local network (`no route to host`) when it's runnning as a non-root user.

Upstream bug: https://github.com/cloudflare/cloudflared/issues/1460

This workaround updates the Go fork to `go1.22.12-devel-cf` and adds `-B gobuildid` so that the binary now has a UUID:

```
❯ dwarfdump --uuid /opt/homebrew/bin/cloudflared
UUID: F2088E17-03A1-34B1-F12C-0DF01F00BA32 (arm64) /opt/homebrew/bin/cloudflared
```

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
