### PR TITLE
scryer-prolog: add rust 1.87 build patch

### DIFF
--- a/Formula/s/scryer-prolog.rb
+++ b/Formula/s/scryer-prolog.rb
@@ -1,10 +1,17 @@
 class ScryerProlog < Formula
   desc "Modern ISO Prolog implementation written mostly in Rust"
   homepage "https://www.scryer.pl"
-  url "https://github.com/mthom/scryer-prolog/archive/refs/tags/v0.9.4.tar.gz"
-  sha256 "ccf533c5c34ee7efbf9c702dbffea21ba1c837144c3592a9e97c515abd4d6904"
   license "BSD-3-Clause"
   head "https://github.com/mthom/scryer-prolog.git", branch: "master"
+
+  stable do
+    url "https://github.com/mthom/scryer-prolog/archive/refs/tags/v0.9.4.tar.gz"
+    sha256 "ccf533c5c34ee7efbf9c702dbffea21ba1c837144c3592a9e97c515abd4d6904"
+
+    # patch libffi to build against rust 1.87
+    # upstream pr ref, https://github.com/mthom/scryer-prolog/pull/2895 and https://github.com/mthom/scryer-prolog/pull/2956
+    patch :DATA
+  end
 
   no_autobump! because: :requires_manual_review
 
@@ -38,3 +45,75 @@ class ScryerProlog < Formula
     assert_equal "Hello from Scryer Prolog", shell_output("#{bin}/scryer-prolog -g 'test,halt' #{testpath}/test.pl")
   end
 end
+
+__END__
+diff --git a/Cargo.lock b/Cargo.lock
+index 5e406c6..26f3d5a 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -1477,9 +1477,9 @@ checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
+
+ [[package]]
+ name = "libffi"
+-version = "3.2.0"
++version = "4.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ce826c243048e3d5cec441799724de52e2d42f820468431fc3fceee2341871e2"
++checksum = "ebfd30a67b482a08116e753d0656cb626548cf4242543e5cc005be7639d99838"
+ dependencies = [
+  "libc",
+  "libffi-sys",
+@@ -1487,9 +1487,9 @@ dependencies = [
+
+ [[package]]
+ name = "libffi-sys"
+-version = "2.3.0"
++version = "3.3.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f36115160c57e8529781b4183c2bb51fdc1f6d6d1ed345591d84be7703befb3c"
++checksum = "f003aa318c9f0ee69eb0ada7c78f5c9d2fedd2ceb274173b5c7ff475eee584a3"
+ dependencies = [
+  "cc",
+ ]
+diff --git a/Cargo.toml b/Cargo.toml
+index 2af52e2..af8a464 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -80,7 +80,7 @@ serde = "1.0.159"
+ crossterm = { version = "0.20.0", optional = true }
+ ctrlc = { version = "3.2.2", optional = true }
+ hostname = { version = "0.3.1", optional = true }
+-libffi = { version = "3.2.0", optional = true }
++libffi = { version = "4.0.0", optional = true }
+ native-tls = { version = "0.2.4", optional = true }
+ reqwest = { version = "0.11.18", optional = true }
+ rustyline = { version = "12.0.0", optional = true }
+diff --git a/src/ffi.rs b/src/ffi.rs
+index a8ffd74..835a06e 100644
+--- a/src/ffi.rs
++++ b/src/ffi.rs
+@@ -53,13 +53,23 @@ pub struct ForeignFunctionTable {
+     structs: HashMap<String, StructImpl>,
+ }
+
+-#[derive(Debug, Clone)]
++#[derive(Clone)]
+ struct StructImpl {
+     ffi_type: ffi_type,
+     fields: Vec<*mut ffi_type>,
+     atom_fields: Vec<Atom>,
+ }
+
++impl std::fmt::Debug for StructImpl {
++    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
++        f.debug_struct("StructImpl")
++            .field("ffi_type", &&"<???>")
++            .field("fields", &self.fields)
++            .field("atom_fields", &self.atom_fields)
++            .finish()
++    }
++}
++
+ struct PointerArgs {
+     pointers: Vec<*mut c_void>,
+     _memory: Vec<Box<dyn Any>>,


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- https://github.com/Homebrew/homebrew-core/pull/223613
- https://github.com/mthom/scryer-prolog/pull/2895
- https://github.com/mthom/scryer-prolog/pull/2956