### PR TITLE
iccdev 2.2.50 (new formula)

### DIFF
--- a/Formula/i/iccdev.rb
+++ b/Formula/i/iccdev.rb
@@ -1,19 +1,9 @@
-class Iccmax < Formula
+class Iccdev < Formula
   desc "Demonstration Implementation for iccMAX color profiles"
   homepage "https://github.com/InternationalColorConsortium/DemoIccMAX"
   url "https://github.com/InternationalColorConsortium/DemoIccMAX/archive/refs/tags/v2.2.50.tar.gz"
   sha256 "f48fc2e3f4cc80f9c73df27bf48fca3de7d0a81266d7084df544941e61b37eb2"
   license "MIT"
-
-  bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "c65b4162c33709671fc0554926edf05d0ab5f0a4f37f9336d36e1f8fb7e237b9"
-    sha256 cellar: :any,                 arm64_sonoma:  "2488ed5d87bbe84c802ba1803ae383c4d2ba6c793c0e3146a4d50c7e0aaa2c95"
-    sha256 cellar: :any,                 arm64_ventura: "725fa427b1a4106eadb49acb96e112249e00dcd737a72e9430a116bde3adbba4"
-    sha256 cellar: :any,                 sonoma:        "d1b0708ef55cbc7ec7a0bc39f87fb98417489fb0e59fbf34f63d836067fdb79c"
-    sha256 cellar: :any,                 ventura:       "2b5aef1ad26aecc5fddf8f097fccf3fb1dedfc72bf5061a577a1720ebe5953ec"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "2df8f147a9e2ed559a38c26cd1030e90982eb5fbf2048eeaac73d7d0937476d5"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8ef04980d03bed8eb5e7cce0480045d252efdcab85167368e75a4090a7274854"
-  end
 
   depends_on "cmake" => :build
   depends_on "nlohmann-json" => :build


### PR DESCRIPTION
Add new formula iccdev v.2.2.5 as successor to iccmax

This PR is based on the existing formula for iccmax renamed and retested as iccdev

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
