### PR TITLE
determine-rebottle-runners: add a missing `-dispatch` tag

### DIFF
--- a/cmd/determine-rebottle-runners.rb
+++ b/cmd/determine-rebottle-runners.rb
@@ -70,6 +70,7 @@ module Homebrew
               runner = macos_version.to_s
               runner += "-#{tag.arch}"
               runner += "-#{ENV.fetch("GITHUB_RUN_ID")}"
+              runner += "-dispatch"
 
               { runner: }
             end


### PR DESCRIPTION
Missed in #232676.
