### PR TITLE
media-control 0.2.0 (new formula)

### DIFF
--- a/Formula/m/media-control.rb
+++ b/Formula/m/media-control.rb
@@ -7,6 +7,14 @@ class MediaControl < Formula
   license "BSD-3-Clause"
   head "https://github.com/ungive/media-control.git", branch: "master"
 
+  bottle do
+    sha256 cellar: :any, arm64_sequoia: "9a6e63050015f633626233fe99d15a3e1d003bb712c06c4bf584ca25529544c5"
+    sha256 cellar: :any, arm64_sonoma:  "5ef45bb85f2c242a99de70fb4ce485cc2c3425bbb0bf019cf4337a062c454610"
+    sha256 cellar: :any, arm64_ventura: "258d6dcfdef799a2e01501b23e3e6122e0784f3288e438f882446e02adbd1ebc"
+    sha256 cellar: :any, sonoma:        "4733d0e7f2584bb3389d5690e985c7dd6ede8aeeb0f20cdce01946b9c82a9069"
+    sha256 cellar: :any, ventura:       "f018330cd63af85e5351cf2b100f84048b91f60b6d59601bb7f48cd6face0745"
+  end
+
   depends_on "cmake" => :build
   depends_on :macos
 

--- a/Formula/m/media-control.rb
+++ b/Formula/m/media-control.rb
@@ -1,0 +1,22 @@
+class MediaControl < Formula
+  desc "Control and observe media playback from the command-line"
+  homepage "https://github.com/ungive/media-control"
+  url "https://github.com/ungive/media-control.git",
+      tag:      "v0.2.0",
+      revision: "f6c7293a8c6199f9ccc07c7d650737fb5d788001"
+  license "BSD-3-Clause"
+  head "https://github.com/ungive/media-control.git", branch: "master"
+
+  depends_on "cmake" => :build
+  depends_on :macos
+
+  def install
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    system bin/"media-control", "get"
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)?
- [ ] If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I've just created this tool within the last couple of days, but regarding the "notability threshold" ([Acceptable Casks](https://docs.brew.sh/Acceptable-Casks#exceptions-to-the-notability-threshold)), I think my tool may qualify to fall under the following exception:

> *A piece of software that was recently released to great fanfare—everyone is talking about it on Twitter and Hacker News and we’ve even gotten multiple premature submissions for it. That’d be a clear case of an app that will reach the threshold in no time so that’s a PR we won’t close immediately (but may wait to merge).*

While the tool is located at [ungive/media-control](https://github.com/ungive/media-control), the projected started over at [ungive/mediaremote-adapter](https://github.com/ungive/mediaremote-adapter).

Since macOS 15.4 media control and media detection has been broken by Apple and formulas like [nowplaying-cli](https://github.com/Homebrew/homebrew-core/blob/master/Formula/n/nowplaying-cli.rb) no longer work: https://github.com/kirtan-shah/nowplaying-cli/issues/28

This is because Apple has added entitlement checks for the use of the MediaRemote private framework which makes it impossible to *directly* use it in an application. You can still use it *indirectly* by loading it in a separate process that passes these new entitlement checks, which is e.g. the case with `/usr/bin/perl`. That's exactly what `media-control` does and what `mediaremote-adapter` implements (which is the main component of this formula, `media-control` is just a small wrapper script written in Perl).

To my knowledge I'm the first person to discover this workaround and people got very excited when I shared the news:
- https://github.com/vincentneo/LosslessSwitcher/issues/161#issuecomment-2974745096
- https://github.com/aviwad/LyricFever/issues/94#issuecomment-2974751942
- https://github.com/kirtan-shah/nowplaying-cli/issues/28#issuecomment-2976239982
- 16 stars since I published the repository 3 days ago: https://github.com/ungive/mediaremote-adapter/stargazers  
Date of publishment: https://github.com/ungive/mediaremote-adapter/commit/1af927ff4c2ba0cb2b6b1a5d9535ecd28b14e02b
- So far one fork exists which turned the whole thing into a Swift package: https://github.com/ungive/mediaremote-adapter/forks (https://github.com/ejbills/mediaremote-adapter)

On a side note, the `mediaremote-adapter` library that `media-control` uses is also used by and bundled with in the recently merged `music-presence` cask, albeit an [older version](https://github.com/ungive/mediaremote-adapter/tree/d75c3e033a086c02898301db4afc3befbc3c7c58): https://github.com/Homebrew/homebrew-cask/pull/216446

I hope this insight helps in deciding whether merging is a viable option for you.