### PR TITLE
html2text: switch to use github release tarball

### DIFF
--- a/Formula/h/html2text.rb
+++ b/Formula/h/html2text.rb
@@ -1,8 +1,7 @@
 class Html2text < Formula
   desc "Advanced HTML-to-text converter"
   homepage "https://gitlab.com/grobian/html2text"
-  # upstream issue report on the github release tarball
-  url "https://gitlab.com/-/project/48313341/uploads/b7a99615c4419cf9a65dc24f12bae0d4/html2text-2.3.0.tar.gz"
+  url "https://github.com/grobian/html2text/releases/download/v2.3.0/html2text-2.3.0.tar.gz"
   sha256 "8cec23ed1ff43313f2d0e4b434cd39871bc002cad947a40d4a3738d1351921f7"
   license "GPL-2.0-or-later"
   head "https://gitlab.com/grobian/html2text.git", branch: "master"


### PR DESCRIPTION
html2text: switch to use github release tarball

---

relates to https://gitlab.com/grobian/html2text/-/issues/68
- #227101