### PR TITLE
ktlint 1.7.0

### DIFF
--- a/Formula/k/ktlint.rb
+++ b/Formula/k/ktlint.rb
@@ -8,7 +8,7 @@ class Ktlint < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "778789c98fd46753ea4176df0a91970a6739ffe1169de393ef5f03aa894801cf"
+    sha256 cellar: :any_skip_relocation, all: "26caa0f95757c4b4e2425cfe4d4655e520b55bad6bec7076bcbb5877203b5a61"
   end
 
   depends_on "openjdk"

--- a/Formula/k/ktlint.rb
+++ b/Formula/k/ktlint.rb
@@ -1,8 +1,8 @@
 class Ktlint < Formula
   desc "Anti-bikeshedding Kotlin linter with built-in formatter"
   homepage "https://ktlint.github.io/"
-  url "https://github.com/pinterest/ktlint/releases/download/1.6.0/ktlint-1.6.0.zip"
-  sha256 "3d7b44230df2a71c17667b59a0d17e2e3658135f29dcfa3e72b6ed5c4d29b34d"
+  url "https://github.com/pinterest/ktlint/releases/download/1.7.0/ktlint-1.7.0.zip"
+  sha256 "5ad9e7de901163c9acd990dd694fcde8dd3b7271aeeac89468bac8267726f10d"
   license "MIT"
 
   no_autobump! because: :requires_manual_review


### PR DESCRIPTION
(Manual bump because formula failed for some reason)

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
