### PR TITLE
brotli: add livecheck

### DIFF
--- a/Formula/b/brotli.rb
+++ b/Formula/b/brotli.rb
@@ -8,6 +8,11 @@ class Brotli < Formula
   license "MIT"
   head "https://github.com/google/brotli.git", branch: "master"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     rebuild 2
     sha256 cellar: :any,                 arm64_sequoia: "64750425b7578860d8b6a75fdb187408667f7d6523169e8dc29528bbc15309f0"


### PR DESCRIPTION
add livecheck to ignore [go/cbrotli/v1.1.0.bcr.0](https://github.com/google/brotli/releases/tag/go%2Fcbrotli%2Fv1.1.0.bcr.0) and [go/cbrotli/v1.1.0](https://github.com/google/brotli/releases/tag/go%2Fcbrotli%2Fv1.1.0)