### PR TITLE
opencv: remove `openvino` dependency

### DIFF
--- a/Formula/o/opencv.rb
+++ b/Formula/o/opencv.rb
@@ -26,11 +26,12 @@ class Opencv < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 arm64_sonoma:  "6f1e7da1e91892e70f8e377e07609b94d82fd35bd9de71e1b30902a19b746f8c"
-    sha256 arm64_ventura: "5285534d46df18b601352dcf18497b35a42ddc26e33c2e5b7aec761000190841"
-    sha256 sonoma:        "83a6bbd2f70557b57e604c57d0c42ce4646aa92110fe5fb65a7d5638d9f19080"
-    sha256 ventura:       "c605b6a7cc24dd68a9d98808a52d24803bad2f559a78fab850651fa744d039a5"
-    sha256 x86_64_linux:  "cf1b86b6f07e90f56f30df73fe0b7316b9b601c87af2da863cd2f2745f5789cf"
+    rebuild 1
+    sha256 arm64_sonoma:  "fcc43b266dfa3e80ca2f3544462b3063cd637bac23ebdc1596472d3bab9dc4bf"
+    sha256 arm64_ventura: "5374b551fdea00ee3dc150b2d577ee03620c96198afc560958007174ea89125d"
+    sha256 sonoma:        "5ca6d006a5a1a7791e7a21e33750ef102d5d338e192d341b1a0f78d56de5cbef"
+    sha256 ventura:       "6d66c4b26a8763fd5f594364e26f6e534661dd2e115fd6c1845f27868debfee8"
+    sha256 x86_64_linux:  "5851925941e55814158233da201a392f8c72e8722f063e621326a5314e3c7dc3"
   end
 
   head do

--- a/Formula/o/opencv.rb
+++ b/Formula/o/opencv.rb
@@ -60,7 +60,6 @@ class Opencv < Formula
   depends_on "openblas"
   depends_on "openexr"
   depends_on "openjpeg"
-  depends_on "openvino"
   depends_on "protobuf"
   depends_on "python@3.13"
   depends_on "tbb"
@@ -97,6 +96,7 @@ class Opencv < Formula
     libdirs = %w[ffmpeg libjasper libjpeg libjpeg-turbo libpng libtiff libwebp openexr openjpeg protobuf tbb zlib]
     libdirs.each { |l| rm_r(buildpath/"3rdparty"/l) }
 
+    # FIXME: `openvino` seems to break often and is difficult to update, so we disable it here for now.
     args = %W[
       -DCMAKE_CXX_STANDARD=17
       -DCMAKE_OSX_DEPLOYMENT_TARGET=
@@ -128,7 +128,7 @@ class Opencv < Formula
       -DWITH_JASPER=OFF
       -DWITH_OPENEXR=ON
       -DWITH_OPENGL=OFF
-      -DWITH_OPENVINO=ON
+      -DWITH_OPENVINO=OFF
       -DWITH_QT=OFF
       -DWITH_TBB=ON
       -DWITH_VTK=ON
@@ -203,7 +203,8 @@ class Opencv < Formula
                     "-L#{lib}", "-lopencv_core", "-lopencv_imgcodecs"
     assert_equal version.to_s, shell_output("./test").strip
 
-    return if OS.linux? && Hardware::CPU.intel?
+    # The test below seems to time out on Linux and Intel macOS.
+    return if OS.linux? || Hardware::CPU.intel?
 
     output = shell_output("#{python3} -c 'import cv2; print(cv2.__version__)'")
     assert_equal version.to_s, output.chomp


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`openvino` is currently broken on Linux and it seems to constantly break
during updates, so let's leave it out for now.

Omitting the `revision` bump since this is getting one in #227169.
