### PR TITLE
misc: remove `no_autobump` from skipped livechecks

### DIFF
--- a/Formula/a/apparix.rb
+++ b/Formula/a/apparix.rb
@@ -9,8 +9,6 @@ class Apparix < Formula
     skip "No version information available"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "c47c60a9ddde3d173404c7337080bf1cbd8c8d314b78092f02068a3fa5a689e0"

--- a/Formula/b/bash-completion.rb
+++ b/Formula/b/bash-completion.rb
@@ -12,8 +12,6 @@ class BashCompletion < Formula
     skip "1.x versions are no longer developed"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "6727e6e418e740531b75aebedaac6ceece0a0865f4f46dd0351d265035b497e9"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "60e79daad9283c5e9f4c814eed837c86aab0b5172c633e7171cbbf26a434bcff"

--- a/Formula/c/chrpath.rb
+++ b/Formula/c/chrpath.rb
@@ -9,8 +9,6 @@ class Chrpath < Formula
     skip "Not actively developed or maintained"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_linux:  "1bef0961b466971c9b4d4fc0ae4ddd059c17f465c8cac8c87e3ea03f3d04d357"
     sha256 cellar: :any_skip_relocation, x86_64_linux: "a820a2841f592b3045eb6e0dc4bdbb6a86789402dea2d97367ec0a58f7d3706f"

--- a/Formula/f/fabric-completion.rb
+++ b/Formula/f/fabric-completion.rb
@@ -11,8 +11,6 @@ class FabricCompletion < Formula
     skip "No version information available to check"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, all: "3d2a6d8ccfa6f87727fb8d7530c7a4fb20fda11dd0a580740bb7a4179b0e54c0"

--- a/Formula/g/gcc@10.rb
+++ b/Formula/g/gcc@10.rb
@@ -11,8 +11,6 @@ class GccAT10 < Formula
     skip "No longer developed or maintained"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256                               ventura:      "1155f38da440c96a9df1442152c3149755dfd369815cf8b967e9bbf2a4874489"
     sha256                               monterey:     "be699cd4f9c26c0023a28eb56e534058cac1ab1b2d06e57b531905cfde49b48e"

--- a/Formula/g/gcc@9.rb
+++ b/Formula/g/gcc@9.rb
@@ -11,8 +11,6 @@ class GccAT9 < Formula
     skip "No longer developed or maintained"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256                               monterey:     "9aa22339b3002ae9b3bde3ed9034238d80b07cff4a5c3c60f3f3653f52c55ce3"
     sha256                               big_sur:      "ea000947da4131b653f137e3e275c061b34d7faa6b961896ecabc3717009df32"

--- a/Formula/g/grok.rb
+++ b/Formula/g/grok.rb
@@ -20,8 +20,6 @@ class Grok < Formula
     skip "No longer developed or maintained"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_sequoia:  "b74690719200cd67624f98e63ed4df5bd400ddc82ab728da9ce152b2bb4f0250"

--- a/Formula/g/gtk+.rb
+++ b/Formula/g/gtk+.rb
@@ -16,8 +16,6 @@ class Gtkx < Formula
     skip "GTK 2 was declared end of life in 2020-12"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_sonoma:   "659b62a2677b7e945221ab78abfab6919d7a4ac7c635de52417ab96eb4970a92"
     sha256 arm64_ventura:  "140729098a62031c80b8e43c29314f84a5d0152b1348612f83d01331251ba02c"

--- a/Formula/h/httperf.rb
+++ b/Formula/h/httperf.rb
@@ -22,8 +22,6 @@ class Httperf < Formula
     skip "No version information available to check"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_sequoia:  "777ac05c7372517913a1dc06a7cfa1499480ed89708baf56d57749bfaf9b3375"

--- a/Formula/j/jrtplib.rb
+++ b/Formula/j/jrtplib.rb
@@ -9,8 +9,6 @@ class Jrtplib < Formula
     skip "No longer developed"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia:  "ef88fc08dc41b679c8ccdcaebabab8303f7eb30ccc8cddb2776e4952f335d2f0"
     sha256 cellar: :any,                 arm64_sonoma:   "c21691446176fd07d6163eece3a708d9088739e61fa29671cdeacdb3737fabc5"

--- a/Formula/l/latex2rtf.rb
+++ b/Formula/l/latex2rtf.rb
@@ -10,8 +10,6 @@ class Latex2rtf < Formula
     skip "New git repository doesn't have 2.x tags yet"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_sequoia:  "1401d5794081fccd0385a9a5fbbb53428c2e5a6e0ea52faf745d3b08223f5ae1"
     sha256 arm64_sonoma:   "0b89a54487cfef6b584b706ed87e270fcbf3a36a840a7f349b2352e82ee0588c"

--- a/Formula/l/lcs.rb
+++ b/Formula/l/lcs.rb
@@ -13,8 +13,6 @@ class Lcs < Formula
     skip "Formula uses an unstable trunk version"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_sequoia:  "1b4eaae7da86c0a3882c11642d4dd5cdeac07f63742c7714e9cc1a57a88baf5b"
     sha256 arm64_sonoma:   "53c3857d8a8d4fbe45e84b0489f9a9b50da8078fc037f470473272ff36d7cb4d"

--- a/Formula/l/llvm@14.rb
+++ b/Formula/l/llvm@14.rb
@@ -10,8 +10,6 @@ class LlvmAT14 < Formula
     skip "No longer developed or maintained"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 4
     sha256 cellar: :any,                 arm64_sonoma:   "1b081d8bd775b69b5c95e98df2689844a3c44a77509bfd9adc1f169e9502c6a7"

--- a/Formula/l/llvm@15.rb
+++ b/Formula/l/llvm@15.rb
@@ -10,8 +10,6 @@ class LlvmAT15 < Formula
     skip "No longer developed or maintained"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_sonoma:   "b767f1c1ae0719c1a8d1b5f7e7c7d9cead4eca26cab4b204c72800e824c06845"

--- a/Formula/lib/libagg.rb
+++ b/Formula/lib/libagg.rb
@@ -16,8 +16,6 @@ class Libagg < Formula
     skip "No longer developed/maintained"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia:  "057104fa9a817af5b41e424b9faa49446cc8c40b4d61c41186afd3a71e7e2e2c"
     sha256 cellar: :any,                 arm64_sonoma:   "eabb00483a8c5c955cc4f4b6351692d4c97709c7a1a14cf465767c7d52c132a7"

--- a/Formula/m/mdf2iso.rb
+++ b/Formula/m/mdf2iso.rb
@@ -9,8 +9,6 @@ class Mdf2iso < Formula
     skip "No longer developed or maintained"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "cb7698f54dab58995f190cb1fa0b27206fdcc26df54ed14340042bbdf5e9bc22"

--- a/Formula/n/netris.rb
+++ b/Formula/n/netris.rb
@@ -9,8 +9,6 @@ class Netris < Formula
     skip "No longer developed or maintained"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "45fd383811db400a50896723b5c7f9e05015d19208c678d14e52e68031dd6887"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "311ecb7d3b6ba50544169823f78960a2da39290fed321d2f0328fd0b4da72359"

--- a/Formula/n/nylon.rb
+++ b/Formula/n/nylon.rb
@@ -10,8 +10,6 @@ class Nylon < Formula
     skip "No version information available to check"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia:  "9d68b83a58d01d235ccc302690fddd22413603e42beae2b8b909eaca8caab83b"
     sha256 cellar: :any,                 arm64_sonoma:   "ab39d342239cf90b5fd6395e5deec9e5664312a8b76d481973f61d7604c1d39b"

--- a/Formula/o/ondir.rb
+++ b/Formula/o/ondir.rb
@@ -13,8 +13,6 @@ class Ondir < Formula
     skip "Not actively developed or maintained"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "a50815d50ce3b1e89cb6b61c496948a36d189436512178182080e6480a86cbc5"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "2eb866fd4fdac434823afb1a3a0dea5197f433dc6fb94aea3fb13adec8e615d0"

--- a/Formula/o/oniguruma.rb
+++ b/Formula/o/oniguruma.rb
@@ -10,8 +10,6 @@ class Oniguruma < Formula
     skip "No longer developed or maintained"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "7d6ab71fff646664b91e8ff91744696ec775357787dbc1a28e45d52759662e8d"
     sha256 cellar: :any,                 arm64_sonoma:  "86beadf2205c134bfc642be07b663476532c10591743461c2c64bc85be51afc8"

--- a/Formula/p/pcre.rb
+++ b/Formula/p/pcre.rb
@@ -25,8 +25,6 @@ class Pcre < Formula
     skip "PCRE was declared end of life in 2021-06"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia:  "50b8e2100e02a8649ac963449bf83bd8036608816b58412baad2310046d44d1f"
     sha256 cellar: :any,                 arm64_sonoma:   "fbc1ec29701c2c3f0eb750a0aecf03b90acb6d47f1bbf1dc07eb8a7c9340650e"

--- a/Formula/p/pip-completion.rb
+++ b/Formula/p/pip-completion.rb
@@ -15,8 +15,6 @@ class PipCompletion < Formula
     skip "No version information available"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "ea3a13ea2cc0274e22c8afff04f203677ea90969ff2a6bcb9eb7eb7d072d1f17"

--- a/Formula/r/ren.rb
+++ b/Formula/r/ren.rb
@@ -9,8 +9,6 @@ class Ren < Formula
     skip "Not actively developed or maintained"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "7a3c1d2e3849aad71fa4b7f54cfbae86184153159a8019839ac7fb69747cebc0"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "7e228ed14477809a0b2e182d476e09213ac70ffa87469e637e3c8d0f446be2a1"

--- a/Formula/r/reop.rb
+++ b/Formula/r/reop.rb
@@ -11,8 +11,6 @@ class Reop < Formula
     skip "No longer developed"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia:  "b1329c9bb7f9a9adb0ccf90c4c045cfa032215406f48c4fbe5d5f010019091a9"
     sha256 cellar: :any,                 arm64_sonoma:   "0a34d7d7270cd31264c8064b44f2fd1475a6edec8d159f2455ba6d5f6a5dce80"

--- a/Formula/s/saxon-b.rb
+++ b/Formula/s/saxon-b.rb
@@ -18,8 +18,6 @@ class SaxonB < Formula
     skip "Not actively developed or maintained"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "689001c5df91d0cf80e9ea2d72a5a8ae88abb45142dd47bf9797728d215d2139"

--- a/Formula/s/sendemail.rb
+++ b/Formula/s/sendemail.rb
@@ -9,8 +9,6 @@ class Sendemail < Formula
     skip "Not actively developed or maintained"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "113001c5e97ed667b4f8401c335b3a337a7354b1562ca8b40b6499e6cdb68278"

--- a/Formula/s/style-check.rb
+++ b/Formula/s/style-check.rb
@@ -13,8 +13,6 @@ class StyleCheck < Formula
     skip "No version information available to check"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "fb1e03c25875d0cf1b78f401e403452420169250d6fd6cee1be00d4d8bb51725"

--- a/Formula/t/texi2html.rb
+++ b/Formula/t/texi2html.rb
@@ -9,8 +9,6 @@ class Texi2html < Formula
     skip "No longer developed or maintained"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 4
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "a2abbe20da6fd14b3e73a4d7f08f366af564a2dc2e86b39de3291a9f7c3b9eec"

--- a/Formula/u/utimer.rb
+++ b/Formula/u/utimer.rb
@@ -10,8 +10,6 @@ class Utimer < Formula
     skip "No longer developed or maintained"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia:  "b81fca5d55f6c336477ac27ce66e9fb030be982864b54be675ee624b73444f7b"
     sha256 cellar: :any,                 arm64_sonoma:   "ee04213e439d3e859b16c5f0e07f19d70400a9dea3bcde536212cee288bfb6f6"

--- a/Formula/w/wv.rb
+++ b/Formula/w/wv.rb
@@ -11,8 +11,6 @@ class Wv < Formula
     skip "Not actively developed or maintained"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 arm64_sequoia: "f43fdf4000603806925c2d0e26fdb5d3f5d6be5c435478964c8dce92484784a3"

--- a/Formula/y/yarn.rb
+++ b/Formula/y/yarn.rb
@@ -9,8 +9,6 @@ class Yarn < Formula
     skip("1.x line is frozen and features/bugfixes only happen on 2+")
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "edb63a1b15d560263270324b63bee4c2aa8145197636a755436cc14424fc1e12"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Autobump implicity ignores formulae with a livecheck [`skip`](https://github.com/Homebrew/brew/blob/dbe68ef80ce1faefddddbade2029c610c6fba3f4/Library/Homebrew/tap.rb#L1038), so we can remove the `no_autobump!` from these formulae
