### PR TITLE
curl: Fix missing regular expression anchor

### DIFF
--- a/Formula/c/curl.rb
+++ b/Formula/c/curl.rb
@@ -55,7 +55,7 @@ class Curl < Formula
 
   def install
     tag_name = "curl-#{version.to_s.tr(".", "_")}"
-    if build.stable? && stable.mirrors.grep(/github\.com/).first.exclude?(tag_name)
+    if build.stable? && stable.mirrors.grep(%r{\Ahttps?://(www\.)?github\.com/}).first.exclude?(tag_name)
       odie "Tag name #{tag_name} is not found in the GitHub mirror URL! " \
            "Please make sure the URL is correct."
     end


### PR DESCRIPTION
Potential fix for [https://github.com/Homebrew/homebrew-core/security/code-scanning/177](https://github.com/Homebrew/homebrew-core/security/code-scanning/177)

To fix the problem, the regular expression `/github\.com/` should be anchored so that it matches only when "github.com" appears in the expected location within the URL, specifically as the host. The best way to do this is to use a regular expression that matches URLs whose host is exactly "github.com" (optionally with a protocol prefix and possibly "www."). In Ruby, the anchors `\A` and `\z` match the start and end of the string, respectively, and should be used instead of `^` and `$` to avoid issues with newlines.

In this case, the mirror URLs are likely to be of the form `https://github.com/...`, so the regular expression should match URLs that start with a protocol and have "github.com" as the host. The updated regular expression should be `/\Ahttps?:\/\/(www\.)?github\.com\//`, which matches URLs that start with "http://" or "https://", optionally "www.", then "github.com", and a slash.

Edit the code in `Formula/c/curl.rb` at line 58 to use the new regular expression.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
