### PR TITLE
tty-airdrop 1.1.1 - new formula

### DIFF
--- a/Formula/tty-airdrop.rb
+++ b/Formula/tty-airdrop.rb
@@ -1,0 +1,17 @@
+class TtyAirdrop < Formula
+  desc "Send files via AirDrop from the terminal on macOS"
+  homepage "https://github.com/su-mt/tty-airdrop"
+  url "https://github.com/su-mt/tty-airdrop/archive/refs/tags/v1.1.1.tar.gz"
+  sha256 "944a31b7f78429723d7efe7ca93a1e97f1b03d02e7718459cbcc4fdb1ae11e28"
+  version "1.1.1"
+  license "MIT"
+
+  def install
+    system "swiftc","main.swift", "-o", "airdrop", "-framework", "AppKit"
+    bin.install "airdrop"
+  end
+
+  test do
+    system "#{bin}/airdrop", "--help"
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
# Pull Request: Add tty-airdrop Formula

## Summary

This PR adds a new Homebrew formula for tty-airdrop — a terminal-based tool for transfer via Apple’s AirDrop.

## Description

macOS command-line tool that lets you send files over AirDrop directly from the terminal.

## Installation

The formula builds and installs the latest stable release from the official GitHub repository:
https://github.com/su-mt/tty-airdrop

## Testing

The formula includes a basic test that verifies the tty-airdrop binary executes and displays the help message as expected.

## Additional notes
	•	License: MIT
	•	Homepage: https://github.com/su-mt/tty-airdrop
	•	Source code is verified and hosted on GitHub

