### PR TITLE
ca-certificates: add workaround for cert bootstrap errors

### DIFF
--- a/Formula/c/ca-certificates.rb
+++ b/Formula/c/ca-certificates.rb
@@ -11,7 +11,8 @@ class CaCertificates < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "f6cb23271f14f7c4e995b177ea9da7957384854cb702ed571f32defcd3909443"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "80f4508a2a5711fcabeeaafdeebb88c9eec6b0e834e75f47b837ffe3da60c7d3"
   end
 
   def install

--- a/Formula/c/ca-certificates.rb
+++ b/Formula/c/ca-certificates.rb
@@ -143,10 +143,7 @@ class CaCertificates < Formula
     pkgetc.mkpath
 
     system_ca_certificates = Pathname.new("/etc/ssl/certs/ca-certificates.crt")
-    if !system_ca_certificates.exist? || !system_ca_certificates.readable?
-      cp pkgshare/"cacert.pem", pkgetc/"cert.pem"
-      return
-    end
+    return if !system_ca_certificates.exist? || !system_ca_certificates.readable?
 
     # Integrate system certificates if OpenSSL is available
     unless which("openssl")
@@ -156,7 +153,6 @@ class CaCertificates < Formula
           brew install openssl
           brew postinstall ca-certificates
       EOS
-      cp pkgshare/"cacert.pem", pkgetc/"cert.pem"
       return
     end
 
@@ -171,6 +167,10 @@ class CaCertificates < Formula
 
     (pkgetc/"cert.pem").atomic_write(trusted_certificates.join("\n") << "\n")
     ohai "CA certificates have been bootstrapped from the system CA store."
+  ensure
+    # FIXME: the steps above can fail. We should handle them properly.
+    # https://github.com/Homebrew/homebrew-core/issues/233206
+    cp pkgshare/"cacert.pem", pkgetc/"cert.pem" unless (pkgetc/"cert.pem").exist?
   end
 
   def caveats


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Workaround for #233206.

It's not quite a fix, but having the cert bundle go missing can break a
lot of things, so we should do something like this now until we have a
proper fix.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->
