### PR TITLE
misc: remove default completion shells

### DIFF
--- a/Formula/a/adr-viewer.rb
+++ b/Formula/a/adr-viewer.rb
@@ -69,8 +69,7 @@ class AdrViewer < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"adr-viewer",
-                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"adr-viewer", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/a/airshare.rb
+++ b/Formula/a/airshare.rb
@@ -141,7 +141,7 @@ class Airshare < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"airshare", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"airshare", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/a/animdl.rb
+++ b/Formula/a/animdl.rb
@@ -163,7 +163,7 @@ class Animdl < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"animdl", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"animdl", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/a/apprise.rb
+++ b/Formula/a/apprise.rb
@@ -71,7 +71,7 @@ class Apprise < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"apprise", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"apprise", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/a/aws-sam-cli.rb
+++ b/Formula/a/aws-sam-cli.rb
@@ -420,7 +420,7 @@ class AwsSamCli < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"sam", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"sam", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/a/aws-sso-util.rb
+++ b/Formula/a/aws-sso-util.rb
@@ -123,8 +123,7 @@ class AwsSsoUtil < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"aws-sso-util",
-                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"aws-sso-util", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/b/beancount.rb
+++ b/Formula/b/beancount.rb
@@ -57,7 +57,7 @@ class Beancount < Formula
     virtualenv_install_with_resources
 
     bin.glob("bean-*") do |executable|
-      generate_completions_from_executable(executable, shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+      generate_completions_from_executable(executable, shell_parameter_format: :click)
     end
   end
 

--- a/Formula/b/bilix.rb
+++ b/Formula/b/bilix.rb
@@ -197,7 +197,7 @@ class Bilix < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"bilix", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"bilix", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/b/bump-my-version.rb
+++ b/Formula/b/bump-my-version.rb
@@ -155,8 +155,7 @@ class BumpMyVersion < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"bump-my-version",
-                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"bump-my-version", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/c/cekit.rb
+++ b/Formula/c/cekit.rb
@@ -79,7 +79,7 @@ class Cekit < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"cekit", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"cekit", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/c/cf2tf.rb
+++ b/Formula/c/cf2tf.rb
@@ -123,7 +123,7 @@ class Cf2tf < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"cf2tf", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"cf2tf", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/c/cfn-flip.rb
+++ b/Formula/c/cfn-flip.rb
@@ -42,7 +42,7 @@ class CfnFlip < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"cfn-flip", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"cfn-flip", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/c/cfripper.rb
+++ b/Formula/c/cfripper.rb
@@ -114,7 +114,7 @@ class Cfripper < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"cfripper", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"cfripper", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/c/check-jsonschema.rb
+++ b/Formula/c/check-jsonschema.rb
@@ -146,11 +146,7 @@ class CheckJsonschema < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(
-      bin/"check-jsonschema",
-      shells:                 [:bash, :fish, :zsh],
-      shell_parameter_format: :click,
-    )
+    generate_completions_from_executable(bin/"check-jsonschema", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/c/cloudsplaining.rb
+++ b/Formula/c/cloudsplaining.rb
@@ -143,8 +143,7 @@ class Cloudsplaining < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"cloudsplaining", shells:
-                                         [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"cloudsplaining", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/c/cobo-cli.rb
+++ b/Formula/c/cobo-cli.rb
@@ -184,7 +184,7 @@ class CoboCli < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"cobo", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"cobo", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/c/codecov-cli.rb
+++ b/Formula/c/codecov-cli.rb
@@ -84,8 +84,7 @@ class CodecovCli < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"codecovcli",
-                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"codecovcli", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/c/compiledb.rb
+++ b/Formula/c/compiledb.rb
@@ -28,8 +28,7 @@ class Compiledb < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"compiledb",
-                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"compiledb", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/c/conda-lock.rb
+++ b/Formula/c/conda-lock.rb
@@ -278,8 +278,7 @@ class CondaLock < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"conda-lock", shells:
-                                         [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"conda-lock", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/c/cookiecutter.rb
+++ b/Formula/c/cookiecutter.rb
@@ -127,8 +127,7 @@ class Cookiecutter < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"cookiecutter",
-                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"cookiecutter", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/d/datasette.rb
+++ b/Formula/d/datasette.rb
@@ -156,8 +156,7 @@ class Datasette < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"datasette",
-                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"datasette", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/d/djlint.rb
+++ b/Formula/d/djlint.rb
@@ -80,7 +80,7 @@ class Djlint < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"djlint", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"djlint", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/d/dnsgen.rb
+++ b/Formula/d/dnsgen.rb
@@ -60,7 +60,7 @@ class Dnsgen < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"dnsgen", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"dnsgen", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/d/dooit.rb
+++ b/Formula/d/dooit.rb
@@ -119,7 +119,7 @@ class Dooit < Formula
 
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"dooit", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"dooit", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/e/ecs-deploy.rb
+++ b/Formula/e/ecs-deploy.rb
@@ -88,7 +88,7 @@ class EcsDeploy < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"ecs", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"ecs", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/e/euler-py.rb
+++ b/Formula/e/euler-py.rb
@@ -28,7 +28,7 @@ class EulerPy < Formula
     inreplace "requirements.txt", "click==4.0", "click"
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"euler", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"euler", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/e/evernote-backup.rb
+++ b/Formula/e/evernote-backup.rb
@@ -93,8 +93,7 @@ class EvernoteBackup < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"evernote-backup",
-                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"evernote-backup", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/f/fava.rb
+++ b/Formula/f/fava.rb
@@ -201,7 +201,7 @@ class Fava < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"fava", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"fava", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/f/fiona.rb
+++ b/Formula/f/fiona.rb
@@ -48,7 +48,7 @@ class Fiona < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"fio", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"fio", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/f/flintrock.rb
+++ b/Formula/f/flintrock.rb
@@ -92,8 +92,7 @@ class Flintrock < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"flintrock",
-                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"flintrock", shell_parameter_format: :click)
   end
 
   test do
@@ -116,5 +115,5 @@ index e95a10e..02925e7 100644
 -        'PyYAML == 6.0.1',
 +        'PyYAML == 6.0.2',
      ],
- 
+
      entry_points={

--- a/Formula/f/fred.rb
+++ b/Formula/f/fred.rb
@@ -56,7 +56,7 @@ class Fred < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"fred", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"fred", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/g/ggshield.rb
+++ b/Formula/g/ggshield.rb
@@ -137,7 +137,7 @@ class Ggshield < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"ggshield", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"ggshield", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/g/gitlint.rb
+++ b/Formula/g/gitlint.rb
@@ -49,9 +49,7 @@ class Gitlint < Formula
   def install
     virtualenv_install_with_resources
 
-    # Click does not support bash version older than 4.4
-    generate_completions_from_executable(bin/"gitlint", shells:                 [:bash, :fish, :zsh],
-                                                        shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"gitlint", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/g/goolabs.rb
+++ b/Formula/g/goolabs.rb
@@ -51,7 +51,7 @@ class Goolabs < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"goolabs", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"goolabs", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/g/gptme.rb
+++ b/Formula/g/gptme.rb
@@ -280,7 +280,7 @@ class Gptme < Formula
 
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"gptme", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"gptme", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/h/harlequin.rb
+++ b/Formula/h/harlequin.rb
@@ -230,8 +230,7 @@ class Harlequin < Formula
       venv.pip_install Pathname.pwd/"mysql-connector-python"
     end
 
-    generate_completions_from_executable(bin/"harlequin",
-                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"harlequin", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/h/hatch.rb
+++ b/Formula/h/hatch.rb
@@ -197,7 +197,7 @@ class Hatch < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"hatch", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"hatch", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/h/homeassistant-cli.rb
+++ b/Formula/h/homeassistant-cli.rb
@@ -177,8 +177,7 @@ class HomeassistantCli < Formula
 
   def install
     virtualenv_install_with_resources
-    generate_completions_from_executable(bin/"hass-cli", shells:                 [:bash, :fish, :zsh],
-                                                         shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"hass-cli", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/h/http-prompt.rb
+++ b/Formula/h/http-prompt.rb
@@ -134,8 +134,7 @@ class HttpPrompt < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"http-prompt",
-                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"http-prompt", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/i/intermodal.rb
+++ b/Formula/i/intermodal.rb
@@ -28,7 +28,7 @@ class Intermodal < Formula
   def install
     system "cargo", "install", *std_cargo_args
     system "cargo", "run", "--package", "gen", "--", "--bin", bin/"imdl", "man"
-    generate_completions_from_executable(bin/"imdl", "completions", shells: [:fish, :zsh, :bash])
+    generate_completions_from_executable(bin/"imdl", "completions")
 
     man1.install Dir["target/gen/man/*.1"]
   end

--- a/Formula/i/iredis.rb
+++ b/Formula/i/iredis.rb
@@ -74,7 +74,7 @@ class Iredis < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"iredis", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"iredis", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/k/khal.rb
+++ b/Formula/k/khal.rb
@@ -91,7 +91,7 @@ class Khal < Formula
     virtualenv_install_with_resources
 
     %w[khal ikhal].each do |cmd|
-      generate_completions_from_executable(bin/cmd, shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+      generate_completions_from_executable(bin/cmd, shell_parameter_format: :click)
     end
   end
 

--- a/Formula/l/langgraph-cli.rb
+++ b/Formula/l/langgraph-cli.rb
@@ -74,8 +74,7 @@ class LanggraphCli < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"langgraph",
-                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"langgraph", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/l/litecli.rb
+++ b/Formula/l/litecli.rb
@@ -59,7 +59,7 @@ class Litecli < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"litecli", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"litecli", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/l/llm.rb
+++ b/Formula/l/llm.rb
@@ -171,7 +171,7 @@ class Llm < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"llm", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"llm", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/l/localstack.rb
+++ b/Formula/l/localstack.rb
@@ -172,8 +172,7 @@ class Localstack < Formula
     virtualenv_install_with_resources
     bin.install_symlink libexec/"bin/localstack"
 
-    generate_completions_from_executable(bin/"localstack",
-                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"localstack", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/m/manim.rb
+++ b/Formula/m/manim.rb
@@ -220,7 +220,7 @@ class Manim < Formula
     end
     virtualenv_install_with_resources(without:)
 
-    generate_completions_from_executable(bin/"manim", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"manim", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/m/meta-package-manager.rb
+++ b/Formula/m/meta-package-manager.rb
@@ -308,7 +308,7 @@ class MetaPackageManager < Formula
     rewrite_shebang detected_python_shebang, "meta_package_manager/bar_plugin.py"
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"mpm", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"mpm", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/m/mkdocs.rb
+++ b/Formula/m/mkdocs.rb
@@ -103,7 +103,7 @@ class Mkdocs < Formula
     ENV["PIP_USE_PEP517"] = "1"
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"mkdocs", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"mkdocs", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/m/molecule.rb
+++ b/Formula/m/molecule.rb
@@ -213,7 +213,7 @@ class Molecule < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"molecule", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"molecule", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/m/mvt.rb
+++ b/Formula/m/mvt.rb
@@ -216,7 +216,7 @@ class Mvt < Formula
     end
 
     %w[mvt-android mvt-ios].each do |script|
-      generate_completions_from_executable(bin/script, shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+      generate_completions_from_executable(bin/script, shell_parameter_format: :click)
     end
   end
 

--- a/Formula/m/mycli.rb
+++ b/Formula/m/mycli.rb
@@ -96,9 +96,7 @@ class Mycli < Formula
   def install
     virtualenv_install_with_resources
 
-    # Click does not support bash version older than 4.4
-    generate_completions_from_executable(bin/"mycli", shells:                 [:bash, :fish, :zsh],
-                                                      shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"mycli", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/n/name-that-hash.rb
+++ b/Formula/n/name-that-hash.rb
@@ -47,7 +47,7 @@ class NameThatHash < Formula
     virtualenv_install_with_resources
 
     %w[name-that-hash nth].each do |cmd|
-      generate_completions_from_executable(bin/cmd, shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+      generate_completions_from_executable(bin/cmd, shell_parameter_format: :click)
     end
   end
 

--- a/Formula/n/notifiers.rb
+++ b/Formula/n/notifiers.rb
@@ -86,8 +86,7 @@ class Notifiers < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"notifiers",
-                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"notifiers", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/o/okta-awscli.rb
+++ b/Formula/o/okta-awscli.rb
@@ -99,8 +99,7 @@ class OktaAwscli < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"okta-awscli",
-                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"okta-awscli", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/o/otterdog.rb
+++ b/Formula/o/otterdog.rb
@@ -265,7 +265,7 @@ class Otterdog < Formula
     ENV["SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PLAYWRIGHT"] = resource("playwright").version
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"otterdog", shell_parameter_format: :click, shells: [:bash, :fish, :zsh])
+    generate_completions_from_executable(bin/"otterdog", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/p/pgcli.rb
+++ b/Formula/p/pgcli.rb
@@ -91,7 +91,7 @@ class Pgcli < Formula
       venv.pip_install Pathname.pwd
     end
 
-    generate_completions_from_executable(bin/"pgcli", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"pgcli", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/p/pip-tools.rb
+++ b/Formula/p/pip-tools.rb
@@ -55,7 +55,7 @@ class PipTools < Formula
     virtualenv_install_with_resources
 
     %w[pip-compile pip-sync].each do |script|
-      generate_completions_from_executable(bin/script, shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+      generate_completions_from_executable(bin/script, shell_parameter_format: :click)
     end
   end
 

--- a/Formula/p/pipenv.rb
+++ b/Formula/p/pipenv.rb
@@ -58,8 +58,7 @@ class Pipenv < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(libexec/"bin/pipenv", shells:                 [:bash, :fish, :zsh],
-                                                               shell_parameter_format: :click)
+    generate_completions_from_executable(libexec/"bin/pipenv", shell_parameter_format: :click)
   end
 
   # Avoid relative paths

--- a/Formula/p/pipgrip.rb
+++ b/Formula/p/pipgrip.rb
@@ -50,7 +50,7 @@ class Pipgrip < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"pipgrip", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"pipgrip", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/p/platformio.rb
+++ b/Formula/p/platformio.rb
@@ -125,7 +125,7 @@ class Platformio < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"pio", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"pio", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/p/policy_sentry.rb
+++ b/Formula/p/policy_sentry.rb
@@ -83,8 +83,7 @@ class PolicySentry < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"policy_sentry",
-                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"policy_sentry", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/p/posting.rb
+++ b/Formula/p/posting.rb
@@ -187,7 +187,7 @@ class Posting < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"posting", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"posting", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/p/proselint.rb
+++ b/Formula/p/proselint.rb
@@ -23,8 +23,7 @@ class Proselint < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"proselint",
-                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"proselint", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/r/rasterio.rb
+++ b/Formula/r/rasterio.rb
@@ -67,7 +67,7 @@ class Rasterio < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"rio", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"rio", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/r/reuse.rb
+++ b/Formula/r/reuse.rb
@@ -81,7 +81,7 @@ class Reuse < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"reuse", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"reuse", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/r/rich-cli.rb
+++ b/Formula/r/rich-cli.rb
@@ -76,7 +76,7 @@ class RichCli < Formula
 
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"rich", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"rich", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/s/sail.rb
+++ b/Formula/s/sail.rb
@@ -141,7 +141,7 @@ class Sail < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"sail", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"sail", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/s/sceptre.rb
+++ b/Formula/s/sceptre.rb
@@ -165,7 +165,7 @@ class Sceptre < Formula
     # Avoid issue if `numpy` is installed, https://github.com/Sceptre/sceptre/issues/1541
     virtualenv_install_with_resources(system_site_packages: false)
 
-    generate_completions_from_executable(bin/"sceptre", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"sceptre", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/s/schemathesis.rb
+++ b/Formula/s/schemathesis.rb
@@ -287,7 +287,7 @@ class Schemathesis < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"st", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"st", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/s/semgrep.rb
+++ b/Formula/s/semgrep.rb
@@ -342,9 +342,7 @@ class Semgrep < Formula
 
     venv.pip_install_and_link buildpath/"cli"
 
-    generate_completions_from_executable(bin/"semgrep", "--legacy",
-                                         shells:                 [:bash, :fish, :zsh],
-                                         shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"semgrep", "--legacy", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/s/sgr.rb
+++ b/Formula/s/sgr.rb
@@ -222,7 +222,7 @@ class Sgr < Formula
     inreplace "pyproject.toml", 'version = "==3.4"', 'version = ">=3.4"'
 
     virtualenv_install_with_resources start_with: "setuptools"
-    generate_completions_from_executable(bin/"sgr", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"sgr", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/s/shallow-backup.rb
+++ b/Formula/s/shallow-backup.rb
@@ -90,11 +90,7 @@ class ShallowBackup < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(
-      bin/"shallow-backup",
-      shells:                 [:bash, :fish, :zsh],
-      shell_parameter_format: :click,
-    )
+    generate_completions_from_executable(bin/"shallow-backup", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/s/shodan.rb
+++ b/Formula/s/shodan.rb
@@ -84,7 +84,7 @@ class Shodan < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"shodan", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"shodan", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/s/shub.rb
+++ b/Formula/s/shub.rb
@@ -97,7 +97,7 @@ class Shub < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"shub", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"shub", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/s/sigma-cli.rb
+++ b/Formula/s/sigma-cli.rb
@@ -113,7 +113,7 @@ class SigmaCli < Formula
 
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"sigma", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"sigma", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/s/snakefmt.rb
+++ b/Formula/s/snakefmt.rb
@@ -62,7 +62,7 @@ class Snakefmt < Formula
 
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"snakefmt", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"snakefmt", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/s/sqlfluff.rb
+++ b/Formula/s/sqlfluff.rb
@@ -108,7 +108,7 @@ class Sqlfluff < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"sqlfluff", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"sqlfluff", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/s/sqlite-utils.rb
+++ b/Formula/s/sqlite-utils.rb
@@ -58,8 +58,7 @@ class SqliteUtils < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"sqlite-utils",
-                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"sqlite-utils", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/s/subliminal.rb
+++ b/Formula/s/subliminal.rb
@@ -192,8 +192,7 @@ class Subliminal < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"subliminal",
-                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"subliminal", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/t/tartufo.rb
+++ b/Formula/t/tartufo.rb
@@ -51,7 +51,7 @@ class Tartufo < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"tartufo", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"tartufo", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/t/tmt.rb
+++ b/Formula/t/tmt.rb
@@ -166,7 +166,7 @@ class Tmt < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"tmt", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"tmt", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/t/trailscraper.rb
+++ b/Formula/t/trailscraper.rb
@@ -101,8 +101,7 @@ class Trailscraper < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"trailscraper",
-                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"trailscraper", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/t/twtxt.rb
+++ b/Formula/t/twtxt.rb
@@ -97,7 +97,7 @@ class Twtxt < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"twtxt", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"twtxt", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/u/uvicorn.rb
+++ b/Formula/u/uvicorn.rb
@@ -81,7 +81,7 @@ class Uvicorn < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"uvicorn", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"uvicorn", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/v/vdirsyncer.rb
+++ b/Formula/v/vdirsyncer.rb
@@ -117,8 +117,7 @@ class Vdirsyncer < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"vdirsyncer",
-                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"vdirsyncer", shell_parameter_format: :click)
   end
 
   service do

--- a/Formula/v/vunnel.rb
+++ b/Formula/v/vunnel.rb
@@ -233,7 +233,7 @@ class Vunnel < Formula
 
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"vunnel", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"vunnel", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/w/waybackpy.rb
+++ b/Formula/w/waybackpy.rb
@@ -46,8 +46,7 @@ class Waybackpy < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"waybackpy",
-                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"waybackpy", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/w/weaviate-cli.rb
+++ b/Formula/w/weaviate-cli.rb
@@ -180,8 +180,7 @@ class WeaviateCli < Formula
   def install
     virtualenv_install_with_resources
 
-    generate_completions_from_executable(bin/"weaviate-cli",
-                                         shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"weaviate-cli", shell_parameter_format: :click)
   end
 
   test do

--- a/Formula/y/ykman.rb
+++ b/Formula/y/ykman.rb
@@ -92,8 +92,7 @@ class Ykman < Formula
 
     man1.install "man/ykman.1"
 
-    # Click doesn't support generating completions for Bash versions older than 4.4
-    generate_completions_from_executable(bin/"ykman", shells: [:bash, :fish, :zsh], shell_parameter_format: :click)
+    generate_completions_from_executable(bin/"ykman", shell_parameter_format: :click)
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Saves some space since `shells` already defaults to these three
