### PR TITLE
touca: deprecate

### DIFF
--- a/Formula/t/touca.rb
+++ b/Formula/t/touca.rb
@@ -1,5 +1,6 @@
 class Touca < Formula
   include Language::Python::Virtualenv
+
   desc "Open source tool for regression testing complex software workflows"
   homepage "https://github.com/trytouca/trytouca/tree/main/sdk/python"
   url "https://files.pythonhosted.org/packages/c8/6d/e1986d8c9b4f6cd2b583d0df8bd1769989b5ce5cb91dcc613b0d187e4a7a/touca-1.8.7.tar.gz"
@@ -11,6 +12,8 @@ class Touca < Formula
     rebuild 3
     sha256 cellar: :any_skip_relocation, all: "28347dcea2a95cf714fad75fb909df2202c64a2ba9f9b83af3f99a7659e0bf17"
   end
+
+  deprecate! date: "2025-08-13", because: :unmaintained
 
   depends_on "certifi"
   depends_on "python@3.13"


### PR DESCRIPTION
`touca` hasn't had a release since 2023, and is still using an old version of flatbuffers which doesn't work with newer setuptools. Additionally, we are inreplacing to allow newer versions of certifi. It makes sense to deprecate it due to these issues along with low install numbers.

```
==> Analytics
install: 11 (30 days), 33 (90 days), 179 (365 days)
install-on-request: 11 (30 days), 33 (90 days), 179 (365 days)
```