### PR TITLE
eatmemory: simplify test for security alert

### DIFF
--- a/Formula/e/eatmemory.rb
+++ b/Formula/e/eatmemory.rb
@@ -25,9 +25,7 @@ class Eatmemory < Formula
 
   test do
     # test version match
-    out = shell_output "#{bin}/eatmemory -?"
-    version_escaped = version.to_s.gsub(".", '\.')
-    assert_match %r{^eatmemory #{version_escaped} - https://github.com/julman99/eatmemory\n.*}, out
+    assert_match "eatmemory #{version}", shell_output("#{bin}/eatmemory --help")
 
     # test for expected output
     out = shell_output "#{bin}/eatmemory -t 0 10M"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This simplifies the test and should fix https://github.com/Homebrew/homebrew-core/security/code-scanning/171 .