### PR TITLE
pypi formulae: review `no_autobump`

### DIFF
--- a/Formula/a/aider.rb
+++ b/Formula/a/aider.rb
@@ -8,7 +8,7 @@ class Aider < Formula
   license "Apache-2.0"
   head "https://github.com/Aider-AI/aider.git", branch: "main"
 
-  no_autobump! because: :requires_manual_review
+  no_autobump! because: "has non-PyPI resources"
 
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "ccb1959903c7f3848d54b0902867bb126d953d140c06a53b0452619d23699ff2"

--- a/Formula/a/airshare.rb
+++ b/Formula/a/airshare.rb
@@ -8,8 +8,6 @@ class Airshare < Formula
   license "MIT"
   revision 17
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "fc2fc265e8be9a05d336542792418620c0fb09ac30a092e926a1d6acd5a87ee1"

--- a/Formula/a/ansible-builder.rb
+++ b/Formula/a/ansible-builder.rb
@@ -7,8 +7,6 @@ class AnsibleBuilder < Formula
   sha256 "d2dc573e26a7bd5095e98aeb37ee9b00bc9f5005abea7147d74229c0f3426fcb"
   license "Apache-2.0"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "579c9ad083782a2e50605b47820f573e1f7ae3d74f78ae7ef6fdfdb752581e22"
     sha256 cellar: :any,                 arm64_sonoma:  "c92bc3474f4736687413164573d5c0ac47ddaf1824634ec1e7877caab3877dea"

--- a/Formula/a/archey4.rb
+++ b/Formula/a/archey4.rb
@@ -7,8 +7,6 @@ class Archey4 < Formula
   sha256 "1cf158ab799fa8a5d15deab0a48df306d2788c81de44d0242c3ab1dfa84865ac"
   license "GPL-3.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "67a20d46c2fe1dbb51cb872d3d4ebb5342aabfda48a7cfbe915c17ad948969e4"

--- a/Formula/a/asciidoc.rb
+++ b/Formula/a/asciidoc.rb
@@ -8,8 +8,6 @@ class Asciidoc < Formula
   license "GPL-2.0-or-later"
   head "https://github.com/asciidoc-py/asciidoc-py.git", branch: "main"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "ec67acbcd8040ec963e8d3c2cab2427254d2b8b411b65db720347518ab341559"

--- a/Formula/a/asciinema.rb
+++ b/Formula/a/asciinema.rb
@@ -8,8 +8,6 @@ class Asciinema < Formula
   license "GPL-3.0-only"
   head "https://github.com/asciinema/asciinema.git", branch: "develop"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 3
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "0f5ecbcebc62f27a2078b240921060282cef4507a007db5aabfc850c36aea51a"

--- a/Formula/a/asitop.rb
+++ b/Formula/a/asitop.rb
@@ -7,8 +7,6 @@ class Asitop < Formula
   sha256 "5df7b59304572a948f71cf94b87adc613869a8a87a933595b1b3e26bf42c3e37"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 3
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "9c1e7fc9030b7f6c0d68368093a95b6eb04a5aea4da0cf482ff7fd0929907dad"

--- a/Formula/a/athenacli.rb
+++ b/Formula/a/athenacli.rb
@@ -8,8 +8,6 @@ class Athenacli < Formula
   license "BSD-3-Clause"
   revision 7
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, all: "5a240ff69a31aa6396802d1e0722e4d86073261d0b61105fb1dbb3a2d9ac94ee"
   end

--- a/Formula/a/aws-google-auth.rb
+++ b/Formula/a/aws-google-auth.rb
@@ -9,8 +9,6 @@ class AwsGoogleAuth < Formula
   revision 13
   head "https://github.com/cevoaustralia/aws-google-auth.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "5aa5e663cf4e5543319a0efdc433ce4321fd56fc27d59b1b541818ed2a723364"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "1def88f9f052eb6c52333bdb24c0f59689f73fbece78526c1eca0165da0e45c2"

--- a/Formula/a/aws-shell.rb
+++ b/Formula/a/aws-shell.rb
@@ -8,8 +8,6 @@ class AwsShell < Formula
   license "Apache-2.0"
   revision 7
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "778c3c225df6ca360277f1c7213af46622acc28987a7a36b11ad3afc1085f07b"
     sha256 cellar: :any,                 arm64_sonoma:  "2fb0be31f58936ac4a8efec47e90266b5de81dadd8d24f53d6c0ba91be75a624"

--- a/Formula/a/aws2-wrap.rb
+++ b/Formula/a/aws2-wrap.rb
@@ -7,8 +7,6 @@ class Aws2Wrap < Formula
   sha256 "77613ae13423a6407e79760bdd35843ddd128612672a0ad3a934ecade76aa7fc"
   license "GPL-3.0-only"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "d80eae08463ca93b1d39861c28412fb9547db8a86d5041e338a72da501f969fd"

--- a/Formula/a/awscli-local.rb
+++ b/Formula/a/awscli-local.rb
@@ -8,8 +8,6 @@ class AwscliLocal < Formula
   license "Apache-2.0"
   revision 2
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "d74091e363168f1b2e59db8592248b9cafe5512270e7ce82053c3869a962ef54"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "d74091e363168f1b2e59db8592248b9cafe5512270e7ce82053c3869a962ef54"

--- a/Formula/a/awsume.rb
+++ b/Formula/a/awsume.rb
@@ -9,8 +9,6 @@ class Awsume < Formula
   revision 2
   head "https://github.com/trek10inc/awsume.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "030e2f49997fed0235ca111b48944bd6f855eaa2d2c59cabd9ba247e22e5ef7c"
     sha256 cellar: :any,                 arm64_sonoma:  "2ecc4d5fd1c6db43db69f746d3f6f1a9da807eda6514bb3c2769977ae2d9fb1b"

--- a/Formula/b/bandcamp-dl.rb
+++ b/Formula/b/bandcamp-dl.rb
@@ -9,8 +9,6 @@ class BandcampDl < Formula
   revision 2
   head "https://github.com/iheanyi/bandcamp-dl.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, all: "1f4c34ed1a9ae0ce495cee8d829d6661a48f3bbfa1ede20dc5ea54b726ef5abd"
   end

--- a/Formula/b/bashate.rb
+++ b/Formula/b/bashate.rb
@@ -8,8 +8,6 @@ class Bashate < Formula
   license "Apache-2.0"
   revision 1
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "007ce884bf1ba757929d119f792b3b414b4ce3d46b842c43e270941cf1fb7b3c"

--- a/Formula/b/bpython.rb
+++ b/Formula/b/bpython.rb
@@ -9,8 +9,6 @@ class Bpython < Formula
   revision 2
   head "https://github.com/bpython/bpython.git", branch: "main"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "43a263d6c3e63b737e4e17b9fba497945b4eed2047c5ffadf482b808ae0c8a59"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "86e7cb8e6e2e13d577a8c8c0af563c9f79e781e2c8e8fdae94623e7621a0f016"

--- a/Formula/c/ccm.rb
+++ b/Formula/c/ccm.rb
@@ -9,8 +9,6 @@ class Ccm < Formula
   revision 5
   head "https://github.com/apache/cassandra-ccm.git", branch: "trunk"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "eb6c2ab38ac79ff2b3718e344517f07ebb2c9391227676a507d721337981b5cc"
     sha256 cellar: :any,                 arm64_sonoma:  "ef958862ebdc0d3203850a3055913742f0a784e339cbdede518f5582f9806185"

--- a/Formula/c/certsync.rb
+++ b/Formula/c/certsync.rb
@@ -8,7 +8,7 @@ class Certsync < Formula
   license "MIT"
   revision 1
 
-  no_autobump! because: :requires_manual_review
+  no_autobump! because: "has non-PyPI resources"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "ce9f96e07b826ca7f88e7324e519c77895a8067fb7a515467b01b8d340e11916"

--- a/Formula/c/cfn-flip.rb
+++ b/Formula/c/cfn-flip.rb
@@ -8,8 +8,6 @@ class CfnFlip < Formula
   license "Apache-2.0"
   revision 2
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 3
     sha256 cellar: :any,                 arm64_sequoia: "5442b8b312ae32f1f553fb978ccf09c63a8faec827d97d1c0ee6c25e6b8bec69"

--- a/Formula/c/chardet.rb
+++ b/Formula/c/chardet.rb
@@ -7,8 +7,6 @@ class Chardet < Formula
   sha256 "1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7"
   license "LGPL-2.1-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, all: "5abd9f3f6191b67dd5c0a9912225873d1aea2371883c7aee8fcc3077e414dc96"

--- a/Formula/c/codecov-cli.rb
+++ b/Formula/c/codecov-cli.rb
@@ -9,8 +9,6 @@ class CodecovCli < Formula
   revision 2
   head "https://github.com/codecov/codecov-cli.git", branch: "main"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_sequoia: "69cb375432f5d70ddfd35b3a33357bbb07aed9bfaff936309718cf037605580a"

--- a/Formula/c/cram.rb
+++ b/Formula/c/cram.rb
@@ -7,8 +7,6 @@ class Cram < Formula
   sha256 "7da7445af2ce15b90aad5ec4792f857cef5786d71f14377e9eb994d8b8337f2f"
   license "GPL-2.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, all: "380d5fde8323ac893ae796f88c68426acda8933ef993101014a5ab839a8abcfd"
   end

--- a/Formula/c/credstash.rb
+++ b/Formula/c/credstash.rb
@@ -9,8 +9,6 @@ class Credstash < Formula
   revision 12
   head "https://github.com/fugue/credstash.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, all: "4e56325504c62536d06570183ad8d7251a003c40685ad6196ffed97f02276958"
   end

--- a/Formula/c/cruft.rb
+++ b/Formula/c/cruft.rb
@@ -9,8 +9,6 @@ class Cruft < Formula
   revision 3
   head "https://github.com/cruft/cruft.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "eb02182e87cf02ddb00d5c0b380b36ef052c96af782b544997df341245146bd7"
     sha256 cellar: :any,                 arm64_sonoma:  "8a4fd594ee5664c3ff287491e935b7707578107fa712726fe412170156d8f3f7"

--- a/Formula/d/dnsviz.rb
+++ b/Formula/d/dnsviz.rb
@@ -8,8 +8,6 @@ class Dnsviz < Formula
   license "GPL-2.0-or-later"
   revision 1
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "caed4a974f2a1111d2a16262e543e453902627186de111aaa61ddb8032dd35a1"
     sha256 cellar: :any,                 arm64_sonoma:  "1581924ecb9d02d792a419193ac546d9bd23cf9eebb6c24036057215bb426155"

--- a/Formula/d/doitlive.rb
+++ b/Formula/d/doitlive.rb
@@ -9,8 +9,6 @@ class Doitlive < Formula
   revision 3
   head "https://github.com/sloria/doitlive.git", branch: "dev"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "dd433d05b749832e59cc133360f6a038b2d9ae472fcb05982074a334d675e884"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "e9132e01287a9fa33d7d541e59353728366c56430e07adab7bd42663b013f08f"

--- a/Formula/d/dotdrop.rb
+++ b/Formula/d/dotdrop.rb
@@ -8,8 +8,6 @@ class Dotdrop < Formula
   license "GPL-3.0-or-later"
   revision 4
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "599f338d0d361a3062194e842c1c361fc7c9424379a4bd8b515ba86a918046c7"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "25a0505ab974e9bb7239bd52903a3b1c5bfe4f3280ac1427707491b83798e694"

--- a/Formula/d/dtrx.rb
+++ b/Formula/d/dtrx.rb
@@ -7,8 +7,6 @@ class Dtrx < Formula
   sha256 "eec67869b85068fac8406f5018d781aee5b55422f3b7698bfea43468b2cec67c"
   license "GPL-3.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "a1c04af670ced811950bb65e3ad904f2fe306b495e9ce1ebc1f0c816d016c088"

--- a/Formula/e/easyeda2kicad.rb
+++ b/Formula/e/easyeda2kicad.rb
@@ -9,8 +9,6 @@ class Easyeda2kicad < Formula
   revision 2
   head "https://github.com/uPesy/easyeda2kicad.py.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "ca4a1da140fed0775fce219fdc949815dbc2f40caeb84265e2a68b630ad79a9c"
     sha256 cellar: :any,                 arm64_sonoma:  "0e4978fcf4183050761e4b428e20c5458aaa9f1985a75fa8705b30691e62c18f"

--- a/Formula/e/enex2notion.rb
+++ b/Formula/e/enex2notion.rb
@@ -8,8 +8,6 @@ class Enex2notion < Formula
   license "MIT"
   revision 13
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "451d06590098d5e5eeaa6062c0fdad9fa7246de643f8ed885235bb453af15d4d"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "faf58471255749032a2ef7724ba27b0caa7a2cc95ea6852e05f748171f3b0ce5"

--- a/Formula/e/euler-py.rb
+++ b/Formula/e/euler-py.rb
@@ -9,8 +9,6 @@ class EulerPy < Formula
   revision 3
   head "https://github.com/iKevinY/EulerPy.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 5
     sha256 cellar: :any_skip_relocation, all: "61c7da218aca560f86ce1aae136927319f9d48d07aae107e531c19d3e0350209"

--- a/Formula/e/evernote-backup.rb
+++ b/Formula/e/evernote-backup.rb
@@ -8,8 +8,6 @@ class EvernoteBackup < Formula
   license "MIT"
   revision 2
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "5516573e372818809c0f505eeb99fdebfc673a40b5740d9819a0def6c432c8e1"

--- a/Formula/e/eye-d3.rb
+++ b/Formula/e/eye-d3.rb
@@ -8,8 +8,6 @@ class EyeD3 < Formula
   license "GPL-3.0-or-later"
   head "https://github.com/nicfit/eyeD3.git", branch: "0.9.x"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, all: "4ac971a65a624577f3d7ec97d49542d39400860e967a8823b78a94afd764f33b"
   end

--- a/Formula/f/fades.rb
+++ b/Formula/f/fades.rb
@@ -7,8 +7,6 @@ class Fades < Formula
   revision 2
   head "https://github.com/PyAr/fades.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "8ae23ce3e986aa461efc9dfbb017e62daf3d47bab6650455c64efa609c9a6561"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "8ae23ce3e986aa461efc9dfbb017e62daf3d47bab6650455c64efa609c9a6561"

--- a/Formula/f/flintrock.rb
+++ b/Formula/f/flintrock.rb
@@ -7,8 +7,6 @@ class Flintrock < Formula
   sha256 "dde4032630ad44c374c2a9b12f0d97db87fa5117995f1c7dd0f70b631f47a035"
   license "Apache-2.0"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 5
     sha256 cellar: :any,                 arm64_sequoia: "74a8a662dc4aee333db1b838cc7f62681b0d3a9fc6e8f8205e20d80d4c2527b1"

--- a/Formula/f/fortran-language-server.rb
+++ b/Formula/f/fortran-language-server.rb
@@ -8,8 +8,6 @@ class FortranLanguageServer < Formula
   license "MIT"
   head "https://github.com/hansec/fortran-language-server.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 5
     sha256 cellar: :any_skip_relocation, all: "7f545be88d71155c02f3022ca7c63f8c75f9010d1ac84f89353d96b15f3b0551"

--- a/Formula/f/fypp.rb
+++ b/Formula/f/fypp.rb
@@ -8,8 +8,6 @@ class Fypp < Formula
   license "BSD-2-Clause"
   head "https://github.com/aradi/fypp.git", branch: "main"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 5
     sha256 cellar: :any_skip_relocation, all: "c8c4c383f5fa91ab12d838277ef39f7b8e11807e3e328379fb52b46c9a5b73f4"

--- a/Formula/g/gimme-aws-creds.rb
+++ b/Formula/g/gimme-aws-creds.rb
@@ -8,7 +8,7 @@ class GimmeAwsCreds < Formula
   license "Apache-2.0"
   revision 5
 
-  no_autobump! because: :requires_manual_review
+  no_autobump! because: "`update-python-resources` cannot determine dependencies"
 
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "c6aa5dc5030ac0f3f460f9a309c751dfdb4804d4303d865cfada04dca2074c80"

--- a/Formula/g/gimmecert.rb
+++ b/Formula/g/gimmecert.rb
@@ -7,7 +7,7 @@ class Gimmecert < Formula
   sha256 "eb00848fab5295903b4d5ef997c411fe063abc5b0f520a78ca2cd23f77e3fd99"
   license "GPL-3.0-or-later"
 
-  no_autobump! because: :requires_manual_review
+  no_autobump! because: "`update-python-resources` cannot determine dependencies"
 
   bottle do
     rebuild 1

--- a/Formula/g/git-plus.rb
+++ b/Formula/g/git-plus.rb
@@ -8,8 +8,6 @@ class GitPlus < Formula
   license "Apache-2.0"
   head "https://github.com/tkrajina/git-plus.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 4
     sha256 cellar: :any_skip_relocation, all: "87c0f95adbf84385ecf889a2efec12ffc43aa494baa99d7581d616db13e65306"

--- a/Formula/g/git-remote-codecommit.rb
+++ b/Formula/g/git-remote-codecommit.rb
@@ -9,8 +9,6 @@ class GitRemoteCodecommit < Formula
   revision 4
   head "https://github.com/aws/git-remote-codecommit.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, all: "6403e992fba39a49e3faa313955b9066ec7459930147d24d3ba1e325de4d4855"
   end

--- a/Formula/g/git-revise.rb
+++ b/Formula/g/git-revise.rb
@@ -8,8 +8,6 @@ class GitRevise < Formula
   license "MIT"
   head "https://github.com/mystor/git-revise.git", branch: "main"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 5
     sha256 cellar: :any_skip_relocation, all: "60d72785f3a41be712e088e432f33aaf774461f8ba07e46bcb95af9cdcbdf358"

--- a/Formula/g/gitlint.rb
+++ b/Formula/g/gitlint.rb
@@ -7,8 +7,6 @@ class Gitlint < Formula
   sha256 "7bf977b03ff581624a9e03f65ebb8502cc12dfaa3e92d23e8b2b54bbdaa29992"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 6
     sha256 cellar: :any_skip_relocation, all: "36439a03cc83049977c6ff628f75a76a33dd727ebbfc7f824f46329f6f880440"

--- a/Formula/g/gitup.rb
+++ b/Formula/g/gitup.rb
@@ -8,8 +8,6 @@ class Gitup < Formula
   license "MIT"
   head "https://github.com/earwig/git-repo-updater.git", branch: "main"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, all: "4ef4421a9edad018b76acd44d00dc3bc99a980623ee00deef7a7aa60bce940d3"
   end

--- a/Formula/g/goolabs.rb
+++ b/Formula/g/goolabs.rb
@@ -8,8 +8,6 @@ class Goolabs < Formula
   license "MIT"
   revision 13
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "491259e4dd6b58ca77057c50f06bc133c6455da70a6851e1e32bb688dd1ed0e8"

--- a/Formula/g/gptline.rb
+++ b/Formula/g/gptline.rb
@@ -9,8 +9,6 @@ class Gptline < Formula
   revision 8
   head "https://github.com/gnachman/gptline.git", branch: "main"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "a98d0665383cfea137900164482c617862307fb3fd03fbdb3066ec94b88dfc38"
     sha256 cellar: :any,                 arm64_sonoma:  "b863ad462a3d726963ef7a9c40d088aa4f3cb8fc7f687a765c8517f73589b191"

--- a/Formula/g/grip.rb
+++ b/Formula/g/grip.rb
@@ -8,8 +8,6 @@ class Grip < Formula
   license "MIT"
   revision 13
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "4840088fa28108fd1d0be591418185e2aa6b0c2dac70389b0bcb61899270ab87"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "48de4a1897a6a69ede5cf97a6b26643e8e9e4b73820933c6177c5c1cc0da12e6"

--- a/Formula/h/harlequin.rb
+++ b/Formula/h/harlequin.rb
@@ -8,7 +8,7 @@ class Harlequin < Formula
   license "MIT"
   revision 1
 
-  no_autobump! because: :requires_manual_review
+  no_autobump! because: "has non-PyPI resources"
 
   bottle do
     rebuild 1

--- a/Formula/h/homeassistant-cli.rb
+++ b/Formula/h/homeassistant-cli.rb
@@ -9,8 +9,6 @@ class HomeassistantCli < Formula
   revision 17
   head "https://github.com/home-assistant-ecosystem/home-assistant-cli.git", branch: "dev"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "14097ae33fea2b0d77d5363e5f6ae93679d9bedb151904e44b5142fc93ec397f"

--- a/Formula/h/honcho.rb
+++ b/Formula/h/honcho.rb
@@ -8,8 +8,6 @@ class Honcho < Formula
   license "MIT"
   head "https://github.com/nickstenning/honcho.git", branch: "main"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "9156231ae4d87e5ec1dadf38d3251849012f02358f8b7461eb165d770963ddb6"

--- a/Formula/h/howdoi.rb
+++ b/Formula/h/howdoi.rb
@@ -8,8 +8,6 @@ class Howdoi < Formula
   license "MIT"
   revision 11
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "a54cdb278b5e996d327c50f5014f1d92382e45950a5e9f9ee4d30a6ac9ee4bfd"
     sha256 cellar: :any,                 arm64_sonoma:  "0e05063e5a28811e3d295ee5ef59e6d7aa3a4a93f9a87d42beb020a3929e3017"

--- a/Formula/h/http-prompt.rb
+++ b/Formula/h/http-prompt.rb
@@ -9,8 +9,6 @@ class HttpPrompt < Formula
   revision 13
   head "https://github.com/httpie/http-prompt.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any,                 arm64_sequoia: "8fb96b2aaf910e390ac7e12f7268f8679311a7782648ddcb066322eccfa43ef5"

--- a/Formula/h/hyfetch.rb
+++ b/Formula/h/hyfetch.rb
@@ -8,8 +8,6 @@ class Hyfetch < Formula
   license "MIT"
   head "https://github.com/hykilpikonna/hyfetch.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "5032952a2e1ded6fc2a2982b8ea254233f5886c54a34717b0affd2890d40765e"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "5032952a2e1ded6fc2a2982b8ea254233f5886c54a34717b0affd2890d40765e"

--- a/Formula/i/img2pdf.rb
+++ b/Formula/i/img2pdf.rb
@@ -7,8 +7,6 @@ class Img2pdf < Formula
   sha256 "306e279eb832bc159d7d6294b697a9fbd11b4be1f799b14b3b2174fb506af289"
   license "LGPL-3.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "1079b3b50de55ff2cb1ddba4de0b6263eb02e19e4b8c71b789a6e06c5a6eb592"
     sha256 cellar: :any,                 arm64_sonoma:  "3de734f6984a7b7e9642891724dabaa3f21d61627c82d06a5d43828eaaf2933e"

--- a/Formula/i/instalooter.rb
+++ b/Formula/i/instalooter.rb
@@ -8,8 +8,6 @@ class Instalooter < Formula
   license "GPL-3.0-or-later"
   revision 13
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "650ba75e01cb3e3afdf79bb83d6c5d03fabbc3c77895d1a52640ec41482658ab"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "650ba75e01cb3e3afdf79bb83d6c5d03fabbc3c77895d1a52640ec41482658ab"

--- a/Formula/i/iocextract.rb
+++ b/Formula/i/iocextract.rb
@@ -9,8 +9,6 @@ class Iocextract < Formula
   revision 8
   head "https://github.com/InQuest/iocextract.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "9201c8ee75261633b76636bb1e7d051d8c71ea2d2910d681ece7bceccad75f3a"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "7b3831b339d144ed98f9c483a690db69433fc95a26672d8c3db0054b6d5ad5b9"

--- a/Formula/j/jello.rb
+++ b/Formula/j/jello.rb
@@ -7,8 +7,6 @@ class Jello < Formula
   sha256 "eee1d43f2d9bb3b3b8c857b713e56191badb9a03a2274defaad1e727fad35521"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, all: "6aee2f309a909d8f46313936879821ecd4dfbef13d3a1c75732fee794eb941b4"
   end

--- a/Formula/j/jinja2-cli.rb
+++ b/Formula/j/jinja2-cli.rb
@@ -8,8 +8,6 @@ class Jinja2Cli < Formula
   license "BSD-2-Clause"
   revision 3
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "69847d8dd63445895938e9a787d879a81c933764fea8b3df683ae18a3c0465e9"
     sha256 cellar: :any,                 arm64_sonoma:  "883bb7f1ecae9adf6e224cec532dac1738f95c82e3a414d2d29be0d6555eed31"

--- a/Formula/k/keepassc.rb
+++ b/Formula/k/keepassc.rb
@@ -8,8 +8,6 @@ class Keepassc < Formula
   license "ISC"
   revision 5
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "2447d5f8a051b1d15efec850c60e58bd372e871270fe494c9a4882309783fc11"

--- a/Formula/k/keepkey-agent.rb
+++ b/Formula/k/keepkey-agent.rb
@@ -8,8 +8,6 @@ class KeepkeyAgent < Formula
   license "LGPL-3.0-only"
   revision 10
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_sequoia: "4ef9604e5cdd45c1cd054e8e9d3be0cc25b7473a784a276129d621d7dd316114"

--- a/Formula/l/legit.rb
+++ b/Formula/l/legit.rb
@@ -9,8 +9,6 @@ class Legit < Formula
   revision 8
   head "https://github.com/frostming/legit.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "7e42ca33477abbbd0614ebe49a653974aeeda576e2ea6341f47c6c8a871eed61"

--- a/Formula/l/ly.rb
+++ b/Formula/l/ly.rb
@@ -5,8 +5,6 @@ class Ly < Formula
   sha256 "cf1780fe53d367efc1f2642cb77c57246106ea7517f8c2d1126f0a36ee26567a"
   license "GPL-2.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, all: "9a28dcdb3270423db13b9b8eb52ef1b65beffa23cd684672e6ebfa8b992cd413"
   end

--- a/Formula/m/mdv.rb
+++ b/Formula/m/mdv.rb
@@ -7,8 +7,6 @@ class Mdv < Formula
   sha256 "eb84ed52a2b68d2e083e007cb485d14fac1deb755fd8f35011eff8f2889df6e9"
   license "BSD-3-Clause"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 4
     sha256 cellar: :any,                 arm64_sequoia: "ef4e272237c57fc919e84a83ec656a2573fc2c2e9abcb1f8ee38337674c4547d"

--- a/Formula/m/memray.rb
+++ b/Formula/m/memray.rb
@@ -7,7 +7,7 @@ class Memray < Formula
   sha256 "eb75c075874a6eccddf361513d9d4a9223dd940580c6370a6ba5339bae5d0ba2"
   license "Apache-2.0"
 
-  no_autobump! because: :requires_manual_review
+  no_autobump! because: "`update-python-resources` cannot update resource blocks"
 
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "1c4efb8fb7ecbf0afe0d4caabec09224e2b2536bd9ed879d158c889328707a6a"

--- a/Formula/m/mkvtomp4.rb
+++ b/Formula/m/mkvtomp4.rb
@@ -9,8 +9,6 @@ class Mkvtomp4 < Formula
   revision 3
   head "https://github.com/gavinbeatty/mkvtomp4.git", branch: "main"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 5
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "19c4993069753ad76887c0d42e472ab10e86c1888747713f0368d31130997a9c"

--- a/Formula/m/mu-repo.rb
+++ b/Formula/m/mu-repo.rb
@@ -7,8 +7,6 @@ class MuRepo < Formula
   sha256 "f557e46e35a6dd8e1a8735c2a74ea1e60e9280040abc22a472e88eff0d23c5ca"
   license "GPL-3.0-only"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, all: "c1a12185e6ce3889731ba486e3fe58b862edcb5123e3877166b361aa7f3132ca"

--- a/Formula/n/name-that-hash.rb
+++ b/Formula/n/name-that-hash.rb
@@ -9,8 +9,6 @@ class NameThatHash < Formula
   revision 1
   head "https://github.com/HashPals/Name-That-Hash.git", branch: "main"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 5
     sha256 cellar: :any_skip_relocation, all: "cbfd105d0e71676df5a3a8e4b7e10ce0bf818c1043c2f101e04461ff19a0e75c"

--- a/Formula/n/neovim-remote.rb
+++ b/Formula/n/neovim-remote.rb
@@ -9,8 +9,6 @@ class NeovimRemote < Formula
   revision 3
   head "https://github.com/mhinz/neovim-remote.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "9edaf9f4d2feb2e6e4f18dc167944ff8823c9c4068c6e07017d8921ca160b28a"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "a9b76e1afa8be0eec8c8fd7197460b4477faaf325cd2fc18c0339ee725b06a8a"

--- a/Formula/n/nicotine-plus.rb
+++ b/Formula/n/nicotine-plus.rb
@@ -8,7 +8,7 @@ class NicotinePlus < Formula
   license "GPL-3.0-or-later"
   head "https://github.com/nicotine-plus/nicotine-plus.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
+  no_autobump! because: "`update-python-resources` cannot determine dependencies"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "86dd09af957c7be8e3c7559e1c9b67d2536f0c3025cd70bbe08a17d98ad1f89a"

--- a/Formula/n/nyx.rb
+++ b/Formula/n/nyx.rb
@@ -8,7 +8,7 @@ class Nyx < Formula
   license "GPL-3.0-only"
   revision 3
 
-  no_autobump! because: :requires_manual_review
+  no_autobump! because: "`update-python-resources` cannot update resource blocks"
 
   bottle do
     rebuild 3

--- a/Formula/o/onlykey-agent.rb
+++ b/Formula/o/onlykey-agent.rb
@@ -8,8 +8,6 @@ class OnlykeyAgent < Formula
   license "LGPL-3.0-only"
   revision 7
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "eb5300e3bdc15543277592ff0fb8af3b7b30493a7d48ce88e7fcaa3d7479db78"
     sha256 cellar: :any,                 arm64_sonoma:  "d2f4dc6df76189333ef590b584ffdc4a7f2ade77a11ab412838167c58940f6d5"

--- a/Formula/o/openai-whisper.rb
+++ b/Formula/o/openai-whisper.rb
@@ -8,7 +8,7 @@ class OpenaiWhisper < Formula
   license "MIT"
   head "https://github.com/openai/whisper.git", branch: "main"
 
-  no_autobump! because: :requires_manual_review
+  no_autobump! because: "`update-python-resources` cannot update resource blocks"
 
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "5ddbd99e57d4b6d19776eb845a391f8931bbb5e33388fb3bf6e729187e34bc0c"

--- a/Formula/o/organize-tool.rb
+++ b/Formula/o/organize-tool.rb
@@ -7,7 +7,7 @@ class OrganizeTool < Formula
   sha256 "034fdcf9ffeb23d21b495e038665278e589fa04dc7c0c0a01a4a3b30a06c539f"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
+  no_autobump! because: "`update-python-resources` cannot update resource blocks"
 
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "b6f9e95698b7fd36da9dd8b1496a8b9f256ec621afd2c5ee9189c0a76209102d"

--- a/Formula/o/osc-cli.rb
+++ b/Formula/o/osc-cli.rb
@@ -8,8 +8,6 @@ class OscCli < Formula
   license "BSD-3-Clause"
   revision 9
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "c7235b2b658f8bbb90bb5137056fb050ca83e1b7d5d18c1a31e2eaa66d83b6aa"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "c7235b2b658f8bbb90bb5137056fb050ca83e1b7d5d18c1a31e2eaa66d83b6aa"

--- a/Formula/p/pass-import.rb
+++ b/Formula/p/pass-import.rb
@@ -9,8 +9,6 @@ class PassImport < Formula
   revision 5
   head "https://github.com/roddhjav/pass-import.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "59113cfc585169c49622aff41d2e9d816d3e44df9978d5b3c80d469abf6e879d"
     sha256 cellar: :any,                 arm64_sonoma:  "434d68c3443172d74cba7292657dc1e9e9a03c1ce1c781cb7002cc34d701d8ff"

--- a/Formula/p/pawk.rb
+++ b/Formula/p/pawk.rb
@@ -7,8 +7,6 @@ class Pawk < Formula
   sha256 "59ec1a4046cf545e1376c8c0a28f5f178a3b88dbc85fb3772aa3ce8c2e088349"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, all: "ac3b1c476a0e40e5eed34672c9d426989456b17907cfeee03c6e6ed88d0d01b9"
   end

--- a/Formula/p/percol.rb
+++ b/Formula/p/percol.rb
@@ -9,8 +9,6 @@ class Percol < Formula
   revision 4
   head "https://github.com/mooz/percol.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 4
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "f21f389ba2e22503900f31d63739513f239347fa1a798a24a1d57812c0b0bcd9"

--- a/Formula/p/pgxnclient.rb
+++ b/Formula/p/pgxnclient.rb
@@ -8,8 +8,6 @@ class Pgxnclient < Formula
   license "BSD-3-Clause"
   revision 2
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "f1b1f557db76ca77277fc59e96c5432107680f75068454279508736f0ccb4116"

--- a/Formula/p/pssh.rb
+++ b/Formula/p/pssh.rb
@@ -8,8 +8,6 @@ class Pssh < Formula
   license "BSD-3-Clause"
   revision 6
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 5
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "d5930def7b287c71f933a5f8cf985135891a2a9e3ca750be4a0960aa5768bdaf"

--- a/Formula/p/pwncat.rb
+++ b/Formula/p/pwncat.rb
@@ -8,8 +8,6 @@ class Pwncat < Formula
   license "MIT"
   head "https://github.com/cytopia/pwncat.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 3
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "1971f6379de0d9d4d43605e1cfe6635c966343e2afd1f18e5075059233853433"

--- a/Formula/p/pygitup.rb
+++ b/Formula/p/pygitup.rb
@@ -7,8 +7,6 @@ class Pygitup < Formula
   sha256 "4a771b9cae8bc6c95e2916bfb120a6ffc76c80fc3f5c91af61f91c21e5980f2e"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "e32f3c3171ea0e3d8c6f4b3c733f76d89b4c16e00b3e66872d8425506dadb79e"

--- a/Formula/p/pyinvoke.rb
+++ b/Formula/p/pyinvoke.rb
@@ -9,8 +9,6 @@ class Pyinvoke < Formula
   revision 2
   head "https://github.com/pyinvoke/invoke.git", branch: "main"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, all: "0244d25e686d6574fcaf35d14725a415c00b33dd0b2c697fc66a78160d9227a1"

--- a/Formula/p/pympress.rb
+++ b/Formula/p/pympress.rb
@@ -8,8 +8,6 @@ class Pympress < Formula
   license "GPL-2.0-or-later"
   head "https://github.com/Cimbali/pympress.git", branch: "main"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "64f35865fbde010d4e3de039977eec6bc1bbe6dabb19fca1f9c3f9da709e1593"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "ad170caf12af4322d5b0f819cdf13616af3d389de0400f157ac7638cce10fcff"

--- a/Formula/p/pyp.rb
+++ b/Formula/p/pyp.rb
@@ -7,8 +7,6 @@ class Pyp < Formula
   sha256 "97c78f8fd6d4550bf67bb5001a4c5c1fa58184d9bd8256abac3e240fa38aa05c"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, all: "0b8eaab0a5475a43fcbc136c96cd81caed5abb0b755395652d6d238cc9968f4b"
   end

--- a/Formula/p/pyqt@5.rb
+++ b/Formula/p/pyqt@5.rb
@@ -5,8 +5,6 @@ class PyqtAT5 < Formula
   sha256 "fda45743ebb4a27b4b1a51c6d8ef455c4c1b5d610c90d2934c7802b5c1557c52"
   license "GPL-3.0-only"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "ee754605e872d1b42d4dafe9b53980d4917a49003f4b54c32d282fafbc2dbe25"
     sha256 cellar: :any,                 arm64_sonoma:  "4d1a259a2b1c7e926f1b84f60bf574348ce11d148e75ab7f47ca1f1310d696b2"

--- a/Formula/p/pyspelling.rb
+++ b/Formula/p/pyspelling.rb
@@ -7,8 +7,6 @@ class Pyspelling < Formula
   sha256 "acd67133c1b7cecd410e3d4489e61f2e4b1f0b6acf1ae6c48c240fbb21729c37"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any,                 arm64_sequoia: "f364a5e63736d91e836130acd9578fd23178557d496b47a8085bc5ea68c9e556"

--- a/Formula/p/python-tabulate.rb
+++ b/Formula/p/python-tabulate.rb
@@ -8,8 +8,6 @@ class PythonTabulate < Formula
   license "MIT"
   revision 1
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 4
     sha256 cellar: :any_skip_relocation, all: "cea38c8f00045852ff2e04f39f4e1e9f1b1a83a4f21f8f94bd2765b2ed75240e"

--- a/Formula/p/pyvim.rb
+++ b/Formula/p/pyvim.rb
@@ -7,8 +7,6 @@ class Pyvim < Formula
   sha256 "2a3506690f73a79dd02cdc45f872d3edf20a214d4c3666d12459e2ce5b644baa"
   license "BSD-3-Clause"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 4
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "704fda45ac7e30a081b5490c20420d172244219adbe364367f10bc0a2d550465"

--- a/Formula/p/pywhat.rb
+++ b/Formula/p/pywhat.rb
@@ -9,8 +9,6 @@ class Pywhat < Formula
   revision 1
   head "https://github.com/bee-san/pyWhat.git", branch: "main"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 7
     sha256 cellar: :any_skip_relocation, all: "eecfe7a731f32a7dfb75fb042843e4042df47df756abcabeb8fa9b5216cc3584"

--- a/Formula/r/rdiff-backup.rb
+++ b/Formula/r/rdiff-backup.rb
@@ -8,8 +8,6 @@ class RdiffBackup < Formula
   license "GPL-2.0-or-later"
   revision 2
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any,                 arm64_sequoia: "b8a183aadfc497b89651c586a63267398a9ffa1b5fc7181bbb3dba635ed50aa8"

--- a/Formula/r/rst-lint.rb
+++ b/Formula/r/rst-lint.rb
@@ -7,8 +7,6 @@ class RstLint < Formula
   sha256 "1b235c0c922341ab6c530390892eb9e92f90b9b75046063e047cacfb0f050c45"
   license "Unlicense"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 8
     sha256 cellar: :any_skip_relocation, all: "33af15142db56039486e955b7a684f745bb02857f97b0aca3d5095a4b389d35b"

--- a/Formula/s/s3cmd.rb
+++ b/Formula/s/s3cmd.rb
@@ -9,8 +9,6 @@ class S3cmd < Formula
   revision 1
   head "https://github.com/s3tools/s3cmd.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "b14b322ca3b3b43c0f0ef051dee2908cf1c16482d4e7ba74a1865860c8956edd"

--- a/Formula/s/s4cmd.rb
+++ b/Formula/s/s4cmd.rb
@@ -9,8 +9,6 @@ class S4cmd < Formula
   revision 4
   head "https://github.com/bloomreach/s4cmd.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, all: "a8e1ae545f2d58cbbd80828342d8732952e47628c4a5640150e9151c9195052d"
   end

--- a/Formula/s/sail.rb
+++ b/Formula/s/sail.rb
@@ -8,8 +8,6 @@ class Sail < Formula
   license "GPL-3.0-only"
   revision 1
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_sequoia: "55df5f7dc3a28ceff6f4f45ed960292003a2acdf7067642c796057f7569392c0"

--- a/Formula/s/salt-lint.rb
+++ b/Formula/s/salt-lint.rb
@@ -7,8 +7,6 @@ class SaltLint < Formula
   sha256 "7f74e682e7fd78722a6d391ea8edc9fc795113ecfd40657d68057d404ee7be8e"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 4
     sha256 cellar: :any,                 arm64_sequoia: "fbb1958185be4aad5fea5c651fd3e8da21fca696c5d213693e4a81936a1feb2b"

--- a/Formula/s/scour.rb
+++ b/Formula/s/scour.rb
@@ -10,8 +10,6 @@ class Scour < Formula
   version_scheme 1
   head "https://github.com/scour-project/scour.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 6
     sha256 cellar: :any_skip_relocation, all: "4c7cfe80210581f2cfa70a91583596326dfe0cd395679ab589d2af4f5e749f94"

--- a/Formula/s/scoutsuite.rb
+++ b/Formula/s/scoutsuite.rb
@@ -9,8 +9,6 @@ class Scoutsuite < Formula
   revision 4
   head "https://github.com/nccgroup/ScoutSuite.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "617a6f8b92f076b5eb121d447b2fc5e10451a00e4afe5380b80f56d40f5a09d5"
     sha256 cellar: :any,                 arm64_sonoma:  "92e3adfb05aa047a2ba078f3c741800c84011d08fb9943cf84fd37065f92fc1c"

--- a/Formula/s/search-that-hash.rb
+++ b/Formula/s/search-that-hash.rb
@@ -9,8 +9,6 @@ class SearchThatHash < Formula
   revision 11
   head "https://github.com/bee-san/Search-That-Hash.git", branch: "main"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "b25fd2d7c6f1e07177496073f1aecf468ffbc410a4948c5be859167304655eaf"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "b25fd2d7c6f1e07177496073f1aecf468ffbc410a4948c5be859167304655eaf"

--- a/Formula/s/shodan.rb
+++ b/Formula/s/shodan.rb
@@ -9,8 +9,6 @@ class Shodan < Formula
   revision 5
   head "https://github.com/achillean/shodan-python.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "ff244c9ab8a940086f91f9a2f08a8266d74053755103ce3dab77680ed7b2c2f4"

--- a/Formula/s/shyaml.rb
+++ b/Formula/s/shyaml.rb
@@ -9,8 +9,6 @@ class Shyaml < Formula
   revision 2
   head "https://github.com/0k/shyaml.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 5
     sha256 cellar: :any,                 arm64_sequoia: "74bc7e9c8716937a88a39c1ad327023297d5f1f55521507be77a43b712ef3d9d"

--- a/Formula/s/sickchill.rb
+++ b/Formula/s/sickchill.rb
@@ -8,8 +8,6 @@ class Sickchill < Formula
   license "GPL-3.0-or-later"
   revision 3
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "0de949c3d5312e5235c4f3221e579a44215042d6e9855971454bab017a401af3"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "4bb1e6c596ddd8c99a708c85cb8c7c721496463d37b981b7d11d3b06f465ae8e"

--- a/Formula/s/slither-analyzer.rb
+++ b/Formula/s/slither-analyzer.rb
@@ -9,8 +9,6 @@ class SlitherAnalyzer < Formula
   revision 3
   head "https://github.com/crytic/slither.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "d3d8b589d9cb2044065b1e21416c94bdbca2ef459ebcf161cb3f2e2b4bef6a78"
     sha256 cellar: :any,                 arm64_sonoma:  "f8f044628ebf98bbe66f788cec5a0f1e9a0739759e6143c5d412c030c42a5e95"

--- a/Formula/s/spoof-mac.rb
+++ b/Formula/s/spoof-mac.rb
@@ -9,8 +9,6 @@ class SpoofMac < Formula
   revision 5
   head "https://github.com/feross/SpoofMAC.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "48c3a037c2b55a1f7849998fbdfa575f4e04726c284eb2190e72e0dcd93b0305"

--- a/Formula/s/supervisor.rb
+++ b/Formula/s/supervisor.rb
@@ -9,8 +9,6 @@ class Supervisor < Formula
   revision 2
   head "https://github.com/Supervisor/supervisor.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "c9dcc3c481ca0d17cd2aab91c2e158b4963d61e2927187a808233ce3bd7b314b"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "c9dcc3c481ca0d17cd2aab91c2e158b4963d61e2927187a808233ce3bd7b314b"

--- a/Formula/t/tarsnapper.rb
+++ b/Formula/t/tarsnapper.rb
@@ -8,8 +8,6 @@ class Tarsnapper < Formula
   license "BSD-2-Clause"
   revision 1
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 7
     sha256 cellar: :any,                 arm64_sequoia: "a3f3c24d9015ea8c6e555746211e7af56deb8ce020c047776cd06166f70c77d2"

--- a/Formula/t/tern.rb
+++ b/Formula/t/tern.rb
@@ -8,7 +8,7 @@ class Tern < Formula
   license "BSD-2-Clause"
   head "https://github.com/tern-tools/tern.git", branch: "main"
 
-  no_autobump! because: :requires_manual_review
+  no_autobump! because: "`update-python-resources` cannot determine dependencies"
 
   bottle do
     rebuild 5

--- a/Formula/t/thefuck.rb
+++ b/Formula/t/thefuck.rb
@@ -8,8 +8,6 @@ class Thefuck < Formula
   license "MIT"
   head "https://github.com/nvbn/thefuck.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 5
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "e9b85cc4f5627d8e8df33c99af43c0a9871b07ffc2eb9d1ff9b6d03e1cfcce52"

--- a/Formula/t/touca.rb
+++ b/Formula/t/touca.rb
@@ -7,8 +7,6 @@ class Touca < Formula
   license "Apache-2.0"
   revision 3
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 3
     sha256 cellar: :any_skip_relocation, all: "28347dcea2a95cf714fad75fb909df2202c64a2ba9f9b83af3f99a7659e0bf17"

--- a/Formula/t/trezor-agent.rb
+++ b/Formula/t/trezor-agent.rb
@@ -11,8 +11,6 @@ class TrezorAgent < Formula
   license "LGPL-3.0-only"
   revision 7
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "6b23b65aed9a20adc1193f1b07f212d15ec1cc63fe4063f812215269bf4469ac"
     sha256 cellar: :any,                 arm64_sonoma:  "e7b9a2a27fd2238cde20aed214f6cb064007042259c15c1957fccbf665186f87"

--- a/Formula/t/trzsz.rb
+++ b/Formula/t/trzsz.rb
@@ -8,8 +8,6 @@ class Trzsz < Formula
   license "MIT"
   revision 1
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "2ae631d662b7807bc3be9aa38befc2e2659e9ce869945a911572c409329a93c0"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "40a22d7d73f5af874c041823e8e26f1ddbd2e52f18067efc9fe1284af2b972f0"

--- a/Formula/t/tvnamer.rb
+++ b/Formula/t/tvnamer.rb
@@ -9,8 +9,6 @@ class Tvnamer < Formula
   revision 10
   head "https://github.com/dbr/tvnamer.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, all: "c488ea5258a320f51fb970cfb226dceb2ea35bf5c62df325577c4d25df1b5077"
   end

--- a/Formula/t/twarc.rb
+++ b/Formula/t/twarc.rb
@@ -8,8 +8,6 @@ class Twarc < Formula
   license "MIT"
   revision 11
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, all: "615f61acd8924f02a4c8dc0c1f905c59b1f8083afa54c7876490b33ad0cae1d7"
   end

--- a/Formula/t/twtxt.rb
+++ b/Formula/t/twtxt.rb
@@ -8,8 +8,6 @@ class Twtxt < Formula
   license "MIT"
   revision 6
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "29cc2de20dc895c385ac0a63e44855b00dbde6e2bc5731b8a2e1a7cfc032e928"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "d5b10bcf1dbbaab2d9a31cac9ac6aeace17f927b3962940c772229213675f1de"

--- a/Formula/t/txt2tags.rb
+++ b/Formula/t/txt2tags.rb
@@ -7,8 +7,6 @@ class Txt2tags < Formula
   sha256 "7e4244db6a63aaa58fc17fa4cdec62b6fb89cc41d3a00ba4edaffa37f27d6746"
   license "GPL-2.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 3
     sha256 cellar: :any_skip_relocation, all: "61a698b49ca220ecb3721f929db0e5965696a44facf0113e8114317da8ec6ec6"

--- a/Formula/u/ufbt.rb
+++ b/Formula/u/ufbt.rb
@@ -7,8 +7,6 @@ class Ufbt < Formula
   sha256 "4f1a858858598ed2e25bbab69e2ea604bc00758c3b1e8ecf897a29866157363b"
   license "GPL-3.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, all: "561e844026e50a7d961338d459851e9d62bca87f7449fc9404234b31a24e73d2"

--- a/Formula/u/urh.rb
+++ b/Formula/u/urh.rb
@@ -8,7 +8,7 @@ class Urh < Formula
   license "GPL-3.0-only"
   head "https://github.com/jopohl/urh.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
+  no_autobump! because: "`update-python-resources` cannot determine dependencies"
 
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "7aab6a172466029fbb7ed528a5edd624866de3c0d5c3c6db9566d5bd7bdd3dc2"

--- a/Formula/v/vermin.rb
+++ b/Formula/v/vermin.rb
@@ -8,8 +8,6 @@ class Vermin < Formula
   license "MIT"
   head "https://github.com/netromdk/vermin.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, all: "e25e54e3725d3f470d93f8272ac428d145eb667beb966d31498d02fee48be0c3"

--- a/Formula/v/vint.rb
+++ b/Formula/v/vint.rb
@@ -9,8 +9,6 @@ class Vint < Formula
   revision 2
   head "https://github.com/Vimjas/vint.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 6
     sha256 cellar: :any,                 arm64_sequoia: "d2e44d7c8f741058e7053452b35c8c95997f96f60bfb3b2327194a5bed7d90de"

--- a/Formula/w/watson.rb
+++ b/Formula/w/watson.rb
@@ -9,8 +9,6 @@ class Watson < Formula
   revision 8
   head "https://github.com/jazzband/Watson.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "02a6250ae9fa9e9342bfb595db2b274aac190703442e23ca6269711dc96cbce5"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "de5094e1fbc8b54ea86d7b4989694d308dff63003e5ce7139698a28d4efa6693"

--- a/Formula/w/waybackpy.rb
+++ b/Formula/w/waybackpy.rb
@@ -8,8 +8,6 @@ class Waybackpy < Formula
   license "MIT"
   revision 8
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "996bcc65b772b98507b7d5134217d463b69bc65948cd0276f0afefb89e0becf9"

--- a/Formula/w/wllvm.rb
+++ b/Formula/w/wllvm.rb
@@ -8,8 +8,6 @@ class Wllvm < Formula
   license "MIT"
   revision 1
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 5
     sha256 cellar: :any_skip_relocation, all: "1f51172a70e011c1666255f2ace6d910d573681b83d50c31b551616dce265e6b"

--- a/Formula/x/xdot.rb
+++ b/Formula/x/xdot.rb
@@ -8,7 +8,7 @@ class Xdot < Formula
   license "LGPL-3.0-or-later"
   head "https://github.com/jrfonseca/xdot.py.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
+  no_autobump! because: "`update-python-resources` cannot determine dependencies"
 
   bottle do
     rebuild 1

--- a/Formula/x/xml2rfc.rb
+++ b/Formula/x/xml2rfc.rb
@@ -8,8 +8,6 @@ class Xml2rfc < Formula
   license "BSD-3-Clause"
   head "https://github.com/ietf-tools/xml2rfc.git", branch: "main"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "9d779c5043e45a65d381bce49e1d3ccc922364d1cade4356664676438defe34f"
     sha256 cellar: :any,                 arm64_sonoma:  "b73d40fa03980a13ccd5adf616719ea307bf10f8c4d28a6232ceff4b2eaf7cae"

--- a/Formula/x/xxh.rb
+++ b/Formula/x/xxh.rb
@@ -7,8 +7,6 @@ class Xxh < Formula
   sha256 "7904c35efdff0a6f50f76b30879d3fbfe726cc765db47a1306ab2f19c03fdfae"
   license "BSD-2-Clause"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_sequoia: "91c67ed304dd2ff1703b87750f81b35238e051b999837ad62b1fdef026b8681f"

--- a/Formula/y/ykdl.rb
+++ b/Formula/y/ykdl.rb
@@ -7,8 +7,6 @@ class Ykdl < Formula
   sha256 "c689b8e4bf303d1582e40d5039539a1a754f7cf897bce73ec57c7e874e354b19"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "eb541b86eded5d4bcc6262795c769d284a9e3c37f42f70121d43864f4066dc1d"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

This audits all our PyPI formuale that still had `no_autobump! because: :requires_manual_review`.
Those compatible with `brew update-python-resources` (as tested locally) will now be autobumped.
For the rest, just update the reason why `update-python-resources` fails.
