### PR TITLE
flang: improve test

### DIFF
--- a/Formula/f/flang.rb
+++ b/Formula/f/flang.rb
@@ -97,12 +97,6 @@ class Flang < Formula
   end
 
   test do
-    # FIXME: We should remove the two variables below from the environment
-    #        to test that `flang` can find our config files correctly, but
-    #        this seems to break CI (but can't be reproduced locally).
-    # ENV.delete "CPATH"
-    # ENV.delete "SDKROOT"
-
     (testpath/"hello.f90").write <<~FORTRAN
       PROGRAM hello
         WRITE(*,'(A)') 'Hello World!'
@@ -166,9 +160,12 @@ class Flang < Formula
 
     return if OS.linux?
 
+    assert_match %r{^Configuration file: #{Regexp.escape(etc)}/clang/.*\.cfg$}i,
+                 shell_output("#{bin/flang_driver} --version")
+
     system "ar", "x", lib/"libFortranCommon.a"
     testpath.glob("*.o").each do |object_file|
-      refute_match(/^LLVM (IR )?bitcode/, shell_output("file --brief #{object_file}"))
+      refute_match(/LLVM (IR )?bitcode/, shell_output("file --brief #{object_file}"))
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- add check that `flang` driver can find our config files
- loosen check for LLVM bitcode in object files to minimise likelihood
  of this test succeeding even when there is LLVM bitcode in the static
  libraries.
