### PR TITLE
Enable Bash completions for formulae using `:click` (15/18)

### DIFF
--- a/Formula/s/semgrep.rb
+++ b/Formula/s/semgrep.rb
@@ -342,7 +342,7 @@ class Semgrep < Formula
     venv.pip_install_and_link buildpath/"cli"
 
     generate_completions_from_executable(bin/"semgrep", "--legacy",
-                                         shells:                 [:fish, :zsh],
+                                         shells:                 [:bash, :fish, :zsh],
                                          shell_parameter_format: :click)
   end
 

--- a/Formula/s/semgrep.rb
+++ b/Formula/s/semgrep.rb
@@ -15,13 +15,14 @@ class Semgrep < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "6df55fd142b3fe60740cd91ca1387cb0f927f0f5b7b2e915787a0e522bcd7625"
-    sha256 cellar: :any,                 arm64_sonoma:  "5f82335d1dd31d38485da234183e99e3eb3d0d2d172cf01a92a1bdcb693a92de"
-    sha256 cellar: :any,                 arm64_ventura: "aff0f5383f8aa2aaf1ba9eae46bb32ab17f1143e6d3fe30a0a15aa2ce29f30cb"
-    sha256 cellar: :any,                 sonoma:        "646f984947c9b63322fc43302e5b9781229f8998ae65141dece948ea9865ae33"
-    sha256 cellar: :any,                 ventura:       "f03eaf70514665cee2414d9e87c8a098d50e9205e3424499b226e3877c52f15d"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "a45a4b6b3d616051f3c11402b3912115fedb29a4179a43bffd3f8de0d90ce697"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "750d3e3d633684d4a4ff4184c60d4dfd55a859c9ea82e26e25aa442bf9173ad4"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "be36d97daac81920674b15e70d53239aad1fd394566fbc81450e34f65d11c953"
+    sha256 cellar: :any,                 arm64_sonoma:  "6e02103c38a5a465930273f19ddabe7fbdb7416293958a971d21b7e98699c89a"
+    sha256 cellar: :any,                 arm64_ventura: "545f2b93529498e0b06e2cbe6ab7523a8719978efc36f3ba762edaf088408bc8"
+    sha256 cellar: :any,                 sonoma:        "05c3c0886a5dc3300a7e2be40c406214eb9d6d1eaf392ae7782d6cea58cbb823"
+    sha256 cellar: :any,                 ventura:       "445c58923aa231640f5df0745f4d8352cd5c8d26b234987073b716b6e19c54a5"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "709a28e3273817129605d2aca8082dc893445463df06ad2b172bd2db8226a6ea"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "dfe3dd32c560bdc4db638c130ce45746d8763db915cc557cf14d530762c462a1"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/s/sgr.rb
+++ b/Formula/s/sgr.rb
@@ -221,7 +221,7 @@ class Sgr < Formula
     inreplace "pyproject.toml", 'version = "==3.4"', 'version = ">=3.4"'
 
     virtualenv_install_with_resources start_with: "setuptools"
-    generate_completions_from_executable(bin/"sgr", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"sgr", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/s/sgr.rb
+++ b/Formula/s/sgr.rb
@@ -9,13 +9,14 @@ class Sgr < Formula
   revision 15
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "89236b60825df7faf2a732c50730fbd1eac0ff0991ffb90cf082e983124814b2"
-    sha256 cellar: :any,                 arm64_sonoma:  "ba87ac70a1aa814b56c2fcfc9d59e1d0cba001fd3efba2e24d8c4ea7342842da"
-    sha256 cellar: :any,                 arm64_ventura: "20b15c267e6ec08bff4a7a6b99a6edc525e651db05e24e9aa21f2359dd24eeba"
-    sha256 cellar: :any,                 sonoma:        "c321ad64b38b581cacfc0458a887b61cc8581d4a986eb361ce59c3a0b6f8e63c"
-    sha256 cellar: :any,                 ventura:       "36367c852e3e7c212e17b3a5d603ae446711b56381bee4e96c3e0254f85f84b2"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "c1ea6742f068b91669e5aecbe41ac63423a8e2b326fbfce435fef6a99220aef0"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b7b4b49b7b877f1c934c839a13f29b3a392a8ced101800f3ccd8611fe1f72104"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "8b6bd0d9d65b7016b133c9d477aa33849ffd840701d1db2fb9a5c3c090315b0a"
+    sha256 cellar: :any,                 arm64_sonoma:  "58817b8360687ae5872644c9e92446a3c04148ba83cee89c164f98d10cdc27a4"
+    sha256 cellar: :any,                 arm64_ventura: "310c1a29339601e36bd39f82a0919f851c74b7284f3eaad89bfa14050f97f6fe"
+    sha256 cellar: :any,                 sonoma:        "ab95cfa5b159b8908abae601bcc28164720b10cb58fbc7c859b9512ea5315da8"
+    sha256 cellar: :any,                 ventura:       "144d8d6b437fc851507e9af0bf52b94b60b48225ce3048cbc7fb39be6fa0a0cb"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "5861073b4b9db73e936df361f0974760224d19b30c43a044cae5f6192fc9dda9"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c956a3928ad6f7473ea2eea0c6124f167d18e02a96cdc3ea584a253314efebff"
   end
 
   deprecate! date: "2025-06-21", because: :unmaintained

--- a/Formula/s/shallow-backup.rb
+++ b/Formula/s/shallow-backup.rb
@@ -91,7 +91,7 @@ class ShallowBackup < Formula
 
     generate_completions_from_executable(
       bin/"shallow-backup",
-      shells:                 [:fish, :zsh],
+      shells:                 [:bash, :fish, :zsh],
       shell_parameter_format: :click,
     )
   end

--- a/Formula/s/shallow-backup.rb
+++ b/Formula/s/shallow-backup.rb
@@ -9,14 +9,15 @@ class ShallowBackup < Formula
   head "https://github.com/alichtman/shallow-backup.git", branch: "master"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "22c6b568aadef08c73903fa4e63af2f185767d01cc49d934357e1e948370440e"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "22c6b568aadef08c73903fa4e63af2f185767d01cc49d934357e1e948370440e"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "22c6b568aadef08c73903fa4e63af2f185767d01cc49d934357e1e948370440e"
-    sha256 cellar: :any_skip_relocation, sonoma:        "faeb8b9d1a0e93fea36e1e93aa473374e598abe938716db7329c80a6be0f2a34"
-    sha256 cellar: :any_skip_relocation, ventura:       "faeb8b9d1a0e93fea36e1e93aa473374e598abe938716db7329c80a6be0f2a34"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "ef099a4f31fbc2d802d7d076c9d809d4368b86bcfc8052a6e277b14c1ff71a6f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "22c6b568aadef08c73903fa4e63af2f185767d01cc49d934357e1e948370440e"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "80a5ec216c280f956b9185dfa69b02c504c92e0b639ec2b061e81f6e58fced7b"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "80a5ec216c280f956b9185dfa69b02c504c92e0b639ec2b061e81f6e58fced7b"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "80a5ec216c280f956b9185dfa69b02c504c92e0b639ec2b061e81f6e58fced7b"
+    sha256 cellar: :any_skip_relocation, sequoia:       "980f0f75aa3eb600b654f8a11935ffce0d3e745ba3d947318bfadbba272aa7f6"
+    sha256 cellar: :any_skip_relocation, sonoma:        "980f0f75aa3eb600b654f8a11935ffce0d3e745ba3d947318bfadbba272aa7f6"
+    sha256 cellar: :any_skip_relocation, ventura:       "980f0f75aa3eb600b654f8a11935ffce0d3e745ba3d947318bfadbba272aa7f6"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "80a5ec216c280f956b9185dfa69b02c504c92e0b639ec2b061e81f6e58fced7b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "80a5ec216c280f956b9185dfa69b02c504c92e0b639ec2b061e81f6e58fced7b"
   end
 
   depends_on "python@3.13"

--- a/Formula/s/shodan.rb
+++ b/Formula/s/shodan.rb
@@ -83,7 +83,7 @@ class Shodan < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"shodan", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"shodan", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/s/shodan.rb
+++ b/Formula/s/shodan.rb
@@ -12,7 +12,8 @@ class Shodan < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "3f6b9722526a2e6b4a1efd5f4395b3fc8bbc4c993b692ab5b8115361501378d2"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "ff244c9ab8a940086f91f9a2f08a8266d74053755103ce3dab77680ed7b2c2f4"
   end
 
   depends_on "certifi"

--- a/Formula/s/shub.rb
+++ b/Formula/s/shub.rb
@@ -96,7 +96,7 @@ class Shub < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"shub", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"shub", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/s/shub.rb
+++ b/Formula/s/shub.rb
@@ -10,13 +10,14 @@ class Shub < Formula
   head "https://github.com/scrapinghub/shub.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "cf3fa1bed2a1955669a03d942809ae004d08d19fae60bf0e3141a4d0970a0d06"
-    sha256 cellar: :any,                 arm64_sonoma:  "f2f758687c59c23081a66055a209a0e025773c8d0016e7187541621602905e6a"
-    sha256 cellar: :any,                 arm64_ventura: "999ee5cc57ccb598b3116644605344ceefd14b65346e64ed1931f7b8822d2bed"
-    sha256 cellar: :any,                 sonoma:        "eb84226cb9787771f053445bff9719d0bc4c49c303eebffff523e5215a2ce2f8"
-    sha256 cellar: :any,                 ventura:       "7116b7d683f796d9cec6299baee94c2ceb9ce23e8607ad69d9692fdaf36bf78c"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "8a1f94d37f9a681b4e5393ec6e3a37b9d4a88a7d80376bd790a784807168a757"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8d484543326c271c81deceab68061220a8be2cd9c6eb295683d30986370b8dd3"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "b50ce3a684b5a0c6014916ddf290ec96f02a12310aec9823d627ff64afcb9f8f"
+    sha256 cellar: :any,                 arm64_sonoma:  "4c61144b808b3607bc732681dd988eef9ba5b29ade333939aee617f879da24fd"
+    sha256 cellar: :any,                 arm64_ventura: "1dd27be818a64f165a9a3b9bdd05149fb7187fc9e9e414048e9de49bc42cf48c"
+    sha256 cellar: :any,                 sonoma:        "5761d8269c923690891ba20c1891c83f0a7f06e27bce0eb95cd8b59a864eaf41"
+    sha256 cellar: :any,                 ventura:       "7f0ca84ddbe6490849aac25a2ab90c526b0d968b9d9239da2e2c469c4c303478"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "4370ad46cf66b857fe40b35055e44aac6c1ab82418d1b7e26a22213181504a46"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e312b485c67099342faa54b7bfb4b8737afe94e7e2a34e791c265b1034c67e1f"
   end
 
   depends_on "certifi"


### PR DESCRIPTION
### Description

CI is taking way too long for https://github.com/Homebrew/homebrew-core/pull/229665 so I'm splitting up the PR into chunks of 5 files.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

