### PR TITLE
ytdx 1.0.0 (new formula): Fast YouTube video downloader with CLI support

### DIFF
--- a/Formula/ytdx.rb
+++ b/Formula/ytdx.rb
@@ -1,0 +1,25 @@
+class Ytdx < Formula
+    include Language::Python::Virtualenv
+  
+    desc "Загрузчик видео с YouTube"
+    homepage "https://github.com/flaymie/ytdx"
+    url "https://github.com/flaymie/ytdx/archive/refs/tags/v1.0.0.tar.gz"
+    sha256 "2a6b5ad01b55717028ab3a5ddf794611e79343238f3d75db21af72f75c46ea0f"
+    license "MIT"
+  
+    depends_on "python@3.10"
+    depends_on "ffmpeg"
+  
+    resource "yt-dlp" do
+      url "https://files.pythonhosted.org/packages/25/68/4f108193ebce3ee7beb5f9a21daa6bc875e261150b510be468626f151959/yt_dlp-2025.5.22-py3-none-any.whl"
+      sha256 "a49c4b76afeaded6254c3e2b759d8d5a13271aa963d5fccb51fe059d1c313151"
+    end
+  
+    def install
+      virtualenv_install_with_resources
+    end
+  
+    test do
+      system bin/"ytdx", "--help"
+    end
+  end 


### PR DESCRIPTION
ytdx is a command-line utility for downloading videos and audio from YouTube with a focus on simplicity and efficiency. It features:

- Download videos in various qualities (1080p, 720p, 480p, 360p)
- Download audio-only option with automatic mp3 conversion
- Format selection (mp4, mp3, webm)
- Custom filenames and output directories
- Non-interactive mode for use in scripts

Built on top of yt-dlp, it provides a simplified interface with sensible defaults.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source ytdx`?
- [x] Is your test running fine `brew test ytdx`?
- [x] Does your build pass `brew audit --new --strict ytdx`?

-----