### PR TITLE
Enable Bash completions for formulae using `:click` (10/18)

### DIFF
--- a/Formula/m/manim.rb
+++ b/Formula/m/manim.rb
@@ -220,7 +220,7 @@ class Manim < Formula
     end
     virtualenv_install_with_resources(without:)
 
-    generate_completions_from_executable(bin/"manim", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"manim", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/m/manim.rb
+++ b/Formula/m/manim.rb
@@ -9,14 +9,14 @@ class Manim < Formula
   head "https://github.com/manimCommunity/manim.git", branch: "main"
 
   bottle do
-    rebuild 2
-    sha256 cellar: :any,                 arm64_sequoia: "052c82c53708a86c2ec03ac13d8c8504d524a34d3cdc648ef1a3a704d9b2b5ee"
-    sha256 cellar: :any,                 arm64_sonoma:  "4cb84e7b594cd5cf9a0d697167b2bd9f5c4d49b0558472fe9d2335bc6e8d9308"
-    sha256 cellar: :any,                 arm64_ventura: "fb89734574ccebed9b22a972b1c6b2289042fcfa33bf380005eadfa7058720f9"
-    sha256 cellar: :any,                 sonoma:        "8e2b70fa257adf0ecbe10c6c7024d14eb99f5a81cc0257ffddd1416069b5c64d"
-    sha256 cellar: :any,                 ventura:       "1868eb0cd025c10002c1c634185da4547a42264b07ace0e94728955efce39a74"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "4f282a4f41152c7b98c52066c949eb6e1098b21bd521b79b3d4e42ca24a84c1f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "cdae0c1a543f2f4b6b60b2952f441027b36c89d11e5c66b1a187304e99d3981d"
+    rebuild 3
+    sha256 cellar: :any,                 arm64_sequoia: "8c517c3d6e5def8042425feca0fc3c8d852add9dd46a0bd8d427cf3cac94a0bc"
+    sha256 cellar: :any,                 arm64_sonoma:  "4f8370db3e6065598e34cdac7adbaa2ec88e0412d27fd9f611da98e9d4d1ede4"
+    sha256 cellar: :any,                 arm64_ventura: "174f15caedad96eb8935b37d341b585ccfa9b23b3631c5b0dd0dfff821669415"
+    sha256 cellar: :any,                 sonoma:        "0a63a760d4168ca845b6ab46c4fb77cd9ec34875f7ff2918c045db346e71fb85"
+    sha256 cellar: :any,                 ventura:       "fcc74db970f3180f72b03fe9efa8d851d07a2dac5c563f9f6ca3e19ea9dbc098"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "95ebd1a635a7a0866d712e04b969ee7fd2530106141dfb1d7ba5c8cf463dabe9"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "cc102d405ebabc301afdd44e8167a51373db4b1e7ca898e8617a89d694deef46"
   end
 
   depends_on "cmake" => :build # for mapbox_earcut

--- a/Formula/m/meta-package-manager.rb
+++ b/Formula/m/meta-package-manager.rb
@@ -307,7 +307,7 @@ class MetaPackageManager < Formula
     rewrite_shebang detected_python_shebang, "meta_package_manager/bar_plugin.py"
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"mpm", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"mpm", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/m/meta-package-manager.rb
+++ b/Formula/m/meta-package-manager.rb
@@ -11,13 +11,14 @@ class MetaPackageManager < Formula
   head "https://github.com/kdeldycke/meta-package-manager.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "3b76194c131eec7f94c39eb56af545aca112f7a2abab10b190f2473d161f8716"
-    sha256 cellar: :any,                 arm64_sonoma:  "b8dd2d1ee0388db84b26a3b1ec2ea0d37eee72f5ce50ce2821d4c4a145fbec60"
-    sha256 cellar: :any,                 arm64_ventura: "3c09ac51da7a00f7b733440d9d7630226cf68a45d85ef8ba27aa371f2e76f565"
-    sha256 cellar: :any,                 sonoma:        "fb3b8eee8b71b57c7164d96c1efcf01df3fcd8d486a42839f3c64f5b9fcfd6e5"
-    sha256 cellar: :any,                 ventura:       "2c811dd3897778fb90dce7a74a6f31907bd945592a637b80a0bc55f9c45f4b09"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "55a2543423f626da0297a66a9cc64fec0f4e8c1faaa853a01e149136e6a33d86"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "bb0f47a483a944b6baab6f6f0c2c981217f5d73c627ca95330c67e7433196b43"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "c7d6894b523b75f457875745d3df9de5994a1e766e4e48f199c97f1b7f41823b"
+    sha256 cellar: :any,                 arm64_sonoma:  "03abd283ca4f5dd5cb27329af605c026acf2b4470c9d0b8b510e817353870d78"
+    sha256 cellar: :any,                 arm64_ventura: "45cbb8c2032a5222da277e95962a3fdcfcd7999df5e28a9598429da7b2ca80dc"
+    sha256 cellar: :any,                 sonoma:        "70cef6033bfa87bd9398d4e8f85b89ef45322d9409091ce7e5026cee4dede1f7"
+    sha256 cellar: :any,                 ventura:       "a1fae01b5cdb00aaf5049efbdc90a6e019207678ba07d09e859211bef36833cc"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "e565ffebd11a7dee8346c0aba1d4a25f094e0b6a196cc436a529cab0f390275d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "56da166000dcd6091fd4577a89c9d7d93fc31b068ba936ba572b4c9af41b480f"
   end
 
   depends_on "rust" => :build # for rpds-py

--- a/Formula/m/mkdocs.rb
+++ b/Formula/m/mkdocs.rb
@@ -102,7 +102,7 @@ class Mkdocs < Formula
     ENV["PIP_USE_PEP517"] = "1"
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"mkdocs", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"mkdocs", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/m/mkdocs.rb
+++ b/Formula/m/mkdocs.rb
@@ -9,13 +9,14 @@ class Mkdocs < Formula
   revision 2
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "8949d2400c8ac7907722453a9dd3eda5fb2fa59d108780cf39ec08c0e6f85839"
-    sha256 cellar: :any,                 arm64_sonoma:  "18027883a996c60ba30c512355f1191f6511012d10f923a823054ec84433d676"
-    sha256 cellar: :any,                 arm64_ventura: "da17c04e73e0303c652227c3430ff796ad56d4413ecf83dd70d56e726a32c50f"
-    sha256 cellar: :any,                 sonoma:        "4ea1fe98fa94007b603783f49613bbb2a78f17e1eef3ed25d4ba8bc7df058093"
-    sha256 cellar: :any,                 ventura:       "a971cd332ce793ad02a26af1c969939159312cae8e8912cade00bd3ed8ff82d5"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "3f5431f94afb48e3c3f075f972b4cbb6ce369a92025cc0c68bf8d56006f8f4aa"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "ef7464dc0f884425c657bd71d5f29700644c6c5ca4825a8bfdfe5daf5ca74481"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "eaef82a9ff0893388cef139c8f7e896f44965ffa29f0387a084ac16974c834ef"
+    sha256 cellar: :any,                 arm64_sonoma:  "1ea9d80905a53a911da2069c07b70f822793b83c4be26fc12e912c7923f64876"
+    sha256 cellar: :any,                 arm64_ventura: "58710b3d30c3225a67bf4d0e1ae908619262cbaa851ba45554c5b7aa0de2f4fb"
+    sha256 cellar: :any,                 sonoma:        "93c269be66a43dd03b228e7e8dc5f7aaa07ced98d6bbaf197d20c9e561e4adaf"
+    sha256 cellar: :any,                 ventura:       "e8c89409c15fa88129e01a3807bb9c422fd8aa96e4ceb0ab40b1fa317e5eb803"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "46b6cdfe3d81fd7c8ea2c0b9871501536a464c3bd92bce77701c0edf57a040a9"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "135c355cc67e825e8cf44f81807ded6cccbe0ef3be3aadfc28994ad99de206f8"
   end
 
   depends_on "libyaml"

--- a/Formula/m/molecule.rb
+++ b/Formula/m/molecule.rb
@@ -212,7 +212,7 @@ class Molecule < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"molecule", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"molecule", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/m/molecule.rb
+++ b/Formula/m/molecule.rb
@@ -8,13 +8,14 @@ class Molecule < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "dee9cc0b0372366e9b1aa05c3b06d3ac9bd9862f0f20f373cf699c03c23750bc"
-    sha256 cellar: :any,                 arm64_sonoma:  "8ccd642a426fbea119b7d5683a4fc5dcc4c6b09350a0c78b517c1daa73e21868"
-    sha256 cellar: :any,                 arm64_ventura: "5634c22d1157f0646c4fb929aeaf6e3464c7907caab4edb081d95ab7a7b43c50"
-    sha256 cellar: :any,                 sonoma:        "974e386a00ae15a0471e9f77b32216b99bf45c8dab6ac6b77c3491ccb6cca6b8"
-    sha256 cellar: :any,                 ventura:       "159421177661a054eaa4692041f5ab890286649def3c79f15bfb3addcdaf68a6"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "da476d38679d1a10cdd1e02dfa26cfca859053a211af193dc91deb396b67be4d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2fdb00206d7ab54bf3bb9d417233964f2ad58413dcbce06bc110d1df5e1cd65f"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "39f153787e6dac64ceefb305581b52b1a1da59dc6ae6758b372fab7b0ea6e85f"
+    sha256 cellar: :any,                 arm64_sonoma:  "0d041a37b9676b542ae4d33dbf4f6269a97a528766a98cd8ab102d66f56502fc"
+    sha256 cellar: :any,                 arm64_ventura: "512296f51e4b0ded3030d38f3d36034d63b0c5648a0b887e69865d81e56d2438"
+    sha256 cellar: :any,                 sonoma:        "87f5332f0af3ce4bf7612db0fd94eead0611283c9e73f12adde5001dcd6836c1"
+    sha256 cellar: :any,                 ventura:       "76d2bd773bfab6cf29c896e652296feb5d0342faafc2ed2a786bec4befaa11da"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "afed458203078ec46fec76fccf27620f00d6ae03df217290c668239641ccf3af"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "22de4cf6aed311a531c2d2125081130639367702517ca77dbe15928f28b05df2"
   end
 
   depends_on "rust" => :build

--- a/Formula/m/mvt.rb
+++ b/Formula/m/mvt.rb
@@ -216,7 +216,7 @@ class Mvt < Formula
     end
 
     %w[mvt-android mvt-ios].each do |script|
-      generate_completions_from_executable(bin/script, shells: [:fish, :zsh], shell_parameter_format: :click)
+      generate_completions_from_executable(bin/script, shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
     end
   end
 

--- a/Formula/m/mvt.rb
+++ b/Formula/m/mvt.rb
@@ -10,14 +10,14 @@ class Mvt < Formula
   head "https://github.com/mvt-project/mvt.git", branch: "main"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_sequoia: "955d527b38e1492b7ea6bf93a5fe35607a678a39d73d13fa8a3001b89cc0ec15"
-    sha256 cellar: :any,                 arm64_sonoma:  "9a64cce2e2128f6ff8ec9b2884399e5dd00a3787bf67cc7f04282978ffe804fa"
-    sha256 cellar: :any,                 arm64_ventura: "ff7bbd647c6630927871f3f416672b8ba9c8eb9d9c9467d6441881e996958248"
-    sha256 cellar: :any,                 sonoma:        "693eec1ac2e0126aaa89852b05fed1b11ad965e1f7b1a8b48f32d000fcdb914c"
-    sha256 cellar: :any,                 ventura:       "9b390df9e22f0f5e39e2bec416bcd02043970a8b75cc5415f9b96cec81ef897e"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "536ae993d9bffb9c8e79f251bbe7e129e92587a34ece23dfa2b2f171635dc718"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b6a96255c481d3c2337dd7987f8a2ebb373118ababb53b53af751273a4c8feb2"
+    rebuild 2
+    sha256 cellar: :any,                 arm64_sequoia: "019a921277efc60788a144d1c68580a98eeeee163b639e0e22f9534c885c72fe"
+    sha256 cellar: :any,                 arm64_sonoma:  "acabd46c127e6a382ce08fedf87518be8ed08ff9e3ce9366b5c82bd2dea98390"
+    sha256 cellar: :any,                 arm64_ventura: "4ce6858ec2368bb64e1e0e4f2cc18826ada7eec0504e5646bd580fa0a7bc5dd7"
+    sha256 cellar: :any,                 sonoma:        "d6b7e78cebd2e155aef747abb2a4e6e3199504b19226f1b4077d78c0501b0cee"
+    sha256 cellar: :any,                 ventura:       "b8848727d7299db1033a5617b885753a7b6aa0f592e204238df8faf66171818e"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "a3c06e9ef9020e4015a79ebf93ee622fdb8c39961702cb762766a8ed352f0809"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "61e7512075c70b3892f9c5407c957f4ec42f5220b7f4c38c6d8f646e8830c66f"
   end
 
   depends_on "rust" => :build # for pydantic_core


### PR DESCRIPTION
### Description

CI is taking way too long for https://github.com/Homebrew/homebrew-core/pull/229665 so I'm splitting up the PR into chunks of 5 files.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

