### PR TITLE
toml-bombadil 4.2.0 (new formula)

### DIFF
--- a/Formula/t/toml-bombadil.rb
+++ b/Formula/t/toml-bombadil.rb
@@ -6,6 +6,15 @@ class TomlBombadil < Formula
   license "MIT"
   head "https://github.com/oknozor/toml-bombadil.git", branch: "main"
 
+  bottle do
+    sha256 cellar: :any,                 arm64_sequoia: "1162919902e899ebeb320fd04132856443deb257f47a073be4bc916dfff322c7"
+    sha256 cellar: :any,                 arm64_sonoma:  "5142e942e2bcf7d79a0935e77e1f1dca2c812a60311ef4b429e60b0606e7042a"
+    sha256 cellar: :any,                 arm64_ventura: "b4e073f82e21d3a73f1ca641524f1cd5b10891dba22e4db989aa1909cafa2477"
+    sha256 cellar: :any,                 sonoma:        "a26d4a4ac5a06a3ebaf3ccf6e6c54f1c8d37faed1fb33f43a2ee89c448aa4df5"
+    sha256 cellar: :any,                 ventura:       "e1b81c25d689463b534a94f6d6d3a0ccf9987eed52b874e8c4a8f80891b5fa71"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "63847b627610a6981f8afe87c9de344b1cad2ac95a6fdfaff3af7b8071235d7a"
+  end
+
   depends_on "pkgconf" => :build
   depends_on "rust" => :build
   depends_on "openssl@3"

--- a/Formula/t/toml-bombadil.rb
+++ b/Formula/t/toml-bombadil.rb
@@ -1,0 +1,39 @@
+class TomlBombadil < Formula
+  desc "Dotfile manager with templating"
+  homepage "https://github.com/oknozor/toml-bombadil"
+  url "https://github.com/oknozor/toml-bombadil/archive/refs/tags/4.2.0.tar.gz"
+  sha256 "b911678642a1229908dfeabbdd7f799354346c0e37f3ac999277655e01b6f229"
+  license "MIT"
+  head "https://github.com/oknozor/toml-bombadil.git", branch: "main"
+
+  depends_on "pkgconf" => :build
+  depends_on "rust" => :build
+  depends_on "openssl@3"
+  uses_from_macos "zlib"
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    config_dir = if OS.mac?
+      testpath/"Library/Application Support"
+    else
+      testpath/".config"
+    end
+
+    config_dir.mkpath
+    (config_dir/"bombadil.toml").write <<~TOML
+      dotfiles_dir = "dotfiles"
+    TOML
+
+    (testpath/"dotfiles").mkpath
+
+    ENV["HOME"] = testpath
+
+    output = shell_output("#{bin}/bombadil get vars")
+
+    assert_match(/"arch":\s*".+"/, output)
+    assert_match(/"os":\s*".+"/, output)
+  end
+end


### PR DESCRIPTION
Adds toml-bombadil 4.2.0.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
