### PR TITLE
yt-auto-dl 1.0.0 (new formula)

### DIFF
--- a/Formula/yt-auto-dl.rb
+++ b/Formula/yt-auto-dl.rb
@@ -25,6 +25,8 @@ class YtAutoDl < Formula
   end
 
   test do
-    assert_match "Usage", shell_output("#{bin}/dla --help", 1)
+    assert_match "dlv", shell_output("#{bin}/dlv --help")
+    assert_match "dla", shell_output("#{bin}/dla --help")
   end
 end
+  

--- a/Formula/yt-auto-dl.rb
+++ b/Formula/yt-auto-dl.rb
@@ -1,0 +1,30 @@
+class YtAutoDl < Formula
+  desc "YouTube audio/video automatic downloader via active browser tab (macOS only)"
+  homepage "https://github.com/chaseungjoon/yt-auto-dl"
+  url "https://github.com/chaseungjoon/yt-auto-dl/archive/refs/tags/v1.0.0.tar.gz"
+  sha256 "ee118efa3bfc7a74f134ac9dadecc734c5586df982c8ac8a3e3f98e50a226861"
+  license "MIT"
+
+  depends_on "ffmpeg"
+  depends_on "yt-dlp"
+
+  def install
+    bin.install "dla"
+    bin.install "dlv"
+  end
+
+  def post_install
+    puts <<~EOS
+      🔧 Required Python package not managed by Homebrew:
+        pip install ffpb
+
+      📦 Commands now available:
+        • dlv : Download and convert YouTube video for QuickTime
+        • dla : Download and convert YouTube audio to mp3
+    EOS
+  end
+
+  test do
+    assert_match "Usage", shell_output("#{bin}/dla --help", 1)
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Adds a new formula for `yt-auto-dl`, a shell-based utility providing two lightweight commands:

- `dla`: downloads audio (`.mp3`) from YouTube
- `dlv`: downloads and re-encodes high-quality video (`.mp4`) for QuickTime compatibility on macOS

This tool detects the currently focused browser and grabs the active YouTube video URL automatically, eliminating the need to manually copy/paste links.

Also includes a `post_install` message to guide the user to install `ffpb` via `pip`, which is used for progress bars during re-encoding.

Tested with Safari, Chrome, Arc, Brave, and other major browsers on macOS.