### PR TITLE
libnghttp3: remove unneeded `pkgconf` test dependency

### DIFF
--- a/Formula/lib/libnghttp3.rb
+++ b/Formula/lib/libnghttp3.rb
@@ -18,7 +18,6 @@ class Libnghttp3 < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "pkgconf" => :test
 
   def install
     system "cmake", "-S", ".", "-B", "build", "-DENABLE_LIB_ONLY=1", *std_cmake_args
@@ -40,8 +39,7 @@ class Libnghttp3 < Formula
       }
     C
 
-    flags = shell_output("pkgconf --cflags --libs libnghttp3").chomp.split
-    system ENV.cc, "test.c", "-o", "test", *flags
+    system ENV.cc, "test.c", "-o", "test", "-I#{include}", "-L#{lib}", "-lnghttp3"
     system "./test"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Needing `pkgconf` to generate the required flags seems a bit much here.
Let's just encode the required flags directly in the formula instead.
