### PR TITLE
node@18: remove livecheck

### DIFF
--- a/Formula/n/node@18.rb
+++ b/Formula/n/node@18.rb
@@ -5,12 +5,6 @@ class NodeAT18 < Formula
   sha256 "36a7bf1a76d62ce4badd881ee5974a323c70e1d8d19165732684e145632460d9"
   license "MIT"
 
-  # Remove livecheck on 2025-04-30
-  livecheck do
-    url "https://nodejs.org/dist/"
-    regex(%r{href=["']?v?(18(?:\.\d+)+)/?["' >]}i)
-  end
-
   bottle do
     sha256 arm64_sequoia: "85339a0121bfd4eade3f70a49197c59fd1d0dee18511edf924d4acf4d81cc012"
     sha256 arm64_sonoma:  "cce72f3a40cb31861f419e0ea364cf0581e6f59b28f3e5c00196ccdea6a9f295"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Node 18.x reached end of life on 2025-04-30. This removes the `livecheck` block, so livecheck will skip it as deprecated.

I haven't uncommented the `disable!` call here, as the `hasura-cli` formula still depends on `node@18` and it doesn't seem like anything has changed since [it was deprecated](https://github.com/Homebrew/homebrew-core/pull/195880) (correct me if I'm wrong).