### PR TITLE
damask-grid: add livecheck

### DIFF
--- a/Formula/d/damask-grid.rb
+++ b/Formula/d/damask-grid.rb
@@ -5,6 +5,13 @@ class DamaskGrid < Formula
   sha256 "82f9b3aefde87193c12a7c908f42b711b278438f6cad650918989e37fb6dbde4"
   license "AGPL-3.0-only"
 
+  # The first-party website doesn't always reflect the newest version, so we
+  # check GitHub releases for now.
+  livecheck do
+    url "https://github.com/damask-multiphysics/damask"
+    strategy :github_latest
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "0b18ca183c5b10361923e36624cd0dd48200735b9e294da7fcb669c835a58d99"
     sha256 cellar: :any,                 arm64_sonoma:  "638f168e4c065d244b6d6fa8b060651058c17a87e6cc1af946cd6d97064a4c5c"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck is unable to identify versions for `damask-grid` and the formula also isn't excluded from autobump, so it's currently failing with an `unable to get versions` error. This adds a `livecheck` block that uses the `GithubLatest` strategy for now, as the first-party website hasn't been updated to list 3.0.2 as the newest version (a month on).

With this setup, livecheck could potentially surface a new version before the tarball is available on the first-party website and autobump would fail. However, it would eventually work when the file for the new version becomes available, so that would only be a problem if there's a long gap between those events. The alternative is to check the source code installation page on the website that contains the tarball URL but that's currently out of date, so we could be stuck on an older version for some indeterminate amount of time. Of those options, the former would ensure we update to the newest version whenever it's ready, so I'm using `GithubLatest` here until the first-party website reliably references the latest version.