### PR TITLE
Enable Bash completions for formulae using `:click` (11/18)

### DIFF
--- a/Formula/m/mycli.rb
+++ b/Formula/m/mycli.rb
@@ -97,7 +97,7 @@ class Mycli < Formula
     virtualenv_install_with_resources
 
     # Click does not support bash version older than 4.4
-    generate_completions_from_executable(bin/"mycli", shells:                 [:fish, :zsh],
+    generate_completions_from_executable(bin/"mycli", shells:                 [:bash, :fish, :zsh],
                                                       shell_parameter_format: :click)
   end
 

--- a/Formula/m/mycli.rb
+++ b/Formula/m/mycli.rb
@@ -8,13 +8,14 @@ class Mycli < Formula
   license "BSD-3-Clause"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "0543476bd7027c82b041ee14ff4cc38afcd7598e863864a48d07248d129534ac"
-    sha256 cellar: :any,                 arm64_sonoma:  "05a19af9c96677dd4178b21b46a1a7182ac78e7fe92aa9488c8ec1e9ba0e2262"
-    sha256 cellar: :any,                 arm64_ventura: "ab74a1bb6b8cd6869ec91c928c399ad0c05b3640748b9501d635e2d5703a9696"
-    sha256 cellar: :any,                 sonoma:        "e9687f422281c13afd25db2729d601b0da9b57ee6b37202bf4a2dd2fad3afa96"
-    sha256 cellar: :any,                 ventura:       "81240732bbd51dedacba6ed3f802743280e695bf57f2e05e7c13117c1e19207a"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "2026e4475856cf7e748312ad77d3a32afe71a5e33aa39ebef4aab8ae3c58d008"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e617655e6f4ad6a132febe2bf1a044a497102af2a0c8d8be02b77ad164749ce9"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "12c1fba3a7f754a4e257fc254355f235619f7fa0e4643ae6530759411d3f555f"
+    sha256 cellar: :any,                 arm64_sonoma:  "27bb4bd1630452b6d13a9deddb2f4f73aec418a32ad946fb21ea3eb946b36d71"
+    sha256 cellar: :any,                 arm64_ventura: "a2a30a51d3457c7fb9156dcb36a6c0481d3690c9e8a63ea3644484505ff458c4"
+    sha256 cellar: :any,                 sonoma:        "a5d9752fc522049d982d7d25cfc6b8a0be3fab271bf498c3ea411f674b6192c5"
+    sha256 cellar: :any,                 ventura:       "f14e7581063b7baf6d40d63084a521ff7ea3382c6bba1f19b8520e23d3605cbb"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "505ea3f3fea1f3b10a2d38a31d71786b935fca2703a1f06fd73d83a3f9f1f202"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "23a553488dbed03fedc798d33ff2be9ad7f46a4f700278b3cf4e773a9c66d0ca"
   end
 
   depends_on "rust" => :build # for sqlglotrs

--- a/Formula/n/name-that-hash.rb
+++ b/Formula/n/name-that-hash.rb
@@ -47,7 +47,7 @@ class NameThatHash < Formula
     virtualenv_install_with_resources
 
     %w[name-that-hash nth].each do |cmd|
-      generate_completions_from_executable(bin/cmd, shells: [:fish, :zsh], shell_parameter_format: :click)
+      generate_completions_from_executable(bin/cmd, shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
     end
   end
 

--- a/Formula/n/name-that-hash.rb
+++ b/Formula/n/name-that-hash.rb
@@ -12,8 +12,8 @@ class NameThatHash < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    rebuild 4
-    sha256 cellar: :any_skip_relocation, all: "ebc63e1cd2a29eded2a1d8bd312f4df14882bd40e4e98f713e69aad521b47e0e"
+    rebuild 5
+    sha256 cellar: :any_skip_relocation, all: "cbfd105d0e71676df5a3a8e4b7e10ce0bf818c1043c2f101e04461ff19a0e75c"
   end
 
   depends_on "python@3.13"

--- a/Formula/n/notifiers.rb
+++ b/Formula/n/notifiers.rb
@@ -85,7 +85,8 @@ class Notifiers < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"notifiers", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"notifiers",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/n/notifiers.rb
+++ b/Formula/n/notifiers.rb
@@ -9,13 +9,14 @@ class Notifiers < Formula
   revision 2
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "0637bb3675b3356c37dce045581e65d2da9283ceb7c110417c1155a51835deb5"
-    sha256 cellar: :any,                 arm64_sonoma:  "dc7d48a5a4ed68a79c1283c7ca50f2ebb41db20873fbcff2bf912f2cde8866e4"
-    sha256 cellar: :any,                 arm64_ventura: "5965974db5b317abff2529cd8141ff788b9c5178f6b63359bf4a6af216ac3f0d"
-    sha256 cellar: :any,                 sonoma:        "0339f4b0978405a1f3e5e26728635fb553085906d8df21c52474996b80e9b12c"
-    sha256 cellar: :any,                 ventura:       "71c0d272547f189249a7d1403860ab965d39108ff4ada03ee256d777a8e2b192"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "b0d27dca6998ad4666103909c60ced1757347e8bdd1b63b2afa48decaa0860d2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "78c31bb847915cf426d38beec2f1585f229686c322d1bdd8ccafa646b8c7a399"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "03a4d55a52e0b9cd1652e49663dca00f3441e027ea5bd0a19c56ab8971bc8fec"
+    sha256 cellar: :any,                 arm64_sonoma:  "b5a47821d8ade65c156518e45316c3a918311b2f2623550a97dbaf7445e9b6b4"
+    sha256 cellar: :any,                 arm64_ventura: "b091fa5ef1add6aaecdcff15cfc62232c4ee281f76e97226ae2f59846b0f6d07"
+    sha256 cellar: :any,                 sonoma:        "5284cf90de776e21fbff97d38b1d0cefa0b3ada4164eb36dd0cf079ff709ad7a"
+    sha256 cellar: :any,                 ventura:       "06ad0cee96d5b1a3b07eb6cccd96e410613ada9579b2825c51b13abb98c2612e"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "c8f66db9e845994de0ddce6a44f485729034f2d43eb9b6d049ba96e4263f0369"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "9a7957576a6d2f9d2fdba6aac44a9353d20c72899f3724ebed0a630fbd78160c"
   end
 
   depends_on "rust" => :build # for rpds-py

--- a/Formula/o/okta-awscli.rb
+++ b/Formula/o/okta-awscli.rb
@@ -98,7 +98,8 @@ class OktaAwscli < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"okta-awscli", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"okta-awscli",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/o/okta-awscli.rb
+++ b/Formula/o/okta-awscli.rb
@@ -9,7 +9,8 @@ class OktaAwscli < Formula
   revision 5
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "d279e4c3b084f2de087c01d4b05af5da5cc14e52469440f35ae7d74abe676c09"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "f101cef261c7645ff4c9cdffe83eb63b340676488525309d018841ad0b5a2e6f"
   end
 
   depends_on "certifi"


### PR DESCRIPTION
### Description

CI is taking way too long for https://github.com/Homebrew/homebrew-core/pull/229665 so I'm splitting up the PR into chunks of 5 files.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

