### PR TITLE
tracy: fix broken CMake config by adding missing IMPORTED_LOCATION

### DIFF
--- a/Formula/t/tracy.rb
+++ b/Formula/t/tracy.rb
@@ -52,6 +52,14 @@ class Tracy < Formula
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
     bin.install_symlink "tracy-profiler" => "tracy"
+    inreplace share/"Tracy/TracyTargets.cmake",
+      'add_library(Tracy::TracyClient SHARED IMPORTED)',
+      <<~EOS.chomp
+        add_library(Tracy::TracyClient SHARED IMPORTED)
+        set_target_properties(Tracy::TracyClient PROPERTIES
+          IMPORTED_LOCATION "#{lib}/libTracyClient.dylib"
+        )
+      EOS
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This patch fixes a bug in the tracy formula where the generated TracyTargets.cmake defines an imported CMake target (Tracy::TracyClient) but does not specify an IMPORTED_LOCATION. This causes find_package(TRACY CONFIG REQUIRED) to fail in downstream CMake projects.

The patch uses inreplace to inject the correct IMPORTED_LOCATION path to libTracyClient.dylib after install.