### PR TITLE
benchi: add new formula for benchmarking tool

### DIFF
--- a/Formula/b/benchi.rb
+++ b/Formula/b/benchi.rb
@@ -1,0 +1,23 @@
+class Benchi < Formula
+  desc "Benchmarking tool for data pipelines"
+  homepage "https://github.com/ConduitIO/benchi"
+  url "https://github.com/ConduitIO/benchi/archive/refs/tags/v0.1.0.tar.gz"
+  sha256 "0f6d9c21ea9d3bc2bff689cb4a258bdf4aa36c7b1e92443d74414a5826ddfefc"
+  license "Apache-2.0"
+  head "https://github.com/ConduitIO/benchi.git", branch: "main"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args, "./cmd/benchi"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/benchi --version")
+  end
+end

--- a/Formula/b/benchi.rb
+++ b/Formula/b/benchi.rb
@@ -14,7 +14,8 @@ class Benchi < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args, "./cmd/benchi"
+    ldflags = "-X main.version=#{version}"
+    system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/benchi"
   end
 
   test do

--- a/Formula/b/benchi.rb
+++ b/Formula/b/benchi.rb
@@ -18,6 +18,6 @@ class Benchi < Formula
   end
 
   test do
-    assert_match version.to_s, shell_output("#{bin}/benchi --version")
+    assert_match version.to_s, shell_output("#{bin}/benchi -v")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)?

Benchi is a benchmarking tool for data pipelines that helps measure and analyze performance metrics. This formula provides an easy way to install and use Benchi on macOS systems.

The formula:
- Uses the latest stable release (v0.1.0)
- Includes proper test to verify installation
- Follows Homebrew's formula guidelines
- Has appropriate dependencies (go)
- Includes livecheck for future updates