### PR TITLE
ncurses: unset TERMINFO when building from source

### DIFF
--- a/Formula/n/ncurses.rb
+++ b/Formula/n/ncurses.rb
@@ -36,6 +36,8 @@ class Ncurses < Formula
     # Linux: configure: error: expected a pathname, not ""
     (lib/"pkgconfig").mkpath
 
+    ENV.delete("TERMINFO")
+
     args = [
       "--prefix=#{prefix}",
       "--enable-pc-files",


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
If `TERMINFO` is set to a system directory, such as `/usr/share/terminfo`, building from source will fail.

To reproduce:
```
docker run --rm \
  -e TERMINFO=/usr/share/terminfo \
  homebrew/brew \
  brew install -s ncurses
```
Result:
```
==> make install
Last 15 lines from /home/linuxbrew/.cache/Homebrew/Logs/ncurses/02.make:
Running sh ./shlib tic to install /usr/share/terminfo ...

        You may see messages regarding extended capabilities, e.g., AX.
        These are extended terminal capabilities which are compiled
        using
                tic -x
        If you have ncurses 4.2 applications, you should read the INSTALL
        document, and install the terminfo without the -x option.

ncurses 6.5.20240427
"terminfo.tmp", line 24325, terminal 'v3220': /usr/share/terminfo: permission denied (errno 13)
? tic could not build /usr/share/terminfo
make[1]: *** [Makefile:109: install.data] Error 1
make[1]: Leaving directory '/var/tmp/ncurses-20250708-843-x3v3hb/ncurses-6.5/misc'
make: *** [Makefile:141: install] Error 2
```

This can be worked around by remembering to unset `TERMINFO` when installing ncurses. But it would be nice if this was part of the formula.

Note: this fails in exactly the same way on macOS as it does on Linux.