### PR TITLE
povray cpprestsdk: apply FreeBSD patches for Xcode 16.3

### DIFF
--- a/Formula/c/cpprestsdk.rb
+++ b/Formula/c/cpprestsdk.rb
@@ -27,6 +27,27 @@ class Cpprestsdk < Formula
 
   uses_from_macos "zlib"
 
+  # Apply FreeBSD patches for libc++ >= 19 needed in Xcode 16.3
+  # https://github.com/microsoft/cpprestsdk/pull/1829
+  on_sequoia :or_newer do
+    patch do
+      url "https://github.com/microsoft/cpprestsdk/commit/d17f091b5a753b33fb455e92b590fc9f4e921119.patch?full_index=1"
+      sha256 "bc68dd08310ba22dc5ceb7506c86a6d4c8bfefa46581eea8cd917354a8b8ae34"
+    end
+    patch do
+      url "https://github.com/microsoft/cpprestsdk/commit/6df13a8c0417ef700c0f164bcd0686ad46f66fd9.patch?full_index=1"
+      sha256 "4205e818f5636958589d2c1e5841a31acfe512eda949d63038e23d8c089a9636"
+    end
+    patch do
+      url "https://github.com/microsoft/cpprestsdk/commit/4188ad89b2cf2e8de3cc3513adcf400fbfdc5ce7.patch?full_index=1"
+      sha256 "3bc72590cbaf6d04e3e5230558647e5b38e7f494cd0e5d3ea5c866ac25f9130a"
+    end
+    patch do
+      url "https://github.com/microsoft/cpprestsdk/commit/32b322b564e5e540ff02393ffe3bd3bade8d299c.patch?full_index=1"
+      sha256 "737567e533405f7f6ef0a83bafef7fdeea95c96947f66be0973e5f362e1b82f5"
+    end
+  end
+
   # Apply vcpkg patch to support Boost 1.87.0+
   # Issue ref: https://github.com/microsoft/cpprestsdk/issues/1815
   # Issue ref: https://github.com/microsoft/cpprestsdk/issues/1323
@@ -53,7 +74,7 @@ class Cpprestsdk < Formula
       #include <iostream>
       #include <cpprest/http_client.h>
       int main() {
-        web::http::client::http_client client(U("https://example.com/"));
+        web::http::client::http_client client(U("https://brew.sh/"));
         std::cout << client.request(web::http::methods::GET).get().extract_string().get() << std::endl;
       }
     CPP
@@ -64,6 +85,6 @@ class Cpprestsdk < Formula
                     "-lssl", "-lcrypto", "-lboost_random", "-lboost_chrono", "-lboost_thread",
                     "-lboost_system", "-lboost_filesystem", "-lcpprest",
                     "-o", "test_cpprest"
-    assert_match "<title>Example Domain</title>", shell_output("./test_cpprest")
+    assert_match "The Missing Package Manager for macOS (or Linux)", shell_output("./test_cpprest")
   end
 end

--- a/Formula/p/povray.rb
+++ b/Formula/p/povray.rb
@@ -1,11 +1,29 @@
 class Povray < Formula
   desc "Persistence Of Vision RAYtracer (POVRAY)"
   homepage "https://www.povray.org/"
-  url "https://github.com/POV-Ray/povray/archive/refs/tags/v3.7.0.10.tar.gz"
-  sha256 "7bee83d9296b98b7956eb94210cf30aa5c1bbeada8ef6b93bb52228bbc83abff"
   license "AGPL-3.0-or-later"
   revision 13
   head "https://github.com/POV-Ray/povray.git", branch: "master"
+
+  stable do
+    url "https://github.com/POV-Ray/povray/archive/refs/tags/v3.7.0.10.tar.gz"
+    sha256 "7bee83d9296b98b7956eb94210cf30aa5c1bbeada8ef6b93bb52228bbc83abff"
+
+    on_sequoia :or_newer do
+      # Apply FreeBSD patches for libc++ >= 19 needed in Xcode 16.3
+      patch :p0 do
+        url "https://raw.githubusercontent.com/freebsd/freebsd-ports/6133473e4227abbfcf023bea6ab5eeed9c17e55b/graphics/povray37/files/patch-vfe_vfe.cpp"
+        sha256 "81e6ad64dadce1581cbab3be9774d5a5c22307e8738ee1452eb7e4d3e5a7e234"
+      end
+      patch :p0 do
+        url "https://raw.githubusercontent.com/freebsd/freebsd-ports/6133473e4227abbfcf023bea6ab5eeed9c17e55b/graphics/povray37/files/patch-vfe_vfeconf.h"
+        sha256 "8e2246c5ded770b0fe835ae062aca44e98fc220314e39ba6c068ed7f270b71b2"
+      end
+
+      # Workaround for Xcode 16.3+, issue ref: https://github.com/POV-Ray/povray/issues/479
+      patch :DATA
+    end
+  end
 
   livecheck do
     url :stable
@@ -37,6 +55,10 @@ class Povray < Formula
 
   def install
     ENV.cxx11
+    # See https://github.com/freebsd/freebsd-ports/commit/6133473e4227abbfcf023bea6ab5eeed9c17e55b
+    if OS.mac? && MacOS.version >= :sequoia
+      ENV.append "CPPFLAGS", "-DPOVMSUCS2=char16_t -DUCS2=char16_t -DUCS4=char32_t"
+    end
 
     args = %W[
       COMPILED_BY=homebrew
@@ -74,3 +96,17 @@ class Povray < Formula
     end
   end
 end
+
+__END__
+diff --git a/source/backend/shape/truetype.cpp b/source/backend/shape/truetype.cpp
+index 7e27ccc3..80ab047c 100644
+--- a/source/backend/shape/truetype.cpp
++++ b/source/backend/shape/truetype.cpp
+@@ -117,7 +117,7 @@ typedef unsigned int ULONG;
+ typedef short FWord;
+ typedef unsigned short uFWord;
+ 
+-#if !defined(TARGET_OS_MAC)
++#if !defined(__MACTYPES__)
+ typedef int Fixed;
+ #endif


### PR DESCRIPTION
Trying to reproduce some failures from #233031 on 15-arm64 runner.

Can't reproduce locally. I have newer macOS and Xcode 16.4 so not sure if this is issue with runner version.

EDIT: Maybe https://developer.apple.com/documentation/xcode-release-notes/xcode-16_4-release-notes#Apple-Clang-Compiler
> Fixed: The base template for `std::char_traits` is restored after being removed in Xcode 16.3; it is still deprecated and is going to be removed in a future release. Restoring the base template allows code that attempts to instantiate `char_traits` with types that are not provided by the Standard (for example, `std::basic_string<long long>` and similar) to still compile, giving it more time to transition.  (149025504)

