### PR TITLE
ca-certificates: add Linux custom certificate integration

### DIFF
--- a/Formula/c/ca-certificates.rb
+++ b/Formula/c/ca-certificates.rb
@@ -11,7 +11,8 @@ class CaCertificates < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "84e089e758e75d61228f97d54b3eb1918737a2272c747206cc4d9d75d8a3cb52"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "cecefecd1faa4638190038aa023529cea2159dccdddcaf6d1a20e63d32cb4139"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

## Summary
This PR implements automatic integration of system CA certificates on Linux systems.

## Changes Made
- **System certificate integration**: Added `linux_post_install` method that reads system CA certificates from `/etc/ssl/certs/ca-certificates.crt`
- **Mozilla store supplementation**: Supplements system certificates with any missing certificates from the Mozilla CA store
- **Fallback behavior**: When no system `openssl` is found, falls back to using only the Mozilla CA store with appropriate warnings

## Platform Support
This implementation targets standard Linux systems that use the `/etc/ssl/certs/ca-certificates.crt` file (Ubuntu, Debian, and most other distributions).

## Disclaimer
This is my first time working with Ruby, so while `brew audit` passes successfully, I'd appreciate extra review regarding Homebrew code style and Ruby best practices. Please let me know if anything needs adjustment\! 🙂