### PR TITLE
gitlab-runner: remove `-B gobuildid` ldflag

### DIFF
--- a/Formula/g/gitlab-runner.rb
+++ b/Formula/g/gitlab-runner.rb
@@ -32,7 +32,6 @@ class GitlabRunner < Formula
       -X #{proj}/common.REVISION=#{Utils.git_short_head(length: 8)}
       -X #{proj}/common.BRANCH=#{version.major}-#{version.minor}-stable
       -X #{proj}/common.BUILT=#{time.strftime("%Y-%m-%dT%H:%M:%S%:z")}
-      -B gobuildid
     ]
     system "go", "build", *std_go_args(ldflags:)
   end

--- a/Formula/g/gitlab-runner.rb
+++ b/Formula/g/gitlab-runner.rb
@@ -13,12 +13,13 @@ class GitlabRunner < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "73d1466c2b90dda3eb93583767756680416ab55ce049d4a02633df7b43e8e1a3"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "73d1466c2b90dda3eb93583767756680416ab55ce049d4a02633df7b43e8e1a3"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "73d1466c2b90dda3eb93583767756680416ab55ce049d4a02633df7b43e8e1a3"
-    sha256 cellar: :any_skip_relocation, sonoma:        "043f9f82c10e4529bcb6da5238fb219ce3ff440a90ffd3a5a376cf57208ca2ba"
-    sha256 cellar: :any_skip_relocation, ventura:       "043f9f82c10e4529bcb6da5238fb219ce3ff440a90ffd3a5a376cf57208ca2ba"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4e117cd8f01fee566da3ea7429dd28dbebdd411c882d98ed94bd668d790b62d9"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "499f68ed5ee27e70230e6e48ec4cbd603321b9b43248e81480c73c2efc057ff7"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "499f68ed5ee27e70230e6e48ec4cbd603321b9b43248e81480c73c2efc057ff7"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "499f68ed5ee27e70230e6e48ec4cbd603321b9b43248e81480c73c2efc057ff7"
+    sha256 cellar: :any_skip_relocation, sonoma:        "d8743302af7dc3a627a061500b532e178a779c8e80b54c97015006be9ca4d3c0"
+    sha256 cellar: :any_skip_relocation, ventura:       "d8743302af7dc3a627a061500b532e178a779c8e80b54c97015006be9ca4d3c0"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "495e47f9cd7a8cd745bdb8cdcf85bbe058482b14e4091847e3d6f440eab7e837"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
Reverts the Go linker flag that caused Go to tag the binary with a UUID which is required by Sequoia firewall to allow local networking access. That flag is no longer required in Go versions 1.24.0 and later which is now the default in homebrew.

Gitlab team has also [updated their default runner builds to use 1.24.3](https://gitlab.com/gitlab-org/gitlab-runner/-/issues/38396).

* see also https://github.com/Homebrew/homebrew-core/pull/198462

---
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
