### PR TITLE
workflows/remove-disabled-packages: use default branch

### DIFF
--- a/.github/workflows/remove-disabled-packages.yml
+++ b/.github/workflows/remove-disabled-packages.yml
@@ -81,12 +81,12 @@ jobs:
         if: fromJson(steps.remove_disabled.outputs.packages-removed)
         uses: Homebrew/actions/create-pull-request@master
         with:
-          token: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
-          base: master
-          head: ${{env.REMOVAL_BRANCH}}
+          token: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
+          base: ${{ github.event.repository.default_branch }}
+          head: ${{ env.REMOVAL_BRANCH }}
           title: Remove disabled packages
           labels: CI-no-bottles
-          body: This pull request was created automatically by the [`remove-disabled-packages`](${{env.RUN_URL}}) workflow.
+          body: This pull request was created automatically by the [`remove-disabled-packages`](${{ env.RUN_URL }}) workflow.
 
   create-issue:
     permissions:


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Follow-up to #227815.
