### PR TITLE
aptos aptos-cli-7.4.0

### DIFF
--- a/Formula/a/aptos.rb
+++ b/Formula/a/aptos.rb
@@ -1,8 +1,8 @@
 class Aptos < Formula
   desc "Layer 1 blockchain built to support fair access to decentralized assets for all"
   homepage "https://aptosfoundation.org/"
-  url "https://github.com/aptos-labs/aptos-core/archive/refs/tags/aptos-cli-v7.2.0.tar.gz"
-  sha256 "135e0c1799cc6bfe4e570d40817f8548c8e89ddb06c690ed4737e56824334222"
+  url "https://github.com/aptos-labs/aptos-core/archive/refs/tags/aptos-cli-v7.4.0.tar.gz"
+  sha256 "25e974b59570fef814be21895510f758b112adf2173621658c651898b9d1f979"
   license "Apache-2.0"
   head "https://github.com/aptos-labs/aptos-core.git", branch: "main"
 
@@ -34,12 +34,6 @@ class Aptos < Formula
     depends_on "elfutils"
     depends_on "openssl@3"
     depends_on "systemd"
-  end
-
-  # rust 1.80.0 build patch, upstream pr ref, https://github.com/aptos-labs/aptos-core/pull/14272
-  patch do
-    url "https://github.com/aptos-labs/aptos-core/commit/72b9657316c699cfbef75216f578a0bd99e0be46.patch?full_index=1"
-    sha256 "f93b4f8b0a61d245e13d6776834cec9ecdd3b0103d53b43dcc79cda3e3f787ed"
   end
 
   def install


### PR DESCRIPTION
Upgrade to latest Rust version and release 7.4.0 of the Aptos CLI.  Since we updated to the latest Rust version, we can get rid of the patch.

Replaces https://github.com/Homebrew/homebrew-core/pull/225645

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
