### PR TITLE
fabric-ai: add yt-dlp runtime dependency to fabric-ai formula

### DIFF
--- a/Formula/f/fabric-ai.rb
+++ b/Formula/f/fabric-ai.rb
@@ -16,6 +16,7 @@ class FabricAi < Formula
   end
 
   depends_on "go" => :build
+  depends_on "yt-dlp" => :runtime
 
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w")


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

# feat: add yt-dlp runtime dependency to fabric-ai formula

## Summary

This PR adds `yt-dlp` as a runtime dependency to the Fabric AI Homebrew formula to ensure video downloading capabilities are available at runtime.

## Files Changed

- **Formula/f/fabric-ai.rb**: Added `yt-dlp` runtime dependency

## Code Changes

```ruby
depends_on "go" => :build
+ depends_on "yt-dlp" => :runtime
```

Added a single line declaring `yt-dlp` as a runtime dependency.

## Reason for Changes

Fabric AI requires `yt-dlp` for video downloading and processing features. Without this dependency, users encounter runtime errors when using video-related functionality.

## Impact

**Benefits:**
- Automatic dependency installation
- Prevents runtime errors
- Better user experience
- Follows Homebrew best practices

**Considerations:**
- Slightly larger installation size
- All users get `yt-dlp` even if not using video features

## Test Plan

1. Install formula on clean system
2. Test video functionality works
3. Verify dependency resolution
4. Test uninstallation cleanup
5. Homebrew related tests:

```
brew install --build-from-source ./Formula/f/fabric-ai.rb
Warning: Treating ./Formula/f/fabric-ai.rb as a formula.
==> Fetching dependencies for fabric-ai: yt-dlp
==> Fetching yt-dlp
==> Downloading https://ghcr.io/v2/homebrew/core/yt-dlp/manifests/2025.6.30
Already downloaded: /Users/kayvan/Library/Caches/Homebrew/downloads/4fcf0263475f37ef37b2308f939b15412effbb53e0b60b50d8d926f5e3474d33--yt-dlp-2025.6.30.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/yt-dlp/blobs/sha256:e2c77d81502dd3f2315bbff5d0d0e2151a
Already downloaded: /Users/kayvan/Library/Caches/Homebrew/downloads/1b42f483b7855fdd4f76bc3724f298eefbd1a0bf9ed6708b27e0983202766615--yt-dlp--2025.6.30.arm64_sequoia.bottle.tar.gz
==> Fetching fabric-ai
==> Downloading https://github.com/danielmiessler/fabric/archive/refs/tags/v1.4.236.tar.gz
==> Downloading from https://codeload.github.com/danielmiessler/Fabric/tar.gz/refs/tags/v1.4.236
         #  -=#=-   #      #                                                                           
==> Installing dependencies for fabric-ai: yt-dlp
==> Installing fabric-ai dependency: yt-dlp
==> Downloading https://ghcr.io/v2/homebrew/core/yt-dlp/manifests/2025.6.30
Already downloaded: /Users/kayvan/Library/Caches/Homebrew/downloads/4fcf0263475f37ef37b2308f939b15412effbb53e0b60b50d8d926f5e3474d33--yt-dlp-2025.6.30.bottle_manifest.json
==> Pouring yt-dlp--2025.6.30.arm64_sequoia.bottle.tar.gz
🍺  /opt/homebrew/Cellar/yt-dlp/2025.6.30: 1,741 files, 19.5MB
==> Installing fabric-ai
==> go build -ldflags=-s -w
🍺  /opt/homebrew/Cellar/fabric-ai/1.4.236: 7 files, 39.9MB, built in 13 seconds
==> Running `brew cleanup fabric-ai`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
```

And

```
brew test fabric-ai
Fetching gem metadata from https://rubygems.org/.......
Fetching minitest 5.25.5
Fetching sorbet-runtime 0.5.12117
Fetching rubocop 1.75.6
Installing minitest 5.25.5
Installing sorbet-runtime 0.5.12117
Installing rubocop 1.75.6
Bundle complete! 43 Gemfile dependencies, 33 gems now installed.
Bundled gems are installed into `../../../../opt/homebrew/Library/Homebrew/vendor/bundle`
Removing rubocop (1.75.5)
==> Testing fabric-ai
==> /opt/homebrew/Cellar/fabric-ai/1.4.236/bin/fabric-ai --version
==> /opt/homebrew/Cellar/fabric-ai/1.4.236/bin/fabric-ai --dry-run < /dev/null 2>&1
```

And 

```
brew audit --strict --online fabric-ai  
```

## Notes

- Backwards-compatible change
- Uses `:runtime` dependency (correct for execution-time needs)
- No version constraints (uses latest available)
- Follows standard Homebrew conventions