### PR TITLE
Enable Bash completions for formulae using `:click` (12/18)

### DIFF
--- a/Formula/o/otterdog.rb
+++ b/Formula/o/otterdog.rb
@@ -13,14 +13,14 @@ class Otterdog < Formula
   no_autobump! because: "'playwright' resource lacks PyPI sdist"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_sequoia: "84d79bed0961e4f0f2eede331e9c32390d9cec05ce0ceaf38d78ed858867158e"
-    sha256 cellar: :any,                 arm64_sonoma:  "f915d0cc490b00c4ed710c01889a7d1f34de6a467cdea731d7e4e7d462a818ff"
-    sha256 cellar: :any,                 arm64_ventura: "8da686db7c21b074fe190b38e15dd6cdc0f30ab96dc64b2c6f80ac224b997116"
-    sha256 cellar: :any,                 sonoma:        "950ada3382ac033e7a4eb0ad88ff4daccb72b21e353f4498c47db4bf167828c3"
-    sha256 cellar: :any,                 ventura:       "48d1f981398abfe6d1d23d1c38033ad11377c683477835384960ced9d985b50b"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "0645288cdabce8066c01616d9d02fc703e761e13a5c3abb548daa3a3f9299096"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c446ba1de2cb9c88362542b6247cd04267c2527a8f2d66637876e3fa2c0ec31b"
+    rebuild 2
+    sha256 cellar: :any,                 arm64_sequoia: "00fc7ce8dba473d8ab103c1641fa2c74a98fb65c17a612a8d6460149392d9f2d"
+    sha256 cellar: :any,                 arm64_sonoma:  "b918dd7f1604ed38130412f107f3491a41a0034ad789e9e3592b43b477cadd02"
+    sha256 cellar: :any,                 arm64_ventura: "46942c098c10794f22b8a55a19695d158165a443887810be0075966d3ddad5d0"
+    sha256 cellar: :any,                 sonoma:        "5eb4d47d9138d5debbfc217084fd7bb4d7668ac17600bd46b97987338f5ac0ea"
+    sha256 cellar: :any,                 ventura:       "0bc913d6189aecbac439d44f87a95712897e5de3ee75401c350d200d73deb778"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "b004dfff8ac70f838bab597e26346e473aed64ad0e2e3896e70e934d5e359f33"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f90b0d5ababf9023615060faa94959ef0b6ddb45adbbfbd5eff889bb7ad56b70"
   end
 
   depends_on "rust" => :build

--- a/Formula/o/otterdog.rb
+++ b/Formula/o/otterdog.rb
@@ -265,7 +265,7 @@ class Otterdog < Formula
     ENV["SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PLAYWRIGHT"] = resource("playwright").version
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"otterdog", shell_parameter_format: :click, shells: [:bash, :zsh])
+    generate_completions_from_executable(bin/"otterdog", shell_parameter_format: :click, shells: [:bash, :fish, :zsh])
   end
 
   test do

--- a/Formula/p/pgcli.rb
+++ b/Formula/p/pgcli.rb
@@ -90,7 +90,7 @@ class Pgcli < Formula
       venv.pip_install Pathname.pwd
     end
 
-    generate_completions_from_executable(bin/"pgcli", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"pgcli", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/p/pgcli.rb
+++ b/Formula/p/pgcli.rb
@@ -8,13 +8,14 @@ class Pgcli < Formula
   license "BSD-3-Clause"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "c94fe9b94951859f7ae906c57baba733adf00dc5f1fcfff6323ad0342bb517a0"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "d7242c372c8216ae21576bcc4a446bbe3b41fbcbc5e2e20e3b7b82474541e416"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "aa6197e523dfa68d26564db1da6fc4d8db2185c4891cec5bd2f7f0a6d1e54b4b"
-    sha256 cellar: :any_skip_relocation, sonoma:        "0d5a3cbee22958f4352243b85b8b762c55404c26d8de4474656f9a2da5814a21"
-    sha256 cellar: :any_skip_relocation, ventura:       "393f05d8cf7191679029acba7ded5c126ef90e064cb9b8d3ed781693790fe766"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "e15814871dc8fc3a7e6ddd94a4ee0a79b8aed7b11aef6302eb59252a2ce80681"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "aa8fb9bf4416e8568cfbd768480ef55024d770204790d947732bed7ba606cac0"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "877e22be3881db1ca08eeabee4bf952db8ac5b9f995515e14fb4cf2c6408dee0"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "05d9ffa4d7c7d8068284e667785ef2fbaf0d605eddbbb3e537e1bddca79f51a6"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "2939f66c2fcb912457380138e14d0cf85fc2876a7052be0600f477ab783b3481"
+    sha256 cellar: :any_skip_relocation, sonoma:        "a1ac7dd2e1844848885bef57afa95d0cbdbde1267e3a86b4ab7e30aa70421939"
+    sha256 cellar: :any_skip_relocation, ventura:       "8385fb2aa81d5503bf6e55cb0d129c01cde7f5e0adc158771dd7d016f1067877"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "de6f2ef02cd683bcea9d8412b6b389a6d19175dcf50cc0591b2aed7652942d3a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "bceaecada660f63c5cae7c511a8729926300d539326a02e7e459c6e1792d3d10"
   end
 
   depends_on "libpq"

--- a/Formula/p/pip-tools.rb
+++ b/Formula/p/pip-tools.rb
@@ -54,7 +54,7 @@ class PipTools < Formula
     virtualenv_install_with_resources
 
     %w[pip-compile pip-sync].each do |script|
-      generate_completions_from_executable(bin/script, shells: [:fish, :zsh], shell_parameter_format: :click)
+      generate_completions_from_executable(bin/script, shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
     end
   end
 

--- a/Formula/p/pip-tools.rb
+++ b/Formula/p/pip-tools.rb
@@ -9,13 +9,14 @@ class PipTools < Formula
   revision 2
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "3b67bd26a51b9375d00adc4fefb23245614d6fe552657127ff4fb122d82b07d6"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "3b67bd26a51b9375d00adc4fefb23245614d6fe552657127ff4fb122d82b07d6"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "3b67bd26a51b9375d00adc4fefb23245614d6fe552657127ff4fb122d82b07d6"
-    sha256 cellar: :any_skip_relocation, sonoma:        "7ed28bd7faa82191f30794a7f8cdaca7a5de1a66276dba16d57df1bd72668c76"
-    sha256 cellar: :any_skip_relocation, ventura:       "7ed28bd7faa82191f30794a7f8cdaca7a5de1a66276dba16d57df1bd72668c76"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "94912844700a4572ab1860aa47d477a4511ce544a0a3112c872404c49a212ff5"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "94912844700a4572ab1860aa47d477a4511ce544a0a3112c872404c49a212ff5"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "7c7fed54e62cfbc96dd6be5d2945b311fe298c9db82be74f7e7d88adccd6129d"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "7c7fed54e62cfbc96dd6be5d2945b311fe298c9db82be74f7e7d88adccd6129d"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "7c7fed54e62cfbc96dd6be5d2945b311fe298c9db82be74f7e7d88adccd6129d"
+    sha256 cellar: :any_skip_relocation, sonoma:        "19edc3f84c1707dc758e90f7ce77427568a34667be1e3724113d2ba882b595a1"
+    sha256 cellar: :any_skip_relocation, ventura:       "19edc3f84c1707dc758e90f7ce77427568a34667be1e3724113d2ba882b595a1"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "4940efa159848f5b5bc1d2cfd52f5079f541aa93f4236e03248dc8d9950d1288"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4940efa159848f5b5bc1d2cfd52f5079f541aa93f4236e03248dc8d9950d1288"
   end
 
   depends_on "python@3.13"

--- a/Formula/p/pipenv.rb
+++ b/Formula/p/pipenv.rb
@@ -57,7 +57,7 @@ class Pipenv < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(libexec/"bin/pipenv", shells:                 [:fish, :zsh],
+    generate_completions_from_executable(libexec/"bin/pipenv", shells:                 [:bash, :fish, :zsh],
                                                                shell_parameter_format: :click)
   end
 

--- a/Formula/p/pipenv.rb
+++ b/Formula/p/pipenv.rb
@@ -8,13 +8,14 @@ class Pipenv < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "72ff8d73973d4503e73fb08b30a6c2f0ab6faf1bf9921e4f22245a538466367a"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "72ff8d73973d4503e73fb08b30a6c2f0ab6faf1bf9921e4f22245a538466367a"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "72ff8d73973d4503e73fb08b30a6c2f0ab6faf1bf9921e4f22245a538466367a"
-    sha256 cellar: :any_skip_relocation, sonoma:        "1bca7a6982a48f46a6b784a5008b6b63f56aa07cbd0d922f21e57016bd1e93ea"
-    sha256 cellar: :any_skip_relocation, ventura:       "1bca7a6982a48f46a6b784a5008b6b63f56aa07cbd0d922f21e57016bd1e93ea"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "a243113cfa8920a0ff33345449d6fdb5ed65c3dbc2160b38b1862ca5e83fd536"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a243113cfa8920a0ff33345449d6fdb5ed65c3dbc2160b38b1862ca5e83fd536"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "d893071d832157295d63f41328a99011754fa494cae1145dae161b0f6a134523"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "d893071d832157295d63f41328a99011754fa494cae1145dae161b0f6a134523"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "d893071d832157295d63f41328a99011754fa494cae1145dae161b0f6a134523"
+    sha256 cellar: :any_skip_relocation, sonoma:        "012d62423d083b855864de35e3493e7e0195cb560a1720b166d8db3b7302789e"
+    sha256 cellar: :any_skip_relocation, ventura:       "012d62423d083b855864de35e3493e7e0195cb560a1720b166d8db3b7302789e"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "0ed68be928dd68a2571a09ddac28d8eb376efd1fa246cae3f29be4a1658e6698"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0ed68be928dd68a2571a09ddac28d8eb376efd1fa246cae3f29be4a1658e6698"
   end
 
   depends_on "certifi"

--- a/Formula/p/pipgrip.rb
+++ b/Formula/p/pipgrip.rb
@@ -49,7 +49,7 @@ class Pipgrip < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"pipgrip", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"pipgrip", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/p/pipgrip.rb
+++ b/Formula/p/pipgrip.rb
@@ -10,13 +10,14 @@ class Pipgrip < Formula
   head "https://github.com/ddelange/pipgrip.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "0b1c975ed5fe8141c6f9506f356d40820124a48a3951e10102d1b17cebe9bb02"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "0b1c975ed5fe8141c6f9506f356d40820124a48a3951e10102d1b17cebe9bb02"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "0b1c975ed5fe8141c6f9506f356d40820124a48a3951e10102d1b17cebe9bb02"
-    sha256 cellar: :any_skip_relocation, sonoma:        "df739b4e578b45adc24206d24a1776d802d47f6f5d80b36988d8160a2d398873"
-    sha256 cellar: :any_skip_relocation, ventura:       "df739b4e578b45adc24206d24a1776d802d47f6f5d80b36988d8160a2d398873"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "2e4a7b5c88fc8f4dcac0b6e0c36283cf2e1802ec4116f92a5e536f421cd240aa"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2e4a7b5c88fc8f4dcac0b6e0c36283cf2e1802ec4116f92a5e536f421cd240aa"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "134399c082ecebcd84125952bdec73728d7f24cb4640fda90413923b7ed39615"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "134399c082ecebcd84125952bdec73728d7f24cb4640fda90413923b7ed39615"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "134399c082ecebcd84125952bdec73728d7f24cb4640fda90413923b7ed39615"
+    sha256 cellar: :any_skip_relocation, sonoma:        "478801aa3624f7d0e77401431e9e6a08c9730c13aa793c81dc790470eafbfadb"
+    sha256 cellar: :any_skip_relocation, ventura:       "478801aa3624f7d0e77401431e9e6a08c9730c13aa793c81dc790470eafbfadb"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "61880555907f5f1f3ca33558af7056e8788b32a6ed3e2ac5f4270805eb8980da"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "61880555907f5f1f3ca33558af7056e8788b32a6ed3e2ac5f4270805eb8980da"
   end
 
   depends_on "python@3.13"


### PR DESCRIPTION
### Description

CI is taking way too long for https://github.com/Homebrew/homebrew-core/pull/229665 so I'm splitting up the PR into chunks of 5 files.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

