### PR TITLE
formula: unify `pkgconf` build dependency declarations

### DIFF
--- a/Formula/a/abi3audit.rb
+++ b/Formula/a/abi3audit.rb
@@ -18,10 +18,10 @@ class Abi3audit < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "pkgconf" => :build
   depends_on "python@3.13"
 
   on_linux do
-    depends_on "pkgconf" => :build
     depends_on "rust" => :build
   end
 

--- a/Formula/a/age-plugin-yubikey.rb
+++ b/Formula/a/age-plugin-yubikey.rb
@@ -18,13 +18,10 @@ class AgePluginYubikey < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "82643b04b611338208b3bed82b767ade73d25bf088ee7bac22d678f4ce0b7651"
   end
 
+  depends_on "pkgconf" => :build
   depends_on "rust" => :build
 
   uses_from_macos "pcsc-lite"
-
-  on_linux do
-    depends_on "pkgconf" => :build
-  end
 
   def install
     system "cargo", "install", *std_cargo_args

--- a/Formula/a/antlr4-cpp-runtime.rb
+++ b/Formula/a/antlr4-cpp-runtime.rb
@@ -23,9 +23,9 @@ class Antlr4CppRuntime < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "pkgconf" => :build
 
   on_linux do
-    depends_on "pkgconf" => :build
     depends_on "util-linux"
   end
 

--- a/Formula/a/asuka.rb
+++ b/Formula/a/asuka.rb
@@ -26,12 +26,12 @@ class Asuka < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "600e1d1324197049502dddfbce2df349657fb4108154a042c6503bdb69f24400"
   end
 
+  depends_on "pkgconf" => :build
   depends_on "rust" => :build
 
   uses_from_macos "ncurses"
 
   on_linux do
-    depends_on "pkgconf" => :build
     depends_on "openssl@3"
   end
 

--- a/Formula/c/cargo-audit.rb
+++ b/Formula/c/cargo-audit.rb
@@ -22,14 +22,11 @@ class CargoAudit < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "e4e7fd69c4d6cfc594f2a5285da7ed6ef174360ebeb0c8f232711617cbd50430"
   end
 
+  depends_on "pkgconf" => :build
   depends_on "rust" => :build
   depends_on "openssl@3"
 
   uses_from_macos "zlib"
-
-  on_linux do
-    depends_on "pkgconf" => :build
-  end
 
   def install
     system "cargo", "install", *std_cargo_args(path: "cargo-audit")

--- a/Formula/c/click.rb
+++ b/Formula/c/click.rb
@@ -23,10 +23,10 @@ class Click < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "4b30c2c15da3c503a541a5f751928abf68496261df9374a23c6d5dce58b9d2b8"
   end
 
+  depends_on "pkgconf" => :build
   depends_on "rust" => :build
 
   on_linux do
-    depends_on "pkgconf" => :build
     depends_on "openssl@3"
   end
 

--- a/Formula/c/code-cli.rb
+++ b/Formula/c/code-cli.rb
@@ -21,14 +21,11 @@ class CodeCli < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "1cd686f546c949211fe8cef99a22633042f99ca07241993456a9b9b908a46275"
   end
 
+  depends_on "pkgconf" => :build
   depends_on "rust" => :build
   depends_on "openssl@3"
 
   uses_from_macos "zlib"
-
-  on_linux do
-    depends_on "pkgconf" => :build
-  end
 
   conflicts_with cask: "visual-studio-code"
 

--- a/Formula/c/code-server.rb
+++ b/Formula/c/code-server.rb
@@ -15,12 +15,11 @@ class CodeServer < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "320a3e07e323e30ff7abeadf933fe3577e8aed1a5f6f9c3d1a3e823ba64f68e7"
   end
 
+  depends_on "pkgconf" => :build
   depends_on "node@20"
-
   uses_from_macos "python" => :build
 
   on_linux do
-    depends_on "pkgconf" => :build
     depends_on "krb5"
     depends_on "libsecret"
     depends_on "libx11"

--- a/Formula/c/couchbase-shell.rb
+++ b/Formula/c/couchbase-shell.rb
@@ -16,12 +16,12 @@ class CouchbaseShell < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "dfbddc03319d40472bdae18473f650e51a29c68b9e2574a58b36f363f43faca0"
   end
 
+  depends_on "pkgconf" => :build
   depends_on "rust" => :build
 
   uses_from_macos "zlib"
 
   on_linux do
-    depends_on "pkgconf" => :build
     depends_on "libx11"
     depends_on "libxcb"
     depends_on "openssl@3"

--- a/Formula/c/cubelib.rb
+++ b/Formula/c/cubelib.rb
@@ -20,11 +20,8 @@ class Cubelib < Formula
     sha256 x86_64_linux:  "f23523ee48a74275d61f881645e96f3a1f37f18a8ca70570e2a915a62930f2dc"
   end
 
+  depends_on "pkgconf" => :build
   uses_from_macos "zlib"
-
-  on_linux do
-    depends_on "pkgconf" => :build
-  end
 
   # Fix -flat_namespace being used on Big Sur and later.
   patch do

--- a/Formula/d/deadfinder.rb
+++ b/Formula/d/deadfinder.rb
@@ -16,6 +16,7 @@ class Deadfinder < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "e0f03ee2a1dd8fc7872d43948f024a6096fa5957e02d4f29655f9e3a0adc3289"
   end
 
+  depends_on "pkgconf" => :build
   depends_on "ruby"
 
   uses_from_macos "libffi"
@@ -23,10 +24,6 @@ class Deadfinder < Formula
   uses_from_macos "libxslt"
   uses_from_macos "xz"
   uses_from_macos "zlib"
-
-  on_linux do
-    depends_on "pkgconf" => :build
-  end
 
   def install
     ENV["GEM_HOME"] = libexec

--- a/Formula/d/docker-credential-helper.rb
+++ b/Formula/d/docker-credential-helper.rb
@@ -17,9 +17,9 @@ class DockerCredentialHelper < Formula
   end
 
   depends_on "go" => :build
+  depends_on "pkgconf" => :build
 
   on_linux do
-    depends_on "pkgconf" => :build
     depends_on "glib"
     depends_on "libsecret"
   end

--- a/Formula/d/dovi_tool.rb
+++ b/Formula/d/dovi_tool.rb
@@ -21,10 +21,10 @@ class DoviTool < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "8254aec7392a826c86b3bbbdcd12c7399ca78f863ff6b9909ee899e948f02072"
   end
 
+  depends_on "pkgconf" => :build
   depends_on "rust" => :build
 
   on_linux do
-    depends_on "pkgconf" => :build
     depends_on "fontconfig"
     depends_on "freetype"
   end

--- a/Formula/d/dura.rb
+++ b/Formula/d/dura.rb
@@ -21,14 +21,11 @@ class Dura < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "b01d4685f6aa2d5fe11722b7c7379695600d6827fa48bd72addebc9cfbd16968"
   end
 
+  depends_on "pkgconf" => :build
   depends_on "rust" => :build
   depends_on "openssl@3"
 
   uses_from_macos "zlib"
-
-  on_linux do
-    depends_on "pkgconf" => :build
-  end
 
   def install
     system "cargo", "install", *std_cargo_args

--- a/Formula/e/easyrpg-player.rb
+++ b/Formula/e/easyrpg-player.rb
@@ -22,6 +22,8 @@ class EasyrpgPlayer < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "pkgconf" => :build
+
   depends_on "fmt"
   depends_on "freetype"
   depends_on "harfbuzz"
@@ -45,7 +47,6 @@ class EasyrpgPlayer < Formula
   end
 
   on_linux do
-    depends_on "pkgconf" => :build
     depends_on "alsa-lib"
   end
 

--- a/Formula/e/espflash.rb
+++ b/Formula/e/espflash.rb
@@ -15,6 +15,7 @@ class Espflash < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "50eff44ba9819e9af58b258224a56270d72773c2f445b070ec1b1ecd69310092"
   end
 
+  depends_on "pkgconf" => :build
   depends_on "rust" => :build
 
   on_macos do
@@ -22,7 +23,6 @@ class Espflash < Formula
   end
 
   on_linux do
-    depends_on "pkgconf" => :build
     depends_on "systemd" # for libudev
   end
 

--- a/Formula/e/eureka.rb
+++ b/Formula/e/eureka.rb
@@ -22,14 +22,11 @@ class Eureka < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "b8df396a1e2c9e87f093dfd44dafed480bd97ff2115beac25725d12d3d028439"
   end
 
+  depends_on "pkgconf" => :build
   depends_on "rust" => :build
   depends_on "openssl@3"
 
   uses_from_macos "zlib"
-
-  on_linux do
-    depends_on "pkgconf" => :build
-  end
 
   def install
     system "cargo", "install", *std_cargo_args

--- a/Formula/f/firefoxpwa.rb
+++ b/Formula/f/firefoxpwa.rb
@@ -16,10 +16,10 @@ class Firefoxpwa < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "9cb80205befaa0b30dccea8760159222340d783d7a785056e8b4ec5caca0d0ce"
   end
 
+  depends_on "pkgconf" => :build
   depends_on "rust" => :build
 
   on_linux do
-    depends_on "pkgconf" => :build
     depends_on "bzip2" # not used on macOS
     depends_on "openssl@3"
   end

--- a/Formula/f/fltk.rb
+++ b/Formula/f/fltk.rb
@@ -25,12 +25,12 @@ class Fltk < Formula
     depends_on "cmake" => :build
   end
 
+  depends_on "pkgconf" => :build
   depends_on "jpeg-turbo"
   depends_on "libpng"
   uses_from_macos "zlib"
 
   on_linux do
-    depends_on "pkgconf" => :build
     depends_on "fontconfig"
     depends_on "libx11"
     depends_on "libxext"

--- a/Formula/f/fltk@1.3.rb
+++ b/Formula/f/fltk@1.3.rb
@@ -22,11 +22,11 @@ class FltkAT13 < Formula
 
   keg_only :versioned_formula
 
+  depends_on "pkgconf" => :build
   depends_on "jpeg-turbo"
   depends_on "libpng"
 
   on_linux do
-    depends_on "pkgconf" => :build
     depends_on "fontconfig"
     depends_on "libx11"
     depends_on "libxext"

--- a/Formula/f/flux.rb
+++ b/Formula/f/flux.rb
@@ -22,11 +22,8 @@ class Flux < Formula
   end
 
   depends_on "go" => :build
+  depends_on "pkgconf" => :build
   depends_on "rust" => :build
-
-  on_linux do
-    depends_on "pkgconf" => :build
-  end
 
   conflicts_with "fantom", because: "both install `flux` binaries"
 

--- a/Formula/g/gdb.rb
+++ b/Formula/g/gdb.rb
@@ -17,6 +17,7 @@ class Gdb < Formula
     sha256 x86_64_linux:  "5dce623e116162d2edb8668a5f5b5085dea0b0dbce8b245985de933ed0079097"
   end
 
+  depends_on "pkgconf" => :build
   depends_on "gmp"
   depends_on "mpfr"
   depends_on "python@3.13"
@@ -38,7 +39,6 @@ class Gdb < Formula
   end
 
   on_linux do
-    depends_on "pkgconf" => :build
     depends_on "guile"
   end
 

--- a/Formula/g/geph4.rb
+++ b/Formula/g/geph4.rb
@@ -21,10 +21,10 @@ class Geph4 < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "bde6c9148a586e0bf317a3991e2567231fcf15be78b1caa2ef340ff0f399c494"
   end
 
+  depends_on "pkgconf" => :build
   depends_on "rust" => :build
 
   on_linux do
-    depends_on "pkgconf" => :build
     depends_on "openssl@3"
   end
 

--- a/Formula/g/git-trim.rb
+++ b/Formula/g/git-trim.rb
@@ -20,14 +20,11 @@ class GitTrim < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "4663a90075b39aa34a60e0b5c097bb69b1820b9a72b1d47c54562fa9e08288de"
   end
 
+  depends_on "pkgconf" => :build
   depends_on "rust" => :build
   depends_on "openssl@3"
 
   uses_from_macos "zlib"
-
-  on_linux do
-    depends_on "pkgconf" => :build
-  end
 
   def install
     system "cargo", "install", *std_cargo_args

--- a/Formula/g/gitless.rb
+++ b/Formula/g/gitless.rb
@@ -22,14 +22,11 @@ class Gitless < Formula
   # https://github.com/gitless-vcs/gitless/issues/248
   deprecate! date: "2024-07-17", because: :unmaintained
 
+  depends_on "pkgconf" => :build
   depends_on "libgit2@1.7"
   depends_on "python@3.13"
 
   uses_from_macos "libffi"
-
-  on_linux do
-    depends_on "pkgconf" => :build
-  end
 
   resource "args" do
     url "https://files.pythonhosted.org/packages/e5/1c/b701b3f4bd8d3667df8342f311b3efaeab86078a840fb826bd204118cc6b/args-0.1.0.tar.gz"

--- a/Formula/g/grin-wallet.rb
+++ b/Formula/g/grin-wallet.rb
@@ -15,11 +15,11 @@ class GrinWallet < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "fb8c9ea2d9d49a06a26ca2fd622921b83ae9144e496829f0c52d451a4fbe7286"
   end
 
+  depends_on "pkgconf" => :build
   depends_on "rust" => :build
   uses_from_macos "llvm" => :build
 
   on_linux do
-    depends_on "pkgconf" => :build
     depends_on "openssl@3" # Uses Secure Transport on macOS
   end
 


### PR DESCRIPTION
formula: unify `pkgconf` build dependency declarations

----

just use pkgconf for both macos and linux builds (we have been doing like this for quite some time)