### PR TITLE
Fix OpenBLAS pkg-config OpenMP flag on macOS

### DIFF
--- a/Formula/o/openblas.rb
+++ b/Formula/o/openblas.rb
@@ -61,6 +61,13 @@ class Openblas < Formula
 
     lib.install_symlink shared_library("libopenblas") => shared_library("libblas")
     lib.install_symlink shared_library("libopenblas") => shared_library("liblapack")
+
+    # Fix pkg-config file on macOS to remove unsupported -fopenmp flag
+    if OS.mac?
+      pkgconfig_file = lib/"pkgconfig/openblas.pc"
+      pkgconfig_content = pkgconfig_file.read
+      pkgconfig_file.write pkgconfig_content.gsub(/^omp_opt=-fopenmp$/, "omp_opt=")
+    end
   end
 
   test do


### PR DESCRIPTION
The OpenBLAS pkg-config file includes `-fopenmp` which is not supported by macOS's default clang compiler, causing build failures for dependent packages. This patch removes the unsupported flag on macOS while preserving OpenMP support on other platforms.

Fixes issues with packages that depend on OpenBLAS and use pkg-config for configuration.

🤖 Generated with [Claude Code](https://claude.ai/code)