### PR TITLE
libayatana-appindicator 0.5.94 (new formula)

### DIFF
--- a/Formula/lib/libayatana-appindicator.rb
+++ b/Formula/lib/libayatana-appindicator.rb
@@ -5,6 +5,10 @@ class LibayatanaAppindicator < Formula
   sha256 "884a6bc77994c0b58c961613ca4c4b974dc91aa0f804e70e92f38a542d0d0f90"
   license any_of: ["GPL-3.0-or-later", "LGPL-2.1-or-later"]
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "589e5c203dbcf5befc48f6e13e0e2e723312ceb2f59b65c7490b6f2e80587dab"
+  end
+
   depends_on "at-spi2-core" => :build
   depends_on "cmake" => :build
   depends_on "gobject-introspection" => :build

--- a/Formula/lib/libayatana-appindicator.rb
+++ b/Formula/lib/libayatana-appindicator.rb
@@ -1,0 +1,56 @@
+class LibayatanaAppindicator < Formula
+  desc "Ayatana Application Indicators Shared Library"
+  homepage "https://github.com/AyatanaIndicators/libayatana-appindicator"
+  url "https://github.com/AyatanaIndicators/libayatana-appindicator/archive/refs/tags/0.5.94.tar.gz"
+  sha256 "884a6bc77994c0b58c961613ca4c4b974dc91aa0f804e70e92f38a542d0d0f90"
+  license any_of: ["GPL-3.0-or-later", "LGPL-2.1-or-later"]
+
+  depends_on "at-spi2-core" => :build
+  depends_on "cmake" => :build
+  depends_on "gobject-introspection" => :build
+  depends_on "intltool" => :build
+  depends_on "libxml2" => :build
+  depends_on "pkgconf" => [:build, :test]
+  depends_on "vala" => :build
+  depends_on "ayatana-ido"
+  depends_on "cairo"
+  depends_on "gdk-pixbuf"
+  depends_on "glib"
+  depends_on "gtk+3"
+  depends_on "harfbuzz"
+  depends_on "libayatana-indicator"
+  depends_on "libdbusmenu"
+  depends_on :linux # libayatana-indicator requires gio/gdesktopappinfo.h which is not available on macOS
+  depends_on "pango"
+
+  def install
+    args = %w[
+      -DENABLE_BINDINGS_MONO=OFF
+      -DENABLE_BINDINGS_VALA=ON
+      -DENABLE_GTKDOC=OFF
+      -DENABLE_TESTS=OFF
+    ]
+
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    (testpath/"test.c").write <<~C
+      #include <libayatana-appindicator/app-indicator.h>
+      #include <assert.h>
+
+      int main() {
+        AppIndicator *indicator = app_indicator_new("test-id", "test-icon", APP_INDICATOR_CATEGORY_APPLICATION_STATUS);
+        assert(indicator != NULL);
+        g_object_unref(indicator);
+        return 0;
+      }
+    C
+
+    flags = shell_output("pkgconf --cflags --libs ayatana-appindicator3-0.1").chomp.split
+    system ENV.cc, "test.c", "-o", "test", *flags
+    system "./test"
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is the last formula in the series of libayatana PRs I have submitted.

Notes:
- This will not pass the notability test, but it is a popular library: https://repology.org/project/libayatana-appindicator/versions
- This PR depends on https://github.com/Homebrew/homebrew-core/pull/231051
- macOS is disabled since libayatana-indicator is a dependency which also has macOS disabled