### PR TITLE
Enable Bash completions for formulae using `:click` (4/18)

### DIFF
--- a/Formula/c/cobo-cli.rb
+++ b/Formula/c/cobo-cli.rb
@@ -183,7 +183,7 @@ class CoboCli < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"cobo", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"cobo", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/c/cobo-cli.rb
+++ b/Formula/c/cobo-cli.rb
@@ -9,13 +9,14 @@ class CoboCli < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "5d71e97d045b3ff66d8f3d76d9b3cdf80249c5f73bd38670da1a3dc35f7b2b97"
-    sha256 cellar: :any,                 arm64_sonoma:  "af1cf59147a884f17ff75a4879d9101e048ffb8c5912ef8bc459d703241032e3"
-    sha256 cellar: :any,                 arm64_ventura: "0aad1f706006f77cedf8ca699c046473a01e4c0a3b9f36a4289797871e9909f8"
-    sha256 cellar: :any,                 sonoma:        "d1e93f0c3c935a7f919f134260c97b61cc45b1f7133aa71b11c57aeb7a5ad15d"
-    sha256 cellar: :any,                 ventura:       "980768c4b191eefa89282f595560c8a704daceb795b745b45fa9e0005524d149"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "067da74d73c9eb25ea35c89e92bdef7957116df1eee7374cd63ba99e649e770d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f6c822eb111fb809ff649f1fda461b03a2fe678cb8b38356aa1bf10ba720fbee"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "7d3d9738eea4c343dc9d72e56cdfad3728cd9fb9ed65049f8ff6d742b1b370b7"
+    sha256 cellar: :any,                 arm64_sonoma:  "05703fa9d04ca938bc65178424b14cc61b9965381d7018747b530311bf905d19"
+    sha256 cellar: :any,                 arm64_ventura: "351b4ab2961a9dff678cef69118703c1d8bc249044f5a46ff21d372e4a11b3f2"
+    sha256 cellar: :any,                 sonoma:        "64e4ca4c8f4e87610f586bb515932c79fb445fe647fc35c4f4f1883b6089e385"
+    sha256 cellar: :any,                 ventura:       "35dacbdf50618e2bb63ae9e934fc67869fbef45b82c80bffa21c86ca698f2588"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "9c4302b4b048a93b2ce658fc5f1cec2ee623da4dbe3a01445525f229ecd4b407"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "de8e9fd6fa00e1ccdeb3b768dfc5e6f7e0288e0036e1cc56c28fec7297d2f18f"
   end
 
   depends_on "certifi"

--- a/Formula/c/codecov-cli.rb
+++ b/Formula/c/codecov-cli.rb
@@ -83,7 +83,8 @@ class CodecovCli < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"codecovcli", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"codecovcli",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/c/codecov-cli.rb
+++ b/Formula/c/codecov-cli.rb
@@ -12,13 +12,14 @@ class CodecovCli < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "ec5fafb332973aa8663135efabd0d6091e9293faa713635ea4c5d850d4938bab"
-    sha256 cellar: :any,                 arm64_sonoma:  "c5f5670939d0b311cbc377dc8b953ffc02847d3bc1d69140f7a66a6aeff50415"
-    sha256 cellar: :any,                 arm64_ventura: "037551e31a523c03eb00779d6894bc1ce53c5a0702966903792c7832d4519a25"
-    sha256 cellar: :any,                 sonoma:        "9598ff14e6f0b89c651d1c6a2c25738ad07983ea20a9b8228a5b9ec6f3195e6e"
-    sha256 cellar: :any,                 ventura:       "cf57b5b73b4e64a01ee1c07531d3b5928e0ab118326fac7050806f41a9d98504"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "a9bfd2caec063ad05d8b405dbb5f61dc93f0d8012e548e0d62e7da3dffea90d8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "45124a3898a9ff63ecf1e7919fd2ef88ea9b122a4e32d1262406cd8e2a509021"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "69cb375432f5d70ddfd35b3a33357bbb07aed9bfaff936309718cf037605580a"
+    sha256 cellar: :any,                 arm64_sonoma:  "97b30c3f3b777638465c8efd14ae485c13c76db3b494fbc202b31cf67005de4f"
+    sha256 cellar: :any,                 arm64_ventura: "d9897494904364c692b2083c279e66e814a2273261de3d82a9471aaf6a0bfd3a"
+    sha256 cellar: :any,                 sonoma:        "54d0d6a2172813aed8d3783f16edcaae938e6a2c335a744b7202fc06d8f180e5"
+    sha256 cellar: :any,                 ventura:       "db40ba9e4816086618c175a6b03f571a6de22896b741f97fe200234f044d82d8"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "366181c9294dc966b4734ee2093a7c6f4f2fbfde9b2756dbecc5814296049ead"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "6cfcb05e3a81f7fc39548dc3b6a2b879e97aee8acf4ee60ccad52e9a4aed86b5"
   end
 
   depends_on "rust" => :build

--- a/Formula/c/compiledb.rb
+++ b/Formula/c/compiledb.rb
@@ -27,7 +27,8 @@ class Compiledb < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"compiledb", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"compiledb",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/c/compiledb.rb
+++ b/Formula/c/compiledb.rb
@@ -9,7 +9,8 @@ class Compiledb < Formula
   head "https://github.com/nickdiego/compiledb.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "e1ba5487728c29b4d7c4c01a7d359a6d7b6879986bb58d9d1798b98a233fbde7"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "a2760dac28a0aa58128feab53e6f51e631f1b7918560cc8772f883b095875143"
   end
 
   depends_on "python@3.13"

--- a/Formula/c/conda-lock.rb
+++ b/Formula/c/conda-lock.rb
@@ -277,7 +277,8 @@ class CondaLock < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"conda-lock", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"conda-lock", shells:
+                                         [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/c/conda-lock.rb
+++ b/Formula/c/conda-lock.rb
@@ -8,13 +8,14 @@ class CondaLock < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "f51af4ce76132853cdbb636c977be2b581983a33cea5254c9caceff59440612f"
-    sha256 cellar: :any,                 arm64_sonoma:  "84cd572834730eaddc9d3eeef5a8151e83e27071e59d70314907d1ae77c86e8c"
-    sha256 cellar: :any,                 arm64_ventura: "4f08edb6a04dc4ce34a109a9b00c57d4f8dcc66e7b0da42338abc75121d59f38"
-    sha256 cellar: :any,                 sonoma:        "17783878da24e3a6febddc829de59b029d21b00b2cbaf617ff238c133186bcca"
-    sha256 cellar: :any,                 ventura:       "086e861abc20a1711655a59efd009bf11519234d8083b0bbfaad34ec03f860aa"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "b72e91b2c77c56fbd2ad338a50f6a55ddfa1c6fe1e8d85acd77626806fe2b6ed"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3824e0a777bc8937b64e0fbdae6141f47935bd2bb9cb6197c15a0c5f7923e8da"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "37265f1903242a301f3fb0429909edbac13654b107c48a27d2c560fe52c3ebd7"
+    sha256 cellar: :any,                 arm64_sonoma:  "5a352901628e149038a11c83452bc58d778657791f345ccf8327e28c2ff740f6"
+    sha256 cellar: :any,                 arm64_ventura: "bd4af451c55ea058c1d7d6c307c2b89dc9ffce97663ca270229e6bbad4d16410"
+    sha256 cellar: :any,                 sonoma:        "1e1320c69f71bea11d8a1f891fd4c60b895e2b10def51bce86720ab3d979b230"
+    sha256 cellar: :any,                 ventura:       "d59f0202ca8418a5bd9d97b8ce7fe5fb22e2e800b6779096462cfa17cd3e73f9"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "7ea76044966108253d7226769064ef0af4b902243ebc2a5e3319c05035650a0b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "9e356f993822fd32bce9de0e051e49460e8ef9018f6198bf248adb1a4c207d0b"
   end
 
   depends_on "rust" => :build # for pydantic

--- a/Formula/c/cookiecutter.rb
+++ b/Formula/c/cookiecutter.rb
@@ -126,7 +126,8 @@ class Cookiecutter < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"cookiecutter", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"cookiecutter",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/c/cookiecutter.rb
+++ b/Formula/c/cookiecutter.rb
@@ -10,13 +10,14 @@ class Cookiecutter < Formula
   head "https://github.com/cookiecutter/cookiecutter.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "06963169eb643901ab0e140039c830b64de47f6be4c18c89c6c0d01df315f824"
-    sha256 cellar: :any,                 arm64_sonoma:  "669caeb267246e0eaf688acecfffb92f30a513cd00bcc0ff989cca32e8cf7816"
-    sha256 cellar: :any,                 arm64_ventura: "16af8d1afe921ce35f9a5dbb85123790d3f57a868618e09f1a85f80b692c73ce"
-    sha256 cellar: :any,                 sonoma:        "3e255d74d461b7f9b6ff97af52b0dc999521ddc51e6cb2fc309e2870f32780d3"
-    sha256 cellar: :any,                 ventura:       "7ba35d5f466876fd97b00f8c9c56507cfc71409988fe14d66e6b1e2d993e6ba1"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "c8f81c293daf78e00e243f97a90b82128d38e7cafbde8d2011962c1c3c831dc1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "56b1aa874da1cb6bee10b64fe043f3886fc9b9f0c137607f2665b365957bf422"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "be87c6e23c5feba86f0ccdabf62c38c9807e895d817a3c7cb4da8f02ad70bf09"
+    sha256 cellar: :any,                 arm64_sonoma:  "90a1804de2418db7dc3e495b51a63ab4c4f317ee3295f1b9db5a14ec3d4020c5"
+    sha256 cellar: :any,                 arm64_ventura: "d8c06a7b8879382099ba5ba4ce4ea115c9be3076b7d741844bc341ef7b09ff2d"
+    sha256 cellar: :any,                 sonoma:        "c504fb6fcbe4d6b10b71f0684bfb95910484b200bf4bb7417c8a41d6d8159e70"
+    sha256 cellar: :any,                 ventura:       "2d9caf06bda46b8e7dcf589bc6d7a99455c5c6786f41b0a9136ed7059b7d2ed4"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "ae6510978243d4488a2da666e8a58b00819c6fb2cbec763fbd854af0670402f1"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "65f980531acb36b45803dd286ba0c581fe6f98124ca7d30380b0b7cebcd7216f"
   end
 
   depends_on "certifi"


### PR DESCRIPTION
### Description

CI is taking way too long for https://github.com/Homebrew/homebrew-core/pull/229665 so I'm splitting up the PR into chunks of 5 files.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

