### PR TITLE
Replace docker-completion with docker completion

### DIFF
--- a/Formula/d/docker.rb
+++ b/Formula/d/docker.rb
@@ -23,7 +23,6 @@ class Docker < Formula
 
   depends_on "go" => :build
   depends_on "go-md2man" => :build
-  depends_on "docker-completion"
 
   conflicts_with cask: "docker-desktop"
 
@@ -51,6 +50,8 @@ class Docker < Formula
       (man/"man#{section}").mkpath
       system "go-md2man", "-in=#{md}", "-out=#{man}/man#{section}/#{md.stem}"
     end
+
+    generate_completions_from_executable(bin/"docker", "completion", shells: [:bash, :fish, :pwsh, :zsh])
   end
 
   test do


### PR DESCRIPTION
The formula [docker-completion](https://github.com/Homebrew/homebrew-core/blob/main/Formula/d/docker-completion.rb) uses [docker/cli/contrib/completion/zsh/_docker](https://github.com/docker/cli/blob/master/contrib/completion/zsh/_docker), which is based on [felixr/docker-zsh-completion](https://github.com/felixr/docker-zsh-completion), which is deprecated and archived. Docker can now generate completions with the `completion` command.

-----

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
