### PR TITLE
wsl2-ssh-agent 0.9.6 (new formula)

### DIFF
--- a/Formula/w/wsl2-ssh-agent.rb
+++ b/Formula/w/wsl2-ssh-agent.rb
@@ -1,0 +1,21 @@
+class Wsl2SshAgent < Formula
+  desc "Bridge from WSL2 ssh client to Windows ssh-agent.exe service"
+  homepage "https://github.com/mame/wsl2-ssh-agent"
+  url "https://github.com/mame/wsl2-ssh-agent/archive/refs/tags/v0.9.6.tar.gz"
+  sha256 "f8aa881bd477e9f12ed487dc325a79b50732b835c7d421fff80177f6ff9ade48"
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args(ldflags: "-s -w")
+  end
+
+  test do
+    run_output = shell_output("#{bin}/wsl2-ssh-agent -socket /var/tmp/.wsl2-ssh-agent.sock 2>&1")
+    assert_match "set -x SSH_AUTH_SOCK /var/tmp/.wsl2-ssh-agent.sock\n", run_output
+
+    version_output = shell_output("#{bin}/wsl2-ssh-agent -version 2>&1")
+    assert_match "wsl2-ssh-agent (development version)", version_output
+  end
+end


### PR DESCRIPTION
[wsl2-ssh-agent](https://github.com/mame/wsl2-ssh-agent) is a tool to use the Windows hosts SSH agent from WSL2.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
