### PR TITLE
postgis pgrouting: add support for postgresql@15 and postgresql@16

### DIFF
--- a/Formula/p/pgrouting.rb
+++ b/Formula/p/pgrouting.rb
@@ -23,6 +23,8 @@ class Pgrouting < Formula
   depends_on "boost" => :build
   depends_on "cmake" => :build
   depends_on "postgresql@14" => [:build, :test]
+  depends_on "postgresql@15" => [:build, :test]
+  depends_on "postgresql@16" => [:build, :test]
   depends_on "postgresql@17" => [:build, :test]
   depends_on "postgis"
 

--- a/Formula/p/postgis.rb
+++ b/Formula/p/postgis.rb
@@ -29,6 +29,8 @@ class Postgis < Formula
 
   depends_on "pkgconf" => :build
   depends_on "postgresql@14" => [:build, :test]
+  depends_on "postgresql@15" => [:build, :test]
+  depends_on "postgresql@16" => [:build, :test]
   depends_on "postgresql@17" => [:build, :test]
 
   depends_on "gdal"

--- a/Formula/p/postgresql@15.rb
+++ b/Formula/p/postgresql@15.rb
@@ -54,21 +54,27 @@ class PostgresqlAT15 < Formula
   end
 
   def install
+    # Modify Makefile to link macOS binaries using Cellar path. Otherwise, binaries are linked
+    # using #{HOMEBREW_PREFIX}/lib path set during ./configure, which will cause audit failures
+    # for broken linkage as the paths are not created until post-install step.
+    inreplace "src/Makefile.shlib", "-install_name '$(libdir)/", "-install_name '#{lib}/postgresql/"
+
+    ENV["XML_CATALOG_FILES"] = etc/"xml/catalog"
     ENV.runtime_cpu_detection
     ENV.delete "PKG_CONFIG_LIBDIR"
     ENV.prepend "LDFLAGS", "-L#{Formula["openssl@3"].opt_lib} -L#{Formula["readline"].opt_lib}"
     ENV.prepend "CPPFLAGS", "-I#{Formula["openssl@3"].opt_include} -I#{Formula["readline"].opt_include}"
 
     # Fix 'libintl.h' file not found for extensions
+    # Update config to fix `error: could not find function 'gss_store_cred_into' required for GSSAPI`
     if OS.mac?
-      ENV.prepend "LDFLAGS", "-L#{Formula["gettext"].opt_lib}"
-      ENV.prepend "CPPFLAGS", "-I#{Formula["gettext"].opt_include}"
+      ENV.prepend "LDFLAGS", "-L#{Formula["gettext"].opt_lib} -L#{Formula["krb5"].opt_lib}"
+      ENV.prepend "CPPFLAGS", "-I#{Formula["gettext"].opt_include} -I#{Formula["krb5"].opt_include}"
     end
 
-    args = std_configure_args + %W[
-      --datadir=#{opt_pkgshare}
-      --libdir=#{opt_lib}
-      --includedir=#{opt_include}
+    args = %W[
+      --datadir=#{HOMEBREW_PREFIX}/share/#{name}
+      --includedir=#{HOMEBREW_PREFIX}/include/#{name}
       --sysconfdir=#{etc}
       --docdir=#{doc}
       --enable-nls
@@ -84,32 +90,30 @@ class PostgresqlAT15 < Formula
       --with-pam
       --with-perl
       --with-uuid=e2fs
-      --with-extra-version=\ (#{tap.user})
     ]
+    args << "--with-extra-version= (#{tap.user})" if tap
     args += %w[--with-bonjour --with-tcl] if OS.mac?
 
     # PostgreSQL by default uses xcodebuild internally to determine this,
     # which does not work on CLT-only installs.
     args << "PG_SYSROOT=#{MacOS.sdk_path}" if OS.mac? && MacOS.sdk_root_needed?
 
-    system "./configure", *args
+    system "./configure", *args, *std_configure_args(libdir: HOMEBREW_PREFIX/"lib/#{name}")
+    system "make"
+    # We use an unversioned `postgresql` subdirectory rather than `#{name}` so that the
+    # post-installed symlinks can use non-conflicting `#{name}` and be retained on `brew unlink`.
+    # Removing symlinks may break PostgreSQL as its binaries expect paths from ./configure step.
+    system "make", "install-world", "datadir=#{share}/postgresql",
+                                    "libdir=#{lib}/postgresql",
+                                    "includedir=#{include}/postgresql"
 
-    # Work around busted path magic in Makefile.global.in. This can't be specified
-    # in ./configure, but needs to be set here otherwise install prefixes containing
-    # the string "postgres" will get an incorrect pkglibdir.
-    # See https://github.com/Homebrew/homebrew-core/issues/62930#issuecomment-709411789
-    system "make", "pkglibdir=#{opt_lib}/postgresql",
-                   "pkgincludedir=#{opt_include}/postgresql",
-                   "includedir_server=#{opt_include}/postgresql/server"
-    system "make", "install-world", "datadir=#{pkgshare}",
-                                    "libdir=#{lib}",
-                                    "pkglibdir=#{lib}/postgresql",
-                                    "includedir=#{include}",
-                                    "pkgincludedir=#{include}/postgresql",
-                                    "includedir_server=#{include}/postgresql/server",
-                                    "includedir_internal=#{include}/postgresql/internal"
+    # Modify the Makefile back so dependents pick up common path
+    makefile = lib/"postgresql/pgxs/src/Makefile.shlib"
+    inreplace makefile, "-install_name '#{lib}/postgresql/", "-install_name '$(libdir)/"
+
     return unless OS.linux?
 
+    # Remove Homebrew shims references from Linux specific Makefile.global
     inreplace lib/"postgresql/pgxs/src/Makefile.global",
               "LD = #{Superenv.shims_path}/ld",
               "LD = #{HOMEBREW_PREFIX}/bin/ld"
@@ -118,6 +122,29 @@ class PostgresqlAT15 < Formula
   def post_install
     (var/"log").mkpath
     postgresql_datadir.mkpath
+
+    # Manually link files from keg to non-conflicting versioned directories in HOMEBREW_PREFIX.
+    %w[include lib share].each do |dir|
+      dst_dir = HOMEBREW_PREFIX/dir/name
+      src_dir = prefix/dir/"postgresql"
+      src_dir.find do |src|
+        dst = dst_dir/src.relative_path_from(src_dir)
+
+        # Retain existing real directories for extensions if directory structure matches
+        next if dst.directory? && !dst.symlink? && src.directory? && !src.symlink?
+
+        rm_r(dst) if dst.exist? || dst.symlink?
+        if src.symlink? || src.file?
+          Find.prune if src.basename.to_s == ".DS_Store"
+          dst.parent.install_symlink src
+        elsif src.directory?
+          dst.mkpath
+        end
+      end
+    end
+
+    # Also link versioned executables
+    bin.each_child { |f| (HOMEBREW_PREFIX/"bin").install_symlink f => "#{f.basename}-#{version.major}" }
 
     # Don't initialize database, it clashes when testing other PostgreSQL versions.
     return if ENV["HOMEBREW_GITHUB_ACTIONS"]
@@ -141,6 +168,9 @@ class PostgresqlAT15 < Formula
     <<~EOS
       This formula has created a default database cluster with:
         initdb --locale=C -E UTF-8 #{postgresql_datadir}
+
+      When uninstalling, some dead symlinks are left behind so you may want to run:
+        brew cleanup --prune-prefix
     EOS
   end
 
@@ -155,11 +185,13 @@ class PostgresqlAT15 < Formula
 
   test do
     system bin/"initdb", testpath/"test" unless ENV["HOMEBREW_GITHUB_ACTIONS"]
-    assert_equal opt_pkgshare.to_s, shell_output("#{bin}/pg_config --sharedir").chomp
-    assert_equal opt_lib.to_s, shell_output("#{bin}/pg_config --libdir").chomp
-    assert_equal (opt_lib/"postgresql").to_s, shell_output("#{bin}/pg_config --pkglibdir").chomp
-    assert_equal (opt_include/"postgresql").to_s, shell_output("#{bin}/pg_config --pkgincludedir").chomp
-    assert_equal (opt_include/"postgresql/server").to_s, shell_output("#{bin}/pg_config --includedir-server").chomp
-    assert_match "-I#{Formula["gettext"].opt_include}", shell_output("#{bin}/pg_config --cppflags") if OS.mac?
+    [bin/"pg_config", HOMEBREW_PREFIX/"bin/pg_config-#{version.major}"].each do |pg_config|
+      assert_equal "#{HOMEBREW_PREFIX}/share/#{name}", shell_output("#{pg_config} --sharedir").chomp
+      assert_equal "#{HOMEBREW_PREFIX}/lib/#{name}", shell_output("#{pg_config} --libdir").chomp
+      assert_equal "#{HOMEBREW_PREFIX}/lib/#{name}", shell_output("#{pg_config} --pkglibdir").chomp
+      assert_equal "#{HOMEBREW_PREFIX}/include/#{name}", shell_output("#{pg_config} --pkgincludedir").chomp
+      assert_equal "#{HOMEBREW_PREFIX}/include/#{name}/server", shell_output("#{pg_config} --includedir-server").chomp
+      assert_match "-I#{Formula["gettext"].opt_include}", shell_output("#{pg_config} --cppflags") if OS.mac?
+    end
   end
 end

--- a/Formula/p/postgresql@16.rb
+++ b/Formula/p/postgresql@16.rb
@@ -54,6 +54,12 @@ class PostgresqlAT16 < Formula
   end
 
   def install
+    # Modify Makefile to link macOS binaries using Cellar path. Otherwise, binaries are linked
+    # using #{HOMEBREW_PREFIX}/lib path set during ./configure, which will cause audit failures
+    # for broken linkage as the paths are not created until post-install step.
+    inreplace "src/Makefile.shlib", "-install_name '$(libdir)/", "-install_name '#{lib}/postgresql/"
+
+    ENV["XML_CATALOG_FILES"] = etc/"xml/catalog"
     ENV.runtime_cpu_detection
     ENV.delete "PKG_CONFIG_LIBDIR"
     ENV.prepend "LDFLAGS", "-L#{Formula["openssl@3"].opt_lib} -L#{Formula["readline"].opt_lib}"
@@ -67,8 +73,8 @@ class PostgresqlAT16 < Formula
     end
 
     args = %W[
-      --datadir=#{opt_pkgshare}
-      --includedir=#{opt_include}
+      --datadir=#{HOMEBREW_PREFIX}/share/#{name}
+      --includedir=#{HOMEBREW_PREFIX}/include/#{name}
       --sysconfdir=#{etc}
       --docdir=#{doc}
       --enable-nls
@@ -92,27 +98,46 @@ class PostgresqlAT16 < Formula
     # which does not work on CLT-only installs.
     args << "PG_SYSROOT=#{MacOS.sdk_path}" if OS.mac? && MacOS.sdk_root_needed?
 
-    system "./configure", *args, *std_configure_args(libdir: opt_lib)
+    system "./configure", *args, *std_configure_args(libdir: HOMEBREW_PREFIX/"lib/#{name}")
+    system "make"
+    # We use an unversioned `postgresql` subdirectory rather than `#{name}` so that the
+    # post-installed symlinks can use non-conflicting `#{name}` and be retained on `brew unlink`.
+    # Removing symlinks may break PostgreSQL as its binaries expect paths from ./configure step.
+    system "make", "install-world", "datadir=#{share}/postgresql",
+                                    "libdir=#{lib}/postgresql",
+                                    "includedir=#{include}/postgresql"
 
-    # Work around busted path magic in Makefile.global.in. This can't be specified
-    # in ./configure, but needs to be set here otherwise install prefixes containing
-    # the string "postgres" will get an incorrect pkglibdir.
-    # See https://github.com/Homebrew/homebrew-core/issues/62930#issuecomment-709411789
-    system "make", "pkglibdir=#{opt_lib}/postgresql",
-                   "pkgincludedir=#{opt_include}/postgresql",
-                   "includedir_server=#{opt_include}/postgresql/server"
-    system "make", "install-world", "datadir=#{pkgshare}",
-                                    "libdir=#{lib}",
-                                    "pkglibdir=#{lib}/postgresql",
-                                    "includedir=#{include}",
-                                    "pkgincludedir=#{include}/postgresql",
-                                    "includedir_server=#{include}/postgresql/server",
-                                    "includedir_internal=#{include}/postgresql/internal"
+    # Modify the Makefile back so dependents pick up common path
+    makefile = lib/"postgresql/pgxs/src/Makefile.shlib"
+    inreplace makefile, "-install_name '#{lib}/postgresql/", "-install_name '$(libdir)/"
   end
 
   def post_install
     (var/"log").mkpath
     postgresql_datadir.mkpath
+
+    # Manually link files from keg to non-conflicting versioned directories in HOMEBREW_PREFIX.
+    %w[include lib share].each do |dir|
+      dst_dir = HOMEBREW_PREFIX/dir/name
+      src_dir = prefix/dir/"postgresql"
+      src_dir.find do |src|
+        dst = dst_dir/src.relative_path_from(src_dir)
+
+        # Retain existing real directories for extensions if directory structure matches
+        next if dst.directory? && !dst.symlink? && src.directory? && !src.symlink?
+
+        rm_r(dst) if dst.exist? || dst.symlink?
+        if src.symlink? || src.file?
+          Find.prune if src.basename.to_s == ".DS_Store"
+          dst.parent.install_symlink src
+        elsif src.directory?
+          dst.mkpath
+        end
+      end
+    end
+
+    # Also link versioned executables
+    bin.each_child { |f| (HOMEBREW_PREFIX/"bin").install_symlink f => "#{f.basename}-#{version.major}" }
 
     # Don't initialize database, it clashes when testing other PostgreSQL versions.
     return if ENV["HOMEBREW_GITHUB_ACTIONS"]
@@ -136,6 +161,9 @@ class PostgresqlAT16 < Formula
     <<~EOS
       This formula has created a default database cluster with:
         initdb --locale=C -E UTF-8 #{postgresql_datadir}
+
+      When uninstalling, some dead symlinks are left behind so you may want to run:
+        brew cleanup --prune-prefix
     EOS
   end
 
@@ -150,11 +178,13 @@ class PostgresqlAT16 < Formula
 
   test do
     system bin/"initdb", testpath/"test" unless ENV["HOMEBREW_GITHUB_ACTIONS"]
-    assert_equal opt_pkgshare.to_s, shell_output("#{bin}/pg_config --sharedir").chomp
-    assert_equal opt_lib.to_s, shell_output("#{bin}/pg_config --libdir").chomp
-    assert_equal (opt_lib/"postgresql").to_s, shell_output("#{bin}/pg_config --pkglibdir").chomp
-    assert_equal (opt_include/"postgresql").to_s, shell_output("#{bin}/pg_config --pkgincludedir").chomp
-    assert_equal (opt_include/"postgresql/server").to_s, shell_output("#{bin}/pg_config --includedir-server").chomp
-    assert_match "-I#{Formula["gettext"].opt_include}", shell_output("#{bin}/pg_config --cppflags") if OS.mac?
+    [bin/"pg_config", HOMEBREW_PREFIX/"bin/pg_config-#{version.major}"].each do |pg_config|
+      assert_equal "#{HOMEBREW_PREFIX}/share/#{name}", shell_output("#{pg_config} --sharedir").chomp
+      assert_equal "#{HOMEBREW_PREFIX}/lib/#{name}", shell_output("#{pg_config} --libdir").chomp
+      assert_equal "#{HOMEBREW_PREFIX}/lib/#{name}", shell_output("#{pg_config} --pkglibdir").chomp
+      assert_equal "#{HOMEBREW_PREFIX}/include/#{name}", shell_output("#{pg_config} --pkgincludedir").chomp
+      assert_equal "#{HOMEBREW_PREFIX}/include/#{name}/server", shell_output("#{pg_config} --includedir-server").chomp
+      assert_match "-I#{Formula["gettext"].opt_include}", shell_output("#{pg_config} --cppflags") if OS.mac?
+    end
   end
 end


### PR DESCRIPTION
@SMillerDev and @cho-m 

This should add postgresql@15 and postgrsql@16 support for pgrouting and postgis, if I understand the formulaes correctly.

Extended the provided functionality of https://github.com/Homebrew/homebrew-core/pull/192064