### PR TITLE
swc 1.11.31

### DIFF
--- a/Formula/s/swc.rb
+++ b/Formula/s/swc.rb
@@ -12,13 +12,13 @@ class Swc < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "8c9d865dc01a5e39977ba398eb872ee5d13745f9c1f880cc72bd88840242c493"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "8b7e4bd74754cbdee2361cffcd506b320dc7320ee54f8022563816177e28b5df"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "7d19c4c3437a45752f9faa279e8abb533f4455e57da47239b3408ed0e71d0f28"
-    sha256 cellar: :any_skip_relocation, sonoma:        "8d49f0175024e7ce7a6e080a99259e1ec28315bd8887bb276c2dc726dabce56d"
-    sha256 cellar: :any_skip_relocation, ventura:       "1a545816ed53c64cf03a0a69d045714db9acf9b275d4be01b4da76b60065e7b9"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "ed36f1ecc1d548e48229f0fb7bb45f2a35c837fe0d3cb3268ed3c05e6341abf4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4e300f564a9d808e054c0070abfec5da9ecc2034412bcc201b7b94bd060fb7b2"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "36a792ac766e31d9a3cf11d9ab67bb8a20c4ec63fe4bb67b7bdea64324ab6391"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "e6fc66e58c0e0598cacd4966956c679ccf0ae04501add013b283643b8e723b18"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "0d9ef8743c6e00037eab6140e991544d869daeded1f030c49787eb557b7654ad"
+    sha256 cellar: :any_skip_relocation, sonoma:        "9fe604ab714295390cbd2226a94007ad6dd70ddd02441c0f1f02babebddfbb4d"
+    sha256 cellar: :any_skip_relocation, ventura:       "167762554f000e82ce7481e7bcf455370b10665f6ce375af48d7e2494474833d"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "3ebee5027619970228164b11339e88b10a1782f2a0bd214e6efb2fd3181c7cc4"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "145c1912e61fb1fb323d20a84ccaf7b49c72d2b48c3be9a27c2eacc6551bedfb"
   end
 
   depends_on "rust" => :build

--- a/Formula/s/swc.rb
+++ b/Formula/s/swc.rb
@@ -1,8 +1,8 @@
 class Swc < Formula
   desc "Super-fast Rust-based JavaScript/TypeScript compiler"
   homepage "https://swc.rs"
-  url "https://github.com/swc-project/swc/archive/refs/tags/v1.11.24.tar.gz"
-  sha256 "115386a63aa890df8ecee6dc3daaeced5baabc0b1e7620b591836ed7586b9cf0"
+  url "https://github.com/swc-project/swc/archive/refs/tags/v1.11.31.tar.gz"
+  sha256 "55dc37f56aafc1841477e55b94ff095a977e640024b241753550704b303bc0c0"
   license "Apache-2.0"
   head "https://github.com/swc-project/swc.git", branch: "main"
 


### PR DESCRIPTION
swc 1.11.31

```

Error: Parameter 'string': Expected type String, got type NilClass
Caller: /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/dev-cmd/bump-formula-pr.rb:405
Definition: /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/utils/formatter.rb:61 (Formatter.truncate)
```

https://github.com/Homebrew/homebrew-core/actions/runs/15520581367/job/43693246532#step:6:14828