### PR TITLE
Fix makepkg on macOS by adding an older version of fakeroot

### DIFF
--- a/Aliases/fakeroot@1.37
+++ b/Aliases/fakeroot@1.37
@@ -1,0 +1,1 @@
+../Formula/f/fakeroot.rb

--- a/Formula/f/fakeroot@1.31.rb
+++ b/Formula/f/fakeroot@1.31.rb
@@ -1,0 +1,43 @@
+class FakerootAT131 < Formula
+  desc "Provide a fake root environment"
+  homepage "https://tracker.debian.org/pkg/fakeroot"
+  url "https://deb.debian.org/debian/pool/main/f/fakeroot/fakeroot_1.31.orig.tar.gz"
+  sha256 "63886d41e11c56c7170b9d9331cca086421b350d257338ef14daad98f77e202f"
+  license "GPL-3.0-or-later"
+
+  livecheck do
+    url "https://deb.debian.org/debian/pool/main/f/fakeroot/"
+    regex(/href=.*?fakeroot[._-]v?(\d+(?:\.\d+)+)[._-]orig\.t/i)
+  end
+
+  # Needed to apply patches below. Remove when no longer needed.
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+
+  on_linux do
+    depends_on "libcap" => :build
+  end
+
+  # https://salsa.debian.org/clint/fakeroot/-/merge_requests/17
+  patch :p0 do
+    # The MR has a typo, so we use MacPorts' version.
+    url "https://raw.githubusercontent.com/macports/macports-ports/0ffd857cab7b021f9dbf2cbc876d8025b6aefeff/sysutils/fakeroot/files/patch-message.h.diff"
+    sha256 "6540eef1c31ffb4ed636c1f4750ee668d2effdfe308d975d835aa518731c72dc"
+  end
+
+  def install
+    system "./bootstrap" # remove when patches are no longer needed
+
+    args = ["--disable-silent-rules"]
+    args << "--disable-static" if OS.mac?
+
+    system "./configure", *args, *std_configure_args
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/fakeroot -v")
+  end
+end

--- a/Formula/m/makepkg.rb
+++ b/Formula/m/makepkg.rb
@@ -23,7 +23,6 @@ class Makepkg < Formula
   depends_on "ninja" => :build
   depends_on "pkgconf" => :build
   depends_on "bash"
-  depends_on "fakeroot"
   depends_on "libarchive"
   depends_on "openssl@3"
 
@@ -31,11 +30,16 @@ class Makepkg < Formula
   uses_from_macos "python" => :build
   uses_from_macos "libxslt"
 
+  on_macos do
+    depends_on "fakeroot@1.31"
+  end
+
   on_sonoma :or_older do
     depends_on "coreutils" => :test # for md5sum
   end
 
   on_linux do
+    depends_on "fakeroot"
     depends_on "gettext"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
