### PR TITLE
git-annex: update build flags to enable p2http

### DIFF
--- a/Formula/g/git-annex.rb
+++ b/Formula/g/git-annex.rb
@@ -13,13 +13,14 @@ class GitAnnex < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "479b8a4312236700a75f5d7ce9f978e4caf3a0dc557733c27d28360e040a4692"
-    sha256 cellar: :any,                 arm64_sonoma:  "cf852d739508cb7be0e0916bb7d03f0773d5cd79a5be8da3631c83a13dfd4106"
-    sha256 cellar: :any,                 arm64_ventura: "dbcc125879a94b74f26022518f64ad975c88bf794e6ef3689345167f1e81d7b9"
-    sha256 cellar: :any,                 sonoma:        "74c4a5a1283979814b7a0e2541d635b6ba1bb862257251857d7e6aa954b60287"
-    sha256 cellar: :any,                 ventura:       "3667b98e16d8908e73276a28d8d4da1881e505a38a2ee838ff79abc36b831b53"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "466998bdc019abab7b61e99bb150b3b334b69a2f9b2770ec82e36b371fed1f74"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "573e3a965f1333a85422a93acf8eeda885019b2d8f60c710e8d8c58d32344669"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "70e6d9fc258bbbd872f729b7ec34c15e4ef019c3c68092198556d6525bdcfe81"
+    sha256 cellar: :any,                 arm64_sonoma:  "f76639420917d1b6631b0ac68a665e757ca22ae21b7edcf48d784fb5bff0446a"
+    sha256 cellar: :any,                 arm64_ventura: "b0d8bd98559e8a7ffdd07f5d862644ccea2e7cbd2ad158ca6a11b559e2457fc3"
+    sha256 cellar: :any,                 sonoma:        "ee4550452b4a839918f6966ed2264e548e6cd3dccae202141ec0ce05b393f74c"
+    sha256 cellar: :any,                 ventura:       "c6656a3746c29a3c4547509edb1c52bc3c128ed57097b1436ab74a897d624999"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "46d5aed0d9d308e7920ca1eca348a341b6bb67bb61fa1182e9e6f24db7a033a1"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a4043d6a03232beac6d5f33c905644dc118336def3fae6ecb1fdc8398f7645c9"
   end
 
   depends_on "cabal-install" => :build

--- a/Formula/g/git-annex.rb
+++ b/Formula/g/git-annex.rb
@@ -31,9 +31,7 @@ class GitAnnex < Formula
 
   def install
     system "cabal", "v2-update"
-    # Work around https://github.com/yesodweb/yesod/issues/1854 with constraint
-    # TODO: Remove once fixed upstream
-    system "cabal", "v2-install", *std_cabal_v2_args, "--flags=+S3", "--constraint=wai-extra<3.1.17"
+    system "cabal", "v2-install", *std_cabal_v2_args, "--flags=+S3 +Servant"
     bin.install_symlink "git-annex" => "git-annex-shell"
   end
 


### PR DESCRIPTION
This commit introduces two changes in the cabal build command, one is a chore and and one enables additional functionality by adding an optional build flag.

### Remove build dependency constraint

Following the TODO in the code comment, the pinned constraint is removed. The underlying issue (yesodweb/yesod/issues/1854) is marked as resolved and issue comments confirm that the bound on wai-extra is no longer needed.

### Add Servant build flag enabling p2http

From git-annex.cabal:

> Use the servant library, enabling using annex+http urls and git-annex p2phttp

This flag and related features were introduced in git-annex v10.20240731. In practice, git-annex built with this flag is able to push annexed files over http(s). An example context where this is useful are Git forges with annex support, such as
https://codeberg.org/forgejo-aneksajo, a soft fork of https://forgejo.org.

This introduces additional build dependencies (`servant-*`, `warp-*`), managed by cabal. When tested in the homebrew/ubuntu22.04:latest container, this increased the binary size from 123M to 129M.

See:
- https://git-annex.branchable.com/git-annex-p2phttp/
- https://git-annex.branchable.com/tips/smart_http_server/
- (edit) https://git-annex.branchable.com/forum/is_it_safe_to_enable_Servant_by_default__63__/

Please note: I wasn't sure if the change warrants adding a `revision` to the formula. The added build flag would change the application's behavior (added features) but it should not affect anything that might depend on  git-annex.

-----
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
