### PR TITLE
libgrapheme: update livecheck

### DIFF
--- a/Formula/lib/libgrapheme.rb
+++ b/Formula/lib/libgrapheme.rb
@@ -7,7 +7,8 @@ class Libgrapheme < Formula
   head "https://git.suckless.org/libgrapheme/", using: :git, branch: "master"
 
   livecheck do
-    url "git://git.suckless.org/libgrapheme"
+    url "https://dl.suckless.org/libgrapheme/"
+    regex(/href=.*?libgrapheme[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   no_autobump! because: :requires_manual_review


### PR DESCRIPTION
To match other formulae from the same org, e.g. [`dwm`](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/d/dwm.rb).