### PR TITLE
certbot: remove unused dialog dependency

### DIFF
--- a/Formula/c/certbot.rb
+++ b/Formula/c/certbot.rb
@@ -22,7 +22,6 @@ class Certbot < Formula
   depends_on "augeas"
   depends_on "certifi"
   depends_on "cryptography"
-  depends_on "dialog"
   depends_on "python@3.13"
 
   uses_from_macos "libffi"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

upstream maintainer of certbot here :wave:

i just noticed this formula still depends on `dialog`. it was initially a dependency of ours, but [we removed it in 2016](https://github.com/certbot/certbot/pull/3665)