### PR TITLE
wasi-libc: use `wasm-micro-runtime` for test

### DIFF
--- a/Formula/w/wasi-libc.rb
+++ b/Formula/w/wasi-libc.rb
@@ -40,7 +40,7 @@ class WasiLibc < Formula
 
   depends_on "llvm" => [:build, :test]
   depends_on "lld" => :test
-  depends_on "wasmtime" => :test
+  depends_on "wasm-micro-runtime" => :test
 
   # Needs clang
   fails_with :gcc
@@ -107,6 +107,6 @@ class WasiLibc < Formula
     (testpath/"lib/wasm32-unknown-wasi").install_symlink "libclang_rt.builtins-wasm32.a" => "libclang_rt.builtins.a"
     wasm_args = %W[--target=wasm32-wasi --sysroot=#{share}/wasi-sysroot]
     system clang, *wasm_args, "-v", "test.c", "-o", "test", "-resource-dir=#{testpath}"
-    assert_equal "the answer is 42", shell_output("wasmtime #{testpath}/test")
+    assert_equal "the answer is 42", shell_output("iwasm #{testpath}/test")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is a much lighter-weight dependency to use for the test. It also
avoids having `rust` in this formula's dependency tree, in case we want
to add a WASI target to `rust` in the future.
