### PR TITLE
screenpipe: fix build with cmake 4

### DIFF
--- a/Formula/s/screenpipe.rb
+++ b/Formula/s/screenpipe.rb
@@ -4,6 +4,7 @@ class Screenpipe < Formula
   url "https://github.com/mediar-ai/screenpipe/archive/refs/tags/v0.2.13.tar.gz"
   sha256 "eb3599daabc1312b5c1a7799c1ec8ab715aa02d9216a6aa42d930039c84a70c9"
   license "MIT"
+  head "https://github.com/mediar-ai/screenpipe.git", branch: "main"
 
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "e19fe81711f2b581441d5ef4e4894229ff0b40bcb7ec97620649b41ccfac3784"
@@ -30,6 +31,8 @@ class Screenpipe < Formula
   end
 
   def install
+    # Support cmake 4, remove after https://github.com/Prior99/libsamplerate-sys/issues/21
+    ENV["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5"
     features = ["--features", "metal,pipes"] if OS.mac? && Hardware::CPU.arm?
     system "cargo", "install", *features, *std_cargo_args(path: "screenpipe-server")
     lib.install "screenpipe-vision/lib/libscreenpipe_#{Hardware::CPU.arch}.dylib" if OS.mac?


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Fixes build failure seen in https://github.com/Homebrew/homebrew-core/actions/runs/15055542156/job/42331830563 (https://github.com/Homebrew/homebrew-core/pull/223613)
