### PR TITLE
synced_versions_formulae: remove cross-GCC formulae

### DIFF
--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -1,13 +1,5 @@
 [
   [
-    "aarch64-elf-gcc",
-    "arm-none-eabi-gcc",
-    "i686-elf-gcc",
-    "m68k-elf-gcc",
-    "riscv64-elf-gcc",
-    "x86_64-elf-gcc"
-  ],
-  [
     "aarch64-elf-binutils",
     "arm-linux-gnueabihf-binutils",
     "arm-none-eabi-binutils",


### PR DESCRIPTION
While these are all built from the same source and therefore can be
updated simultaneously, there really is no need for them to. These
formulae work fine even if their versions differ from each other, and
insisting that they have synced versions just uses up https://github.com/Homebrew/homebrew-core/labels/long%20build slots
in CI.

See, for example, #232796.

Let's just bump all these formulae separately instead.
