### PR TITLE
unitycatalog: build an `:all` bottle

### DIFF
--- a/Formula/u/unitycatalog.rb
+++ b/Formula/u/unitycatalog.rb
@@ -6,12 +6,8 @@ class Unitycatalog < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "19b009e2d141df4fca169ea68b5c1d01938e9f65e7b8433472e72a2aec9abd80"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "19b009e2d141df4fca169ea68b5c1d01938e9f65e7b8433472e72a2aec9abd80"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "19b009e2d141df4fca169ea68b5c1d01938e9f65e7b8433472e72a2aec9abd80"
-    sha256 cellar: :any_skip_relocation, sonoma:        "19b009e2d141df4fca169ea68b5c1d01938e9f65e7b8433472e72a2aec9abd80"
-    sha256 cellar: :any_skip_relocation, ventura:       "19b009e2d141df4fca169ea68b5c1d01938e9f65e7b8433472e72a2aec9abd80"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "bb4fb9ab2d49654bf9a56b439a6ce891283e6360662251f77a6ff7b67c4d57a9"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "8d0ef55f20e1d003a29001a2e018e6b0fb839a6c0bab924c25815a92ec7ed421"
   end
 
   depends_on "sbt" => :build

--- a/Formula/u/unitycatalog.rb
+++ b/Formula/u/unitycatalog.rb
@@ -32,9 +32,9 @@ class Unitycatalog < Formula
       pkgetc.install "etc"
     end
 
-    env = Language::Java.overridable_java_home_env("21")
-    env["PATH"] = "${JAVA_HOME}/bin:${PATH}" if OS.linux?
-    bin.env_script_all_files libexec/"bin", env
+    java_env = Language::Java.overridable_java_home_env("21")
+    java_env["PATH"] = "${JAVA_HOME}/bin:${PATH}"
+    bin.env_script_all_files libexec/"bin", java_env
   end
 
   service do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We can make this have an `:all` bottle by just adding the `PATH`
adjustment unconditionally so there is no deviation between OSes.
