### PR TITLE
jenv: update homepage

### DIFF
--- a/Formula/j/jenv.rb
+++ b/Formula/j/jenv.rb
@@ -1,6 +1,6 @@
 class Jenv < Formula
   desc "Manage your Java environment"
-  homepage "https://www.jenv.be/"
+  homepage "https://github.com/jenv/jenv"
   url "https://github.com/jenv/jenv/archive/refs/tags/0.5.7.tar.gz"
   sha256 "5865f7839eda303467fb1ad3dfb606b31566001beeb05360f653905346c2624f"
   license "MIT"


### PR DESCRIPTION
Original homepage (https://www.jenv.be/) [has been down](https://github.com/jenv/jenv/issues/448) for a few weeks now.