### PR TITLE
workflows/triage: remove autobump labelling

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -436,10 +436,6 @@ jobs:
             - label: pip-audit
               pr_body_content: Created by `brew-pip-audit`
 
-            - label: autobump
-              path: \.github/autobump\.txt
-              allow_any_match: true
-
             - label: alias
               path: Aliases/.+
               allow_any_match: true


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-core/pull/231791