### PR TITLE
cmd/check-bottle-modification: fix handling of removed files

### DIFF
--- a/cmd/check-bottle-modification.rb
+++ b/cmd/check-bottle-modification.rb
@@ -38,9 +38,10 @@ module Homebrew
 
         files = response.fetch("files")
         files.reject! do |file|
-          filename = file.fetch("filename")
+          next true if file.fetch("status") == "removed"
 
-          !filename.start_with?("Formula") || !filename.end_with?(".rb")
+          filename = file.fetch("filename")
+          !filename.start_with?("Formula/") || !filename.end_with?(".rb")
         end
 
         files.any? { |file| patch_modifies_bottle_block?(file.fetch("patch")) }


### PR DESCRIPTION
We don't need to error out here if a formula is removed. This is also
fixes handling of formula renames. See, for example, #230744 or #230831.
