### PR TITLE
dcm2niix: remove cmake 4 build workaround

### DIFF
--- a/Formula/d/dcm2niix.rb
+++ b/Formula/d/dcm2niix.rb
@@ -25,9 +25,6 @@ class Dcm2niix < Formula
   depends_on "cmake" => :build
 
   def install
-    # Workaround to build with CMake 4
-    ENV["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5"
-
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"


### PR DESCRIPTION
dcm2niix: remove cmake 4 build workaround

---

relates to:
- https://github.com/Homebrew/homebrew-core/pull/224968
- https://github.com/rordenlab/dcm2niix/issues/942