### PR TITLE
tldx: inject version at build time via ldflags

### DIFF
--- a/Formula/t/tldx.rb
+++ b/Formula/t/tldx.rb
@@ -17,10 +17,12 @@ class Tldx < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args(ldflags: "-s -w")
+    system "go", "build", *std_go_args(ldflags: "-s -w -X github.com/brandonyoungdev/tldx/cmd.Version=#{version}")
   end
 
   test do
     assert_match "brew.sh is not available", shell_output("#{bin}/tldx brew --tlds sh")
+
+    assert_match version.to_s, shell_output("#{bin}/tldx --version")
   end
 end

--- a/Formula/t/tldx.rb
+++ b/Formula/t/tldx.rb
@@ -6,12 +6,13 @@ class Tldx < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "ab5bbc8ef07c3f43a68179a3cd262fafd5343bd0aa65ff9cae8156551a85f080"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "ab5bbc8ef07c3f43a68179a3cd262fafd5343bd0aa65ff9cae8156551a85f080"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "ab5bbc8ef07c3f43a68179a3cd262fafd5343bd0aa65ff9cae8156551a85f080"
-    sha256 cellar: :any_skip_relocation, sonoma:        "27b519e5514e47309bce8a346a7c03102441ddacd4c4963ea68f1cc4cda08733"
-    sha256 cellar: :any_skip_relocation, ventura:       "27b519e5514e47309bce8a346a7c03102441ddacd4c4963ea68f1cc4cda08733"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "98190d8631eff7b04f343ef9030aebb1241ba0eed74061d299eaa3d8ec15bb62"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "1c612ef36e0440e412999867521b005966e45c8cd57b42e03cdec3817cb7efe7"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "1c612ef36e0440e412999867521b005966e45c8cd57b42e03cdec3817cb7efe7"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "1c612ef36e0440e412999867521b005966e45c8cd57b42e03cdec3817cb7efe7"
+    sha256 cellar: :any_skip_relocation, sonoma:        "3f82dc3db2fc83afd4056689c6c641e736f039a47cdfd2fbae71dddfb0752833"
+    sha256 cellar: :any_skip_relocation, ventura:       "3f82dc3db2fc83afd4056689c6c641e736f039a47cdfd2fbae71dddfb0752833"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "dc5a475ee20d17587e1be1de815f5e34dc8fd4460c78f8979ebddd2b839f5db5"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Changes:
- Updated the `install` step to inject the version with:
    - `-X github.com/brandonyoungdev/tldx/cmd.Version=#{version}`
- Updated the `test` block to assert that `tldx --version` correctly reports the formula version.

These changes align the Homebrew build process with how upstream builds releases using GoReleaser.