### PR TITLE
node: improve `--shared-*` flag check

### DIFF
--- a/Formula/n/node.rb
+++ b/Formula/n/node.rb
@@ -132,19 +132,17 @@ class Node < Formula
     ].map { |library| "--shared-#{library}" }
 
     configure_help = Utils.safe_popen_read("./configure", "--help")
-    shared_flag_regex = /\[(?<flag>--shared-[^ ]+)\]/
-    configure_help.each_line do |line|
-      matchdata = line.strip.match(shared_flag_regex)
-      next if matchdata.nil?
+    shared_flag_regex = /\[(--shared-[^ \]]+)\]/
+    configure_help.scan(shared_flag_regex) do |matches|
+      matches.each do |flag|
+        next if args.include?(flag) || ignored_shared_flags.include?(flag)
 
-      flag = matchdata[:flag]
-      next if args.include?(flag) || ignored_shared_flags.include?(flag)
-
-      message = "Unused `--shared-*` flag: #{flag}"
-      if build.head?
-        opoo message
-      else
-        odie message
+        message = "Unused `--shared-*` flag: #{flag}"
+        if build.head?
+          opoo message
+        else
+          odie message
+        end
       end
     end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is a port of #230770.

- use `String#scan` to ensure we capture all matches per line
- tighten regex by avoiding inadvertently capturing `]` characters
