### PR TITLE
*gdb: fix TUI, make dependencies uniform

### DIFF
--- a/Formula/a/aarch64-elf-gdb.rb
+++ b/Formula/a/aarch64-elf-gdb.rb
@@ -14,13 +14,14 @@ class Aarch64ElfGdb < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 arm64_sequoia: "0a926fe5dc3bc4e539f41c646716b31f5d1286edb897298b01f32134cbb3abef"
-    sha256 arm64_sonoma:  "f521ba77ba54ff94b1bed1e5cd0b42a57d9854922dfff195f71e8eb7e55dcd6b"
-    sha256 arm64_ventura: "4cf29fad518c942bd1310ba0bfd38c0ecbcdf30b7e36312d129719278da7175b"
-    sha256 sonoma:        "bb07e3cc246b3668c6cc918fc3ba3702b155b11674533d75e02dbe4664c4c2b6"
-    sha256 ventura:       "763a0c51b03e2e614429e0a5598e6cf242ebea2be8f5c94fa5a23cc511dfd101"
-    sha256 arm64_linux:   "05c39d0fccad36e0b46a99eeb08c129bf61744522aac5e9fde1cfff57454cbc3"
-    sha256 x86_64_linux:  "09ad9bdbf4e7cce7979fa2fed88e9b31ee1a06cc82e5f625dd6dae9d1ab2e9a9"
+    rebuild 1
+    sha256 arm64_sequoia: "e7db20ed948d7a6bfde4f5c2681d6e9a8a2c28a7583174db3620a43b1c2a9382"
+    sha256 arm64_sonoma:  "deb6bb2ba235a54d37a78bff3c1a7eee52adf0a8c8908294b4652be74acbd7ee"
+    sha256 arm64_ventura: "b93b9aab9faa8beb55a447dbfa2e588708d455723a7d50fde9a8c3c53aec3f08"
+    sha256 sonoma:        "17196d00ed529a99ef0c96369de15e0fb5a94b0ff1e09f364e1cc8e537bd82d9"
+    sha256 ventura:       "30a2662009762f18301b52730338afdb0efbd34ad547fc4d7048fbe68fec36a1"
+    sha256 arm64_linux:   "fb87b609951161a5b9bb9a1bd8ae0c0452ebfa32ed4e4d1f3b1bba7f4c60018d"
+    sha256 x86_64_linux:  "f7973bb38142516974f41cf187d9d7ed5a9cc3f4bea1e98003374cc5f73c2fb3"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/a/aarch64-elf-gdb.rb
+++ b/Formula/a/aarch64-elf-gdb.rb
@@ -27,13 +27,13 @@ class Aarch64ElfGdb < Formula
   depends_on "aarch64-elf-gcc" => :test
   depends_on "gmp"
   depends_on "mpfr"
+  depends_on "ncurses" # https://github.com/Homebrew/homebrew-core/issues/224294
   depends_on "python@3.13"
   depends_on "readline"
   depends_on "xz" # required for lzma support
   depends_on "zstd"
 
   uses_from_macos "expat", since: :sequoia # minimum macOS due to python
-  uses_from_macos "ncurses"
   uses_from_macos "zlib"
 
   # Workaround for https://github.com/Homebrew/brew/issues/19315
@@ -55,6 +55,8 @@ class Aarch64ElfGdb < Formula
       --includedir=#{include}/#{target}
       --infodir=#{info}/#{target}
       --mandir=#{man}
+      --disable-binutils
+      --disable-nls
       --enable-tui
       --with-curses
       --with-expat
@@ -63,8 +65,6 @@ class Aarch64ElfGdb < Formula
       --with-system-readline
       --with-system-zlib
       --with-zstd
-      --disable-binutils
-      --disable-nls
     ]
 
     mkdir "build" do

--- a/Formula/a/arm-none-eabi-gdb.rb
+++ b/Formula/a/arm-none-eabi-gdb.rb
@@ -23,14 +23,17 @@ class ArmNoneEabiGdb < Formula
     sha256 x86_64_linux:  "9152a2b777ee25f0aace40a118467eccaed53cfdf8ba171d304c6751606812a9"
   end
 
+  depends_on "pkgconf" => :build
   depends_on "arm-none-eabi-gcc" => :test
   depends_on "gmp"
   depends_on "mpfr"
+  depends_on "ncurses" # https://github.com/Homebrew/homebrew-core/issues/224294
   depends_on "python@3.13"
+  depends_on "readline"
   depends_on "xz" # required for lzma support
+  depends_on "zstd"
 
   uses_from_macos "expat", since: :sequoia # minimum macOS due to python
-  uses_from_macos "ncurses"
   uses_from_macos "zlib"
 
   # Workaround for https://github.com/Homebrew/brew/issues/19315
@@ -52,10 +55,16 @@ class ArmNoneEabiGdb < Formula
       --includedir=#{include}/#{target}
       --infodir=#{info}/#{target}
       --mandir=#{man}
-      --with-lzma
-      --with-python=#{Formula["python@3.13"].opt_bin}/python3.13
-      --with-system-zlib
       --disable-binutils
+      --disable-nls
+      --enable-tui
+      --with-curses
+      --with-expat
+      --with-lzma
+      --with-python=#{which("python3.13")}
+      --with-system-readline
+      --with-system-zlib
+      --with-zstd
     ]
 
     mkdir "build" do

--- a/Formula/a/arm-none-eabi-gdb.rb
+++ b/Formula/a/arm-none-eabi-gdb.rb
@@ -14,13 +14,14 @@ class ArmNoneEabiGdb < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 arm64_sequoia: "54bb4fd38fdd0c2e6b322d6ea7f05a9e101509e774b906a2048cc5a0a6df5b84"
-    sha256 arm64_sonoma:  "fb92c479ff811cc52de43c83059cbfddbcdc397e39c6e79bcdafd8ac3034ef34"
-    sha256 arm64_ventura: "86d36e5462f353f30a107d3e8ad067018573559d1cf6194c54826ea90d72400f"
-    sha256 sonoma:        "ffddd2a96ef21bca9ca6064924f3a447a8b6eb663572bb57e587f1e772fd2cf9"
-    sha256 ventura:       "bcd01adedff4f680b76b82704de6f09eb1e299c26fd4e45ab3deb377a50088cc"
-    sha256 arm64_linux:   "ad9c74395a546cbe50b8bed7aa3382218326b3e1cfaa8c486d50b7de76c6f27d"
-    sha256 x86_64_linux:  "9152a2b777ee25f0aace40a118467eccaed53cfdf8ba171d304c6751606812a9"
+    rebuild 1
+    sha256 arm64_sequoia: "1a7301cc72a0e20ca3210b0a039226319eaa33259670ef53d9f2fe57a3ad91ef"
+    sha256 arm64_sonoma:  "e3f460c763a63f70e0b3f93a9763638a3e2a358e561d3216d102cabea65cebb5"
+    sha256 arm64_ventura: "185b464524777e63901da56fb727d6ae6c3b1d776213294d330ca7ffa8c0b55f"
+    sha256 sonoma:        "0768015caa13cddc4e56cfa265e396bef30e786d052417d530595f6965fc6e13"
+    sha256 ventura:       "bafd4327eaf7943a9b11d28e9d99699245b8e1ff2302db8474a4466142446b15"
+    sha256 arm64_linux:   "2866df5b2c8bb8e5d8a7ee04b407cca220877c0494004cda4e35bb17af9b4069"
+    sha256 x86_64_linux:  "50f19c339ae4ea0e2e15300ef4d1720f3550c99cffe4ed4f9b3302a543e34d97"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/g/gdb.rb
+++ b/Formula/g/gdb.rb
@@ -22,11 +22,13 @@ class Gdb < Formula
   depends_on "pkgconf" => :build
   depends_on "gmp"
   depends_on "mpfr"
+  depends_on "ncurses" # https://github.com/Homebrew/homebrew-core/issues/224294
   depends_on "python@3.13"
+  depends_on "readline"
   depends_on "xz" # required for lzma support
+  depends_on "zstd"
 
   uses_from_macos "expat", since: :sequoia # minimum macOS due to python
-  uses_from_macos "ncurses"
   uses_from_macos "zlib"
 
   # Workaround for https://github.com/Homebrew/brew/issues/19315
@@ -59,10 +61,16 @@ class Gdb < Formula
 
     args = %W[
       --enable-targets=all
+      --disable-binutils
+      --disable-nls
+      --enable-tui
+      --with-curses
+      --with-expat
       --with-lzma
       --with-python=#{which("python3.13")}
-      --disable-binutils
+      --with-system-readline
       --with-system-zlib
+      --with-zstd
     ]
 
     # Fix: Apple Silicon build, this is only way to build native GDB

--- a/Formula/g/gdb.rb
+++ b/Formula/g/gdb.rb
@@ -10,13 +10,14 @@ class Gdb < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 arm64_sequoia: "9e5f18aa75cef9f236a7f07d4e444d54a8cccf3ff7e119f9923db8bef62d1252"
-    sha256 arm64_sonoma:  "06baf22991ec402640b1d6d886e3218d208abd368e8ba50c2116b17923f633ae"
-    sha256 arm64_ventura: "b0d0fc6a961b484803767ee5a1ba108de2a61e06522236536c7e600ea1d541cc"
-    sha256 sonoma:        "1f09c138f3bdeaf1066dc83fe96e6c6a9bdab4e1a73553048606708c84fc5d70"
-    sha256 ventura:       "1f477ff41885a15a223c3c17931e4f8cd530262f3c7286969028af78dfa8e8bf"
-    sha256 arm64_linux:   "bdc566b8b01f046ce432ed7445f7a9ff929f155bf48643288362b78340239bb3"
-    sha256 x86_64_linux:  "5dce623e116162d2edb8668a5f5b5085dea0b0dbce8b245985de933ed0079097"
+    rebuild 1
+    sha256 arm64_sequoia: "86430d65b980c9b2f7bed6f6f0d20d9735b48f72a0edd435e7833fcd1a635c4b"
+    sha256 arm64_sonoma:  "b9a4d48e9eaac185639cad6e643b2006aa844e855eb91aa68f7acab9e5a2fa47"
+    sha256 arm64_ventura: "4e7be3bb2cf45fd603167877908faae6d6d08baf8ca118abd81ea2ac5b23087a"
+    sha256 sonoma:        "899a766e0055e46c29593e14f6b451ce9b88e851bde09a1fd020acdcd8077995"
+    sha256 ventura:       "c69b4edf3decec0ae65161625aa706e1320d70d6e57fa0ade1f90665fd01e08d"
+    sha256 arm64_linux:   "b426d4b79eb37d5b7ca4b920b4e89bb0a3829395c3d777f3f6d8517683578043"
+    sha256 x86_64_linux:  "39237eae583ff94cca2ebea1cc8a61688933603b9f51679fc0f20e4d8ae55f46"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/i/i386-elf-gdb.rb
+++ b/Formula/i/i386-elf-gdb.rb
@@ -23,14 +23,17 @@ class I386ElfGdb < Formula
     sha256 x86_64_linux:  "3f2f5cd65a663532604928725a87b015fd9f596ae92b647a4ee6b4fb9c61fd97"
   end
 
+  depends_on "pkgconf" => :build
   depends_on "i686-elf-gcc" => :test
   depends_on "gmp"
   depends_on "mpfr"
+  depends_on "ncurses" # https://github.com/Homebrew/homebrew-core/issues/224294
   depends_on "python@3.13"
+  depends_on "readline"
   depends_on "xz" # required for lzma support
+  depends_on "zstd"
 
   uses_from_macos "expat", since: :sequoia # minimum macOS due to python
-  uses_from_macos "ncurses"
   uses_from_macos "zlib"
 
   # Workaround for https://github.com/Homebrew/brew/issues/19315
@@ -52,10 +55,16 @@ class I386ElfGdb < Formula
       --includedir=#{include}/#{target}
       --infodir=#{info}/#{target}
       --mandir=#{man}
+      --disable-binutils
+      --disable-nls
+      --enable-tui
+      --with-curses
+      --with-expat
       --with-lzma
       --with-python=#{which("python3.13")}
+      --with-system-readline
       --with-system-zlib
-      --disable-binutils
+      --with-zstd
     ]
 
     mkdir "build" do

--- a/Formula/i/i386-elf-gdb.rb
+++ b/Formula/i/i386-elf-gdb.rb
@@ -14,13 +14,14 @@ class I386ElfGdb < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 arm64_sequoia: "af939496c6245db5f2f812e196fb9e4b3623f15a2db5035716f392d6633ffe8c"
-    sha256 arm64_sonoma:  "951dac8073ae7de6fb7d74db8b7694a4bc323e02013f1ac541b1f03f45e8d319"
-    sha256 arm64_ventura: "b8c97775ea52dfbb3459fae62aa433402a2fb23a1d3b4553be7c206b38e63701"
-    sha256 sonoma:        "a7a43697ffade75a422458eb851588a15b042272729d9850339ae465069cd5cf"
-    sha256 ventura:       "c9d550dcb8ddb0db49e41f7a72339424e320ee23537ed52e8f66b2887185d889"
-    sha256 arm64_linux:   "2a7f9f61e3f2faac56dfd439e1488567643896454a98acf4d03fa7e201a6d57f"
-    sha256 x86_64_linux:  "3f2f5cd65a663532604928725a87b015fd9f596ae92b647a4ee6b4fb9c61fd97"
+    rebuild 1
+    sha256 arm64_sequoia: "a8404abfee4bdd057c859323a3d3860c0e3dc91d6d1eaa9a8e8b396cd06f16ea"
+    sha256 arm64_sonoma:  "38e6e069cd8ffc3947627429e9623de6c142f334691b2cf5916aeabe1213d637"
+    sha256 arm64_ventura: "e78e568042d2142374827e9f972b311f24f09dbbc9ab93ad2169f38892fc1a19"
+    sha256 sonoma:        "234fff305c7934001f7bbdd0b85126c4ea4c93698bda3d2309e61b63b182b72a"
+    sha256 ventura:       "d34cc34bc0868a65dbafaf5abb4058f9ec41c393955e5afeaff27f348eeb6d90"
+    sha256 arm64_linux:   "17d3006eac24ac4a60269370022370cec2433938e2e3ea9d5ff3c9caf1c03d1a"
+    sha256 x86_64_linux:  "c29025ac9d4d8f200925d8e326e16c2691bda17c1efecfca873b1900b60317e0"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/r/riscv64-elf-gdb.rb
+++ b/Formula/r/riscv64-elf-gdb.rb
@@ -23,14 +23,17 @@ class Riscv64ElfGdb < Formula
     sha256 x86_64_linux:  "8bf342fa7ae748f0917c42d37db64a0b44e7f2f5c867898f975b93928bd3c292"
   end
 
+  depends_on "pkgconf" => :build
   depends_on "riscv64-elf-gcc" => :test
   depends_on "gmp"
   depends_on "mpfr"
+  depends_on "ncurses" # https://github.com/Homebrew/homebrew-core/issues/224294
   depends_on "python@3.13"
+  depends_on "readline"
   depends_on "xz" # required for lzma support
+  depends_on "zstd"
 
   uses_from_macos "expat", since: :sequoia # minimum macOS due to python
-  uses_from_macos "ncurses"
   uses_from_macos "zlib"
 
   # Workaround for https://github.com/Homebrew/brew/issues/19315
@@ -52,10 +55,16 @@ class Riscv64ElfGdb < Formula
       --includedir=#{include}/#{target}
       --infodir=#{info}/#{target}
       --mandir=#{man}
+      --disable-binutils
+      --disable-nls
+      --enable-tui
+      --with-curses
+      --with-expat
       --with-lzma
       --with-python=#{which("python3.13")}
+      --with-system-readline
       --with-system-zlib
-      --disable-binutils
+      --with-zstd
     ]
 
     mkdir "build" do

--- a/Formula/r/riscv64-elf-gdb.rb
+++ b/Formula/r/riscv64-elf-gdb.rb
@@ -14,13 +14,14 @@ class Riscv64ElfGdb < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 arm64_sequoia: "fc182c3f9b43f0706c5e38ad0cc227b5a0462f413b3e7975137baafcbf9f75bb"
-    sha256 arm64_sonoma:  "0e376f70fab060eb7a19ea146565b21f25c39fad626b9345f16ba541f98b7e05"
-    sha256 arm64_ventura: "c6289ed531b09195c7288e49bdd5ea128b7b95d0c28b15408a8a24041dbdc748"
-    sha256 sonoma:        "67fbc5381005c1223d1c3bdd444f7114c748448913a81daa57db9d27df947b1b"
-    sha256 ventura:       "efcdc16f939bad13162938caf972b390bbd62be3f5888af79bf0062d6f87adfb"
-    sha256 arm64_linux:   "1cec187ec64758bdacd6fb7707fbc7851a70efcbe6ba3f42881c0889d19b710e"
-    sha256 x86_64_linux:  "8bf342fa7ae748f0917c42d37db64a0b44e7f2f5c867898f975b93928bd3c292"
+    rebuild 1
+    sha256 arm64_sequoia: "0496ebf857fd732860b99a501ee7d65e7ccbbd169042413ce702c5444ded3f1e"
+    sha256 arm64_sonoma:  "fe42283e0b56442eb93c110b6a308182324e1eeff5c7cf43cd7d768894485eb0"
+    sha256 arm64_ventura: "96ea7bd381f364f0e5875560a9fd7bef09add6395a53af8d4bea2f12e81e51ec"
+    sha256 sonoma:        "a002cb7302b7dfe52feab0134b31284196a52e65e9bb59f6d00b82ae97960cbd"
+    sha256 ventura:       "05be81fd9d083a1e3996ebb84fae6dfbe60014193e983a9fcaf13fd4569fdadf"
+    sha256 arm64_linux:   "4e3030c62a51aeb071e926c8846f9b5fde6c6b1b6ccce58979219cca0826effd"
+    sha256 x86_64_linux:  "a85cca3d9b3db5281ad8fd34174be330b290d4f6dae08c8029037bb9e8c2d60e"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/x/x86_64-elf-gdb.rb
+++ b/Formula/x/x86_64-elf-gdb.rb
@@ -14,13 +14,14 @@ class X8664ElfGdb < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 arm64_sequoia: "28f100b92ecb7457ced120b8d0522a178c1c7b41602ce928a135573196f0f118"
-    sha256 arm64_sonoma:  "f3bfe8ae0d22a8a29df3487ab9a02183c03ebc40aee4dbb791f951152739d451"
-    sha256 arm64_ventura: "12f8ce79c5b517f25f323720050fb2f348e556f90cd510b4d58e3f5ae20fc3dc"
-    sha256 sonoma:        "e4b1c236f1b4317c08f212b2ee18e12c511edf81adb3a376697da97e286b88c0"
-    sha256 ventura:       "6a08a716548bb8e045f191db3854584be6d48619a64886e69d2f6617bf09c623"
-    sha256 arm64_linux:   "8b54865a39c1be49422e670ffd3992d391159acba028d87a1b73affa796c86cd"
-    sha256 x86_64_linux:  "38caa41e87bae9d85259c0497a9300af7c51f236e299476a8fc38da29f7d76ca"
+    rebuild 1
+    sha256 arm64_sequoia: "1a4c275dd54c82d2fb7565983fb7258ac7ef8d69f21e6d8a0c2c33b24f67e70f"
+    sha256 arm64_sonoma:  "06ec3ddcb48354b451944b928999451d75ce5fbea906257cd3181ccc9f18e090"
+    sha256 arm64_ventura: "921cea748af120a02e9feb5b9a2e13922171f1bf31607f8687c7fe5e761fe3e9"
+    sha256 sonoma:        "947637121994d679bc77abbb2ccaa676358b854ef6df40db771476b4ac0b5052"
+    sha256 ventura:       "38ce87c28c52fb3bc004059ebc8366e1dfdf24b56c44768aeade91b09fe17d21"
+    sha256 arm64_linux:   "f256c8f267620dc8139228e6fab3a955a07146fd378d6e0d6fd8f31363f2831d"
+    sha256 x86_64_linux:  "b498816b6889d583fa35ebb8cc38bcbf5138e47e3487a89c05650d87d578d1f8"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/x/x86_64-elf-gdb.rb
+++ b/Formula/x/x86_64-elf-gdb.rb
@@ -23,15 +23,17 @@ class X8664ElfGdb < Formula
     sha256 x86_64_linux:  "38caa41e87bae9d85259c0497a9300af7c51f236e299476a8fc38da29f7d76ca"
   end
 
+  depends_on "pkgconf" => :build
   depends_on "x86_64-elf-gcc" => :test
-
   depends_on "gmp"
   depends_on "mpfr"
+  depends_on "ncurses" # https://github.com/Homebrew/homebrew-core/issues/224294
   depends_on "python@3.13"
+  depends_on "readline"
   depends_on "xz" # required for lzma support
+  depends_on "zstd"
 
   uses_from_macos "expat", since: :sequoia # minimum macOS due to python
-  uses_from_macos "ncurses"
   uses_from_macos "zlib"
 
   # Workaround for https://github.com/Homebrew/brew/issues/19315
@@ -53,10 +55,16 @@ class X8664ElfGdb < Formula
       --includedir=#{include}/#{target}
       --infodir=#{info}/#{target}
       --mandir=#{man}
+      --disable-binutils
+      --disable-nls
+      --enable-tui
+      --with-curses
+      --with-expat
       --with-lzma
       --with-python=#{which("python3.13")}
+      --with-system-readline
       --with-system-zlib
-      --disable-binutils
+      --with-zstd
     ]
 
     mkdir "build" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fixes #224294.

Let's also make the dependencies uniform across the various GDB formulae.

- **aarch64-elf-gdb: fix TUI, make dependencies uniform**
- **arm-none-eabi-gdb: fix TUI, make dependencies uniform**
- **gdb: fix TUI, make dependencies uniform**
- **i386-elf-gdb: fix TUI, make dependencies uniform**
- **riscv64-elf-gdb: fix TUI, make dependencies uniform**
- **x86_64-elf-gdb: fix TUI, make dependencies uniform**

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

