### PR TITLE
workflows: use `xargs -t`

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           BREW_BUMP=(brew bump --no-fork --open-pr --formulae --bump-synced)
           if [[ -n "${FORMULAE-}" ]]; then
-            xargs "${BREW_BUMP[@]}" <<<"${FORMULAE}"
+            xargs -t "${BREW_BUMP[@]}" <<<"${FORMULAE}"
           else
             "${BREW_BUMP[@]}" --auto --tap=Homebrew/core
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -238,7 +238,7 @@ jobs:
       - name: Test formulae
         id: brew-test-bot-formulae
         run: |
-          xargs brew test-bot \
+          xargs -t brew test-bot \
             --testing-formulae="$TESTING_FORMULAE" \
             --added-formulae="$ADDED_FORMULAE" \
             --deleted-formulae="$DELETED_FORMULAE" \
@@ -372,7 +372,7 @@ jobs:
 
       - name: Test dependents
         run: |
-          xargs brew test-bot \
+          xargs -t brew test-bot \
             --testing-formulae="$TESTING_FORMULAE" \
             --tested-formulae="$TESTED_FORMULAE" \
             <<<"$TEST_BOT_DEPENDENTS_ARGS"


### PR DESCRIPTION
`-t` prints the command line that will be run prior to execution, and
this follows the spirit of our usage of `bash -x` everywhere.

We can also consider using `--verbose`, but `-t` is POSIX and I don't
know how far back `--verbose` is supported on macOS.
