### PR TITLE
libayatana-indicator 0.9.4 (new formula)

### DIFF
--- a/Formula/lib/libayatana-indicator.rb
+++ b/Formula/lib/libayatana-indicator.rb
@@ -1,0 +1,51 @@
+class LibayatanaIndicator < Formula
+  desc "Ayatana Indicators Shared Library"
+  homepage "https://github.com/AyatanaIndicators/libayatana-indicator"
+  url "https://github.com/AyatanaIndicators/libayatana-indicator/archive/refs/tags/0.9.4.tar.gz"
+  sha256 "a18d3c682e29afd77db24366f8475b26bda22b0e16ff569a2ec71cd6eb4eac95"
+  license "GPL-3.0-or-later"
+
+  depends_on "cmake" => :build
+  depends_on "gobject-introspection" => :build
+  depends_on "pkgconf" => [:build, :test]
+  depends_on "vala" => :build
+  depends_on "at-spi2-core"
+  depends_on "ayatana-ido"
+  depends_on "cairo"
+  depends_on "gdk-pixbuf"
+  depends_on "glib"
+  depends_on "gtk+3"
+  depends_on "harfbuzz"
+  depends_on :linux # PR ref: https://github.com/AyatanaIndicators/libayatana-indicator/pull/77
+  depends_on "pango"
+
+  def install
+    args = %w[
+      -DENABLE_IDO=ON
+      -DENABLE_LOADER=ON
+      -DENABLE_TESTS=OFF
+      -DFLAVOUR_GTK3=ON
+    ]
+
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    (testpath/"test.c").write <<~C
+      #include <libayatana-indicator/indicator-service.h>
+      #include <assert.h>
+      int main() {
+        IndicatorService *service = indicator_service_new("homebrew-test");
+        assert(service != NULL && "indicator_service_new should not return NULL");
+        g_object_unref(service);
+        return 0;
+      }
+    C
+
+    flags = shell_output("pkgconf --cflags --libs ayatana-indicator3-0.4").chomp.split
+    system ENV.cc, "test.c", "-o", "test", *flags
+    system "./test"
+  end
+end

--- a/Formula/lib/libayatana-indicator.rb
+++ b/Formula/lib/libayatana-indicator.rb
@@ -5,6 +5,10 @@ class LibayatanaIndicator < Formula
   sha256 "a18d3c682e29afd77db24366f8475b26bda22b0e16ff569a2ec71cd6eb4eac95"
   license "GPL-3.0-or-later"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "38823b368d0eb88a0cbaff12fe3d6dae2e78ac39092214bad70a290d44ccb7c1"
+  end
+
   depends_on "cmake" => :build
   depends_on "gobject-introspection" => :build
   depends_on "pkgconf" => [:build, :test]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Notes:

- This will not pass the notability test, but it is a popular library: https://repology.org/project/libayatana-indicator/versions
- macOS build will fail, it can work with patches though
  - https://github.com/AyatanaIndicators/libayatana-indicator/pull/77
  - https://github.com/macports/macports-ports/blob/6ada4e5de6d5f6f36f7367f326c4d0237957c8ec/devel/libayatana-indicator/files/0001-Fix-build-on-macOS.patch