### PR TITLE
mapnik: remove conflict with `osrm-backend`

### DIFF
--- a/Formula/m/mapnik.rb
+++ b/Formula/m/mapnik.rb
@@ -43,7 +43,6 @@ class Mapnik < Formula
 
   uses_from_macos "zlib"
 
-  conflicts_with "osrm-backend", because: "both install Mapbox Variant headers"
   conflicts_with "svg2png", because: "both install `svg2png` binaries"
 
   def install

--- a/Formula/o/osrm-backend.rb
+++ b/Formula/o/osrm-backend.rb
@@ -50,7 +50,6 @@ class OsrmBackend < Formula
   end
 
   conflicts_with "flatbuffers", because: "both install flatbuffers headers"
-  conflicts_with "mapnik", because: "both install Mapbox Variant headers"
 
   def install
     # Work around build failure: duplicate symbol 'boost::phoenix::placeholders::uarg9'


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Mapbox Variant usage was removed in https://github.com/Project-OSRM/osrm-backend/commit/c1ed73126dd467171dc7adb4ad07864909bcb90f