### PR TITLE
c2rust: comment for issue hit using LLVM 20

### DIFF
--- a/Formula/c/c2rust.rb
+++ b/Formula/c/c2rust.rb
@@ -18,7 +18,7 @@ class C2rust < Formula
 
   depends_on "cmake" => [:build, :test]
   depends_on "rust" => :build
-  depends_on "llvm@19"
+  depends_on "llvm@19" # LLVM 20 hits https://github.com/immunant/c2rust/issues/1252
 
   # cmake 4.0 build patch, upstream pr ref, https://github.com/immunant/c2rust/pull/1214
   patch do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Although compilation succeeds with https://github.com/immunant/c2rust/commit/6df557bd06ffcca3cd3d9339df2289970f5f6f66, the test fails like
```
warning: c2rust: Encountered unsupported BuiltinType kind 104 for type __mfp8
1 warning generated.
Transpiling qsort.c

thread 'main' panicked at c2rust-transpile/src/c_ast/conversion.rs:889:22:
Type conversion not implemented for TagTypeUnknown expecting 3
```
