### PR TITLE
neovim-remote: update test

### DIFF
--- a/Formula/n/neovim-remote.rb
+++ b/Formula/n/neovim-remote.rb
@@ -54,21 +54,19 @@ class NeovimRemote < Formula
   test do
     socket = testpath/"nvimsocket"
     file = testpath/"test.txt"
-    ENV["NVIM_LISTEN_ADDRESS"] = socket
 
     nvim = spawn(
-      { "NVIM_LISTEN_ADDRESS" => socket },
-      Formula["neovim"].opt_bin/"nvim", "--headless", "-i", "NONE", "-u", "NONE", file,
+      Formula["neovim"].opt_bin/"nvim", "--headless", "-i", "NONE", "-u", "NONE", "--listen", socket, file,
       [:out, :err] => "/dev/null"
     )
     sleep 5
 
     str = "Hello from neovim-remote!"
-    system bin/"nvr", "--remote-send", "i#{str}<esc>:write<cr>"
+    system bin/"nvr", "--servername", socket, "--remote-send", "i#{str}<ESC>:write<CR>"
     assert_equal str, file.read.chomp
     assert_equal Process.kill(0, nvim), 1
 
-    system bin/"nvr", "--remote-send", ":quit<cr>"
+    system bin/"nvr", "--servername", socket, "--remote-send", ":quit<CR>"
 
     # Test will be terminated by the timeout
     # if `:quit` was not sent correctly


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`NVIM_LISTEN_ADDRESS` is deprecated in `nvim`, but not in
`neovim-remote`, so let's remove it from the `nvim` invocation.
