### PR TITLE
kafkactl: fix version format

### DIFF
--- a/Formula/k/kafkactl.rb
+++ b/Formula/k/kafkactl.rb
@@ -20,7 +20,7 @@ class Kafkactl < Formula
   def install
     ldflags = %W[
       -s -w
-      -X github.com/deviceinsight/kafkactl/v5/cmd.Version=#{version}
+      -X github.com/deviceinsight/kafkactl/v5/cmd.Version=v#{version}
       -X github.com/deviceinsight/kafkactl/v5/cmd.GitCommit=#{tap.user}
       -X github.com/deviceinsight/kafkactl/v5/cmd.BuildTime=#{time.iso8601}
     ]

--- a/Formula/k/kafkactl.rb
+++ b/Formula/k/kafkactl.rb
@@ -7,12 +7,13 @@ class Kafkactl < Formula
   head "https://github.com/deviceinsight/kafkactl.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "32ca932cf76f1450a60e8a47b521a20c971486773c0c5babadbe124238e95b23"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "32ca932cf76f1450a60e8a47b521a20c971486773c0c5babadbe124238e95b23"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "32ca932cf76f1450a60e8a47b521a20c971486773c0c5babadbe124238e95b23"
-    sha256 cellar: :any_skip_relocation, sonoma:        "f82860fbd94c40183891a0ca035a36e8f3efbe6df4fb016f997df070a187dda2"
-    sha256 cellar: :any_skip_relocation, ventura:       "f82860fbd94c40183891a0ca035a36e8f3efbe6df4fb016f997df070a187dda2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b9e674403b9462d608bc88eb84ede915b338849506af5959ac4a388619ae4fc8"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "8e9335fdb4fa576340e429988675911a3aec62a5bd1ed2312e3cc74c1ba83cfb"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "8e9335fdb4fa576340e429988675911a3aec62a5bd1ed2312e3cc74c1ba83cfb"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "8e9335fdb4fa576340e429988675911a3aec62a5bd1ed2312e3cc74c1ba83cfb"
+    sha256 cellar: :any_skip_relocation, sonoma:        "800c386fd8f3d2c38b6be04e13da506b50604f4632b6ddc3dcbe3592e0310f02"
+    sha256 cellar: :any_skip_relocation, ventura:       "800c386fd8f3d2c38b6be04e13da506b50604f4632b6ddc3dcbe3592e0310f02"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "539c1a9f7373d13d863cdebfdd32e48be1c6da8364b8d818cbeaf9afa99092a7"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
add v prefix to version variable to align with how kafkactl is build elsewhere

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
