### PR TITLE
xmodmap: fix pathname and sleep test

### DIFF
--- a/Formula/x/xmodmap.rb
+++ b/Formula/x/xmodmap.rb
@@ -39,6 +39,7 @@ class Xmodmap < Formula
     end
     ENV["DISPLAY"] = ":1"
     sleep 10
-    assert_match "pointer buttons defined", shell_output(bin/"xmodmap -pp")
+    sleep 10 if OS.mac? && Hardware::CPU.intel?
+    assert_match "pointer buttons defined", shell_output("#{bin}/xmodmap -pp")
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Separate from https://github.com/Homebrew/homebrew-core/pull/232120
update test