### PR TITLE
fd: Add missing Powershell completions to install path

### DIFF
--- a/Formula/f/fd.rb
+++ b/Formula/f/fd.rb
@@ -24,7 +24,7 @@ class Fd < Formula
   def install
     system "cargo", "install", *std_cargo_args
 
-    generate_completions_from_executable(bin/"fd", "--gen-completions", shells: [:bash, :fish])
+    generate_completions_from_executable(bin/"fd", "--gen-completions", shells: [:bash, :fish, :pwsh])
     zsh_completion.install "contrib/completion/_fd"
     man1.install "doc/fd.1"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This adds `fd.ps1` to `#{prefix}/share/pwsh/completions`, as it was not added to the formula initially, and was first added to the package in sharkdp/fd@4e7b403

For an example of a build output that proves `fd.ps1` is included in the macOS aarch64 release builds, see https://github.com/sharkdp/fd/actions/runs/15128752111/job/42525598460

Unfortunately, I am not too sure how one is supposed to rename `fd.ps1` to `_fd.ps1` when using `generate_completions_from_executable`, if someone else is able to fix that I would greatly appreciate it.

---

Please see the following for an example of where this private API is already used for the same reason: https://github.com/Homebrew/homebrew-core/blob/e1992a944aaa9d1450be3184d8e7e20e080bc75b/Formula/r/rip2.rb
