### PR TITLE
ca-certificates: improve Linux post-install

### DIFF
--- a/Formula/c/ca-certificates.rb
+++ b/Formula/c/ca-certificates.rb
@@ -11,8 +11,8 @@ class CaCertificates < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, all: "cecefecd1faa4638190038aa023529cea2159dccdddcaf6d1a20e63d32cb4139"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, all: "20530418311d44dea76182c270cf51cfc01b59110cc6fbeda72d2504521f18db"
   end
 
   def install

--- a/Formula/c/ca-certificates.rb
+++ b/Formula/c/ca-certificates.rb
@@ -96,7 +96,7 @@ class CaCertificates < Formula
     end
 
     # Now process Mozilla certificates we downloaded.
-    pem_certificates_list = File.read(pkgshare/"cacert.pem")
+    pem_certificates_list = (pkgshare/"cacert.pem").read
     pem_certificates = pem_certificates_list.scan(
       /-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----/m,
     )
@@ -121,9 +121,6 @@ class CaCertificates < Formula
   end
 
   def load_certificates_from_file(file_path, trusted_certificates, fingerprints, certificate_type)
-    file_path = Pathname(file_path)
-    return unless file_path.exist?
-
     certificates_list = file_path.read
     certificates = certificates_list.scan(
       /-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----/m,
@@ -143,8 +140,15 @@ class CaCertificates < Formula
   end
 
   def linux_post_install
-    rm(pkgetc/"cert.pem") if (pkgetc/"cert.pem").exist?
+    rm(pkgetc/"cert.pem", force: true)
     pkgetc.mkpath
+
+    system_ca_certificates = Pathname.new("/etc/ssl/certs/ca-certificates.crt")
+    if !system_ca_certificates.exist? || !system_ca_certificates.readable?
+      cp pkgshare/"cacert.pem", pkgetc/"cert.pem"
+      return
+    end
+
     # Integrate system certificates if OpenSSL is available
     unless which("openssl")
       opoo "Cannot find OpenSSL: skipping system certificates."
@@ -161,8 +165,7 @@ class CaCertificates < Formula
     fingerprints = Set.new
 
     # First, load system certificates from standard Linux location
-    load_certificates_from_file("/etc/ssl/certs/ca-certificates.crt",
-                                trusted_certificates, fingerprints, "system")
+    load_certificates_from_file(system_ca_certificates, trusted_certificates, fingerprints, "system")
 
     # Now process Mozilla certs and append only new ones
     load_certificates_from_file(pkgshare/"cacert.pem", trusted_certificates, fingerprints, "Mozilla")
@@ -180,7 +183,11 @@ class CaCertificates < Formula
 
     on_linux do
       <<~EOS
-        CA certificates have been bootstrapped from both the system CA store and the Mozilla CA store.
+        CA certificates have been bootstrapped from both the Mozilla CA store and the system CA store at
+
+          /etc/ssl/certs/ca-certificates.crt
+
+        if this path exists and is readable.
       EOS
     end
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Let's check that the expected system CA certificates path exists and is
readable early so that, if it doesn't, we don't print the spurious
message about doing

    brew install openssl
    brew postinstall ca-certificates

This also allows us to avoid the early return in
`load_certificates_from_file`, which can risk silently ignoring the
Mozilla CA bundle we wanted to install if something went wrong.

The caveats have been updated accordingly.

While we're here:
- call `rm` with `force: true` so we don't need to check for existence
- use `Pathname#read` more consistently (as it's what's used elsewhere
  in this formula)
