### PR TITLE
saxon: add gizmo script

### DIFF
--- a/Formula/s/saxon.rb
+++ b/Formula/s/saxon.rb
@@ -20,7 +20,8 @@ class Saxon < Formula
   no_autobump! because: :incompatible_version_format
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "52b46e48018fc8f9837456bf22e740bb5c1372c481465f15198e7c196b1e0017"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "c3aee8af279e05a32c2d398e6be4c5a35314e81b72c6e7c116b561e4762bbf99"
   end
 
   depends_on "openjdk"


### PR DESCRIPTION
In the saxon jar, there is actually a second tool to interactively perform simple operations such as examining the content of a document, renaming or deletion of selected elements in the document, or performing simple XSLT transformation and XSD validation.

This adds a shell script so that it is directly executable.

See here: https://www.saxonica.com/html/documentation10/gizmo/index.html

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
