### PR TITLE
osx-trash 0.7.1 (new formula)

### DIFF
--- a/Formula/o/osx-trash.rb
+++ b/Formula/o/osx-trash.rb
@@ -11,6 +11,10 @@ class OsxTrash < Formula
     regex(/^trash[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, all: "1ff2a7e4c4d9e83a5cf38815cbbae8407295d8c830d85211677d6041add46bfa"
+  end
+
   depends_on :macos
 
   def install

--- a/Formula/o/osx-trash.rb
+++ b/Formula/o/osx-trash.rb
@@ -1,0 +1,24 @@
+class OsxTrash < Formula
+  desc "Allows trashing of files instead of tempting fate with rm"
+  homepage "https://github.com/morgant/tools-osx#trash"
+  url "https://github.com/morgant/tools-osx/archive/refs/tags/trash-0.7.1.tar.gz"
+  sha256 "9ac54a5eb87c4c6a71568256c0e29094a913f2adf538fb2c504f6c8b1f63be12"
+  license "MIT"
+  head "https://github.com/morgant/tools-osx.git", branch: "master"
+
+  livecheck do
+    url :stable
+    regex(/^trash[._-]v?(\d+(?:\.\d+)+)$/i)
+  end
+
+  depends_on :macos
+
+  def install
+    bin.install "src/trash"
+  end
+
+  test do
+    # Direct execution would trigger accessibility permissions, failing CI.
+    assert_match "v#{version}", shell_output("strings #{bin}/trash")
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Following https://github.com/Homebrew/homebrew-core/pull/123002#issuecomment-1435907020, related to https://github.com/morgant/tools-osx/pull/26.