### PR TITLE
openssl@3.0: deprecate on 2026-09-07

### DIFF
--- a/Formula/o/openssl@3.0.rb
+++ b/Formula/o/openssl@3.0.rb
@@ -22,6 +22,9 @@ class OpensslAT30 < Formula
 
   keg_only :versioned_formula
 
+  # See: https://www.openssl.org/policies/releasestrat.html
+  deprecate! date: "2026-09-07", because: :unsupported
+
   depends_on "ca-certificates"
 
   on_linux do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Add future deprecation date for previous LTS. Should have no usage in core formulae once `virtuoso` is migrated (`virtuoso` supports current LTS 3.5 so can use `openssl@3.5` when OpenSSL 3.6 is out).