### PR TITLE
codex: add dependency on ripgrep

### DIFF
--- a/Formula/c/codex.rb
+++ b/Formula/c/codex.rb
@@ -12,13 +12,14 @@ class Codex < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "dbc4704ce9292bb6449b35ff88353d23679d0fe4d682cc83f1d696e373478b17"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "2f69dc112b4aa846af83bd56bea401476bd10ffff17777d54ed3d5aaed7d74c7"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "140e9e04908f05b3af1b0045be8daaae897ad2f51c7d5062d4a1c0c44e254cf1"
-    sha256 cellar: :any_skip_relocation, sonoma:        "e6b9596dcf1c6bd1381ba06d232ec3d3bdc64bb7aa2fe525430b18bbc1962efe"
-    sha256 cellar: :any_skip_relocation, ventura:       "f01d75d420265082d96fb49443b3c452eb475e1a69accab9c9ac3d5b087e02ac"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "2aa32bd79e3411f0c6a4a66cf4f74b737e9fd0e94175039e7e46d17572d9a6e2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4f39f47dada6f850b2eb63ad88ccfd03f7c8a060d76ab33b8173a47b48b181f3"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "7b93b110a1ec1582e439ef604099e3de9fb1db3b2d0d52d0ddb6efd2db24d1db"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "998bd81d1d5f71b4eec9fe5e657672f1bc2c80b12e685f61c15d321153353255"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "4b91f70df0f6ad76743b1b318a5cf28ce72816ec77fa6151b7d446a0ddc450be"
+    sha256 cellar: :any_skip_relocation, sonoma:        "12f288af892905c06fb1505c1547701013e6e035270c788dff8c8f19ddd5f340"
+    sha256 cellar: :any_skip_relocation, ventura:       "6c7a8e5c0c9ecdbdf3a173abc5a3b9e33bd1e18de2817b8b6d66b93263519bc5"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "0ea4d3bf1091efaa2aaa4d5c8460cce604502141835213f0db9a239472aa4899"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a65476fa61cbc9b685b6a8e33c4deae3c1c3b11f7d207e991416002ec4796745"
   end
 
   depends_on "rust" => :build

--- a/Formula/c/codex.rb
+++ b/Formula/c/codex.rb
@@ -22,6 +22,7 @@ class Codex < Formula
   end
 
   depends_on "rust" => :build
+  depends_on "ripgrep"
 
   on_linux do
     depends_on "openssl@3"


### PR DESCRIPTION
Codex CLI prefers using ripgrep over grep, as it is much faster, particularly for large repositories because it is multi-threaded and honors .gitignore files.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
