### PR TITLE
ip 1.0.0 (new formula)

### DIFF
--- a/Formula/i/ip.rb
+++ b/Formula/i/ip.rb
@@ -5,12 +5,25 @@ class Ip < Formula
   sha256 "0f1e6099eb568f3027db981177a1062c84036171cb13b697c38c992a81339ba0"
   license "MIT"
   head "https://github.com/StarkChristmas/ipget.git", branch: "main"
-  
-  depends_on :macOS
+
   depends_on "go" => :build
+  depends_on :macos
+
+  def install
+    return unless OS.mac?
+
+    system "go", "build", *std_go_args, "./main.go"
+  end
+
+  def caveats
+    <<~EOS
+      This formula is only supported on macOS.
+    EOS
+  end
 
   test do
     return unless OS.mac?
+
     output = shell_output("#{bin}/ip 2>&1")
     assert_match(/\d+\.\d+\.\d+\.\d+/, output)
   end

--- a/Formula/i/ip.rb
+++ b/Formula/i/ip.rb
@@ -1,5 +1,5 @@
 class Ip < Formula
-  desc "ifconfig alternative showing external IP, active interfaces & internal IPv4 only."
+  desc "Display public and private IPs and city for active network interfaces"
   homepage "https://github.com/StarkChristmas/ipget"
   url "https://github.com/StarkChristmas/ipget/archive/refs/tags/v1.0.0.tar.gz"
   sha256 "0f1e6099eb568f3027db981177a1062c84036171cb13b697c38c992a81339ba0"
@@ -13,6 +13,7 @@ class Ip < Formula
 
   test do
     output = shell_output("#{bin}/ip 2>&1")
-    assert_match /\d+\.\d+\.\d+\.\d+/, output
+    assert_match(/\d+\.\d+\.\d+\.\d+/, output)
+    assert_equal 0, $CHILD_STATUS.exitstatus
   end
 end

--- a/Formula/i/ip.rb
+++ b/Formula/i/ip.rb
@@ -6,7 +6,7 @@ class Ip < Formula
   license "MIT"
   head "https://github.com/StarkChristmas/ipget.git", branch: "main"
 
-  depends_on "go" => [:build, ">= 1.18"]
+  depends_on "go" => :build
 
   on_macos do
     def install

--- a/Formula/i/ip.rb
+++ b/Formula/i/ip.rb
@@ -1,5 +1,5 @@
 class Ip < Formula
-  desc "Optimize ifconfig output of macos to only display the network interfaces that are activated and have obtained valid IP addresses. The output includes Network Service, Local IPv4 Address, Public IP, and City."
+  desc "ifconfig alternative showing external IP, active interfaces & internal IPv4 only."
   homepage "https://github.com/StarkChristmas/ipget"
   url "https://github.com/StarkChristmas/ipget/archive/refs/tags/v1.0.0.tar.gz"
   sha256 "0f1e6099eb568f3027db981177a1062c84036171cb13b697c38c992a81339ba0"
@@ -12,7 +12,7 @@ class Ip < Formula
   end
 
   test do
-    output = shell_output("#{bin}/ipget 2>&1")
+    output = shell_output("#{bin}/ip 2>&1")
     assert_match /\d+\.\d+\.\d+\.\d+/, output
   end
 end

--- a/Formula/i/ip.rb
+++ b/Formula/i/ip.rb
@@ -31,6 +31,5 @@ class Ip < Formula
 
     output = shell_output("#{bin}/ip 2>&1")
     assert_match(/\d+\.\d+\.\d+\.\d+/, output)
-    assert_equal 0, $CHILD_STATUS.exitstatus
   end
 end

--- a/Formula/i/ip.rb
+++ b/Formula/i/ip.rb
@@ -1,0 +1,18 @@
+class Ip < Formula
+  desc "Optimize ifconfig output of macos to only display the network interfaces that are activated and have obtained valid IP addresses. The output includes Network Service, Local IPv4 Address, Public IP, and City."
+  homepage "https://github.com/StarkChristmas/ipget"
+  url "https://github.com/StarkChristmas/ipget/archive/refs/tags/v1.0.0.tar.gz"
+  sha256 "0f1e6099eb568f3027db981177a1062c84036171cb13b697c38c992a81339ba0"
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args, "./main.go"
+  end
+
+  test do
+    output = shell_output("#{bin}/ipget 2>&1")
+    assert_match /\d+\.\d+\.\d+\.\d+/, output
+  end
+end

--- a/Formula/i/ip.rb
+++ b/Formula/i/ip.rb
@@ -34,4 +34,3 @@ class Ip < Formula
     assert_equal 0, $CHILD_STATUS.exitstatus
   end
 end
-

--- a/Formula/i/ip.rb
+++ b/Formula/i/ip.rb
@@ -5,30 +5,12 @@ class Ip < Formula
   sha256 "0f1e6099eb568f3027db981177a1062c84036171cb13b697c38c992a81339ba0"
   license "MIT"
   head "https://github.com/StarkChristmas/ipget.git", branch: "main"
-
+  
+  depends_on :macOS
   depends_on "go" => :build
-
-  on_macos do
-    def install
-      system "go", "build", *std_go_args, "./main.go"
-    end
-
-    def caveats
-      <<~EOS
-        This formula is only supported on macOS.
-      EOS
-    end
-  end
-
-  on_linux do
-    def install
-      odie "This formula is not supported on Linux."
-    end
-  end
 
   test do
     return unless OS.mac?
-
     output = shell_output("#{bin}/ip 2>&1")
     assert_match(/\d+\.\d+\.\d+\.\d+/, output)
   end

--- a/Formula/i/ip.rb
+++ b/Formula/i/ip.rb
@@ -6,17 +6,11 @@ class Ip < Formula
   license "MIT"
   head "https://github.com/StarkChristmas/ipget.git", branch: "main"
 
-  depends_on "go" => :build
+  depends_on "go" => [:build, ">= 1.18"]
 
   on_macos do
     def install
-      system "go", "build", *std_go_args, "."
-    end
-
-    test do
-      output = shell_output("#{bin}/ip 2>&1")
-      assert_match(/\d+\.\d+\.\d+\.\d+/, output)
-      assert_equal 0, $CHILD_STATUS.exitstatus
+      system "go", "build", *std_go_args, "./main.go"
     end
 
     def caveats
@@ -24,6 +18,20 @@ class Ip < Formula
         This formula is only supported on macOS.
       EOS
     end
+  end
+
+  on_linux do
+    def install
+      odie "This formula is not supported on Linux."
+    end
+  end
+
+  test do
+    return unless OS.mac?
+
+    output = shell_output("#{bin}/ip 2>&1")
+    assert_match(/\d+\.\d+\.\d+\.\d+/, output)
+    assert_equal 0, $CHILD_STATUS.exitstatus
   end
 end
 

--- a/Formula/i/ip.rb
+++ b/Formula/i/ip.rb
@@ -10,20 +10,10 @@ class Ip < Formula
   depends_on :macos
 
   def install
-    return unless OS.mac?
-
     system "go", "build", *std_go_args, "./main.go"
   end
 
-  def caveats
-    <<~EOS
-      This formula is only supported on macOS.
-    EOS
-  end
-
   test do
-    return unless OS.mac?
-
     output = shell_output("#{bin}/ip 2>&1")
     assert_match(/\d+\.\d+\.\d+\.\d+/, output)
   end

--- a/Formula/i/ip.rb
+++ b/Formula/i/ip.rb
@@ -4,16 +4,26 @@ class Ip < Formula
   url "https://github.com/StarkChristmas/ipget/archive/refs/tags/v1.0.0.tar.gz"
   sha256 "0f1e6099eb568f3027db981177a1062c84036171cb13b697c38c992a81339ba0"
   license "MIT"
+  head "https://github.com/StarkChristmas/ipget.git", branch: "main"
 
   depends_on "go" => :build
 
-  def install
-    system "go", "build", *std_go_args, "./main.go"
-  end
+  on_macos do
+    def install
+      system "go", "build", *std_go_args, "."
+    end
 
-  test do
-    output = shell_output("#{bin}/ip 2>&1")
-    assert_match(/\d+\.\d+\.\d+\.\d+/, output)
-    assert_equal 0, $CHILD_STATUS.exitstatus
+    test do
+      output = shell_output("#{bin}/ip 2>&1")
+      assert_match(/\d+\.\d+\.\d+\.\d+/, output)
+      assert_equal 0, $CHILD_STATUS.exitstatus
+    end
+
+    def caveats
+      <<~EOS
+        This formula is only supported on macOS.
+      EOS
+    end
   end
 end
+


### PR DESCRIPTION
The native `ifconfig` command on `macOS` provides comprehensive information about all network interfaces, which can be overwhelming if you only need to check the IP address of the active network connection.
! Note:
1. `ip` is only allowed to be installed and used on `macOS`
2. I have searched `homebrew-core/Formula` and found no similar `Formula`
3. There is  currently no `ip` command on `macOS`
4. If the name is too short or violates `Homebrew rules`, please let me know
---
`IP` simplifies this process by:
- Filtering out inactive `network interfaces`
- Focusing on important `IP information`
- Providing clearer and more readable output
- Easier to quickly identify the current network configuration
---
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
