### PR TITLE
charm: allow using bzr for Go module dependancy from launchpad

### DIFF
--- a/Formula/c/charm.rb
+++ b/Formula/c/charm.rb
@@ -23,9 +23,12 @@ class Charm < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "623e2d62e1dc1210de466ff4e4ea1d8e0c8ea059dbdc491ff5b8f3ec1cc9603e"
   end
 
+  depends_on "breezy" => :build
   depends_on "go" => :build
 
   def install
+    # Charm requires bzr (bazaar vcs) for fetching launchpad.net/lpad Go module.
+    ENV["GOVCS"] = "launchpad.net:bzr"
     system "go", "build", *std_go_args, "./cmd/charm"
   end
 

--- a/Formula/c/charm.rb
+++ b/Formula/c/charm.rb
@@ -9,18 +9,13 @@ class Charm < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "e6863b87f5141d695d361b1b0b7c68d9ab4edf710935a82d1839e0d7890cd2e3"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "76693903d37a9dc93095fd09c496c21d0651a71f39b1abbce782519ea2859f6c"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "2235de1789688bdc50e5e8443b4748a52dd36c7887e4d6b20d9e41417c5cdad0"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "3f0cac05e7c2c0990fd6c186405a13c832ff84b47fb77c2928aab7c29548b670"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "406f7bc14f44bd5462dde85da36d37cf5218ba7db06f7e27121ca2cc504d4eb8"
-    sha256 cellar: :any_skip_relocation, sonoma:         "537c03caa99579d5141651ef25365ee5f0af06840beb5c72926cef99826d4039"
-    sha256 cellar: :any_skip_relocation, ventura:        "f7ed8885d301a9b4bba15d657de9ee132dbb2603de8367523b0d9d41750bb0ab"
-    sha256 cellar: :any_skip_relocation, monterey:       "117bca978b5d65dc38f4e63d54ca0ef24f3b3e8cc808c97488854afb3a48a2ba"
-    sha256 cellar: :any_skip_relocation, big_sur:        "6c5e1f0af81ab86774fe87eb7c793c390386cc45b255348dc6467ad030f740d8"
-    sha256 cellar: :any_skip_relocation, catalina:       "2cfca124d8f2bdc973797c2a290b36f87e4d8d4d39e7ebb4358b552e12ac89eb"
-    sha256 cellar: :any_skip_relocation, mojave:         "a50370e9787fc797efc1b7c0dcc45fff5fd2ee02fea66e2d7db5d132c2153665"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "623e2d62e1dc1210de466ff4e4ea1d8e0c8ea059dbdc491ff5b8f3ec1cc9603e"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e2ddeaf1bab0b233267484c6bdac331a9113af93d5819e6f48ef7642b4696dc1"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "e2ddeaf1bab0b233267484c6bdac331a9113af93d5819e6f48ef7642b4696dc1"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "e2ddeaf1bab0b233267484c6bdac331a9113af93d5819e6f48ef7642b4696dc1"
+    sha256 cellar: :any_skip_relocation, sonoma:        "4a50613b56ac6dbd9bd7c8def6f03899188f3a4a0992098e75e6d49493b4cd19"
+    sha256 cellar: :any_skip_relocation, ventura:       "4a50613b56ac6dbd9bd7c8def6f03899188f3a4a0992098e75e6d49493b4cd19"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "393502f468997806b663a548026487a0cc7bdceec9bfce3bfa6cccba45551d59"
   end
 
   depends_on "breezy" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Detected charm: [build failure](https://github.com/Homebrew/homebrew-core/actions/runs/16788155185/job/47549802968?pr=226636#step:3:4723):
```
  go: github.com/canonical/candid@v1.4.3 requires
  	launchpad.net/lpad@v0.0.0-20131113112110-000000000065: unrecognized import path "launchpad.net/lpad": GOVCS disallows using bzr for public launchpad.net/lpad; see 'go help vcs'
```
in 
* https://github.com/Homebrew/homebrew-core/pull/226636