### PR TITLE
Enable Bash completions for formulae using `:click` (17/18)

### DIFF
--- a/Formula/t/tartufo.rb
+++ b/Formula/t/tartufo.rb
@@ -51,7 +51,7 @@ class Tartufo < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"tartufo", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"tartufo", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/t/tartufo.rb
+++ b/Formula/t/tartufo.rb
@@ -9,8 +9,8 @@ class Tartufo < Formula
   head "https://github.com/godaddy/tartufo.git", branch: "main"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, all: "05cc94b2f9e74a5ac241b68a8ab028d5c66a4f7bd346e104ecc100e183cf04f7"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, all: "550f55071ca93f1388cc65d5544ab7024c595b9abb5aeb641c0fcb36352b4ae3"
   end
 
   depends_on "pygit2"

--- a/Formula/t/tmt.rb
+++ b/Formula/t/tmt.rb
@@ -165,7 +165,7 @@ class Tmt < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"tmt", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"tmt", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/t/tmt.rb
+++ b/Formula/t/tmt.rb
@@ -8,13 +8,14 @@ class Tmt < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "a82f24c61ff61da3a9be307c8f932bc0b079ae37e8feb44665e287f318a9b1eb"
-    sha256 cellar: :any,                 arm64_sonoma:  "a384ba1b00f684c97f3a6e3b6f837131cb706a2781f43d9e703022246e24db03"
-    sha256 cellar: :any,                 arm64_ventura: "39ac1519281dcd74a6fa58a85d49ecdb6f2a70464d3542dccebc17dcb798a3d3"
-    sha256 cellar: :any,                 sonoma:        "d46320b6bf1ee138a5dec9312bdf344861ea9981c0691704572ce85a1547d779"
-    sha256 cellar: :any,                 ventura:       "c4ccc5c89d067df945f1ef00b9f0ec012aa3b912f61676977b111effd85cfe80"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "588b4db6cdc6bc6ee0364b58fbae21844c6c9a3a54d3e1e0b00c84c5f275a3bc"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "80ed9819d6b7ab8a3b20a89a614222e199806b568480e0a3bd2331540ed4a9fe"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "70fe364e29ea3e6fe9f6bc079a28a9944cf579ea1a94c43c27784aa4c004a838"
+    sha256 cellar: :any,                 arm64_sonoma:  "ccc8641a250dbc8dfb4aabf44479ae1e26123ed3d87aa77b209277f86f93400e"
+    sha256 cellar: :any,                 arm64_ventura: "759496b8e2fde51c651350b463a5ba000aac961c20f3b17380fd1329afa006a6"
+    sha256 cellar: :any,                 sonoma:        "7a7c6cfa8ab8baf2121597dd3b16f5ddec7466fc46cca105ddb68a4032a605be"
+    sha256 cellar: :any,                 ventura:       "22bebbb2ef264f31c2b766939ad308bec55644029e52797af04a43e7e38b8004"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "75beaba48ea7f078b77cb2c46b6bb2d15002c742ba35b7d97dff53f53d486bbe"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f63406ed6bbd7503cf0a3f979e49f7c88992ad234e1a38e53ffe9a2d251a1511"
   end
 
   depends_on "rust" => :build # for rpds-py

--- a/Formula/t/trailscraper.rb
+++ b/Formula/t/trailscraper.rb
@@ -10,13 +10,15 @@ class Trailscraper < Formula
   head "https://github.com/flosell/trailscraper.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "b4cb81dbd07d5b954c840c77d25d505eb5bbc0fab8a1ba9c46a29665122cf6b6"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "b0f37017da786d814f17fc2b764664f0d2994c1b30fe3b256c3dd658b7250a26"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "78f1550ff391d81a34ecd071c63fd260644951c2029d5e0f4b53305b373591b7"
-    sha256 cellar: :any_skip_relocation, sonoma:        "e4add39e6f156428ac78c1cdc034d26995eefc750070749fcb486f094d8449b5"
-    sha256 cellar: :any_skip_relocation, ventura:       "2ebf657a5c1b51b31e545afc4565d2f18d0fdec4ff7045c0916dc21480e32672"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "c2d1f045859402ee432b9237f614e9898d0f1d01b6576182e8c7d3d9c5290005"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a21e764f1726cb448636b2f58f899b15c288abefbf1217d6c011db742add58f1"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "59024c08d9d88aa1211efa7f644efa0db475733418be871dcc2cd0f61671d45d"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "4bb31c987d5e4afd7a5b41f070f01ae5fe16ba645b1ed6230dc568c187119f9b"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "395b8a25ea0d058516b32d6d2693805cc72a7f3e7f68298aeed14895aef9d7d8"
+    sha256 cellar: :any_skip_relocation, sequoia:       "130e4ea5fd7b1ec80cb2e1cea65084d18bbcaf76a8ccc23171dbe5c4a5e47c7d"
+    sha256 cellar: :any_skip_relocation, sonoma:        "d4d4fbf044800fcfa9545d203715cf3ed81eda18904009bd33decee0e88e2e4d"
+    sha256 cellar: :any_skip_relocation, ventura:       "817ae180fdc8ed0e1ab691a3e4d6e66ae61af83a77d30a509554887f28a6b4b8"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "c1c62900b368af894d14847492ce4b5a703426c0f232ad996f1eb02f57573c88"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a71e88ae77f4070955e0fefcbd3523577597a1790a9fd7e9a2365a6d596a8021"
   end
 
   depends_on "python@3.13"

--- a/Formula/t/trailscraper.rb
+++ b/Formula/t/trailscraper.rb
@@ -99,7 +99,8 @@ class Trailscraper < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"trailscraper", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"trailscraper",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/t/twtxt.rb
+++ b/Formula/t/twtxt.rb
@@ -96,7 +96,7 @@ class Twtxt < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"twtxt", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"twtxt", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/t/twtxt.rb
+++ b/Formula/t/twtxt.rb
@@ -11,13 +11,15 @@ class Twtxt < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "edb8ea5c3391196da08836218420f89c6bd007decd33854e0c2e306789489076"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "47364ec472d99034f372dc075295ee98d3e7ebb38e29d9a692b353d7dc46eb4c"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "682fab3d700db2019e0e40e049950be61c64fd995d2fe9d44cb451f07d03f877"
-    sha256 cellar: :any_skip_relocation, sonoma:        "e07965ffd9743f2bb45dd95af5f3b1a45e090388116234aa52fee0da93a645fb"
-    sha256 cellar: :any_skip_relocation, ventura:       "d1853863f6717ea82bbafa030651b0975700a319d6637aba0e7a619518e425d0"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "fed11c702b5f8867cfe4fa33ac6df610ef77f0a6871db24b797c9f9e4f725a8a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8c5d0c9f7b62813e47e77c796d0ed351e038091ed3dbd91b1a6fd90187fd252f"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "969b8713e890189a067c53f5a782ed7066116a877cdf11b5c998151aaec1afcc"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "4ea88e47ac13dacef608d4e4c0108d6668624027ac7ee935b52dc4eba24f634b"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "0089b0c2e58c09ef427e9eff9f64a6b4f8c9909676c3a84c31d23c590d433b99"
+    sha256 cellar: :any_skip_relocation, sequoia:       "741bcde7e895ee2787f3a926be30c8c07433298e5b7a7d1dd4df8094a39dfcb8"
+    sha256 cellar: :any_skip_relocation, sonoma:        "82237838b5d8e4a308433ff9087f17bb79cf9ad8a09c87fd2e01b66e0bcbd8e5"
+    sha256 cellar: :any_skip_relocation, ventura:       "b06daa93502419d9781add8fc806b60d60b18f781590e3c3baf2d87f5bb1b307"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "5473c1d33da38697f7373a0e4e6441794b5cdd8edc1a51db6b78ade3b8a23696"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5d222898652fa5abc40f17c06e6dffda758e8b39b84602e1e66c1796b0b406a9"
   end
 
   depends_on "python@3.13"

--- a/Formula/u/uvicorn.rb
+++ b/Formula/u/uvicorn.rb
@@ -80,7 +80,7 @@ class Uvicorn < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"uvicorn", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"uvicorn", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/u/uvicorn.rb
+++ b/Formula/u/uvicorn.rb
@@ -9,13 +9,14 @@ class Uvicorn < Formula
   head "https://github.com/encode/uvicorn.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "7ad28e9b82ddaaef7f56d31881a664a75e6f8ac854e784fc6c6ee72dd74e44ce"
-    sha256 cellar: :any,                 arm64_sonoma:  "8c178772f7aea468f5ebfcbd1305ff82bb02a0213e06c368929d1805d529f1dc"
-    sha256 cellar: :any,                 arm64_ventura: "62c3e3e66c714511683b7fb74b1beb94a806ea8f150d4360d7d869d3917c92f7"
-    sha256 cellar: :any,                 sonoma:        "6dc7315b86bcebf44bf7204e0aaab09d007f374fada645b9e32a47590885b66e"
-    sha256 cellar: :any,                 ventura:       "59843fa8aba63f77fdf3dad0e3bc66ad05bbdf297b1431116f6d555d7fc6d9a1"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "6d2bb748e7ecdadc09450d193edcf3ef3490f4684a67bd4d4e79e4b5ba88e31f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f84f7af472451b52c675c8e3891d47bee78cb36a9326eb5cad581c3d43314836"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "c07c75bdbc6ffc63e037ebc042869aeb598e6eb4fc18e8f982d67ed91b76136d"
+    sha256 cellar: :any,                 arm64_sonoma:  "c474596155e32d2f9f4c4c739ff0bf1ad157427b663e69cc1d90f07b63b82a3b"
+    sha256 cellar: :any,                 arm64_ventura: "2a025fb37ca7c1bb72a9e7edf46a5b4d097b71271800b8b0f337d2ebbff6e09c"
+    sha256 cellar: :any,                 sonoma:        "85edf95614677432bfc0baa8b48337a419e1dd430a9780f924d1aef1b5ef65b8"
+    sha256 cellar: :any,                 ventura:       "d8e1ddcaa2cf29a6bd931eedae11b19322bb7d3d24db222dcdb078a653be4f2c"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "f250451c953f8af9d27b4974ae073cb8440eda6f2e306bcb52530ae35eab29b5"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "300db9344e309e032ec60aaac9685fbe05784d851119b7f84bb31d1794907afc"
   end
 
   depends_on "rust" => :build


### PR DESCRIPTION
### Description

CI is taking way too long for https://github.com/Homebrew/homebrew-core/pull/229665 so I'm splitting up the PR into chunks of 5 files.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

