### PR TITLE
onigmo: add livecheck

### DIFF
--- a/Formula/o/onigmo.rb
+++ b/Formula/o/onigmo.rb
@@ -6,6 +6,11 @@ class Onigmo < Formula
   license "BSD-2-Clause"
   head "https://github.com/k-takata/Onigmo.git", branch: "master"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "7dfc12c6ac3db48e2927137723a4d9ee1cf0b48d3188b142231b87add252e101"
     sha256 cellar: :any,                 arm64_sonoma:  "3e7750a967115b4f15803abf886f850cb8840f42c67749bb4b5c3bb96861273c"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `onigmo` but it is incorrectly returning 6.2.0_for_bregonig as the latest version, as upstream creates `_for_bregonig` tags for some versions. The formula uses a GitHub release asset in the `stable` URL, so this adds a `livecheck` block that uses the `GithubLatest` strategy (i.e., the release tags use an `Onigmo-1.2.3` format).