### PR TITLE
workflows: set `HOMEBREW_DISABLE_LOAD_FORMULA` for `pull_request_target` workflows

### DIFF
--- a/.github/workflows/automerge-triggers.yml
+++ b/.github/workflows/automerge-triggers.yml
@@ -13,6 +13,9 @@ defaults:
   run:
     shell: bash -xeuo pipefail {0}
 
+env:
+  HOMEBREW_DISABLE_LOAD_FORMULA: 1
+
 jobs:
   check:
     if: >

--- a/.github/workflows/clean-up-closed-prs.yml
+++ b/.github/workflows/clean-up-closed-prs.yml
@@ -17,6 +17,7 @@ env:
   GH_REPO: ${{ github.repository }}
   GH_NO_UPDATE_NOTIFIER: 1
   GH_PROMPT_DISABLED: 1
+  HOMEBREW_DISABLE_LOAD_FORMULA: 1
   PR: ${{ github.event.number }}
 
 jobs:

--- a/.github/workflows/manage-pull-request-labels.yml
+++ b/.github/workflows/manage-pull-request-labels.yml
@@ -17,6 +17,7 @@ env:
   GH_REPO: ${{ github.repository }}
   GH_NO_UPDATE_NOTIFIER: 1
   GH_PROMPT_DISABLED: 1
+  HOMEBREW_DISABLE_LOAD_FORMULA: 1
   PR: ${{ github.event.number }}
 
 jobs:

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -6,6 +6,7 @@ env:
   GH_REPO: ${{ github.repository }}
   GH_NO_UPDATE_NOTIFIER: 1
   GH_PROMPT_DISABLED: 1
+  HOMEBREW_DISABLE_LOAD_FORMULA: 1
 
 defaults:
   run:
@@ -73,7 +74,6 @@ jobs:
     if: always() && github.repository_owner == 'Homebrew'
     runs-on: ubuntu-latest
     env:
-      HOMEBREW_DISABLE_LOAD_FORMULA: 1
       PR: ${{ github.event.number }}
     steps:
       - name: Set up Homebrew


### PR DESCRIPTION
Workflows that run on `pull_request_target` run with elevated
privileges, so let's set `HOMEBREW_DISABLE_LOAD_FORMULA` to minimise the
risk of executing malicious code in these workflows.
