### PR TITLE
g3log googletest: add `conflicts_with`

### DIFF
--- a/Formula/g/g3log.rb
+++ b/Formula/g/g3log.rb
@@ -21,6 +21,8 @@ class G3log < Formula
 
   depends_on "cmake" => :build
 
+  conflicts_with "googletest", because: "both install `libgmock.a` and `libgtest.a` libraries"
+
   def install
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args
     system "cmake", "--build", "build"

--- a/Formula/g/googletest.rb
+++ b/Formula/g/googletest.rb
@@ -18,6 +18,8 @@ class Googletest < Formula
 
   depends_on "cmake" => :build
 
+  conflicts_with "g3log", because: "both install `libgmock.a` and `libgtest.a` libraries"
+
   def install
     system "cmake", "-S", ".", "-B", "build",
       "-DCMAKE_CXX_STANDARD=17", *std_cmake_args


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
After trying to update g3log formula I got this error:
```
==> Cleaning
==> Finishing up
ln -s ../Cellar/g3log/2.5/include/g3log g3log
rm /opt/homebrew/include/gmock
ln -s ../../Cellar/googletest/1.17.0/include/gmock/gmock-actions.h gmock-actions.h
ln -s ../../Cellar/googletest/1.17.0/include/gmock/gmock-cardinalities.h gmock-cardinalities.h
ln -s ../../Cellar/googletest/1.17.0/include/gmock/gmock-function-mocker.h gmock-function-mocker.h
ln -s ../../Cellar/googletest/1.17.0/include/gmock/gmock-matchers.h gmock-matchers.h
ln -s ../../Cellar/googletest/1.17.0/include/gmock/gmock-more-actions.h gmock-more-actions.h
ln -s ../../Cellar/googletest/1.17.0/include/gmock/gmock-more-matchers.h gmock-more-matchers.h
ln -s ../../Cellar/googletest/1.17.0/include/gmock/gmock-nice-strict.h gmock-nice-strict.h
ln -s ../../Cellar/googletest/1.17.0/include/gmock/gmock-spec-builders.h gmock-spec-builders.h
ln -s ../../Cellar/googletest/1.17.0/include/gmock/gmock.h gmock.h
mkdir -p /opt/homebrew/include/gmock/internal
mkdir -p /opt/homebrew/include/gmock/internal/custom
ln -s ../../../../Cellar/googletest/1.17.0/include/gmock/internal/custom/README.md README.md
ln -s ../../../../Cellar/googletest/1.17.0/include/gmock/internal/custom/gmock-generated-actions.h gmock-generated-actions.h
ln -s ../../../../Cellar/googletest/1.17.0/include/gmock/internal/custom/gmock-matchers.h gmock-matchers.h
ln -s ../../../../Cellar/googletest/1.17.0/include/gmock/internal/custom/gmock-port.h gmock-port.h
ln -s ../../../Cellar/googletest/1.17.0/include/gmock/internal/gmock-internal-utils.h gmock-internal-utils.h
ln -s ../../../Cellar/googletest/1.17.0/include/gmock/internal/gmock-port.h gmock-port.h
ln -s ../../../Cellar/googletest/1.17.0/include/gmock/internal/gmock-pp.h gmock-pp.h
rm /opt/homebrew/include/g3log
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /opt/homebrew
Could not symlink include/gmock/gmock-actions.h
Target /opt/homebrew/include/gmock/gmock-actions.h
is a symlink belonging to googletest. You can unlink it:
  brew unlink googletest

To force the link and overwrite all conflicting files:
  brew link --overwrite g3log

To list all files that would be deleted:
  brew link --overwrite g3log --dry-run
```