### PR TITLE
carapace: do not register all completers

### DIFF
--- a/Formula/c/carapace.rb
+++ b/Formula/c/carapace.rb
@@ -7,12 +7,13 @@ class Carapace < Formula
   head "https://github.com/carapace-sh/carapace-bin.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "bd0b1905afce3324801a0cc8861a6097ac068b5cfe06c8f28a9fe97dc30fbf1e"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "d29466853838fa6b09fb6eac678aa463317787c8a29621d07bfe91a72dcbafaf"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "b82a756d84ab02124a78edcac33d9cb409dc423eb204e1e3b5aab306007c8ed8"
-    sha256 cellar: :any_skip_relocation, sonoma:        "1102e5429e8062300db6b369f1a1e043347fe954874c78acc5490193b8f61c3b"
-    sha256 cellar: :any_skip_relocation, ventura:       "3324d1e2b86f2e23434ae154f718a58b3481ccd71ec5e9ca21e1defbd5ca28cd"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "111c3aeb5a3c91fc3cc4f6dec11089152474986645fbf68b9c9f084ce8cdf298"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "7a67e00e824df654068fbb83d8700bd1dca16fd646bd7542a4852e46938d74e4"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "7a67e00e824df654068fbb83d8700bd1dca16fd646bd7542a4852e46938d74e4"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "7a67e00e824df654068fbb83d8700bd1dca16fd646bd7542a4852e46938d74e4"
+    sha256 cellar: :any_skip_relocation, sonoma:        "d92b9cb0bf6efa6c3ef5cdb3c67caa2be9295eb369b0e65262f282799cb48a47"
+    sha256 cellar: :any_skip_relocation, ventura:       "d92b9cb0bf6efa6c3ef5cdb3c67caa2be9295eb369b0e65262f282799cb48a47"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "6f6b67ee070ce4f1331fe98f01842667a8ef75930389c6a59b03fac45583adc0"
   end
 
   depends_on "go" => :build

--- a/Formula/c/carapace.rb
+++ b/Formula/c/carapace.rb
@@ -25,7 +25,7 @@ class Carapace < Formula
     ]
     system "go", "build", *std_go_args(ldflags:, tags: "release"), "./cmd/carapace"
 
-    generate_completions_from_executable(bin/"carapace", "_carapace")
+    generate_completions_from_executable(bin/"carapace", "carapace")
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Per [carapace docs](https://carapace-sh.github.io/carapace-bin/setup.html), `carapace _carapace` registers **all** available completers, which has the side effect of replacing completions of other commands with carapace's.

This pull request makes the vendored completions only contain completions for carapace itself.