### PR TITLE
bitcoin: stop skipping tests

### DIFF
--- a/Formula/b/bitcoin.rb
+++ b/Formula/b/bitcoin.rb
@@ -60,12 +60,6 @@ class Bitcoin < Formula
     end
   end
 
-  # Skip two tests that currently fail in the brew CI
-  patch do
-    url "https://github.com/fanquake/bitcoin/commit/9b03fb7603709395faaf0fac409465660bbd7d81.patch?full_index=1"
-    sha256 "1d56308672024260e127fbb77f630b54a0509c145e397ff708956188c96bbfb3"
-  end
-
   def install
     # https://github.com/bitcoin/bitcoin/blob/master/doc/build-unix.md#berkeley-db
     # https://github.com/bitcoin/bitcoin/blob/master/depends/packages/bdb.mk


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

These no-longer fail, after testing-locally with the brew container image.