### PR TITLE
container 0.3.0 (new formula)

### DIFF
--- a/Formula/c/container.rb
+++ b/Formula/c/container.rb
@@ -1,0 +1,45 @@
+class Container < Formula
+  desc "Create and run Linux containers using lightweight virtual machines"
+  homepage "https://apple.github.io/container/documentation/"
+  url "https://github.com/apple/container/archive/refs/tags/0.3.0.tar.gz"
+  sha256 "366d800be3c9c1af2d7fb7a1abe2af3f8aa7e9c97af966c48d1e1297fe2518d9"
+  license "Apache-2.0"
+  head "https://github.com/apple/container.git", branch: "main"
+
+  depends_on xcode: ["26.0", :build]
+  depends_on macos: :sequoia
+  depends_on :macos
+  uses_from_macos "swift" => :build # Recheck on Linux with swift@6.2, once released
+
+  def install
+    if build.head?
+      ENV["GIT_COMMIT"] = system "git", "rev-parse", "HEAD"
+    else
+      ENV["RELEASE_VERSION"] = version
+    end
+
+    args = if OS.mac?
+      ["--disable-sandbox"]
+    else
+      ["--static-swift-stdlib"]
+    end
+
+    system "swift", "build", *args, "--configuration", "release", "--product", "container"
+    bin.install ".build/release/container"
+  end
+
+  service do
+    run [opt_bin/"container", "system", "start"]
+    keep_alive true
+    working_dir var
+    log_path var/"log/container.log"
+    error_log_path var/"log/container.log"
+  end
+
+  test do
+    system bin/"container", "system", "start"
+    container_cmd = "\"echo 'Hello, world!' › index.html ; python3 -m http.server 88 --bind 0.0.0.0\""
+    container_id = shell_output("#{bin}/container container run -it --m -d python:slim sh -c #{container_cmd}")
+    assert_match(container_id, shell_output("#{bin}/container ls"))
+  end
+end


### PR DESCRIPTION
Reopen of https://github.com/Homebrew/homebrew-core/pull/226884, now that https://github.com/Homebrew/brew/pull/20062 is merged and 4.6.0 released with preliminary Tahoe (& Xcode 26) support.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
