### PR TITLE
typeshare: add livecheck

### DIFF
--- a/Formula/t/typeshare.rb
+++ b/Formula/t/typeshare.rb
@@ -6,6 +6,11 @@ class Typeshare < Formula
   license any_of: ["Apache-2.0", "MIT"]
   head "https://github.com/1Password/typeshare.git", branch: "main"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "d04400d66c5bcbcd1babe6a500563294a0f6e5b79100be34d0b0465db7e43bae"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "8a6691da6e2e6761fb371fda9b4a50e68c8e362673c7fd5d2664f23d40ec88cd"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `typeshare` but it is incorrectly returning 29883 as the latest version (from an `unprotected_ci_automation_test/lucretiel/29883` tag) instead of 1.13.2. This addresses the issue by adding a `livecheck` block that uses the standard regex for Git tags like `1.2.3`/`v1.2.3`.