### PR TITLE
oxen: disable autobump

### DIFF
--- a/Formula/o/oxen.rb
+++ b/Formula/o/oxen.rb
@@ -13,6 +13,8 @@ class Oxen < Formula
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
+  no_autobump! because: :bumped_by_upstream
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "1b4e7b4fda97e6584944b80c07bade93b100fde8ccdca2ad271267d3c9582143"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "80556835a1853e21d345afb8a9e4bf4d2d8d976772fac36871b8f460695b27c8"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Hi, I am an Oxen maintainer. We would like to disable autobump so that we can control when a release gets published. We will be adding `brew bump-formula-pr` to our release workflow.

Thank you.