### PR TITLE
agda: bump cubical dependency to 0.8

### DIFF
--- a/Formula/a/agda.rb
+++ b/Formula/a/agda.rb
@@ -4,7 +4,7 @@ class Agda < Formula
   # agda2hs.cabal specifies BSD-3-Clause but it installs an MIT LICENSE file.
   # Everything else specifies MIT license and installs corresponding file.
   license all_of: ["MIT", "BSD-3-Clause"]
-  revision 1
+  revision 2
 
   stable do
     url "https://github.com/agda/agda/archive/refs/tags/v2.7.0.1.tar.gz"
@@ -22,14 +22,8 @@ class Agda < Formula
     end
 
     resource "cubical" do
-      url "https://github.com/agda/cubical/archive/refs/tags/v0.7.tar.gz"
-      sha256 "25a0d1a0a01ba81888a74dfe864883547dbc1b06fa89ac842db13796b7389641"
-
-      # Bump Agda compat
-      patch do
-        url "https://github.com/agda/cubical/commit/6220641fc7c297a84c5e2c49614fae518cf6307d.patch?full_index=1"
-        sha256 "c6919e394ac9dc6efa016fa6b4e9163ce58142d48f7100b6bc354678fc982986"
-      end
+      url "https://github.com/agda/cubical/archive/refs/tags/v0.8.tar.gz"
+      sha256 "27b22f2ed981d608f3cbf5d132e9016510c859435b5ce46adc3b76078c136275"
     end
 
     resource "categories" do
@@ -140,7 +134,9 @@ class Agda < Formula
     # so generated interface files work on basic use case. Options like -Werror
     # will need re-generation: https://github.com/agda/agda/issues/5151
     system "make", "-C", agdalib, "listings", "AGDA_OPTIONS="
-    system "make", "-C", cubicallib, "gen-everythings", "listings", "AGDA_FLAGS="
+    # We need to force order between these next two lines, so they can't be combined.
+    system "make", "-C", cubicallib, "gen-everythings", "AGDA_FLAGS="
+    system "make", "-C", cubicallib, "listings", "AGDA_FLAGS="
     system "make", "-C", categorieslib, "html", "OTHEROPTS="
 
     # Clean up references to Homebrew shims and temporary generated files

--- a/Formula/a/agda.rb
+++ b/Formula/a/agda.rb
@@ -53,13 +53,13 @@ class Agda < Formula
   end
 
   bottle do
-    sha256 arm64_sequoia: "490a11d0bbcbd3f24f5f93b9bb3e3ddafd5eb12f146102947f694f7beef4f265"
-    sha256 arm64_sonoma:  "82eeeadbf9509eb0aa895ae08816a0e44360be3d37446bfb7d43e9314d81e9fc"
-    sha256 arm64_ventura: "36482626ec686b45ccbdd4b3687a9712b9e6536289aa9ca837800ef7c412a94f"
-    sha256 sonoma:        "4fc274813a4bd8253be86441068fe9d9839ec63f9b0e2054353363924c93afda"
-    sha256 ventura:       "a308ed26bc07c352ddc0dcaca281fe4071394dafe727634df199dbce741b9df9"
-    sha256 arm64_linux:   "71576e2ceb209a3c7ffeb5d81893b0cd6467ce31a1fa3f72fec9541701d5058b"
-    sha256 x86_64_linux:  "5f40483798d6b0f2bee203693b81ff5c500c1bd8ebf93386e0fb2ca6bee803d4"
+    sha256 arm64_sequoia: "6ccb91547fa1089a51f5509ae6adfcf32a9221dfcc6bc0a7c280c1b251311f2a"
+    sha256 arm64_sonoma:  "427d2fb8a22bc5929eadb1e855e02b24658b3cda05645dc03fc02ee10f1ecee4"
+    sha256 arm64_ventura: "9ab79232aae4d1781b046d4a620faade6047ab1a1512d55fe3fc01ee201951e4"
+    sha256 sonoma:        "7249da70860667e11c32532966eb455be22832e87efb318f753b2282f74fee50"
+    sha256 ventura:       "9ecfc864ab875692abf9f83092938261c5596f456fa86efafa296025c752f11c"
+    sha256 arm64_linux:   "d172a07287def95bfc0245f351a1ef52bc9b7f16b36dfcada31fddc77673c414"
+    sha256 x86_64_linux:  "0383a41e66f1487ea96b3d616d54e1fd9c6890be1aa4965be3365429b9d49ba0"
   end
 
   head do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
