### PR TITLE
cfssl: remove unneeded file system access

### DIFF
--- a/Formula/c/cfssl.rb
+++ b/Formula/c/cfssl.rb
@@ -58,8 +58,8 @@ class Cfssl < Formula
         ]
       }
     JSON
-    shell_output("#{bin}/cfssl genkey -initca request.json > response.json")
-    response = JSON.parse(File.read(testpath/"response.json"))
+    response_json = shell_output("#{bin}/cfssl genkey -initca request.json")
+    response = JSON.parse(response_json)
     assert_match(/^-----BEGIN CERTIFICATE-----.*/, response["cert"])
     assert_match(/.*-----END CERTIFICATE-----$/, response["cert"])
     assert_match(/^-----BEGIN RSA PRIVATE KEY-----.*/, response["key"])


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We don't need to muck about in the file system here.
