### PR TITLE
cmd/check-bottle-modification: ignore merge commits

### DIFF
--- a/cmd/check-bottle-modification.rb
+++ b/cmd/check-bottle-modification.rb
@@ -24,7 +24,8 @@ module Homebrew
         response = GitHub::API.open_rest(GitHub.url_to("repos", owner, repo, "pulls", pull_request, "commits"))
 
         response.reject! do |item|
-          UNCHECKED_COMMIT_AUTHORS.include?(item.dig("commit", "author", "name")) ||
+          item.fetch("parents").count > 1 ||
+            UNCHECKED_COMMIT_AUTHORS.include?(item.dig("commit", "author", "name")) ||
             UNCHECKED_COMMIT_AUTHORS.include?(item.dig("commit", "committer", "name"))
         end
 


### PR DESCRIPTION
These are false positives. See, for example, #229878 and #229879.
