### PR TITLE
tcpflow: update livecheck

### DIFF
--- a/Formula/t/tcpflow.rb
+++ b/Formula/t/tcpflow.rb
@@ -6,8 +6,13 @@ class Tcpflow < Formula
   license "GPL-3.0-only"
 
   livecheck do
-    url "https://corp.digitalcorpora.org/downloads/tcpflow/"
-    regex(/href=.*?tcpflow[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url "https://digitalcorpora.s3.us-west-2.amazonaws.com/?list-type=2&delimiter=%2F&prefix=downloads%2Ftcpflow%2F"
+    regex(/tcpflow[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    strategy :xml do |xml, regex|
+      xml.get_elements("//Contents/Key").filter_map do |item|
+        item.text&.[](regex, 1)
+      end
+    end
   end
 
   no_autobump! because: :requires_manual_review


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `tcpflow` now redirects to an AWS S3 file listing page, which doesn't contain any tarball links in the HTML as the file metadata is fetched client-side. This updates the `livecheck` block to check the XML file containing the file information and loosens the regex to be able to continue matching in this new context.