### PR TITLE
Enable Bash completions for formulae using `:click` (1/18)

### DIFF
--- a/Formula/a/adr-viewer.rb
+++ b/Formula/a/adr-viewer.rb
@@ -68,7 +68,8 @@ class AdrViewer < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"adr-viewer", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"adr-viewer",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/a/adr-viewer.rb
+++ b/Formula/a/adr-viewer.rb
@@ -9,13 +9,14 @@ class AdrViewer < Formula
   revision 3
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "c1efd8ef88f39d6598004615184612871efc040d1d7b05aeb306a5732e0770bb"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "3cca20e479818c98d5fe2a005af51a1fdd742a7d914e6f44f5dffc32ee2f972e"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "c8b5d19a206d65635a9da6eacd09b232a7ef73c560049cc63a28e03f1f8b0b41"
-    sha256 cellar: :any_skip_relocation, sonoma:        "58674e3fb84c3e62f1aba6a501abd1c856b6807c8bcaf7df74eb4d04ef81f1e4"
-    sha256 cellar: :any_skip_relocation, ventura:       "880572d016d57566ee09ba653c09b78b0a668d423eba6661c788e09b65436c66"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "f97231985140d38128b767f86821bfb9a825def6170ed0cb901cd15b49a9361a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a3f3e22f63e93ae52d53b8a07b3ccef467d8b213b5a55fb66118fa1681681525"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "ae4cd968f406792edc2acd31cf16b52c02f2e86b7fcf7ead074db74a459f428a"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "683fa11655a13acfaf5dec1d2fa6b47b9df98e3423691745da8c46e967ee3acb"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "a53efd827bb4a2f8d5e37985c42031b7cb52bccf6a62b2027a0876629866d9db"
+    sha256 cellar: :any_skip_relocation, sonoma:        "e7c0c39970d821411b41f596c200055508e4d9ed62dee8931f54396c853585c5"
+    sha256 cellar: :any_skip_relocation, ventura:       "59f780215b254d5007dacaeca3f38dc3067fc7b476a81d63104771ab4ecaafd8"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "f96efc5d3499cb7e1027af335e6462f62df4bb269ed7ce7fd9f617c31fed319c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f0be24b13a206caaeaa1ab085627c82aed37e3e646c7b59ff159444464ec2143"
   end
 
   depends_on "python@3.13"

--- a/Formula/a/airshare.rb
+++ b/Formula/a/airshare.rb
@@ -141,7 +141,7 @@ class Airshare < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"airshare", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"airshare", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/a/airshare.rb
+++ b/Formula/a/airshare.rb
@@ -11,14 +11,14 @@ class Airshare < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "788ff35c84c01d325cbd7d839079907c0ada77e021cf3b34ff6aff956d31eb8d"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "01c360fd06e99a1369ef80f35b7e14b1ecbc245b3d75d4d176148a2adfeb33e1"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "25d3b02104872f23235580f7532dbe1bd684190da52029ade86fb2fc1a1a6e3e"
-    sha256 cellar: :any_skip_relocation, sonoma:        "c0862464272168098ab9cbb8023d533959cb6ab71aa70c1c1fd644e59bf127c6"
-    sha256 cellar: :any_skip_relocation, ventura:       "fa8122ee12d03cd7c1c2e9b765625c057cb346df0e9894aceb781f7121a0af78"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "5dccfccf439a763b946ce2869831603cc7230097fe04b4c516eba18ab2acb38b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e4abda68288e930659bf701b6a32c8a4926604bfa3257394ee91c2f7e8106115"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "fc2fc265e8be9a05d336542792418620c0fb09ac30a092e926a1d6acd5a87ee1"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "859b6db2661fdb20f710693730eeae3c30c89e8bd260db1d2ce53f7d51ecb900"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "972acfce7af9a8ef431eb137fe2f5ec48177db978962cad0687524cc24dc0573"
+    sha256 cellar: :any_skip_relocation, sonoma:        "f09abd1ac0a352798f405b074722c0eddd1eb3e9070ce7157e52e5fa18cb1009"
+    sha256 cellar: :any_skip_relocation, ventura:       "6395e59119b24a37f59395b61816c3c16f91c2e8bda194b6186e82125489bf99"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "4f12117cdf50e56e225377e775ef48498e25d084041805a9f0dcbaa95c6fa91d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "551112f8b8feb6e355698603453ef55dff83e6dc748efdf852df03fae62caa2c"
   end
 
   depends_on "python@3.13"

--- a/Formula/a/animdl.rb
+++ b/Formula/a/animdl.rb
@@ -163,7 +163,7 @@ class Animdl < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"animdl", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"animdl", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/a/animdl.rb
+++ b/Formula/a/animdl.rb
@@ -11,14 +11,14 @@ class Animdl < Formula
   head "https://github.com/justfoolingaround/animdl.git", branch: "master"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_sequoia: "5aaa37e63ae5e8b1e9fb2fd0412373e8c5bcceb7eb79380ca0fc3f34b047f20c"
-    sha256 cellar: :any,                 arm64_sonoma:  "efaaca845d0eecd8bf4bc5eb17c608b8e160981f435ece7ef7f1c2974e7ff014"
-    sha256 cellar: :any,                 arm64_ventura: "9525f12cfd47300b58e2d8dd1fe726b5271e5efc88c7df3d5ad1d5ff8b7751e4"
-    sha256 cellar: :any,                 sonoma:        "0f4968fcb2a2aad6e52bd1660a4397e9a4f07ae2fec2d3ca3bdc1dda09e9c82a"
-    sha256 cellar: :any,                 ventura:       "f5d300f45f9da97629c76e70689d90ce818e328701774b1cb6cb034bb9a19518"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "8f23fb533affd1c176c1e76f379d12127da98c7b6f084ec7819bc13527beac93"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "165920e2f9da447e3b0ef0877851af4f38b339c145fe2d27bcb7a1e57148e714"
+    rebuild 2
+    sha256 cellar: :any,                 arm64_sequoia: "2b0c0de475dffa18492e1a16521cf7ec2f872775e46b0ecfb9d7cf3020249bc9"
+    sha256 cellar: :any,                 arm64_sonoma:  "84ab0b66c20b91d73bfabfe2920d26cac6a977c6fd2d242c5865a054bb604f7e"
+    sha256 cellar: :any,                 arm64_ventura: "1171ffe573d8b07b3a333209b5622efb8f5c813aeabadf2e731a2f915e03b307"
+    sha256 cellar: :any,                 sonoma:        "534f8a346498a96db436a66e3d83bc7ecedddd9a004545d0fe1af778586a91e6"
+    sha256 cellar: :any,                 ventura:       "9a0b6cb8188f69858fc3f0c56209f7e08a236d80399a8ce102865ffb33f2db5c"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "a1d5346b5628b33480591b0ef6a899be0d1516fc7d213f8eb3cbe23fdb74b1ec"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2e1cc7ad0a8e6d7bdb86a9ff830c7a05e8cc375d50178c7b30e897538f8cb852"
   end
 
   depends_on "certifi"

--- a/Formula/a/apprise.rb
+++ b/Formula/a/apprise.rb
@@ -70,7 +70,7 @@ class Apprise < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"apprise", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"apprise", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/a/apprise.rb
+++ b/Formula/a/apprise.rb
@@ -9,13 +9,14 @@ class Apprise < Formula
   revision 2
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "b2a2a2c4d22593b4f902920e37e90e26c36ae7433fa15f0b49d5b0a0bfd4da0b"
-    sha256 cellar: :any,                 arm64_sonoma:  "1adb251b14e2a853a4c4d87078270bbe73b905097d345ada03a8132ddf0b7677"
-    sha256 cellar: :any,                 arm64_ventura: "13abcb9e42c91e1401d988d59ff7bbe680a76a81b452e46fcad758f156a0e23e"
-    sha256 cellar: :any,                 sonoma:        "edf57c6280285d856f65cce0340cf891da6babc5e6f15d6a07071b6f78a1828d"
-    sha256 cellar: :any,                 ventura:       "b34de266a4e33ad7f2477fd054fd4d46c1a32e613538f7c542dd31307bfcc663"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "79d1048684dcd8869ece274486faa0dbc01251f99814f088f9220c866fdfef05"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "fdf5fb4db8756632f304419f5ff5ee4d817eef5c0ddf74dfe9e905492fcc2417"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "a7c82a682ecf103d6137e6b334e453d28d461720352621506b88b54e082a060f"
+    sha256 cellar: :any,                 arm64_sonoma:  "a65aff91277ab155606aa7cfc1eef89cfec14ff4fa847d15b4670b1e59d47ddc"
+    sha256 cellar: :any,                 arm64_ventura: "6310cc3947bf9179df035378bd5f1c1c453ffb6f635da2efc0a93092124d7531"
+    sha256 cellar: :any,                 sonoma:        "bb8363ad02d2ca2e75496ab5833a9d45a85d0b8eda746e3ad87a17ccf39f8609"
+    sha256 cellar: :any,                 ventura:       "e262256143f9b0bce8c3804444944b382f61602fe655744500cd0433e6b3924e"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "fa3b052f8c8db8cc749b325bfa1df6b58bcc38ce995b7e3ac0d46062035a65e9"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "fd4db6e05c3f60e449e0697a7d987e2399fb6abe5d1226abb3a022508951ba97"
   end
 
   depends_on "certifi"

--- a/Formula/a/aws-sam-cli.rb
+++ b/Formula/a/aws-sam-cli.rb
@@ -419,7 +419,7 @@ class AwsSamCli < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"sam", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"sam", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/a/aws-sam-cli.rb
+++ b/Formula/a/aws-sam-cli.rb
@@ -8,13 +8,14 @@ class AwsSamCli < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "a5a1e96a46cbd3a83bf4bb55b5f904a358df212d305b835e850aecef14901071"
-    sha256 cellar: :any,                 arm64_sonoma:  "7572f7a2dcf1f473142a5e4fd58386df1f7e6b2a20433465505cc44b32ead94c"
-    sha256 cellar: :any,                 arm64_ventura: "91ed689b09aecd15d7145881e39bf651d723aa191751314b0a23aa1643746d3b"
-    sha256 cellar: :any,                 sonoma:        "f2c15869cd47cb19f9c7d5a9dbf3a1a734c2f4140d3c56eb736b2ce29078985b"
-    sha256 cellar: :any,                 ventura:       "51d67fa9eb8776633de6b727b4bd0914e817527658e08e56648b29604cbc6c36"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "62ee1bba29b70224f7f88f8485fa9023c97159ee779f2291cfc8f581512fa265"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d62b4c616ea18081deea699ed2ca62f511c9e0d6c27c5a719899b72066f404be"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "9e6a1ee07cd9b412b987a794815d93f3ed093a5ff4de11e397046498153121d0"
+    sha256 cellar: :any,                 arm64_sonoma:  "b0c7082adbab7feb697169d565cd3943166a06dece0fe335af05a0c5821c1d29"
+    sha256 cellar: :any,                 arm64_ventura: "e5ab73ed9faa321729540550854fed350928196d56928473ce718e8eae871a30"
+    sha256 cellar: :any,                 sonoma:        "edf40666ac2a96c45f4b68e2024ae4fc8f32c6649dcc37629766a80a44f43957"
+    sha256 cellar: :any,                 ventura:       "24e8752158da654abbeabf36ef4d9836cd9f668747efe2e442ead8e15ca29769"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "44891b6cb8cd881358648f537429206cbb1d87b8b9b553f2ea7012134f0fb949"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "fcbb710507d3298eb95b2e4f76b6491d0fc04cb062ef97a56d7aa7525b156792"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/a/aws-sso-util.rb
+++ b/Formula/a/aws-sso-util.rb
@@ -122,7 +122,8 @@ class AwsSsoUtil < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"aws-sso-util", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"aws-sso-util",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/a/aws-sso-util.rb
+++ b/Formula/a/aws-sso-util.rb
@@ -10,13 +10,14 @@ class AwsSsoUtil < Formula
   head "https://github.com/benkehoe/aws-sso-util.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "9b0de72d218774baa7fe3fc5cd7952945080f10f41360c5ac644ec727a718b22"
-    sha256 cellar: :any,                 arm64_sonoma:  "6fd418debe55255e4d7bf2b619251d1a383f44f931e223d4bc1d6231a5147ad1"
-    sha256 cellar: :any,                 arm64_ventura: "3cf8890dc4fb3370a3813e86161ac6da5253798932c5b9de701cd1bd50810674"
-    sha256 cellar: :any,                 sonoma:        "54bc1cef47b78f23d4cf3bbe9c14f94f094c40def535268ff85fc1fa506ca81d"
-    sha256 cellar: :any,                 ventura:       "1fd983273a29a581c6aba4dc47af4346eadff4468ae7f9969c6dad086ebbfa71"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "3444c15cb7f0fe88a3cd70ab244b13bca55ca1fd509ca7bd453b13762e1e83ff"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "53134b0ef76fa56c95fa1ba0ee9cc989a987c0040d87256cae1621d745407a3d"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "bab323da7693aca57ed3e3471b3cc3f167462798d1387d1ae2d1b0934d602fda"
+    sha256 cellar: :any,                 arm64_sonoma:  "6ebabf3294219f2ab3c6f135e90a7cf43e28eaebc1f1765bdb341fe83c6b8bcd"
+    sha256 cellar: :any,                 arm64_ventura: "2e4dc4ea27a97b8eeb89059d77842d21f2b6ce42712938f87ec78e2684d00c39"
+    sha256 cellar: :any,                 sonoma:        "8ca33fe59987e3a1a0900bfabb01b31fcf5967b7058c3da76ef6dba55136eb6f"
+    sha256 cellar: :any,                 ventura:       "323c4ba449820a47dff76a78dab8fdba28467b218d4645f4de7a9ac4e9a02175"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "dd406c079f352fe10c7e2edd987cd813f40a9dfd05a16b492c91bd0b99bc92e5"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4fdf3d0a107bf8706edae93fd5212debbaafc78289ab384b630b979128379fd3"
   end
 
   depends_on "rust" => :build # for rpds-py


### PR DESCRIPTION
### Description

CI is taking way too long for https://github.com/Homebrew/homebrew-core/pull/229665 so I'm splitting up the PR to chunks of 5-6 files.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
