### PR TITLE
Enable Bash completions for formulae using `:click` (16/18)

### DIFF
--- a/Formula/s/sigma-cli.rb
+++ b/Formula/s/sigma-cli.rb
@@ -112,7 +112,7 @@ class SigmaCli < Formula
 
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"sigma", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"sigma", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/s/sigma-cli.rb
+++ b/Formula/s/sigma-cli.rb
@@ -10,13 +10,14 @@ class SigmaCli < Formula
   head "https://github.com/SigmaHQ/sigma-cli.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "b18427249afea4d8a243dc8d06c3f23cbb20015c4159a37c7b867d92de385817"
-    sha256 cellar: :any,                 arm64_sonoma:  "21821ebff6bae82c7ba5f8309ca7cbad60dab532281197549e99f546158c3363"
-    sha256 cellar: :any,                 arm64_ventura: "0fc3b0f2f62a3ac88819b7211c72d0419c108962e9b032467c2241202c8f6d99"
-    sha256 cellar: :any,                 sonoma:        "52aba79993805b237e6d37075bca80fc2c58b81159ccdffcf13d23b629ae7d13"
-    sha256 cellar: :any,                 ventura:       "83acc63f82aa04d8dc1222027f6d315a1eef3fc674eb25d18a1fdfd41dba5db3"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "041979bbd2952ed0325189ac1ee3e8f86f9b8b4a4565f1849e3f2c48a8d07afd"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a5eddb46141461fbb192ddad50745cd034f9e57b03d279d33afc88b755af5db0"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "c52a3d701cb7954648073ab399acf23aa9ba92001c1616b78509f58a904c2aed"
+    sha256 cellar: :any,                 arm64_sonoma:  "54ff4d366f2bd84868094772ea97010b70eab5ff747025b713e81904fa793983"
+    sha256 cellar: :any,                 arm64_ventura: "7249cf7861b6cb71bc72f301d9a5d6063b9101253f95787b9221205c50072d8c"
+    sha256 cellar: :any,                 sonoma:        "cccba010339924acd2086d9067db8c9ba572cdd04be8fa0df1c12d60ca72d3ae"
+    sha256 cellar: :any,                 ventura:       "bc4db80a1e8db098cc30cf8bd4c785f6eef7ed645c209824d84976560b0558ed"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "e9464d4ecedc600741583518048cd27c0126e1bef18130136527698bb795e6a3"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "7d24671a6f4c327b4b170eb1e4a47c5d97cddaac7848370e03d87e447821b80b"
   end
 
   depends_on "certifi"

--- a/Formula/s/snakefmt.rb
+++ b/Formula/s/snakefmt.rb
@@ -61,7 +61,7 @@ class Snakefmt < Formula
 
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"snakefmt", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"snakefmt", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/s/snakefmt.rb
+++ b/Formula/s/snakefmt.rb
@@ -9,13 +9,14 @@ class Snakefmt < Formula
   head "https://github.com/snakemake/snakefmt.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "c6f3b238883159ea5e23d01cb0892963b4bd953d24c1698012b53bc5f26a9c4c"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "c6f3b238883159ea5e23d01cb0892963b4bd953d24c1698012b53bc5f26a9c4c"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "c6f3b238883159ea5e23d01cb0892963b4bd953d24c1698012b53bc5f26a9c4c"
-    sha256 cellar: :any_skip_relocation, sonoma:        "7b5c55a0907942d9ce338e1a2edab23febf8e9fd3d6411c6310ace4c1e2784bb"
-    sha256 cellar: :any_skip_relocation, ventura:       "7b5c55a0907942d9ce338e1a2edab23febf8e9fd3d6411c6310ace4c1e2784bb"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "f1630f33ef1dea71add311265206881e08a08e00ce2f9fb866a5c97d1eb1fd09"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f1630f33ef1dea71add311265206881e08a08e00ce2f9fb866a5c97d1eb1fd09"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "edcdce032c7d4e55385c2691f7f0ffccd023b39e7d99adfdb700e34226f75548"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "edcdce032c7d4e55385c2691f7f0ffccd023b39e7d99adfdb700e34226f75548"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "edcdce032c7d4e55385c2691f7f0ffccd023b39e7d99adfdb700e34226f75548"
+    sha256 cellar: :any_skip_relocation, sonoma:        "b994ad55990344d75e06330d9e8ca98d55985fd331ef7cedae4805aa5c2fe4be"
+    sha256 cellar: :any_skip_relocation, ventura:       "b994ad55990344d75e06330d9e8ca98d55985fd331ef7cedae4805aa5c2fe4be"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "b27e3398c9cdcb69e2b24ecf184641fd56beb6f2b8648c18cc13212d988d6f89"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b27e3398c9cdcb69e2b24ecf184641fd56beb6f2b8648c18cc13212d988d6f89"
   end
 
   depends_on "python@3.13"

--- a/Formula/s/sqlfluff.rb
+++ b/Formula/s/sqlfluff.rb
@@ -108,7 +108,7 @@ class Sqlfluff < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"sqlfluff", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"sqlfluff", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/s/sqlfluff.rb
+++ b/Formula/s/sqlfluff.rb
@@ -8,13 +8,14 @@ class Sqlfluff < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "e4ad36c8b7ae6c9a7ad90a1cdae9ed75b4e64e88b40480bbade5be1248f2902f"
-    sha256 cellar: :any,                 arm64_sonoma:  "1c2db9b2b6ef9ff644e44c7443db38ab93cd78216118bc5e1fffc16ff27ca68a"
-    sha256 cellar: :any,                 arm64_ventura: "af07ffd171de43d3c78306b01f35ee62bd8e6afa9ceec0c7a9c867a3021350be"
-    sha256 cellar: :any,                 sonoma:        "308bbc3de915d52b57f836dd4e4e513e34e09fffd2fc9ed946f17dcc39412a22"
-    sha256 cellar: :any,                 ventura:       "2c5ec51f5af2ab974d06c0ba1dd8e345eadbf50913a5309f7c94ec37db50c0dc"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "073ea38f566c4d067837b4a4b5957e441a71eb70408a6663013a41220e0175da"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c7fe17c8e4012a3ce76acd0aceb6a2b09cb6bcb2ef2aeb75cc68f689950d2dce"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "00df0b59a44577d15dcc95a8e4b5617bccb6e75a295dd9eb8657c390777af705"
+    sha256 cellar: :any,                 arm64_sonoma:  "e9fddc0b6af20e56f98800f11e76eeceabcbd30ed5a3f5a8fb7f720e56622f7d"
+    sha256 cellar: :any,                 arm64_ventura: "1b218c47a9af7040becd822b270dd4130fbe725a9501f2c973a2ba1184e59000"
+    sha256 cellar: :any,                 sonoma:        "b01712f83ceb61b57ec3b3794d3e2b8877a4db0ca9208b83f8ba125b11403f8f"
+    sha256 cellar: :any,                 ventura:       "8f2725e03f95fe805d932b977c648e562d1cde26fd5554952c8fecd1ae43c343"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "7483805504dcf40c6c3088824e6fe7052c3fd26b5484011f0225b6469c1426eb"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4f1f99740cac004bdd8374ee0e55bdc8ac0f1fa71487735c41ce51dbecf47546"
   end
 
   depends_on "libyaml"

--- a/Formula/s/sqlite-utils.rb
+++ b/Formula/s/sqlite-utils.rb
@@ -57,7 +57,8 @@ class SqliteUtils < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"sqlite-utils", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"sqlite-utils",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/s/sqlite-utils.rb
+++ b/Formula/s/sqlite-utils.rb
@@ -8,13 +8,14 @@ class SqliteUtils < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "2ba7d7894a17d995f13bbc6e028709736092ffda97c57e226446635ac463fe23"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "2ba7d7894a17d995f13bbc6e028709736092ffda97c57e226446635ac463fe23"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "2ba7d7894a17d995f13bbc6e028709736092ffda97c57e226446635ac463fe23"
-    sha256 cellar: :any_skip_relocation, sonoma:        "33df8c15199c62afd1e5892a815caa0f5450f6e9f3678f50fa23469ee1a48d9c"
-    sha256 cellar: :any_skip_relocation, ventura:       "33df8c15199c62afd1e5892a815caa0f5450f6e9f3678f50fa23469ee1a48d9c"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "7ec6f3fbb01080aeb3da17bd54bc940089e0d2fca223d83be9b4f76ff46f6866"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "801f58dacffee3dd06633556ec40db111693a2031e0f6011748bf9e0681cdd11"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "6bae85f5cf6afe2f60ac7c154d7a364a635b65628de948dc9709e23c0af9bbde"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "6bae85f5cf6afe2f60ac7c154d7a364a635b65628de948dc9709e23c0af9bbde"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "6bae85f5cf6afe2f60ac7c154d7a364a635b65628de948dc9709e23c0af9bbde"
+    sha256 cellar: :any_skip_relocation, sonoma:        "a2b1742ba548f5fe04a5781292cb27ab85f520f5bb6046ce0996b0ab31609e41"
+    sha256 cellar: :any_skip_relocation, ventura:       "a2b1742ba548f5fe04a5781292cb27ab85f520f5bb6046ce0996b0ab31609e41"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "80976f079353627f3923086d276cf5707b4e482e148531a34adf0f8d141fb8fe"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "80976f079353627f3923086d276cf5707b4e482e148531a34adf0f8d141fb8fe"
   end
 
   depends_on "python@3.13"

--- a/Formula/s/subliminal.rb
+++ b/Formula/s/subliminal.rb
@@ -191,7 +191,8 @@ class Subliminal < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"subliminal", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"subliminal",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/s/subliminal.rb
+++ b/Formula/s/subliminal.rb
@@ -10,13 +10,14 @@ class Subliminal < Formula
   head "https://github.com/Diaoul/subliminal.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "7aa070c9a3d2426dffc709da012ae80e6419dc35e1eb372d177eedc70eb35c55"
-    sha256 cellar: :any,                 arm64_sonoma:  "b128e27859ae0d5a7ebd82e2a4d3e5d1568db7f77378b9efbc2b51893c7844aa"
-    sha256 cellar: :any,                 arm64_ventura: "3d9180133e5cd7f212208636d4155bd2f1c32fae3968a859efaa74d3638f0006"
-    sha256 cellar: :any,                 sonoma:        "3b937fd8d1113159d277dedf4a066f0b43e589a2ba07882eb24409186844ec7d"
-    sha256 cellar: :any,                 ventura:       "6fd7a2e29599eb5c79510ea84336de029ec40066953929792c0b94da24820530"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "8a92b71f800b6cc8459f38ca72494911ada8e6deaf16f38654fc1dd3f260305a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a9ff97cabcf1083019380583ca4b454183c6c761344fc6ff0c1a95a3b53b767c"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "7ef2d779b37ac8893792dbe85344fdd5e66a41a7ff026e928df9cc5069857f01"
+    sha256 cellar: :any,                 arm64_sonoma:  "9c701b1b35b5f701e855a66b2204c550ca0c5569cdc01ec092ff7318947e0fe4"
+    sha256 cellar: :any,                 arm64_ventura: "e4cb2b55889d3eb232eed5d8c8ff74bef8bfe29d552f732adadd9331443a7a7a"
+    sha256 cellar: :any,                 sonoma:        "b364d5d7051f89d62e58464d8a82b8d2ef1b8bf9f25ed1cda9a9654d9e33fb4f"
+    sha256 cellar: :any,                 ventura:       "2c16a2ee1d2ac22eb1cf437bf8b9fa795b8cf5ae7a6787fd88747bfcf4a9afd3"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "c8b2fdbbed0bf325167ac51370959c322fb973711aae245944b85fcd0d748c26"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5535e61d5320ae97f94b9baba9d370793e3f7306d663e98845f5d3f7e54c7023"
   end
 
   depends_on "certifi"


### PR DESCRIPTION
### Description

CI is taking way too long for https://github.com/Homebrew/homebrew-core/pull/229665 so I'm splitting up the PR into chunks of 5 files.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

