### PR TITLE
Enable Bash completions for formulae using `:click` (7/18)

### DIFF
--- a/Formula/f/fred.rb
+++ b/Formula/f/fred.rb
@@ -54,7 +54,7 @@ class Fred < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"fred", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"fred", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/f/fred.rb
+++ b/Formula/f/fred.rb
@@ -9,13 +9,15 @@ class Fred < Formula
   revision 3
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "5196561738312e479a8c55346ff7b2e62b67c3188920d5ec2e891758001de2e3"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "5196561738312e479a8c55346ff7b2e62b67c3188920d5ec2e891758001de2e3"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "5196561738312e479a8c55346ff7b2e62b67c3188920d5ec2e891758001de2e3"
-    sha256 cellar: :any_skip_relocation, sonoma:        "1359952e7fc17c1541a7e84499ea9188701efd79e38139a2ec4bdf54d16358c3"
-    sha256 cellar: :any_skip_relocation, ventura:       "1359952e7fc17c1541a7e84499ea9188701efd79e38139a2ec4bdf54d16358c3"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "5196561738312e479a8c55346ff7b2e62b67c3188920d5ec2e891758001de2e3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5196561738312e479a8c55346ff7b2e62b67c3188920d5ec2e891758001de2e3"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "bf7e2ff3527b70acf8ae9d3880f9f7272623f831e25453efee8100e4a6beeef5"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "bf7e2ff3527b70acf8ae9d3880f9f7272623f831e25453efee8100e4a6beeef5"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "bf7e2ff3527b70acf8ae9d3880f9f7272623f831e25453efee8100e4a6beeef5"
+    sha256 cellar: :any_skip_relocation, sequoia:       "b3be8042d767192bc4dcfc57dd74458506c4d0f8e2b6771eb11dec225893848b"
+    sha256 cellar: :any_skip_relocation, sonoma:        "b3be8042d767192bc4dcfc57dd74458506c4d0f8e2b6771eb11dec225893848b"
+    sha256 cellar: :any_skip_relocation, ventura:       "b3be8042d767192bc4dcfc57dd74458506c4d0f8e2b6771eb11dec225893848b"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "bf7e2ff3527b70acf8ae9d3880f9f7272623f831e25453efee8100e4a6beeef5"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "bf7e2ff3527b70acf8ae9d3880f9f7272623f831e25453efee8100e4a6beeef5"
   end
 
   depends_on "certifi"

--- a/Formula/g/ggshield.rb
+++ b/Formula/g/ggshield.rb
@@ -136,7 +136,7 @@ class Ggshield < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"ggshield", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"ggshield", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/g/ggshield.rb
+++ b/Formula/g/ggshield.rb
@@ -9,13 +9,14 @@ class Ggshield < Formula
   head "https://github.com/GitGuardian/ggshield.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "a3b14ebe680d12dfbdf93d815d43028f7dea61ba9051aedb458ce1a0f7d7154a"
-    sha256 cellar: :any,                 arm64_sonoma:  "a97c07112c7da3167c7bd773b313fd03f7c538222ce096c7e162ffe2869e0e54"
-    sha256 cellar: :any,                 arm64_ventura: "cd5770ea2717f3a51a20a44795f1f662c7260c723d456b65206c93c3270c1f2f"
-    sha256 cellar: :any,                 sonoma:        "6390b5b338e9ea9f8f543ac5397ff50ddc05826b2f6b62139aa09a734c60806d"
-    sha256 cellar: :any,                 ventura:       "b44691730fc92ee73f886ecd8d7648f5706cf33246c1cbfd3e1f63284b721651"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "5cc1932c5c259790df880f04ef4c99828d23b627facca134e2206f138607f5d4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1ff433ce33f50962571dcdf949fddc8d064f6200fbe148904dd9cbd155b0ff82"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "189c7fb26996b840aca21c43aed5c00c10683c8fae75b8124ea957649095ed1e"
+    sha256 cellar: :any,                 arm64_sonoma:  "aa906bf0b77457b24af1dd53490fea6adc3e3694ed01f9d97446eaf2eb4e467b"
+    sha256 cellar: :any,                 arm64_ventura: "8be25a5943f7e41a37410e9d8e9081da74610a4e6242035365545e28f0828833"
+    sha256 cellar: :any,                 sonoma:        "0b142f22601bf7a4c550d38b8c860cb4c8cedc2bb4f7c8785114435686e56593"
+    sha256 cellar: :any,                 ventura:       "89d17d595632345664e4c998dcf11fa526d415d2c424d07c734a934dfeb0fd94"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "f6ceb3a508813677fe821af78f07a0b1464603798d270e1a55567eddf3f36733"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "15b9587c6eb484c2333a2c461524ddbf54cb90b1b3b58ec84b8278480fc85ecd"
   end
 
   depends_on "certifi"

--- a/Formula/g/gitlint.rb
+++ b/Formula/g/gitlint.rb
@@ -50,7 +50,7 @@ class Gitlint < Formula
     virtualenv_install_with_resources
 
     # Click does not support bash version older than 4.4
-    generate_completions_from_executable(bin/"gitlint", shells:                 [:fish, :zsh],
+    generate_completions_from_executable(bin/"gitlint", shells:                 [:bash, :fish, :zsh],
                                                         shell_parameter_format: :click)
   end
 

--- a/Formula/g/gitlint.rb
+++ b/Formula/g/gitlint.rb
@@ -10,8 +10,8 @@ class Gitlint < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    rebuild 5
-    sha256 cellar: :any_skip_relocation, all: "7b347048bcc8bd14d3d1e1cb1ab96d19753c4ccf52c9b37f4fd1f353db79bfc0"
+    rebuild 6
+    sha256 cellar: :any_skip_relocation, all: "36439a03cc83049977c6ff628f75a76a33dd727ebbfc7f824f46329f6f880440"
   end
 
   depends_on "python@3.13"

--- a/Formula/g/goolabs.rb
+++ b/Formula/g/goolabs.rb
@@ -50,7 +50,7 @@ class Goolabs < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"goolabs", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"goolabs", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/g/goolabs.rb
+++ b/Formula/g/goolabs.rb
@@ -11,7 +11,8 @@ class Goolabs < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "b92fcd048d0f353a8ece560fad57fe26567ced4eced08fa560d36c18cc8be3bf"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "491259e4dd6b58ca77057c50f06bc133c6455da70a6851e1e32bb688dd1ed0e8"
   end
 
   depends_on "certifi"

--- a/Formula/g/gptme.rb
+++ b/Formula/g/gptme.rb
@@ -279,7 +279,7 @@ class Gptme < Formula
 
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"gptme", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"gptme", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/g/gptme.rb
+++ b/Formula/g/gptme.rb
@@ -10,13 +10,14 @@ class Gptme < Formula
   head "https://github.com/ErikBjare/gptme.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "a9cc31d5fbf414bac4a5f4f5871f175c1a05081380b26c3f394e82acada803c8"
-    sha256 cellar: :any,                 arm64_sonoma:  "027c933dcb66e14260f89b2c0f635b97a84bd4769c0887b7cdbbcbfe90203e0f"
-    sha256 cellar: :any,                 arm64_ventura: "bdea219c75ab7f7f6ca8d7a3a0d950b8a9297b76f8ad004e1b81c8cddec52eea"
-    sha256 cellar: :any,                 sonoma:        "e99d5e1e7e837b39b9d871eb09161e6372f66eac3d97ca05fbf6ca690c4ba385"
-    sha256 cellar: :any,                 ventura:       "b1d4771841989a53e27e62f346ad9b3391b71c18f5e12fda21ed3039bafc2111"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "c7b00248979eb3c367d2a0cf8c43cf715666a2fa5a7772af5436f6c8e8805cc7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f6be5e8de310ec0f6af97a98c18f6a069358291fcb619289e632a66a787d9c59"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "a0c6728a8e0bdf0e3174f356cfb05571e7e9d96f230b79b0906c15908273001c"
+    sha256 cellar: :any,                 arm64_sonoma:  "021fe908e6382c4325bb12b7204c257f7a420c1492a4190f28229b7194c16a8c"
+    sha256 cellar: :any,                 arm64_ventura: "d755f15f5fe7cbfdb7c868a1ab15f41fa4bbaab4be2200289edfc6a14c52d9b8"
+    sha256 cellar: :any,                 sonoma:        "2220c5dad0209c8d349533bad86a4c62ba7776ef073e72aba78fcdd05168c0c3"
+    sha256 cellar: :any,                 ventura:       "de10426374a40c0eec86026511d9ef7c5b3a58cb60b02570b6d409e3ba2ceebd"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "e4bc750e9608327aee86ce0a1c7d2b3be00dd48810ded4482bff8e58d4dba1d2"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "ba127e9a2e2c0ea3c6ca52e6979df5921bdff4b803ec5381a5291ed7129e5738"
   end
 
   depends_on "rust" => :build


### PR DESCRIPTION
### Description

CI is taking way too long for https://github.com/Homebrew/homebrew-core/pull/229665 so I'm splitting up the PR into chunks of 5 files.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

