### PR TITLE
workflows: use `--branch=main` for `brew pr-publish`

### DIFF
--- a/.github/workflows/automerge-from-merge-queue.yml
+++ b/.github/workflows/automerge-from-merge-queue.yml
@@ -264,7 +264,7 @@ jobs:
           cask: false
           test-bot: false
 
-      - run: brew pr-publish "$PR"
+      - run: brew pr-publish --branch=main "$PR"
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ needs.status-check.outputs.pull-number }}

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -194,7 +194,7 @@ jobs:
           cask: false
           test-bot: false
 
-      - run: brew pr-publish "$PR"
+      - run: brew pr-publish --branch=main "$PR"
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ needs.status-check.outputs.pull-number }}


### PR DESCRIPTION
`brew pr-publish` defaults to using the workflow from the `master`
branch when the `--branch` flag is not specified.

We could probably change the default of `pr-publish`, but that could
break external users and likely needs a deprecation cycle. Let's just
set `--branch=main` here for now instead.
