### PR TITLE
go@1.23 1.23.11

### DIFF
--- a/Formula/g/go@1.23.rb
+++ b/Formula/g/go@1.23.rb
@@ -1,9 +1,9 @@
 class GoAT123 < Formula
   desc "Open source programming language to build simple/reliable/efficient software"
   homepage "https://go.dev/"
-  url "https://go.dev/dl/go1.23.10.src.tar.gz"
-  mirror "https://fossies.org/linux/misc/go1.23.10.src.tar.gz"
-  sha256 "800a7ae1bff179a227b653a2f644517c800443b8b4abf3273af5e1cb7113de59"
+  url "https://go.dev/dl/go1.23.11.src.tar.gz"
+  mirror "https://fossies.org/linux/misc/go1.23.11.src.tar.gz"
+  sha256 "296381607a483a8a8667d7695331752f94a1f231c204e2527d2f22e1e3d1247d"
   license "BSD-3-Clause"
 
   livecheck do

--- a/Formula/g/go@1.23.rb
+++ b/Formula/g/go@1.23.rb
@@ -20,13 +20,13 @@ class GoAT123 < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "1ea733b8992ef75e11e70133d5b29d21024ae1eb9de0f1de62537c98ad49fef7"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "1ea733b8992ef75e11e70133d5b29d21024ae1eb9de0f1de62537c98ad49fef7"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "1ea733b8992ef75e11e70133d5b29d21024ae1eb9de0f1de62537c98ad49fef7"
-    sha256 cellar: :any_skip_relocation, sonoma:        "11dbfe0a1f11d431e0fbe96da497382aae33b4dccc9245266b403608cc298970"
-    sha256 cellar: :any_skip_relocation, ventura:       "11dbfe0a1f11d431e0fbe96da497382aae33b4dccc9245266b403608cc298970"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "239bb0e2c34de2c54fc206cded4a2ce578d867df731af3026d764222ecc43fa8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "93a5e598fd23a409d39c7c91ee24b109f5c76611b074e7e941cfe58b50e0d030"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "40c7d7c251ac3deeb87dd69f98f9dd72bfffc668172d3a9c4cee310cab7e6199"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "40c7d7c251ac3deeb87dd69f98f9dd72bfffc668172d3a9c4cee310cab7e6199"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "40c7d7c251ac3deeb87dd69f98f9dd72bfffc668172d3a9c4cee310cab7e6199"
+    sha256 cellar: :any_skip_relocation, sonoma:        "31a7ed57a3c96afdd4ab85477344909279a6ca9a41a835b1da3644ad3535cab0"
+    sha256 cellar: :any_skip_relocation, ventura:       "31a7ed57a3c96afdd4ab85477344909279a6ca9a41a835b1da3644ad3535cab0"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "444534631cf0e666f6edf81bd787b1f6fb18571eb4595d37ded03e465d888a4c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "ea77dc3f2dee9619526c96478e80fc3aae13143331cdf22fd34e1d6fde19f582"
   end
 
   keg_only :versioned_formula


### PR DESCRIPTION
Fixes CVE-2025-4674 - https://github.com/golang/go/issues/74380
https://go.dev/doc/devel/release#go1.23.11
>go1.23.11 (released 2025-07-08) includes security fixes to the go command, as well as bug fixes to the compiler, the linker, and the runtime. See the [Go 1.23.11 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.23.11+label%3ACherryPickApproved) on our issue tracker for details.

https://go.dev/dl/
https://groups.google.com/g/golang-announce/c/gTNJnDXmn34
https://groups.google.com/g/golang-announce/c/q2mjAt9PfF4


<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
