### PR TITLE
Enable Bash completions for formulae using `:click`

### DIFF
--- a/Formula/a/adr-viewer.rb
+++ b/Formula/a/adr-viewer.rb
@@ -68,7 +68,8 @@ class AdrViewer < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"adr-viewer", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"adr-viewer",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/a/airshare.rb
+++ b/Formula/a/airshare.rb
@@ -141,7 +141,7 @@ class Airshare < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"airshare", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"airshare", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/a/animdl.rb
+++ b/Formula/a/animdl.rb
@@ -163,7 +163,7 @@ class Animdl < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"animdl", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"animdl", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/a/apprise.rb
+++ b/Formula/a/apprise.rb
@@ -70,7 +70,7 @@ class Apprise < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"apprise", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"apprise", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/a/aws-sam-cli.rb
+++ b/Formula/a/aws-sam-cli.rb
@@ -419,7 +419,7 @@ class AwsSamCli < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"sam", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"sam", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/a/aws-sso-util.rb
+++ b/Formula/a/aws-sso-util.rb
@@ -122,7 +122,8 @@ class AwsSsoUtil < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"aws-sso-util", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"aws-sso-util",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/b/beancount.rb
+++ b/Formula/b/beancount.rb
@@ -56,7 +56,7 @@ class Beancount < Formula
     virtualenv_install_with_resources
 
     bin.glob("bean-*") do |executable|
-      generate_completions_from_executable(executable, shells: [:fish, :zsh], shell_parameter_format: :click)
+      generate_completions_from_executable(executable, shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
     end
   end
 

--- a/Formula/b/bilix.rb
+++ b/Formula/b/bilix.rb
@@ -196,7 +196,7 @@ class Bilix < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"bilix", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"bilix", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/b/black.rb
+++ b/Formula/b/black.rb
@@ -94,7 +94,7 @@ class Black < Formula
     ENV["HATCH_BUILD_HOOK_ENABLE_MYPYC"] = "1"
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"black", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"black", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   service do

--- a/Formula/b/bump-my-version.rb
+++ b/Formula/b/bump-my-version.rb
@@ -154,7 +154,8 @@ class BumpMyVersion < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"bump-my-version", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"bump-my-version",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/c/cekit.rb
+++ b/Formula/c/cekit.rb
@@ -78,7 +78,7 @@ class Cekit < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"cekit", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"cekit", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/c/cf2tf.rb
+++ b/Formula/c/cf2tf.rb
@@ -122,7 +122,7 @@ class Cf2tf < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"cf2tf", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"cf2tf", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/c/cfn-flip.rb
+++ b/Formula/c/cfn-flip.rb
@@ -42,7 +42,7 @@ class CfnFlip < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"cfn-flip", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"cfn-flip", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/c/cfripper.rb
+++ b/Formula/c/cfripper.rb
@@ -115,7 +115,7 @@ class Cfripper < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"cfripper", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"cfripper", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/c/check-jsonschema.rb
+++ b/Formula/c/check-jsonschema.rb
@@ -147,7 +147,7 @@ class CheckJsonschema < Formula
 
     generate_completions_from_executable(
       bin/"check-jsonschema",
-      shells:                 [:fish, :zsh],
+      shells:                 [:bash, :fish, :zsh],
       shell_parameter_format: :click,
     )
   end

--- a/Formula/c/cloudsplaining.rb
+++ b/Formula/c/cloudsplaining.rb
@@ -142,7 +142,8 @@ class Cloudsplaining < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"cloudsplaining", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"cloudsplaining", shells:
+                                         [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/c/cobo-cli.rb
+++ b/Formula/c/cobo-cli.rb
@@ -183,7 +183,7 @@ class CoboCli < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"cobo", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"cobo", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/c/codecov-cli.rb
+++ b/Formula/c/codecov-cli.rb
@@ -83,7 +83,8 @@ class CodecovCli < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"codecovcli", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"codecovcli",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/c/compiledb.rb
+++ b/Formula/c/compiledb.rb
@@ -27,7 +27,8 @@ class Compiledb < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"compiledb", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"compiledb",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/c/conda-lock.rb
+++ b/Formula/c/conda-lock.rb
@@ -277,7 +277,8 @@ class CondaLock < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"conda-lock", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"conda-lock", shells:
+                                         [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/c/cookiecutter.rb
+++ b/Formula/c/cookiecutter.rb
@@ -126,7 +126,8 @@ class Cookiecutter < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"cookiecutter", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"cookiecutter",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/d/datasette.rb
+++ b/Formula/d/datasette.rb
@@ -155,7 +155,8 @@ class Datasette < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"datasette", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"datasette",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/d/djlint.rb
+++ b/Formula/d/djlint.rb
@@ -80,7 +80,7 @@ class Djlint < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"djlint", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"djlint", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/d/dnsgen.rb
+++ b/Formula/d/dnsgen.rb
@@ -59,7 +59,7 @@ class Dnsgen < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"dnsgen", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"dnsgen", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/d/dooit.rb
+++ b/Formula/d/dooit.rb
@@ -118,7 +118,7 @@ class Dooit < Formula
 
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"dooit", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"dooit", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/e/ecs-deploy.rb
+++ b/Formula/e/ecs-deploy.rb
@@ -87,7 +87,7 @@ class EcsDeploy < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"ecs", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"ecs", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/e/euler-py.rb
+++ b/Formula/e/euler-py.rb
@@ -28,7 +28,7 @@ class EulerPy < Formula
     inreplace "requirements.txt", "click==4.0", "click"
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"euler", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"euler", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/e/evernote-backup.rb
+++ b/Formula/e/evernote-backup.rb
@@ -91,7 +91,8 @@ class EvernoteBackup < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"evernote-backup", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"evernote-backup",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/f/fava.rb
+++ b/Formula/f/fava.rb
@@ -201,7 +201,7 @@ class Fava < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"fava", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"fava", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/f/fiona.rb
+++ b/Formula/f/fiona.rb
@@ -47,7 +47,7 @@ class Fiona < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"fio", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"fio", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/f/flintrock.rb
+++ b/Formula/f/flintrock.rb
@@ -92,7 +92,8 @@ class Flintrock < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"flintrock", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"flintrock",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/f/fred.rb
+++ b/Formula/f/fred.rb
@@ -54,7 +54,7 @@ class Fred < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"fred", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"fred", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/g/ggshield.rb
+++ b/Formula/g/ggshield.rb
@@ -136,7 +136,7 @@ class Ggshield < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"ggshield", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"ggshield", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/g/gitlint.rb
+++ b/Formula/g/gitlint.rb
@@ -50,7 +50,7 @@ class Gitlint < Formula
     virtualenv_install_with_resources
 
     # Click does not support bash version older than 4.4
-    generate_completions_from_executable(bin/"gitlint", shells:                 [:fish, :zsh],
+    generate_completions_from_executable(bin/"gitlint", shells:                 [:bash, :fish, :zsh],
                                                         shell_parameter_format: :click)
   end
 

--- a/Formula/g/goolabs.rb
+++ b/Formula/g/goolabs.rb
@@ -50,7 +50,7 @@ class Goolabs < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"goolabs", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"goolabs", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/g/gptme.rb
+++ b/Formula/g/gptme.rb
@@ -279,7 +279,7 @@ class Gptme < Formula
 
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"gptme", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"gptme", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/h/harlequin.rb
+++ b/Formula/h/harlequin.rb
@@ -229,7 +229,8 @@ class Harlequin < Formula
       venv.pip_install Pathname.pwd/"mysql-connector-python"
     end
 
-    generate_completions_from_executable(bin/"harlequin", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"harlequin",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/h/hatch.rb
+++ b/Formula/h/hatch.rb
@@ -196,7 +196,7 @@ class Hatch < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"hatch", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"hatch", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/h/homeassistant-cli.rb
+++ b/Formula/h/homeassistant-cli.rb
@@ -176,7 +176,7 @@ class HomeassistantCli < Formula
 
   def install
     virtualenv_install_with_resources
-    generate_completions_from_executable(bin/"hass-cli", shells:                 [:fish, :zsh],
+    generate_completions_from_executable(bin/"hass-cli", shells:                 [:bash, :fish, :zsh],
                                                          shell_parameter_format: :click)
   end
 

--- a/Formula/h/http-prompt.rb
+++ b/Formula/h/http-prompt.rb
@@ -134,7 +134,8 @@ class HttpPrompt < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"http-prompt", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"http-prompt",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/i/iredis.rb
+++ b/Formula/i/iredis.rb
@@ -73,7 +73,7 @@ class Iredis < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"iredis", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"iredis", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/k/khal.rb
+++ b/Formula/k/khal.rb
@@ -89,7 +89,7 @@ class Khal < Formula
     virtualenv_install_with_resources
 
     %w[khal ikhal].each do |cmd|
-      generate_completions_from_executable(bin/cmd, shells: [:fish, :zsh], shell_parameter_format: :click)
+      generate_completions_from_executable(bin/cmd, shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
     end
   end
 

--- a/Formula/l/langgraph-cli.rb
+++ b/Formula/l/langgraph-cli.rb
@@ -73,7 +73,8 @@ class LanggraphCli < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"langgraph", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"langgraph",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/l/litecli.rb
+++ b/Formula/l/litecli.rb
@@ -58,7 +58,7 @@ class Litecli < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"litecli", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"litecli", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/l/llm.rb
+++ b/Formula/l/llm.rb
@@ -170,7 +170,7 @@ class Llm < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"llm", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"llm", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/l/localstack.rb
+++ b/Formula/l/localstack.rb
@@ -171,7 +171,8 @@ class Localstack < Formula
     virtualenv_install_with_resources
     bin.install_symlink libexec/"bin/localstack"
 
-    generate_completions_from_executable(bin/"localstack", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"localstack",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/m/manim.rb
+++ b/Formula/m/manim.rb
@@ -220,7 +220,7 @@ class Manim < Formula
     end
     virtualenv_install_with_resources(without:)
 
-    generate_completions_from_executable(bin/"manim", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"manim", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/m/meta-package-manager.rb
+++ b/Formula/m/meta-package-manager.rb
@@ -307,7 +307,7 @@ class MetaPackageManager < Formula
     rewrite_shebang detected_python_shebang, "meta_package_manager/bar_plugin.py"
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"mpm", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"mpm", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/m/mkdocs.rb
+++ b/Formula/m/mkdocs.rb
@@ -102,7 +102,7 @@ class Mkdocs < Formula
     ENV["PIP_USE_PEP517"] = "1"
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"mkdocs", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"mkdocs", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/m/molecule.rb
+++ b/Formula/m/molecule.rb
@@ -212,7 +212,7 @@ class Molecule < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"molecule", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"molecule", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/m/mvt.rb
+++ b/Formula/m/mvt.rb
@@ -216,7 +216,7 @@ class Mvt < Formula
     end
 
     %w[mvt-android mvt-ios].each do |script|
-      generate_completions_from_executable(bin/script, shells: [:fish, :zsh], shell_parameter_format: :click)
+      generate_completions_from_executable(bin/script, shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
     end
   end
 

--- a/Formula/m/mycli.rb
+++ b/Formula/m/mycli.rb
@@ -97,7 +97,7 @@ class Mycli < Formula
     virtualenv_install_with_resources
 
     # Click does not support bash version older than 4.4
-    generate_completions_from_executable(bin/"mycli", shells:                 [:fish, :zsh],
+    generate_completions_from_executable(bin/"mycli", shells:                 [:bash, :fish, :zsh],
                                                       shell_parameter_format: :click)
   end
 

--- a/Formula/n/name-that-hash.rb
+++ b/Formula/n/name-that-hash.rb
@@ -47,7 +47,7 @@ class NameThatHash < Formula
     virtualenv_install_with_resources
 
     %w[name-that-hash nth].each do |cmd|
-      generate_completions_from_executable(bin/cmd, shells: [:fish, :zsh], shell_parameter_format: :click)
+      generate_completions_from_executable(bin/cmd, shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
     end
   end
 

--- a/Formula/n/notifiers.rb
+++ b/Formula/n/notifiers.rb
@@ -85,7 +85,8 @@ class Notifiers < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"notifiers", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"notifiers",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/o/oci-cli.rb
+++ b/Formula/o/oci-cli.rb
@@ -104,7 +104,7 @@ class OciCli < Formula
       venv.pip_install_and_link Pathname.pwd
     end
 
-    generate_completions_from_executable(bin/"oci", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"oci", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/o/okta-awscli.rb
+++ b/Formula/o/okta-awscli.rb
@@ -98,7 +98,8 @@ class OktaAwscli < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"okta-awscli", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"okta-awscli",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/o/otterdog.rb
+++ b/Formula/o/otterdog.rb
@@ -265,7 +265,7 @@ class Otterdog < Formula
     ENV["SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PLAYWRIGHT"] = resource("playwright").version
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"otterdog", shell_parameter_format: :click, shells: [:bash, :zsh])
+    generate_completions_from_executable(bin/"otterdog", shell_parameter_format: :click, shells: [:bash, :bash, :zsh])
   end
 
   test do

--- a/Formula/p/pgcli.rb
+++ b/Formula/p/pgcli.rb
@@ -90,7 +90,7 @@ class Pgcli < Formula
       venv.pip_install Pathname.pwd
     end
 
-    generate_completions_from_executable(bin/"pgcli", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"pgcli", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/p/pip-tools.rb
+++ b/Formula/p/pip-tools.rb
@@ -54,7 +54,7 @@ class PipTools < Formula
     virtualenv_install_with_resources
 
     %w[pip-compile pip-sync].each do |script|
-      generate_completions_from_executable(bin/script, shells: [:fish, :zsh], shell_parameter_format: :click)
+      generate_completions_from_executable(bin/script, shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
     end
   end
 

--- a/Formula/p/pipenv.rb
+++ b/Formula/p/pipenv.rb
@@ -57,7 +57,7 @@ class Pipenv < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(libexec/"bin/pipenv", shells:                 [:fish, :zsh],
+    generate_completions_from_executable(libexec/"bin/pipenv", shells:                 [:bash, :fish, :zsh],
                                                                shell_parameter_format: :click)
   end
 

--- a/Formula/p/pipgrip.rb
+++ b/Formula/p/pipgrip.rb
@@ -49,7 +49,7 @@ class Pipgrip < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"pipgrip", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"pipgrip", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/p/platformio.rb
+++ b/Formula/p/platformio.rb
@@ -124,7 +124,7 @@ class Platformio < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"pio", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"pio", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/p/policy_sentry.rb
+++ b/Formula/p/policy_sentry.rb
@@ -82,7 +82,8 @@ class PolicySentry < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"policy_sentry", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"policy_sentry",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/p/posting.rb
+++ b/Formula/p/posting.rb
@@ -186,7 +186,7 @@ class Posting < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"posting", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"posting", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/p/proselint.rb
+++ b/Formula/p/proselint.rb
@@ -23,7 +23,8 @@ class Proselint < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"proselint", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"proselint",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/r/rasterio.rb
+++ b/Formula/r/rasterio.rb
@@ -67,7 +67,7 @@ class Rasterio < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"rio", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"rio", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/r/reuse.rb
+++ b/Formula/r/reuse.rb
@@ -79,7 +79,7 @@ class Reuse < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"reuse", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"reuse", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/r/rich-cli.rb
+++ b/Formula/r/rich-cli.rb
@@ -75,7 +75,7 @@ class RichCli < Formula
 
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"rich", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"rich", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/s/sail.rb
+++ b/Formula/s/sail.rb
@@ -140,7 +140,7 @@ class Sail < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"sail", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"sail", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/s/sceptre.rb
+++ b/Formula/s/sceptre.rb
@@ -164,7 +164,7 @@ class Sceptre < Formula
     # Avoid issue if `numpy` is installed, https://github.com/Sceptre/sceptre/issues/1541
     virtualenv_install_with_resources(system_site_packages: false)
 
-    generate_completions_from_executable(bin/"sceptre", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"sceptre", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/s/schemathesis.rb
+++ b/Formula/s/schemathesis.rb
@@ -287,7 +287,7 @@ class Schemathesis < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"st", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"st", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/s/semgrep.rb
+++ b/Formula/s/semgrep.rb
@@ -342,7 +342,7 @@ class Semgrep < Formula
     venv.pip_install_and_link buildpath/"cli"
 
     generate_completions_from_executable(bin/"semgrep", "--legacy",
-                                         shells:                 [:fish, :zsh],
+                                         shells:                 [:bash, :fish, :zsh],
                                          shell_parameter_format: :click)
   end
 

--- a/Formula/s/sgr.rb
+++ b/Formula/s/sgr.rb
@@ -221,7 +221,7 @@ class Sgr < Formula
     inreplace "pyproject.toml", 'version = "==3.4"', 'version = ">=3.4"'
 
     virtualenv_install_with_resources start_with: "setuptools"
-    generate_completions_from_executable(bin/"sgr", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"sgr", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/s/shallow-backup.rb
+++ b/Formula/s/shallow-backup.rb
@@ -91,7 +91,7 @@ class ShallowBackup < Formula
 
     generate_completions_from_executable(
       bin/"shallow-backup",
-      shells:                 [:fish, :zsh],
+      shells:                 [:bash, :fish, :zsh],
       shell_parameter_format: :click,
     )
   end

--- a/Formula/s/shodan.rb
+++ b/Formula/s/shodan.rb
@@ -83,7 +83,7 @@ class Shodan < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"shodan", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"shodan", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/s/shub.rb
+++ b/Formula/s/shub.rb
@@ -96,7 +96,7 @@ class Shub < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"shub", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"shub", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/s/sigma-cli.rb
+++ b/Formula/s/sigma-cli.rb
@@ -112,7 +112,7 @@ class SigmaCli < Formula
 
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"sigma", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"sigma", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/s/snakefmt.rb
+++ b/Formula/s/snakefmt.rb
@@ -61,7 +61,7 @@ class Snakefmt < Formula
 
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"snakefmt", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"snakefmt", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/s/sqlfluff.rb
+++ b/Formula/s/sqlfluff.rb
@@ -108,7 +108,7 @@ class Sqlfluff < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"sqlfluff", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"sqlfluff", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/s/sqlite-utils.rb
+++ b/Formula/s/sqlite-utils.rb
@@ -57,7 +57,8 @@ class SqliteUtils < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"sqlite-utils", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"sqlite-utils",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/s/subliminal.rb
+++ b/Formula/s/subliminal.rb
@@ -191,7 +191,8 @@ class Subliminal < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"subliminal", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"subliminal",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/t/tartufo.rb
+++ b/Formula/t/tartufo.rb
@@ -51,7 +51,7 @@ class Tartufo < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"tartufo", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"tartufo", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/t/tmt.rb
+++ b/Formula/t/tmt.rb
@@ -165,7 +165,7 @@ class Tmt < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"tmt", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"tmt", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/t/twtxt.rb
+++ b/Formula/t/twtxt.rb
@@ -96,7 +96,7 @@ class Twtxt < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"twtxt", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"twtxt", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/u/uvicorn.rb
+++ b/Formula/u/uvicorn.rb
@@ -80,7 +80,7 @@ class Uvicorn < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"uvicorn", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"uvicorn", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/v/vdirsyncer.rb
+++ b/Formula/v/vdirsyncer.rb
@@ -116,7 +116,8 @@ class Vdirsyncer < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"vdirsyncer", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"vdirsyncer",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   service do

--- a/Formula/v/vunnel.rb
+++ b/Formula/v/vunnel.rb
@@ -232,7 +232,7 @@ class Vunnel < Formula
 
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"vunnel", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"vunnel", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/w/waybackpy.rb
+++ b/Formula/w/waybackpy.rb
@@ -45,7 +45,8 @@ class Waybackpy < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"waybackpy", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"waybackpy",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/w/weaviate-cli.rb
+++ b/Formula/w/weaviate-cli.rb
@@ -179,7 +179,8 @@ class WeaviateCli < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"weaviate-cli", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"weaviate-cli",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/y/ykman.rb
+++ b/Formula/y/ykman.rb
@@ -92,7 +92,7 @@ class Ykman < Formula
     man1.install "man/ykman.1"
 
     # Click doesn't support generating completions for Bash versions older than 4.4
-    generate_completions_from_executable(bin/"ykman", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"ykman", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do


### PR DESCRIPTION
### Description
Click can generate completions for Bash versions newer than 4.4. Bash was previously excluded from the completions list because even generating the completions needed a new version of Bash. This is no longer the case meaning the completions can always be generated, even if the system is using an old version of Bash (e.g. macOS's built-in Bash running v3.2.57).

Changes generated by running:
```sh
grep ":click" -R -l Formula/ | xargs -I {} sed -i 's/\(shells: \[\)/\1:bash, /g' {}
```
And manually fixing up any formulae that used multi-line `generate_completions_from_executable` calls.

Fixes https://github.com/Homebrew/brew/issues/20188

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
