### PR TITLE
dbus: update caveats

### DIFF
--- a/Formula/d/dbus.rb
+++ b/Formula/d/dbus.rb
@@ -65,17 +65,17 @@ class Dbus < Formula
   def caveats
     on_macos do
       <<~EOS
-        To load #{name} at startup, activate the included Launch Daemon:
+        To load #{name} at startup, activate the included Launch Agent:
 
-          sudo cp #{lib}/Library/LaunchDaemons/org.freedesktop.dbus-session.plist /Library/LaunchDaemons
-          sudo chmod 644 /Library/LaunchDaemons/org.freedesktop.dbus-session.plist
-          sudo launchctl load -w /Library/LaunchDaemons/org.freedesktop.dbus-session.plist
+          sudo cp #{lib}/Library/LaunchAgents/org.freedesktop.dbus-session.plist /Library/LaunchAgents
+          sudo chmod 644 /Library/LaunchAgents/org.freedesktop.dbus-session.plist
+          sudo launchctl load -w /Library/LaunchAgents/org.freedesktop.dbus-session.plist
 
-        If this is an upgrade and you already have the Launch Daemon loaded, you
-        have to unload the Launch Daemon before reinstalling it:
+        If this is an upgrade and you already have the Launch Agent loaded, you
+        have to unload the Launch Agent before reinstalling it:
 
-          sudo launchctl unload -w /Library/LaunchDaemons/org.freedesktop.dbus-session.plist
-          sudo rm /Library/LaunchDaemons/org.freedesktop.dbus-session.plist
+          sudo launchctl unload -w /Library/LaunchAgents/org.freedesktop.dbus-session.plist
+          sudo rm /Library/LaunchAgents/org.freedesktop.dbus-session.plist
       EOS
     end
   end


### PR DESCRIPTION
Correct the instructions to point at dbus's LaunchAgent, which exists, and not its LaunchDaemon, which doesn't.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
