### PR TITLE
s6-rc 0.5.6.0 (new formula)

### DIFF
--- a/Formula/e/execline.rb
+++ b/Formula/e/execline.rb
@@ -5,6 +5,16 @@ class Execline < Formula
   sha256 "73c9160efc994078d8ea5480f9161bfd1b3cf0b61f7faab704ab1898517d0207"
   license "ISC"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e8bbbad617bb8ac9e26e9631efdf913a74a06b7f5a88b06363dd1d29aa7b2dac"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "d5fe2632e0befbca3259c9fef9072b4f64dab302bea224139726a4b89052a3ae"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "ea0514d4e9ef6f17b557d38150fa968c578cce538f460fa18e19913b884b2905"
+    sha256 cellar: :any_skip_relocation, sonoma:        "56bb7856a71a5077be1f29a8e0ada34478f502f4eb60284dc1e7a9d763f2c25a"
+    sha256 cellar: :any_skip_relocation, ventura:       "1765cdd721993a610bbdbd27a19939450d6f4fe8f3296151e8e09da4a0c5c0ea"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "ae2121f67e055f6b0dee1a23c671629de78ce3b4c589caa17e0b0f8e77b88aa9"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "135280851c5d80d05338574a9714112313e6358d0f4d572de470998bcdf503b9"
+  end
+
   depends_on "pkgconf" => :build
   depends_on "skalibs"
 

--- a/Formula/e/execline.rb
+++ b/Formula/e/execline.rb
@@ -1,0 +1,35 @@
+class Execline < Formula
+  desc "Interpreter-less scripting language"
+  homepage "https://skarnet.org/software/execline/"
+  url "https://skarnet.org/software/execline/execline-2.9.7.0.tar.gz"
+  sha256 "73c9160efc994078d8ea5480f9161bfd1b3cf0b61f7faab704ab1898517d0207"
+  license "ISC"
+
+  depends_on "pkgconf" => :build
+  depends_on "skalibs"
+
+  def install
+    # Shared libraries are linux targets and not supported on macOS.
+    args = %W[
+      --disable-silent-rules
+      --disable-shared
+      --enable-pkgconfig
+      --with-pkgconfig=#{Formula["pkgconf"].opt_bin}/pkg-config
+      --with-sysdeps=#{Formula["skalibs"].opt_lib}/skalibs/sysdeps
+    ]
+    system "./configure", *args, *std_configure_args
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.eb").write <<~EOS
+      foreground
+      {
+        sleep 1
+      }
+      "echo"
+      "Homebrew"
+    EOS
+    assert_match "Homebrew", shell_output("#{bin}/execlineb test.eb")
+  end
+end

--- a/Formula/s/s6-rc.rb
+++ b/Formula/s/s6-rc.rb
@@ -1,0 +1,38 @@
+class S6Rc < Formula
+  desc "Process supervision suite"
+  homepage "https://skarnet.org/software/s6-rc/"
+  url "https://skarnet.org/software/s6-rc/s6-rc-0.5.6.0.tar.gz"
+  sha256 "81277f6805e8d999ad295bf9140a909943b687ffcfb5aa3c4efd84b1a574586e"
+  license "ISC"
+
+  depends_on "pkgconf" => :build
+  depends_on "execline"
+  depends_on "s6"
+  depends_on "skalibs"
+
+  def install
+    # Shared libraries are linux targets and not supported on macOS.
+    args = %W[
+      --disable-silent-rules
+      --disable-shared
+      --enable-pkgconfig
+      --with-pkgconfig=#{Formula["pkgconf"].opt_bin}/pkg-config
+      --with-sysdeps=#{Formula["skalibs"].opt_lib}/skalibs/sysdeps
+    ]
+    system "./configure", *args, *std_configure_args
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"services/test").mkpath
+    (testpath/"services/test/up").write <<~SHELL
+      #!/bin/sh
+      echo "test"
+    SHELL
+    (testpath/"services/test/type").write "oneshot"
+    (testpath/"services/bundle/contents.d").mkpath
+    (testpath/"services/bundle/type").write "bundle"
+    touch testpath/"services/bundle/contents.d/test"
+    system bin/"s6-rc-compile", testpath/"compiled", testpath/"services"
+  end
+end

--- a/Formula/s/s6-rc.rb
+++ b/Formula/s/s6-rc.rb
@@ -5,6 +5,16 @@ class S6Rc < Formula
   sha256 "81277f6805e8d999ad295bf9140a909943b687ffcfb5aa3c4efd84b1a574586e"
   license "ISC"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "ffb8c25c6c698f13c255d694dfc6218116857cf633b6764a6ee4c026de314e20"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "120ab3b0a9ca7cf2db5f0b27ee6dffcebb3560e718956f5cab8693655d9aac14"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "06402eee4fafa9c0bcdbcce7dcd88054b9f142263a8ce6019ee1ec54b534beb3"
+    sha256 cellar: :any_skip_relocation, sonoma:        "66888c1bab3552b773e18e694b52ce22bc525d343cdaf3622fded2921832c642"
+    sha256 cellar: :any_skip_relocation, ventura:       "486096d10e4ce41f00e27aa5d62d30c9acab44c539542db7ac34afc36ac25571"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "e84a61c37b4988f98170ca737ea6b2fc95720619bb07253ea1e1a4d45233e36a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "26be7908d0ae2d584614d6aefe7b4bc4ffc1b45dce5743b801f416fdf5310282"
+  end
+
   depends_on "pkgconf" => :build
   depends_on "execline"
   depends_on "s6"

--- a/Formula/s/s6.rb
+++ b/Formula/s/s6.rb
@@ -11,13 +11,14 @@ class S6 < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "67e7b84ebe8f1610f2edeba0bfafb362eb0c6f8fc9bd2e31bbc777ebf384840f"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "81cb72f4806fb26f29f6537da49a1c5e7fcccdaa8a8a34d7d878ef3e19e7803c"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "c59164a75b08590c40b69598f6d846230fe8288de366c5d371f8f7e3d276446a"
-    sha256 cellar: :any_skip_relocation, sonoma:        "f282796bae69dd7ccc641601060115edec8bdf4f95889492574725e07eb566c7"
-    sha256 cellar: :any_skip_relocation, ventura:       "f985eafa60d7504a2efd641f591189a88467444ccf528a5ef9301ee369bec659"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "ec4890a947f1e2aa3363969112a8f80ca3f3bdf647c9ede8fd74a39cb4ec213a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a50281696347be24e9cbfc2a0beb51ad926bdc10bf8efb86b55e57ee3d6afd4c"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "88fb583281e696ad18a4dab7b34ec8794d1c58dfa48c40a4b6a020138f26b0d5"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "105a08c0079ab7fb9fd049443a888ec673c2f3e4e241d4a7cd52065403881b8a"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "de13a9f0b0d00175ce1365152621f160759d3de1d8344f520d19ff29418d5c38"
+    sha256 cellar: :any_skip_relocation, sonoma:        "ecc8dab8a302e3f58a67b5e48269eb272018d9cc8d22ba6d2bfaebb5ade0835e"
+    sha256 cellar: :any_skip_relocation, ventura:       "1ae26881433c5dfaa3b514e161423d44f8bf22431c75a39d54a0c6507ff4d9d0"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "267d6e94207cb929ba43e44a4bd589e7628fde0cbf42d242069e1c5af2f82f5f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f710b9295a5a5101c380603ed1741a4df17e5af0f5b21b7ea953c6a46065d12f"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/s/skalibs.rb
+++ b/Formula/s/skalibs.rb
@@ -5,6 +5,16 @@ class Skalibs < Formula
   sha256 "0e626261848cc920738f92fd50a24c14b21e30306dfed97b8435369f4bae00a5"
   license "ISC"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "c668db63e78d6fc7ebe695706f1d26081db734729bdb6892f783d128b8943291"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "43990849b9d5f38a0a33a6dc0f25b4ee9ff409507a88e1e6128e4667a1b3713a"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "01857e93e5a8a2704431e7c6b2ace60186c31b81c43f1d6c47fd3fd52076367b"
+    sha256 cellar: :any_skip_relocation, sonoma:        "a3fe1ab96abe85ef7adfb3171a518adcd560fcab2e9cb0b6f94bad4234f9c159"
+    sha256 cellar: :any_skip_relocation, ventura:       "d2c4b2975ac522a649ed12b2d5274adf349b742ba2ec340b26856fd599184097"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "b8b80b464e01b3bee02137e71cbcdc44003ebede2c435a4ee267358044588ea9"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d45e63d528bb32ffe845bcfcacf39d8e52809c0975273aa51a2dd324fea60c5d"
+  end
+
   def install
     # Shared libraries are linux targets and not supported on macOS.
     args = %w[

--- a/Formula/s/skalibs.rb
+++ b/Formula/s/skalibs.rb
@@ -1,0 +1,29 @@
+class Skalibs < Formula
+  desc "Skarnet's library collection"
+  homepage "https://skarnet.org/software/skalibs/"
+  url "https://skarnet.org/software/skalibs/skalibs-2.14.4.0.tar.gz"
+  sha256 "0e626261848cc920738f92fd50a24c14b21e30306dfed97b8435369f4bae00a5"
+  license "ISC"
+
+  def install
+    # Shared libraries are linux targets and not supported on macOS.
+    args = %w[
+      --disable-silent-rules
+      --disable-shared
+      --enable-pkgconfig
+    ]
+    system "./configure", *args, *std_configure_args
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<~C
+      #include <skalibs/skalibs.h>
+      int main() {
+        return 0;
+      }
+    C
+    system ENV.cc, "test.c", "-L#{lib}", "-lskarnet", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
https://skarnet.org/software/s6-rc/index.html: s6-rc is a service manager for s6-based systems, i.e. a suite of programs that can start and stop services, both long-running daemons and one-time initialization scripts, in the proper order according to a dependency tree.

This formula depends on the existing "s6" formula and can be used to control s6 supervision trees.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
