### PR TITLE
java-service-wrapper: fix test failure under openjdk@24

### DIFF
--- a/Formula/j/java-service-wrapper.rb
+++ b/Formula/j/java-service-wrapper.rb
@@ -59,7 +59,8 @@ class JavaServiceWrapper < Formula
       wrapper.java.command=#{java_home}/bin/java
       wrapper.java.mainclass=org.tanukisoftware.wrapper.WrapperSimpleApp
       wrapper.jarfile=#{libexec}/lib/wrapper.jar
-      wrapper.java.classpath.1=#{testpath}
+      wrapper.java.classpath.1=#{libexec}/lib/wrapper.jar
+      wrapper.java.classpath.2=#{testpath}
       wrapper.java.library.path.1=#{libexec}/lib
       wrapper.java.additional.auto_bits=TRUE
       wrapper.java.additional.1=-Xms128M


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
For Reference:
- #212057

In `openjdk` versions,
- Before 24:
```
wrapper  | Java Command Line (Bootstrap):
wrapper  |   Command: /usr/local/Cellar/openjdk@21/21.0.7/libexec/openjdk.jdk/Contents/Home/bin/java -classpath /usr/local/Cellar/java-service-wrapper/3.6.2/libexec/lib/wrapper.jar:/private/tmp/java-service-wrapper-test-20250609-25628-dokc8u org.tanukisoftware.wrapper.bootstrap.WrapperBootstrap 1 HelloWorld 1
```

- Since 24:
```
wrapper  | Java Command Line (Bootstrap):
wrapper  |   Command: /usr/local/Cellar/openjdk/24.0.1/libexec/openjdk.jdk/Contents/Home/bin/java -classpath /private/tmp/java-service-wrapper-test-20250609-19608-7fztso --upgrade-module-path /usr/local/Cellar/java-service-wrapper/3.6.2/libexec/lib/wrapper.jar org.tanukisoftware.wrapper.bootstrap.WrapperBootstrap 1 HelloWorld 1
```

The `wrapper.jar` is no longer automatically added to the classpath, but instead placed on the `--upgrade-module-path`. However, `--upgrade-module-path` relies on `module-info.class`, which is not compiled into the JAR when using the `javac.target.version=1.8` compiler option.

---

A snippet of the source code is as follows:

```c
// wrappereventloop.c

// ......

addWrapperToUpgradeModulePath = FALSE;
if (isJava24 || wrapperData->moduleList || wrapperData->mainModule) {
    /* Use Java Module(s) - Note: At least one root module is required to launch a modularized application (wrapperData->mainModule is not configurable in 3.5.x and should always be NULL here). */
    if (!wrapperData->wrapperJar) {
        if (isJava24) {
            log_printf(WRAPPER_SOURCE_WRAPPER, LEVEL_FATAL, TEXT("The %s property must be set when using Java %s."), TEXT("wrapper.jarfile"), wrapperData->javaVersion->displayName);
        } else {
            log_printf(WRAPPER_SOURCE_WRAPPER, LEVEL_FATAL, TEXT("Use of Java modules requires the %s property to be set."), TEXT("wrapper.jarfile"));
        }
        /* Note: 'stop=TRUE' (to allow other errors to be printed) should work, but is dangerous if the code changes and assumes wrapperData->wrapperJar is set.
         *       Prefer to stop.  This message is the only one of its type and is also more visible if it is the last one. */
        goto stop;
    } else if (!isWrapperJarEmbedded) {
        /* wrapper.jar must be added to the upgrade module path unless it is included in the runtime image. */
        addWrapperToUpgradeModulePath = TRUE;
    }
} else {
    /* No module - use ClassPath */
}

// ......

/* ClassPath */
if (!addWrapperToUpgradeModulePath && wrapperData->wrapperJar && !isWrapperJarEmbedded) {
    addWrapperToClassPath = TRUE;
} else {
    addWrapperToClassPath = FALSE;
}
if (wrapperBuildJavaClasspath(&wrapperData->classpath, addWrapperToClassPath) < 0) {
    goto stop;
}

// ......
```