### PR TITLE
pnpm@8: remove livecheck

### DIFF
--- a/Formula/p/pnpm@8.rb
+++ b/Formula/p/pnpm@8.rb
@@ -5,13 +5,6 @@ class PnpmAT8 < Formula
   sha256 "daa27a0b541bc635323ff96c2ded995467ff9fe6d69ff67021558aa9ad9dcc36"
   license "MIT"
 
-  livecheck do
-    url "https://registry.npmjs.org/pnpm/latest-8"
-    strategy :json do |json|
-      json["version"]
-    end
-  end
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_sequoia:  "d27023c0a4cd4905688132e77e2729c06816516b1e35d9c73fcc4f70aedb05bf"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

pnpm 8.x reached end of life on 2025-04-30 and the formula was disabled. This removes the `livecheck` block, so it will automatically be skipped as disabled.