### PR TITLE
go 1.24.5

### DIFF
--- a/Formula/g/garble.rb
+++ b/Formula/g/garble.rb
@@ -4,7 +4,7 @@ class Garble < Formula
   url "https://github.com/burrowers/garble/archive/refs/tags/v0.14.2.tar.gz"
   sha256 "aea6e0a172296b50e3671a9b753aeb2eb7080a3103575cdf5e4d1aeccfe14ede"
   license "BSD-3-Clause"
-  revision 2
+  revision 3
   head "https://github.com/burrowers/garble.git", branch: "master"
 
   bottle do

--- a/Formula/g/garble.rb
+++ b/Formula/g/garble.rb
@@ -8,12 +8,12 @@ class Garble < Formula
   head "https://github.com/burrowers/garble.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "dbcc54a78762a37d6ce38d3697e08abdf910f9e4353dcfe116a2b0fd707cecea"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "dbcc54a78762a37d6ce38d3697e08abdf910f9e4353dcfe116a2b0fd707cecea"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "dbcc54a78762a37d6ce38d3697e08abdf910f9e4353dcfe116a2b0fd707cecea"
-    sha256 cellar: :any_skip_relocation, sonoma:        "23d0fe32e99b6949a0937b904da3c8b3e2c9dd1f7139850296f41c58d741738f"
-    sha256 cellar: :any_skip_relocation, ventura:       "23d0fe32e99b6949a0937b904da3c8b3e2c9dd1f7139850296f41c58d741738f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "02c56bb272699827a82d36b5420ba881a8b9bb1ea554ebaab5af4d7ea0369582"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "09dfd46a9b72ad64bb2f89547a75613c5e6c53213f44f933cd77d85e1d1e53ce"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "09dfd46a9b72ad64bb2f89547a75613c5e6c53213f44f933cd77d85e1d1e53ce"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "09dfd46a9b72ad64bb2f89547a75613c5e6c53213f44f933cd77d85e1d1e53ce"
+    sha256 cellar: :any_skip_relocation, sonoma:        "8187285498221c374f65a4983b5d9ecc0599c45454bec7a5aea103b157d8eb15"
+    sha256 cellar: :any_skip_relocation, ventura:       "8187285498221c374f65a4983b5d9ecc0599c45454bec7a5aea103b157d8eb15"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e8f28b8e37cef16d86fca4b5a46190112e7d95718102b9ba764d25e71608d3bf"
   end
 
   depends_on "go" => [:build, :test]

--- a/Formula/g/go.rb
+++ b/Formula/g/go.rb
@@ -21,13 +21,13 @@ class Go < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "5094b9cb0e763d24167d36a7660697de5f8f1a455ffb5cb892f3e86bac24198b"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "5094b9cb0e763d24167d36a7660697de5f8f1a455ffb5cb892f3e86bac24198b"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "5094b9cb0e763d24167d36a7660697de5f8f1a455ffb5cb892f3e86bac24198b"
-    sha256 cellar: :any_skip_relocation, sonoma:        "1f352e43db6b6980e881a3855df4c1c0097eedff135146302ccbbb4d79ebcdee"
-    sha256 cellar: :any_skip_relocation, ventura:       "1f352e43db6b6980e881a3855df4c1c0097eedff135146302ccbbb4d79ebcdee"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "e08e43be8d671e4cfd282aae97f87b0482d5aebbae01a2f41e84e7deecdf578e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "617fd19381edf1f0ac09ca19b24ac5217f55c6b389dbd45408c3f582912e76fb"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "4fae2143edc4e580c1721b7f187e97340991a61e817a5ba56547c9e4ef81c1e3"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "4fae2143edc4e580c1721b7f187e97340991a61e817a5ba56547c9e4ef81c1e3"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "4fae2143edc4e580c1721b7f187e97340991a61e817a5ba56547c9e4ef81c1e3"
+    sha256 cellar: :any_skip_relocation, sonoma:        "6111921503a0c9caf265e835008326617bcefa1b6417f2a2f54fa70e853855c8"
+    sha256 cellar: :any_skip_relocation, ventura:       "6111921503a0c9caf265e835008326617bcefa1b6417f2a2f54fa70e853855c8"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "cb4dd632fd54c407230253bc8f34ebcc9d877bb589509a15eba6aee849ca0619"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2e75858a5db5209f32a30972f79bc51c4e1e792b074d1dcdfdea57c1f278880f"
   end
 
   # Don't update this unless this version cannot bootstrap the new version.

--- a/Formula/g/go.rb
+++ b/Formula/g/go.rb
@@ -1,9 +1,9 @@
 class Go < Formula
   desc "Open source programming language to build simple/reliable/efficient software"
   homepage "https://go.dev/"
-  url "https://go.dev/dl/go1.24.4.src.tar.gz"
-  mirror "https://fossies.org/linux/misc/go1.24.4.src.tar.gz"
-  sha256 "5a86a83a31f9fa81490b8c5420ac384fd3d95a3e71fba665c7b3f95d1dfef2b4"
+  url "https://go.dev/dl/go1.24.5.src.tar.gz"
+  mirror "https://fossies.org/linux/misc/go1.24.5.src.tar.gz"
+  sha256 "74fdb09f2352e2b25b7943e56836c9b47363d28dec1c8b56c4a9570f30b8f59f"
   license "BSD-3-Clause"
   head "https://go.googlesource.com/go.git", branch: "master"
 

--- a/Formula/s/staticcheck.rb
+++ b/Formula/s/staticcheck.rb
@@ -4,7 +4,7 @@ class Staticcheck < Formula
   url "https://github.com/dominikh/go-tools/archive/refs/tags/2025.1.1.tar.gz"
   sha256 "259aaf528e4d98e7d3652e283e8551cfdb98cd033a7c01003cd377c2444dd6de"
   license "MIT"
-  revision 3
+  revision 4
   head "https://github.com/dominikh/go-tools.git", branch: "master"
 
   bottle do

--- a/Formula/s/staticcheck.rb
+++ b/Formula/s/staticcheck.rb
@@ -8,12 +8,12 @@ class Staticcheck < Formula
   head "https://github.com/dominikh/go-tools.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "c90b2411f849db5cf6e99b5927aff6f9d31f1dbc684beae2e3a965e1f61e02c6"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "c90b2411f849db5cf6e99b5927aff6f9d31f1dbc684beae2e3a965e1f61e02c6"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "c90b2411f849db5cf6e99b5927aff6f9d31f1dbc684beae2e3a965e1f61e02c6"
-    sha256 cellar: :any_skip_relocation, sonoma:        "934c58bb900abdd91812f3ceca33d3a1a80cfe6295dd9cc9c6c412090b06f81f"
-    sha256 cellar: :any_skip_relocation, ventura:       "934c58bb900abdd91812f3ceca33d3a1a80cfe6295dd9cc9c6c412090b06f81f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "667bf55c540aa0a6bbd3aa9d34c15e68557831176885b6b9dfcc81aeea28dcaa"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "97d24c73aa0598dafc875025951862bfcd04bbef62059129d1588f601d04fc58"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "97d24c73aa0598dafc875025951862bfcd04bbef62059129d1588f601d04fc58"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "97d24c73aa0598dafc875025951862bfcd04bbef62059129d1588f601d04fc58"
+    sha256 cellar: :any_skip_relocation, sonoma:        "83239474b6f3f53be115968cfcbcd3e133968577a7d7d4cd05e24ad5109935cc"
+    sha256 cellar: :any_skip_relocation, ventura:       "83239474b6f3f53be115968cfcbcd3e133968577a7d7d4cd05e24ad5109935cc"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "41393ab1609059ba804f3fc4f77bc631e3e843fc37c4e0bf791e45162d9515c1"
   end
 
   depends_on "go"


### PR DESCRIPTION
Fixes CVE-2025-4674 - https://github.com/golang/go/issues/74380
https://go.dev/doc/devel/release#go1.24.5
> go1.24.5 (released 2025-07-08) includes security fixes to the go command, as well as bug fixes to the compiler, the linker, the runtime, and the go command. See the [Go 1.24.5 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.24.5+label%3ACherryPickApproved) on our issue tracker for details.

https://go.dev/dl/
https://groups.google.com/g/golang-announce/c/gTNJnDXmn34
https://groups.google.com/g/golang-announce/c/q2mjAt9PfF4

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Note: staticcheck and garble have no arm64/linux bottle yet