### PR TITLE
go: requires macOS 12 Monterey or later

### DIFF
--- a/Formula/g/go.rb
+++ b/Formula/g/go.rb
@@ -30,6 +30,8 @@ class Go < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "01574eeb30d53c35d5bec9ef2c8fe3d7f14db16835e25353fa371bd11ac11c3c"
   end
 
+  depends_on macos: :monterey
+
   # Don't update this unless this version cannot bootstrap the new version.
   resource "gobootstrap" do
     checksums = {


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

As noted in <https://tip.golang.org/doc/go1.25#darwin>:

> As [announced](https://tip.golang.org/doc/go1.24#darwin) in the Go 1.24 release notes, Go 1.25 requires macOS 12 Monterey or later. Support for previous versions has been discontinued.

Build failure log:

```
Building packages and commands for darwin/amd64.
dyld: Symbol not found: _SecTrustCopyCertificateChain
  Referenced from: /usr/local/Cellar/go/1.25.0/libexec/bin/go (which was built for Mac OS X 12.0)
  Expected in: /System/Library/Frameworks/Security.framework/Versions/A/Security
 in /usr/local/Cellar/go/1.25.0/libexec/bin/go

go tool dist: FAILED: /usr/local/Cellar/go/1.25.0/libexec/bin/go list -f={{if .Stale}}	STALE {{.ImportPath}}: {{.StaleReason}}{{end}} std: signal: abort trap
```