### PR TITLE
lesspipe: build an `:all` bottle

### DIFF
--- a/Formula/l/lesspipe.rb
+++ b/Formula/l/lesspipe.rb
@@ -11,12 +11,8 @@ class Lesspipe < Formula
   ]
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "ba151d7b9a0525b3782c1b06315166e45d7b60acb95459aff6731705e2b23b46"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "ba151d7b9a0525b3782c1b06315166e45d7b60acb95459aff6731705e2b23b46"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "ba151d7b9a0525b3782c1b06315166e45d7b60acb95459aff6731705e2b23b46"
-    sha256 cellar: :any_skip_relocation, sonoma:        "ba151d7b9a0525b3782c1b06315166e45d7b60acb95459aff6731705e2b23b46"
-    sha256 cellar: :any_skip_relocation, ventura:       "ba151d7b9a0525b3782c1b06315166e45d7b60acb95459aff6731705e2b23b46"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "ed1c9414decbfbdb557090c3a85590bbf60ed504c2fb6e4665c4e9af7d82d408"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "c43495d6387ef2b753bd107583ec0d7016722a24ccec3d5b5ca7b54ccd5a33db"
   end
 
   uses_from_macos "zsh" => :build # needed to guarantee installation of zsh completions

--- a/Formula/l/lesspipe.rb
+++ b/Formula/l/lesspipe.rb
@@ -19,6 +19,7 @@ class Lesspipe < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "ed1c9414decbfbdb557090c3a85590bbf60ed504c2fb6e4665c4e9af7d82d408"
   end
 
+  uses_from_macos "zsh" => :build # needed to guarantee installation of zsh completions
   uses_from_macos "perl"
 
   on_macos do
@@ -26,8 +27,7 @@ class Lesspipe < Formula
   end
 
   def install
-    system "./configure", "--prefix=#{prefix}"
-    man1.mkpath
+    system "./configure", "--prefix=#{prefix}", "--shell=#{which("bash")}"
     system "make", "install"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This (along with the `:arm64_linux` bottle) was dropped in #230395.

Also, remove an unneeded `man1.mkpath`.
