### PR TITLE
workflows/publish-commit-bottles: remove `master` branch handling

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -176,10 +176,6 @@ jobs:
           then
             branch="$head_repo_owner/main"
             remote_branch="main"
-          elif [[ "$branch" = "master" ]]
-          then
-            branch="$head_repo_owner/master"
-            remote_branch="master"
           else
             remote_branch="$branch"
           fi


### PR DESCRIPTION
This causes `git push` failures. See:
- https://github.com/Homebrew/homebrew-core/pull/229921
- https://github.com/Homebrew/homebrew-core/actions/runs/16256248205/job/45893021647#step:11:33
