### PR TITLE
systemc: Switch to autotools configure

### DIFF
--- a/Formula/s/systemc.rb
+++ b/Formula/s/systemc.rb
@@ -20,12 +20,24 @@ class Systemc < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "6db51dd6f15d86564a1d9a5758497d514b1328222c0635fa9b20ccc86b0a9716"
   end
 
-  depends_on "cmake" => :build
+  depends_on "autoconf" => :build
+  depends_on "autoconf-archive" => :build
+  depends_on "automake" => :build
+  depends_on "doxygen" => :build
+  depends_on "libtool" => :build
+
+  # Workaround "No rule to make target 'DEVELOPMENT.md', needed by 'all-am'":
+  # Ref: https://forums.accellera.org/topic/8068-no-rule-to-make-target-developmentmd-needed-by-all-am/
+  patch do
+    url "https://sources.debian.org/data/main/s/systemc/3.0.1-1/debian/patches/doc-targets.patch"
+    sha256 "3c4c79453599fed2a0082b9564e6a2dd845615afcc173d0e235933b2d2b18bf4"
+  end
 
   def install
-    system "cmake", "-S", ".", "-B", "build", "-DCMAKE_CXX_STANDARD=17", *std_cmake_args
-    system "cmake", "--build", "build"
-    system "cmake", "--install", "build"
+    ENV.append "CXXFLAGS", "-std=gnu++17"
+    system "autoreconf", "--force", "--install", "--verbose"
+    system "./configure", "--with-unix-layout", *std_configure_args
+    system "make", "install"
   end
 
   test do

--- a/Formula/s/systemc.rb
+++ b/Formula/s/systemc.rb
@@ -11,13 +11,14 @@ class Systemc < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "441b9e5eeeb6d385c2cfcf2c6500d24c42b67d3bd4ed37b3d8eff2499b71f061"
-    sha256 cellar: :any,                 arm64_sonoma:  "3a0cde321c4507f2167a85f007b41f746428892da203926ec36349bd3772b32e"
-    sha256 cellar: :any,                 arm64_ventura: "0318c7fe56225d68c28f70aced8caf7e29481bd54b143abd2e8c1979e6046a9c"
-    sha256 cellar: :any,                 sonoma:        "cce974365677a77f35b9e9210c458fc3983c24bd2f71607cac18acd43d718491"
-    sha256 cellar: :any,                 ventura:       "dba48d318338030082a310813e68f3708029a7fb9a69a323bc18355db12b5cbf"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "d204f75195a30aad451d44efc64b1ff98e5d9713876cff4458865be3acd073bb"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "6db51dd6f15d86564a1d9a5758497d514b1328222c0635fa9b20ccc86b0a9716"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "b2580caeadfaaa3e0dee957d949e24e1a7efea6d2e08a5ac5a944ed940af119f"
+    sha256 cellar: :any,                 arm64_sonoma:  "3caf64beca918351c3def6491f3f44ab6d6e30944256598042c06e27f4c3f69d"
+    sha256 cellar: :any,                 arm64_ventura: "2a53ee4fc148a6cff3e4dd3bc9fb90ead7473bea18330d1165df302eff50ca42"
+    sha256 cellar: :any,                 sonoma:        "2f71a7bdcf98225af604842ac634e8b6f6e5b6e04f88c220a870832620c67332"
+    sha256 cellar: :any,                 ventura:       "36d4a60c1bf2ed3f6af253cf8c7691c1bcf6d4c544a1eed52e1978bcc94f1808"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "323a1432c8de12dbab0de9552daf0ed9f399ba98cb708118e6aafd0493b50531"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "38bc41a193499a5d8487437cd0aa90ada0456938807ed8b091564ca301606b00"
   end
 
   depends_on "autoconf" => :build


### PR DESCRIPTION
systemc's cmake build lacks many features, namely
pkg-config files and document & example files.

Fix by switching to autotools configure based build flow, also applying patch from Debian to fix document build.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
