### PR TITLE
qt: apply Arch Linux patches for assimp 6

### DIFF
--- a/Formula/f/f3d.rb
+++ b/Formula/f/f3d.rb
@@ -14,11 +14,12 @@ class F3d < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:  "b4d6c998da4b4400ec393db77b1179bff8d831da62ec0bc14f2dcbf3b148092e"
-    sha256 cellar: :any,                 arm64_ventura: "19fb79db099dfa5bec63e662356608de158a8b81aa6e16b885e857d46a4598f8"
-    sha256 cellar: :any,                 sonoma:        "25ba5dbee1df01d8c1e76b0ca7d2df0fc94d194ae222200f5093ac80533556ee"
-    sha256 cellar: :any,                 ventura:       "2ac0379fa03532632b72f2d09589f8b73986ffee89f3eb3f2eabb1e6d369b46e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c7d3ce5e14c08f8b86b7ac555d8a0307cf3e9c0d5d90eeff4167ae2d3ddfcb25"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sonoma:  "1faed344ab1ecf8e01237497bd8f7e3a070a1d46a5c72e3d5ff38c227450476d"
+    sha256 cellar: :any,                 arm64_ventura: "6da591c7f40eb2cbb41e61df02f09824c4b6f7b9be795d0cf0047c27ba7a8d8f"
+    sha256 cellar: :any,                 sonoma:        "3540128eb1eeedb8d9898431caa2ca7e614ce8098507e54404cc8548727cc839"
+    sha256 cellar: :any,                 ventura:       "fe1247dc2c9968ce4a6c4821a90746ce1b37a540bd7948697588c873381d0141"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "25a4248c63f025c936823e845c5c833b65dd85279d783ecbaf473dd6b290f5e3"
   end
 
   depends_on "cmake" => :build

--- a/Formula/f/f3d.rb
+++ b/Formula/f/f3d.rb
@@ -23,7 +23,7 @@ class F3d < Formula
 
   depends_on "cmake" => :build
   depends_on "alembic"
-  depends_on "assimp@5"
+  depends_on "assimp"
   depends_on "glew"
   depends_on "jsoncpp"
   depends_on "opencascade"

--- a/Formula/q/qt.rb
+++ b/Formula/q/qt.rb
@@ -24,11 +24,12 @@ class Qt < Formula
   end
 
   bottle do
-    sha256 cellar: :any, arm64_sonoma:  "1cf02761bf4f637e566b41fbb98fdc569ebf813ebd20fc5ab47178758728194c"
-    sha256 cellar: :any, arm64_ventura: "63597d1fc6c6637bf094bd81f5653ed4738d7ff9e6e2bb64890627b7ccd7e61e"
-    sha256 cellar: :any, sonoma:        "119fe4df5bc1b88b1282bc26545094ea1a6bfe8679765c795d05943922e279e6"
-    sha256 cellar: :any, ventura:       "965a804ac6a3dba6efbe0639602005b8cdc622517eac7d16ccbe81cbfe839ce8"
-    sha256               x86_64_linux:  "d6b6ebda449e8066ec1ae3ee61074925d2b74edade6d9b77d3caa46f6eeb76aa"
+    rebuild 1
+    sha256 cellar: :any, arm64_sonoma:  "5b02cafecab509082f82311a538b088285033788affb96b419a0df0bbb5cd849"
+    sha256 cellar: :any, arm64_ventura: "6bf023de45eff4208fdecd2cb63a7edee9c5747df75d3b7e3fc83988431f4864"
+    sha256 cellar: :any, sonoma:        "1a0065fe535aae8d3b90a2416a48062639c10657e42feac7ddd681a4db195300"
+    sha256 cellar: :any, ventura:       "400f1fe51a0cb21266ed724f86d25e5b1537e75b9d084b0632dc0c7a8783f153"
+    sha256               x86_64_linux:  "493a42d2d1744a449f23c2840f7ce1cee7a5da35d2ac4d9e175ae649ee1c7569"
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/q/qt.rb
+++ b/Formula/q/qt.rb
@@ -41,7 +41,7 @@ class Qt < Formula
   depends_on "vulkan-loader" => [:build, :test]
   depends_on xcode: :build
 
-  depends_on "assimp@5"
+  depends_on "assimp"
   depends_on "brotli"
   depends_on "dbus"
   depends_on "double-conversion"
@@ -149,6 +149,19 @@ class Qt < Formula
   patch do
     url "https://raw.githubusercontent.com/Homebrew/formula-patches/e013656cb06ab4a1a54ca6fd9269647d4bf530bc/qt/6.9.1-unique_lock.patch"
     sha256 "6bca73d693e8fc24a5b30109e8d652f666a7b5b0fe1f5ae76202f14044eda02c"
+  end
+
+  # Apply Arch Linux patches for assimp 6 support
+  # Issue ref: https://bugreports.qt.io/browse/QTBUG-139028 / https://bugreports.qt.io/browse/QTBUG-139029
+  patch do
+    url "https://gitlab.archlinux.org/archlinux/packaging/packages/qt6-3d/-/raw/811dd8b18b4042f7120722b63953499830b51ddd/assimp-6.patch"
+    sha256 "244589b0a353da757d61ce6b86d4fcf2fc8c11e9c0d9c5b109180cec9273055a"
+    directory "qt3d"
+  end
+  patch do
+    url "https://gitlab.archlinux.org/archlinux/packaging/packages/qt6-quick3d/-/raw/2c6f918ee81adb61290cf56453c2d67e5dce259f/assimp-6.patch"
+    sha256 "573f00cdad90d77786fba80066d61d5ee97fc56a8b11d0896949acd16bda8e91"
+    directory "qtquick3d"
   end
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
