### PR TITLE
percona-xtrabackup: try to remove workaround

### DIFF
--- a/Formula/p/percona-xtrabackup.rb
+++ b/Formula/p/percona-xtrabackup.rb
@@ -175,10 +175,6 @@ class PerconaXtrabackup < Formula
     # Remove conflicting manpages
     rm (Dir["man/*"] - ["man/CMakeLists.txt"])
 
-    # Workaround for
-    # error: a template argument list is expected after a name prefixed by the template keyword
-    ENV.append_to_cflags "-Wno-missing-template-arg-list-after-template-kw"
-
     system "cmake", "-S", ".", "-B", "build", *cmake_args, *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Let's see if this is no longer needed.
