### PR TITLE
aerc: build with notmuch support

### DIFF
--- a/Formula/a/aerc.rb
+++ b/Formula/a/aerc.rb
@@ -8,12 +8,13 @@ class Aerc < Formula
   head "https://git.sr.ht/~rjarry/aerc", branch: "master"
 
   bottle do
-    sha256 arm64_sequoia: "2cd6028c68dc0e5aeb8e82bc07aa4c5b7a925bf7d278d78f827c55a208356664"
-    sha256 arm64_sonoma:  "6a7dd569bd087a878888764dbe231530e859bfa177dfe04173a9c244cc3a4490"
-    sha256 arm64_ventura: "dec8d978d3efcb21fc615bf145daff38474ff032d22572b03906398366349f59"
-    sha256 sonoma:        "d9a7ebee7208939165429112a6acdeabd22095078acdf26d36a32c5202e58b20"
-    sha256 ventura:       "3cdfcc6ef2b5e6d2461a5727c187790b955ec79dab57b953101602fb9c7aaa8e"
-    sha256 x86_64_linux:  "15fe42751917e3f22f595cc4d67a3e2e573e6c9fe84a154fb222c50e70bb9d2a"
+    rebuild 1
+    sha256 arm64_sequoia: "1f797aed769e542d8820ab3a1cf3f6c14683ef4f580eedce095dee79b7eaabc2"
+    sha256 arm64_sonoma:  "9c0f8509ca2e627927b09ffb8690bc294d0bf45bbaa76046b26215b44160353b"
+    sha256 arm64_ventura: "4397fc6735cadb6e89f0c99d5025fb66a7fcf98b7f04bd98a409bc93667df9e5"
+    sha256 sonoma:        "efac3df1f65980bf5e4c70100e26f037901fbe79022afb6a6dc08168114ef035"
+    sha256 ventura:       "cbe0cac33a2af190f5ed08de35b790d9d414dd57e018a3518a3cc9878395053e"
+    sha256 x86_64_linux:  "b7194c18ca1bec5a8d678178dd92c06e8fbe35aa6f2902e082f2a4c1e9e0eccb"
   end
 
   depends_on "go" => :build

--- a/Formula/a/aerc.rb
+++ b/Formula/a/aerc.rb
@@ -18,6 +18,7 @@ class Aerc < Formula
 
   depends_on "go" => :build
   depends_on "scdoc" => :build
+  depends_on "notmuch"
 
   def install
     system "make", "PREFIX=#{prefix}", "VERSION=#{version}"
@@ -25,6 +26,7 @@ class Aerc < Formula
   end
 
   test do
-    system bin/"aerc", "-v"
+    output = shell_output("#{bin}/aerc -v")
+    assert_match(/aerc #{version} \+notmuch\.*/, output)
   end
 end


### PR DESCRIPTION
Add notmuch as a build dependency to build aerc with [notmuch](https://notmuchmail.org/) support, so that it can be used as a [backend for aerc](https://git.sr.ht/~rjarry/aerc/tree/master/item/doc/aerc-notmuch.5.scd), as per [upstream build documentation](https://git.sr.ht/~rjarry/aerc/#from-source).

With this, the version output from `-v` will contain the notmuch tag, I've added a test for this.
```shell
❯ aerc -v
aerc 0.20.1 +notmuch-5.6.0 (go1.24.4 amd64 linux 2025-07-01)
```
I've tested building this package using the following commands, and I'm using the notmuch backend:
```shell
❯ brew --edit
❯ brew reinstall --build-from-source aerc
```