### PR TITLE
snap: update checksum

### DIFF
--- a/Formula/s/snap.rb
+++ b/Formula/s/snap.rb
@@ -3,7 +3,7 @@ class Snap < Formula
   homepage "https://snapcraft.io/"
   url "https://github.com/canonical/snapd/releases/download/2.70/snapd_2.70.vendor.tar.xz"
   version "2.70"
-  sha256 "208c4356e17e96f25f8e5d4cc9c5494157099d15c091a530bb4f260aae9cf88b"
+  sha256 "4092c7e02d9d03c4c3c0546a0cddcff288ffffe484cd872f7df7565ab1428dbf"
   license "GPL-3.0-only"
 
   livecheck do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Build [failed](https://github.com/Homebrew/homebrew-core/actions/runs/16922847115/job/47953670013?pr=226636#step:3:23028) with:
```
  ==> Downloading https://github.com/canonical/snapd/releases/download/2.70/snapd_2.70.vendor.tar.xz
  Already downloaded: /Users/brew/Library/Caches/Homebrew/downloads/d7c3ceee1cfa207e626ad2f8f4e168b23b425b4a93a1f3bb79cbfdd32123e9bd--snapd_2.70.vendor.tar.xz
  Error: snap: SHA-256 mismatch
  Expected: 208c4356e17e96f25f8e5d4cc9c5494157099d15c091a530bb4f260aae9cf88b
    Actual: 4092c7e02d9d03c4c3c0546a0cddcff288ffffe484cd872f7df7565ab1428dbf
      File: /Users/brew/Library/Caches/Homebrew/downloads/d7c3ceee1cfa207e626ad2f8f4e168b23b425b4a93a1f3bb79cbfdd32123e9bd--snapd_2.70.vendor.tar.xz
```

Apparently upstream source hash has changed since
* https://github.com/Homebrew/homebrew-core/pull/229626

Found in
* https://github.com/Homebrew/homebrew-core/pull/226636
