### PR TITLE
ghidra 11.4.2 (new formula)

### DIFF
--- a/Formula/g/ghidra.rb
+++ b/Formula/g/ghidra.rb
@@ -5,6 +5,14 @@ class Ghidra < Formula
   sha256 "ac2af20b6d20bee37e5238df2566664d824a5a3205db4dacbebdcb62b1394d00"
   license "Apache-2.0"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "fd0ad065dd2b8d1ae14fbaab2611f90c038adcaaaba4fa61f806375e35f479d9"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "15224d115d878fa789746ec8143fa5023a2229a29ca3642c17830b3f2e575f13"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "5018e1332048501fb33df633bea8d532837b98cdc8c592bc74245f22accc5016"
+    sha256 cellar: :any_skip_relocation, sonoma:        "0e900d0d4853e7f1f7d99b7f6e5f7d94804d81ba45da5dc5c6a08b7989405506"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "55b95f3d14b8b72ea2379ffc0b6bc047953933f6e852d3fbeb131976c2a7d0ca"
+  end
+
   depends_on "gradle" => :build
   depends_on "python@3.13" => :build
   depends_on "openjdk@21"

--- a/Formula/g/ghidra.rb
+++ b/Formula/g/ghidra.rb
@@ -1,0 +1,32 @@
+class Ghidra < Formula
+  desc "Multi-platform software reverse engineering framework"
+  homepage "https://github.com/NationalSecurityAgency/ghidra"
+  url "https://github.com/NationalSecurityAgency/ghidra/archive/refs/tags/Ghidra_11.4.2_build.tar.gz"
+  sha256 "ac2af20b6d20bee37e5238df2566664d824a5a3205db4dacbebdcb62b1394d00"
+  license "Apache-2.0"
+
+  depends_on "gradle" => :build
+  depends_on "python@3.13" => :build
+  depends_on "openjdk@21"
+
+  def install
+    inreplace "Ghidra/application.properties", "DEV", "PUBLIC" # Mark as a release
+    system "gradle", "-I", "gradle/support/fetchDependencies.gradle"
+
+    system "gradle", "buildNatives"
+    system "gradle", "assembleAll", "-x", "FileFormats:extractSevenZipNativeLibs"
+
+    libexec.install (buildpath/"build/dist/ghidra_#{version}_PUBLIC").children
+    (bin/"ghidraRun").write_env_script libexec/"ghidraRun",
+                                       Language::Java.overridable_java_home_env("21")
+  end
+
+  test do
+    (testpath/"analyzeHeadless").write_env_script libexec/"support/analyzeHeadless",
+                                                  Language::Java.overridable_java_home_env("21")
+    (testpath/"project").mkpath
+    system "/bin/bash", testpath/"analyzeHeadless", testpath/"project",
+                        "HomebrewTest", "-import", "/bin/bash", "-noanalysis"
+    assert_path_exists testpath/"project/HomebrewTest.rep"
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

_The following is out of date_
```
  * line 5, col 3: `url` (line 5) should be put before `version` (line 4)
  * line 27, col 119: Line is too long. [124/118]
  * The homepage URL https://www.nsa.gov/ghidra is not reachable (HTTP status code 403)
  * Stable: version 11.3.2 is redundant with version scanned from URL
  * Binaries built for a non-native architecture were installed into ghidra's prefix.
    The offending files are:
      /opt/homebrew/Cellar/ghidra/11.3.2/Ghidra/Features/FileFormats/data/sevenzipnativelibs/Mac-x86_64/lib7-Zip-JBinding.dylib	(x86_64)
```
All for good reason:
 - Line cannot really be wrapped (can it?)
 - nsa blocks bot requests, I'm guessing
 - url-version order is reversed because of variable interpolation.
-----
 - Suceeds #37656, since Ghidra should now be fully open-source. (I shamelessly stole the test case from that PR too.)
 - This formula is designed to behave identically to the cask. However, it now has no intel components when built on arm (see the `gradle buildNative` line), which resolves issues like https://github.com/NationalSecurityAgency/ghidra/issues/3622.