### PR TITLE
open-mpi: force build with Homebrew’s brewed GCC

### DIFF
--- a/Formula/o/open-mpi.rb
+++ b/Formula/o/open-mpi.rb
@@ -29,6 +29,7 @@ class OpenMpi < Formula
   end
 
   depends_on "gcc" # for gfortran
+  fails_with :clang
   depends_on "hwloc"
   depends_on "libevent"
   depends_on "pmix"
@@ -50,8 +51,8 @@ class OpenMpi < Formula
       ompi/tools/ompi_info/param.c
       oshmem/tools/oshmem_info/param.c
     ]
-    cxx = OS.linux? ? "g++" : ENV.cxx
-    cc = OS.linux? ? "gcc" : ENV.cc
+    cxx = ENV.cxx
+    cc = ENV.cc
     inreplace inreplace_files, "OMPI_CXX_ABSOLUTE", "\"#{cxx}\""
     inreplace inreplace_files, "OPAL_CC_ABSOLUTE", "\"#{cc}\""
     inreplace "3rd-party/prrte/src/tools/prte_info/param.c", "PRTE_CC_ABSOLUTE", "\"#{cc}\""
@@ -74,6 +75,7 @@ class OpenMpi < Formula
 
     system "./configure", *args, *std_configure_args
     system "make", "all"
+
     system "make", "check"
     system "make", "install"
 


### PR DESCRIPTION
This patch makes Open MPI always compile with the Homebrew-installed GCC (e.g. gcc-11, gcc-12, etc.) rather than Apple’s system Clang. By setting ENV["CC"]/ENV["CXX"] to the brewed-GCC shims at install time, we ensure:

Stability across Xcode/Clang upgrades. Every time Apple bumps its Clang, the “fixed headers” in GCC can go out of sync (see e.g. errors in include-fixed/stdio.h), breaking MPI builds.

Consistency for downstream formula that rely on GNU Fortran (gfortran) and MPI wrappers—PETSc, Trilinos, etc.—so that they all link against the same compiler and runtime ABI.

Minimal user overhead: folks who already depend on gcc (as Open MPI does) get the correct toolchain “for free,” without extra flags or brew extract hacks.

This change preserves all existing options and defaults (no user-visible flag changes) and only affects the build environment. We bump revision to force users’ bottles to rebuild under the new compiler settings.


<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
