### PR TITLE
workflows/remove-disabled-packages: fix invalid base branch for pull request creation

### DIFF
--- a/.github/workflows/remove-disabled-packages.yml
+++ b/.github/workflows/remove-disabled-packages.yml
@@ -82,7 +82,7 @@ jobs:
         uses: Homebrew/actions/create-pull-request@master
         with:
           token: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
-          base: HEAD
+          base: master
           head: ${{env.REMOVAL_BRANCH}}
           title: Remove disabled packages
           labels: CI-no-bottles


### PR DESCRIPTION
seeing action run failure as

```
Error: HttpError: Validation Failed: {"resource":"PullRequest","field":"base","code":"invalid"} - https://docs.github.com/rest/pulls/pulls#create-a-pull-request
```

https://github.com/Homebrew/homebrew-core/actions/runs/15800976960/job/44557125187