### PR TITLE
Tweak GitHub Actions workflows

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,8 +1,10 @@
-name: actionlint
+# This file is synced from the `.github` repository, do not modify it directly.
+name: Actionlint
 
 on:
   push:
     branches:
+      - main
       - master
     paths:
       - '.github/workflows/*.ya?ml'
@@ -28,53 +30,52 @@ env:
 
 permissions: {}
 
-# FIXME: The `Install tools` step fails inside the Docker container for some reason.
 jobs:
   workflow_syntax:
     if: github.repository_owner == 'Homebrew'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Set up Homebrew
         id: setup-homebrew
         uses: Homebrew/actions/setup-homebrew@master
         with:
-          core: true
+          core: false
           cask: false
           test-bot: false
 
       - name: Install tools
         run: brew install actionlint shellcheck zizmor
 
-      - name: Set up GITHUB_WORKSPACE
-        env:
-          HOMEBREW_TAP_REPOSITORY: ${{ steps.setup-homebrew.outputs.repository-path }}
-        run: |
-          # Annotations work only relative to GITHUB_WORKSPACE
-          (shopt -s dotglob; rm -rf "${GITHUB_WORKSPACE:?}"/*; mv "${HOMEBREW_TAP_REPOSITORY:?}"/* "$GITHUB_WORKSPACE")
-          rmdir "$HOMEBREW_TAP_REPOSITORY"
-          ln -vs "$GITHUB_WORKSPACE" "$HOMEBREW_TAP_REPOSITORY"
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - run: zizmor --format sarif . > results.sarif
 
       - name: Upload SARIF file
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        # We can't use the SARIF file when triggered by `merge_group` so we don't upload it.
+        if: always() && github.event_name != 'merge_group'
         with:
           name: results.sarif
           path: results.sarif
 
       - name: Set up actionlint
-        run: |
-          # Setting `shell: /bin/bash` prevents shellcheck from running on
-          # those steps, so let's change them to `shell: bash` for linting.
-          sed -i 's|shell: /bin/bash -x|shell: bash -x|' .github/workflows/*.y*ml
-          # The JSON matcher needs to be accessible to the container host.
-          cp "$(brew --repository)/.github/actionlint-matcher.json" "$HOME"
-          echo "::add-matcher::$HOME/actionlint-matcher.json"
+        run: echo "::add-matcher::$(brew --repository)/.github/actionlint-matcher.json"
 
       - run: actionlint
 
   upload_sarif:
     needs: workflow_syntax
+    # We want to always upload this even if `actionlint` failed.
+    # This is only available on public repositories.
+    if: >
+      always() &&
+      !contains(fromJSON('["cancelled", "skipped"]'), needs.workflow_syntax.result) &&
+      !github.event.repository.private &&
+      github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -3,6 +3,7 @@ name: Bump formulae on schedule or request
 on:
   push:
     branches:
+      - main
       - master
     paths:
       - .github/workflows/autobump.yml
@@ -27,6 +28,7 @@ jobs:
     if: github.repository_owner == 'Homebrew'
     runs-on: ubuntu-latest
     container:
+      # TODO: switch to main when we're pushing those images
       image: ghcr.io/homebrew/ubuntu22.04:master
     env:
       GNUPGHOME: /tmp/gnupghome

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - .github/workflows/cache.yml
     branches:
+      - main
       - master
   schedule:
     - cron: '30 19/6 * * *'
@@ -33,6 +34,7 @@ jobs:
     if: github.repository_owner == 'Homebrew'
     runs-on: ubuntu-latest
     container:
+      # TODO: switch to main when we're pushing those images
       image: ghcr.io/homebrew/ubuntu22.04:master
     outputs:
       runners: ${{ steps.determine-runners.outputs.runners }}

--- a/.github/workflows/remove-disabled-packages.yml
+++ b/.github/workflows/remove-disabled-packages.yml
@@ -3,6 +3,7 @@ name: Remove disabled packages
 on:
   push:
     branches:
+      - main
       - master
     paths:
       - .github/workflows/remove-disabled-packages.yml
@@ -29,6 +30,7 @@ jobs:
     if: github.repository_owner == 'Homebrew'
     runs-on: ubuntu-latest
     container:
+      # TODO: switch to main when we're pushing those images
       image: ghcr.io/homebrew/ubuntu22.04:master
     env:
       REMOVAL_BRANCH: remove-disabled-packages
@@ -80,7 +82,7 @@ jobs:
         uses: Homebrew/actions/create-pull-request@master
         with:
           token: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
-          base: master
+          base: HEAD
           head: ${{env.REMOVAL_BRANCH}}
           title: Remove disabled packages
           labels: CI-no-bottles

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -3,6 +3,7 @@ name: Scheduled online check
 on:
   push:
     branches:
+      - main
       - master
     paths:
       - .github/workflows/scheduled.yml
@@ -32,6 +33,7 @@ jobs:
     if: startsWith( github.repository, 'Homebrew/' )
     runs-on: ubuntu-latest
     container:
+      # TODO: switch to main when we're pushing those images
       image: ghcr.io/homebrew/ubuntu22.04:master
     outputs:
       json: ${{ steps.matrix.outputs.json }}
@@ -96,6 +98,7 @@ jobs:
     if: startsWith( github.repository, 'Homebrew/' )
     runs-on: ubuntu-latest
     container:
+      # TODO: switch to main when we're pushing those images
       image: ghcr.io/homebrew/ubuntu22.04:master
     permissions:
       issues: write

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches:
+      - main
       - master
   pull_request:
   merge_group:
@@ -42,6 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.stable }}
     container:
+      # TODO: switch to main when we're pushing those images
       image: ghcr.io/homebrew/ubuntu22.04:${{ matrix.stable && 'latest' || 'master'}}
     env:
       HOMEBREW_SIMULATE_MACOS_ON_LINUX: 1
@@ -59,8 +61,8 @@ jobs:
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: /home/linuxbrew/.cache/Homebrew/style
-          key: style-cache-${{ matrix.stable && 'stable-' || 'master-' }}${{ github.sha }}
-          restore-keys: style-cache-${{ matrix.stable && 'stable-' || 'master-' }}
+          key: style-cache-${{ matrix.stable && 'stable-' || 'main-' }}${{ github.sha }}
+          restore-keys: style-cache-${{ matrix.stable && 'stable-' || 'main-' }}
 
       - run: brew test-bot --only-tap-syntax ${{ matrix.stable && '--stable' || '' }}
 
@@ -68,6 +70,7 @@ jobs:
     if: github.repository_owner == 'Homebrew' && github.event_name != 'push'
     runs-on: ubuntu-latest
     container:
+      # TODO: switch to main when we're pushing those images
       image: ghcr.io/homebrew/ubuntu22.04:master
     outputs:
       testing_formulae: ${{ steps.formulae-detect.outputs.testing_formulae }}
@@ -89,7 +92,7 @@ jobs:
         if: >
           github.event_name == 'merge_group' ||
           (contains(github.event.pull_request.labels.*.name, 'CI-published-bottle-commits') &&
-           github.base_ref != 'master')
+           github.base_ref != 'master' && github.base_ref != 'main')
         env:
           TESTING_FORMULAE: ${{ steps.formulae-detect.outputs.formulae_to_fetch }}
         run: brew test-bot --only-bottles-fetch --testing-formulae="$TESTING_FORMULAE"
@@ -182,6 +185,7 @@ jobs:
       !fromJson(needs.setup_tests.outputs.syntax-only)
     runs-on: ubuntu-latest
     container:
+      # TODO: switch to main when we're pushing those images
       image: ghcr.io/homebrew/ubuntu22.04:master
     outputs:
       runners: ${{steps.determine-runners.outputs.runners}}
@@ -310,6 +314,7 @@ jobs:
       fromJson(needs.setup_dep_tests.outputs.test-dependents)
     runs-on: ubuntu-latest
     container:
+      # TODO: switch to main when we're pushing those images
       image: ghcr.io/homebrew/ubuntu22.04:master
     outputs:
       runners: ${{steps.determine-dependent-runners.outputs.runners}}


### PR DESCRIPTION
- prepare to use `main` instead of `master`.
- use synced `actionlint.yml` to simplify Homebrew/.github sync logic.