### PR TITLE
ncurses: update CFLAGS when building with gcc>=15

### DIFF
--- a/Formula/n/ncurses.rb
+++ b/Formula/n/ncurses.rb
@@ -52,6 +52,9 @@ class Ncurses < Formula
     ]
     args << "--with-terminfo-dirs=#{share}/terminfo:/etc/terminfo:/lib/terminfo:/usr/share/terminfo" if OS.linux?
 
+    odie "`-std=gnu17` workaround should be removed!" if build.stable? && version > "6.5"
+    ENV.append_to_cflags "-std=gnu17" if OS.linux? && DevelopmentTools.gcc_version("gcc") >= 15
+
     system "./configure", *args
     system "make", "install"
     make_libncurses_symlinks


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
When building from source on Linux with gcc >= 15, the compile fails.

To reproduce:
```
docker run --rm homebrew/brew sh -c '
brew install gcc
sudo apt-get remove -y cpp-11 gcc-11-base
ln -s gcc-15 $(brew --prefix)/bin/gcc
brew install -s ncurses
'
```

Result:
```
==> make install
Last 15 lines from /home/linuxbrew/.cache/Homebrew/Logs/ncurses/02.make:
In file included from /home/linuxbrew/.linuxbrew/Cellar/gcc/15.1.0/include/c++/15/bits/memory_resource.h:40,
                 from /home/linuxbrew/.linuxbrew/Cellar/gcc/15.1.0/include/c++/15/string:72:
/home/linuxbrew/.linuxbrew/Cellar/gcc/15.1.0/include/c++/15/cstddef:81:21: error: redefinition of 'struct std::__byte_operand<
unsigned char>'
   81 |   template<> struct __byte_operand<unsigned char> { using __type = byte; };
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/linuxbrew/.linuxbrew/Cellar/gcc/15.1.0/include/c++/15/cstddef:78:21: note: previous definition of 'struct std::__byte_op
erand<unsigned char>'
   78 |   template<> struct __byte_operand<bool> { using __type = byte; };
      |                     ^~~~~~~~~~~~~~~~~~~~
make[1]: *** [Makefile:443: ../obj_s/cursespad.o] Error 1
make[1]: *** Waiting for unfinished jobs....
make[1]: *** [Makefile:438: ../obj_s/cursesw.o] Error 1
make[1]: *** [Makefile:433: ../obj_s/cursesm.o] Error 1
make[1]: *** [Makefile:427: ../obj_s/cursesf.o] Error 1
make[1]: Leaving directory '/var/tmp/ncurses-20250711-2701-kef5cn/ncurses-6.5/c++'
make: *** [Makefile:142: install] Error 2
```

Adding this flag to CFLAGS fixes this issue.

Others have made similar fixes:
- archlinux- [bug](https://gitlab.archlinux.org/archlinux/packaging/packages/ncurses/-/issues/3), [fix](https://gitlab.archlinux.org/archlinux/packaging/packages/ncurses/-/commit/c56355cb826998ad04ab7a319d7fd4460d8a8053#9b9baac1eb9b72790eef5540a1685306fc43fd6c_75_75) 