### PR TITLE
tidy-html5: fix pathname and cmake

### DIFF
--- a/Formula/t/tidy-html5.rb
+++ b/Formula/t/tidy-html5.rb
@@ -32,13 +32,16 @@ class TidyHtml5 < Formula
   depends_on "cmake" => :build
 
   def install
+    # Workaround for CMake 4.0+
+    ENV["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5"
+
     system "cmake", "-S", ".", "-B", "builddir", *std_cmake_args
     system "cmake", "--build", "builddir"
     system "cmake", "--install", "builddir"
   end
 
   test do
-    output = pipe_output(bin/"tidy -q", "<!doctype html><title></title>")
+    output = pipe_output("#{bin}/tidy -q", "<!doctype html><title></title>")
     assert_match(/^<!DOCTYPE html>/, output)
     assert_match "HTML Tidy for HTML5", output
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Separated from https://github.com/Homebrew/homebrew-core/pull/232117
CMake issue