### PR TITLE
Enable Bash completions for formulae using `:click` (18/18)

### DIFF
--- a/Formula/v/vdirsyncer.rb
+++ b/Formula/v/vdirsyncer.rb
@@ -116,7 +116,8 @@ class Vdirsyncer < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"vdirsyncer", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"vdirsyncer",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   service do

--- a/Formula/v/vdirsyncer.rb
+++ b/Formula/v/vdirsyncer.rb
@@ -10,14 +10,15 @@ class Vdirsyncer < Formula
   head "https://github.com/pimutils/vdirsyncer.git", branch: "main"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "a9d31635befb103569792086faf231e49a2a06bf68d52e7ed646f9bda84b2733"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "b220a13c2ce7a1d078adf23c2d6dfa1be499ceb30b3b60059cd12df06dd9b7ee"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "0288bfdb9f4f9d2c84c03d2a91a3b420f30cd2b8ca44d4e697c414b8804dc367"
-    sha256 cellar: :any_skip_relocation, sonoma:        "22942f7993c00edce873eb4b285e5f7d42f8a458d1b52a9f07cda8ba2dc88c53"
-    sha256 cellar: :any_skip_relocation, ventura:       "17e5b4a0a90b39691dd64095777379686a5cec45aa06f184ea9f446f48dc6a6b"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "98583633c94504f75782e85018aaa6a1d897fc9c83bbe0fe474d6926bff87988"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0a94c2831c20f191d175bfc156fa6b7b4fdebb5c899c21cbe64af9dd861126e3"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "3657bc1eaffd27f2668c60f33e89f9f37fafeb64f4198fce7bf5c8a779357586"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "cfeee986c1a79967d262818996887ec9860fa6bc00c608814a968fbbb662347a"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "f461ae1043502856a606a1aa38bc9c7423d71205e1e6a074a2d31024a2b678ee"
+    sha256 cellar: :any_skip_relocation, sequoia:       "62671d42404089375e1c46a2ab1e20da558b3e5ab4f5f3259c96e8a6297c4de0"
+    sha256 cellar: :any_skip_relocation, sonoma:        "88dea32f7752c424343ddb77219cc1ab163a0aca17da6de42d74434ddbc901b5"
+    sha256 cellar: :any_skip_relocation, ventura:       "891bc227096bd03144f4e8d1d557d83cae7b8179a7f271289dadcbb916c07861"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "8c39fa7339230154b24fe6ce4147f59f657d086f7f680f4edebf4689be4cc285"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2d4743921ee8aaf3ad99f638956cd42979f1cd084bad796e88a773e20c9852aa"
   end
 
   depends_on "certifi"

--- a/Formula/v/vunnel.rb
+++ b/Formula/v/vunnel.rb
@@ -232,7 +232,7 @@ class Vunnel < Formula
 
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"vunnel", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"vunnel", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/v/vunnel.rb
+++ b/Formula/v/vunnel.rb
@@ -9,13 +9,14 @@ class Vunnel < Formula
   head "https://github.com/anchore/vunnel.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "8f5c56a5e90a30599f4a9c2840edc06899ef93810f2b51a3d13f7818b9cdf1a0"
-    sha256 cellar: :any,                 arm64_sonoma:  "5e7e7cef131e93d6a85f27de883ae5c3b2f8d147c0b94349222cad31dba2f943"
-    sha256 cellar: :any,                 arm64_ventura: "c9fa553ec62a56911064e037f4aa146390754bf40d072d26a9e1a0f000b9973f"
-    sha256 cellar: :any,                 sonoma:        "a5ce1f5cb46c6b08343fc948da7eff90452af75e2bee0d4c60646a8a155dae17"
-    sha256 cellar: :any,                 ventura:       "c0cfcb2b9dba027f4828ddcd593b2949023a7e562fa41165e302e68d23f7d950"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "321970ece2f2f2f8effb11777357c60467a8d440b49b8c589277225c8d598879"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "02d0f0df63a890e40c7685c98cd89579c9ff19962d7728005dcb88c8155d1f5c"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "eecd440ffc8d96b888453a4b3264a1a7f2d3949722e7382c157550385b7a763b"
+    sha256 cellar: :any,                 arm64_sonoma:  "34e6d48a3cee7a5472a3fceb185e22a9030f14eb42a84e6fc08d7df33fd783b9"
+    sha256 cellar: :any,                 arm64_ventura: "1ae2ef716bc20d5ce4832af749c2ebba984368c7e6892d9edd2fb8187dffedf1"
+    sha256 cellar: :any,                 sonoma:        "a3802f259775bc15fe24d4c8c541628fb21e8d89e193007b0b5360427b29ec10"
+    sha256 cellar: :any,                 ventura:       "a46b9f98dc54828d99f0b0a98dc70aa5bc5c3f4a7cf4fa9ad5c09901413bbf58"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "6cedda3543d08c930d2b1039ba9dd71489a036fbdc94953d8a9d0f359307f257"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e561c61896216e27b5a401460744c94715fcec1ff301281f5468d924d35ec0a2"
   end
 
   depends_on "rust" => :build

--- a/Formula/w/waybackpy.rb
+++ b/Formula/w/waybackpy.rb
@@ -45,7 +45,8 @@ class Waybackpy < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"waybackpy", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"waybackpy",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/w/waybackpy.rb
+++ b/Formula/w/waybackpy.rb
@@ -11,7 +11,8 @@ class Waybackpy < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "0cdd02bf216c002bc9ba5e7f6f21bdfe5fec3594b6432031502eeb916e4fcdce"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "996bcc65b772b98507b7d5134217d463b69bc65948cd0276f0afefb89e0becf9"
   end
 
   depends_on "certifi"

--- a/Formula/w/weaviate-cli.rb
+++ b/Formula/w/weaviate-cli.rb
@@ -179,7 +179,8 @@ class WeaviateCli < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"weaviate-cli", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"weaviate-cli",
+                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/w/weaviate-cli.rb
+++ b/Formula/w/weaviate-cli.rb
@@ -8,13 +8,14 @@ class WeaviateCli < Formula
   license "BSD-3-Clause"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "83d12311877e48ace3ea05ff67cd26225afd64f27472dbe508f733f2505d9879"
-    sha256 cellar: :any,                 arm64_sonoma:  "8d9ac3295c2f7f6d16cd14f60645ad1dfc2c8106277a53396ade895b3c08ad64"
-    sha256 cellar: :any,                 arm64_ventura: "26b9ddfa29c25a4bed2265fbbbf4a6fe4d78913bca0b3f8a36a888e427c72a91"
-    sha256 cellar: :any,                 sonoma:        "d838f9c372ab64c6134f8e357ccb6f5c04665aa2ad41027ff5fe10944076607a"
-    sha256 cellar: :any,                 ventura:       "affde9f30106e4a4f8f285b8e3b6d9809e59d142d95e25a0b18facfa67a6b9bd"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "fab5d6c1a2f719d6b11d857b114390345e66978f8a4424e3509504944199024e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "eb74ff4e81f48026aeb62d52175e7289048ccc976cd16ef289de6390f2f7c104"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "650abbef118c44a8ebe76773f861656276ba0243f0930d3061539365d82ee5bb"
+    sha256 cellar: :any,                 arm64_sonoma:  "bf4e41e5388b51c2626d04fae0de4a9c73307d0e53ddd2c3f10235eab087c236"
+    sha256 cellar: :any,                 arm64_ventura: "9e16a758d59c0496f8b7cdde8c466993dbbceb7654bf408fed18f9952dfc0032"
+    sha256 cellar: :any,                 sonoma:        "e339304f00a42f189bbb8785a6cd39d4f60a40ed3f018566fcbfd2580d437720"
+    sha256 cellar: :any,                 ventura:       "50a951d27ac46d4d74471a40a3132e235e60581bf1c6baabafa8d554aede57be"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "a3f539c680dd3e3c21dfda7e9b43a47cd79328e77b36e07166f7778da819c912"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "9878b7a18bf87a8808a36ed9129997d3873e3c5483b7f0f78d990fa0c868cdf7"
   end
 
   depends_on "ninja" => :build

--- a/Formula/y/ykman.rb
+++ b/Formula/y/ykman.rb
@@ -92,7 +92,7 @@ class Ykman < Formula
     man1.install "man/ykman.1"
 
     # Click doesn't support generating completions for Bash versions older than 4.4
-    generate_completions_from_executable(bin/"ykman", shells: [:fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"ykman", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/y/ykman.rb
+++ b/Formula/y/ykman.rb
@@ -9,13 +9,14 @@ class Ykman < Formula
   head "https://github.com/Yubico/yubikey-manager.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "842d4ca75c0b971050d7cdded4b1e07f7c9472877ad694a541d3368325203959"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "a7c97aeecfc6a6d4215a1cde16c1223accd6afa605c1895f819c1ba0e41bbc98"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "3c47a5676ca014e2ce4288ee335eb833755b71fe97fdb625e7c2f78f743a529a"
-    sha256 cellar: :any_skip_relocation, sonoma:        "447ddc8d23fc9eb6cca78fb691491e9dfd03f2d9ef9597760bdab09ffd3726bf"
-    sha256 cellar: :any_skip_relocation, ventura:       "ad9312ba3779433916fea7621376722a292cc2d5795b9bfe655d19b50edf01fa"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "ca0cdbf6e8f97e6f250de8f3dbe083fdae6709c1dd59fa0268d34f0b22810d45"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "fb400bfd7f5cf9d35a4bb749d02ca67d611a29b083c3798ef9bc12d0842a82b1"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "87773a77350d507bd05943f10c30a60a14d73b30043dd0e71ee9a8304bc9773b"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "f7b44cc3f306a4626e0851078692fda43e73ca3ab1bde9d9da7d8894460a4261"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "cfab40b274c9ce7d0461bbcdaeb5e4282c14c149bd74b6c498786847d40ac994"
+    sha256 cellar: :any_skip_relocation, sonoma:        "c6a92f7805145991992181297c85062d88c556fe97216aa8e9a663b18bf4db77"
+    sha256 cellar: :any_skip_relocation, ventura:       "f07721117ed5dd7fd675fad16b98c8045ccefcd99ba8cbd10b4206e12056d3c2"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "7fa0324093131a4a4185cd01586e29031d1762475018e59cf6e94a6bbe77a4c0"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "25a6128e15cffa903450e28521abf1c5ec918ff7bf29c32dc52a751af47c8a3e"
   end
 
   depends_on "swig" => :build


### PR DESCRIPTION
### Description

CI is taking way too long for https://github.com/Homebrew/homebrew-core/pull/229665 so I'm splitting up the PR into chunks of 5 files.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

