### PR TITLE
workflows/triage: run `check-bottle-block` job in container

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -72,6 +72,8 @@ jobs:
       pull-requests: write
     if: always() && github.repository_owner == 'Homebrew'
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/homebrew/ubuntu22.04:main
     env:
       HOMEBREW_DISABLE_LOAD_FORMULA: 1
       PR: ${{ github.event.number }}


### PR DESCRIPTION
This will make the `setup-homebrew` step run a lot faster.
