### PR TITLE
action-validator: add rust 1.87 build patch

### DIFF
--- a/Formula/a/action-validator.rb
+++ b/Formula/a/action-validator.rb
@@ -18,6 +18,12 @@ class ActionValidator < Formula
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/ffcaead14f73c08531313dcb7c300918db576c3b/action-validator/0.6.0-completion-manpage.patch"
       sha256 "91b0f5170e52537f78e4b196e3b3dd580e3e56e6479f14ba59cdfcff556f4680"
     end
+
+    # rust 1.87.0 patch
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/9bc980d441be50bce28156456113fa52af0d0ff3/action-validator/0.6.0-rust-1.87.patch"
+      sha256 "5748743bb855cdb2eae732a6dca354a27dcf57ebbead3dbc645775b7029a97a9"
+    end
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- https://github.com/Homebrew/homebrew-core/pull/223613
- https://github.com/Homebrew/formula-patches/pull/1026