### PR TITLE
workflows: add comment reminder for proper usage of `CI-test-bot-no-concurrent-downloads`

### DIFF
--- a/.github/workflows/manage-pull-request-labels.yml
+++ b/.github/workflows/manage-pull-request-labels.yml
@@ -3,6 +3,7 @@ name: Manage pull request labels
 on:
   pull_request_target:
     types:
+      - labeled
       - unlabeled
 
 defaults:
@@ -21,12 +22,13 @@ env:
   PR: ${{ github.event.number }}
 
 jobs:
-  label:
+  workflows-label:
     permissions:
       pull-requests: write # for `gh pr edit`
     runs-on: ubuntu-latest
     if: >
       github.repository_owner == 'Homebrew' &&
+      github.event.action == 'unlabeled' &&
       contains(fromJson('["workflows"]'), github.event.label.name)
     steps:
       - name: Re-label PR
@@ -34,3 +36,21 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LABEL: ${{ github.event.label.name }}
+
+  concurrent-downloads-label:
+    permissions:
+      pull-requests: write # for `gh pr edit`
+    runs-on: ubuntu-latest
+    if: >
+      github.repository_owner == 'Homebrew' &&
+      github.event.action == 'labeled' &&
+      contains(fromJson('["CI-test-bot-no-concurrent-downloads"]'), github.event.label.name)
+    steps:
+      - name: Post comment
+        run: gh pr comment "$PR" --body "$COMMENT" --repo "$GITHUB_REPOSITORY"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENT: >-
+            @${{ github.actor }}, please file an issue at Homebrew/brew for all uses of
+            ${{ github.server_url }}/${{ github.repository }}/labels/${{ github.event.label.name }}.
+            Thanks!


### PR DESCRIPTION
We want usage of the https://github.com/Homebrew/homebrew-core/labels/CI-test-bot-no-concurrent-downloads to be
accompanied by an issue at Homebrew/brew so that these get fixed. To
help that along, let's add a comment to any PRs where this label is
added with a reminder to do so so it's not forgotten.
