### PR TITLE
ada-url: install adaparse tool by default

### DIFF
--- a/Formula/a/ada-url.rb
+++ b/Formula/a/ada-url.rb
@@ -7,11 +7,12 @@ class AdaUrl < Formula
   head "https://github.com/ada-url/ada.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any, arm64_sequoia: "49e7c96a4cc3c978894c93607aed26e7a0ab64fffb1b8f5725a16ff68a236e9a"
-    sha256 cellar: :any, arm64_sonoma:  "5a8a2e7c50c06fca1fbc9f6682fd31569cfbe9c5f075ab742cccba39280cb4a4"
-    sha256 cellar: :any, arm64_ventura: "8b54308b388ce3ae1e417aae2716513faaa77e96d6435b73a136739352d7aad1"
-    sha256 cellar: :any, sonoma:        "e22d95f05db7451750c0a411522fa57d6c6f67caba6d21ae276a2050a5672ed4"
-    sha256 cellar: :any, ventura:       "4a0257b458c101fd82a19cc0602fe4cd9a5982142cd596ea191593be7c86d062"
+    rebuild 1
+    sha256 cellar: :any, arm64_sequoia: "efa1ad50cbbefa23cfc229055732e22cef47900b66fa3578624dd15b7ca12110"
+    sha256 cellar: :any, arm64_sonoma:  "2da93d743e1bb7e2b2c73e54e6a4e55704d5df75b93b0bcc698545fc4ef05b99"
+    sha256 cellar: :any, arm64_ventura: "2c6cbed3dd1e562fb171721fd77311d4162a7132fbc75a97b685c4d990d8a2e1"
+    sha256 cellar: :any, sonoma:        "958d8a4bfc0bb863c878c4d7cfcc47004e8273d415fd66eddff8b49ad2a46180"
+    sha256 cellar: :any, ventura:       "c614d293847ad99afbf94ae4615e28c3f5c5e42b769f8801b589375f6c9c928b"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
- Enable installation of the adaparse command-line tool by default
- Add test to verify adaparse tool installation

This change adds the adaparse command-line tool to the default installation of ada-url. The tool is useful for parsing and validating URLs from the command line.

The change is implemented by:
1. Adding `-DADA_TOOLS=ON` to the CMake arguments
2. Adding a test to verify the tool is installed and working