### PR TITLE
pulseaudio: avoid wiping user configuration on upgrades

### DIFF
--- a/Formula/p/pulseaudio.rb
+++ b/Formula/p/pulseaudio.rb
@@ -15,15 +15,14 @@ class Pulseaudio < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 arm64_sequoia:  "ceb92ec9cc890a989907d2b0fe1de997e619cde589fbcc5a31eda87f8adccedb"
-    sha256 arm64_sonoma:   "aea71892ba21ebdc3e619819ddc6f641a59d87d0688b671b82352af062cf860b"
-    sha256 arm64_ventura:  "63b0ba13d5187af0e2f9bd56f638bf2f1060c60327bb78f97f094cde6756a07c"
-    sha256 arm64_monterey: "25d41b1a184588db2fdb9f39367ff6d20f6c7542f9de2e6b67b73bc4f7bd5e09"
-    sha256 sonoma:         "57c4f8e47c04145f0851d231d0c92bd43f57e59bf3416689e25b8e619a7913a3"
-    sha256 ventura:        "fd0835395b77a321e3b5a4542496c02dd0dbdd8134e700bacbfb80c46d6e14cc"
-    sha256 monterey:       "e28e0f3a10c94b089acb2a6f82fd31d19c3cd8cbd7ad180d50a794f473b9adaa"
-    sha256 arm64_linux:    "366a4e3c371e6b5ba54d7f1f8ede79db83865e6e2767b3960b5c78a0ce581a9f"
-    sha256 x86_64_linux:   "504035dfda3bffabae42f352d0e7c0a90c6b8c1f6b925fe7e17502124d5d6529"
+    rebuild 1
+    sha256 arm64_sequoia: "f279ea9efd07106c6e049b0d5bcca39a5fb06f5bd95079f998b2175726050c79"
+    sha256 arm64_sonoma:  "6c8704f6c5bce3450d75da7983a9d5ef2eca52ce9ef944c85a54e8e86c9c4354"
+    sha256 arm64_ventura: "8f36cbfefb820a38dce3efca6458c3837950448a59ff77337105f7f3cd550429"
+    sha256 sonoma:        "43cc094dbeb0681caa68cc3ed6e3dab115a0c52ae09fb39b6e3ac16a810edd4b"
+    sha256 ventura:       "26a46b5af9fa4436be2057e2c838ff5b4220cb6724ffa28ad10dec4437ba99ea"
+    sha256 arm64_linux:   "cbb10721c978f2be94f38829b6f1ab941cd6dd310fc00c45ee8b1d4ebdb16ab1"
+    sha256 x86_64_linux:  "0a8deac02332caf78aef95c279d76dd381ae1b08e0c8f74277880570a4d60527"
   end
 
   depends_on "gettext" => :build

--- a/Formula/p/pulseaudio.rb
+++ b/Formula/p/pulseaudio.rb
@@ -63,6 +63,7 @@ class Pulseaudio < Formula
 
     # Default `tdb` database isn't available in Homebrew
     args = %W[
+      --sysconfdir=#{etc}
       -Ddatabase=simple
       -Ddoxygen=false
       -Dman=true
@@ -89,6 +90,14 @@ class Pulseaudio < Formula
     system "meson", "setup", "build", *args, *std_meson_args
     system "meson", "compile", "-C", "build", "--verbose"
     system "meson", "install", "-C", "build"
+
+    # Don't hardcode Cellar references in configuration files
+    inreplace etc.glob("pulse/*"), prefix, opt_prefix, audit_result: false
+
+    # Create the `default.pa.d` directory to avoid error messages like
+    # https://github.com/Homebrew/homebrew-core/issues/224722
+    (etc/"pulse/default.pa.d").mkpath
+    touch etc/"pulse/default.pa.d/.keepme"
   end
 
   service do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This installs user configuration into the formula prefix. Let's make it
install into `etc` instead.

Let's also create the `default.pa.d` directory to avoid unexpected error
messages.

Fixes #224722.
