### PR TITLE
various: improve `conflicts_with` / `keg_only` reason wording

### DIFF
--- a/Formula/a/apt.rb
+++ b/Formula/a/apt.rb
@@ -16,7 +16,7 @@ class Apt < Formula
     sha256 x86_64_linux: "1691a75c06d897023dc2be230e3ade0f18c0d946e7a97de0f8d829fb1f9966cf"
   end
 
-  keg_only "not linked to prevent conflicts with system apt"
+  keg_only "it conflicts with system apt"
 
   depends_on "cmake" => :build
   depends_on "docbook" => :build

--- a/Formula/c/ctags.rb
+++ b/Formula/c/ctags.rb
@@ -52,7 +52,7 @@ class Ctags < Formula
     depends_on "autoconf" => :build
   end
 
-  conflicts_with "universal-ctags", because: "this formula installs the same executable as the ctags formula"
+  conflicts_with "universal-ctags", because: "both install `ctags` binaries"
 
   # fixes https://sourceforge.net/p/ctags/bugs/312/
   patch :p2 do

--- a/Formula/d/dpkg.rb
+++ b/Formula/d/dpkg.rb
@@ -36,7 +36,7 @@ class Dpkg < Formula
   uses_from_macos "zlib"
 
   on_linux do
-    keg_only "not linked to prevent conflicts with system dpkg"
+    keg_only "it conflicts with system dpkg"
   end
 
   patch :DATA

--- a/Formula/g/glkterm.rb
+++ b/Formula/g/glkterm.rb
@@ -28,7 +28,7 @@ class Glkterm < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "f57f1075e4afed829d717f987b4511626a5871e3532a98698862da6ee42989dc"
   end
 
-  keg_only "conflicts with other Glk libraries"
+  keg_only "it conflicts with other Glk libraries"
 
   uses_from_macos "ncurses"
 

--- a/Formula/g/glktermw.rb
+++ b/Formula/g/glktermw.rb
@@ -28,7 +28,7 @@ class Glktermw < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "a3391048ffb327060e3cf8e18e253ac1a44de556fbef1c453ee0186c92b3b079"
   end
 
-  keg_only "conflicts with other Glk libraries"
+  keg_only "it conflicts with other Glk libraries"
 
   uses_from_macos "ncurses"
 

--- a/Formula/h/heimdal.rb
+++ b/Formula/h/heimdal.rb
@@ -27,7 +27,7 @@ class Heimdal < Formula
     sha256 x86_64_linux:   "50b84d04c9adf4ea658519cdc158a68aa264300bdaf290675010529d6d72e6ac"
   end
 
-  keg_only "conflicts with Kerberos"
+  keg_only "it conflicts with Kerberos"
 
   depends_on "bison" => :build
   depends_on "pkgconf" => :build

--- a/Formula/lib/libpq.rb
+++ b/Formula/lib/libpq.rb
@@ -20,7 +20,7 @@ class Libpq < Formula
     sha256 x86_64_linux:  "0c73376d125c4d80714135ebbd2deb1aa56bb4938f5420ecf4fb592beba55295"
   end
 
-  keg_only "conflicts with postgres formula"
+  keg_only "it conflicts with PostgreSQL"
 
   depends_on "docbook" => :build
   depends_on "docbook-xsl" => :build

--- a/Formula/lib/libtorrent-rakshasa.rb
+++ b/Formula/lib/libtorrent-rakshasa.rb
@@ -28,7 +28,7 @@ class LibtorrentRakshasa < Formula
 
   uses_from_macos "zlib"
 
-  conflicts_with "libtorrent-rasterbar", because: "they both use the same libname"
+  conflicts_with "libtorrent-rasterbar", because: "both use the same libname"
 
   def install
     system "autoreconf", "--force", "--install", "--verbose"

--- a/Formula/lib/libtorrent-rasterbar.rb
+++ b/Formula/lib/libtorrent-rasterbar.rb
@@ -29,7 +29,7 @@ class LibtorrentRasterbar < Formula
   depends_on "openssl@3"
   depends_on "python@3.13"
 
-  conflicts_with "libtorrent-rakshasa", because: "they both use the same libname"
+  conflicts_with "libtorrent-rakshasa", because: "both use the same libname"
 
   def install
     args = %W[

--- a/Formula/lib/libunwind.rb
+++ b/Formula/lib/libunwind.rb
@@ -15,7 +15,7 @@ class Libunwind < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux: "cbb66984b0bb438330bf35650c0039dce1db45a16110dccad8169e0b8add0dfe"
   end
 
-  keg_only "libunwind conflicts with LLVM"
+  keg_only "it conflicts with LLVM"
 
   depends_on :linux
   depends_on "xz"

--- a/Formula/m/maven.rb
+++ b/Formula/m/maven.rb
@@ -23,7 +23,7 @@ class Maven < Formula
 
   depends_on "openjdk"
 
-  conflicts_with "mvnvm", because: "also installs a 'mvn' executable"
+  conflicts_with "mvnvm", because: "both install `mvn` executables"
 
   def install
     # Remove windows files

--- a/Formula/m/mozjpeg.rb
+++ b/Formula/m/mozjpeg.rb
@@ -24,7 +24,7 @@ class Mozjpeg < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "e69f9e76bf590d31a85839acdc52bbee9b1c4ccef0370f82f5a80e9d21c69298"
   end
 
-  keg_only "mozjpeg is not linked to prevent conflicts with the standard libjpeg"
+  keg_only "it conflicts with the standard libjpeg"
 
   depends_on "cmake" => :build
   depends_on "nasm" => :build

--- a/Formula/m/mvnvm.rb
+++ b/Formula/m/mvnvm.rb
@@ -13,7 +13,7 @@ class Mvnvm < Formula
 
   depends_on "openjdk"
 
-  conflicts_with "maven", because: "also installs a 'mvn' executable"
+  conflicts_with "maven", because: "both install `mvn` executables"
 
   def install
     bin.install "mvn"

--- a/Formula/p/pax.rb
+++ b/Formula/p/pax.rb
@@ -27,9 +27,7 @@ class Pax < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "3ebf0c050c23153d61d4bd703a0f9a4194018a54ad873a5594a70182058280ec"
   end
 
-  on_macos do
-    keg_only "provided by macOS"
-  end
+  keg_only :provided_by_macos
 
   def install
     mkdir "build" do

--- a/Formula/p/pod2man.rb
+++ b/Formula/p/pod2man.rb
@@ -22,7 +22,7 @@ class Pod2man < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "269cdc0db938df147bab44127e86b05cf46074741bd9d8644b08f88a00e62f97"
   end
 
-  keg_only "perl ships with pod2man"
+  keg_only "it conflicts with the pod2man that ships with Perl"
 
   resource "Pod::Simple" do
     url "https://cpan.metacpan.org/authors/id/K/KH/KHW/Pod-Simple-3.45.tar.gz"

--- a/Formula/s/socket_vmnet.rb
+++ b/Formula/s/socket_vmnet.rb
@@ -14,7 +14,7 @@ class SocketVmnet < Formula
     sha256 cellar: :any_skip_relocation, ventura:       "72fb6bd3a1d7aa852e052529697f675b216d1b718db94281fcd5062bae9afbc5"
   end
 
-  keg_only "Homebrew's bin directory is often writable by a non-admin user"
+  keg_only "it should not be in Homebrew's bin directory, which is often writable by a non-admin user"
 
   depends_on :macos
   depends_on macos: :catalina

--- a/Formula/u/universal-ctags.rb
+++ b/Formula/u/universal-ctags.rb
@@ -33,7 +33,7 @@ class UniversalCtags < Formula
 
   uses_from_macos "libxml2"
 
-  conflicts_with "ctags", because: "this formula installs the same executable as the ctags formula"
+  conflicts_with "ctags", because: "both install `ctags` binaries"
 
   def install
     system "./autogen.sh"


### PR DESCRIPTION
Reasons for `conflicts_with` and `keg_only` need to be worded to follow ", because …" in `brew info <formula>` output.