### PR TITLE
workflows/triage: skip bottle check for `BrewTestBot`

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -71,7 +71,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    if: always() && github.repository_owner == 'Homebrew'
+    if: always() && github.repository_owner == 'Homebrew' && github.actor != 'BrewTestBot'
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/homebrew/ubuntu22.04:main


### PR DESCRIPTION
We don't need to check for bottle block modifications on pushes by
@BrewTestBot, so let's skip this check in those cases. It'll also save
us a few extra API calls per PR.
