### PR TITLE
wb32-dfu-updater_cli: fix pathname and cmake

### DIFF
--- a/Formula/w/wb32-dfu-updater_cli.rb
+++ b/Formula/w/wb32-dfu-updater_cli.rb
@@ -26,6 +26,13 @@ class Wb32DfuUpdaterCli < Formula
   depends_on "cmake" => :build
   depends_on "libusb"
 
+  # Fix compatibility with cmake 4+
+  # PR ref: https://github.com/WestberryTech/wb32-dfu-updater/pull/17
+  patch do
+    url "https://github.com/WestberryTech/wb32-dfu-updater/commit/34725776e4b21be89e5d4eb0ea83346f26fc5d1f.patch?full_index=1"
+    sha256 "bfcc362f17c3063b90531e2795e7d33743dc754cce5dac2a93582994f9a88479"
+  end
+
   def install
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args
     system "cmake", "--build", "build"
@@ -33,6 +40,7 @@ class Wb32DfuUpdaterCli < Formula
   end
 
   test do
-    assert_match "No DFU capable USB device available\n", shell_output(bin/"wb32-dfu-updater_cli -U 111.bin 2>&1", 74)
+    assert_match "No DFU capable USB device available\n",
+                 shell_output("#{bin}/wb32-dfu-updater_cli -U 111.bin 2>&1", 74)
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Separated from https://github.com/Homebrew/homebrew-core/pull/232120
cmake issue