### PR TITLE
python3: Chainload venvs' sitecustomize.py from global

### DIFF
--- a/Formula/p/python@3.13.rb
+++ b/Formula/p/python@3.13.rb
@@ -439,6 +439,17 @@ class PythonAT313 < Formula
           split_prefix = f"#{HOMEBREW_PREFIX}/opt/python-{split_module}@#{version.major_minor}/libexec"
           if os.path.isdir(split_prefix):
               sys.path.append(split_prefix)
+      # Chainload venv-local sitecustomize.py if it exists
+      # (only if we're in a venv and haven't already done so)
+      if sys.prefix != sys.base_prefix and not os.environ.get("_HOMEBREW_CHAINLOADED_SITECUSTOMIZE"):
+          os.environ["_HOMEBREW_CHAINLOADED_SITECUSTOMIZE"] = "1"
+          venv_sitecustomize = f"{sys.prefix}/lib/python{sys.version_info.major}.{sys.version_info.minor}/site-packages/sitecustomize.py"
+          if os.path.isfile(venv_sitecustomize):
+              import importlib.util
+              spec = importlib.util.spec_from_file_location("venv_sitecustomize", venv_sitecustomize)
+              if spec and spec.loader:
+                  module = importlib.util.module_from_spec(spec)
+                  spec.loader.exec_module(module)
     PYTHON
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Homebrew’s sitecustomize.py currently overrides any sitecustomize.py provided by virtual environments, which breaks expected Python behavior.

This change adds logic to detect when Python is running inside a virtual environment and, if so, dynamically imports and executes the venv’s own sitecustomize.py (if it exists).

i have only commited this change for 3.13 so far, but i have all other versions stashed if that is also wanted.