### PR TITLE
scdoc: don't clobber environment `LDFLAGS`

### DIFF
--- a/Formula/s/scdoc.rb
+++ b/Formula/s/scdoc.rb
@@ -21,7 +21,7 @@ class Scdoc < Formula
 
   def install
     # scdoc sets by default LDFLAGS=-static which doesn't work on macos(x)
-    system "make", "LDFLAGS=", "PREFIX=#{prefix}"
+    system "make", "LDFLAGS=#{ENV.ldflags}", "PREFIX=#{prefix}"
     system "make", "install", "PREFIX=#{prefix}"
   end
 
@@ -35,6 +35,6 @@ class Scdoc < Formula
       .ad l
       .\\" Begin generated content:
     EOF
-    assert_equal preamble, shell_output("#{bin}/scdoc </dev/null")
+    assert_equal preamble, pipe_output(bin/"scdoc", "")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Let's make sure our `LDFLAGS` are always passed to the build in case
we've set them elsewhere (e.g. in superenv).
