### PR TITLE
kontroll 1.0.4

### DIFF
--- a/Formula/k/kontroll.rb
+++ b/Formula/k/kontroll.rb
@@ -1,0 +1,20 @@
+class Kontroll < Formula
+  desc "Keyboard layout switcher for ZSA keyboards"
+  homepage "https://github.com/zsa/kontroll"
+  url "https://github.com/zsa/kontroll/releases/download/1.0.4/kontroll-1.0.4-macos-universal.zip"
+  sha256 "fad2dde5d53114a8ff30ed75df414f169c13e00f04536e700c70785563811c5d"
+  license "MIT"
+
+  livecheck do
+    url "https://github.com/zsa/kontroll/releases/latest"
+    regex(%r{href=.*?/tag/(\d+(?:\.\d+)+)}i)
+  end
+
+  def install
+    bin.install "kontroll"
+  end
+
+  test do
+    system bin/"kontroll", "--version"
+  end
+end


### PR DESCRIPTION
This adds the `kontroll` app for keyboards shipped by ZSA.io like the Moonlander and Voyager.

The upstream URL is https://github.com/zsa/kontroll. The app has a MIT license. Upgrades are infrequent.

I extracted this from a local tap. They do binary releases (only) upstream so I used a livecheck locally with a URL, which I believe I need to change for distribution in homebred-core. Suggestion for that included in a comment