### PR TITLE
btop: cmake and statically link rocm_smi_lib

### DIFF
--- a/Formula/b/btop.rb
+++ b/Formula/b/btop.rb
@@ -4,6 +4,7 @@ class Btop < Formula
   url "https://github.com/aristocratos/btop/archive/refs/tags/v1.4.4.tar.gz"
   sha256 "98d464041015c888c7b48de14ece5ebc6e410bc00ca7bb7c5a8010fe781f1dd8"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/aristocratos/btop.git", branch: "main"
 
   bottle do
@@ -16,7 +17,9 @@ class Btop < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "b3043f3fabe0b6c0231cf4541cab6cf7637300bf377465c0b32fd635acca34f0"
   end
 
+  depends_on "cmake" => :build
   depends_on "lowdown" => :build
+  depends_on "ninja" => :build
 
   on_macos do
     depends_on "coreutils" => :build
@@ -28,6 +31,10 @@ class Btop < Formula
     depends_on "llvm" => :build
   end
 
+  on_linux do
+    depends_on "llvm" => :build
+  end
+
   # -ftree-loop-vectorize -flto=12 -s
   # Needs Clang 16 / Xcode 15+
   fails_with :clang do
@@ -36,14 +43,38 @@ class Btop < Formula
   end
 
   fails_with :gcc do
-    version "9"
-    cause "requires GCC 10+"
+    version "10"
+    cause "requires GCC 11+"
+  end
+
+  resource "rocm_smi_lib" do
+    on_linux do
+      url "https://github.com/ROCm/rocm_smi_lib/archive/refs/tags/rocm-6.3.3.tar.gz"
+      sha256 "679dfd0cbd213d27660e546584ab013afea286eff95928d748d168503305c9c4"
+    end
   end
 
   def install
-    ENV.llvm_clang if OS.mac? && (DevelopmentTools.clang_build_version <= 1499 || MacOS.version == :ventura)
-    system "make", "CXX=#{ENV.cxx}", "STRIP=true"
-    system "make", "PREFIX=#{prefix}", "install"
+    rsmi_static = OS.linux? ? "ON" : "OFF"
+    gpu = OS.linux? ? "ON" : "OFF"
+
+    if OS.linux?
+      ENV["CC"] = Formula["llvm"].opt_bin/"clang"
+      ENV["CXX"] = Formula["llvm"].opt_bin/"clang++"
+      resource("rocm_smi_lib").stage buildpath/"lib/rocm_smi_lib"
+    elsif OS.mac?
+      ENV.llvm_clang if DevelopmentTools.clang_build_version <= 1499 || MacOS.version == :ventura
+    end
+
+    args = %W[
+      -DCMAKE_CXX_COMPILER=#{ENV.cxx}
+      -DCMAKE_EXE_LINKER_FLAGS=-s
+      -DBTOP_GPU=#{gpu}
+      -DBTOP_RSMI_STATIC=#{rsmi_static}
+    ]
+    system "cmake", "-S", ".", "-B", "build", "-G", "Ninja", *args, *std_cmake_args
+    system "cmake", "--build", "build", "--verbose"
+    system "cmake", "--install", "build"
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ x ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ x ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ x ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ x ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

Rationale: I encountered issues on homebrew-provided btop on linux being unable to find my system's rocm_smi_lib 6.3.x package because rocm_smi_lib was linked against glibc 2.41. The btop build allows for static compilation of rocm_smi_lib so this PR enables that. This adds about 1.1M to the binary size.
This also changes the build to use cmake and enables ninja for potential parallel compilation.
The gcc min version is updated as documented in btop's README.md, but I was unable to make use of a pinned version of homebrew gcc to compile it so I changed the linux build to use clang like it is for macos.

-----
