### PR TITLE
meroku 3.1.6 (new formula)

### DIFF
--- a/Formula/m/meroku.rb
+++ b/Formula/m/meroku.rb
@@ -1,0 +1,22 @@
+class Meroku < Formula
+  desc "Easy infrastructure management"
+  homepage "https://madappgang.com"
+  url "https://github.com/MadAppGang/infrastructure/archive/refs/tags/v3.1.6.tar.gz"
+  sha256 "c7b2ac49923b36978809f5fbc601764c82b44689bee796f21b6bddd2236cf439"
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def install
+    cd "app" do
+      system "go", "build", *std_go_args(ldflags: "-s -w")
+    end
+  end
+
+  test do
+    # meroku requires TTY for AWS profile selection
+    # Just verify the binary exists and is executable
+    assert_predicate bin/"meroku", :exist?
+    assert_predicate bin/"meroku", :executable?
+  end
+end


### PR DESCRIPTION
## Description
New formula for meroku - Easy infrastructure management

## Checklist
- [ ] The formula is unmodified from `brew create` output, or `brew audit --strict <formula>` reports no errors
- [ ] The formula builds on all Homebrew-supported macOS versions
- [ ] The formula installs without reporting any Caveats
- [ ] `brew test <formula>` passes

## Notes
meroku is a CLI tool for managing infrastructure as code with Terraform.
Homepage: https://madappgang.com