### PR TITLE
deprecate: gorilla-cli

### DIFF
--- a/Formula/g/gorilla-cli.rb
+++ b/Formula/g/gorilla-cli.rb
@@ -9,7 +9,8 @@ class GorillaCli < Formula
   revision 3
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "13c6b4c8f4293e105f99bfcc56e39dbd2134aec665131deaa08ff12a4d9f9b20"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "ba6432daac48104b89bfd8d0ebc549e05f9b010f4e2c9be42349ba7959560af6"
   end
 
   # service is down: https://github.com/gorilla-llm/gorilla-cli/issues/64

--- a/Formula/g/gorilla-cli.rb
+++ b/Formula/g/gorilla-cli.rb
@@ -12,6 +12,9 @@ class GorillaCli < Formula
     sha256 cellar: :any_skip_relocation, all: "13c6b4c8f4293e105f99bfcc56e39dbd2134aec665131deaa08ff12a4d9f9b20"
   end
 
+  # service is down: https://github.com/gorilla-llm/gorilla-cli/issues/64
+  deprecate! date: "2025-06-17", because: :unmaintained
+
   depends_on "certifi"
   depends_on "python@3.13"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The tool uses 3rd party web API which doesn't work anymore https://github.com/gorilla-llm/gorilla-cli/issues/64