### PR TITLE
iipsrv 1.3 (new formula)

### DIFF
--- a/Formula/i/iipsrv.rb
+++ b/Formula/i/iipsrv.rb
@@ -1,0 +1,41 @@
+class Iipsrv < Formula
+  desc "High performance image server for high resolution and scientific images"
+  homepage "https://iipimage.sourceforge.io"
+  url "https://downloads.sourceforge.net/iipimage/IIP%20Server/iipsrv-1.3/iipsrv-1.3.tar.bz2"
+  sha256 "d4bdfd137bcd7856d49fafddb15c03913ae00ff781672f8239d0ca0988cfc752"
+  license "GPL-3.0-or-later"
+
+  livecheck do
+    url :stable
+    regex(%r{ url=.*?/iipimage/files/IIP%20Server/.*?[-_/](\d+(?:[-.]\d+)+)[-_/%.]}i)
+  end
+
+  depends_on "pkgconf" => :build
+  depends_on "fcgi"
+  depends_on "jpeg-turbo"
+  depends_on "libavif"
+  depends_on "libmemcached"
+  depends_on "libpng"
+  depends_on "libtiff"
+  depends_on "openjpeg"
+  depends_on "webp"
+
+  def install
+    system "./configure", *std_configure_args, "--disable-silent-rules"
+    system "make", "install"
+  end
+
+  service do
+    run [opt_sbin/"iipsrv", "--bind", "0.0.0.0:9000"]
+    environment_variables LOGFILE: "/dev/stdout", URI_MAP: "iiif=>IIIF"
+    log_path var/"log/iipsrv.log"
+    keep_alive crashed: true
+  end
+
+  test do
+    # Test whether iipsrv is able to create log file
+    ENV["LOGFILE"] = testpath/"iipsrv.log"
+    assert_equal "", shell_output(sbin/"iipsrv", 1)
+    assert_path_exists testpath/"iipsrv.log"
+  end
+end


### PR DESCRIPTION
New formula for iipsrv, the image server from the IIPImage project (https://iipimage.sourceforge.io).
iipsrv is a high performance image server used for web-based image streaming and transcoding that supports multiple APIs such as IIIF and Deepzoom. The formula compiles iipsrv and provides both test and service blocks

This new upstream version fixes the issues identified in this previous pull request: https://github.com/Homebrew/homebrew-core/pull/152869

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
