### PR TITLE
asdf: add missing runtime dependency for version 0.17.0

### DIFF
--- a/Formula/a/asdf.rb
+++ b/Formula/a/asdf.rb
@@ -22,6 +22,7 @@ class Asdf < Formula
   end
 
   depends_on "go" => :build
+  depends_on "git"
 
   def install
     # fix https://github.com/asdf-vm/asdf/issues/1992

--- a/Formula/a/asdf.rb
+++ b/Formula/a/asdf.rb
@@ -12,13 +12,14 @@ class Asdf < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "0b4c0eec0a8be0893c7c2b2a85bcbefe34c2c704d80ea6a48f9169bdf8ebbb0e"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "0b4c0eec0a8be0893c7c2b2a85bcbefe34c2c704d80ea6a48f9169bdf8ebbb0e"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "0b4c0eec0a8be0893c7c2b2a85bcbefe34c2c704d80ea6a48f9169bdf8ebbb0e"
-    sha256 cellar: :any_skip_relocation, sonoma:        "e1b390d15fb975f467d2bfda6dcb6fcf94889ff7d3d7c331427de145aedbb0f8"
-    sha256 cellar: :any_skip_relocation, ventura:       "e1b390d15fb975f467d2bfda6dcb6fcf94889ff7d3d7c331427de145aedbb0f8"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "2454e692672cb020223dfd8319403a8e7a4be44560ed18399150eef92aec682b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b47178c6ef8fa25491ef83de6ba7d6bda76343d714b6b5ba321c98c8bda7a91e"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "1fd57ba8ec2e1b39ed8d34efb08c794c7f0ea05e6e352e2ab7a8b974ee82b644"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "1fd57ba8ec2e1b39ed8d34efb08c794c7f0ea05e6e352e2ab7a8b974ee82b644"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "1fd57ba8ec2e1b39ed8d34efb08c794c7f0ea05e6e352e2ab7a8b974ee82b644"
+    sha256 cellar: :any_skip_relocation, sonoma:        "59d0ac671690b617c0711a827af5e8b09ca0a102ee1aac5452b80e865e8c679e"
+    sha256 cellar: :any_skip_relocation, ventura:       "59d0ac671690b617c0711a827af5e8b09ca0a102ee1aac5452b80e865e8c679e"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "cb61474dd1cdf6aa17db4b0c28ecf5e5e969634f26b8a9f91a3cb8fddc1ad1b9"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "9661381baaa99124e46746a0181b5b808db58b66bb9d6c25be76f934f104b38b"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
Git is once again a runtime dependency of asdf due to switching from the go-git library back to the `git` CLI client.

See https://github.com/asdf-vm/asdf/pull/1998

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
