### PR TITLE
sing-box: Add `with_tailscale` build tag

### DIFF
--- a/Formula/s/sing-box.rb
+++ b/Formula/s/sing-box.rb
@@ -25,6 +25,7 @@ class SingBox < Formula
       with_dhcp
       with_gvisor
       with_quic
+      with_tailscale
       with_utls
       with_wireguard
     ]

--- a/Formula/s/sing-box.rb
+++ b/Formula/s/sing-box.rb
@@ -7,12 +7,13 @@ class SingBox < Formula
   head "https://github.com/SagerNet/sing-box.git", branch: "dev-next"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "5215b7009aeca772d1111729c5f84c0dfa6751cef46fb774c2fa5dec3c5e65da"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "07733668d189e60b9e843a943dc8262b1169fddeef674e5b5ff9305aeb78dcce"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "107340b4c31f4d01265f859bebe1f5ea4320d72b017b9f7bd5e16a3f2e44ece8"
-    sha256 cellar: :any_skip_relocation, sonoma:        "b8c42f1c9f0111ac0277c971165e9af2620f18830cda5df44ff61812aa984b5f"
-    sha256 cellar: :any_skip_relocation, ventura:       "2f7119609aede78a01f8ab80672bd40afde052d60f43114e390690bf8f336e05"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "7fa0bff9e081221b2247cee6ee6db993dfe2914f476bece09bfb4ec6fb1415c6"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "8308cbcb0e270a1a94c8e7f753d0088ac11f4fea16d74610c854344401b3af72"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "bc8ae77fdd1fc216480a8adc433955dcfad9cdc50434ff928a8e0e298432a0c4"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "aaedfd7440167dcda704ddb7655e516e71c8c49e22be3be01e92475b76efce9b"
+    sha256 cellar: :any_skip_relocation, sonoma:        "567dad60b7c1c07a96096ba4a11d9224432a5db50bcd9d122b9d3e510b6be30a"
+    sha256 cellar: :any_skip_relocation, ventura:       "f04a96ea728b519122129c4d2b964760d656c3a12774fb522d59032e1ef4fd34"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5e4121beb2f4dad6d2046860fd8edbc7f140d524c70a22824aa7e314eb69c56b"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
The `with_tailscale` build tag has been added to the sing-box formula. This aligns with the official sing-box release, as `with_tailscale` has been a default build tag since version 1.12.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
