### PR TITLE
dotslash: add livecheck

### DIFF
--- a/Formula/d/dotslash.rb
+++ b/Formula/d/dotslash.rb
@@ -5,6 +5,11 @@ class Dotslash < Formula
   sha256 "92e8f39796931436e122e6c57bfd49d2050eae07d800a920ce2bf52238c1ff02"
   license "Apache-2.0"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "91b6b4a9b932a4dd6cfbe44ac4d3ffc00a1e1e501cd806a5b97460687119ed3c"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "45e7b52fd8f24163f285681fe6314ee0e660ebe99a7c42252a295b434ce9c55d"


### PR DESCRIPTION
add livecheck to ignore [feature_dotslash_1.0.0](https://github.com/facebook/dotslash/releases/tag/feature_dotslash_1.0.0)

---

<img width="560" alt="image" src="https://github.com/user-attachments/assets/58c7135b-bcd8-4c54-8755-0f827d4e1ec9" />
