### PR TITLE
kuzu: drop runtime versioned GCC

### DIFF
--- a/Formula/k/kuzu.rb
+++ b/Formula/k/kuzu.rb
@@ -7,13 +7,14 @@ class Kuzu < Formula
   head "https://github.com/kuzudb/kuzu.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "94608aca4d744e3536a11933e8ea3cf7381aa3220eaae7bb9ec3fe9ffe467467"
-    sha256 cellar: :any,                 arm64_sonoma:  "50459e3361e69c0e46f16866e5b58f798ea626e3c7f2f4af1ebbdd471d502ff5"
-    sha256 cellar: :any,                 arm64_ventura: "51e100c08dd1f38764cb16abb16a9ea27f87576cd527511942d797dadb978174"
-    sha256 cellar: :any,                 sonoma:        "dae30f4dceec817bd02b1143e7ba0fc4aba0f6d3b4a62886c38a668f4fb49eea"
-    sha256 cellar: :any,                 ventura:       "d92b394ecef03c0de03400922a73e86ece84b1c27824952e5a1b3f9794d2cbe1"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "f6fa4fa217f1bf64383b991ec183016445b001a6151de2e1708ce95ebaccc4e5"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "9bafad12c8ec515a0ea73275ee2b034609682dec2661e6355d42bf2a16435826"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "7b29b4ae2df088932fab87dc77df54720622fa2c78c2b4203a03bbd4ff13737e"
+    sha256 cellar: :any,                 arm64_sonoma:  "0bea81ebab52fc643e4aa036b4bd2d3a2f5eb47a4a5e6c78f61370d582b21c4e"
+    sha256 cellar: :any,                 arm64_ventura: "4a08837b40109f1480ee3427a266844f355bc6dc728522f7ab2b28cffeae5f15"
+    sha256 cellar: :any,                 sonoma:        "02ddf95116a0657c437e007348ecde64b13603b48951005dc830ffad3e848442"
+    sha256 cellar: :any,                 ventura:       "38ce1807674dec3405f1b3393f27ab1c880a0e88e125c0fcc6af7670cefdd680"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "694830a475c766ab54840f28e9be11f91791fd6bb8c7b9ed8150609fc968427a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "fca3925106804625d590a0d7ea39aedbbc6ebaee4fb1fcb01034bafe5f9b800f"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We shouldn't be adding runtime dependency on versioned GCC.

Only scenario of using versioned GCC would be build time when it doesn't increase ABI. Otherwise, all runtime usage should be unversioned GCC, which guarantees we must manually verify Linux only usage.

Trying with GCC 11 as seemed to work on local arm64 Linux container. If it doesn't work, then may need to just drop Linux support until we move to GCC 12 as `kuzu` has libraries.