### PR TITLE
dcadec: remove conflicts

### DIFF
--- a/Formula/d/dcadec.rb
+++ b/Formula/d/dcadec.rb
@@ -30,8 +30,6 @@ class Dcadec < Formula
   deprecate! date: "2024-06-30", because: :deprecated_upstream
   disable! date: "2025-07-02", because: :deprecated_upstream
 
-  conflicts_with "libdca", because: "both install `dcadec` binaries"
-
   def install
     system "make", "all"
     system "make", "PREFIX=#{prefix}", "install"

--- a/Formula/lib/libdca.rb
+++ b/Formula/lib/libdca.rb
@@ -33,8 +33,6 @@ class Libdca < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
 
-  conflicts_with "dcadec", because: "both install `dcadec` binaries"
-
   def install
     # Fixes "duplicate symbol ___sputc" error when building with clang
     # https://github.com/Homebrew/homebrew/issues/31456


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`dcadec` is disabled, so it is safe to remove its conflicts. It will make its future removal smoother, since the removal PR will not need manual intervention to merge.[^1]

- **dcadec: remove conflicts**
- **libdca: remove conflict with `dcadec`**

[^1]: See, for example, #233039.

