### PR TITLE
tofu-ls 0.0.9 (new formula)

### DIFF
--- a/Formula/t/tofu-ls.rb
+++ b/Formula/t/tofu-ls.rb
@@ -11,6 +11,15 @@ class TofuLs < Formula
     strategy :github_latest
   end
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "eeb813558e7c0b53839efb0be344b9bce8e704cb37dad5d161bd6cbe362611a5"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "eeb813558e7c0b53839efb0be344b9bce8e704cb37dad5d161bd6cbe362611a5"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "eeb813558e7c0b53839efb0be344b9bce8e704cb37dad5d161bd6cbe362611a5"
+    sha256 cellar: :any_skip_relocation, sonoma:        "2393223139ffd08bc902c9b42fc6f3a4d0a5d26fa87720cc8ab719bd9f659a92"
+    sha256 cellar: :any_skip_relocation, ventura:       "2393223139ffd08bc902c9b42fc6f3a4d0a5d26fa87720cc8ab719bd9f659a92"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "11af98ca5b53dbbb4d4d3459def3b6d5a18a9c2ec84e8e813651e5b248eae808"
+  end
+
   depends_on "go" => :build
 
   def install

--- a/Formula/t/tofu-ls.rb
+++ b/Formula/t/tofu-ls.rb
@@ -1,0 +1,45 @@
+class TofuLs < Formula
+  desc "OpenTofu Language Server"
+  homepage "https://github.com/opentofu/tofu-ls"
+  url "https://github.com/opentofu/tofu-ls/archive/refs/tags/v0.0.9.tar.gz"
+  sha256 "b51402936314f4495a440a99eecedccc07c0175f81c9533eb3510f9e4f76d879"
+  license "MPL-2.0"
+  head "https://github.com/opentofu/tofu-ls.git", branch: "main"
+
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = %W[
+      -s -w
+      -X main.rawVersion=#{version}+#{tap.user}
+    ]
+    system "go", "build", *std_go_args(ldflags: ldflags.join(" "))
+  end
+
+  test do
+    port = free_port
+
+    pid = fork do
+      exec "#{bin}/tofu-ls serve -port #{port} /dev/null"
+    end
+    sleep 2
+
+    begin
+      tcp_socket = TCPSocket.new("localhost", port)
+      tcp_socket.puts <<~EOF
+        Content-Length: 59
+
+        {"jsonrpc":"2.0","method":"initialize","params":{},"id":1}
+      EOF
+      assert_match "Content-Type", tcp_socket.gets("\n")
+    ensure
+      Process.kill("SIGINT", pid)
+      Process.wait(pid)
+    end
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Adds https://github.com/opentofu/tofu-ls/releases/tag/v0.0.9 , a fork of terraform-ls by the opentofu organization.

`brew audit --new tofu-ls` tells me "New formulae in homebrew/core should not have a `bottle do` block", so I removed it, but there are prebuilt binaries available.

The formula is largely identical to terraform-ls.
