### PR TITLE
x265: correct license to GPL-2.0-or-later

### DIFF
--- a/Formula/x/x265.rb
+++ b/Formula/x/x265.rb
@@ -3,7 +3,7 @@ class X265 < Formula
   homepage "https://bitbucket.org/multicoreware/x265_git"
   url "https://bitbucket.org/multicoreware/x265_git/downloads/x265_4.1.tar.gz"
   sha256 "a31699c6a89806b74b0151e5e6a7df65de4b49050482fe5ebf8a4379d7af8f29"
-  license "GPL-2.0-only"
+  license "GPL-2.0-or-later"
   head "https://bitbucket.org/multicoreware/x265_git.git", branch: "master"
 
   bottle do


### PR DESCRIPTION
The x265 project source code states "either version 2 of the License, or (at your option) any later version" indicating GPL-2.0-or-later rather than GPL-2.0-only.

This correction ensures Homebrew's ffmpeg build is properly licensed.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
