### PR TITLE
gcsfuse 2.12.2

### DIFF
--- a/Formula/g/gcsfuse.rb
+++ b/Formula/g/gcsfuse.rb
@@ -12,8 +12,8 @@ class Gcsfuse < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_linux:  "0cb99ea922426bc87d0e4db4fd42f7ce7c1df14efa60509527ab76860d369888"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "33043ad71940992014f1f15eea3a9b49e5f319b98bb4dd4b3b36da503f293bd1"
+    sha256 cellar: :any_skip_relocation, arm64_linux:  "d4a9e82b84a4747e41f1985465bcae05e2b1bd941bd36902dbc267b194e0d56a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "919bdf947f23887cab413aac87b0833d5af9703245bd797db265ed577dedcfa0"
   end
 
   depends_on "go" => :build

--- a/Formula/g/gcsfuse.rb
+++ b/Formula/g/gcsfuse.rb
@@ -1,8 +1,8 @@
 class Gcsfuse < Formula
   desc "User-space file system for interacting with Google Cloud"
   homepage "https://github.com/googlecloudplatform/gcsfuse"
-  url "https://github.com/GoogleCloudPlatform/gcsfuse/archive/refs/tags/v2.12.1.tar.gz"
-  sha256 "f2645cfb7e485df0791bf8774d3b39081132c1e9bedc173f8952759a46a1b76c"
+  url "https://github.com/GoogleCloudPlatform/gcsfuse/archive/refs/tags/v2.12.2.tar.gz"
+  sha256 "500048d3659454ada2d2cad790ec8641dde5ffb2419d040218d7e35f46bce251"
   license "Apache-2.0"
   head "https://github.com/GoogleCloudPlatform/gcsfuse.git", branch: "master"
 
@@ -20,8 +20,6 @@ class Gcsfuse < Formula
   depends_on "libfuse"
   depends_on :linux # on macOS, requires closed-source macFUSE
 
-  patch :DATA
-
   def install
     # Build the build_gcsfuse tool. Ensure that it doesn't pick up any
     # libraries from the user's GOPATH; it should have no dependencies.
@@ -38,18 +36,3 @@ class Gcsfuse < Formula
     system "#{sbin}/mount.gcsfuse", "--help"
   end
 end
-
-__END__
-diff --git a/tools/build_gcsfuse/main.go b/tools/build_gcsfuse/main.go
-index b1a4022..678f747 100644
---- a/tools/build_gcsfuse/main.go
-+++ b/tools/build_gcsfuse/main.go
-@@ -134,8 +134,6 @@ func buildBinaries(dstDir, srcDir, version string, buildArgs []string) (err erro
- 		cmd := exec.Command(
- 			"go",
- 			"build",
--			"-C",
--			srcDir,
- 			"-o",
- 			path.Join(dstDir, bin.outputPath))
- 


### PR DESCRIPTION
gcsfuse 2.12.2

---

autobump failed, https://github.com/Homebrew/homebrew-core/actions/runs/15348241173/job/43189552820#step:6:5062

```
Error: Parameter 'string': Expected type String, got type NilClass
```