### PR TITLE
Enable Bash completions for formulae using `:click` (9/18)

### DIFF
--- a/Formula/k/khal.rb
+++ b/Formula/k/khal.rb
@@ -89,7 +89,7 @@ class Khal < Formula
     virtualenv_install_with_resources
 
     %w[khal ikhal].each do |cmd|
-      generate_completions_from_executable(bin/cmd, shells: [:fish, :zsh], shell_parameter_format: :click)
+      generate_completions_from_executable(bin/cmd, shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
     end
   end
 

--- a/Formula/k/khal.rb
+++ b/Formula/k/khal.rb
@@ -9,13 +9,15 @@ class Khal < Formula
   head "https://github.com/pimutils/khal.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "18cf8d3d72969bf1da0e4cb64248f66a0438b0ebacf7e4254bd987191639cfee"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "18cf8d3d72969bf1da0e4cb64248f66a0438b0ebacf7e4254bd987191639cfee"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "18cf8d3d72969bf1da0e4cb64248f66a0438b0ebacf7e4254bd987191639cfee"
-    sha256 cellar: :any_skip_relocation, sonoma:        "d78b0935110727286c3a7cbb62f0bda1ebaa0c8290b8f14ac4494a8f2427bfb8"
-    sha256 cellar: :any_skip_relocation, ventura:       "d78b0935110727286c3a7cbb62f0bda1ebaa0c8290b8f14ac4494a8f2427bfb8"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "18cf8d3d72969bf1da0e4cb64248f66a0438b0ebacf7e4254bd987191639cfee"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "18cf8d3d72969bf1da0e4cb64248f66a0438b0ebacf7e4254bd987191639cfee"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "722a6edbaa805ad50bea276867c5b99c059c35533e3b8ec904d06b482cbe9808"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "722a6edbaa805ad50bea276867c5b99c059c35533e3b8ec904d06b482cbe9808"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "722a6edbaa805ad50bea276867c5b99c059c35533e3b8ec904d06b482cbe9808"
+    sha256 cellar: :any_skip_relocation, sequoia:       "68b25a1c8229009db588f27dfff8bdf3498af5b2638be59c3fd3ca2d1e5d3607"
+    sha256 cellar: :any_skip_relocation, sonoma:        "68b25a1c8229009db588f27dfff8bdf3498af5b2638be59c3fd3ca2d1e5d3607"
+    sha256 cellar: :any_skip_relocation, ventura:       "68b25a1c8229009db588f27dfff8bdf3498af5b2638be59c3fd3ca2d1e5d3607"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "722a6edbaa805ad50bea276867c5b99c059c35533e3b8ec904d06b482cbe9808"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "722a6edbaa805ad50bea276867c5b99c059c35533e3b8ec904d06b482cbe9808"
   end
 
   depends_on "python@3.13"

--- a/Formula/l/langgraph-cli.rb
+++ b/Formula/l/langgraph-cli.rb
@@ -73,7 +73,8 @@ class LanggraphCli < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"langgraph", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"langgraph",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/l/langgraph-cli.rb
+++ b/Formula/l/langgraph-cli.rb
@@ -8,13 +8,14 @@ class LanggraphCli < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "ec94b2c43b7d856cce1628a10de396fbae974533c3cb0497bd20395c3f8c6472"
-    sha256 cellar: :any,                 arm64_sonoma:  "3e50f46f5a398cbb3a6b865df1138020e6b712cc01868d8ee03bcae797186f97"
-    sha256 cellar: :any,                 arm64_ventura: "08a63c00d66d15f11a209dc31590d350433243aaa14c5b0320b44e5c028d944a"
-    sha256 cellar: :any,                 sonoma:        "50703849f2a9510196fd6da7a882ca17d1633d98177034d8bf6d76700dbac4a8"
-    sha256 cellar: :any,                 ventura:       "4e3261426855219d406f8c25fb8047598fe426c58ea33cd3933ae664445c4c8b"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "6ebde5934b9ba0fbc575ca6d4e8607899ce22a221341e67b8b27255c180ead5e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "915dc1aff2721b3e76b5137de7dc9788618294231d04210435534916495c3e12"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "0775cae834985eb80c60829314e987ab1a27757efd98348aa29d6ceaf5006b6b"
+    sha256 cellar: :any,                 arm64_sonoma:  "312b74ad155ec0981948cb51adbcff1efafa0ab8d0f37a8f8bfe7e6ead1ec89a"
+    sha256 cellar: :any,                 arm64_ventura: "944040abd612ddbfd7f622c4924dae43c2055247390d81541f205549352ad4fb"
+    sha256 cellar: :any,                 sonoma:        "92c153bf2723fbe68abb554e3e80935f7178eb55d9201ff2ebcb13fc3cfb5957"
+    sha256 cellar: :any,                 ventura:       "4a6f3bd7259ab263673490d30e354835fedf5ba3ac5d5d8890cf41e44ff1d247"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "9f5e4e68f5a5914e51a4e97b1b947056da90a81efe3fc22348fe5fd7005fe00a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "86a07cfe64df3e6f2b73b369810ccb658d6980adf55f97a6df16774799120d0d"
   end
 
   depends_on "rust" => :build # for orjson

--- a/Formula/l/litecli.rb
+++ b/Formula/l/litecli.rb
@@ -58,7 +58,7 @@ class Litecli < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"litecli", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"litecli", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/l/litecli.rb
+++ b/Formula/l/litecli.rb
@@ -8,7 +8,8 @@ class Litecli < Formula
   license "BSD-3-Clause"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "00e6275a871d0b4f4a923cd74de9ba4d04739c799d8ce75744408822089a09cc"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "baca9e5f10b5be9e8e93354e08bf44d163103531a2819d87fbce735b541d50ea"
   end
 
   depends_on "python@3.13"

--- a/Formula/l/llm.rb
+++ b/Formula/l/llm.rb
@@ -170,7 +170,7 @@ class Llm < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"llm", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"llm", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/l/llm.rb
+++ b/Formula/l/llm.rb
@@ -8,13 +8,14 @@ class Llm < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "ac4b66f3356702fe5fef8cc38f64875ce82be84e35a37608333472e9b8013290"
-    sha256 cellar: :any,                 arm64_sonoma:  "30a303861495064a48745b1d31018fe41f96a94533f84f758557d3563574fc7d"
-    sha256 cellar: :any,                 arm64_ventura: "23e714b5c04cb6a73b728550a305fea187df5bd4060c42a9b54bc90381014361"
-    sha256 cellar: :any,                 sonoma:        "524a88569c9c999bdee90744360172a13f0afc6d668191b1b877ec8449c73340"
-    sha256 cellar: :any,                 ventura:       "d367f45383530b2e1dd8a1bff5cfb11658a06b69b746375f94ec70f3bd5ba5e4"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "9c865d933360cb531e25f749034370b832ad47df5cbb1e7e30ca6f8c6dca2244"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d08b13b66285fb781744f78bc24be8561835c3dd24a9f9645d2b0b9dde8bba6c"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "e8eee3b28ce9d2cd848531592609e023b2e49034e7069dfea30f085dbcd6992e"
+    sha256 cellar: :any,                 arm64_sonoma:  "9a1f76ab4fffd8bf0267ae6ba25830989aabf01f74848fa757fc04d414a4c175"
+    sha256 cellar: :any,                 arm64_ventura: "cb158749f4f4994e998c14c096f5cbc519454ac74bfa3658ce1e50a3ea4b9884"
+    sha256 cellar: :any,                 sonoma:        "99d175f6563c39de29957ed2544bc61a74912ca44e48f7e22fdfe811e45dd5cf"
+    sha256 cellar: :any,                 ventura:       "a56e350faed6edbf4e540a65299c9b44dff80d29daf6b7dcd8768b46f834cf29"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "302ae19515d97457bbb78e61beaf751b69a451017e6d9524826a37b7088d2858"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "aae861700c61d5433be2b213373e300743e17ba9e7e383842acb1cc32cd19e7c"
   end
 
   depends_on "rust" => :build

--- a/Formula/l/localstack.rb
+++ b/Formula/l/localstack.rb
@@ -171,7 +171,8 @@ class Localstack < Formula
     virtualenv_install_with_resources
     bin.install_symlink libexec/"bin/localstack"
 
-    generate_completions_from_executable(bin/"localstack", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"localstack",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/l/localstack.rb
+++ b/Formula/l/localstack.rb
@@ -8,12 +8,13 @@ class Localstack < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "2ebb6ebffccf50f7c3d4ca5571281b5b9bfe7b60be5c65071876e13510123627"
-    sha256 cellar: :any,                 arm64_sonoma:  "ebf9780ea63d7ca24bd553009cd869a1dfb600ed2b9f41e42c861f94c4a63a76"
-    sha256 cellar: :any,                 arm64_ventura: "3468a4dc723271a6aadac2c27603f0f14d93fb25fe5d9d29b457ba0cadbff729"
-    sha256 cellar: :any,                 sonoma:        "90e44ff9e00ac9db9836bebe758c7d4d4bbdcce8e9b7459cc88f704a540fda7a"
-    sha256 cellar: :any,                 ventura:       "e3502ed67a5334da9dd11ece12d425bdd9d83f3cee4918d5e6444feba007b15f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b6f9583874e0c45e47cb08c3ba7fa4a7cbd63dcfbc579ceedf8b175858943c2a"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "96d8274971aa0e77d6ce48c25a30214128c2b5c605aebc8fd94a72c7e9d7d34e"
+    sha256 cellar: :any,                 arm64_sonoma:  "12406f79909234352ea070bfa75ccc674bf08d9d16b812e6cf9e944afee7369b"
+    sha256 cellar: :any,                 arm64_ventura: "a41617f5ec9071bebfdd82c18c621a0d2eb09f1114df58a5848aa2329e8dbc97"
+    sha256 cellar: :any,                 sonoma:        "8e37d3b061d82b364d47e173ea44b1026e21b37e36b4df22505c1c67aea11cbc"
+    sha256 cellar: :any,                 ventura:       "0f550c690fbe53419b327c6965beb859c5012b01878bd38e95b5a4a5fcf994dd"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2207b96b497e404df3b5f90a3d8da028dedaef58369fe5f6751707ca6c4c4cfa"
   end
 
   depends_on "docker" => :test


### PR DESCRIPTION
### Description

CI is taking way too long for https://github.com/Homebrew/homebrew-core/pull/229665 so I'm splitting up the PR into chunks of 5 files.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

