### PR TITLE
libgit2: update homepage

### DIFF
--- a/Formula/lib/libgit2.rb
+++ b/Formula/lib/libgit2.rb
@@ -1,6 +1,6 @@
 class Libgit2 < Formula
   desc "C library of Git core methods that is re-entrant and linkable"
-  homepage "https://libgit2.github.com/"
+  homepage "https://libgit2.org/"
   url "https://github.com/libgit2/libgit2/archive/refs/tags/v1.9.0.tar.gz"
   sha256 "75b27d4d6df44bd34e2f70663cfd998f5ec41e680e1e593238bbe517a84c7ed2"
   license "GPL-2.0-only" => { with: "GCC-exception-2.0" }


### PR DESCRIPTION
Now has its own domain name at [libgit2.org](https://libgit2.org).