### PR TITLE
bug.yml: include check box confirming issue is not about a failed source build

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -24,6 +24,8 @@ body:
           required: true
         - label: I searched for recent similar issues at https://github.com/Homebrew/homebrew-core/issues?q=is%3Aissue and found no duplicates.
           required: true
+        - label: My issue is not about a failure to build a formula from source.
+          required: true
   - type: textarea
     attributes:
       label: What were you trying to do (and why)?


### PR DESCRIPTION
We still get issues about failed source builds on a semi-regular basis.
Let's adjust the template to make it clearer that we don't provide
support for failed source builds on our issue tracker.
