### PR TITLE
Avoid 0.0.0.0

### DIFF
--- a/Formula/k/knot.rb
+++ b/Formula/k/knot.rb
@@ -69,7 +69,7 @@ class Knot < Formula
     <<~EOS
       server:
         rundir: "#{var}/knot"
-        listen: [ "0.0.0.0@53", "::@53" ]
+        listen: [ "127.0.0.1@53", "::@53" ]
 
       log:
         - target: "stderr"

--- a/Formula/k/knot.rb
+++ b/Formula/k/knot.rb
@@ -11,13 +11,14 @@ class Knot < Formula
   end
 
   bottle do
-    sha256 arm64_sequoia: "1fb8278e561ed7d9a99f4ba23c25a88b537dd237e9db452e4b62717c48130841"
-    sha256 arm64_sonoma:  "5234cf8758edf2892799102953dd273394716cc5be1a9841012b269da540d8cb"
-    sha256 arm64_ventura: "a7744ed3ae7ac074e555e500273763bcf8243535b211ee9e2d6bb70dd70ca044"
-    sha256 sonoma:        "bb04dda43aa53b3dbda4ef5aa899c81cccceb6dcaf2cf927a3f4b74a7d24ddc2"
-    sha256 ventura:       "553cdc9c373828a8fb90b87d6f73723f294dc3a0a5021d18eebdccc7b4396750"
-    sha256 arm64_linux:   "9e9a49395d66917fda7c89d86d2df83def6d3d91c4f3a733af2dcf144e6dd806"
-    sha256 x86_64_linux:  "c1f15009c4df1619d610ae555a92c0e1cec16bb65f03183bc7fc25e849127e79"
+    rebuild 1
+    sha256 arm64_sequoia: "1dc4d7ee983b698f773fa5d55a8f0bbe9a328a335966e632f627823c1271c95b"
+    sha256 arm64_sonoma:  "b9d60eb58dc99bb7bd452488aa32baf855a4a453804efe60dc0494d9c95c9480"
+    sha256 arm64_ventura: "08e467b47054a840ccfc604113df50af71f0499c78a829fc04c77ec8f96c72dd"
+    sha256 sonoma:        "924d0d12a0d7b17716b8d4d373441b048b07a85d8e7a4af59176dc02c3a7660d"
+    sha256 ventura:       "86e4f45035be1f9a197fbf9cd23351c904a1c6c4d1b375025192ec08800ba0c7"
+    sha256 arm64_linux:   "f1f7baf441b646da5acecf8240d9ea865c1dd6413b170a6e5762da937be279c5"
+    sha256 x86_64_linux:  "11d5ee8ee5370e2fd1dcececdb6b5e46531306995bda35f5131265a5108680fa"
   end
 
   head do

--- a/Formula/l/launch_socket_server.rb
+++ b/Formula/l/launch_socket_server.rb
@@ -39,7 +39,7 @@ class LaunchSocketServer < Formula
     require_root true
     error_log_path var/"log/launch_socket_server.log"
     log_path var/"log/launch_socket_server.log"
-    sockets "tcp://0.0.0.0:80"
+    sockets "tcp://127.0.0.1:80"
   end
 
   test do

--- a/Formula/l/launch_socket_server.rb
+++ b/Formula/l/launch_socket_server.rb
@@ -9,18 +9,12 @@ class LaunchSocketServer < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "4dc5f49b22d19b1a6d79d1697b52883dfb9ef8f39d2777a49c6aed182b9ef0be"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "9ce6af2c7124bc91494a306292073b296f109482869a4c01870ef97e81d5d62d"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "f097f91e97343b78e0208793705506ccec3ea9deddb38d9a15d11c11103888cf"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "055953e5098f4c8e2c823d58e123eb3a905174c9619791b3fa54de1d671b193d"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "b95b2bbe04b54feb6b103b5ead74f984160ff920a8914619004b40c1402bceb7"
-    sha256 cellar: :any_skip_relocation, sonoma:         "0fd45ecadc044db17343dcbd89327fd2324512e7055f9b30e26f40dc4c513bc2"
-    sha256 cellar: :any_skip_relocation, ventura:        "1201c5615810d1e37d6c6c2c26ccadf8ffd9a346905cbf064ea637aab8f04629"
-    sha256 cellar: :any_skip_relocation, monterey:       "165fd5a279db8b88e586ca82f2c1017946a7675c8f0c158921d9cb48d152e13b"
-    sha256 cellar: :any_skip_relocation, big_sur:        "0d490a674d736272ea67f2289d5eb715b5aa48acf5e289a6a8e8327cd4cbc4a4"
-    sha256 cellar: :any_skip_relocation, catalina:       "ff86499103ad1d9d33cdc039e24f065aa08405bda980c9e242c46ed157bc33ff"
-    sha256 cellar: :any_skip_relocation, mojave:         "823d84eddeb72fdabeccdc189bc19269485bfeb23d0a57824cdbf95c92a6ccb8"
-    sha256 cellar: :any_skip_relocation, high_sierra:    "ef58f2afc33d6454282d1e1b92e4d16269885464707ae58079c29514f4cadc60"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "6974a57e3a6bd5f01dc3b62d4a4592afb791af68f230b7ea5e60a46cffc0d395"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "92a59f265b9a67885cd73be07b4fa591b0ff76e382ac7c2db5099e02d2212bfe"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "7d09862a50bec1441d8d5cf4eabb2318942fab969ebddb67b9f3739e784e5a13"
+    sha256 cellar: :any_skip_relocation, sonoma:        "570f75f0fa24b34b03a278f1dc9f46f554c651b966204943fb3b5f25f412ee81"
+    sha256 cellar: :any_skip_relocation, ventura:       "38b8161c24c87504fe237154e1b287d1493f9a16f41bced1f942ebb5ce9b6d06"
   end
 
   depends_on "go" => :build

--- a/Formula/v/varnish.rb
+++ b/Formula/v/varnish.rb
@@ -64,7 +64,7 @@ class Varnish < Formula
 
   service do
     run [opt_sbin/"varnishd", "-n", var/"varnish", "-f", etc/"varnish/default.vcl", "-s", "malloc,1G", "-T",
-         "127.0.0.1:2000", "-a", "0.0.0.0:8080", "-F"]
+         "127.0.0.1:2000", "-a", "127.0.0.1:8080", "-F"]
     keep_alive true
     working_dir HOMEBREW_PREFIX
     log_path var/"varnish/varnish.log"

--- a/Formula/v/varnish.rb
+++ b/Formula/v/varnish.rb
@@ -12,13 +12,14 @@ class Varnish < Formula
   end
 
   bottle do
-    sha256 arm64_sequoia: "fb5cbe8656ede605c0237b5547fd8597cc28f6610f7c6a0055eb4c1abce170f8"
-    sha256 arm64_sonoma:  "ffb66142d7b11573ae3678aeabb73a3562f4d88d1ed685275ec6bd2a455c1a96"
-    sha256 arm64_ventura: "83d569419f98c2f552bf12e7976933c06951923659c0c5f7e78cabd15145f802"
-    sha256 sonoma:        "be72b7f7e58cb4978f546ee7fef88b54e524217a4626712872933103a52c70f4"
-    sha256 ventura:       "d098652ecc801d17d010faf7e18ce1767773bd41c2b8fd8562657279f9ba506f"
-    sha256 arm64_linux:   "87f26a2116f5a9345eb1bdd23bf3573d27daafdfb93f5a160d1a32fc8cbed8bc"
-    sha256 x86_64_linux:  "58c14e678d32e15e03fb6f88bf4cc886244dd7e8d47521e57a97bce1c3c68d9f"
+    rebuild 1
+    sha256 arm64_sequoia: "fd568d267ee9b5844a3c2b0233c12a51e8a00022b031cdfb569988aa92fc1f73"
+    sha256 arm64_sonoma:  "4223322b623694e089924b568cd1fae3e9b67c31c1faead969abd8ee323a7825"
+    sha256 arm64_ventura: "322c722503c07ddccb64054f88cb9e2f526dd02aee8069361f36dc7f7b88ec8a"
+    sha256 sonoma:        "88831645eae4467af0e537c506dcf4cdd99078d93cfa9d2fe0c01329c27e1714"
+    sha256 ventura:       "0181d254c66b3b6676b387770bcd38ce6899aeb5d80a68539cb3a319c2bee5ca"
+    sha256 arm64_linux:   "9551bad52ea1d85bd154180a46b38f95d806b3d50b85d74140be235b946607d3"
+    sha256 x86_64_linux:  "dc1f0dbc8fbf3683d83c6e2e324d519b9b30daf7c70744340ff91ef0427aaa9d"
   end
 
   depends_on "docutils" => :build


### PR DESCRIPTION
The use of 0.0.0.0 in formulae indicates binding to all network interfaces, internally or externally, so is a bad default and potentially a security risk.

See Homebrew/brew#20233