### PR TITLE
various: remove, move, and add `no_autobump!`

### DIFF
--- a/Formula/a/abpoa.rb
+++ b/Formula/a/abpoa.rb
@@ -6,6 +6,8 @@ class Abpoa < Formula
   license "MIT"
   head "https://github.com/yangao07/abPOA.git", branch: "main"
 
+  no_autobump! because: :requires_manual_review
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "8d23123224da086f407a2026aed50483642b6cb1cd773a95677e8823a7d203f7"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "c32ab54105465ce6413049fa3e0b61751b4380ecd7f9cb8e871d7aaa4fd0fefa"

--- a/Formula/a/adamstark-audiofile.rb
+++ b/Formula/a/adamstark-audiofile.rb
@@ -6,8 +6,6 @@ class AdamstarkAudiofile < Formula
   license "MIT"
   head "https://github.com/adamstark/AudioFile.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, all: "be3c28ee81b69cd235ffdc3a9085037178558b2714b431781404b13d2a4cc5b3"
   end

--- a/Formula/b/bash.rb
+++ b/Formula/b/bash.rb
@@ -93,11 +93,11 @@ class Bash < Formula
         versions << "#{newest_version.major_minor}.#{match[0]}"
       end
 
-      no_autobump! because: :requires_manual_review
-
       versions
     end
   end
+
+  no_autobump! because: :requires_manual_review
 
   bottle do
     rebuild 2

--- a/Formula/b/bcftools.rb
+++ b/Formula/b/bcftools.rb
@@ -12,8 +12,6 @@ class Bcftools < Formula
     strategy :github_latest
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_sequoia: "7bfda27c183789cb73ade0e4aeb4437a31edbee0bc0cfd16191ad3572f4d9f44"
     sha256 arm64_sonoma:  "b158694e48f72aa30dfa323d0ff8ef2745f57eab6d0e0092b5178e5506c834e9"

--- a/Formula/b/blastem.rb
+++ b/Formula/b/blastem.rb
@@ -17,10 +17,10 @@ class Blastem < Formula
 
         match[1]
       end
-
-      no_autobump! because: :requires_manual_review
     end
   end
+
+  no_autobump! because: :requires_manual_review
 
   bottle do
     rebuild 2

--- a/Formula/b/blueprint-compiler.rb
+++ b/Formula/b/blueprint-compiler.rb
@@ -7,6 +7,8 @@ class BlueprintCompiler < Formula
   license "LGPL-3.0-or-later"
   head "https://gitlab.gnome.org/GNOME/blueprint-compiler.git", branch: "main"
 
+  no_autobump! because: :requires_manual_review
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "934e915f724789737e2aff49d9607966366342257941e1f44ee5d03c358d331a"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "934e915f724789737e2aff49d9607966366342257941e1f44ee5d03c358d331a"

--- a/Formula/b/breseq.rb
+++ b/Formula/b/breseq.rb
@@ -6,6 +6,8 @@ class Breseq < Formula
   license all_of: ["GPL-2.0-or-later", "MIT", "BSD-3-Clause"]
   head "https://github.com/barricklab/breseq.git", branch: "master"
 
+  no_autobump! because: :requires_manual_review
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "f22120bae403eb392bec70333093e7176e565853bf5108b51ed37b82a8b39d54"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "a5d0b6591968d4b5747cf81d8f377560da5e8b2633d401d5e60f36e954655e49"

--- a/Formula/b/btcli.rb
+++ b/Formula/b/btcli.rb
@@ -8,6 +8,8 @@ class Btcli < Formula
   license "MIT"
   head "https://github.com/opentensor/btcli.git", branch: "main"
 
+  no_autobump! because: :requires_manual_review
+
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "7a855c3b77bc12b92d18e3bb279885368adbc44d137109d0e7cb7289a926197b"
     sha256 cellar: :any,                 arm64_sonoma:  "c2a6d8207d25da2ea01199c9b2772bc0c1e130eccf3513c3f464e70280c715dd"

--- a/Formula/c/calabash.rb
+++ b/Formula/c/calabash.rb
@@ -24,10 +24,10 @@ class Calabash < Formula
 
         match[1] if match[1].end_with?(saxon_suffix)
       end
-
-      no_autobump! because: :requires_manual_review
     end
   end
+
+  no_autobump! because: :requires_manual_review
 
   bottle do
     rebuild 1

--- a/Formula/c/clang-include-graph.rb
+++ b/Formula/c/clang-include-graph.rb
@@ -6,6 +6,8 @@ class ClangIncludeGraph < Formula
   license "Apache-2.0"
   head "https://github.com/bkryza/clang-include-graph.git", branch: "main"
 
+  no_autobump! because: :requires_manual_review
+
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "3480c320bbd4af88fc4d12d612c55f4b5f79a9cf4e2479dcc4d9d38ca483acc4"
     sha256 cellar: :any,                 arm64_sonoma:  "2906d24fb1455310992f9003714951dcd9cf2a4f82bdad3bbe454e6e57807fd1"

--- a/Formula/c/claude-squad.rb
+++ b/Formula/c/claude-squad.rb
@@ -6,6 +6,8 @@ class ClaudeSquad < Formula
   license "AGPL-3.0-only"
   head "https://github.com/smtg-ai/claude-squad.git", branch: "main"
 
+  no_autobump! because: :requires_manual_review
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "48e8807b7069cc2d76610fa465202fdfdf31b40bc339358fbed88d4fcff39a7e"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "48e8807b7069cc2d76610fa465202fdfdf31b40bc339358fbed88d4fcff39a7e"

--- a/Formula/c/clojure-lsp.rb
+++ b/Formula/c/clojure-lsp.rb
@@ -13,8 +13,6 @@ class ClojureLsp < Formula
     regex(/^v?(\d{4}(?:[.-]\d+)+)$/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, all: "d76985179a3d8c069da2c240f8436264b20441ee16cc875215c26f37ff37fbc2"
   end

--- a/Formula/c/cmix.rb
+++ b/Formula/c/cmix.rb
@@ -5,6 +5,8 @@ class Cmix < Formula
   sha256 "a95b0d7430d61b558731e7627f41e170cb7802d1a8a862f38628f8d921dc61b2"
   license "GPL-3.0-or-later"
 
+  no_autobump! because: :requires_manual_review
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "8eebb90a33656eaff7664633fa0422d594d6c5e3fd2c8270e9831516844b610a"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "4e9ba39f214720c1b65d25eb08fd16b0a84cfc424143817bb8fcbb33a863cea3"

--- a/Formula/e/elf2uf2-rs.rb
+++ b/Formula/e/elf2uf2-rs.rb
@@ -5,6 +5,8 @@ class Elf2uf2Rs < Formula
   sha256 "c6845f696112193bbe6517ab0c9b9fc85dff1083911557212412e07c506ccd7c"
   license "0BSD"
 
+  no_autobump! because: :requires_manual_review
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "b2502c3b12665d304fc3f016c68eef40119b4b529867d67cc26fb641e844b5de"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "4cd37371cbeb7dd6be732e6db993b226dea3dc7fbbd2c321e81665c68c6de036"

--- a/Formula/f/fastk.rb
+++ b/Formula/f/fastk.rb
@@ -10,6 +10,8 @@ class Fastk < Formula
   ]
   head "https://github.com/thegenemyers/FASTK.git", branch: "master"
 
+  no_autobump! because: :requires_manual_review
+
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "3353729044c15f3346d333ce0193e5b44a1acb6930dd366dcfc6866ded0799eb"
     sha256 cellar: :any,                 arm64_sonoma:  "9c4a36e6d522b8f31f730f540d0b1e6965670f3ff255614b775f846a4da52f9a"

--- a/Formula/f/flye.rb
+++ b/Formula/f/flye.rb
@@ -8,6 +8,8 @@ class Flye < Formula
   license all_of: ["BSD-3-Clause", "Apache-2.0", "BSD-2-Clause", "BSL-1.0", "MIT"]
   head "https://github.com/mikolmogorov/Flye.git", branch: "flye"
 
+  no_autobump! because: :requires_manual_review
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "f6ff4135fbbe3045cf3bf6f1660be67fe941b86504248a8168a0d0f6b31480e2"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "810af69fce87083de1a03681770ff518870625396b869d73f56940437682bc04"

--- a/Formula/f/foxglove-cli.rb
+++ b/Formula/f/foxglove-cli.rb
@@ -6,6 +6,8 @@ class FoxgloveCli < Formula
   license "MIT"
   head "https://github.com/foxglove/foxglove-cli.git", branch: "main"
 
+  no_autobump! because: :requires_manual_review
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "5f868121298b783e4e1927a784877025ba11502f91f49914959b1f07b6851a66"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "2bb87cd65e811de27dfcbb9ace613a8f604b808fa78524dd6739b058b8b610b0"

--- a/Formula/f/frege.rb
+++ b/Formula/f/frege.rb
@@ -19,10 +19,10 @@ class Frege < Formula
 
         match[1]
       end
-
-      no_autobump! because: :requires_manual_review
     end
   end
+
+  no_autobump! because: :requires_manual_review
 
   bottle do
     rebuild 2

--- a/Formula/g/glibc@2.13.rb
+++ b/Formula/g/glibc@2.13.rb
@@ -68,6 +68,8 @@ class GlibcAT213 < Formula
   license all_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later"]
   revision 1
 
+  no_autobump! because: :requires_manual_review
+
   bottle do
     sha256 x86_64_linux: "fcfd8511ae57b126f377789db1294e74bd48c2be941badd8e33a378dbdef9e16"
   end

--- a/Formula/g/glibc@2.17.rb
+++ b/Formula/g/glibc@2.17.rb
@@ -67,6 +67,8 @@ class GlibcAT217 < Formula
   sha256 "a3b2086d5414e602b4b3d5a8792213feb3be664ffc1efe783a829818d3fca37a"
   license all_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later"]
 
+  no_autobump! because: :requires_manual_review
+
   bottle do
     rebuild 1
     sha256 arm64_linux:  "c7e6ac88b5b12fdbecfe5f82846bbd0071fc7ff7c5b8d01c6896ed1318416499"

--- a/Formula/g/gradle@7.rb
+++ b/Formula/g/gradle@7.rb
@@ -10,8 +10,6 @@ class GradleAT7 < Formula
     regex(/href=.*?gradle[._-]v?(7(?:\.\d+)+)-all\.(?:zip|t)/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, all: "06d7151adcd4d1affc762de7ff751c7a9c7e79f0187b66f27a54684f34aad1f9"
   end

--- a/Formula/h/htslib.rb
+++ b/Formula/h/htslib.rb
@@ -10,8 +10,6 @@ class Htslib < Formula
     strategy :github_latest
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "3f2f3384d807cf96d55f5d9ee31b073b289fb4c64ba9a11f8fb3242d8dc1858e"
     sha256 cellar: :any,                 arm64_sonoma:  "3c77b5d9fd49d47b2b564b8ee27fc49e9edd26823acd90f9404e20a9e2475fe8"

--- a/Formula/h/http_load.rb
+++ b/Formula/h/http_load.rb
@@ -16,10 +16,10 @@ class HttpLoad < Formula
         date_str = match&.first
         date_str ? Date.parse(date_str)&.strftime("%Y%m%d") : nil
       end
-
-      no_autobump! because: :requires_manual_review
     end
   end
+
+  no_autobump! because: :requires_manual_review
 
   bottle do
     rebuild 1

--- a/Formula/j/jq.rb
+++ b/Formula/j/jq.rb
@@ -10,8 +10,6 @@ class Jq < Formula
     regex(/^(?:jq[._-])?v?(\d+(?:\.\d+)+)$/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "5911dafda561f792305dbc34b1f2ca5265bede9d7e60c655d9390511b560df4e"
     sha256 cellar: :any,                 arm64_sonoma:  "de8dbc03158683f974e8ef52f886abe1d6d6250dba92e2b0e5c7758eb1a5168c"

--- a/Formula/j/jwt-hack.rb
+++ b/Formula/j/jwt-hack.rb
@@ -6,6 +6,8 @@ class JwtHack < Formula
   license "MIT"
   head "https://github.com/hahwul/jwt-hack.git", branch: "main"
 
+  no_autobump! because: :requires_manual_review
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "a873fbf22a7fdda5a65150c817257cefc89ccd562286ede59d01e4a970e74847"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "ccc825f3b87b0bfe0e309e217cac7f8a10c2d9a5e6bfb103c47818ace888eeef"

--- a/Formula/k/kraken2.rb
+++ b/Formula/k/kraken2.rb
@@ -6,6 +6,8 @@ class Kraken2 < Formula
   license "MIT"
   head "https://github.com/DerrickWood/kraken2.git", branch: "master"
 
+  no_autobump! because: :requires_manual_review
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "3ee275caf279a788ea6a7bce93190ab31165bbdc79fd1dc812ba120336a1918f"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "fb22cec35e13ee86ec66e1f65f90a4b6454e418da5df13bf786e48a1dc846e8b"

--- a/Formula/l/lzsa.rb
+++ b/Formula/l/lzsa.rb
@@ -5,6 +5,8 @@ class Lzsa < Formula
   sha256 "c65ca1e6a43696f4ca5edc2c98229fba1044806bd21bc2a8ce4b867dc9cfc45c"
   license all_of: ["Zlib", "CC0-1.0"]
 
+  no_autobump! because: :requires_manual_review
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "d7eaaf3697f803f186818868d7559275d20ea9ec91226108fe89ef69473956bc"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "6084774e138106256a64ac04b7982215238030aeaa01683b27e18b49dcf38e2f"

--- a/Formula/lib/libbsc.rb
+++ b/Formula/lib/libbsc.rb
@@ -5,6 +5,8 @@ class Libbsc < Formula
   sha256 "d287535feaf18a05c3ffc9ccba3ee4eacd7604224b4648121d7388727160f107"
   license "Apache-2.0"
 
+  no_autobump! because: :requires_manual_review
+
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "c7ed848197e074d4ffbf597c051dcc37399d2d589c6ada3a15f90fd049859470"
     sha256 cellar: :any,                 arm64_sonoma:  "e9f13fa761075788e61ac51a14ab27649231f3355f7f7fe3d56d848c74714e96"

--- a/Formula/lib/liblcf.rb
+++ b/Formula/lib/liblcf.rb
@@ -6,8 +6,6 @@ class Liblcf < Formula
   license "MIT"
   head "https://github.com/EasyRPG/liblcf.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "3b50d8d26ad9ae4223f2b32c6e6339286076967625db097d6f59e51e301839ef"
     sha256 cellar: :any,                 arm64_sonoma:  "b46ebee74b740c0c6fab8ed2c4d54126a190cb2f16d9c6528e9900e3dc51fb0e"

--- a/Formula/lib/libpq@16.rb
+++ b/Formula/lib/libpq@16.rb
@@ -10,6 +10,8 @@ class LibpqAT16 < Formula
     regex(%r{href=["']?v?(16(?:\.\d+)+)/?["' >]}i)
   end
 
+  no_autobump! because: :requires_manual_review
+
   bottle do
     sha256 arm64_sequoia: "67a3882334f2448796238f87a74a594218dbf8cf19ab4161d7de7b0ca6146415"
     sha256 arm64_sonoma:  "25b4ea9f563b4d7098da7aec89f0891af7f4c60bd2fec6cc914b6791266c882d"

--- a/Formula/lib/libtatsu.rb
+++ b/Formula/lib/libtatsu.rb
@@ -6,8 +6,6 @@ class Libtatsu < Formula
   license "LGPL-2.1-or-later"
   head "https://github.com/libimobiledevice/libtatsu.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "e729a89bd9fba8be9355e7c4dd4dfc89cb039f6c063ffcd1adb102d3dfec75d5"
     sha256 cellar: :any,                 arm64_sonoma:  "efb9b3d41f8e825551a9047fd46788477ee53b3fa40f1c032bb74297be7ca21b"

--- a/Formula/lib/libtpms.rb
+++ b/Formula/lib/libtpms.rb
@@ -5,8 +5,6 @@ class Libtpms < Formula
   sha256 "ebc24f3191d90f6cf0b4d4200cd876db4bd224b3c565708bbea0a82ee275e0fb"
   license "BSD-2-Clause"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "15359aca8b873a6965f40e824368108637c9f8cf48b28fba6323f9752071023c"
     sha256 cellar: :any,                 arm64_sonoma:  "42a7c3f06554cb88deeff3b7b79ab082ed8eff5180ce06a0612a6f2b1191de95"

--- a/Formula/lib/libzdb.rb
+++ b/Formula/lib/libzdb.rb
@@ -10,8 +10,6 @@ class Libzdb < Formula
     regex(%r{href=.*?dist/libzdb[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "7ada18691b69fb2fe14cbc26b6e37acc064386f8126d94ce2ee52bc1a33d1aa4"
     sha256 cellar: :any,                 arm64_sonoma:  "ca0e3601cb111cc6c2bd04831af5c9d18a8ae39297bc89f16d53c0678c1cad51"

--- a/Formula/m/macpine.rb
+++ b/Formula/m/macpine.rb
@@ -17,10 +17,10 @@ class Macpine < Formula
         # Naively convert tags like `v.01` to `0.1`
         tag.match?(/^v\.?\d+$/i) ? version.chars.join(".") : version
       end
-
-      no_autobump! because: :requires_manual_review
     end
   end
+
+  no_autobump! because: :requires_manual_review
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "2e93c3ad2fff32d4d7010b2d1fda57f8b82abc315ad3254ae6594f26675957ca"

--- a/Formula/m/maeparser.rb
+++ b/Formula/m/maeparser.rb
@@ -6,8 +6,6 @@ class Maeparser < Formula
   license "MIT"
   head "https://github.com/schrodinger/maeparser.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "fbcc6b87403bf3ee4ceae13512659743cc3393caececa0f7837a6848e60237b3"
     sha256 cellar: :any,                 arm64_sonoma:  "65bea7147115cac9532e7a76903519dbe14cf0b3e2059ebb1de6f37932d5c54a"

--- a/Formula/m/mesa.rb
+++ b/Formula/m/mesa.rb
@@ -22,8 +22,6 @@ class Mesa < Formula
   ]
   head "https://gitlab.freedesktop.org/mesa/mesa.git", branch: "main"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_sequoia: "25a43786f25a951721f4f239ecbdac034ef452ab1d0eeab3310dbbaade9dceee"
     sha256 arm64_sonoma:  "7b7dbefe2293830585c8f135e140ed31db797cc8aa0aa5d41a28c8d35f712ae8"

--- a/Formula/m/mingw-w64.rb
+++ b/Formula/m/mingw-w64.rb
@@ -10,8 +10,6 @@ class MingwW64 < Formula
     regex(%r{url=.*?release/mingw-w64[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_sequoia: "cc7fe16c47d1f1f5f9410d05e02149b62ad97dbf77db7d85c05cda4785540579"
     sha256 arm64_sonoma:  "c9717e6c2afeb5954b82e626a8bbd5f7ace1178ee1fcd13783693022a62c6aea"

--- a/Formula/m/mint.rb
+++ b/Formula/m/mint.rb
@@ -5,8 +5,6 @@ class Mint < Formula
   sha256 "e99c0a351cf7452451d72180c8ccd18e1da710dc55d036502809a0db52779a99"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "03f825e0fd5918402a464d928e1e8ae91622c95cf62098858bd2b40424716e94"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "89bc9449b108a6cae523b0435820043a1834654662067582543304aab7f32290"

--- a/Formula/m/mongo-c-driver@1.rb
+++ b/Formula/m/mongo-c-driver@1.rb
@@ -10,6 +10,8 @@ class MongoCDriverAT1 < Formula
     regex(/^v?(1(?:\.\d+)+)$/i)
   end
 
+  no_autobump! because: :requires_manual_review
+
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "11ec4903de5e8816f1e3670644995240062bf6fb7f55a17c76a571b9b0576f51"
     sha256 cellar: :any,                 arm64_sonoma:  "679d591289a2da855fb9091c41518207af700dd1ea888be468707960c228f705"

--- a/Formula/n/nx.rb
+++ b/Formula/n/nx.rb
@@ -5,6 +5,8 @@ class Nx < Formula
   sha256 "187250adb2505d659caebf8644e9c47b185a4f7efba508d75b97ce0e515e2cca"
   license "MIT"
 
+  no_autobump! because: :requires_manual_review
+
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "3d69ab9b9ca6e037ee3cd91b7ac7105fa4b706b2301b38d48d5cd120186b1de8"
     sha256 cellar: :any,                 arm64_sonoma:  "3d69ab9b9ca6e037ee3cd91b7ac7105fa4b706b2301b38d48d5cd120186b1de8"

--- a/Formula/o/osx-trash.rb
+++ b/Formula/o/osx-trash.rb
@@ -11,6 +11,8 @@ class OsxTrash < Formula
     regex(/^trash[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 
+  no_autobump! because: :requires_manual_review
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "1ff2a7e4c4d9e83a5cf38815cbbae8407295d8c830d85211677d6041add46bfa"
   end

--- a/Formula/p/pangene.rb
+++ b/Formula/p/pangene.rb
@@ -6,6 +6,8 @@ class Pangene < Formula
   license "MIT"
   head "https://github.com/lh3/pangene.git", branch: "main"
 
+  no_autobump! because: :requires_manual_review
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "08730dae3029ce76ebbf0bef953e839242f80bfd64f4ba430b7c94bf89b20a3c"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "b448acf9c369e6a67524e8d7c68fb781c5f526a3c41a74679a251965c8a5de3b"

--- a/Formula/p/perbase.rb
+++ b/Formula/p/perbase.rb
@@ -6,6 +6,8 @@ class Perbase < Formula
   license "MIT"
   head "https://github.com/sstadick/perbase.git", branch: "master"
 
+  no_autobump! because: :requires_manual_review
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "7e10cf0a82a532a75ceefcbbbd3f57966848dfc051b17adb69ef89331cc3caad"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "36518d86e409d3fa652505da67ce0496dbdaf0d77e3a71ec554e29513d0b66fc"

--- a/Formula/p/polypolish.rb
+++ b/Formula/p/polypolish.rb
@@ -6,6 +6,8 @@ class Polypolish < Formula
   license "GPL-3.0-or-later"
   head "https://github.com/rrwick/Polypolish.git", branch: "main"
 
+  no_autobump! because: :requires_manual_review
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "c1422d344c3b60428cf5e201ecbe405edad60e3f0404ce8029e3d713846220ae"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "0b90a3ac3ed81082d4da52cf6a596dfe61a397dac3a4e994bbea5ca3417f6476"

--- a/Formula/p/poppler-qt5.rb
+++ b/Formula/p/poppler-qt5.rb
@@ -10,8 +10,6 @@ class PopplerQt5 < Formula
     formula "poppler"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_sequoia: "abc46a084ffe74832cfd9ccac1f432bcb700829cee87c276f4d114c8637bf74f"
     sha256 arm64_sonoma:  "31da5336eb89d5bcfa8e1910d767528b27de0815f8ab9ca4eb8abc58e842ced9"

--- a/Formula/p/poppler.rb
+++ b/Formula/p/poppler.rb
@@ -11,8 +11,6 @@ class Poppler < Formula
     regex(/href=.*?poppler[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_sequoia: "171cb4923ee967042878eaf4056aa0b7abe625f2ca90f4d8735ce88c0d748696"
     sha256 arm64_sonoma:  "04bdaa029f26a0bd70f8faa59d3e6ddb4434cbfaa2abcc8e14c42302e158f5ec"

--- a/Formula/r/ropebwt3.rb
+++ b/Formula/r/ropebwt3.rb
@@ -6,6 +6,8 @@ class Ropebwt3 < Formula
   license all_of: ["MIT", "Apache-2.0"]
   head "https://github.com/lh3/ropebwt3.git", branch: "master"
 
+  no_autobump! because: :requires_manual_review
+
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "bd66115bce6f069c5b16a3c87fba2a4e3e0a158965a4062ebba86e2f2598d0a5"
     sha256 cellar: :any,                 arm64_sonoma:  "9f099ff6a4f3cff8d08cda4f651550cc8a8767f264133aba3e1052381619da6e"

--- a/Formula/s/samtools.rb
+++ b/Formula/s/samtools.rb
@@ -5,8 +5,6 @@ class Samtools < Formula
   sha256 "4911d01720f246cb97855870b410bbe4d2c2fd7fbf823ea0f7daf0f32545819d"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "220446fda87460adab2eb115c4544317ac4efbd4fde226b912910500953de9f1"
     sha256 cellar: :any,                 arm64_sonoma:  "2e5e85e52f71cc46f3a13deb0f1846fb878f24aec58f820d92f0ceb7214b6a11"

--- a/Formula/s/sql-lint.rb
+++ b/Formula/s/sql-lint.rb
@@ -5,8 +5,6 @@ class SqlLint < Formula
   sha256 "17575266273fe3f762595fe404f49ff5fbd4c360f605cda0718cb62d65ad82b8"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "cc63ba9d01196aa966e93b34c8e644c0c6c3471f6c4c3b91e5166e358352945e"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "cc63ba9d01196aa966e93b34c8e644c0c6c3471f6c4c3b91e5166e358352945e"

--- a/Formula/s/squashfs.rb
+++ b/Formula/s/squashfs.rb
@@ -21,8 +21,6 @@ class Squashfs < Formula
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "17a8eef6f5e4f1651dffacbf86ab7431b1b2141cc6c607f2512f505c7396d048"
     sha256 cellar: :any,                 arm64_sonoma:  "9072950634ac3014a50e01ec2654f20441f493ff701273e4266be1538f4b81f3"

--- a/Formula/s/stringtie.rb
+++ b/Formula/s/stringtie.rb
@@ -6,6 +6,8 @@ class Stringtie < Formula
   license "MIT"
   head "https://github.com/gpertea/stringtie.git", branch: "master"
 
+  no_autobump! because: :requires_manual_review
+
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "b8635ef5a2c5bb7d9badbab1fc0cebd6251eb37b2e86b7e3a49398946c77db10"
     sha256 cellar: :any,                 arm64_sonoma:  "e0cfafab884859f6f119ad427f41383c5db78602e17d0125e83855f8574388ad"

--- a/Formula/t/tabixpp.rb
+++ b/Formula/t/tabixpp.rb
@@ -5,6 +5,8 @@ class Tabixpp < Formula
   sha256 "c850299c3c495221818a85c9205c60185c8ed9468d5ec2ed034470bb852229dc"
   license "MIT"
 
+  no_autobump! because: :requires_manual_review
+
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "8feff85967f3147f174f965ab1aaadee620fdcdfb8a7f1292613b35b552cf717"
     sha256 cellar: :any,                 arm64_sonoma:  "646a0fe583346a08a86b7d4b4f9af547b762ee01d7dc108d3c5436c7fdb1d09b"

--- a/Formula/t/tea.rb
+++ b/Formula/t/tea.rb
@@ -6,8 +6,6 @@ class Tea < Formula
   license "MIT"
   head "https://gitea.com/gitea/tea.git", branch: "main"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "1e5dcc9c1edc11e0b9a0aa340d3b90169b1b4d9f4c2d30713761f7ac87390d68"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "1e5dcc9c1edc11e0b9a0aa340d3b90169b1b4d9f4c2d30713761f7ac87390d68"

--- a/Formula/t/toml-bombadil.rb
+++ b/Formula/t/toml-bombadil.rb
@@ -6,6 +6,8 @@ class TomlBombadil < Formula
   license "MIT"
   head "https://github.com/oknozor/toml-bombadil.git", branch: "main"
 
+  no_autobump! because: :requires_manual_review
+
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_sequoia: "905ddd0270646b44ff488fb84dfb605629359c4d3621f6ad4539b8965116dbef"

--- a/Formula/t/trimal.rb
+++ b/Formula/t/trimal.rb
@@ -6,6 +6,8 @@ class Trimal < Formula
   license "GPL-3.0-only"
   head "https://github.com/inab/trimal.git", branch: "trimAl"
 
+  no_autobump! because: :requires_manual_review
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "7601f4fa41f4b2c49221fcfd10680dae2d7ba2ecf7b118ada2626df50b3dfe56"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "0d9046969829e57b325ddb627977fccaf33ec9b3b9dd17fdd1acec4c45af0ed7"

--- a/Formula/u/urx.rb
+++ b/Formula/u/urx.rb
@@ -5,6 +5,8 @@ class Urx < Formula
   sha256 "5e501198e6d910b39d0800266c32a22a17845e6b6324dbc16c5725525b8aec9a"
   license "MIT"
 
+  no_autobump! because: :requires_manual_review
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "949b36c006a4c88b7561392129ae672695b18605211d622b2cebe72f74630d35"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "e36f20d458d20ad6113bf1fe16fb01a33fdba4c791c6317e6a23ceaa574f468e"

--- a/Formula/z/zebra.rb
+++ b/Formula/z/zebra.rb
@@ -10,8 +10,6 @@ class Zebra < Formula
     regex(/href=.*?idzebra[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_sequoia: "2aa244713add7f2e0e9e28955dc2403c08b79097cbb85fae1ee7d414324eec39"
     sha256 arm64_sonoma:  "28d8199235458e3a14f907308dfd9c61c1573ce9567d00e15c5d6cd874647660"

--- a/Formula/z/zsh-history-enquirer.rb
+++ b/Formula/z/zsh-history-enquirer.rb
@@ -5,6 +5,8 @@ class ZshHistoryEnquirer < Formula
   sha256 "dab146c955f167089bbe8f24a79b4a6cabe4c9ce2b8b246eb9fca27eca2bc4ae"
   license "MIT"
 
+  no_autobump! because: :requires_manual_review
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "c61e96873b75859cd6d6a9a634df6f432914b96b893b739a14f8579a637ca81f"
   end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
This is my last PR related to `no_autobump!` method. It adds `no_autobump!` method to those formulae that are not in `autobump.txt` but have `autobump` set to `true` and removed it from the formulae with the opposite situation

Some `no_autobump!` methods where inside `livecheck do` block (i made a mistake in the script), it should be fixes here as well