### PR TITLE
rbenv: document why bash completion not installed

### DIFF
--- a/Formula/r/rbenv.rb
+++ b/Formula/r/rbenv.rb
@@ -25,6 +25,7 @@ class Rbenv < Formula
                                            %Q(\\1"\\2-g#{git_revision}")
     end
 
+    # bash completion handled by rbenv-init
     zsh_completion.install "completions/_rbenv" => "_rbenv"
     prefix.install ["bin", "completions", "libexec", "rbenv.d"]
     man1.install "share/man/man1/rbenv.1"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Extracted from https://github.com/Homebrew/homebrew-core/pull/231749