### PR TITLE
or-tools: re-enable scip

### DIFF
--- a/Formula/o/or-tools.rb
+++ b/Formula/o/or-tools.rb
@@ -13,12 +13,13 @@ class OrTools < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "d9e21df58ba94dbf6c91b84b5a2077273732cee4c13bc0eb3f2f73a203db5438"
-    sha256 cellar: :any,                 arm64_sonoma:  "1af6505b110527a7d42a100e322111b5002491ac07116796d5360f12bcc8b734"
-    sha256 cellar: :any,                 arm64_ventura: "c54d8ab752370dd67633e5aa75c97bcfde837352a221964d1168d32d60247116"
-    sha256 cellar: :any,                 sonoma:        "2c6a323eddb3ee293f2a6e603538468c91486911927836d7c25e3d45d4c18fef"
-    sha256 cellar: :any,                 ventura:       "c8fb7f51c6b20b5c7c202dfc58cd524b5f8e2aa90eaf54630a0b98019a79f806"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "09c5f989198f535a4e15a7b5745ae63e47bbfcac963e821fe2191312c339812a"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "7ce8536119bdc17013e8e1af390d35089c90a82c00a2e2b7f060664d8a6ebcc6"
+    sha256 cellar: :any,                 arm64_sonoma:  "cf67629211b9483eda40865ef3d73b22931237fc6ad33c6add8d1860d06ffaee"
+    sha256 cellar: :any,                 arm64_ventura: "8007ad563566751f66d77f871b4ecc81bd66b51d331d5416f560fa4e88d57ace"
+    sha256 cellar: :any,                 sonoma:        "e8e5cef74403cbdbabdb6ffb46bdd4a02031af1d26b6b3be9672d2a9efd4faf6"
+    sha256 cellar: :any,                 ventura:       "abb9cc2a587012012bc89bf9c892cfe5e3c894c35efc20277870d985feeb0c66"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "a57fca0beeca2fc09d465e54f4ca599d5fdc313b3371232e5db3d5bbdb43bf43"
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/o/or-tools.rb
+++ b/Formula/o/or-tools.rb
@@ -33,18 +33,40 @@ class OrTools < Formula
   depends_on "osi"
   depends_on "protobuf"
   depends_on "re2"
+  depends_on "scip"
   uses_from_macos "bzip2"
   uses_from_macos "zlib"
 
   def install
+    # Fix for wrong target name for `libscip`.
+    # Reported at https://github.com/google/or-tools/issues/4750.
+    libscip_files = %w[
+      cmake/check_deps.cmake
+      cmake/docs/cmake.dot
+      cmake/docs/cmake.svg
+      cmake/docs/deps.dot
+      cmake/docs/deps.svg
+      cmake/java.cmake
+      cmake/ortoolsConfig.cmake.in
+      cmake/python.cmake
+      cmake/system_deps.cmake
+      ortools/dotnet/Google.OrTools.runtime.csproj.in
+      ortools/gscip/CMakeLists.txt
+      ortools/linear_solver/CMakeLists.txt
+      ortools/linear_solver/proto_solver/CMakeLists.txt
+      ortools/linear_solver/wrappers/CMakeLists.txt
+      ortools/math_opt/io/CMakeLists.txt
+      ortools/math_opt/solvers/CMakeLists.txt
+    ]
+    inreplace libscip_files, "SCIP::libscip", "libscip"
+
     # FIXME: Upstream enabled Highs support in their binary distribution, but our build fails with it.
-    # FIXME: turned off SCIP, otherwise or-tools fails to build with "Target SCIP::libscip not available."
     args = %w[
       -DUSE_HIGHS=OFF
       -DBUILD_DEPS=OFF
       -DBUILD_SAMPLES=OFF
       -DBUILD_EXAMPLES=OFF
-      -DUSE_SCIP=OFF
+      -DUSE_SCIP=ON
     ]
     system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
     system "cmake", "--build", "build"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Let's try to fix regressions from #227389.

This also brings the formula closer in line with the binary packages
that upstream builds.
