### PR TITLE
parallel-disk-usage: add rust 1.87 build patch

### DIFF
--- a/Formula/p/parallel-disk-usage.rb
+++ b/Formula/p/parallel-disk-usage.rb
@@ -18,6 +18,12 @@ class ParallelDiskUsage < Formula
 
   depends_on "rust" => :build
 
+  # rust 1.87 build patch, upstream pr ref, https://github.com/KSXGitHub/parallel-disk-usage/pull/276
+  patch do
+    url "https://github.com/KSXGitHub/parallel-disk-usage/commit/20fe7513f96cfbc456b835faf36c003d039500e2.patch?full_index=1"
+    sha256 "cd7555caa0e2f976fe2dfab81be0077ac1b95977accf70a3d6975c86123207d3"
+  end
+
   def install
     system "cargo", "install", "--features", "cli,cli-completions", *std_cargo_args
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- https://github.com/Homebrew/homebrew-core/pull/223613
- https://github.com/KSXGitHub/parallel-disk-usage/pull/276
