### PR TITLE
zsh-fast-syntax-highlighting: build an `:all` bottle

### DIFF
--- a/Formula/z/zsh-fast-syntax-highlighting.rb
+++ b/Formula/z/zsh-fast-syntax-highlighting.rb
@@ -7,14 +7,8 @@ class ZshFastSyntaxHighlighting < Formula
   head "https://github.com/zdharma-continuum/fast-syntax-highlighting.git", branch: "master"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "c3a55d48ef2b9a3ea68ebf10382de3a45f12c473de78bed8b1cf2f3e0b071946"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "c3a55d48ef2b9a3ea68ebf10382de3a45f12c473de78bed8b1cf2f3e0b071946"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "c3a55d48ef2b9a3ea68ebf10382de3a45f12c473de78bed8b1cf2f3e0b071946"
-    sha256 cellar: :any_skip_relocation, sonoma:        "977af2a311fd759aa590facd7fe406abbf97764f4b7ea302ce290aa3ee89e9c8"
-    sha256 cellar: :any_skip_relocation, ventura:       "977af2a311fd759aa590facd7fe406abbf97764f4b7ea302ce290aa3ee89e9c8"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "c3a55d48ef2b9a3ea68ebf10382de3a45f12c473de78bed8b1cf2f3e0b071946"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c3a55d48ef2b9a3ea68ebf10382de3a45f12c473de78bed8b1cf2f3e0b071946"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, all: "548b80e35f30d83768a48dee91e0f3e39ef7a3b1af70d65560fd15a75a5218ba"
   end
 
   uses_from_macos "zsh" => [:build, :test]

--- a/Formula/z/zsh-fast-syntax-highlighting.rb
+++ b/Formula/z/zsh-fast-syntax-highlighting.rb
@@ -20,6 +20,9 @@ class ZshFastSyntaxHighlighting < Formula
   uses_from_macos "zsh" => [:build, :test]
 
   def install
+    # build an `:all` bottle.
+    inreplace %w[fast-highlight fast-theme test/parse.zsh test/to-parse.zsh],
+              "/usr/local", HOMEBREW_PREFIX
     pkgshare.install Dir["*", ".fast-*"]
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
