### PR TITLE
x264: correct license to GPL-2.0-or-later

### DIFF
--- a/Formula/x/x264.rb
+++ b/Formula/x/x264.rb
@@ -5,7 +5,7 @@ class X264 < Formula
   url "https://code.videolan.org/videolan/x264.git",
       revision: "31e19f92f00c7003fa115047ce50978bc98c3a0d"
   version "r3108"
-  license "GPL-2.0-only"
+  license "GPL-2.0-or-later"
   head "https://code.videolan.org/videolan/x264.git", branch: "master"
 
   # Cross-check the abbreviated commit hashes from the release filenames with


### PR DESCRIPTION
x264: correct license to GPL-2.0-or-later

The x264 project source code states "either version 2 of the License, or
(at your option) any later version" indicating GPL-2.0-or-later rather
than GPL-2.0-only.

This correction ensures Homebrew's ffmpeg build is properly licensed.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
