### PR TITLE
Enable Bash completions for formulae using `:click` (6/18)

### DIFF
--- a/Formula/e/euler-py.rb
+++ b/Formula/e/euler-py.rb
@@ -28,7 +28,7 @@ class EulerPy < Formula
     inreplace "requirements.txt", "click==4.0", "click"
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"euler", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"euler", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/e/euler-py.rb
+++ b/Formula/e/euler-py.rb
@@ -12,8 +12,8 @@ class EulerPy < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    rebuild 4
-    sha256 cellar: :any_skip_relocation, all: "f8eb151dc399181c54578565197ae582def2067d466150f7558c2f9746d886cd"
+    rebuild 5
+    sha256 cellar: :any_skip_relocation, all: "61c7da218aca560f86ce1aae136927319f9d48d07aae107e531c19d3e0350209"
   end
 
   depends_on "python@3.13"

--- a/Formula/e/evernote-backup.rb
+++ b/Formula/e/evernote-backup.rb
@@ -91,7 +91,8 @@ class EvernoteBackup < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"evernote-backup", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"evernote-backup",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/e/evernote-backup.rb
+++ b/Formula/e/evernote-backup.rb
@@ -11,13 +11,15 @@ class EvernoteBackup < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "7060917b0212fc5c5973287ee48ac45ca0eebcea78f76b5f001f5e40f078b78c"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "d672368149ed96daffbd216bb666d00226273d7d5e488504a19a13934f2e5084"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "2eb9f36dc86fdd93876b0086f7a20117b71f6391bc155a8998c7e99766031b47"
-    sha256 cellar: :any_skip_relocation, sonoma:        "4e775c13acf5894978f9078d754be052ee8fd2fb8d4520857bc266919167030e"
-    sha256 cellar: :any_skip_relocation, ventura:       "6f3124baa58fd60064dd9eca526b05d472ebb30f2ce7867d494e81c7b7b65f99"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "4ea886c7450874e65a8463a7c64d71cdcc00c151cd2c32c62ed6b57a5c5d43a3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "bb860c214d98a8d6561649c738533bd2c3841812d7f18baf0b16661029427c40"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "5516573e372818809c0f505eeb99fdebfc673a40b5740d9819a0def6c432c8e1"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "ec2b17250613406e1e86b86a30db2fb096988e13b04ecc59b8081cc925565a12"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "acc09d3d8a6f9c64f39e867a9ca41924542b052345edfecc1132266cc9350c18"
+    sha256 cellar: :any_skip_relocation, sequoia:       "9a9b855906d0055d09b6a0f3400173ffab60be8bfd89c1bd7eb407b134678c3d"
+    sha256 cellar: :any_skip_relocation, sonoma:        "e264b9089a95e9cf4ea2cf9422354ae480dc9894de0e9c1c631878ee02254c63"
+    sha256 cellar: :any_skip_relocation, ventura:       "2f50ec167567b5969f2f5dcf144fbc4620d3f8cb86bcab2e0b6441c3ac48f9d2"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "130cca0b9f6b743f96969187ff43f3144d22912425f79bd8dd0c02ae2c6f4246"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "80aef7476652cfb176c34cd7fd9ad27ee3ce482812cb3e80c5b0cc13b4bdc8a9"
   end
 
   depends_on "certifi"

--- a/Formula/f/fava.rb
+++ b/Formula/f/fava.rb
@@ -201,7 +201,7 @@ class Fava < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"fava", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"fava", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/f/fava.rb
+++ b/Formula/f/fava.rb
@@ -9,13 +9,14 @@ class Fava < Formula
   head "https://github.com/beancount/fava.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "2f476f54a34cbdc175720635fac1b5bf7cb7b517ab1d82853d6e4d488b499e31"
-    sha256 cellar: :any,                 arm64_sonoma:  "57ed91aaa2bc5e651ebbdf689e2dc8a6a8095063f4dab48b029b60f453310866"
-    sha256 cellar: :any,                 arm64_ventura: "6a3a2dd73765b4d6dd0e072c3805057163f3d06d5ed3ec82c7d458e343df39b0"
-    sha256 cellar: :any,                 sonoma:        "84ebc7b9713431d57ae1b8e0160e05e5d09bf741f8e15d1eb97e18482a04de40"
-    sha256 cellar: :any,                 ventura:       "b75bd504395c71aefd1f38d0d08d06c6077709df14e200f96c73a71f6f88d104"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "2d44b177eb8816f02f30fb2b937b229e51865b64cd5e8809299b5c5f1a22270a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "58eb851b48950cb92ef1f7bd9acabbc32f94cb7c4104ccf0536f550455c86967"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "3f96e838f49f355594f8cc6ce6f29423a9c9a951c18d0f174e022505f576d061"
+    sha256 cellar: :any,                 arm64_sonoma:  "f2635f273a5b1727d5b32ec589e962e2264da87cce37e5915353380703fc9046"
+    sha256 cellar: :any,                 arm64_ventura: "2d463d0487825947c7dbee3b4b5f98b52021c3bb951a994a167070febe1884db"
+    sha256 cellar: :any,                 sonoma:        "905cd56355176dc7cfb1364abeef6bd0a64db7cbba289b8d153d49fca69d25e2"
+    sha256 cellar: :any,                 ventura:       "415f126d469bc7f66663faec2ccd15d726e24acc1339dec7933317a9e2508cf2"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "e5d3aec670cd1ded9e962f2d35309ee85d40a715e1d7d1c04ec369b04ffbca92"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "409416087f64160a238e0dcf3b78b122265c162c98d7be6103cc934f92c3f6a9"
   end
 
   depends_on "bison" => :build # for beancount

--- a/Formula/f/fiona.rb
+++ b/Formula/f/fiona.rb
@@ -47,7 +47,7 @@ class Fiona < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"fio", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"fio", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/f/fiona.rb
+++ b/Formula/f/fiona.rb
@@ -9,13 +9,14 @@ class Fiona < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "72cb09fe015aa6d5dbcc6a9dd639c641db2920f8e335a0a3acbd694ad255e83f"
-    sha256 cellar: :any,                 arm64_sonoma:  "7732fc049ef4ba6b47e790f9f14e621807fcb70f8f58f663e2d44513ca33380c"
-    sha256 cellar: :any,                 arm64_ventura: "765b472e5789020dc487ae96df3b55b111abb0ba4430e0e4e0f1f8fbc8a1c536"
-    sha256 cellar: :any,                 sonoma:        "3b0640448524a574978757a4c7c72bc7b361306f775ef946e35f8219e59154ce"
-    sha256 cellar: :any,                 ventura:       "6f4b27a8ce35aee27d824efba12de4d0114815c303e27bd9e4577c78bef725e7"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "fb6e42631c5db0154636fde816272135bf6e50e95fe4016c6c8e7c54c0b56ee0"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "ccb14cd8a348d6362e922e69e72785bc775726c9929da360dcca9919cc839c5e"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "00b95ac4bf7772eb38a49123a2bda485fabb21c0e1c92ba49fb4630ddf9f0a8c"
+    sha256 cellar: :any,                 arm64_sonoma:  "00eadb2d61339a282cff600a0b0914decfc4ae1cb53ac1d4546b40528811147c"
+    sha256 cellar: :any,                 arm64_ventura: "3887127436fd935145d865af7549a050e7ad7b1b307ea295b412060beef310f7"
+    sha256 cellar: :any,                 sonoma:        "2a2cf6a51c01bc67a4bc2e661d0e0c2e0ffe0b09bb8b661e4071d6dab6d613a6"
+    sha256 cellar: :any,                 ventura:       "f13fc2f8c11c0f918f2761725e7483cdd91948d21041fa51c15a73bb3182bf13"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "3a306357c631c92a7f61e46b0211ea0d910a6883e849edc8c400e0bb122a804d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "16820e10169e49e3787ff5c4507ce74a9fd95188d045fdd0173e00f4a08e9880"
   end
 
   depends_on "certifi"

--- a/Formula/f/flintrock.rb
+++ b/Formula/f/flintrock.rb
@@ -92,7 +92,8 @@ class Flintrock < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"flintrock", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"flintrock",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/f/flintrock.rb
+++ b/Formula/f/flintrock.rb
@@ -10,14 +10,14 @@ class Flintrock < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    rebuild 4
-    sha256 cellar: :any,                 arm64_sequoia: "a1211bc4ea1c062dfa95b3c14f6da61dcab02b1d6216e6687ef58b6680379089"
-    sha256 cellar: :any,                 arm64_sonoma:  "199ee4726b6a069ff33ccf5fb1650b74645d89c9fb42b16d85a89df361c33afe"
-    sha256 cellar: :any,                 arm64_ventura: "8e34466bfce9510389d673167e2b86430f034ff8f51c7a830af341f76fb7d54f"
-    sha256 cellar: :any,                 sonoma:        "53dd4e7e69bd54ca81bb968017244dbaa6b7179b065461c475050aeab2d8f3f9"
-    sha256 cellar: :any,                 ventura:       "97151962e88f570735fd2a02769f7d3bc6c1ef13ea5bd54643fb4ddeb71b00cb"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "1bdfc10132b27137d907e52dda03f03591389a8b9bea778cd54acef3b1adb874"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "48fe7af4aefa589974da8e5eab93f9a9c159aa16d701699930ddaad0a943a20a"
+    rebuild 5
+    sha256 cellar: :any,                 arm64_sequoia: "74a8a662dc4aee333db1b838cc7f62681b0d3a9fc6e8f8205e20d80d4c2527b1"
+    sha256 cellar: :any,                 arm64_sonoma:  "fe7ad09c56f48d70f3e01b5cd140bb549efbb9853d5563a646a7dd903fe6f59c"
+    sha256 cellar: :any,                 arm64_ventura: "6410fd282b7957ac56b1cfc1af125e719da2cf0abaf0910a3d2de375b17d2b34"
+    sha256 cellar: :any,                 sonoma:        "7cb921528a346d5644a3eabea2ae4e05acb08b03b9f30aa83075c925dbced21c"
+    sha256 cellar: :any,                 ventura:       "138d6d702cd47fb30d49fdb48058c740ac01accac3bb644cc040dbd6542556be"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "ab3e830362e5e1eb5f548506b5ad07f35aa30811715865c2eb084ff5d81b157e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8cb71305e97a64921e0676e6be13283a65e4ffe809bf62c1cc31b339396a8bd0"
   end
 
   depends_on "rust" => :build # for bcrypt


### PR DESCRIPTION
### Description

CI is taking way too long for https://github.com/Homebrew/homebrew-core/pull/229665 so I'm splitting up the PR into chunks of 5 files.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

