### PR TITLE
triage: remove `percona-server` from `long build` list

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -303,7 +303,6 @@ jobs:
                 openfast|\
                 openvino|\
                 pcl|\
-                percona-server|\
                 ponyc|\
                 pytorch|\
                 qt|\


### PR DESCRIPTION
This finishes under an hour on arm64 macOS and under two hours on x86_64
macOS, so it doesn't seem like `long build` is needed here.

See #225846.
