### PR TITLE
supertux: add upstream cmake 4 build support note

### DIFF
--- a/Formula/s/supertux.rb
+++ b/Formula/s/supertux.rb
@@ -46,6 +46,7 @@ class Supertux < Formula
   end
 
   def install
+    # Support cmake 4 build, upstream pr ref, https://github.com/SuperTux/supertux/pull/3290
     ENV["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5"
 
     args = [


### PR DESCRIPTION
supertux: add upstream cmake 4 build support note

---

- https://github.com/SuperTux/supertux/pull/3290