### PR TITLE
publish-commit-bottles: render force-push warning using Caution blockquote

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -53,9 +53,9 @@ env:
   ORG_FORK_MESSAGE: >-
     :no_entry: It looks like @BrewTestBot cannot push to your PR branch. Please open
     future pull requests from a non-organization fork to simplify the merge process.
-  BOTTLE_COMMIT_PUSH_MESSAGE: >-
-    Please **do not** push to this PR branch before the bottle commits have been pushed, as this results in a state that is difficult to recover from.
-    If you need to resolve a merge conflict, please use a merge commit. Do not force-push to this PR branch.
+  BOTTLE_COMMIT_PUSH_MESSAGE: |-
+    > [!CAUTION]
+    > Please **do not** push to this PR branch before the bottle commits have been pushed, as this results in a state that is difficult to recover from. If you need to resolve a merge conflict, please use a merge commit. Do not force-push to this PR branch.
 
 jobs:
   check:


### PR DESCRIPTION
This will make the message more noticeable when viewed on GitHub. For example:

> [!CAUTION]
> Please **do not** push to this PR branch before the bottle commits have been pushed, as this results in a state that is difficult to recover from. If you need to resolve a merge conflict, please use a merge commit. Do not force-push to this PR branch.
