### PR TITLE
Enable Bash completions for formulae using `:click` (5/18)

### DIFF
--- a/Formula/d/datasette.rb
+++ b/Formula/d/datasette.rb
@@ -155,7 +155,8 @@ class Datasette < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"datasette", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"datasette",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/d/datasette.rb
+++ b/Formula/d/datasette.rb
@@ -9,13 +9,14 @@ class Datasette < Formula
   head "https://github.com/simonw/datasette.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "9f65f9736edf713f241072bca204d7e5723857dfb119c5c1266361815ed9b604"
-    sha256 cellar: :any,                 arm64_sonoma:  "03efc5c4fafe4358b3cf399e3d6d9d887d97307b87826739813eb5e168194894"
-    sha256 cellar: :any,                 arm64_ventura: "5de8c52f155dd5f33f7a1aff42942bac393a29876e326b3dca05c2437ec311df"
-    sha256 cellar: :any,                 sonoma:        "9e0c935cab57607f2454dea1ca0718d12dc46eca93f0089c5f6c3de5ef40b911"
-    sha256 cellar: :any,                 ventura:       "480a2aa22129db6b00bfdb54740cf35142938e7cf4a839913038ae541776d94a"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "234642d734a55112c10aaee4e372886055fbc529b793cbe406c13785f4f092bd"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "54d23ce2aeb1362d1cd9d3fc7ccf0993d191adf9978ebe13452c7ab3370f8e1a"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "6ac6f324e544be531f3483798a79c889c9040acbfe486e2b6e7602707cde10d3"
+    sha256 cellar: :any,                 arm64_sonoma:  "c7fd8155d2ff8e98e9b75537508dafc00b3dd8a4db66b46bc40968d6e5d49c70"
+    sha256 cellar: :any,                 arm64_ventura: "1999b4bdbbfa0c0ca2c3d641b19f86ee3e3e21f3a199a4905f36d987f828b68d"
+    sha256 cellar: :any,                 sonoma:        "97aba1a9945c656497a1ac717794589b4b11109a4d69677c3cc31c3c0432d437"
+    sha256 cellar: :any,                 ventura:       "65ae7f93604692762b575c8253835e4e8434929c0b46dc27ff759428ccafd4f5"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "1d0d3675b3bd805561839fb882d783ff6f3f296aa4165bed8517c3cfde25fb1d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2abce07039f63cba49ba6cdc0189b88f7ca11f4048d9f45d68c34f0f71898b6a"
   end
 
   depends_on "certifi"

--- a/Formula/d/djlint.rb
+++ b/Formula/d/djlint.rb
@@ -80,7 +80,7 @@ class Djlint < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"djlint", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"djlint", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/d/djlint.rb
+++ b/Formula/d/djlint.rb
@@ -9,14 +9,14 @@ class Djlint < Formula
   head "https://github.com/djlint/djLint.git", branch: "master"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_sequoia: "ffffd50d9a981e616541d88a685b44ddd5fdb425873563681e3c0611775f48f7"
-    sha256 cellar: :any,                 arm64_sonoma:  "15f38fb5cc8c6d57101be9f42ddef52a9e8c82b23874dff59b2051c282656e11"
-    sha256 cellar: :any,                 arm64_ventura: "25d8dd0b2238eef47a3f7d9cde2ff99c5bac124bdae44855aba1ef11fd4f977b"
-    sha256 cellar: :any,                 sonoma:        "b6d24985a8a4d539ff7b2ce6f121eda24a96691ef42b5785714cd0394e9c7d9e"
-    sha256 cellar: :any,                 ventura:       "2f351016b97bf06731b52dfca66ae25fd7b2d8a95442bf70e0c011789dd63105"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "5ed4e4ed73c1cddad3648f66cd8c9e87bfc8aa9aefaccefb7528b4f200171f89"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "fa3b3445307399671cdda0fb78276dc88e33823b28c4db26a27ded1f8ff9e4e9"
+    rebuild 2
+    sha256 cellar: :any,                 arm64_sequoia: "428664b35299f18cab4b5f935e4f299816d99a514171f3b470a544f2323ed043"
+    sha256 cellar: :any,                 arm64_sonoma:  "590751835518d79ddbf02d69c49a145b2305802489396095a9f8061cd9e819fe"
+    sha256 cellar: :any,                 arm64_ventura: "d3133c1dab320a85397234a620707d1aad101afef96e3f3591e57589ad5f2dea"
+    sha256 cellar: :any,                 sonoma:        "af3c136ef8e467055510d4965fd746488627b195345316c64f110d9521811ccc"
+    sha256 cellar: :any,                 ventura:       "49527b926c72964984ef30031d4c65a45dc3d34e377f49e9d95f63421e77b437"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "f50ec98d0f4b0aae48abbc6583b97556a177ea2eee84dfe7487d41771900943c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8d854bb8952eca91091798ad4bd02235726aa0a0c1aca1eaf66adfae79b42640"
   end
 
   depends_on "libyaml"

--- a/Formula/d/dnsgen.rb
+++ b/Formula/d/dnsgen.rb
@@ -59,7 +59,7 @@ class Dnsgen < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"dnsgen", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"dnsgen", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/d/dnsgen.rb
+++ b/Formula/d/dnsgen.rb
@@ -10,7 +10,8 @@ class Dnsgen < Formula
   head "https://github.com/AlephNullSK/dnsgen.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "594d413181417c628e90dfbd438513d88eaad991d3bfd4e6ef686aea9669f4fe"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "cf225b6dec77f197304858d44ca2d7789028e55922da378d290ecb3b84e5df73"
   end
 
   depends_on "certifi"

--- a/Formula/d/dooit.rb
+++ b/Formula/d/dooit.rb
@@ -118,7 +118,7 @@ class Dooit < Formula
 
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"dooit", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"dooit", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/d/dooit.rb
+++ b/Formula/d/dooit.rb
@@ -9,13 +9,14 @@ class Dooit < Formula
   head "https://github.com/dooit-org/dooit.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "8047ea87fead5fee013e42473bfc468ecea6c4e92c5613e20fa351b6b6868102"
-    sha256 cellar: :any,                 arm64_sonoma:  "69ee89a2ac8de7643e8027db3c47c66cda323812f5cda655eb55a7b713489598"
-    sha256 cellar: :any,                 arm64_ventura: "193c34d754ee15a4c34ac70126513bc6728444fdae801f9faaf7124adfcb42c5"
-    sha256 cellar: :any,                 sonoma:        "9e6508f0952cebb70e33c1e52263a17ee86ace45614cd67983598f9eab5c0b72"
-    sha256 cellar: :any,                 ventura:       "4b0b6625df2341d618c5aa8f747fb50f383eeda34c6a9205d382038772b4f929"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "91e4c510fe23e24702bcec6b1bbeca2e9ad76f8fc20b8e567f9ae6c053d501df"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "bba39beee68ca9679573e86bea3528a63fa1efbf2f9106098d6674d7467d8c02"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "304427e9a2282b9f0f20460361fc8a567704642cb96dcc4df4ab0bf276cc8ca1"
+    sha256 cellar: :any,                 arm64_sonoma:  "3570249df6e4267ef9eec314dfa03f6a2a4f047805088d123c46b36a1c90c86a"
+    sha256 cellar: :any,                 arm64_ventura: "4d842a0c2b6f1c67e966befc3523f9c3abb7d63543de2f045955d5b3513a2e3a"
+    sha256 cellar: :any,                 sonoma:        "ec308eb160c648bb3d5eaac51a0c8b08e2c47c228ad57eb1a0e59dd631c4fefa"
+    sha256 cellar: :any,                 ventura:       "89ba2e2050a028006589868958bbde1287388c23e857fbef578dbaf3ee5effb2"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "41872511cccf3e87d764f8fbace0bd76ea1df49ecc3167b0fa2b7cb9be200749"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2192cd9d73cc81adb2918bd297af7f9a7d1dc49598dd94e775b02cfbd5477069"
   end
 
   depends_on "cmake" => :build

--- a/Formula/e/ecs-deploy.rb
+++ b/Formula/e/ecs-deploy.rb
@@ -87,7 +87,7 @@ class EcsDeploy < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"ecs", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"ecs", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/e/ecs-deploy.rb
+++ b/Formula/e/ecs-deploy.rb
@@ -8,7 +8,8 @@ class EcsDeploy < Formula
   license "BSD-3-Clause"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "637c520b46cdabb777fbf09da5a12ffe80dc71c88ba9db27da462a6bc11e2b68"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "7700ab664da8e9d5a8b6368cb3cddca0fcb28a9928ead83b8170a3730cd35601"
   end
 
   depends_on "certifi"


### PR DESCRIPTION
### Description

CI is taking way too long for https://github.com/Homebrew/homebrew-core/pull/229665 so I'm splitting up the PR into chunks of 5 files.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

