### PR TITLE
python@3.*: add IDLE caveats

### DIFF
--- a/Formula/p/python@3.10.rb
+++ b/Formula/p/python@3.10.rb
@@ -461,7 +461,7 @@ class PythonAT310 < Formula
       They will install into the site-package directory
         #{HOMEBREW_PREFIX}/lib/python#{version.major_minor}/site-packages
 
-      tkinter is no longer included with this formula, but it is available separately:
+      `idle#{version.major_minor}` requires tkinter, which is available separately:
         brew install python-tk@#{version.major_minor}
 
       If you do not need a specific version of Python, and always want Homebrew's `python3` in your PATH:

--- a/Formula/p/python@3.11.rb
+++ b/Formula/p/python@3.11.rb
@@ -464,7 +464,7 @@ class PythonAT311 < Formula
       They will install into the site-package directory
         #{HOMEBREW_PREFIX}/lib/python#{version.major_minor}/site-packages
 
-      tkinter is no longer included with this formula, but it is available separately:
+      `idle#{version.major_minor}` requires tkinter, which is available separately:
         brew install python-tk@#{version.major_minor}
 
       gdbm (`dbm.gnu`) is no longer included in this formula, but it is available separately:

--- a/Formula/p/python@3.12.rb
+++ b/Formula/p/python@3.12.rb
@@ -465,6 +465,9 @@ class PythonAT312 < Formula
       If you do not need a specific version of Python, and always want Homebrew's `python3` in your PATH:
         brew install python3
 
+      `idle#{version.major_minor}` requires tkinter, which is available separately:
+        brew install python-tk@#{version.major_minor}
+
       See: https://docs.brew.sh/Homebrew-and-Python
     EOS
   end

--- a/Formula/p/python@3.13.rb
+++ b/Formula/p/python@3.13.rb
@@ -451,6 +451,9 @@ class PythonAT313 < Formula
       `python3`, `python3-config`, `pip3` etc., respectively, are installed into
         #{opt_libexec}/bin
 
+      `idle#{version.major_minor}` requires tkinter, which is available separately:
+        brew install python-tk@#{version.major_minor}
+
       See: https://docs.brew.sh/Homebrew-and-Python
     EOS
   end

--- a/Formula/p/python@3.9.rb
+++ b/Formula/p/python@3.9.rb
@@ -473,7 +473,7 @@ class PythonAT39 < Formula
       They will install into the site-package directory
         #{HOMEBREW_PREFIX}/lib/python#{version.major_minor}/site-packages
 
-      tkinter is no longer included with this formula, but it is available separately:
+      `idle#{version.major_minor}` requires tkinter, which is available separately:
         brew install python-tk@#{version.major_minor}
 
       If you do not need a specific version of Python, and always want Homebrew's `python3` in your PATH:


### PR DESCRIPTION
The bundled Python IDE requires Tkinter, which creates a circular dependency if declared. This PR addresses that by adding/clarifying caveats telling the user to install the necessary by hand.

Closes #232901.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
