### PR TITLE
yt-dlp: update test

### DIFF
--- a/Formula/y/yt-dlp.rb
+++ b/Formula/y/yt-dlp.rb
@@ -82,10 +82,6 @@ class YtDlp < Formula
   test do
     system bin/"yt-dlp", "https://raw.githubusercontent.com/Homebrew/brew/refs/heads/master/Library/Homebrew/test/support/fixtures/test.gif"
 
-    # YouTube tests fail bot detection
-    return if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"]
-
-    system bin/"yt-dlp", "--simulate", "https://www.youtube.com/watch?v=pOtd1cbOP7k"
-    system bin/"yt-dlp", "--simulate", "--yes-playlist", "https://www.youtube.com/watch?v=pOtd1cbOP7k&list=PLMsZ739TZDoLj9u_nob8jBKSC-mZb0Nhj"
+    system bin/"yt-dlp", "--simulate", "https://x.com/X/status/1922008207133671652"
   end
 end


### PR DESCRIPTION
yt-dlp: update test (right now failed with youtube bot detection across board)

```
   ==> /opt/homebrew/Cellar/yt-dlp/2025.6.9/bin/yt-dlp --simulate https://www.youtube.com/watch?v=pOtd1cbOP7k
  [youtube] Extracting URL: https://www.youtube.com/watch?v=pOtd1cbOP7k
  [youtube] pOtd1cbOP7k: Downloading webpage
  [youtube] pOtd1cbOP7k: Downloading tv client config
  [youtube] pOtd1cbOP7k: Downloading player 94f771d8-main
  [youtube] pOtd1cbOP7k: Downloading tv player API JSON
  [youtube] pOtd1cbOP7k: Downloading ios player API JSON
  ERROR: [youtube] pOtd1cbOP7k: Sign in to confirm you’re not a bot. Use --cookies-from-browser or --cookies for the authentication. See  https://github.com/yt-dlp/yt-dlp/wiki/FAQ#how-do-i-pass-cookies-to-yt-dlp  for how to manually pass cookies. Also see  https://github.com/yt-dlp/yt-dlp/wiki/Extractors#exporting-youtube-cookies  for tips on effectively exporting YouTube cookies
```

https://github.com/Homebrew/homebrew-core/actions/runs/15659668030/job/44126379352?pr=226945#step:3:2167
https://github.com/Homebrew/homebrew-core/pull/226945