### PR TITLE
automerge: block automerge with 'maintainer feedback` label

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -65,9 +65,10 @@ jobs:
           publishable=true
           while IFS='' read -r label
           do
-            if [[ "$label" = "automerge-skip" ]] ||
-               [[ "$label" = "pre-release" ]] ||
-               [[ "$label" = "CI-published-bottle-commits" ]]
+            if [[ "$label" = "CI-published-bottle-commits" ]] ||
+               [[ "$label" = "automerge-skip" ]] ||
+               [[ "$label" = "maintainer feedback" ]] ||
+               [[ "$label" = "pre-release" ]]
             then
               publishable=false
               break


### PR DESCRIPTION
Noticed this when 'automerge-skip' was inadvertently removed while waiting for feedback in https://github.com/Homebrew/homebrew-core/pull/226935. Let's make sure we don't automerge until someone removes this label. Also ASCII sorted the labels here.