### PR TITLE
tika: move resource version check to install block

### DIFF
--- a/Formula/t/tika.rb
+++ b/Formula/t/tika.rb
@@ -23,6 +23,7 @@ class Tika < Formula
   end
 
   def install
+    odie "update `server` resource" if version != resource("server").version
     libexec.install "tika-app-#{version}.jar"
     bin.write_jar_script libexec/"tika-app-#{version}.jar", "tika"
 
@@ -36,7 +37,6 @@ class Tika < Formula
   end
 
   test do
-    assert_match version.to_s, resource("server").version.to_s, "server resource out of sync with formula"
     pdf = test_fixtures("test.pdf")
     assert_equal "application/pdf\n", shell_output("#{bin}/tika --detect #{pdf}")
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
I think it makes more logic to check resource version during installation and this is how it is handled in other formulae:
https://github.com/Homebrew/homebrew-core/blob/b40e26c2975cb42282f3b3688b9eabea0bf38f60/Formula/e/erlang.rb#L61-L64