### PR TITLE
codex 0.2.0

### DIFF
--- a/Formula/c/codex.rb
+++ b/Formula/c/codex.rb
@@ -1,9 +1,8 @@
 class Codex < Formula
   desc "OpenAI's coding agent that runs in your terminal"
   homepage "https://github.com/openai/codex"
-  url "https://github.com/openai/codex/archive/2925136536b06a324551627468d17e959afa18d4.tar.gz"
-  version "0.2.0-alpha.2"
-  sha256 "314bbd1c705e2262d146d4924bc864fc3e61293b5cb27bbb94306e1c64c4e6f4"
+  url "https://github.com/openai/codex/archive/refs/tags/rust-v0.2.0.tar.gz"
+  sha256 "aa59d6af465d1fe89a82ae684ae3d8d5e6c1f6fbc270cc389c5966c6e969d867"
   license "Apache-2.0"
   head "https://github.com/openai/codex.git", branch: "main"
 

--- a/Formula/c/codex.rb
+++ b/Formula/c/codex.rb
@@ -1,14 +1,21 @@
-# frozen_string_literal: true
-
-# Formula for installing the Codex CLI tool.
 class Codex < Formula
-  desc     "OpenAI's coding agent that runs in your terminal"
+  desc "OpenAI's coding agent that runs in your terminal"
   homepage "https://github.com/openai/codex"
-  url      "https://github.com/openai/codex/archive/2925136536b06a324551627468d17e959afa18d4.tar.gz"
-  version  "0.2.0-alpha.2"
-  sha256   "314bbd1c705e2262d146d4924bc864fc3e61293b5cb27bbb94306e1c64c4e6f4"
-  license  "Apache-2.0"
-  head     "https://github.com/openai/codex.git", branch: "main"
+  url "https://github.com/openai/codex/archive/2925136536b06a324551627468d17e959afa18d4.tar.gz"
+  version "0.2.0-alpha.2"
+  sha256 "314bbd1c705e2262d146d4924bc864fc3e61293b5cb27bbb94306e1c64c4e6f4"
+  license "Apache-2.0"
+  head "https://github.com/openai/codex.git", branch: "main"
+
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "754cf31c59ec4bffde64e85e00a5e4de09400cb29aac35bf86003922e764b987"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "754cf31c59ec4bffde64e85e00a5e4de09400cb29aac35bf86003922e764b987"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "754cf31c59ec4bffde64e85e00a5e4de09400cb29aac35bf86003922e764b987"
+    sha256 cellar: :any_skip_relocation, sonoma:        "16d121f1f81e90c950fdc5b8b9bba62ab1c3445fd7ee5d06882e39e799535a16"
+    sha256 cellar: :any_skip_relocation, ventura:       "16d121f1f81e90c950fdc5b8b9bba62ab1c3445fd7ee5d06882e39e799535a16"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "754cf31c59ec4bffde64e85e00a5e4de09400cb29aac35bf86003922e764b987"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "754cf31c59ec4bffde64e85e00a5e4de09400cb29aac35bf86003922e764b987"
+  end
 
   depends_on "rust" => :build
   depends_on "openssl@3"
@@ -21,6 +28,7 @@ class Codex < Formula
   end
 
   test do
+    # codex is a TUI application
     assert_match version.to_s, shell_output("#{bin}/codex --version")
   end
 end

--- a/Formula/c/codex.rb
+++ b/Formula/c/codex.rb
@@ -11,8 +11,12 @@ class Codex < Formula
   head     "https://github.com/openai/codex.git", branch: "main"
 
   depends_on "rust" => :build
+  depends_on "openssl@3"
 
   def install
+    ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
+    ENV["OPENSSL_NO_VENDOR"] = "1"
+
     system "cargo", "install", "--bin", "codex", *std_cargo_args(path: "codex-rs/cli")
   end
 

--- a/Formula/c/codex.rb
+++ b/Formula/c/codex.rb
@@ -1,35 +1,22 @@
+# frozen_string_literal: true
+
+# Formula for installing the Codex CLI tool.
 class Codex < Formula
-  desc "OpenAI's coding agent that runs in your terminal"
+  desc     "OpenAI's coding agent that runs in your terminal"
   homepage "https://github.com/openai/codex"
-  url "https://registry.npmjs.org/@openai/codex/-/codex-0.1.2505291658.tgz"
-  sha256 "066a11322e815d680799330cf360bc9601deb0a40d907546c2cda9eb22cca86a"
-  license "Apache-2.0"
+  url      "https://github.com/openai/codex/archive/2925136536b06a324551627468d17e959afa18d4.tar.gz"
+  version  "0.2.0-alpha.2"
+  sha256   "314bbd1c705e2262d146d4924bc864fc3e61293b5cb27bbb94306e1c64c4e6f4"
+  license  "Apache-2.0"
+  head     "https://github.com/openai/codex.git", branch: "main"
 
-  bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "754cf31c59ec4bffde64e85e00a5e4de09400cb29aac35bf86003922e764b987"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "754cf31c59ec4bffde64e85e00a5e4de09400cb29aac35bf86003922e764b987"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "754cf31c59ec4bffde64e85e00a5e4de09400cb29aac35bf86003922e764b987"
-    sha256 cellar: :any_skip_relocation, sonoma:        "16d121f1f81e90c950fdc5b8b9bba62ab1c3445fd7ee5d06882e39e799535a16"
-    sha256 cellar: :any_skip_relocation, ventura:       "16d121f1f81e90c950fdc5b8b9bba62ab1c3445fd7ee5d06882e39e799535a16"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "754cf31c59ec4bffde64e85e00a5e4de09400cb29aac35bf86003922e764b987"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "754cf31c59ec4bffde64e85e00a5e4de09400cb29aac35bf86003922e764b987"
-  end
-
-  depends_on "node"
+  depends_on "rust" => :build
 
   def install
-    system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
-
-    # Remove incompatible pre-built binaries
-    libexec.glob("lib/node_modules/@openai/codex/bin/*")
-           .each { |f| rm_r(f) if f.extname != ".js" }
-
-    generate_completions_from_executable(bin/"codex", "completion")
+    system "cargo", "install", "--bin", "codex", *std_cargo_args(path: "codex-rs/cli")
   end
 
   test do
-    # codex is a TUI application
     assert_match version.to_s, shell_output("#{bin}/codex --version")
   end
 end


### PR DESCRIPTION
Bump to 0.2.0 and builds Rust from source.

As we are moving to the Rust CLI as the source of truth for the Codex CLI:

https://github.com/openai/codex/discussions/1174

This updates the brew formula to build the Rust CLI from source.

https://github.com/openai/codex/releases/tag/rust-v0.2.0 is the first GitHub Release that is not tagged as "pre-release."

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
