### PR TITLE
jetty-runner: deprecate

### DIFF
--- a/Formula/j/jetty-runner.rb
+++ b/Formula/j/jetty-runner.rb
@@ -11,7 +11,8 @@ class JettyRunner < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "15aef216430d1b1c1a0d7823e12102cf7a8d5b1974bb8611ee6bbc3363394844"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "09bbc60a77038dc30b859e15ef151f4766c8d301950fd5d8c55d7d57a31e7823"
   end
 
   # See: https://github.com/jetty/jetty.project/issues/1905#issuecomment-409662335

--- a/Formula/j/jetty-runner.rb
+++ b/Formula/j/jetty-runner.rb
@@ -14,6 +14,9 @@ class JettyRunner < Formula
     sha256 cellar: :any_skip_relocation, all: "15aef216430d1b1c1a0d7823e12102cf7a8d5b1974bb8611ee6bbc3363394844"
   end
 
+  # See: https://github.com/jetty/jetty.project/issues/1905#issuecomment-409662335
+  deprecate! date: "2018-08-02", because: :deprecated_upstream
+
   depends_on "openjdk"
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
For reference:
- https://github.com/Homebrew/homebrew-core/pull/223398#issuecomment-2938863050

FYI, we should probably **disable** this formula after jetty/jetty.project#10854 is closed.
