### PR TITLE
qwt: add path to qwt.framework/Headers to Cflags in the .pc

### DIFF
--- a/Formula/q/qwt.rb
+++ b/Formula/q/qwt.rb
@@ -4,7 +4,6 @@ class Qwt < Formula
   url "https://downloads.sourceforge.net/project/qwt/qwt/6.3.0/qwt-6.3.0.tar.bz2"
   sha256 "dcb085896c28aaec5518cbc08c0ee2b4e60ada7ac929d82639f6189851a6129a"
   license "LGPL-2.1-only" => { with: "Qwt-exception-1.0" }
-  revision 1
 
   livecheck do
     url :stable

--- a/Formula/q/qwt.rb
+++ b/Formula/q/qwt.rb
@@ -44,6 +44,7 @@ class Qwt < Formula
     system "make"
     system "make", "install"
 
+    # reported at https://sourceforge.net/p/qwt/bugs/382/
     pc = lib/"pkgconfig"/"Qt6Qwt6.pc"
     inreplace pc do |s|
       s.gsub!(/^Cflags:(.*)$/, "Cflags:\\1 -I${libdir}/qwt.framework/Headers")

--- a/Formula/q/qwt.rb
+++ b/Formula/q/qwt.rb
@@ -4,6 +4,7 @@ class Qwt < Formula
   url "https://downloads.sourceforge.net/project/qwt/qwt/6.3.0/qwt-6.3.0.tar.bz2"
   sha256 "dcb085896c28aaec5518cbc08c0ee2b4e60ada7ac929d82639f6189851a6129a"
   license "LGPL-2.1-only" => { with: "Qwt-exception-1.0" }
+  revision 1
 
   livecheck do
     url :stable
@@ -42,6 +43,11 @@ class Qwt < Formula
     system "qmake", "-config", "release", "-spec", "#{os}-#{compiler}"
     system "make"
     system "make", "install"
+
+    pc = lib/"pkgconfig"/"Qt6Qwt6.pc"
+    inreplace pc do |s|
+      s.gsub!(/^Cflags:(.*)$/, "Cflags:\\1 -I${libdir}/qwt.framework/Headers")
+    end
 
     # Backwards compatibility symlinks. Remove in a future release
     odie "Remove backwards compatibility symlinks!" if version >= 7


### PR DESCRIPTION
The original `.pc` file only sets `Cflags` to be `Cflags: -I${includedir} -F${libdir}`. Since Qwt installs the actual, non-Qt-style-proxy headers to `qwt.framework/Headers`, projects relying on pkgconfig fail to find those. This change appends the path to the framework's `Headers` as well.

-----

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?