### PR TITLE
inko: use `llvm` on HEAD

### DIFF
--- a/Formula/i/inko.rb
+++ b/Formula/i/inko.rb
@@ -1,10 +1,13 @@
 class Inko < Formula
   desc "Safe and concurrent object-oriented programming language"
   homepage "https://inko-lang.org/"
-  url "https://releases.inko-lang.org/0.18.1.tar.gz"
-  sha256 "498d7062ab2689850f56f5a85f5331115a8d1bee147e87c0fdfe97894bc94d80"
   license "MPL-2.0"
-  head "https://github.com/inko-lang/inko.git", branch: "main"
+
+  stable do
+    url "https://releases.inko-lang.org/0.18.1.tar.gz"
+    sha256 "498d7062ab2689850f56f5a85f5331115a8d1bee147e87c0fdfe97894bc94d80"
+    depends_on "llvm@17" # TODO: update LLVM version on next release
+  end
 
   # The upstream website doesn't provide easily accessible version information
   # or link to release tarballs, so we check the release manifest file that
@@ -25,14 +28,18 @@ class Inko < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "7af46ba20d2d34d8d5ec23574d97caa98a50278eca21fd9e1573856cf58ee24f"
   end
 
+  head do
+    url "https://github.com/inko-lang/inko.git", branch: "main"
+    depends_on "llvm"
+  end
+
   depends_on "rust" => :build
-  depends_on "llvm@17" # see https://github.com/inko-lang/inko/blob/4738b81dbec1f50dadeec3608dde855583f80dda/ci/mac.sh#L5
 
   uses_from_macos "libffi", since: :catalina
 
   def install
     # Avoid statically linking to LLVM
-    inreplace "compiler/Cargo.toml", 'features = ["prefer-static"]', 'features = ["force-dynamic"]'
+    inreplace "compiler/Cargo.toml", 'prefer-static"]', 'force-dynamic"]'
 
     system "make", "build", "PREFIX=#{prefix}"
     system "make", "install", "PREFIX=#{prefix}"
@@ -42,7 +49,7 @@ class Inko < Formula
     (testpath/"hello.inko").write <<~INKO
       import std.stdio (Stdout)
 
-      class async Main {
+      type async Main {
         fn async main {
           Stdout.new.print('Hello, world!')
         }


### PR DESCRIPTION
Also replace deprecated `class` with `type` in test

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

No issue building with LLVM 20:
```console
❯ brew linkage inko
System libraries:
  /usr/lib/libSystem.B.dylib
  /usr/lib/libc++.1.dylib
  /usr/lib/libffi.dylib
  /usr/lib/libiconv.2.dylib
Homebrew libraries:
  /opt/homebrew/opt/llvm/lib/libLLVM.dylib (llvm)
```