### PR TITLE
Enable Bash completions for formulae using `:click` (3/18)

### DIFF
--- a/Formula/c/cf2tf.rb
+++ b/Formula/c/cf2tf.rb
@@ -122,7 +122,7 @@ class Cf2tf < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"cf2tf", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"cf2tf", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/c/cf2tf.rb
+++ b/Formula/c/cf2tf.rb
@@ -10,13 +10,14 @@ class Cf2tf < Formula
   head "https://github.com/DontShaveTheYak/cf2tf.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "dee1cafafadbec76e76e6c1067d69834d4480f1c4d29418dd62d6b8170960448"
-    sha256 cellar: :any,                 arm64_sonoma:  "4c9da4fe4a216d2582bf4697113ae11fdb702de033e9c0c3de21a8fd0b188f85"
-    sha256 cellar: :any,                 arm64_ventura: "89c3cbd0df422c3f664b890e1276a4bceb32f4d5f3f915e5b2c2b5783d629be6"
-    sha256 cellar: :any,                 sonoma:        "64848649aa0251117c930deb6127da1131312ec5c901326171534bdb167bcb5c"
-    sha256 cellar: :any,                 ventura:       "58f4d020aa5449fbe06a5c7e799cb7d8ff9bdd2175e68b8b4f9fa975aeb42818"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "c126b8ca45243d4eac7bec1c1c47f3d303ad3d46c5eb91090b38929f80255980"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "292c68f1d889a89319aec7ff6cb21e40f8e5530f1fe48435a0d3e53e739a5602"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "58b4d16d56e6444cbacdb54b1673e387663eadbbe84c3badaf7c8e21b012c1db"
+    sha256 cellar: :any,                 arm64_sonoma:  "21bbc0286eb033a2a6801ff1bd3ae4969f1ef8def4f3fcb65e95451cd66de630"
+    sha256 cellar: :any,                 arm64_ventura: "e85c4d4bce44cab594c31be432cec4a718029f79ffd885b544e6f6af13c0cc82"
+    sha256 cellar: :any,                 sonoma:        "fb42d64794f5d65ddba3f4fa3591f3c58d556c13bfb1cb51d4f1ce2c48b1b26b"
+    sha256 cellar: :any,                 ventura:       "8e9c8638a4a1603a43bbd14ef68945a9b47b00e2bc58c759ae37b859020d6656"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "1edee2efe4d507470e4d0244a539870da2f72b3df1025383598e306e157ea962"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "081fee5499068882416bf48bf3ca1aed4163eb56ab3b8b8a00ea6d96d5db8eff"
   end
 
   depends_on "cmake" => :build

--- a/Formula/c/cfn-flip.rb
+++ b/Formula/c/cfn-flip.rb
@@ -42,7 +42,7 @@ class CfnFlip < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"cfn-flip", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"cfn-flip", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/c/cfn-flip.rb
+++ b/Formula/c/cfn-flip.rb
@@ -11,14 +11,14 @@ class CfnFlip < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    rebuild 2
-    sha256 cellar: :any,                 arm64_sequoia: "07d7a01e5e4b2cf04a12cf05b6255c452326347afc72cf22c755f11eee638fac"
-    sha256 cellar: :any,                 arm64_sonoma:  "a30142eaa1b55eacf35e1c2573e38e516779882086ddb7c417e7bee97e556f5c"
-    sha256 cellar: :any,                 arm64_ventura: "21a22fd0985168ca5c0ac5836ca4a85928d159833fdd4e75553e9295b8e74514"
-    sha256 cellar: :any,                 sonoma:        "c1497cca44686eab9b0031d34deab63258a1d891c7f8854e39558c7c60f01f96"
-    sha256 cellar: :any,                 ventura:       "92e08c7a0fb66b3c691bf141fac782213907d85989945519e1dc1aa55bb686a0"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "b828fc938febf9080fe045b0d8d185c3286172b5ee8b664604f2a7e992ad2e48"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8a009e9b1951f2f55ff9891c6e3366a2a66a2599f211f75ee420274f7b1ed811"
+    rebuild 3
+    sha256 cellar: :any,                 arm64_sequoia: "5442b8b312ae32f1f553fb978ccf09c63a8faec827d97d1c0ee6c25e6b8bec69"
+    sha256 cellar: :any,                 arm64_sonoma:  "e34be5905def03dfd1a3b2e978175a2a20c04c9a707526437f747f290f72d575"
+    sha256 cellar: :any,                 arm64_ventura: "0f477d1324b35e9d08f22bf9440d350dbef9eb7064a4a349dc61634037ccdc38"
+    sha256 cellar: :any,                 sonoma:        "8621b8bd4592dbff5713e74fe7ba0e2df3e49ed586b11dd29f28c8cd3a716579"
+    sha256 cellar: :any,                 ventura:       "0cbd0c1da955391882c5993e2c5ca0673b31aa9e96ccfa4735efe0bd179ec41d"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "0cfc26cd8e493d0423d00e49da1185a278aa84b79e3cd4325678fb161856607a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f22cd5a684f506f67a27cb9bcd7c4a9192909ec3222ae9b87eacba18776f43c8"
   end
 
   depends_on "libyaml"

--- a/Formula/c/cfripper.rb
+++ b/Formula/c/cfripper.rb
@@ -115,7 +115,7 @@ class Cfripper < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"cfripper", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"cfripper", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/c/cfripper.rb
+++ b/Formula/c/cfripper.rb
@@ -9,13 +9,14 @@ class Cfripper < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "76f97ce48cb4bae745690b1c4fa9e81524ef68f9dd68d0909e57ef9cce2c83b0"
-    sha256 cellar: :any,                 arm64_sonoma:  "4ebb06545d68a22c69887de7c175312aa86a98350c8a10fe90169ed0aae5a630"
-    sha256 cellar: :any,                 arm64_ventura: "f814179940427dd853e8176e1c133336512e22027caa47ea42008b8f23fca28e"
-    sha256 cellar: :any,                 sonoma:        "20f9ed527e4763bf502a9d2ddce42f89496cf4387d499f97e559fadc3648f18b"
-    sha256 cellar: :any,                 ventura:       "107cc0a2b02af1e767c0003a792a880965ec0ba945b1aa319079921fca04fe66"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "0db7c32c89bd9ecd43f8d83aef120cb334ffd2de5f96e0104a89b6bf3f30ef53"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "433fa7dcf4d67ae46f879c34af86bed45c678be2f52e0c3ac56c3d01ab5866e6"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "202607aa25dbcb1dcc4bd4483131aead63e7c5a8030e95b7f922386b9c71060d"
+    sha256 cellar: :any,                 arm64_sonoma:  "889b4b7a8b3223988ce50c9f9d155a1ce454c20e82bb6b2d7abf40a39d68887a"
+    sha256 cellar: :any,                 arm64_ventura: "1c61648fd190ff0c8545dbe84be6e06edf7f7d95eb39b188fdabb766d7964b89"
+    sha256 cellar: :any,                 sonoma:        "dc4ad409efaafa2cee0c6faabdf495ae0bedb719a6a9224edaae8c3b4b8e4cdf"
+    sha256 cellar: :any,                 ventura:       "ff01a5144f7fcce5ad5238ee4c2bbbe0ed1a91d74309c17cd191b871e6f9fa4b"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "0871ae8b3f537852236806b66a756d64790b553fc410a11d99789bd1439f9b9f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "739b049c15cbc41ffcc65756440d7e810ce88677ebe176d213d9ac8c8b32b8f0"
   end
 
   depends_on "rust" => :build # for pydantic_core

--- a/Formula/c/check-jsonschema.rb
+++ b/Formula/c/check-jsonschema.rb
@@ -147,7 +147,7 @@ class CheckJsonschema < Formula
 
     generate_completions_from_executable(
       bin/"check-jsonschema",
-      shells:                 [:fish, :zsh],
+      shells:                 [:bash, :fish, :zsh],
       shell_parameter_format: :click,
     )
   end

--- a/Formula/c/check-jsonschema.rb
+++ b/Formula/c/check-jsonschema.rb
@@ -9,13 +9,14 @@ class CheckJsonschema < Formula
   head "https://github.com/python-jsonschema/check-jsonschema.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "ad64a28db9250e02e11f78ab1cb4908e38adccf69c02fdce603ea8402c185b8a"
-    sha256 cellar: :any,                 arm64_sonoma:  "544a7f856a4743b4172acc6fabe7fd1ffb72b14c92887bb7e5e7342d59a44e8c"
-    sha256 cellar: :any,                 arm64_ventura: "f39f8aa21b908098c7057da92e0e3e39991cfec2202640821574de8d3a27859c"
-    sha256 cellar: :any,                 sonoma:        "40dc34f220db80c4ee0cc9f7bbfd6a0cb9a9a218dfe1db9f874ea1326919dc49"
-    sha256 cellar: :any,                 ventura:       "873a1353832263008d81d66551adf585301f4f9edd55441994a40086b474e532"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "f7707755f3fdd505ed5a7f6d835333ecaf1485bcb90165a4d23a9798b353a8f2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "9cfdb3891f709e124dd0ecc910ef6d6d92f488eff9ff87a0d4dcc7ba10120792"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "3df91b3e5ec3f90a3a9eb73983acdd6550567b0d9fa5420147564cb89a512ad7"
+    sha256 cellar: :any,                 arm64_sonoma:  "d060f51f9dea52beb04b1783e82a1293bf18ec93712031287cfd1f47b87a1485"
+    sha256 cellar: :any,                 arm64_ventura: "a81c95f5df8b30e807cb3cede449f4ee754030bcec42de95fa0d9f9a6f9ac44c"
+    sha256 cellar: :any,                 sonoma:        "7aa1f8c7bd0943c6f82eef19769b53a66cbbff438b77470ed65171a6049eff92"
+    sha256 cellar: :any,                 ventura:       "5a467d971bcab4cf579174ff2902ea9e575641abea67fe4c46b6568f2e62ae88"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "866c06d3a807b2991106d9c073e21fae989ce3b04581e54cc47651855c181b3d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2ed4e648d088ed03ad1be758b1f95aa19aded2317a13df37e57e7e4eedfb1614"
   end
 
   depends_on "rust" => :build

--- a/Formula/c/cloudsplaining.rb
+++ b/Formula/c/cloudsplaining.rb
@@ -142,7 +142,8 @@ class Cloudsplaining < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"cloudsplaining", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"cloudsplaining", shells:
+                                         [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/c/cloudsplaining.rb
+++ b/Formula/c/cloudsplaining.rb
@@ -10,13 +10,14 @@ class Cloudsplaining < Formula
   head "https://github.com/salesforce/cloudsplaining.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "144f6f91e93f43e5e9bc34e4b179e33fe3c6cc1088d9031921613e15e7ea60d4"
-    sha256 cellar: :any,                 arm64_sonoma:  "3b446b4905d74a0cb5f8f705e650e499b082b609e56a84f00b1e820c9ca57a86"
-    sha256 cellar: :any,                 arm64_ventura: "f315208139d57b28330489129f70ee12f4793c35ebf24427100bf3d7083c01d2"
-    sha256 cellar: :any,                 sonoma:        "5a844fde80ad27f5296472e0de86aa5fbdd54c1a0ec270bb649ca674833676a9"
-    sha256 cellar: :any,                 ventura:       "28d06d2663397c0a4becfcb430be77ba9658a1ad75f130a9618b4585d9b22eb2"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "e9900e0fd5ec7a7ae9ddb9a73d6dfc3979b3462d8634a954517c23d65a5c127b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "6763af972ac92a37d2aa14fff32edd408e775e804b7e794521cf08b67c9e9a69"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "48b4acede5eb5b4f635b1a506dbcbf9698a7247993656e1633ab64b71a3d96b2"
+    sha256 cellar: :any,                 arm64_sonoma:  "8ddf6f257babd0a4d65a796fe10a9163b80a221612ffaf19db32ce251c83ac97"
+    sha256 cellar: :any,                 arm64_ventura: "0fa574e4ad463dadd904e1e628207171bba6ad0524b9ea2ce2cf71f026cbf5d8"
+    sha256 cellar: :any,                 sonoma:        "cda069559fb8b000312d48023a2b0712f1a9034d1d1490605ce64638d2eb05b8"
+    sha256 cellar: :any,                 ventura:       "b90b887ea3286d3993ddb2b970719338b0d695281bf0af18041bd07c925d6253"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "359c22a44ec43cf008ef07a7e6b1a18bab9da6f3d4bc8e770c40da22b873c194"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f2dd728d1aa2204e5ad596eb6a1e33deb937bf59a55763e37d7ca2b062043135"
   end
 
   depends_on "rust" => :build # for orjson


### PR DESCRIPTION
### Description

CI is taking way too long for https://github.com/Homebrew/homebrew-core/pull/229665 so I'm splitting up the PR into chunks of 5 files.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

