### PR TITLE
Enable Bash completions for formulae using `:click` (13/18)

### DIFF
--- a/Formula/p/platformio.rb
+++ b/Formula/p/platformio.rb
@@ -124,7 +124,7 @@ class Platformio < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"pio", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"pio", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/p/platformio.rb
+++ b/Formula/p/platformio.rb
@@ -10,7 +10,8 @@ class Platformio < Formula
   head "https://github.com/platformio/platformio-core.git", branch: "develop"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "d3b937c46359883226dbd06ae3c955020120398448381c9ee957473efe3b8100"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "f4691b1cb65222c639f1bdfd2f86bb782e3d0dccfc0d6d6c34cdc660c3089721"
   end
 
   depends_on "certifi"

--- a/Formula/p/policy_sentry.rb
+++ b/Formula/p/policy_sentry.rb
@@ -82,7 +82,8 @@ class PolicySentry < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"policy_sentry", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"policy_sentry",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/p/policy_sentry.rb
+++ b/Formula/p/policy_sentry.rb
@@ -10,13 +10,14 @@ class PolicySentry < Formula
   head "https://github.com/salesforce/policy_sentry.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "c4bfdf7d1ca10359b721ad58fba1b33e631fd57fba623ba3e3cef243a0d68f26"
-    sha256 cellar: :any,                 arm64_sonoma:  "a7d31909c5732e8dd10570a155c97cc0a03dd18a4a35ed158687019738873601"
-    sha256 cellar: :any,                 arm64_ventura: "a1e515dbe0a2da72a4e40a52199bb653041bb283760b7c1c4027efd790500bcd"
-    sha256 cellar: :any,                 sonoma:        "c7652fbf34b514c7c9f272b3b749fab80ddd57f94bcb6573113a1093f3bc4264"
-    sha256 cellar: :any,                 ventura:       "e1c42231dd7f07dda17e4610c5b114361db50f1bf08a14cf4f8e9f0a20103be4"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "5c61b11ed32c270e2c5df8b87db0c6ff3036d213bd47e85a107def54fb2a7165"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f26e8bafd4c6bf15034feb1f7a6332a089ddccbd511c0891d9e89fdc241ef82d"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "04bda82b81431750a22f6bef478631fbb349d3645c42d2723fdeb42975f01ef5"
+    sha256 cellar: :any,                 arm64_sonoma:  "edd81e3b6f8efe358eda2677150ff9d08b344022c375e004f52d733e8d51636f"
+    sha256 cellar: :any,                 arm64_ventura: "13e9ef949135fe5ea1887a16bf3199caba35004e6f29e16244681f51d967ebe0"
+    sha256 cellar: :any,                 sonoma:        "cc7c288816f58e3b3a1f4c637f73688f014ec26611624acb7bbe41ece7c1b704"
+    sha256 cellar: :any,                 ventura:       "e02e95addd95546b193e6c0c5a2d9a97742fed235ba551022ca95d123d3644c5"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "1547d7066ad10558cbb0b9a4a025bd5b91d32496dacb643ad243896182cd6f0d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b83f57c4df176b9d6c7902d41a8d0b1927b88fd0d2ba5898a751923443a40be3"
   end
 
   depends_on "rust" => :build # for orjson

--- a/Formula/p/posting.rb
+++ b/Formula/p/posting.rb
@@ -186,7 +186,7 @@ class Posting < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"posting", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"posting", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/p/posting.rb
+++ b/Formula/p/posting.rb
@@ -8,13 +8,14 @@ class Posting < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "104b4c64dbb8364e1b09952405db0c48bf5a901ef9b90681b05f6b5e3c9934f4"
-    sha256 cellar: :any,                 arm64_sonoma:  "9b76d6af1d70bdbe77ed393853e29eca2c8f4893a6a82e1b91f30f3a699e4fb3"
-    sha256 cellar: :any,                 arm64_ventura: "44848246f531e8800cd1eb38b11a81047b32ff9ce9d4b64735e5c6902852b98d"
-    sha256 cellar: :any,                 sonoma:        "9170fd60a78cc6aba8081ba0492897dbfccacea60c16ae9c7c6aabf52a264a29"
-    sha256 cellar: :any,                 ventura:       "4424415f29b6e9553eeabc773f7dd80e08e80dadca79e6998bdc5874235cf4c1"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "d22e0c1da88f01a742e41cd3ad3d16c303a5b1d76fd375c8bcd0e4e92b3fa4b1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b4aaa8fbcfa8112aa69e36d8b10af8c88f1c12db9bffa4b983574d37d4c8095d"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "e0b6848e80d40d9d147511941a0afac0f763b337572a303a981e21c393600b61"
+    sha256 cellar: :any,                 arm64_sonoma:  "e653f1366b8925f417d415892f1d61e6c1c87c86e159341b8cccf74ebbdcd1fd"
+    sha256 cellar: :any,                 arm64_ventura: "cbc2c8f2e53c5fb967935654424830e53ae2d5cb4ad36029b14fa3371c75842c"
+    sha256 cellar: :any,                 sonoma:        "bed07c24b535624dd866541c20a8cc564d416eecc645f9a4be2be238e75b9e77"
+    sha256 cellar: :any,                 ventura:       "44f509e73bc4fe6f12467b9931442f820b9c2b16ddd26133ce0f56a2111a59a1"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "d13f7abe4fc2f188910088976c85ffc78c7f799c8060e394fc1c407a51c48846"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2a4c1eae10dfcbfd5d7a025ebe973349dcba346033965cd299b13c3c71130732"
   end
 
   depends_on "cmake" => :build

--- a/Formula/p/proselint.rb
+++ b/Formula/p/proselint.rb
@@ -23,7 +23,8 @@ class Proselint < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"proselint", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"proselint",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/p/proselint.rb
+++ b/Formula/p/proselint.rb
@@ -9,8 +9,8 @@ class Proselint < Formula
   head "https://github.com/amperser/proselint.git", branch: "main"
 
   bottle do
-    rebuild 2
-    sha256 cellar: :any_skip_relocation, all: "fe5583b1309c7b518421055b260ab9d02734219408b363a30daf2feefb54ecee"
+    rebuild 3
+    sha256 cellar: :any_skip_relocation, all: "64dfc964e1a9bb4f8b7ad0f4c2387f8bf86cce14f14513575979cc6400557767"
   end
 
   depends_on "python@3.13"

--- a/Formula/r/rasterio.rb
+++ b/Formula/r/rasterio.rb
@@ -67,7 +67,7 @@ class Rasterio < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"rio", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"rio", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/r/rasterio.rb
+++ b/Formula/r/rasterio.rb
@@ -9,14 +9,14 @@ class Rasterio < Formula
   revision 1
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_sequoia: "4ef36558ac6e8d989f632c769937b8ccd9ced748c0b823db3e5cb71bf9eaa936"
-    sha256 cellar: :any,                 arm64_sonoma:  "7694d294efc5a2d14ab956f41acae3cf82b76a730e665ce21183c9a4ba29fe98"
-    sha256 cellar: :any,                 arm64_ventura: "30e512537c68292a9fd0b94e53a8ac322928fdb5135ffbd99e00cad2a46a8bd2"
-    sha256 cellar: :any,                 sonoma:        "b7a80a3acc90424d3ae0639353194ad86832e84f1584a94bcb5d2d442efc3584"
-    sha256 cellar: :any,                 ventura:       "f226f12cd61b1b188fce44cd8880f9a1146c7dea3e54d948b43c6c8876b2207f"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "40cce37129c3b70c087b1c08d38a93946f0fa595f1ea5d29e6f33bf8cc201caa"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "03de82be905d85d0b06a221e202f511ff99af401d08d9cd60c2741eb2cb6f00b"
+    rebuild 2
+    sha256 cellar: :any,                 arm64_sequoia: "69d6254809fe65612da5354e838772c31f1511fd9307e151da921b595cca7ff8"
+    sha256 cellar: :any,                 arm64_sonoma:  "e8ce574ad5c9c74fb0643ac62fff89fb94867619ee31cf38dfd5e3aee74c5d36"
+    sha256 cellar: :any,                 arm64_ventura: "49c3192e555a01d0fd652911a7354ec290bd1ce811fb76ffd8c7bb1c88eef823"
+    sha256 cellar: :any,                 sonoma:        "b45e231a05de506dc858047edc3a85df5de047fc7f4b400529dd64bca67ab502"
+    sha256 cellar: :any,                 ventura:       "05c0132ae71b41656bed058dc097893d70a9183a54b4b3fd8bcfaefa34ea6210"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "c360906d37469280284a0bd960e29c13808561ea499bfbafc80b4be87f5d7960"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a408e0ce4ed6b9b105791dee0d8b098c0741990984477516683c68417fa332be"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
### Description

CI is taking way too long for https://github.com/Homebrew/homebrew-core/pull/229665 so I'm splitting up the PR into chunks of 5 files.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

