### PR TITLE
magic-wormhole: fix '-bash: complete: nosort: invalid option name'

### DIFF
--- a/Formula/m/magic-wormhole.rb
+++ b/Formula/m/magic-wormhole.rb
@@ -150,8 +150,8 @@ class MagicWormhole < Formula
   end
 
   patch do
-    url "https://github.com/magic-wormhole/magic-wormhole/commit/cc3867fe140ec487b2dc6fc1644662baff3e4679.diff?full_index=1"
-    sha256 "e505fbc2acc83a9fdf3d46257a3c5c5218594427ed9567f862805a65f58f8c19"
+    url "https://github.com/magic-wormhole/magic-wormhole/commit/cc3867fe140ec487b2dc6fc1644662baff3e4679.patch?full_index=1"
+    sha256 "53b2449dfe3c6b6809c9c25d5d1080b28d66ed91db336e70e6f00cd1cec86bea"
   end
   
   def install

--- a/Formula/m/magic-wormhole.rb
+++ b/Formula/m/magic-wormhole.rb
@@ -149,6 +149,11 @@ class MagicWormhole < Formula
     sha256 "8b49f1a3d1ee4cdaf5b32d2e738362c7f5e40ac8b46dd7d1a65e82a4872728fe"
   end
 
+  patch do
+    url "https://github.com/magic-wormhole/magic-wormhole/commit/cc3867fe140ec487b2dc6fc1644662baff3e4679.diff?full_index=1"
+    sha256 "e505fbc2acc83a9fdf3d46257a3c5c5218594427ed9567f862805a65f58f8c19"
+  end
+  
   def install
     virtualenv_install_with_resources
     man1.install "docs/wormhole.1"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
macOS builtin bash which does not support 'complete -o nosort'. This feature is added since bash 4.4.
See https://github.com/magic-wormhole/magic-wormhole/issues/524.
I don't know why the code author removed this patch from the recent releases.