### PR TITLE
fix jd

### DIFF
--- a/Formula/j/jd.rb
+++ b/Formula/j/jd.rb
@@ -18,6 +18,7 @@ class Jd < Formula
   depends_on "go" => :build
 
   def install
+    Dir.chdir('v2/jd')
     system "go", "build", *std_go_args(ldflags: "-s -w")
   end
 

--- a/Formula/j/jd.rb
+++ b/Formula/j/jd.rb
@@ -18,7 +18,7 @@ class Jd < Formula
   depends_on "go" => :build
 
   def install
-    Dir.chdir('v2/jd')
+    Dir.chdir("v2/jd")
     system "go", "build", *std_go_args(ldflags: "-s -w")
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

At some point, the developer deprecated v1 and started development of v2, but inside of a subdirectory of the repo, while the root still contains source for v1.

If you install jd using `brew` right now and run `jd -version` it outputs "jd version deprecated", which is how it is defined in the [main.go in the root](https://github.com/search?q=repo%3Ajosephburnett%2Fjd%20deprecated&type=code) of the project. This change compiles a different [main.go inside v2](https://github.com/josephburnett/jd/blob/master/v2/jd/main.go), which is actually version 2. After this change, jd now reports "jd version 2.2.3".