### PR TITLE
gh 2.75.0

### DIFF
--- a/Formula/g/gh.rb
+++ b/Formula/g/gh.rb
@@ -1,8 +1,8 @@
 class Gh < Formula
   desc "GitHub command-line tool"
   homepage "https://cli.github.com/"
-  url "https://github.com/cli/cli/archive/refs/tags/v2.74.2.tar.gz"
-  sha256 "58d383e75e1a6f3eb5e5694f232d1ed6f7f53681fda9c6a997e6e1be344edd94"
+  url "https://github.com/cli/cli/archive/refs/tags/v2.75.0.tar.gz"
+  sha256 "a99fce70ccb8e0a311a504eda0cfd24e23431e158bf136d81ac7ad25f0431597"
   license "MIT"
   head "https://github.com/cli/cli.git", branch: "trunk"
 

--- a/Formula/g/gh.rb
+++ b/Formula/g/gh.rb
@@ -14,12 +14,12 @@ class Gh < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "d8d12facc23d7e2efdb21bc4eaa55058d8385609d1c8734685f406996074ff12"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "d8d12facc23d7e2efdb21bc4eaa55058d8385609d1c8734685f406996074ff12"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "d8d12facc23d7e2efdb21bc4eaa55058d8385609d1c8734685f406996074ff12"
-    sha256 cellar: :any_skip_relocation, sonoma:        "f3f8a873387da7e9087c2ce2e38ddcf9bdd8e5365033db59c10517972c741062"
-    sha256 cellar: :any_skip_relocation, ventura:       "53d91576a846085b553ec452e38ebbca52202fa5957b5576140fdc8aa42965e8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f3e209130aadf0f998201e5b588498b6f538488bf55eadd4672822a7ab4a8161"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "b4d1cb36d01b6bc0dc765c80d0ab9dff0e26c176bae7b26a2f4bcdc02c3af646"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "b4d1cb36d01b6bc0dc765c80d0ab9dff0e26c176bae7b26a2f4bcdc02c3af646"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "b4d1cb36d01b6bc0dc765c80d0ab9dff0e26c176bae7b26a2f4bcdc02c3af646"
+    sha256 cellar: :any_skip_relocation, sonoma:        "78a6877fad9e8813d130fae384a2b868408a9d2ddf9aa203910ea3020dd67b7e"
+    sha256 cellar: :any_skip_relocation, ventura:       "5c5e76ca78ad78de1c784fb893fb25cdec9dfcf50f23afaaac5072e98222f066"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8e010e955a02836a96a692f587acbc55a44ee58e8a267615ad44a76731c8e674"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is a one-off out of band update for `gh` formula as https://github.com/cli/cli/releases/tag/v2.75.0 release failed at the end of https://github.com/cli/cli/actions/runs/16171834495/job/45647725091 workflow to bump the formula due to `homebrew-core` default branch name change.
