### PR TITLE
xtensor: depends on xtl not resource

### DIFF
--- a/Formula/x/xtensor.rb
+++ b/Formula/x/xtensor.rb
@@ -7,7 +7,7 @@ class Xtensor < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "2348111bd2e2567d4f0a1d9958b625ec145dbfb6666989e164c99700bedbf12a"
+    sha256 cellar: :any_skip_relocation, all: "23748f41560d55a42246189b6d61d66fd35ef922ae55e9379f493d46abbd868d"
   end
 
   depends_on "cmake" => :build

--- a/Formula/x/xtensor.rb
+++ b/Formula/x/xtensor.rb
@@ -4,26 +4,17 @@ class Xtensor < Formula
   url "https://github.com/xtensor-stack/xtensor/archive/refs/tags/0.26.0.tar.gz"
   sha256 "f5f42267d850f781d71097b50567a480a82cd6875a5ec3e6238555e0ef987dc6"
   license "BSD-3-Clause"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "2348111bd2e2567d4f0a1d9958b625ec145dbfb6666989e164c99700bedbf12a"
   end
 
   depends_on "cmake" => :build
-
-  resource "xtl" do
-    url "https://github.com/xtensor-stack/xtl/archive/refs/tags/0.8.0.tar.gz"
-    sha256 "ee38153b7dd0ec84cee3361f5488a4e7e6ddd26392612ac8821cbc76e740273a"
-  end
+  depends_on "xtl"
 
   def install
-    resource("xtl").stage do
-      system "cmake", "-S", ".", "-B", "build", *std_cmake_args
-      system "cmake", "--build", "build"
-      system "cmake", "--install", "build"
-    end
-
-    system "cmake", "-S", ".", "-B", "build", "-Dxtl_DIR=#{lib}/cmake/xtl", *std_cmake_args
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
   end


### PR DESCRIPTION
Fix https://github.com/Homebrew/homebrew-core/issues/224655
Remove `xtl` resource and add `depends_on "xtl"`

---

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
