### PR TITLE
tenv: Add terramate binary

### DIFF
--- a/Formula/t/tenv.rb
+++ b/Formula/t/tenv.rb
@@ -1,5 +1,5 @@
 class Tenv < Formula
-  desc "OpenTofu / Terraform / Terragrunt / Atmos version manager"
+  desc "OpenTofu / Terraform / Terragrunt / Terramate / Atmos version manager"
   homepage "https://tofuutils.github.io/tenv/"
   url "https://github.com/tofuutils/tenv/archive/refs/tags/v4.6.2.tar.gz"
   sha256 "f3ebd348301163509d23c0cb6963c6f69bc9b942c54188c09605cd63f08475a0"
@@ -33,7 +33,7 @@ class Tenv < Formula
   def install
     ENV["CGO_ENABLED"] = "0"
     ldflags = "-s -w -X main.version=#{version}"
-    %w[tenv terraform terragrunt tf tofu atmos].each do |f|
+    %w[tenv terraform terragrunt terramate tf tofu atmos].each do |f|
       system "go", "build", *std_go_args(ldflags:, output: bin/f), "./cmd/#{f}"
     end
     generate_completions_from_executable(bin/"tenv", "completion")

--- a/Formula/t/tenv.rb
+++ b/Formula/t/tenv.rb
@@ -12,13 +12,14 @@ class Tenv < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "3e6ce7e9bad09e8bd50992c95b5f8d35ac5b28e8700fee5ac514fa3d779ee9b5"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "3e6ce7e9bad09e8bd50992c95b5f8d35ac5b28e8700fee5ac514fa3d779ee9b5"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "3e6ce7e9bad09e8bd50992c95b5f8d35ac5b28e8700fee5ac514fa3d779ee9b5"
-    sha256 cellar: :any_skip_relocation, sonoma:        "5b1b9b245f934dffae30508c0379a5c2bd32af1178a490b1dedd3dcd1c3920a3"
-    sha256 cellar: :any_skip_relocation, ventura:       "5b1b9b245f934dffae30508c0379a5c2bd32af1178a490b1dedd3dcd1c3920a3"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "9bb14dcad2a77055f27f37602e94053a2778063390e7343321543059c08c936b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "24a700c655d9d5e746c6b3aa2a7f6919e1125a35a937ed091d77e0ce82f3d487"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "4979db9217a1754ec4a42a5242a7ad8548d47eef60885551c50de8c5c7a2851b"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "4979db9217a1754ec4a42a5242a7ad8548d47eef60885551c50de8c5c7a2851b"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "4979db9217a1754ec4a42a5242a7ad8548d47eef60885551c50de8c5c7a2851b"
+    sha256 cellar: :any_skip_relocation, sonoma:        "5bf32d9d7e7083c7aaa6f765f5b5209af8920720ee9d4970300a0cf719cf36ac"
+    sha256 cellar: :any_skip_relocation, ventura:       "5bf32d9d7e7083c7aaa6f765f5b5209af8920720ee9d4970300a0cf719cf36ac"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "119d4999e5653c0fb3908518b44ff310498fc8846e783a6a003735feecbaf490"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "fc81e559643d113da84a932b8ec3788541bbe5474586cadef2b08ba670d95217"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
Terramate support was added in tenv v4.6.2. The binary was missing from the build.

To resolve build and install the terramate binary.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
