### PR TITLE
kingfisher 1.9.0 (new formula)

### DIFF
--- a/Formula/k/kingfisher.rb
+++ b/Formula/k/kingfisher.rb
@@ -5,6 +5,15 @@ class Kingfisher < Formula
   sha256 "749c5532ee49d9a358e8be9f925abda5589002398fec664bbd54db029af13e88"
   license "Apache-2.0"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e0eb0cd6fba2e9977739200896b5c28e7cffc15411f857cd92588f9e958d7cb3"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "d233a59ba04ccf23fec9bfe70941f8a0f4f80540cd8a553ccc39d6b21cc2a577"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "6a3ef8a03d5fade6934c8e6d7dcfc9c8ad08cd1c39650fda4a75f45f0d7768a5"
+    sha256 cellar: :any_skip_relocation, sonoma:        "276fbd7389fcf55c5b628cc1fcb92b944d6d54d16274aadc9f5d115c6cc7380c"
+    sha256 cellar: :any_skip_relocation, ventura:       "8c194d7846d281bee9ad974f41e9628d55637bd2f2ede1a157019b0dd3833ceb"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3b23f276ef14ea3c135027104c67b74d0fe54781d38e82cb49e413f0d08b3e07"
+  end
+
   depends_on "boost" => :build
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build

--- a/Formula/k/kingfisher.rb
+++ b/Formula/k/kingfisher.rb
@@ -1,0 +1,23 @@
+class Kingfisher < Formula
+  desc "MongoDB's blazingly fast secret scanning and validation tool"
+  homepage "https://github.com/mongodb/kingfisher"
+  url "https://github.com/mongodb/kingfisher/archive/refs/tags/v1.9.0.tar.gz"
+  sha256 "749c5532ee49d9a358e8be9f925abda5589002398fec664bbd54db029af13e88"
+  license "Apache-2.0"
+
+  depends_on "boost" => :build
+  depends_on "cmake" => :build
+  depends_on "pkgconf" => :build
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", "--features", "system-alloc", *std_cargo_args
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/kingfisher --version")
+
+    output = shell_output(bin/"kingfisher scan --git-url https://github.com/homebrew/.github")
+    assert_match "|Findings....................: 0", output
+  end
+end


### PR DESCRIPTION
Initial public release of MongoDB's Kingfisher application. Blazingly fast secret scanning and validation tool, that can scan files, git repos, github, and gitlab. Announced publicly on the MongoDB blog.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

This fails the brew audit only on the notability threshold. I am the maintainer and developer of this application, and am requesting an exception to the notability threshold based on that: 
https://docs.brew.sh/Acceptable-Casks#exceptions-to-the-notability-threshold

This project was recently announced on the MongoDB blog, X, and LinkedIn accounts:
- https://www.mongodb.com/blog/post/product-release-announcements/introducing-kingfisher-real-time-secret-detection-validation
- https://x.com/MongoDB/status/1934590681692959142
- https://www.linkedin.com/posts/mongodbinc_kingfisher-for-fast-accurate-open-source-activity-7340356454773661696-TN9P/
-----
