### PR TITLE
workflows/triage: update for `openssl@3`

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -361,6 +361,7 @@ jobs:
                 numpy|\
                 openblas|\
                 openjpeg|\
+                openssl@3|\
                 p11-kit|\
                 pango|\
                 pcre2|\
@@ -422,6 +423,7 @@ jobs:
                 libcap|\
                 libva|\
                 libxml2|\
+                openssl@3|\
                 python@3.13|\
                 wayland-protocols|\
                 zlib|\


### PR DESCRIPTION
Let's ensure `openssl@3` PRs automatically have `long dependent tests`
and `CI-linux-self-hosted-deps`.

See https://github.com/Homebrew/homebrew-core/actions/runs/16763413137?pr=232485
