### PR TITLE
lua-language-server: use `-a $0` in exec script

### DIFF
--- a/Formula/l/lua-language-server.rb
+++ b/Formula/l/lua-language-server.rb
@@ -41,7 +41,7 @@ class LuaLanguageServer < Formula
     # Make sure `lua-language-server` does not need to write into the Cellar.
     (bin/"lua-language-server").write <<~BASH
       #!/bin/bash
-      exec -a lua-language-server #{libexec}/bin/lua-language-server \
+      exec -a "${0}" #{libexec}/bin/lua-language-server \
         --logpath="${XDG_CACHE_HOME:-${HOME}/.cache}/lua-language-server/log" \
         --metapath="${XDG_CACHE_HOME:-${HOME}/.cache}/lua-language-server/meta" \
         "$@"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This will make the exec script look more transparent in the process
table.
