### PR TITLE
check-bottle-modification: fix regex false positive

### DIFF
--- a/cmd/check-bottle-modification.rb
+++ b/cmd/check-bottle-modification.rb
@@ -17,7 +17,7 @@ module Homebrew
       end
 
       UNCHECKED_COMMIT_AUTHORS = ["BrewTestBot"].freeze
-      MODIFIED_BOTTLE_BLOCK_REGEX = /^(\+|-)\s*(bottle do|sha256.*"\h{64}")/
+      MODIFIED_BOTTLE_BLOCK_REGEX = /^(\+|-)\s*(bottle do|sha256.*:\s+"\h{64}")/
 
       def get_pull_request_commits(pull_request)
         owner, repo = ENV.fetch("GITHUB_REPOSITORY").split("/")


### PR DESCRIPTION
As written, this matches any PR that updates the formula's `sha256`. We
should tighten the regex a bit to capture only lines that modify
`sha256` lines the bottle block.

See, for example, #229565.
