### PR TITLE
zsh-fast-syntax-highlighting: include .fast-*

### DIFF
--- a/Formula/z/zsh-fast-syntax-highlighting.rb
+++ b/Formula/z/zsh-fast-syntax-highlighting.rb
@@ -7,13 +7,14 @@ class ZshFastSyntaxHighlighting < Formula
   head "https://github.com/zdharma-continuum/fast-syntax-highlighting.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "92d65197b6bbc546272e39daecc43aec0a884213f6fee5d4b44982e8dc57242e"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "92d65197b6bbc546272e39daecc43aec0a884213f6fee5d4b44982e8dc57242e"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "92d65197b6bbc546272e39daecc43aec0a884213f6fee5d4b44982e8dc57242e"
-    sha256 cellar: :any_skip_relocation, sonoma:        "9ef6826ede6de08521db68f3088cf67f4de7b5026f9df28a4ec53b48aa11a54b"
-    sha256 cellar: :any_skip_relocation, ventura:       "9ef6826ede6de08521db68f3088cf67f4de7b5026f9df28a4ec53b48aa11a54b"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "92d65197b6bbc546272e39daecc43aec0a884213f6fee5d4b44982e8dc57242e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "92d65197b6bbc546272e39daecc43aec0a884213f6fee5d4b44982e8dc57242e"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "c3a55d48ef2b9a3ea68ebf10382de3a45f12c473de78bed8b1cf2f3e0b071946"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "c3a55d48ef2b9a3ea68ebf10382de3a45f12c473de78bed8b1cf2f3e0b071946"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "c3a55d48ef2b9a3ea68ebf10382de3a45f12c473de78bed8b1cf2f3e0b071946"
+    sha256 cellar: :any_skip_relocation, sonoma:        "977af2a311fd759aa590facd7fe406abbf97764f4b7ea302ce290aa3ee89e9c8"
+    sha256 cellar: :any_skip_relocation, ventura:       "977af2a311fd759aa590facd7fe406abbf97764f4b7ea302ce290aa3ee89e9c8"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "c3a55d48ef2b9a3ea68ebf10382de3a45f12c473de78bed8b1cf2f3e0b071946"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c3a55d48ef2b9a3ea68ebf10382de3a45f12c473de78bed8b1cf2f3e0b071946"
   end
 
   uses_from_macos "zsh" => [:build, :test]

--- a/Formula/z/zsh-fast-syntax-highlighting.rb
+++ b/Formula/z/zsh-fast-syntax-highlighting.rb
@@ -19,7 +19,7 @@ class ZshFastSyntaxHighlighting < Formula
   uses_from_macos "zsh" => [:build, :test]
 
   def install
-    pkgshare.install Dir["*"]
+    pkgshare.install Dir["*", ".fast-*"]
   end
 
   def caveats


### PR DESCRIPTION
The current formula installs files matching `"*"`, but that wildcard doesn't match hidden (`.*`) files - and there are a few that are needed.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

**illustration:**

```zsh

# run `exec zsh` before each command below to guarantee a fresh zsh session


# BEFORE PR
# ---------

brew reinstall zsh-fast-syntax-highlighting >/dev/null &&
source $(brew --prefix)/share/zsh-fast-syntax-highlighting/fast-syntax-highlighting.plugin.zsh &&
fast-theme --quiet default
# fast-theme:243: .fast-read-ini-file: function definition file not found

ls -a  $(brew --prefix)/share/zsh-fast-syntax-highlighting/.*
# zsh: no matches found: /opt/homebrew/share/zsh-fast-syntax-highlighting/.*


# AFTER PR
# --------

HOMEBREW_NO_INSTALL_FROM_API=1 brew reinstall --build-from-source zsh-fast-syntax-highlighting &>/dev/null &&
source $(brew --prefix)/share/zsh-fast-syntax-highlighting/fast-syntax-highlighting.plugin.zsh &&
fast-theme --quiet default
# (no error printed)

ls -a  $(brew --prefix)/share/zsh-fast-syntax-highlighting/.*
# /opt/homebrew/share/zsh-fast-syntax-highlighting/.fast-make-targets
# /opt/homebrew/share/zsh-fast-syntax-highlighting/.fast-read-ini-file
# /opt/homebrew/share/zsh-fast-syntax-highlighting/.fast-run-command
# /opt/homebrew/share/zsh-fast-syntax-highlighting/.fast-run-git-command
# /opt/homebrew/share/zsh-fast-syntax-highlighting/.fast-zts-read-all

brew test zsh-fast-syntax-highlighting >/dev/null &&
brew audit --strict zsh-fast-syntax-highlighting &&
echo OK
# OK

```