### PR TITLE
rage: Fix incomplete URL substring sanitization

### DIFF
--- a/Formula/r/rage.rb
+++ b/Formula/r/rage.rb
@@ -42,7 +42,7 @@ class Rage < Formula
     system bin/"rage", "-r", "age1y8m84r6pwd4da5d45zzk03rlgv2xr7fn9px80suw3psrahul44ashl0usm",
       "-o", "#{testpath}/test.txt.age", "#{testpath}/test.txt"
     assert_path_exists testpath/"test.txt.age"
-    assert File.read(testpath/"test.txt.age").start_with?("age-encryption.org")
+    assert_equal "age-encryption.org/v1", File.open(testpath/"test.txt.age", &:gets).chomp
 
     # Test decryption
     (testpath/"test.key").write("AGE-SECRET-KEY-1TRYTV7PQS5XPUYSTAQZCD7DQCWC7Q77YJD7UVFJRMW4J82Q6930QS70MRX\n")


### PR DESCRIPTION
Potential fix for [https://github.com/Homebrew/homebrew-core/security/code-scanning/169](https://github.com/Homebrew/homebrew-core/security/code-scanning/169)

To fix the problem, the test should verify that the file starts with the exact expected header line for age-encrypted files, rather than just checking for a substring. The age file format specifies that the first line should be exactly `"age-encryption.org/v1"`. Therefore, the test should read the first line of the file and assert that it matches this string exactly. This can be done by reading the file and comparing the first line to `"age-encryption.org/v1"`. The change should be made in the test block, specifically replacing line 45 in `Formula/r/rage.rb`.

No new imports or dependencies are needed, as Ruby's standard library provides the necessary file reading functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
