### PR TITLE
Enable Bash completions for formulae using `:click` (8/18)

### DIFF
--- a/Formula/h/harlequin.rb
+++ b/Formula/h/harlequin.rb
@@ -229,7 +229,8 @@ class Harlequin < Formula
       venv.pip_install Pathname.pwd/"mysql-connector-python"
     end
 
-    generate_completions_from_executable(bin/"harlequin", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"harlequin",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/h/harlequin.rb
+++ b/Formula/h/harlequin.rb
@@ -11,13 +11,14 @@ class Harlequin < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "d388ca07a0405df9647b982b90f2019cb762b678cf392d4d5cc2314337c3e2fa"
-    sha256 cellar: :any,                 arm64_sonoma:  "191fe78c66db0bf1e00cfcf7dc1c6e9f4220b0ecf636dd0c33404846b0693f7d"
-    sha256 cellar: :any,                 arm64_ventura: "668d41903c0fe577bafaa9929a8b03ad12ddfe95b98b3add94bb5069a8d177df"
-    sha256 cellar: :any,                 sonoma:        "ffb0d5a1130ce055f42af9370ae8be15daab30a44c3570ec3be884b81d55162d"
-    sha256 cellar: :any,                 ventura:       "1efc6ff8a852c49e2b4fa8e04588df81295387c684a6d5b5ab98f2502416afa1"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "97bb2d74192231101a74f71fd95765df6a12dc62edffaf9727b7b73c01372b5d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "ba917eb9650e3f10c3266f5b707898ff948cf98497f1963f03f586b06092793c"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "01c5e9fe952509f9b96d0c4ba8c2ee281ff78468b8b2b592fdce56651668b4af"
+    sha256 cellar: :any,                 arm64_sonoma:  "b112a33bd6b243721fd6840ff708ade2b3d6d4e2243bbcf506afb0b9b8b2fd4c"
+    sha256 cellar: :any,                 arm64_ventura: "2ea06f29225b9e6b4704ce40745e7248e657f57f92a26c71d07a42e0a8498dcc"
+    sha256 cellar: :any,                 sonoma:        "dd8ad67c59e82c13cfcd47f52285510f58a6d4a5a672c00e36d0e7b52a965558"
+    sha256 cellar: :any,                 ventura:       "d17251ae7ccd8b439fee9752b0212f6cc8cb0d5bca60f1669c03c646ded3e6dd"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "5b4d97ceda03a65200fe247f823ab0a51df334fa4e7fa88afeebe96df5b08793"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "838bea24ca085fb4632d4c3dc626a2c111888eb08dd9174185cea4931bedb333"
   end
 
   depends_on "cmake" => :build

--- a/Formula/h/hatch.rb
+++ b/Formula/h/hatch.rb
@@ -196,7 +196,7 @@ class Hatch < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"hatch", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"hatch", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/h/hatch.rb
+++ b/Formula/h/hatch.rb
@@ -9,13 +9,14 @@ class Hatch < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "a4eda7fb30534534d4faae868ad401f83d4f42166f097d45e47ebc2a55a42483"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "bdf1828ac87e8a2e4f42f88d898383846e7bd85598090a962dd22ac2647dbcef"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "b06966c90c33a346877cfc84c09d51270fbb8c37e4f8df258dcb9e09e6d0eef6"
-    sha256 cellar: :any_skip_relocation, sonoma:        "a274928615946c8530317b3491b8ae65a0d9b699e75243801b0d9b5ebcf4b5d8"
-    sha256 cellar: :any_skip_relocation, ventura:       "425135d328dbcf49d264d243967a78267249439e547f00f02b7ab8402b1a4f1b"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "f98a7b38bad0e6482bff83ce27ae3396165fd86ddb129fbf8c4c823948ea8d62"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c4c3c96c76b37bc851bc07d14dedc6ce5339c21ec7293b9340dc92c08a2ddaa6"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "1616343ee1e1ba34f6fe6d76c91370b2ec328aea54e91c4a1c2685ad1c9d40d8"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "186d100dadf972e9c062d3405314b414815b6a601d3c79d87897e2f400a491a3"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "f944a2ca1f7232832c9ada1725f50e5711072455909afd789a30bee58b385b4a"
+    sha256 cellar: :any_skip_relocation, sonoma:        "8f497ac5e81d8ac7a54ab73db2ff3d0107722179b8fa8609835a8672a7adfe03"
+    sha256 cellar: :any_skip_relocation, ventura:       "dd94431380969e29f2df5b1e9cf57fdd53ffb8d2b6e4c28409f14395de5cdd91"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "30719e2bd30dd98726b48555e313c29795e30d921f3742e7e3321d061c76005d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8f15b9b561deaab503aca01b510845e54275420fd066c2813cbf0224dd36c3ca"
   end
 
   depends_on "certifi"

--- a/Formula/h/homeassistant-cli.rb
+++ b/Formula/h/homeassistant-cli.rb
@@ -176,7 +176,7 @@ class HomeassistantCli < Formula
 
   def install
     virtualenv_install_with_resources
-    generate_completions_from_executable(bin/"hass-cli", shells:                 [:fish, :zsh],
+    generate_completions_from_executable(bin/"hass-cli", shells:                 [:bash, :fish, :zsh],
                                                          shell_parameter_format: :click)
   end
 

--- a/Formula/h/homeassistant-cli.rb
+++ b/Formula/h/homeassistant-cli.rb
@@ -12,14 +12,15 @@ class HomeassistantCli < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "532fdbfa1fd0ab793db6f69f918e92c4cdc4ebc344ce9e6a8cfcc342b3430789"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "680fa2d3fc49e8d6e029b79ed3cac8f803b739469be57b6a60eb06787e6e887a"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "fc709b3119117842175d0145afe957a19a7174c287a3cc6e789ff93eee65fd7c"
-    sha256 cellar: :any_skip_relocation, sonoma:        "84d60b9d401a5c5543c13e6e5f384ac52c24b975418fb68de32168e5b368d1e2"
-    sha256 cellar: :any_skip_relocation, ventura:       "ab023c6d393385716e7621bdd16be0e00aee52a833da39cdb8d7c89265f018fd"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "f426b5be1589660625222a5f892433488b03ece7ccc4a23ae8bb3a0c9b5a33d4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c171bbc37cad686513e7bdef4d360b36adc25f87ecc4415ddff737e7a1d79dad"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "14097ae33fea2b0d77d5363e5f6ae93679d9bedb151904e44b5142fc93ec397f"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "1cee8de39515ba9f20532f1087b0306d86a6ce1b7c7be88238eb8b8dcca8fa3b"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "837a0a83085ca60fe4cd87450a3bee0d7358e73a61aca65323ea719f8eea1899"
+    sha256 cellar: :any_skip_relocation, sequoia:       "db6a25db6cd469930d3de33aca9b1bf6eef3c7b32c97afe2d50323e3f3579c2f"
+    sha256 cellar: :any_skip_relocation, sonoma:        "f860f0751af5e27ead4cea58aa8ade9df19a01f2a1329f95e8d641ee8f1de8d6"
+    sha256 cellar: :any_skip_relocation, ventura:       "fdfe44c2d48970dc85a6eb09e850fb97267bbda675ce899040d67a2dc8f958bd"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "59171904c78d5bea8fac7d0a51c1004de37d43b06a715f04132edc15ee0d9bd6"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "376cfba4260399d338367c5e6997b692f6d98881b396ad5ec4fe340de8aebc58"
   end
 
   depends_on "python@3.13"

--- a/Formula/h/http-prompt.rb
+++ b/Formula/h/http-prompt.rb
@@ -134,7 +134,8 @@ class HttpPrompt < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"http-prompt", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"http-prompt",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/h/http-prompt.rb
+++ b/Formula/h/http-prompt.rb
@@ -12,14 +12,14 @@ class HttpPrompt < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_sequoia: "c0b2dc82f155e842743d8a7cafc07312b5697217e18655984273bc767ff19a34"
-    sha256 cellar: :any,                 arm64_sonoma:  "f03dca9d3ef4c36f3d209874fec2cfb66bd6013ff6ac106bb5f06427cbd4c824"
-    sha256 cellar: :any,                 arm64_ventura: "9086c810cca4816d80cf3a4f00b8374292819cb3556039cebec5ae3a9afc2512"
-    sha256 cellar: :any,                 sonoma:        "4636f2c190078b9de80f5f09c9e74be000c40586e5ca238c420a5682e417be4e"
-    sha256 cellar: :any,                 ventura:       "e57f064c6c45ae60b9800b9f4f76181aef2ce0be6c9a835ed6788fb0c5019162"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "81ce6c610d84f132cb8c97261f001249445180c22708c3599e83f349b36ac23f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "77b18c458944383ba9ae6b45f40cb5a788482fcf8770224830194e95f4b530b1"
+    rebuild 2
+    sha256 cellar: :any,                 arm64_sequoia: "8fb96b2aaf910e390ac7e12f7268f8679311a7782648ddcb066322eccfa43ef5"
+    sha256 cellar: :any,                 arm64_sonoma:  "ad2764c7662bfbc1f34e93161f87981ad2ff41166f75b9c244704d9bb7598264"
+    sha256 cellar: :any,                 arm64_ventura: "0532a8228129394bf13ee6f053858ffd7954404bd53dbb5b7da5da0274f10a6a"
+    sha256 cellar: :any,                 sonoma:        "dacf348561198beea4d248bd7a9d816a30399f707d08ec4fec8342db6fc05f28"
+    sha256 cellar: :any,                 ventura:       "9e0a279b469685fc81daaaa65b61b25d0869e797fc161972152529a585260b5b"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "64128e8649f032b5515f1692641730b1a18b01c8f8526e7ec7f71df02ca2fb6b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "16bd9aa4d0b7cbaa76f7a09fd2ab89e5d5d61aa7529175ac213e592a1d8d1970"
   end
 
   depends_on "certifi"

--- a/Formula/i/iredis.rb
+++ b/Formula/i/iredis.rb
@@ -73,7 +73,7 @@ class Iredis < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"iredis", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"iredis", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/i/iredis.rb
+++ b/Formula/i/iredis.rb
@@ -10,7 +10,8 @@ class Iredis < Formula
   head "https://github.com/laixintao/iredis.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "66c959d579adce97b5933c6972665a554d57016979fbd00aa35624c211470c94"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "787e1911a7620858ce774d1b236e28cb08f4e1d17ded0aa41d3678a3e6a40baa"
   end
 
   depends_on "python@3.13"


### PR DESCRIPTION
### Description

CI is taking way too long for https://github.com/Homebrew/homebrew-core/pull/229665 so I'm splitting up the PR into chunks of 5 files.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

