### PR TITLE
tiledb: add livecheck

### DIFF
--- a/Formula/t/tiledb.rb
+++ b/Formula/t/tiledb.rb
@@ -5,6 +5,11 @@ class Tiledb < Formula
   sha256 "de731cd0c8e82fe8cfca084b937dc0df41e451c8eb93071e4cc5aba7bbef854e"
   license "MIT"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "9468ff50f991980cd4a1f271157acda6c86180ade8ba9bb6d112c77a9376e791"
     sha256 cellar: :any,                 arm64_sonoma:  "40161d0f697370e27e84f0c0a070936a9e1cf0f648d1b3797f85c36dc16d2525"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default livecheck checks the Git tags for `tiledb` but this is now incorrectly returning 10040-azr-osx-lnxto-ga as the latest version, from a `dlh/ch10040-azr-osx-lnxto-ga` tag. This adds a `livecheck` block that uses the standard regex for Git tags like `1.2.3`/`v1.2.3`, which will match stable tags in this repository and omit unstable tags (e.g., `1.2.3-rc0`) as well as one-off oddities like the aforementioned tag.