### PR TITLE
bloaty: Add head URL

### DIFF
--- a/Formula/b/bloaty.rb
+++ b/Formula/b/bloaty.rb
@@ -1,10 +1,21 @@
 class Bloaty < Formula
   desc "Size profiler for binaries"
   homepage "https://github.com/google/bloaty"
-  url "https://github.com/google/bloaty/releases/download/v1.1/bloaty-1.1.tar.bz2"
-  sha256 "a308d8369d5812aba45982e55e7c3db2ea4780b7496a5455792fb3dcba9abd6f"
   license "Apache-2.0"
   revision 36
+  head "https://github.com/google/bloaty.git", branch: "main"
+
+  stable do
+    url "https://github.com/google/bloaty/releases/download/v1.1/bloaty-1.1.tar.bz2"
+    sha256 "a308d8369d5812aba45982e55e7c3db2ea4780b7496a5455792fb3dcba9abd6f"
+
+    # Support system Abseil. Needed for Protobuf 22+.
+    # Backport of: https://github.com/google/bloaty/pull/347
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/86c6fb2837e5b96e073e1ee5a51172131d2612d9/bloaty/system-abseil.patch"
+      sha256 "d200e08c96985539795e13d69673ba48deadfb61a262bdf49a226863c65525a7"
+    end
+  end
 
   no_autobump! because: :requires_manual_review
 
@@ -25,21 +36,16 @@ class Bloaty < Formula
   depends_on "protobuf"
   depends_on "re2"
 
-  # Support system Abseil. Needed for Protobuf 22+.
-  # Backport of: https://github.com/google/bloaty/pull/347
-  patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/86c6fb2837e5b96e073e1ee5a51172131d2612d9/bloaty/system-abseil.patch"
-    sha256 "d200e08c96985539795e13d69673ba48deadfb61a262bdf49a226863c65525a7"
-  end
-
   def install
     # https://github.com/protocolbuffers/protobuf/issues/9947
     ENV.append_to_cflags "-DNDEBUG"
     # Remove vendored dependencies
     %w[abseil-cpp capstone protobuf re2].each { |dir| rm_r(buildpath/"third_party"/dir) }
     abseil_cxx_standard = 17 # Keep in sync with C++ standard in abseil.rb
-    inreplace "CMakeLists.txt", "CMAKE_CXX_STANDARD 11", "CMAKE_CXX_STANDARD #{abseil_cxx_standard}"
-    inreplace "CMakeLists.txt", "-std=c++11", "-std=c++17"
+    if build.stable?
+      inreplace "CMakeLists.txt", "CMAKE_CXX_STANDARD 11", "CMAKE_CXX_STANDARD #{abseil_cxx_standard}"
+      inreplace "CMakeLists.txt", "-std=c++11", "-std=c++17"
+    end
 
     system "cmake", "-S", ".", "-B", "build", "-DCMAKE_CXX_STANDARD=#{abseil_cxx_standard}", *std_cmake_args
     system "cmake", "--build", "build"


### PR DESCRIPTION
Bloaty's most recent tag is from May 2020; it has issues with DWARF5, among others.

The tip of its main branch fixes many of these and is now 292 commits ahead.

Move url, sha256, patch, and inreplace into stable blocks to make them specific to the current v1.1.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
