### PR TITLE
Enable Bash completions for formulae using `:click` (2/18)

### DIFF
--- a/Formula/b/beancount.rb
+++ b/Formula/b/beancount.rb
@@ -56,7 +56,7 @@ class Beancount < Formula
     virtualenv_install_with_resources
 
     bin.glob("bean-*") do |executable|
-      generate_completions_from_executable(executable, shells: [:fish, :zsh], shell_parameter_format: :click)
+      generate_completions_from_executable(executable, shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
     end
   end
 

--- a/Formula/b/beancount.rb
+++ b/Formula/b/beancount.rb
@@ -9,13 +9,14 @@ class Beancount < Formula
   head "https://github.com/beancount/beancount.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "8dc1fcd7f2317ea72784d7fbf2f76c54e2db0326d7526f22a1b9a9c291efc222"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "9a4c201840e45d79de983afd1068d188f3bc8d55d6d45f7cb2bb3434920f1e77"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "ea4e49c721b56ee17b5c3cb7adbf37427f73beb5feb9dba8b96319f2c15e6a00"
-    sha256 cellar: :any_skip_relocation, sonoma:        "c87741dafbf02e62986b0fa4b485542bb2f1e8cbc2d8f967475e94d46058c6a9"
-    sha256 cellar: :any_skip_relocation, ventura:       "0417cdbffbbb58e14ed1f6496f390da38ffddf7f43483206ae61ceb97dff809b"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "1b9d0b7dd0cbb81adba41b95cf6f87bd7810d5236d087c884c2398fdfffefba3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f61124a05787d02519432086cbbbafef2b979e40747d7e9801559d81b0b1003f"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "39c80fbd4ff41b065982713794dc3c9a6f024c25b8ff7cb39ed28bda78d2ddf0"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "a423e9224c67f96095e9e5a2663ffd285088315890be3689abf742db767dbc4b"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "4ed2293c7df4680ef507cb497ea9e4367912650e944510ed05083b95331f7b3f"
+    sha256 cellar: :any_skip_relocation, sonoma:        "39ff208f5f23b73eec9f15974f0e0e4165acf98b5927f1884e5b29cac1717277"
+    sha256 cellar: :any_skip_relocation, ventura:       "5772e0476fcd2348f87e2a05236af991e27ac1a49445bee67a40ffa558aef8ff"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "89bf5a7f146f0d41c9366c7a5465ae019a99af50ae801ee4d6d00b96e0c5c10c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5c25a49250979c8840ef7feae60728d2d4f0653793719e66744266bdf499433d"
   end
 
   depends_on "bison" => :build

--- a/Formula/b/bilix.rb
+++ b/Formula/b/bilix.rb
@@ -196,7 +196,7 @@ class Bilix < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"bilix", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"bilix", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/b/bilix.rb
+++ b/Formula/b/bilix.rb
@@ -9,13 +9,14 @@ class Bilix < Formula
   revision 3
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "f6d25831cdcf6dc12ea85b7fc95408029fb88f863aee52735a4d2648e224cfa4"
-    sha256 cellar: :any,                 arm64_sonoma:  "dcd367d68c92ceaa081afa8157ec481a4cf5380d60b5731c07a1f7b87198168a"
-    sha256 cellar: :any,                 arm64_ventura: "38bedeb03e5ae71c34dcadd1cc62a3092c4320fe91020992ed9ce82272a6a8ec"
-    sha256 cellar: :any,                 sonoma:        "2db818c33731749fc5e115236dcbd09467b363397d13fbc0bdd8f3a3150ece67"
-    sha256 cellar: :any,                 ventura:       "0c4805e7d3fb9d83a4179a44c5f5bb19154382418fbbd2a280d369eaaddbb176"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "904cf1a5ec51f55e76fd2a3d98c984964ba3ef4c24313d12f6ea7f7f532b6354"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "bad44739863c76498556c7dd8b826a258d334385d752752f10e00f86a127ad64"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "c16690eeb5628c7ed8f03d9417face05b06a97e944ce6339516890f8bb330a3a"
+    sha256 cellar: :any,                 arm64_sonoma:  "62e1fa53ed738b9bbbc4d0a53695968f209c55896030c1c21701450c350ed105"
+    sha256 cellar: :any,                 arm64_ventura: "bc9d1ea3692846f852870798b987c2e1d6182fa34022db56824978fb697210a0"
+    sha256 cellar: :any,                 sonoma:        "6982fb952d549f4a71bc89550d899b5293313c1a9a05466f4dd21a4e323244f6"
+    sha256 cellar: :any,                 ventura:       "16fce51192e322c14c609322126944808e0e6c283002eae7566f5ce9bd0d51c4"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "050d10917e07b05f90a5a58cf7e226ecda3fc27eadf9fe51d86bcd2886a657fc"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "6de89d1672a9749c36009b61e6397104305f83548ee2298b990ee7373845bf2d"
   end
 
   depends_on "rust" => :build # for pydantic_core

--- a/Formula/b/bump-my-version.rb
+++ b/Formula/b/bump-my-version.rb
@@ -154,7 +154,8 @@ class BumpMyVersion < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"bump-my-version", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"bump-my-version",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/b/bump-my-version.rb
+++ b/Formula/b/bump-my-version.rb
@@ -9,13 +9,14 @@ class BumpMyVersion < Formula
   head "https://github.com/callowayproject/bump-my-version.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "3d955f10b072bbdd66618d4795540c1403313425ec76fe49753ddb2c873b850f"
-    sha256 cellar: :any,                 arm64_sonoma:  "206261c5a514cb1839712c32794f63d0e5aab1c21f6d3618224e6b70ac753c81"
-    sha256 cellar: :any,                 arm64_ventura: "3fec34f0a0b2e0d87672e124a8edf06e93d6c710cd5038445137c248fc0a6d55"
-    sha256 cellar: :any,                 sonoma:        "75ffb88646f7486a0c9de44854909a4b67cacef44d52f8e0dfcba2c3a952de56"
-    sha256 cellar: :any,                 ventura:       "89186bb3ace7ea633afa3ce8a5abba7c059552226b8a440211d6669e1305d9aa"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "4585c18d9125c54ed5f2e2d2549b1d9febac5542c6550d38760483f794ec27f8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "9561f1b35c520a5209fe9747b5a37b3549de0b1fed2b79e44c9808b9ded1b135"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "2a22d5171785969c46d9ed0c13ebf4d4160553cf421a72d1f387d98b4e291e04"
+    sha256 cellar: :any,                 arm64_sonoma:  "5f22994debf21fdf4d66682c680938e64619249f14cd94c3f5a321c566f15600"
+    sha256 cellar: :any,                 arm64_ventura: "62020589912dc2aed9dfd9a1637c9e22eed88b737b0b0022b70061e33daa55b6"
+    sha256 cellar: :any,                 sonoma:        "3c35c1f6305fb9c936b02d9decb17296bbf1d2909b0354624849c7dd4a177c3f"
+    sha256 cellar: :any,                 ventura:       "e7ecad78e16b28a843b59f43b9ebad7023df121b8dac2e4e08b95c9689ed3fd1"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "270f0bd93a64f1215477dda57950b0214a61e3a969b5d9c3b409daca9a372670"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "9cbf0fb978c9c52ecc75e9464c8f086256510b587a7654c0297429576d302c98"
   end
 
   depends_on "rust" => :build # for pydantic_core

--- a/Formula/c/cekit.rb
+++ b/Formula/c/cekit.rb
@@ -78,7 +78,7 @@ class Cekit < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"cekit", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"cekit", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/c/cekit.rb
+++ b/Formula/c/cekit.rb
@@ -8,13 +8,14 @@ class Cekit < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "b8b3f0bbe83f0c8a5aa1074e8d0c0eb203b9984cca78a2c33d131a23d55344e5"
-    sha256 cellar: :any,                 arm64_sonoma:  "edd7964819caef1448222ace74fcd6662bfaaa86b217f6d4a2ea375d68743819"
-    sha256 cellar: :any,                 arm64_ventura: "11b5a994c414eb5da1d067ceff2d0e39e9283ac76c483aefca3e0e28a6e930e3"
-    sha256 cellar: :any,                 sonoma:        "3bbd6a4ccd41e14f74656f9955f6a1e9e35a4fe6e5149d524be0acd7f1839e03"
-    sha256 cellar: :any,                 ventura:       "7f260afdeb6c019731fad22987af4f1d58669b7d9148dccc501766a05c09c150"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "0ce6285077882bc971758f48c71d22202d3bcdf105cc923daea26f1ad5037d82"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "071761f34a39ecb8ce7b7a806b5cd29b47a01402bf57c29ad376d3835d294d6d"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "d2f8831c610b2abfb398c173417afc377e77a70b94db09a123f23c052450c0f3"
+    sha256 cellar: :any,                 arm64_sonoma:  "8139a72bc96db48f85d9d70ad38378a5556c947f02e5f6810b577962e7e181f5"
+    sha256 cellar: :any,                 arm64_ventura: "e6158e2fc700c8f20fc57fc40541b5ad677bb260caf43b5fbcec7c8cb95ef206"
+    sha256 cellar: :any,                 sonoma:        "8a029bcd505e6ea9e20b419b8e4f8172a759dc16ff2099e63d9408388e093744"
+    sha256 cellar: :any,                 ventura:       "5f64f4d851ea7703fa7f204be8261607ee35219fc95bca447adbf94d3fb8f6b8"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "6251e9a307320ecf348e1270a2ec03811427460d276fceebd57dd45d45fb92fc"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "9aaa87b50f5774325dca9be632a0d79ae75c1dc07c7d65c57f99e99ee3134d4d"
   end
 
   depends_on "libyaml"


### PR DESCRIPTION
### Description

CI is taking way too long for https://github.com/Homebrew/homebrew-core/pull/229665 so I'm splitting up the PR to chunks of 5-6 files.

I've dropped `black` from the list of packages here because it fails CI. The failure looks unrelated to my changes: https://github.com/Homebrew/homebrew-core/actions/runs/16221764472/job/45804059244?pr=229757

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

