### PR TITLE
phoronix-test-suite: build an `:all` bottle

### DIFF
--- a/Formula/p/phoronix-test-suite.rb
+++ b/Formula/p/phoronix-test-suite.rb
@@ -32,6 +32,18 @@ class PhoronixTestSuite < Formula
     system "./install-sh", prefix
     prefix.install (buildpath/"dest/#{prefix}").children
     bash_completion.install "dest/#{prefix}/../etc/bash_completion.d/phoronix-test-suite"
+
+    # build an `:all` bottle.
+    inreplace_files = [
+      bin/"phoronix-test-suite",
+      *pkgshare.glob("ob-cache/test-profiles/pts/*/install.sh"),
+      pkgshare/"pts-core/external-test-dependencies/xml/dragonfly-packages.xml",
+      pkgshare/"pts-core/objects/client/pts_client.php",
+      pkgshare/"pts-core/objects/client/pts_external_dependencies.php",
+      pkgshare/"pts-core/objects/phodevi/components/phodevi_system.php",
+      pkgshare/"pts-core/pts-core.php",
+    ]
+    inreplace inreplace_files, "/usr/local", HOMEBREW_PREFIX, audit_result: false
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
