### PR TITLE
task@2: remove livecheck

### DIFF
--- a/Formula/t/task@2.rb
+++ b/Formula/t/task@2.rb
@@ -5,11 +5,6 @@ class TaskAT2 < Formula
   sha256 "b1d3a7f000cd0fd60640670064e0e001613c9e1cb2242b9b3a9066c78862cfec"
   license "MIT"
 
-  livecheck do
-    url :stable
-    regex(/^v?(2\.\d+\.\d+)$/i)
-  end
-
   bottle do
     sha256                               arm64_sequoia:  "f8c1a9cf2878e0f0167b9ec74d1ef1ffb393048efa96309e6c39295e1a83843e"
     sha256                               arm64_sonoma:   "82df1c51fe66c7f8981adea3530dcb68c461a994e4f63eb3010b9478bf66ee76"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `task@2` formula was disabled on 2025-04-30, as upstream doesn't maintain 2.x versions and there hasn't been one since before 3.0.0 (2.6.2 is from 2022-03-16). This removes the `livecheck` block, so it will be automatically skipped as disabled.