### PR TITLE
lima 1.1.1 lima-additional-guestagents 1.1.1 (new formula) 

### DIFF
--- a/Formula/l/lima-additional-guestagents.rb
+++ b/Formula/l/lima-additional-guestagents.rb
@@ -1,0 +1,29 @@
+class LimaAdditionalGuestagents < Formula
+  desc "Additional guest agents for Lima"
+  homepage "https://lima-vm.io/"
+  url "https://github.com/lima-vm/lima/archive/refs/tags/v1.1.1.tar.gz"
+  sha256 "82577e2223dc0ba06ea5aac539ab836e1724cdd0440d800e47c8b7d0f23d7de5"
+  license "Apache-2.0"
+  head "https://github.com/lima-vm/lima.git", branch: "master"
+
+  depends_on "go" => :build
+  depends_on "lima"
+  depends_on "qemu"
+
+  def install
+    if build.head?
+      system "make", "additional-guestagents"
+    else
+      # VERSION has to be explicitly specified when building from tar.gz, as it does not contain git tags
+      system "make", "additional-guestagents", "VERSION=#{version}"
+    end
+
+    bin.install Dir["_output/bin/*"]
+    share.install Dir["_output/share/*"]
+  end
+
+  test do
+    info = JSON.parse shell_output("limactl info")
+    assert_includes info["guestAgents"], "riscv64"
+  end
+end

--- a/Formula/l/lima-additional-guestagents.rb
+++ b/Formula/l/lima-additional-guestagents.rb
@@ -6,6 +6,16 @@ class LimaAdditionalGuestagents < Formula
   license "Apache-2.0"
   head "https://github.com/lima-vm/lima.git", branch: "master"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "8e21b3e7d70b997b1dd6e7d996d903edffb6055339a1b6c15911f5282efd1cea"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "fd6d9cda49a969422b199c4f40f8e30a1fc5d725a03ae4004c694dfcd3826076"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "90316c2e8fd2027a848b40fe642b3d81acb20b87c8b169920c4b223ecb515d1a"
+    sha256 cellar: :any_skip_relocation, sonoma:        "de1807b8111dd71f1eb779fbad785beecef840216c9506ccdf9923f62980b61c"
+    sha256 cellar: :any_skip_relocation, ventura:       "f8ff74c221f986226128c968eb2b1fe73c3ed16a86215d09ebaf44520a5ad0ba"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "c029ca0dc5d56d6606c1c53b81493ae3cec81d09205f9469538a6bef8843023e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "bb471e21416e4c445e30e96209e965677ebc99fbc9809baad2e6be3dbb5f939c"
+  end
+
   depends_on "go" => :build
   depends_on "lima"
   depends_on "qemu"

--- a/Formula/l/lima.rb
+++ b/Formula/l/lima.rb
@@ -1,8 +1,8 @@
 class Lima < Formula
   desc "Linux virtual machines"
   homepage "https://lima-vm.io/"
-  url "https://github.com/lima-vm/lima/archive/refs/tags/v1.0.7.tar.gz"
-  sha256 "90f682e96a370c342c3b16deb1858f37ee28ce88e888e1d6b2634ba24228fdbb"
+  url "https://github.com/lima-vm/lima/archive/refs/tags/v1.1.1.tar.gz"
+  sha256 "82577e2223dc0ba06ea5aac539ab836e1724cdd0440d800e47c8b7d0f23d7de5"
   license "Apache-2.0"
   head "https://github.com/lima-vm/lima.git", branch: "master"
 
@@ -23,11 +23,14 @@ class Lima < Formula
   end
 
   def install
+    # make (default):              build everything
+    # make native:                 build core + native guest agent
+    # make additional-guestagents: build non-native guest agents
     if build.head?
-      system "make"
+      system "make", "native"
     else
       # VERSION has to be explicitly specified when building from tar.gz, as it does not contain git tags
-      system "make", "VERSION=#{version}"
+      system "make", "native", "VERSION=#{version}"
     end
 
     bin.install Dir["_output/bin/*"]
@@ -35,6 +38,14 @@ class Lima < Formula
 
     # Install shell completions
     generate_completions_from_executable(bin/"limactl", "completion")
+  end
+
+  def caveats
+    # since lima 1.1
+    <<~EOS
+      The guest agents for non-native architectures are now provided in a separate formula:
+        brew install lima-additional-guestagents
+    EOS
   end
 
   test do

--- a/Formula/l/lima.rb
+++ b/Formula/l/lima.rb
@@ -7,13 +7,13 @@ class Lima < Formula
   head "https://github.com/lima-vm/lima.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "7a99cf98dbfdbd0b3ad62f4d84640c5cfcef5242cbaa4b8d043c1d12c41809b0"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "fd766f555146d659f9841554a8270e704156b48ae3502c584b0e1f4af076688a"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "69ef12a79d1a2057073cdb7e659d6f903fc02cb816f49c856e032df853b549fa"
-    sha256 cellar: :any_skip_relocation, sonoma:        "bfabc4017b8412a0d6d69445c2a398a387af58c5b5c232542d07689d00e1c345"
-    sha256 cellar: :any_skip_relocation, ventura:       "2f04d37e54c94d413434f5e0ac74f52d7c2714df72f12198e86545b7aa71310d"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "b6385e14aa7c7b095f780d3143121353dd63383cac97f050e0b45e86ea7975ba"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "7dee156f0206d0ddb735d4da04a1eeade34799dd9b5e37db32da404a14fb49cf"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "9cd1a319ae657c32218da384ab05a8de1af594b5b298687ab5f0082a4bae570f"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "ef3da306aebcec4125f01376855bc422e629375914866217206f4b84cb05f17c"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "ae4f6f583bcfac4cd65d0a5a435f029fcad07c912001b34b69c4b86989f8a1a0"
+    sha256 cellar: :any_skip_relocation, sonoma:        "c45416f1811568ee8800d55440e281a223b06bdc43783eddf361d118213b4b4c"
+    sha256 cellar: :any_skip_relocation, ventura:       "f41f7371692a2d18cb3068fb49d63e00c26a24cd7d99458eab6678d972bccbdd"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "3e81a7100ebccbd85fda8c6de1908cb8930cd5c51443532c167b90b4325f09af"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f62f734e16c2d4bbe15acb813acffba55c25fa1e378d4c3763c7c184470fcd50"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
The formula is now split to two to save the disk space:
- lima
- lima-additional-guestagents

The latter one is needed only for running a VM with a non-native architecture (e.g., Intel on ARM).

See also the release note:
https://github.com/lima-vm/lima/releases/tag/v1.1.0
https://github.com/lima-vm/lima/releases/tag/v1.1.1

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
