### PR TITLE
various: update `head` URLs

### DIFF
--- a/Formula/a/amtterm.rb
+++ b/Formula/a/amtterm.rb
@@ -4,7 +4,7 @@ class Amtterm < Formula
   url "https://www.kraxel.org/releases/amtterm/amtterm-1.7.tar.gz"
   sha256 "8c58b76b3237504d751bf3588fef25117248a0569523f0d86deaf696d14294d4"
   license "GPL-2.0-or-later"
-  head "https://git.kraxel.org/git/amtterm/", branch: "master", using: :git
+  head "https://github.com/kraxel/amtterm.git", branch: "master"
 
   livecheck do
     url "https://www.kraxel.org/releases/amtterm/"

--- a/Formula/c/curlftpfs.rb
+++ b/Formula/c/curlftpfs.rb
@@ -5,7 +5,6 @@ class Curlftpfs < Formula
   sha256 "4eb44739c7078ba0edde177bdd266c4cfb7c621075f47f64c85a06b12b3c6958"
   license "GPL-2.0-only"
   revision 1
-  head ":pserver:anonymous:@curlftpfs.cvs.sourceforge.net:/cvsroot/curlftpfs", using: :cvs
 
   no_autobump! because: :requires_manual_review
 

--- a/Formula/d/dwm.rb
+++ b/Formula/d/dwm.rb
@@ -4,7 +4,7 @@ class Dwm < Formula
   url "https://dl.suckless.org/dwm/dwm-6.5.tar.gz"
   sha256 "21d79ebfa9f2fb93141836c2666cb81f4784c69d64e7f1b2352f9b970ba09729"
   license "MIT"
-  head "https://git.suckless.org/dwm", using: :git, branch: "master"
+  head "https://git.suckless.org/dwm/", using: :git, branch: "master"
 
   livecheck do
     url "https://dl.suckless.org/dwm/"

--- a/Formula/f/fuse-zip.rb
+++ b/Formula/f/fuse-zip.rb
@@ -4,7 +4,7 @@ class FuseZip < Formula
   url "https://bitbucket.org/agalanin/fuse-zip/downloads/fuse-zip-0.7.2.tar.gz"
   sha256 "3dd0be005677442f1fd9769a02dfc0b4fcdd39eb167e5697db2f14f4fee58915"
   license "GPL-3.0-or-later"
-  head "https://bitbucket.org/agalanin/fuse-zip", using: :hg
+  head "https://bitbucket.org/agalanin/fuse-zip.git", branch: "master"
 
   no_autobump! because: :requires_manual_review
 

--- a/Formula/i/id3lib.rb
+++ b/Formula/i/id3lib.rb
@@ -1,24 +1,10 @@
 class Id3lib < Formula
   desc "ID3 tag manipulation"
   homepage "https://id3lib.sourceforge.net/"
+  url "https://downloads.sourceforge.net/project/id3lib/id3lib/3.8.3/id3lib-3.8.3.tar.gz"
+  sha256 "2749cc3c0cd7280b299518b1ddf5a5bcfe2d1100614519b68702230e26c7d079"
   license "LGPL-2.0-or-later"
   revision 1
-  head ":pserver:anonymous:@id3lib.cvs.sourceforge.net:/cvsroot/id3lib", using: :cvs, module: "id3lib-devel"
-
-  stable do
-    url "https://downloads.sourceforge.net/project/id3lib/id3lib/3.8.3/id3lib-3.8.3.tar.gz"
-    sha256 "2749cc3c0cd7280b299518b1ddf5a5bcfe2d1100614519b68702230e26c7d079"
-
-    patch do
-      url "https://raw.githubusercontent.com/Homebrew/formula-patches/e223e971/id3lib/id3lib-vbr-overflow.patch"
-      sha256 "0ec91c9d89d80f40983c04147211ced8b4a4d8a5be207fbe631f5eefbbd185c2"
-    end
-
-    patch do
-      url "https://raw.githubusercontent.com/Homebrew/formula-patches/e223e971/id3lib/id3lib-main.patch"
-      sha256 "83c8d2fa54e8f88b682402b2a8730dcbcc8a7578681301a6c034fd53e1275463"
-    end
-  end
 
   no_autobump! because: :requires_manual_review
 
@@ -46,6 +32,16 @@ class Id3lib < Formula
   depends_on "libtool" => :build
 
   uses_from_macos "zlib"
+
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/e223e971/id3lib/id3lib-main.patch"
+    sha256 "83c8d2fa54e8f88b682402b2a8730dcbcc8a7578681301a6c034fd53e1275463"
+  end
+
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/e223e971/id3lib/id3lib-vbr-overflow.patch"
+    sha256 "0ec91c9d89d80f40983c04147211ced8b4a4d8a5be207fbe631f5eefbbd185c2"
+  end
 
   patch do
     url "https://raw.githubusercontent.com/Homebrew/formula-patches/e223e971/id3lib/no-iomanip.h.patch"

--- a/Formula/i/ii.rb
+++ b/Formula/i/ii.rb
@@ -4,7 +4,7 @@ class Ii < Formula
   url "https://dl.suckless.org/tools/ii-2.0.tar.gz"
   sha256 "4f67afcd208c07939b88aadbf21497a702ad0a07f9b5a6ce861f9f39ffe5425b"
   license "MIT"
-  head "https://git.suckless.org/ii", using: :git, branch: "master"
+  head "https://git.suckless.org/ii/", using: :git, branch: "master"
 
   livecheck do
     url "https://dl.suckless.org/tools/"

--- a/Formula/lib/libcanberra.rb
+++ b/Formula/lib/libcanberra.rb
@@ -40,7 +40,7 @@ class Libcanberra < Formula
   end
 
   head do
-    url "git://git.0pointer.de/libcanberra", branch: "master"
+    url "https://git.0pointer.net/libcanberra.git", branch: "master"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build

--- a/Formula/m/monetdb.rb
+++ b/Formula/m/monetdb.rb
@@ -4,7 +4,7 @@ class Monetdb < Formula
   url "https://www.monetdb.org/downloads/sources/Mar2025/MonetDB-11.53.3.tar.xz"
   sha256 "23e1f6a73ac721298f9b611f18930b8ceda34c6f497a4e458034b7131660c070"
   license "MPL-2.0"
-  head "https://dev.monetdb.org/hg/MonetDB", using: :hg
+  head "https://www.monetdb.org/hg/MonetDB", using: :hg
 
   livecheck do
     url "https://www.monetdb.org/downloads/sources/archive/"

--- a/Formula/m/myman.rb
+++ b/Formula/m/myman.rb
@@ -4,7 +4,6 @@ class Myman < Formula
   url "https://downloads.sourceforge.net/project/myman/myman-cvs/myman-cvs-2009-10-30/myman-wip-2009-10-30.tar.gz"
   sha256 "bf69607eabe4c373862c81bf56756f2a96eecb8eaa8c911bb2abda78b40c6d73"
   license "MIT"
-  head ":pserver:anonymous:@myman.cvs.sourceforge.net:/cvsroot/myman", using: :cvs
 
   no_autobump! because: :requires_manual_review
 

--- a/Formula/o/octave.rb
+++ b/Formula/o/octave.rb
@@ -23,7 +23,7 @@ class Octave < Formula
   end
 
   head do
-    url "https://hg.savannah.gnu.org/hgweb/octave", branch: "default", using: :hg
+    url "https://hg.octave.org/octave", using: :hg
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build

--- a/Formula/o/optipng.rb
+++ b/Formula/o/optipng.rb
@@ -4,7 +4,7 @@ class Optipng < Formula
   url "https://downloads.sourceforge.net/project/optipng/OptiPNG/optipng-7.9.1/optipng-7.9.1.tar.gz"
   sha256 "c2579be58c2c66dae9d63154edcb3d427fef64cb00ec0aff079c9d156ec46f29"
   license "Zlib"
-  head "http://hg.code.sf.net/p/optipng/mercurial", using: :hg
+  head "https://git.code.sf.net/p/optipng/code.git", branch: "tmp/main"
 
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "c2d204ed132d5c5268baf7b464e862e8201a5f80e0d3aa5891204ccccbdca28a"

--- a/Formula/p/percona-toolkit.rb
+++ b/Formula/p/percona-toolkit.rb
@@ -4,7 +4,7 @@ class PerconaToolkit < Formula
   url "https://downloads.percona.com/downloads/percona-toolkit/3.7.0-2/source/tarball/percona-toolkit-3.7.0.tar.gz"
   sha256 "192c899dcfa26eca1b9e8692b7b687d143154902b6089afb03c14ea1b93e432d"
   license any_of: ["GPL-2.0-only", "Artistic-1.0-Perl"]
-  head "lp:percona-toolkit", using: :bzr
+  head "https://github.com/percona/percona-toolkit.git", branch: "3.x"
 
   livecheck do
     url "https://www.percona.com/products-api.php", post_form: {

--- a/Formula/p/pidgin.rb
+++ b/Formula/p/pidgin.rb
@@ -58,7 +58,7 @@ class Pidgin < Formula
   end
 
   head do
-    url "https://keep.imfreedom.org/pidgin/pidgin/", branch: "default", using: :hg
+    url "https://keep.imfreedom.org/pidgin/pidgin/", using: :hg
 
     depends_on "gobject-introspection" => :build
     depends_on "gstreamer" => :build

--- a/Formula/s/schroedinger.rb
+++ b/Formula/s/schroedinger.rb
@@ -28,14 +28,6 @@ class Schroedinger < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "32c7db0617f2a2d01b89d446860529fc3520f377e601a460fadc5e3ce2bc0baa"
   end
 
-  head do
-    url "lp:schroedinger", using: :bzr
-
-    depends_on "autoconf" => :build
-    depends_on "automake" => :build
-    depends_on "libtool" => :build
-  end
-
   depends_on "pkgconf" => :build
   depends_on "orc"
 
@@ -44,7 +36,6 @@ class Schroedinger < Formula
     # Help old config scripts identify arm64 linux
     args << "--build=aarch64-unknown-linux-gnu" if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
 
-    system "autoreconf", "--force", "--install", "--verbose" if build.head?
     system "./configure", *args, *std_configure_args
 
     # The test suite is known not to build against Orc >0.4.16 in Schroedinger 1.0.11.

--- a/Formula/s/sic.rb
+++ b/Formula/s/sic.rb
@@ -4,7 +4,7 @@ class Sic < Formula
   url "https://dl.suckless.org/tools/sic-1.3.tar.gz"
   sha256 "30478fab3ebc75f2eb5d08cbb5b2fedcaf489116e75a2dd7197e3e9c733d65d2"
   license "MIT"
-  head "https://git.suckless.org/sic", branch: "master", using: :git
+  head "https://git.suckless.org/sic/", using: :git, branch: "master"
 
   livecheck do
     url "https://dl.suckless.org/tools/"

--- a/Formula/t/texi2mdoc.rb
+++ b/Formula/t/texi2mdoc.rb
@@ -4,6 +4,7 @@ class Texi2mdoc < Formula
   url "https://mandoc.bsd.lv/texi2mdoc/snapshots/texi2mdoc-0.1.2.tgz"
   sha256 "7a45fd87c27cc8970a18db9ddddb2f09f18b8dd5152bf0ca377c3a5e7d304bfe"
   license "ISC"
+  head "anoncvs@mandoc.bsd.lv:/cvs", using: :cvs
 
   livecheck do
     url "https://mandoc.bsd.lv/texi2mdoc/snapshots/"


### PR DESCRIPTION
Found several that have changed domains, switched protocols, or are no longer available. In particular, *.cvs.sourceforge.net domains are out of commission, and launchpad.net `:bzr` repositories now require `breezy` to have been built with `launchpadlib`, which doesn't seem worthwhile given only two core formulae use the protocol, both of which were woefully out of date. (Repositories hosted [elsewhere](https://bzr.savannah.gnu.org/lh/) will still work.)