### PR TITLE
osctrl-cli: checksum update

### DIFF
--- a/Formula/o/osctrl-cli.rb
+++ b/Formula/o/osctrl-cli.rb
@@ -2,7 +2,7 @@ class OsctrlCli < Formula
   desc "Fast and efficient osquery management"
   homepage "https://osctrl.net"
   url "https://github.com/jmpsec/osctrl/archive/refs/tags/v0.4.5.tar.gz"
-  sha256 "4509039d10e9d7613b7cbaac1033ae249e867fb02d88c5f9f3b119b59996d197"
+  sha256 "3e802fe7d6706b5025ec8c36d1b2f18cafffb6b5168ede3d1271616fe63855c5"
   license "MIT"
   head "https://github.com/jmpsec/osctrl.git", branch: "main"
 

--- a/Formula/o/osctrl-cli.rb
+++ b/Formula/o/osctrl-cli.rb
@@ -7,12 +7,13 @@ class OsctrlCli < Formula
   head "https://github.com/jmpsec/osctrl.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "78ab44c6ef035a6329e758639bfdf08808d00c5b45005536ae1bf7f3a7db572b"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "2137e093ebb79dc3223f4b54c8d91e1e7ff55a1e78383967aa12106ec10c486a"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "ebfba3ffe011ef436f951cc74d97cc71b2cbcdc4b4525bbfe9552e8bcc04617d"
-    sha256 cellar: :any_skip_relocation, sonoma:        "2888668753f2534591d04f335192b64225db67675207d91ac56e40d3c6eede96"
-    sha256 cellar: :any_skip_relocation, ventura:       "1eee094e689bed067f24249e58be278f161c7b5c0c9af69372361831f11abb11"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "aa5abd682eeac0841b0941418118bb91cda5f1a6d56277944d4c93dff76c1eb7"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e7c3eefd65c2301ff108f96a449cdbb74d709cca5184311cc28ddc7682a59217"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "5e64d48a864ee360d08af3688a7274c0ea7821380703657e45ed3105b962b1ed"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "0fbbfe0563716834dac7c255d5545fab1ead39f9b58a9e318506cc1c70a4e1ef"
+    sha256 cellar: :any_skip_relocation, sonoma:        "8f6203e4fae31407690538109d95fd3703bdcd63e3121fe3ba35cf72ab63bc7e"
+    sha256 cellar: :any_skip_relocation, ventura:       "162dd78e818fea8633e9295bf6865982ede21c0e0027659a3258f0e5f53d761d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a7a324f7ae2941205ff08367b28fbe3b616d940760bed43b3856d66f1db943ff"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Build [failed](https://github.com/Homebrew/homebrew-core/actions/runs/16922847115/job/47953670013?pr=226636#step:3:20324) with:
```
  ==> Downloading https://github.com/jmpsec/osctrl/archive/refs/tags/v0.4.5.tar.gz
  Already downloaded: /Users/brew/Library/Caches/Homebrew/downloads/d6afc9a80059edc3824b0975d41348903e0400119e06a2f34b26eeff1d1ce394--osctrl-0.4.5.tar.gz
  Error: osctrl-cli: SHA-256 mismatch
  Expected: 4509039d10e9d7613b7cbaac1033ae249e867fb02d88c5f9f3b119b59996d197
    Actual: 3e802fe7d6706b5025ec8c36d1b2f18cafffb6b5168ede3d1271616fe63855c5
      File: /Users/brew/Library/Caches/Homebrew/downloads/d6afc9a80059edc3824b0975d41348903e0400119e06a2f34b26eeff1d1ce394--osctrl-0.4.5.tar.gz
```

Apparently upstream source hash has changed since
* https://github.com/Homebrew/homebrew-core/pull/232922

Found in
* https://github.com/Homebrew/homebrew-core/pull/226636
