### PR TITLE
syslog-ng: add livecheck

### DIFF
--- a/Formula/s/syslog-ng.rb
+++ b/Formula/s/syslog-ng.rb
@@ -9,6 +9,11 @@ class SyslogNg < Formula
   revision 12
   head "https://github.com/syslog-ng/syslog-ng.git", branch: "master"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     sha256 arm64_sequoia: "bb698ed0b7dcf3e503c7a955d94b70e1efc80ee89dcecd2ed7be418d9a9c18dd"
     sha256 arm64_sonoma:  "d3a9688396c9be181b83dfd04f09dad7c745a13d312ce5a9c6127987b627f4ff"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `syslog-ng` but it's incorrectly returning 2018 as the newest version (from a `gsoc-2018` tag) instead of 4.8.3. This addresses the issue by adding a `livecheck` block that uses the `GithubLatest` strategy, as the `stable` tarball is a GitHub release asset.

For what it's worth, there's a 4.8.3 update but it produced a segmentation fault when I built/tested it locally, so that's better left to a separate PR.