### PR TITLE
workflow/autobump: rely on new autobump list

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -7,11 +7,6 @@ on:
       - master
     paths:
       - .github/workflows/autobump.yml
-  workflow_dispatch:
-    inputs:
-      formulae:
-        description: Custom list of formulae to livecheck and bump if outdated
-        required: false
   schedule:
     # Every 3 hours from 1 through 23 with an offset of 45 minutes
     - cron: "45 1-23/3 * * *"
@@ -57,11 +52,4 @@ jobs:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_CORE_REPO_WORKFLOW_TOKEN }}
           HOMEBREW_GIT_COMMITTER_NAME: BrewTestBot
           HOMEBREW_GIT_COMMITTER_EMAIL: 1589480+BrewTestBot@users.noreply.github.com
-          FORMULAE: ${{ inputs.formulae }}
-        run: |
-          BREW_BUMP=(brew bump --no-fork --open-pr --formulae --bump-synced)
-          if [[ -n "${FORMULAE-}" ]]; then
-            xargs "${BREW_BUMP[@]}" <<<"${FORMULAE}"
-          else
-            "${BREW_BUMP[@]}" --auto --tap=Homebrew/core
-          fi
+        run: brew bump --no-fork --open-pr --formulae --bump-synced --auto --tap=Homebrew/core


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Homebrew/brew#20117