### PR TITLE
ktmm 0.5.1 (new formula)

### DIFF
--- a/Formula/k/ktmm.rb
+++ b/Formula/k/ktmm.rb
@@ -1,0 +1,26 @@
+class Ktmm < Formula
+  desc "Keep That Mouse Moving - Prevents system sleep by making periodic mouse movements"
+  homepage "https://github.com/ao/ktmm"
+  url "https://github.com/ao/ktmm/archive/refs/tags/v0.5.1.tar.gz"
+  sha256 "5962df6852d5d1b78ace3248f26d5737fee131dda80f2f8b53bbdf1319e85b76"  # source
+  license "MIT"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    assert_match "ktmm 0.5.1", shell_output("#{bin}/ktmm --version")
+  end
+
+  def caveats
+    <<~EOS
+      KTMM requires accessibility permissions on macOS.
+      After installation, go to:
+      System Preferences > Security & Privacy > Privacy > Accessibility
+      and add KTMM to the list of allowed applications.
+    EOS
+  end
+end

--- a/Formula/k/ktmm.rb
+++ b/Formula/k/ktmm.rb
@@ -1,18 +1,14 @@
 class Ktmm < Formula
-  desc "Keep That Mouse Moving - Prevents system sleep by making periodic mouse movements"
+  desc "Prevents system sleep by making periodic mouse movements"
   homepage "https://github.com/ao/ktmm"
   url "https://github.com/ao/ktmm/archive/refs/tags/v0.5.1.tar.gz"
-  sha256 "5962df6852d5d1b78ace3248f26d5737fee131dda80f2f8b53bbdf1319e85b76"  # source
+  sha256 "5962df6852d5d1b78ace3248f26d5737fee131dda80f2f8b53bbdf1319e85b76"
   license "MIT"
 
   depends_on "rust" => :build
 
   def install
     system "cargo", "install", *std_cargo_args
-  end
-
-  test do
-    assert_match "ktmm 0.5.1", shell_output("#{bin}/ktmm --version")
   end
 
   def caveats
@@ -23,4 +19,9 @@ class Ktmm < Formula
       and add KTMM to the list of allowed applications.
     EOS
   end
+
+  test do
+    assert_match "ktmm 0.5.1", shell_output("#{bin}/ktmm --version")
+  end
+
 end

--- a/Formula/k/ktmm.rb
+++ b/Formula/k/ktmm.rb
@@ -23,5 +23,4 @@ class Ktmm < Formula
   test do
     assert_match "ktmm 0.5.1", shell_output("#{bin}/ktmm --version")
   end
-
 end


### PR DESCRIPTION
Keep That Mouse Moving (ktmm) is a utility that prevents system sleep by making periodic mouse movements. It's written in Rust and requires accessibility permissions on macOS to function properly. This formula adds ktmm version 0.5.1 to Homebrew.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
