### PR TITLE
determine-rebottle-runners: add `-dispatch` tag to runner names

### DIFF
--- a/cmd/determine-rebottle-runners.rb
+++ b/cmd/determine-rebottle-runners.rb
@@ -54,7 +54,7 @@ module Homebrew
             if macos_version.outdated_release? || macos_version.prerelease?
               nil
             else
-              ephemeral_suffix = "-#{ENV.fetch("GITHUB_RUN_ID")}"
+              ephemeral_suffix = "-#{ENV.fetch("GITHUB_RUN_ID")}-dispatch"
               macos_runners = [{ runner: "#{macos_version}-x86_64#{ephemeral_suffix}" }]
               macos_runners << { runner: "#{macos_version}-arm64#{ephemeral_suffix}" }
               macos_runners


### PR DESCRIPTION
This mirrors what we do in `dispatch-build-bottle.yml` workflow:

https://github.com/Homebrew/homebrew-core/blob/5474481a5618a9c363d707765b8e34bb37488eed/.github/workflows/dispatch-build-bottle.yml#L83
