### PR TITLE
apache-flink-cdc: add iceberg connector resources

### DIFF
--- a/Formula/a/apache-flink-cdc.rb
+++ b/Formula/a/apache-flink-cdc.rb
@@ -5,6 +5,7 @@ class ApacheFlinkCdc < Formula
   mirror "https://archive.apache.org/dist/flink/flink-cdc-3.4.0/flink-cdc-3.4.0-bin.tar.gz"
   sha256 "d85090e41d077cb8ccbe6fdaf33807c234f1b4de685751e0fee3ba3be5a737e4"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/apache/flink-cdc.git", branch: "master"
 
   bottle do
@@ -49,6 +50,10 @@ class ApacheFlinkCdc < Formula
   resource "values-connector" do
     url "https://search.maven.org/remotecontent?filepath=org/apache/flink/flink-cdc-pipeline-connector-values/3.4.0/flink-cdc-pipeline-connector-values-3.4.0.jar"
     sha256 "abfe81db11388aebb26419e875ccf813b6e5307f7cc2fbb4ef81a9a2ff72574f"
+  end
+  resource "iceberg-connector" do
+    url "https://search.maven.org/remotecontent?filepath=org/apache/flink/flink-cdc-pipeline-connector-iceberg/3.4.0/flink-cdc-pipeline-connector-iceberg-3.4.0.jar"
+    sha256 "b3be61da77c87c7dcd03b1837d3ae90fa58a9ce2fd497b6f0066477e59895ec5"
   end
 
   def install

--- a/Formula/a/apache-flink-cdc.rb
+++ b/Formula/a/apache-flink-cdc.rb
@@ -9,7 +9,7 @@ class ApacheFlinkCdc < Formula
   head "https://github.com/apache/flink-cdc.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "52a84db042b76bf5eadec61fd6e6296eabcc68a46fa9edef37c165500fc3ee2f"
+    sha256 cellar: :any_skip_relocation, all: "89a4c157f350f28c507ad091a44d06d018107a9b41dcadc35821e8b47ea81930"
   end
 
   depends_on "apache-flink@1" => :test


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

[Apache Flink CDC 3.4.0](https://github.com/apache/flink-cdc/releases/tag/release-3.4.0) introduces new Iceberg connector, which might should be included in the resources set.
