### PR TITLE
bind: avoid deprecated funcs on all macOS

### DIFF
--- a/Formula/b/bind.rb
+++ b/Formula/b/bind.rb
@@ -23,13 +23,13 @@ class Bind < Formula
   end
 
   bottle do
-    sha256 arm64_sequoia: "91770706d4f5b7f01c9568c141d10089ad68bf37ac6cd6a53cb104b2aee21149"
-    sha256 arm64_sonoma:  "30d7b0fa3a88c134233bccb4bf957618c93984c9c66c8acdc1edc11a20fdb0c1"
-    sha256 arm64_ventura: "6da17b95947422e17f9f4b0841cd30a030a044fa5dfc05f6b6e7a1d09c827c3e"
-    sha256 sonoma:        "3de7831218d1deff7cc09d87f9c8d37ed562da4018b19298b275ed1cffb35281"
-    sha256 ventura:       "20865e955b2db8533060182ec053f71c8cf19684cd4d7a7578b05d95c06cabd3"
-    sha256 arm64_linux:   "dad7969335fa805548d1cc5efa1ad82595e74e6bf5b56088530dc6cf8f076fbb"
-    sha256 x86_64_linux:  "5c413322a82109929e3a5446005895b8de914120eea9f22217d4cb0eaf42b511"
+    sha256 arm64_sequoia: "ec86c918acab962d82267f20bf3b2baad077dacfbc2ce5968c4ec841dde34b89"
+    sha256 arm64_sonoma:  "736a239a4027b77698f52503a8103844702c51566eba9e628ea2aef528d4f34e"
+    sha256 arm64_ventura: "7a4119bce30046c23d032198dd165e3e16295308ddb2d28f8e86d6e2bcb864ec"
+    sha256 sonoma:        "2b6cddfc3f454c4b0e46ed80b05671d07b070de3b410b34173012a92f2b8600e"
+    sha256 ventura:       "d58dcf153aef18b184dab9e869da55b90ae111ee7e83ff803439ecfba367991d"
+    sha256 arm64_linux:   "07b07a13b4d712a1d4b5ee038a2634eab381dcae30a0964b0cb3357c4c3c1b4a"
+    sha256 x86_64_linux:  "1f4bbe94883a40c0ad6d5f7d8a74e190752a8d72b284742593d1fb0cda2bbd5b"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/b/bind.rb
+++ b/Formula/b/bind.rb
@@ -11,6 +11,7 @@ class Bind < Formula
   url "https://downloads.isc.org/isc/bind9/9.20.11/bind-9.20.11.tar.xz"
   sha256 "4da2d532e668bc21e883f6e6d9d3d81794d9ec60b181530385649a56f46ee17a"
   license "MPL-2.0"
+  revision 1
   version_scheme 1
   head "https://gitlab.isc.org/isc-projects/bind9.git", branch: "main"
 
@@ -50,6 +51,11 @@ class Bind < Formula
   end
 
   def install
+    # Apply macOS 15+ libxml2 deprecation to all macOS versions.
+    # This allows our macOS 14-built Intel bottle to work on macOS 15+
+    # and also cover the case where a user on macOS 14- updates to macOS 15+.
+    ENV.append_to_cflags "-DLIBXML_HAS_DEPRECATED_MEMORY_ALLOCATION_FUNCTIONS" if OS.mac?
+
     args = [
       "--prefix=#{prefix}",
       "--sysconfdir=#{pkgetc}",


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-core/issues/230454 is caused by us not building macOS 15 Intel bottles. Let's just avoid the deprecated functions on all macOS to handle this much smoother.

This will also fix a case where a user installed `bind` on macOS 14 but later updates to macOS 15 without reinstalling.