### PR TITLE
container 0.1.0 (new formula)

### DIFF
--- a/Formula/c/container.rb
+++ b/Formula/c/container.rb
@@ -37,7 +37,8 @@ class Container < Formula
 
   test do
     system bin/"container", "system", "start"
-    container_id = shell_output("#{bin}/container container run -it --m -d python:slim sh -c \"echo 'Hello, world!' › index.html ; python3 -m http.server 88 --bind 0.0.0.0\"")
-    system bin/"container", "ls"
+    container_cmd = "\"echo 'Hello, world!' › index.html ; python3 -m http.server 88 --bind 0.0.0.0\""
+    container_id = shell_output("#{bin}/container container run -it --m -d python:slim sh -c #{container_cmd}")
+    assert_match(container_id, shell_output("#{bin}/container ls"))
   end
 end

--- a/Formula/c/container.rb
+++ b/Formula/c/container.rb
@@ -1,0 +1,43 @@
+class Container < Formula
+  desc "Create and run Linux containers using lightweight virtual machines"
+  homepage "https://apple.github.io/container/documentation/"
+  url "https://github.com/apple/container/archive/refs/tags/0.1.0.tar.gz"
+  sha256 "1e82d56b5c8ccb9212a1da8e18c9ed099a8a41b928e7951fee841637270f3b02"
+  license "Apache-2.0"
+  head "https://github.com/apple/container.git", branch: "main"
+
+  depends_on xcode: ["26.0", :build]
+  depends_on macos: :sequoia
+  uses_from_macos "swift" => :build
+
+  def install
+    if build.head?
+      ENV["GIT_COMMIT"] = system "git", "rev-parse", "HEAD"
+    else
+      ENV["RELEASE_VERSION"] = version
+    end
+
+    args = if OS.mac?
+      ["--disable-sandbox"]
+    else
+      ["--static-swift-stdlib"]
+    end
+
+    system "swift", "build", *args, "--configuration", "release", "--product", "container"
+    bin.install ".build/release/container"
+  end
+
+  # service do
+  #   run [opt_bin/"container", "system", "start"]
+  #   keep_alive true
+  #   working_dir var
+  #   log_path var/"log/container.log"
+  #   error_log_path var/"log/container.log"
+  # end
+
+  test do
+    system bin/"container", "system", "start"
+    container_id = shell_output("#{bin}/container container run -it --m -d python:slim sh -c \"echo 'Hello, world!' › index.html ; python3 -m http.server 88 --bind 0.0.0.0\"")
+    system bin/"container", "ls"
+  end
+end

--- a/Formula/c/container.rb
+++ b/Formula/c/container.rb
@@ -6,9 +6,12 @@ class Container < Formula
   license "Apache-2.0"
   head "https://github.com/apple/container.git", branch: "main"
 
-  depends_on xcode: ["26.0", :build]
   depends_on macos: :sequoia
   uses_from_macos "swift" => :build
+
+  on_system :linux, macos: :sequoia_or_older do
+    depends_on xcode: ["26.0", :build]
+  end
 
   def install
     if build.head?

--- a/Formula/c/container.rb
+++ b/Formula/c/container.rb
@@ -6,12 +6,9 @@ class Container < Formula
   license "Apache-2.0"
   head "https://github.com/apple/container.git", branch: "main"
 
+  depends_on xcode: ["26.0", :build]
   depends_on macos: :sequoia
   uses_from_macos "swift" => :build
-
-  on_system :linux, macos: :sequoia_or_older do
-    depends_on xcode: ["26.0", :build]
-  end
 
   def install
     if build.head?


### PR DESCRIPTION
Depends on Xcode 26 beta which I presume is currently not supported.

homebrew/cask/container should migrate to this formula, once ready.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
