### PR TITLE
orbuculum: fix for code scanning alert (Incomplete string escaping or encoding)

### DIFF
--- a/Formula/o/orbuculum.rb
+++ b/Formula/o/orbuculum.rb
@@ -57,7 +57,7 @@ class Orbuculum < Formula
     assert_match "orblcd version #{version}", shell_output("#{bin}/orblcd --version 2>&1", 255)
     assert_match "Elf File not specified", shell_output("#{bin}/orbmortem 2>&1")
     assert_match "This utility is in development. Use at your own risk!!\nElf File not specified",
-                 shell_output("#{bin}/orbprofile 2>&1", 254).sub("\r", "")
+                 shell_output("#{bin}/orbprofile 2>&1", 254).delete("\r")
     assert_match "Elf File not specified", shell_output("#{bin}/orbstat 2>&1", 254)
     assert_match "Elf File not specified", shell_output("#{bin}/orbtop 2>&1", 247)
     assert_match "No devices found", shell_output("#{bin}/orbtrace 2>&1")


### PR DESCRIPTION
Potential fix for [https://github.com/Homebrew/homebrew-core/security/code-scanning/172](https://github.com/Homebrew/homebrew-core/security/code-scanning/172)

To fix the problem, replace the use of `String#sub("\r", "")` with `String#gsub("\r", "")`, which will remove *all* occurrences of the carriage return character from the string, not just the first. This change should be made on line 60 of `Formula/o/orbuculum.rb`. No additional imports or dependencies are required, as `gsub` is a standard Ruby method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._