### PR TITLE
nodenv 1.6.1

### DIFF
--- a/Formula/n/nodenv.rb
+++ b/Formula/n/nodenv.rb
@@ -9,15 +9,7 @@ class Nodenv < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia:  "cb8c3e5c3bec0417f019c7c50ed7151ff7f401ab52a3e6eabd63f7d67a523700"
-    sha256 cellar: :any,                 arm64_sonoma:   "95484196709cd9fa76534d9baf11807a588699fef0e706723732fda6560e1f15"
-    sha256 cellar: :any,                 arm64_ventura:  "ea7d85a9a683cfa60b81ff25dd6f5cf03147f7c1a96865356bfcc3240b5fa183"
-    sha256 cellar: :any,                 arm64_monterey: "ca9de16f487e86fe442702a0a7e88b3abfd5020c355659fd8c052989397a22d4"
-    sha256 cellar: :any,                 sonoma:         "0cd1dc555dc16d7120944a6e5998c037573d9aa2fed040d2d53eb9ccfb35f330"
-    sha256 cellar: :any,                 ventura:        "7d77938b7d856eeca7535de6171805392a59338e3a22f31fcfa478ab37fcbc29"
-    sha256 cellar: :any,                 monterey:       "2f344ef55716f73ee7ad9ebe9b6b09581010dea4955559eb1f7d5519c14a9c89"
-    sha256 cellar: :any_skip_relocation, arm64_linux:    "33a5bcabce0ae707a9b863ff16f16cab19c064fdfbe13d5f0a1af5c78a58f248"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "506fa918399e018d9492f86a2caa5bfe58ec4fe42561cfcd46c3a4c34e3bc81c"
+    sha256 cellar: :any_skip_relocation, all: "c55d5fa041bff0f7c662111988bb1b67f78ccf8e6caab9f77d7088c6445db44d"
   end
 
   depends_on "node" => :test


### PR DESCRIPTION
Created by https://github.com/mislav/bump-homebrew-formula-action

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Replaces #231345 
Updates the formula per nodenv's 1.6.0 changes (modified completion scripts, removal of native extension, addition of manpages).
Adds exhaustive tests.

Basically brings nodenv's formula to parity with rbenv's formula.