### PR TITLE
mmseqs2: add cmake-4 removal note

### DIFF
--- a/Formula/m/mmseqs2.rb
+++ b/Formula/m/mmseqs2.rb
@@ -39,6 +39,8 @@ class Mmseqs2 < Formula
   end
 
   def install
+    odie "Remove cmake 4 build patch" if build.stable? && version > "17-b804f"
+
     args = %W[
       -DCMAKE_POLICY_VERSION_MINIMUM=3.5
       -DHAVE_TESTS=0


### PR DESCRIPTION
mmseqs2: add cmake-4 removal note

---

relates to https://github.com/soedinglab/MMseqs2/commit/da0b2c3fe85f43603a2cc2e5411153981084114e