### PR TITLE
ollama: bind it to all network interfaces

### DIFF
--- a/Formula/o/ollama.rb
+++ b/Formula/o/ollama.rb
@@ -51,7 +51,8 @@ class Ollama < Formula
     log_path var/"log/ollama.log"
     error_log_path var/"log/ollama.log"
     environment_variables OLLAMA_FLASH_ATTENTION: "1",
-                          OLLAMA_KV_CACHE_TYPE:   "q8_0"
+                          OLLAMA_KV_CACHE_TYPE:   "q8_0",
+                          OLLAMA_HOST:            "0.0.0.0"
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

From Ollama [v0.9.4](https://github.com/ollama/ollama/releases/tag/v0.9.4):

>**Expose Ollama on the network**
>Ollama can now be exposed on the network, allowing others to access Ollama on other devices or even over the internet. This is useful for having Ollama running on a powerful Mac, PC or Linux computer while making it accessible to less powerful devices.

Allowing the formula to do the same seems like a good idea.
