### PR TITLE
anyzig 2025.08.03 (new formula)

### DIFF
--- a/Formula/a/anyzig.rb
+++ b/Formula/a/anyzig.rb
@@ -1,0 +1,31 @@
+class Anyzig < Formula
+  desc "Universal zig executable that runs any version of zig"
+  homepage "https://github.com/marler8997/anyzig"
+  url "https://github.com/marler8997/anyzig/archive/refs/tags/v2025_08_13.tar.gz"
+  sha256 "13511963d0dc570f5fe47ec83a23ff2982b53f1516076014aab6ec54638c0f3e"
+  license "MIT"
+
+  keg_only "it conflicts with zig"
+
+  depends_on "zig" => :build
+
+  def install
+    args = %W[-Dforce-version=v#{version.to_s.tr(".", "_")}]
+
+    # Fix illegal instruction errors when using bottles on older CPUs.
+    # https://github.com/Homebrew/homebrew-core/issues/92282
+    cpu = case ENV.effective_arch
+    when :arm_vortex_tempest then "apple_m1" # See `zig targets`.
+    when :armv8 then "xgene1" # Closest to `-march=armv8-a`
+    else ENV.effective_arch
+    end
+    args << "-Dcpu=#{cpu}" if build.bottle?
+
+    system "zig", "build", *args, *std_zig_args
+  end
+
+  test do
+    assert_match "v#{version.to_s.tr(".", "_")}", shell_output("#{bin}/zig any version").strip
+    system bin/"zig", "any", "list-installed"
+  end
+end

--- a/Formula/a/anyzig.rb
+++ b/Formula/a/anyzig.rb
@@ -5,6 +5,15 @@ class Anyzig < Formula
   sha256 "13511963d0dc570f5fe47ec83a23ff2982b53f1516076014aab6ec54638c0f3e"
   license "MIT"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "3a99919f4b637901bae427daed3dddf878f9451e91478865002cdc69ce6cd76c"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "75f2f35ec40057c925cc718abdf3459c81579e48024ed7b6ca241411997dea35"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "24180b09b6c8af369b6477ad37ceabd6e852cce19f6e19a8442eec86fcf94224"
+    sha256 cellar: :any_skip_relocation, sonoma:        "3efd0d1c34480b8fd4174b30156740addf1afa7eedaf207b71f0602205d95569"
+    sha256 cellar: :any_skip_relocation, ventura:       "a5c9630295c2bbc7ebe1115812140c7cdff797e3caff6ee9d82a8935dc978f62"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1d68a435c3c52c8d944409175fe05f977932382420388bda1f341edb3270d6cc"
+  end
+
   keg_only "it conflicts with zig"
 
   depends_on "zig" => :build


### PR DESCRIPTION
anyzig is a universal zig executable that can forward invocations to any zig version. Since you can only have one `zig` in your `PATH`, anyzig removes the limitation that this can only be one version.

anyzig does this by treating "zig" itself like any other build dependency. It reads the version of zig to invoke from a project's `build.zig.zon` file and forwards to that version of zig. If this is the first time that
version of zig has been needed, it will automatically fetch zig itself into zig's global cache, just like it would any other dependency.

Note that anyzig is mostly a wrapper around zig itself, leveraging zig's own dependency fetch implementation.

Anyzig is relatively young, only being created 6 months ago (Feb 2025). However, it already has over 3K downloads from GitHub. I also consider it an improved spiritual successor to my older zigup project which has been highly used by the community for many years.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
