### PR TITLE
djview4 4.12.3

### DIFF
--- a/Formula/d/djview4.rb
+++ b/Formula/d/djview4.rb
@@ -13,16 +13,11 @@ class Djview4 < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia:  "50f358049ae7371431b1640620050d40f9075e998695efc69e3cfc228955d189"
-    sha256 cellar: :any,                 arm64_sonoma:   "aeec9249493e568780d0760a7c11d597c51e9a89835d9d7be3a3512510dd6e09"
-    sha256 cellar: :any,                 arm64_ventura:  "a852adaa4bb85ae49414a271aa1b183595b523d994d338567a18384097ce1abf"
-    sha256 cellar: :any,                 arm64_monterey: "7386959e5881c110ca398bd1ec94f962a4d726ea659ef26c804cbf68aaf4fceb"
-    sha256 cellar: :any,                 arm64_big_sur:  "2da284a44e3e0a0a1a5dc29c7b6c71ef3e014d13d81846c9d7e88293b005081f"
-    sha256 cellar: :any,                 sonoma:         "fb06597b392db6503ee92b70ee0074a0880b58e2d5fed3999d3b2c40b0039d28"
-    sha256 cellar: :any,                 ventura:        "7c8e2da786b4d91a1d4af0991a7d8e49903c80101377a10f8b6920559e25aff1"
-    sha256 cellar: :any,                 monterey:       "d5c2c116e402498ec6ffd6261ee5eeaec4374a6d9ec7b37c7cb4f5ff7f316b81"
-    sha256 cellar: :any,                 big_sur:        "8f03e13feeb1f0e19b8a1f1b5638990557aaad04916e06826bee7511a0dbfbf4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "9ad7de2463c9ef2720b7bd1a854ac73ed84bdf0ecb6273146a9a404a48b78eca"
+    sha256 cellar: :any,                 arm64_sonoma:  "b393017f8b974e7dc17a48f65941fc9ddde96ed8984d8512eee36c8696d92226"
+    sha256 cellar: :any,                 arm64_ventura: "ad42188575bb0381ad12eacebd07697e2e9ff2d006ee8ce2f6f13ea4dedb3b20"
+    sha256 cellar: :any,                 sonoma:        "7c6e8d7e367fb01bb6ab1ce25937baad8216b3eeba387c02b818f7181c5aded4"
+    sha256 cellar: :any,                 ventura:       "feb0dbe394dd086949cb1c383b4d88999073173b84fbaadde047160c064c4bdd"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "782df64753001f0fcda840c52acda38ce36c0468d478eb05a669955e2c6f2b3c"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/d/djview4.rb
+++ b/Formula/d/djview4.rb
@@ -1,10 +1,9 @@
 class Djview4 < Formula
   desc "Viewer for the DjVu image format"
   homepage "https://djvu.sourceforge.net/djview4.html"
-  url "https://downloads.sourceforge.net/project/djvu/DjView/4.12/djview-4.12.tar.gz"
-  sha256 "5673c6a8b7e195b91a1720b24091915b8145de34879db1158bc936b100eaf3e3"
+  url "https://downloads.sourceforge.net/project/djvu/DjView/4.12/djview-4.12.3.tar.gz"
+  sha256 "17bfb9731ab8070e01235381f08e57b1231ffb5f49eb031873ebfa189cdaf47d"
   license "GPL-2.0-or-later"
-  revision 2
 
   livecheck do
     url :stable
@@ -32,54 +31,37 @@ class Djview4 < Formula
   depends_on "pkgconf" => :build
   depends_on "djvulibre"
   depends_on "libtiff"
-  depends_on "qt@5"
-
-  # Fix QT detection when multiple Xcode installations are present.
-  # Submitted upstream: https://sourceforge.net/p/djvu/patches/44/
-  patch :DATA
+  depends_on "qt"
 
   def install
-    system "autoreconf", "--force", "--install", "--verbose"
-
-    system "./configure", "--with-x=no",
-                          "--disable-nsdejavu",
-                          "--disable-desktopfiles",
-                          "--with-tiff=#{Formula["libtiff"].opt_prefix}",
-                          *std_configure_args
+    system "./autogen.sh", "--with-x=no",
+                            "--disable-nsdejavu",
+                            "--#{OS.mac? ? "disable" : "enable"}-desktopfiles",
+                            "--#{OS.mac? ? "enable" : "disable"}-mac",
+                            "--with-tiff=#{Formula["libtiff"].opt_prefix}",
+                            *std_configure_args
     system "make", "CC=#{ENV.cc}", "CXX=#{ENV.cxx}"
 
     # From the djview4.8 README:
     # NOTE: Do not use command "make install".
     # Simply copy the application bundle where you want it.
     if OS.mac?
-      prefix.install "src/djview.app"
-      bin.write_exec_script prefix/"djview.app/Contents/MacOS/djview"
+      # This script creates a more complete bundle, still relying on homebrew libs
+      cd("mac") { system "sh", "./make_djview_bundle_small.sh" }
+      prefix.install "mac/DjView.app"
+      bin.write_exec_script prefix/"DjView.app/Contents/MacOS/djview"
     else
+      # Should we use make install DESTDIR=<cellardir> instead?
       prefix.install "src/djview"
     end
   end
 
   test do
     name = if OS.mac?
-      "djview.app"
+      "DjView.app"
     else
       "djview"
     end
     assert_path_exists prefix/name
   end
 end
-
-__END__
-diff --git a/config/acinclude.m4 b/config/acinclude.m4
-index 3c78d41..8eb0575 100644
---- a/config/acinclude.m4
-+++ b/config/acinclude.m4
-@@ -314,7 +314,7 @@ message(QT_INSTALL_BINS="$$[QT_INSTALL_BINS]")
- changequote([, ])dnl
- EOF
-   if ( cd conftest.d && $QMAKE > conftest.out 2>&1 ) ; then
--    sed -e 's/^.*: *//' < conftest.d/conftest.out > conftest.d/conftest.sh
-+    grep "Project MESSAGE:" < conftest.d/conftest.out | sed -e 's/^.*: *//' > conftest.d/conftest.sh
-     . conftest.d/conftest.sh
-     rm -rf conftest.d
-   else


### PR DESCRIPTION
I am the author of djview4 and I would like to stop building a dmg manually, 
directing instead people to use "brew install djview4".  The proposed changes consist of:
* Using a new tarball with an extra script 
* Building with qt6
* Removing the patch for the already included qt detection change
* Using the autogen.sh script and configure option --enable-mac to build the spotlight/quicklook plugins
* Use the extra script to create a bundle that contains the translations and the spotlight/quicklook plugins.  This bundle is very light because it depends on the installed homebrew libraries (qt, djvulibre, jpeg, tiff).  The executable works better inside the bundle because this is how it locates the translations (which were missing from the previous formula).  

I believe I followed all the guidelines.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
