### PR TITLE
fonttools: add lxml dependency

### DIFF
--- a/Formula/f/fonttools.rb
+++ b/Formula/f/fonttools.rb
@@ -20,9 +20,17 @@ class Fonttools < Formula
 
   depends_on "python@3.13"
 
+  uses_from_macos "libxml2"
+  uses_from_macos "libxslt"
+
   resource "brotli" do
     url "https://files.pythonhosted.org/packages/2f/c2/f9e977608bdf958650638c3f1e28f85a1b075f075ebbe77db8555463787b/Brotli-1.1.0.tar.gz"
     sha256 "81de08ac11bcb85841e440c13611c00b67d3bf82698314928d0b676362546724"
+  end
+
+  resource "lxml" do
+    url "https://files.pythonhosted.org/packages/c5/ed/60eb6fa2923602fba988d9ca7c5cdbd7cf25faa795162ed538b527a35411/lxml-6.0.0.tar.gz"
+    sha256 "032e65120339d44cdc3efc326c9f660f5f7205f3a535c1fdbf898b29ea01fb72"
   end
 
   resource "zopfli" do

--- a/Formula/f/fonttools.rb
+++ b/Formula/f/fonttools.rb
@@ -9,13 +9,14 @@ class Fonttools < Formula
   head "https://github.com/fonttools/fonttools.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "69cbb0245f0d9227961c2971a5e2a42906e724717ab2ea8a84f4a2848b6093c5"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "5e5d173f2ba037189eb26369d53f293a77964c14a26a497bbe230ad5c2df6bd1"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "c2db306117265be80d8b5952e285f780b777133e69d17e047dbd81bab761156a"
-    sha256 cellar: :any_skip_relocation, sonoma:        "a3f499a0e007c15061a58d0c523f2d0912889bfab57c662f8080c81d6d32990a"
-    sha256 cellar: :any_skip_relocation, ventura:       "58c4f9393d51eac35414dbbd3e8930531fd8a8217943aed9b53c0d8c1c1c99e1"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "5fbaca03ee6951348e845c4f131227c425f43d703ab5c121518d7847d8fdfc6f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "ab34cba81dfc20a027cdbb991ab31e91170b6fed48f7b511b6996158c0b4f638"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e7973303e1a05170e16651a5a5f0dc661074e16c26d12a832a21e47f9ea23b57"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "45e1723bf678a25851c3d011fc0a91356a21360d16159d7ea4ef6d8b44d30043"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "69c075cc29d69850f83b95d353fc53cefab8120172223a7c67ced8446372d509"
+    sha256 cellar: :any_skip_relocation, sonoma:        "513303c4e58a041aa261bd20d81e21101482c5f2cf2a7a2b46fc169b7e4166f9"
+    sha256 cellar: :any_skip_relocation, ventura:       "a41079da505b5c71642aae63997247ecdd2b0054e1bcf1ec09ed3edbbb937bb2"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "464af4550b9d4b5cc8f7e67f44367754a6a706b9897804d3ff7450b6d75353cd"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2806fce9b3b6c0149ec7024694334e46ab28fb160abf2a7ce97f45cf4a8130ab"
   end
 
   depends_on "python@3.13"

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -348,7 +348,7 @@
   "flit": {
     "exclude_packages": ["certifi"]
   },
-  "fonttools": "fonttools[woff]",
+  "fonttools": "fonttools[lxml,woff]",
   "forbidden": {
     "exclude_packages": ["certifi", "cffi", "cryptography", "pycparser"]
   },


### PR DESCRIPTION
Resolve https://github.com/Homebrew/homebrew-core/issues/229120

---

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
