### PR TITLE
kubernetes-cli@1.30: remove livecheck

### DIFF
--- a/Formula/k/kubernetes-cli@1.30.rb
+++ b/Formula/k/kubernetes-cli@1.30.rb
@@ -6,11 +6,6 @@ class KubernetesCliAT130 < Formula
       revision: "50af91c466658b6a33d123fae8a487db1630971c"
   license "Apache-2.0"
 
-  livecheck do
-    url :stable
-    regex(/^v?(1\.30(?:\.\d+)+)$/i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "449a3876eac5b7508ae83162e78df0cc0ab7c7e849a8637beb5fa0a21b547e60"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "d5b7b3e0df3acf0fb2e27f40369396f0e9b3f848dec675bfaa9af47330271992"
@@ -24,7 +19,7 @@ class KubernetesCliAT130 < Formula
   keg_only :versioned_formula
 
   # https://kubernetes.io/releases/patch-releases/#1-30
-  disable! date: "2025-06-28", because: :deprecated_upstream
+  disable! date: "2025-07-15", because: :deprecated_upstream
 
   depends_on "bash" => :build
   depends_on "go" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The 1.30 branch of `kubernetes-cli` reached end of life on 2025-07-15. This removes the `livecheck` block so it will be automatically skipped as disabled.