### PR TITLE
pyside@2: remove livecheck

### DIFF
--- a/Formula/p/pyside@2.rb
+++ b/Formula/p/pyside@2.rb
@@ -12,11 +12,6 @@ class PysideAT2 < Formula
     { any_of: ["LGPL-3.0-only", "GPL-2.0-only", "GPL-3.0-only"] },
   ]
 
-  livecheck do
-    url "https://download.qt.io/official_releases/QtForPython/pyside2/"
-    regex(%r{href=.*?PySide2[._-]v?(\d+(?:\.\d+)+)-src/}i)
-  end
-
   bottle do
     sha256                               arm64_sequoia: "49044784ca72cc2c0b6a2cbf1c531854d8cf6293b13fa60c8265835e52403d2a"
     sha256                               arm64_sonoma:  "20ba3bca0f3bfea74630e7caa6fcd82f5da40e4970f5073fe5091a6c08e48d8b"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `pyside@2` formula was disabled on 2025-05-26. This removes the `livecheck` block, so it will be automatically skipped as disabled.