### PR TITLE
elixir: Target specific Erlang version in dependency

### DIFF
--- a/Formula/e/elixir.rb
+++ b/Formula/e/elixir.rb
@@ -21,11 +21,14 @@ class Elixir < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "d20440fd271698c9f737a0a8fecde327f0a737abb600facc1f104b3c6f566a77"
   end
 
-  depends_on "erlang"
+  depends_on "erlang@27"
 
   def install
     # Set `Q=` for verbose `make` output
-    system "make", "Q=", "PREFIX=#{prefix}", "install"
+    system "make", "Q=", "PREFIX=#{libexec}", "install"
+    (libexec/"bin").each_child do |f|
+      (bin/f.basename).write_env_script f, PATH: "#{Formula["erlang@27"].opt_bin}:$PATH"
+    end
   end
 
   test do

--- a/Formula/t/teslamate.rb
+++ b/Formula/t/teslamate.rb
@@ -17,7 +17,6 @@ class Teslamate < Formula
   depends_on "node" => :build
   depends_on "postgresql@17" => :test
   depends_on "elixir"
-  depends_on "erlang"
   depends_on "openssl@3"
 
   uses_from_macos "ncurses"


### PR DESCRIPTION
~**NOTE: I have yet to test this locally, as well as go through the checklist below. Creating as a draft for now.**~

~Most notably, I don't know if the `erlang@27` package differs in a meaningful way from the `erlang` package. It warned me when I installed it that I had to manipulate my `PATH` manually. If so, this might need addressing for this to work.~

Edit: both the above paragraphs are hopefully addressed now.

Background: https://github.com/orgs/Homebrew/discussions/6192#discussioncomment-13331225

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
