### PR TITLE
cmd/check-bottle-modification: skip renamed files too

### DIFF
--- a/cmd/check-bottle-modification.rb
+++ b/cmd/check-bottle-modification.rb
@@ -38,7 +38,7 @@ module Homebrew
 
         files = response.fetch("files")
         files.reject! do |file|
-          next true if file.fetch("status") == "removed"
+          next true if %w[renamed removed].include?(file.fetch("status"))
 
           filename = file.fetch("filename")
           !filename.start_with?("Formula/") || !filename.end_with?(".rb")


### PR DESCRIPTION
This should help avoid some of the issues that motivated
Homebrew/brew#20316.
