### PR TITLE
publish-commit-bottles: avoid merging PRs that target the `master` branch

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -104,6 +104,7 @@ jobs:
           )"
 
           pushable="$(jq .maintainer_can_modify <<< "$pr_data")"
+          base_branch="$(jq --raw-output .base.ref <<< "$pr_data")"
           branch="$(jq --raw-output .head.ref <<< "$pr_data")"
           remote="$(jq --raw-output .head.repo.clone_url <<< "$pr_data")"
           head_repo="$(jq --raw-output .head.repo.full_name <<< "$pr_data")"
@@ -116,6 +117,7 @@ jobs:
           automerge_enabled="$(jq --raw-output '.auto_merge != null' <<< "$pr_data")"
 
           if [[ -z "$pushable" ]] ||
+             [[ -z "$base_branch" ]] ||
              [[ -z "$branch" ]] ||
              [[ -z "$remote" ]] ||
              [[ -z "$head_repo" ]] ||
@@ -134,6 +136,12 @@ jobs:
           if [[ "$state" = "closed" ]]
           then
             echo "::error ::PR #$PR is closed!"
+            exit 1
+          fi
+
+          if [[ "$base_branch" = "master" ]]
+          then
+            echo "::error ::PR #$PR targets the \`master\` branch!"
             exit 1
           fi
 


### PR DESCRIPTION
Commits that are merged directly to the `master` branch will get
clobbered by the `sync-default-branches` workflow, so we don't want to
merge these PRs.
