### PR TITLE
workflows: discourage bottle block modification with a comment

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -65,6 +65,41 @@ jobs:
           PR: ${{ github.event.number }}
         run: gh pr edit --add-label workflows "$PR" --repo "$GITHUB_REPOSITORY"
 
+  check-bottle-block:
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    if: always() && github.repository_owner == 'Homebrew'
+    runs-on: ubuntu-latest
+    env:
+      HOMEBREW_DISABLE_LOAD_FORMULA: 1
+      PR: ${{ github.event.number }}
+    steps:
+      - name: Set up Homebrew
+        id: setup-homebrew
+        uses: Homebrew/actions/setup-homebrew@main
+        with:
+          core: true
+          cask: false
+          test-bot: false
+
+      - name: Check that bottle block is not modified
+        id: bottle-block
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: brew check-bottle-modification "${PR}"
+
+      - name: Post comment
+        if: failure() && steps.bottle-block.conclusion == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BODY: |-
+            > [!CAUTION]
+            > Please **do not** modify the bottle block. Bottle block modifications can cause CI to misbehave.
+            > @BrewTestBot will handle updating the bottle block before this PR is merged.
+        run: gh pr comment "${PR}" --body "${BODY}" --repo "${GITHUB_REPOSITORY}"
+
   triage:
     runs-on: ubuntu-latest
     permissions:

--- a/cmd/check-bottle-modification.rb
+++ b/cmd/check-bottle-modification.rb
@@ -1,0 +1,60 @@
+# typed: true
+# frozen_string_literal: true
+
+require "abstract_command"
+
+module Homebrew
+  module Cmd
+    class CheckBottleModificationCmd < AbstractCommand
+      cmd_args do
+        description <<~EOS
+          Check that the bottle block of a formula is modified only by BrewTestBot.
+        EOS
+
+        named_args :pull_request_number, number: 1
+
+        hide_from_man_page!
+      end
+
+      UNCHECKED_COMMIT_AUTHORS = ["BrewTestBot"].freeze
+      MODIFIED_BOTTLE_BLOCK_REGEX = /^(\+|-)\s*(bottle do|sha256.*"\h{64}")/
+
+      def get_pull_request_commits(pull_request)
+        owner, repo = ENV.fetch("GITHUB_REPOSITORY").split("/")
+        response = GitHub::API.open_rest(GitHub.url_to("repos", owner, repo, "pulls", pull_request, "commits"))
+
+        response.reject! do |item|
+          UNCHECKED_COMMIT_AUTHORS.include?(item.dig("commit", "author", "name")) ||
+            UNCHECKED_COMMIT_AUTHORS.include?(item.dig("commit", "committer", "name"))
+        end
+
+        response.map { |item| item.fetch("sha") }
+      end
+
+      def commit_modifies_bottle_block?(sha)
+        owner, repo = ENV.fetch("GITHUB_REPOSITORY").split("/")
+        response = GitHub::API.open_rest(GitHub.url_to("repos", owner, repo, "commits", sha))
+
+        files = response.fetch("files")
+        files.reject! do |file|
+          filename = file.fetch("filename")
+
+          !filename.start_with?("Formula") || !filename.end_with?(".rb")
+        end
+
+        files.any? { |file| patch_modifies_bottle_block?(file.fetch("patch")) }
+      end
+
+      def patch_modifies_bottle_block?(patch)
+        patch.lines.any? { |line| line.match?(MODIFIED_BOTTLE_BLOCK_REGEX) }
+      end
+
+      def run
+        pr = args.named.first.to_i
+        commits = get_pull_request_commits(pr)
+
+        odie "PR##{pr} modifies the bottle block" if commits.any? { |sha| commit_modifies_bottle_block?(sha) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
We often have to remind users not to touch the bottle blocks. Modifying
the bottle block can cause our CI to misbehave, so let's automate this
reminder to avoid that.

See, for example, #229472.
