### PR TITLE
workflows/triage: handle PRs that target the `master` branch

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -30,6 +30,55 @@ jobs:
           name: event_payload
           path: ${{ github.event_path }}
 
+  check-base-branch:
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    if: always() && github.repository_owner == 'Homebrew' && github.actor != 'BrewTestBot'
+    runs-on: ubuntu-latest
+    env:
+      PR: ${{ github.event.number }}
+    steps:
+      - name: Check pull request base branch
+        id: base
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          branch="$(
+            gh api \
+              --header 'Accept: application/vnd.github+json' \
+              --header 'X-GitHub-Api-Version: 2022-11-28' \
+              "repos/$GITHUB_REPOSITORY/pulls/$PR" \
+              --jq '.base.ref'
+          )"
+          echo "branch=${branch}" >>"${GITHUB_OUTPUT}"
+
+      - name: Change base branch to `main`
+        id: change
+        if: steps.base.outputs.branch == 'master'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr edit "${PR}" --base main
+
+      - name: Post comment
+        if: steps.base.outputs.branch == 'master'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BODY: |-
+            > [!TIP]
+            > This pull request targets the `master` branch. For future pull requests, please target the `main` branch instead.
+        run: gh pr comment "${PR}" --body "${BODY}" --repo "${GITHUB_REPOSITORY}"
+
+      - name: Post failure comment
+        if: failure() && steps.change.conclusion == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BODY: |-
+            > [!CAUTION]
+            > Failed to change base branch to `main`. Please edit your pull request manually to target the `main` branch instead of the `master` branch.
+        run: gh pr comment "${PR}" --body "${BODY}" --repo "${GITHUB_REPOSITORY}"
+
   workflows-label:
     permissions:
       contents: read
@@ -37,12 +86,13 @@ jobs:
       pull-requests: write
     if: always() && github.repository_owner == 'Homebrew'
     runs-on: ubuntu-latest
+    env:
+      PR: ${{ github.event.number }}
     steps:
       - name: Check pull request changed files
         id: files
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR: ${{ github.event.number }}
         run: |
           workflow_modified="$(
             gh api \
@@ -63,7 +113,6 @@ jobs:
         if: always() && fromJson(steps.files.outputs.workflow_modified)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR: ${{ github.event.number }}
         run: gh pr edit --add-label workflows "$PR" --repo "$GITHUB_REPOSITORY"
 
   check-bottle-block:


### PR DESCRIPTION
We still get PRs that target the `master` branch occasionally. See, for
example, #229923 or #229921.

Let's handle that by editing the PR to target the `main` branch
automatically whenever they target the `master` branch, and then posting
a comment if that fails.
