### PR TITLE
json2hcl: replace `shell_output` with `pipe_output`

### DIFF
--- a/Formula/j/json2hcl.rb
+++ b/Formula/j/json2hcl.rb
@@ -31,12 +31,13 @@ class Json2hcl < Formula
       }
     JSON
 
-    assert_equal "\"hello\" = \"world\"", shell_output("#{bin}/json2hcl < input.json")
+    assert_equal "\"hello\" = \"world\"", pipe_output("#{bin}/json2hcl", (testpath/"input.json").read, 0)
 
     (testpath/"input.tf").write <<~HCL
       hello = "world"
     HCL
 
-    assert_equal "{\n  \"hello\": \"world\"\n}", shell_output("#{bin}/json2hcl -reverse < input.tf").chomp
+    output = pipe_output("#{bin}/json2hcl -reverse", (testpath/"input.tf").read, 0).chomp
+    assert_equal "{\n  \"hello\": \"world\"\n}", output
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
