### PR TITLE
iproute2: suggest iproute2mac on failed install when on macOS

### DIFF
--- a/Formula/i/iproute2.rb
+++ b/Formula/i/iproute2.rb
@@ -28,6 +28,8 @@ class Iproute2 < Formula
   depends_on :linux
 
   def install
+    odie "iproute2 requires linux. Try using iproute2mac" if OS.mac?
+
     system "make"
     system "make", "install",
            "PREFIX=#{prefix}",


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
