### PR TITLE
mapcidr 1.1.94

### DIFF
--- a/Formula/m/mapcidr.rb
+++ b/Formula/m/mapcidr.rb
@@ -7,14 +7,12 @@ class Mapcidr < Formula
   head "https://github.com/projectdiscovery/mapcidr.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "0f78e69af4afb917cf0a41804f2519b6bea04bdb690b01510b7101fddcc13d19"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "cb89cba8eb2951d6031b6596f645ff095a0a45fa32e801eba3428112e9805262"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "14c162c1728ed3a4db440a87a7c50a83a56e1850cf3b63ffe6141a13dea3685f"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "d6bdc1c16bde927ed10481ae997d383d1cc8e51ba21c8c8d70f287dc16607939"
-    sha256 cellar: :any_skip_relocation, sonoma:         "402aadaa69b3d0d49ea79073f889c83abc4e06ce2168aa9d8970271e3ae14805"
-    sha256 cellar: :any_skip_relocation, ventura:        "8e872b8888bcd318860259bd57a024b1fc4f339ecfc226f8f9473b230d040843"
-    sha256 cellar: :any_skip_relocation, monterey:       "e8dfa1fb2323413d735e839062901fff2b9ede039ce62c1ce62cf0ac46f58507"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "59d005c2c7a7f0e9f40d332ab2eca37651bb4480d83baeef707d1c9619d99c62"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "686bfce3317571c04dce3cac870517c935268e7640c10430066ef36f51936079"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "dac8b92952f6143c0083c49aaec1806fd1f5bde2c26a6671f98450623820ebe0"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "71df5c68774568b12f5edc82f3ea2eb792f10c7602a03099fa85f2ced8b46c0e"
+    sha256 cellar: :any_skip_relocation, sonoma:        "1a4b205a3339eeb94c4ce605303fb7be40c1c0a9ef2a3567dd0fbb0702c84c9b"
+    sha256 cellar: :any_skip_relocation, ventura:       "a0ead83131742a6efcd5d84694521041d359bb131dfdeb7b08fd3cc673b92b94"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "70109f0a3ef54ef62fd245cc4e05e598c342812a2e390b0670d28799509958ed"
   end
 
   depends_on "go" => :build

--- a/Formula/m/mapcidr.rb
+++ b/Formula/m/mapcidr.rb
@@ -1,8 +1,8 @@
 class Mapcidr < Formula
   desc "Subnet/CIDR operation utility"
   homepage "https://projectdiscovery.io"
-  url "https://github.com/projectdiscovery/mapcidr/archive/refs/tags/v1.1.34.tar.gz"
-  sha256 "296950c4123d34554a9f0746f1bef074374b7ff778fa5fbcc92a24fe149fe78d"
+  url "https://github.com/projectdiscovery/mapcidr/archive/refs/tags/1.1.94.tar.gz"
+  sha256 "2c905a2993638d57dc335005a709e19e37ba8c6512f2a8136a7df278cd49df08"
   license "MIT"
   head "https://github.com/projectdiscovery/mapcidr.git", branch: "master"
 


### PR DESCRIPTION
mapcidr 1.1.94

---

```
Failed to download resource "mapcidr" Download failed: https://github.com/projectdiscovery/mapcidr/archive/refs/tags/v1.1.94.tar.gz
```