### PR TITLE
liquibase: update livecheck

### DIFF
--- a/Formula/l/liquibase.rb
+++ b/Formula/l/liquibase.rb
@@ -6,8 +6,8 @@ class Liquibase < Formula
   license "Apache-2.0"
 
   livecheck do
-    url "https://www.liquibase.com/download"
-    regex(/href=.*?liquibase[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url :stable
+    strategy :github_latest
   end
 
   no_autobump! because: :requires_manual_review


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----


The existing `livecheck` block for `liquibase` is returning an `Unable to get versions` error, as the URL now redirects to https://www.liquibase.com/download-pro and that page links to a Pro tarball instead of the OSS distribution that the formula uses. The OSS download page can be found at https://www.liquibase.com/download-oss but the tarball link is hosted on package.liquibase.com, not GitHub.

This resolves the issue by updating the `livecheck` block to simply use the `GithubLatest` strategy, as the formula is using a GitHub release asset.