### PR TITLE
codex 0.2.0 (TypeScript -> Rust)

### DIFF
--- a/Formula/c/codex.rb
+++ b/Formula/c/codex.rb
@@ -7,13 +7,13 @@ class Codex < Formula
   head "https://github.com/openai/codex.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "754cf31c59ec4bffde64e85e00a5e4de09400cb29aac35bf86003922e764b987"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "754cf31c59ec4bffde64e85e00a5e4de09400cb29aac35bf86003922e764b987"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "754cf31c59ec4bffde64e85e00a5e4de09400cb29aac35bf86003922e764b987"
-    sha256 cellar: :any_skip_relocation, sonoma:        "16d121f1f81e90c950fdc5b8b9bba62ab1c3445fd7ee5d06882e39e799535a16"
-    sha256 cellar: :any_skip_relocation, ventura:       "16d121f1f81e90c950fdc5b8b9bba62ab1c3445fd7ee5d06882e39e799535a16"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "754cf31c59ec4bffde64e85e00a5e4de09400cb29aac35bf86003922e764b987"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "754cf31c59ec4bffde64e85e00a5e4de09400cb29aac35bf86003922e764b987"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "de52c42521b1eb60600fbdf03acc0ad0d26fd1be3eefbc52025ea480499ce75f"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "6f1148326eb88cd542defb40f3a67e516f68b43ba5c125e0051b8b2001286b71"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "cf952e4aaa33a0e7a466f88142b2308b666183356817078009fa509287a1bfd0"
+    sha256 cellar: :any_skip_relocation, sonoma:        "900f5c341f0d92d0ab57f154feb36e9e74c194adbf7b8780fcc0ed5d185bcfbe"
+    sha256 cellar: :any_skip_relocation, ventura:       "4294b7944faf2913410c33215d751f507ccd1f845ed2be06acaf6bb72915df1a"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "5ca98099f91a0c67dfc91b7d598078ca8daa926de395259f25dffb26e38a8b38"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "cd89a26bfadf9c88d5f7aac77ab4832cf0c2f78eb4bfed8990b509589fa1a2c2"
   end
 
   depends_on "rust" => :build

--- a/Formula/c/codex.rb
+++ b/Formula/c/codex.rb
@@ -1,9 +1,10 @@
 class Codex < Formula
   desc "OpenAI's coding agent that runs in your terminal"
   homepage "https://github.com/openai/codex"
-  url "https://registry.npmjs.org/@openai/codex/-/codex-0.1.2505291658.tgz"
-  sha256 "066a11322e815d680799330cf360bc9601deb0a40d907546c2cda9eb22cca86a"
+  url "https://github.com/openai/codex/archive/refs/tags/rust-v0.2.0.tar.gz"
+  sha256 "aa59d6af465d1fe89a82ae684ae3d8d5e6c1f6fbc270cc389c5966c6e969d867"
   license "Apache-2.0"
+  head "https://github.com/openai/codex.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "754cf31c59ec4bffde64e85e00a5e4de09400cb29aac35bf86003922e764b987"
@@ -15,21 +16,29 @@ class Codex < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "754cf31c59ec4bffde64e85e00a5e4de09400cb29aac35bf86003922e764b987"
   end
 
-  depends_on "node"
+  depends_on "rust" => :build
+
+  on_linux do
+    depends_on "openssl@3"
+  end
 
   def install
-    system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    if OS.linux?
+      ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
+      ENV["OPENSSL_NO_VENDOR"] = "1"
+    end
 
-    # Remove incompatible pre-built binaries
-    libexec.glob("lib/node_modules/@openai/codex/bin/*")
-           .each { |f| rm_r(f) if f.extname != ".js" }
-
-    generate_completions_from_executable(bin/"codex", "completion")
+    system "cargo", "install", "--bin", "codex", *std_cargo_args(path: "codex-rs/cli")
   end
 
   test do
-    # codex is a TUI application
     assert_match version.to_s, shell_output("#{bin}/codex --version")
+
+    assert_equal "Reading prompt from stdin...\nNo prompt provided via stdin.\n",
+pipe_output("#{bin}/codex exec 2>&1", "", 1)
+
+    return unless OS.linux?
+
+    assert_equal "hello\n", shell_output("#{bin}/codex debug landlock echo hello")
   end
 end


### PR DESCRIPTION
Bump to 0.2.0 and builds the CLI from its Rust sources instead of downloading pre-built artifacts from npm.

As we are moving to the Rust version as the source of truth for the Codex CLI:

https://github.com/openai/codex/discussions/1174

This updates the brew formula to build the Rust version of the CLI from source.

https://github.com/openai/codex/releases/tag/rust-v0.2.0 is the first GitHub Release that is not tagged as "pre-release."

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
