### PR TITLE
workflows/triage: add missing `--repo` flag

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -59,7 +59,7 @@ jobs:
         if: steps.base.outputs.branch == 'master'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr edit "${PR}" --base main
+        run: gh pr edit "${PR}" --base main --repo "${GITHUB_REPOSITORY}"
 
       - name: Post comment
         if: steps.base.outputs.branch == 'master'


### PR DESCRIPTION
See Homebrew/homebrew-cask#220033.
