### PR TITLE
mongo-cxx-driver 4.1.0

### DIFF
--- a/Formula/m/mongo-cxx-driver.rb
+++ b/Formula/m/mongo-cxx-driver.rb
@@ -1,10 +1,9 @@
 class MongoCxxDriver < Formula
   desc "C++ driver for MongoDB"
   homepage "https://github.com/mongodb/mongo-cxx-driver"
-  url "https://github.com/mongodb/mongo-cxx-driver/releases/download/r4.0.0/mongo-cxx-driver-r4.0.0.tar.gz"
-  sha256 "d8a254bde203d0fe2df14243ef2c3bab7f12381dc9206d0c1b450f6ae02da7cf"
+  url "https://github.com/mongodb/mongo-cxx-driver/releases/download/r4.1.0/mongo-cxx-driver-r4.1.0.tar.gz"
+  sha256 "2abadcdce57cb841218a16c5153d7cdae132f310a72f650879320358feac62ba"
   license "Apache-2.0"
-  revision 1
   head "https://github.com/mongodb/mongo-cxx-driver.git", branch: "master"
 
   livecheck do
@@ -24,7 +23,7 @@ class MongoCxxDriver < Formula
 
   depends_on "cmake" => :build
   depends_on "pkgconf" => :test
-  depends_on "mongo-c-driver@1"
+  depends_on "mongo-c-driver"
 
   def install
     # We want to avoid shims referencing in examples,
@@ -32,7 +31,7 @@ class MongoCxxDriver < Formula
     pkgshare.install "examples"
     (buildpath / "examples/CMakeLists.txt").write ""
 
-    mongo_c_prefix = Formula["mongo-c-driver@1"].opt_prefix
+    mongo_c_prefix = Formula["mongo-c-driver"].opt_prefix
     args = %W[
       -DBUILD_VERSION=#{version}
       -DLIBBSON_DIR=#{mongo_c_prefix}

--- a/Formula/m/mongo-cxx-driver.rb
+++ b/Formula/m/mongo-cxx-driver.rb
@@ -12,13 +12,13 @@ class MongoCxxDriver < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "076899436db520e9cf26e596fb15e6b55bc91a241941a0e72ca50a03ced7f4e4"
-    sha256 cellar: :any,                 arm64_sonoma:  "8f0a2e351df8f50bde18a2cb1269f7809a61e7295bd427ee8306d4b2abd8135c"
-    sha256 cellar: :any,                 arm64_ventura: "9f485a724048cec2715471819a53c3ba859c54a6c123f582ee1c64fb773d2660"
-    sha256 cellar: :any,                 sonoma:        "7f9b6811d5a8dee9177503d3f7026ef05e51ca89d343ab2dc04dfd5e8c7e278c"
-    sha256 cellar: :any,                 ventura:       "0e00e45fe2dd1a90ee4ad14e9012f82aed82f5acd88450f2748b83e3b9f82150"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "e01b0c332699922df9f0e959bbaf6e49af29800a4fcffcd51a2a54aed2929eae"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "ae7613b42a1e10964b6df62cf8d337feccadda20b5ccb3c8fc34b6c8de1575d3"
+    sha256 cellar: :any,                 arm64_sequoia: "15e5486f75a19657fd653d970140f0322328446fa64f4ecdcb1c9c7f1d8f94c3"
+    sha256 cellar: :any,                 arm64_sonoma:  "3ebc5250eb31452205ca3addb07ede68a12844450722678ee5a132cb9fb504a1"
+    sha256 cellar: :any,                 arm64_ventura: "c01ddb4060afeef9114a9b7cd15a528b95a7a9b6313cf7c7c204f6bfd6d39854"
+    sha256 cellar: :any,                 sonoma:        "acb0f918f5a9a5d779625039e408161c812b93ca6cab4c13eed8ce6fd19840d0"
+    sha256 cellar: :any,                 ventura:       "5ae84067b6395912b1713b38e964925f9a66d0c191371346765bfdac0b884f1c"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "fd90967c83e0cd91a7f7601ddf0a3693d10126f4cd575a5b39927cc5bb66c654"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "da24e9deab656d631ae582ccaf9b02fb94e56c74f5a67235851dd7132e1eb0d5"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
Update the mongo-cxx-driver formula from v4.0.0 to v4.1.0.

The generated PR to update the formula (https://github.com/Homebrew/homebrew-core/pull/222154) was closed. The MongoDB C++ driver v4.1 bumps the minimum required C driver from v1 to v2. This PR updates the dependency from `mongo-c-driver@1` to `mongo-c-driver`.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
