### PR TITLE
erlang@24: switch to `wxwidgets@3.2`

### DIFF
--- a/Formula/e/erlang@24.rb
+++ b/Formula/e/erlang@24.rb
@@ -8,13 +8,13 @@ class ErlangAT24 < Formula
   revision 2
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "4b033ab7693bc346cfcdc745afe84cabb0a67326ec1651cd2294e6f0bb84eb24"
-    sha256 cellar: :any,                 arm64_sonoma:  "034839e7b3d701ed14dfb55a2e025bacc979106e12907a94f65a367bb71c13de"
-    sha256 cellar: :any,                 arm64_ventura: "57b237d5803642973cb653d25c8934a34edbf72ee1b1624ae328d6928ba3144e"
-    sha256 cellar: :any,                 sonoma:        "e3a714e6cb9575535d9f42a82e21757285a1cfd9141055f4924392768bdde52f"
-    sha256 cellar: :any,                 ventura:       "bd2eb3ff1de20d55737b6de2d6fe806f557ed3e1c25ac1c9aa875e50396db8e5"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "35c345a8de635902b798111366a269f48cbe5940eb4c12934f857327ec448c25"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1d7b48ce5b43fe07e78116d0c40ead3da8c54876a94aba05f7e4f893954e76a0"
+    sha256 cellar: :any,                 arm64_sequoia: "5dc7fb39df4822f6aedb31cdda284b8a1bdb8d23907d9c1f5391a5daaeb9cea0"
+    sha256 cellar: :any,                 arm64_sonoma:  "c23064f7cb67c96c630da1a470b9181c9296bdb74e347f77adf63a8fe493e9e6"
+    sha256 cellar: :any,                 arm64_ventura: "aff54c8543fb8471bfd80e565a9abea7a212835dd59802291035a108007396a9"
+    sha256 cellar: :any,                 sonoma:        "429e934b2cc7246538235f09c3f999cac23d58e41e4350ef94a88c4c88c41cd1"
+    sha256 cellar: :any,                 ventura:       "7ad814904a5b00ae3b698f37ed52bc16ec1bf4526e39c4171ee2d694a3aa7d4f"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "4e94076e1922d3a01253a031443cdfd5efebfe18cac0f6cfca22f0fd940307fc"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c3d53a2ec45d9831e696febdaa39d29febaa56f23ce2e2f1454de2fef5bb4fc2"
   end
 
   keg_only :versioned_formula


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is needed after #230768. This wasn't done in that PR since
`erlang@24` is deprecated, and will be disabled in 2 days.

Let's update it anyway since it's relatively straightforward to do, and
ensures that `brew extract` works properly even after this is disabled.
