### PR TITLE
softhsm: fix broken source tarball download link

### DIFF
--- a/Formula/s/softhsm.rb
+++ b/Formula/s/softhsm.rb
@@ -1,7 +1,7 @@
 class Softhsm < Formula
   desc "Cryptographic store accessible through a PKCS#11 interface"
-  homepage "https://www.opendnssec.org/softhsm/"
-  url "https://dist.opendnssec.org/source/softhsm-2.6.1.tar.gz"
+  homepage "https://www.opendnssec.org/en/latest/softhsm/"
+  url "https://github.com/opendnssec/opendnssec/releases/download/2.1.14/softhsm-2.6.1.tar.gz"
   sha256 "61249473054bcd1811519ef9a989a880a7bdcc36d317c9c25457fc614df475f2"
   license "BSD-2-Clause"
 


### PR DESCRIPTION
It is not currently possible to run `brew install --build-from-source softhsm` because the current softhsm.rb formula references a broken source tarball download link.

Per [https://github.com/softhsm/SoftHSMv2/issues/789](https://github.com/softhsm/SoftHSMv2/issues/789), softhsm binary downloads are no longer available from https://dist.opendnssec.org/. This PR updates the softhsm formula to reference the GitHub-hosted official release binary until the new SoftHSM2 maintainers choose a new host.

