### PR TITLE
got: disable autobump

### DIFF
--- a/Formula/g/got.rb
+++ b/Formula/g/got.rb
@@ -11,6 +11,8 @@ class Got < Formula
     regex(/href=.*?got-portable[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
+  no_autobump! because: "GitHub runners are not abile to access the homepage or livecheck URL"
+
   bottle do
     sha256 arm64_sequoia: "de57fc967046ef9aa8fcc1581fe067be0a6ec7b895440b0f667fd783fa0b00d0"
     sha256 arm64_sonoma:  "9b069ff44e0c2074c2f5d76721be9e79372a44a00a224af6e5ee65cb35adb966"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Trying to do `brew bump` with this formula doesn't work in CI for some reason.
I think GitHub runners are blocked from accessing the `livecheck` URL.

See:
- https://github.com/Homebrew/homebrew-core/actions/runs/16602578083/job/46966011267#step:6:29
- https://github.com/Homebrew/homebrew-core/pull/231706
- https://github.com/Homebrew/homebrew-core/actions/runs/16615399679/job/47023752343?pr=231706#step:4:51
- https://github.com/Homebrew/homebrew-core/actions/runs/16615399679/job/47007055998?pr=231706#step:4:51
