### PR TITLE
formulae: use ftpmirror.gnu.org as primary URL

### DIFF
--- a/Formula/a/a2ps.rb
+++ b/Formula/a/a2ps.rb
@@ -1,8 +1,8 @@
 class A2ps < Formula
   desc "Any-to-PostScript filter"
   homepage "https://www.gnu.org/software/a2ps/"
-  url "https://ftp.gnu.org/gnu/a2ps/a2ps-4.15.7.tar.gz"
-  mirror "https://ftpmirror.gnu.org/a2ps/a2ps-4.15.7.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/a2ps/a2ps-4.15.7.tar.gz"
+  mirror "https://ftp.gnu.org/a2ps/a2ps-4.15.7.tar.gz"
   sha256 "715f38670afd950b4ca71c01f468feefad265ca52d3f112934c63c0a8bfbb8af"
   license "GPL-3.0-or-later"
 

--- a/Formula/a/aarch64-elf-binutils.rb
+++ b/Formula/a/aarch64-elf-binutils.rb
@@ -1,8 +1,8 @@
 class Aarch64ElfBinutils < Formula
   desc "GNU Binutils for aarch64-elf cross development"
   homepage "https://www.gnu.org/software/binutils/"
-  url "https://ftp.gnu.org/gnu/binutils/binutils-2.45.tar.bz2"
-  mirror "https://ftpmirror.gnu.org/binutils/binutils-2.45.tar.bz2"
+  url "https://ftpmirror.gnu.org/gnu/binutils/binutils-2.45.tar.bz2"
+  mirror "https://ftp.gnu.org/binutils/binutils-2.45.tar.bz2"
   sha256 "1393f90db70c2ebd785fb434d6127f8888c559d5eeb9c006c354b203bab3473e"
   license "GPL-3.0-or-later"
 

--- a/Formula/a/aarch64-elf-gcc.rb
+++ b/Formula/a/aarch64-elf-gcc.rb
@@ -1,8 +1,8 @@
 class Aarch64ElfGcc < Formula
   desc "GNU compiler collection for aarch64-elf"
   homepage "https://gcc.gnu.org"
-  url "https://ftp.gnu.org/gnu/gcc/gcc-15.2.0/gcc-15.2.0.tar.xz"
-  mirror "https://ftpmirror.gnu.org/gcc/gcc-15.2.0/gcc-15.2.0.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/gcc/gcc-15.2.0/gcc-15.2.0.tar.xz"
+  mirror "https://ftp.gnu.org/gcc/gcc-15.2.0/gcc-15.2.0.tar.xz"
   sha256 "438fd996826b0c82485a29da03a72d71d6e3541a83ec702df4271f6fe025d24e"
   license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }
 

--- a/Formula/a/aarch64-elf-gdb.rb
+++ b/Formula/a/aarch64-elf-gdb.rb
@@ -1,8 +1,8 @@
 class Aarch64ElfGdb < Formula
   desc "GNU debugger for aarch64-elf cross development"
   homepage "https://www.gnu.org/software/gdb/"
-  url "https://ftp.gnu.org/gnu/gdb/gdb-16.3.tar.xz"
-  mirror "https://ftpmirror.gnu.org/gdb/gdb-16.3.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/gdb/gdb-16.3.tar.xz"
+  mirror "https://ftp.gnu.org/gdb/gdb-16.3.tar.xz"
   sha256 "bcfcd095528a987917acf9fff3f1672181694926cc18d609c99d0042c00224c5"
   license "GPL-3.0-or-later"
   head "https://sourceware.org/git/binutils-gdb.git", branch: "master"

--- a/Formula/a/arm-linux-gnueabihf-binutils.rb
+++ b/Formula/a/arm-linux-gnueabihf-binutils.rb
@@ -1,8 +1,8 @@
 class ArmLinuxGnueabihfBinutils < Formula
   desc "FSF/GNU binutils for cross-compiling to arm-linux"
   homepage "https://www.gnu.org/software/binutils/binutils.html"
-  url "https://ftp.gnu.org/gnu/binutils/binutils-2.45.tar.bz2"
-  mirror "https://ftpmirror.gnu.org/binutils/binutils-2.45.tar.bz2"
+  url "https://ftpmirror.gnu.org/gnu/binutils/binutils-2.45.tar.bz2"
+  mirror "https://ftp.gnu.org/binutils/binutils-2.45.tar.bz2"
   sha256 "1393f90db70c2ebd785fb434d6127f8888c559d5eeb9c006c354b203bab3473e"
   license "GPL-3.0-or-later"
 

--- a/Formula/a/arm-none-eabi-binutils.rb
+++ b/Formula/a/arm-none-eabi-binutils.rb
@@ -1,8 +1,8 @@
 class ArmNoneEabiBinutils < Formula
   desc "GNU Binutils for arm-none-eabi cross development"
   homepage "https://www.gnu.org/software/binutils/"
-  url "https://ftp.gnu.org/gnu/binutils/binutils-2.45.tar.bz2"
-  mirror "https://ftpmirror.gnu.org/binutils/binutils-2.45.tar.bz2"
+  url "https://ftpmirror.gnu.org/gnu/binutils/binutils-2.45.tar.bz2"
+  mirror "https://ftp.gnu.org/binutils/binutils-2.45.tar.bz2"
   sha256 "1393f90db70c2ebd785fb434d6127f8888c559d5eeb9c006c354b203bab3473e"
   license "GPL-3.0-or-later"
 

--- a/Formula/a/arm-none-eabi-gcc.rb
+++ b/Formula/a/arm-none-eabi-gcc.rb
@@ -1,8 +1,8 @@
 class ArmNoneEabiGcc < Formula
   desc "GNU compiler collection for arm-none-eabi"
   homepage "https://gcc.gnu.org"
-  url "https://ftp.gnu.org/gnu/gcc/gcc-15.2.0/gcc-15.2.0.tar.xz"
-  mirror "https://ftpmirror.gnu.org/gcc/gcc-15.2.0/gcc-15.2.0.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/gcc/gcc-15.2.0/gcc-15.2.0.tar.xz"
+  mirror "https://ftp.gnu.org/gcc/gcc-15.2.0/gcc-15.2.0.tar.xz"
   sha256 "438fd996826b0c82485a29da03a72d71d6e3541a83ec702df4271f6fe025d24e"
   license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }
 

--- a/Formula/a/arm-none-eabi-gdb.rb
+++ b/Formula/a/arm-none-eabi-gdb.rb
@@ -1,8 +1,8 @@
 class ArmNoneEabiGdb < Formula
   desc "GNU debugger for arm-none-eabi cross development"
   homepage "https://www.gnu.org/software/gdb/"
-  url "https://ftp.gnu.org/gnu/gdb/gdb-16.3.tar.xz"
-  mirror "https://ftpmirror.gnu.org/gdb/gdb-16.3.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/gdb/gdb-16.3.tar.xz"
+  mirror "https://ftp.gnu.org/gdb/gdb-16.3.tar.xz"
   sha256 "bcfcd095528a987917acf9fff3f1672181694926cc18d609c99d0042c00224c5"
   license "GPL-3.0-or-later"
   head "https://sourceware.org/git/binutils-gdb.git", branch: "master"

--- a/Formula/a/aspell.rb
+++ b/Formula/a/aspell.rb
@@ -1,8 +1,8 @@
 class Aspell < Formula
   desc "Spell checker with better logic than ispell"
   homepage "http://aspell.net/"
-  url "https://ftp.gnu.org/gnu/aspell/aspell-0.60.8.1.tar.gz"
-  mirror "https://ftpmirror.gnu.org/aspell/aspell-0.60.8.1.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/aspell/aspell-0.60.8.1.tar.gz"
+  mirror "https://ftp.gnu.org/aspell/aspell-0.60.8.1.tar.gz"
   sha256 "d6da12b34d42d457fa604e435ad484a74b2effcd120ff40acd6bb3fb2887d21b"
   license "LGPL-2.1-only"
   revision 1
@@ -22,536 +22,536 @@ class Aspell < Formula
   uses_from_macos "ncurses"
 
   resource "af" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/af/aspell-af-0.50-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/af/aspell-af-0.50-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/af/aspell-af-0.50-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/af/aspell-af-0.50-0.tar.bz2"
     sha256 "9d6000aeca5911343278bd6ed9e21d42c8cb26247dafe94a76ff81d8ac98e602"
   end
 
   resource "am" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/am/aspell6-am-0.03-1.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/am/aspell6-am-0.03-1.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/am/aspell6-am-0.03-1.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/am/aspell6-am-0.03-1.tar.bz2"
     sha256 "bf27dd21f8871e2b3332c211b402cd46604d431a7773e599729c242cdfb9d487"
   end
 
   resource "ar" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/ar/aspell6-ar-1.2-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/ar/aspell6-ar-1.2-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/ar/aspell6-ar-1.2-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/ar/aspell6-ar-1.2-0.tar.bz2"
     sha256 "041ea24a82cdd6957040e2fb84262583bf46b3a8301283a75d257a7417207cab"
   end
 
   resource "ast" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/ast/aspell6-ast-0.01.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/ast/aspell6-ast-0.01.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/ast/aspell6-ast-0.01.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/ast/aspell6-ast-0.01.tar.bz2"
     sha256 "43f23ed01c338c37f9bbb820db757b36ede1cea47a7b93dc8b6d7bd66b410f92"
   end
 
   resource "az" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/az/aspell6-az-0.02-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/az/aspell6-az-0.02-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/az/aspell6-az-0.02-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/az/aspell6-az-0.02-0.tar.bz2"
     sha256 "063176ec459d61acd59450ae49b5076e42abb1dcd54c1f934bae5fa6658044c3"
   end
 
   resource "be" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/be/aspell5-be-0.01.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/be/aspell5-be-0.01.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/be/aspell5-be-0.01.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/be/aspell5-be-0.01.tar.bz2"
     sha256 "550bad0c03a142241ffe5ecc183659d80020b566003a05341cd1e97c6ed274eb"
   end
 
   resource "bg" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/bg/aspell6-bg-4.1-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/bg/aspell6-bg-4.1-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/bg/aspell6-bg-4.1-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/bg/aspell6-bg-4.1-0.tar.bz2"
     sha256 "74570005dc2be5a244436fa2b46a5f612be84c6843f881f0cb1e4c775f658aaa"
   end
 
   resource "bn" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/bn/aspell6-bn-0.01.1-1.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/bn/aspell6-bn-0.01.1-1.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/bn/aspell6-bn-0.01.1-1.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/bn/aspell6-bn-0.01.1-1.tar.bz2"
     sha256 "b03f9cc4feb00df9bfd697b032f4f4ae838ad5a6bb41db798eefc5639a1480d9"
   end
 
   resource "br" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/br/aspell-br-0.50-2.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/br/aspell-br-0.50-2.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/br/aspell-br-0.50-2.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/br/aspell-br-0.50-2.tar.bz2"
     sha256 "c2122a6dcca653c082d785f0da4bf267363182a017fea4129e8b0882aa6d2a3b"
   end
 
   resource "ca" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/ca/aspell6-ca-2.1.5-1.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/ca/aspell6-ca-2.1.5-1.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/ca/aspell6-ca-2.1.5-1.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/ca/aspell6-ca-2.1.5-1.tar.bz2"
     sha256 "ebdae47edf87357a4df137dd754737e6417452540cb1ed34b545ccfd66f165b9"
   end
 
   resource "cs" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/cs/aspell6-cs-20040614-1.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/cs/aspell6-cs-20040614-1.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/cs/aspell6-cs-20040614-1.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/cs/aspell6-cs-20040614-1.tar.bz2"
     sha256 "01c091f907c2fa4dfa38305c2494bb80009407dfb76ead586ad724ae21913066"
   end
 
   resource "csb" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/csb/aspell6-csb-0.02-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/csb/aspell6-csb-0.02-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/csb/aspell6-csb-0.02-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/csb/aspell6-csb-0.02-0.tar.bz2"
     sha256 "c166ad07d50e9e13ac9f87d5a8938b3f675a0f8a01017bd8969c2053e7f52298"
   end
 
   resource "cy" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/cy/aspell-cy-0.50-3.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/cy/aspell-cy-0.50-3.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/cy/aspell-cy-0.50-3.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/cy/aspell-cy-0.50-3.tar.bz2"
     sha256 "d5399dcd70061e5ed5af1214eb580f62864dd35ea4fa1ec2882ffc4f03307897"
   end
 
   resource "da" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/da/aspell6-da-1.6.36-11-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/da/aspell6-da-1.6.36-11-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/da/aspell6-da-1.6.36-11-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/da/aspell6-da-1.6.36-11-0.tar.bz2"
     sha256 "dbc6cbceaa7a4528f3756f0b5cce5c3d0615c2103d3899b47e9df2ed9582e2f7"
   end
 
   resource "de" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/de/aspell6-de-20161207-7-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/de/aspell6-de-20161207-7-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/de/aspell6-de-20161207-7-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/de/aspell6-de-20161207-7-0.tar.bz2"
     sha256 "c2125d1fafb1d4effbe6c88d4e9127db59da9ed92639c7cbaeae1b7337655571"
   end
 
   resource "de_alt" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/de-alt/aspell6-de-alt-2.1-1.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/de-alt/aspell6-de-alt-2.1-1.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/de-alt/aspell6-de-alt-2.1-1.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/de-alt/aspell6-de-alt-2.1-1.tar.bz2"
     sha256 "36d13c6c743a6b1ff05fb1af79134e118e5a94db06ba40c076636f9d04158c73"
   end
 
   resource "el" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/el/aspell6-el-0.08-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/el/aspell6-el-0.08-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/el/aspell6-el-0.08-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/el/aspell6-el-0.08-0.tar.bz2"
     sha256 "4af60f1a8adf8b1899680deefdf49288d7406a2c591658f880628bf7c1604cd2"
   end
 
   resource "en" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/en/aspell6-en-2020.12.07-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/en/aspell6-en-2020.12.07-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/en/aspell6-en-2020.12.07-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/en/aspell6-en-2020.12.07-0.tar.bz2"
     sha256 "4c8f734a28a088b88bb6481fcf972d0b2c3dc8da944f7673283ce487eac49fb3"
   end
 
   resource "eo" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/eo/aspell6-eo-2.1.20000225a-2.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/eo/aspell6-eo-2.1.20000225a-2.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/eo/aspell6-eo-2.1.20000225a-2.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/eo/aspell6-eo-2.1.20000225a-2.tar.bz2"
     sha256 "41d2d18d6a4de6422185a31ecfc1a3de2e751f3dfb2cbec8f275b11857056e27"
   end
 
   resource "es" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/es/aspell6-es-1.11-2.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/es/aspell6-es-1.11-2.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/es/aspell6-es-1.11-2.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/es/aspell6-es-1.11-2.tar.bz2"
     sha256 "ad367fa1e7069c72eb7ae37e4d39c30a44d32a6aa73cedccbd0d06a69018afcc"
   end
 
   resource "et" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/et/aspell6-et-0.1.21-1.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/et/aspell6-et-0.1.21-1.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/et/aspell6-et-0.1.21-1.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/et/aspell6-et-0.1.21-1.tar.bz2"
     sha256 "b1e857aa3daaea2a19462b2671e87c26a7eb7337c83b709685394eed8472b249"
   end
 
   resource "fa" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/fa/aspell6-fa-0.11-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/fa/aspell6-fa-0.11-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/fa/aspell6-fa-0.11-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/fa/aspell6-fa-0.11-0.tar.bz2"
     sha256 "482d26ea879a8ea02d9373952205f67e07c85a7550841b13b5079bb2f9f2e15b"
   end
 
   resource "fi" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/fi/aspell6-fi-0.7-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/fi/aspell6-fi-0.7-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/fi/aspell6-fi-0.7-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/fi/aspell6-fi-0.7-0.tar.bz2"
     sha256 "f8d7f07b4511e606eb56392ddaa76fd29918006331795e5942ad11b510d0a51d"
   end
 
   resource "fo" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/fo/aspell5-fo-0.2.16-1.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/fo/aspell5-fo-0.2.16-1.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/fo/aspell5-fo-0.2.16-1.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/fo/aspell5-fo-0.2.16-1.tar.bz2"
     sha256 "f7e0ddc039bb4f5c142d39dab72d9dfcb951f5e46779f6e3cf1d084a69f95e08"
   end
 
   resource "fr" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/fr/aspell-fr-0.50-3.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/fr/aspell-fr-0.50-3.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/fr/aspell-fr-0.50-3.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/fr/aspell-fr-0.50-3.tar.bz2"
     sha256 "f9421047519d2af9a7a466e4336f6e6ea55206b356cd33c8bd18cb626bf2ce91"
   end
 
   resource "fy" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/fy/aspell6-fy-0.12-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/fy/aspell6-fy-0.12-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/fy/aspell6-fy-0.12-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/fy/aspell6-fy-0.12-0.tar.bz2"
     sha256 "3447cfa90e459af32183a6bc8af9ba3ed571087811cdfc336821454bac8995aa"
   end
 
   resource "ga" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/ga/aspell5-ga-4.5-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/ga/aspell5-ga-4.5-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/ga/aspell5-ga-4.5-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/ga/aspell5-ga-4.5-0.tar.bz2"
     sha256 "455fdbbca24cecb4667fbcf9544d84ae83e5b2505caae79afa6b2cb76b4d0679"
   end
 
   resource "gd" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/gd/aspell5-gd-0.1.1-1.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/gd/aspell5-gd-0.1.1-1.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/gd/aspell5-gd-0.1.1-1.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/gd/aspell5-gd-0.1.1-1.tar.bz2"
     sha256 "e316a08a75da8a0d4d15eb892023073a971e0a326382a5532db29856768e0929"
   end
 
   resource "gl" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/gl/aspell6-gl-0.5a-2.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/gl/aspell6-gl-0.5a-2.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/gl/aspell6-gl-0.5a-2.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/gl/aspell6-gl-0.5a-2.tar.bz2"
     sha256 "b3cdcf65971e70b8c09fb7f319164c6344a80d260b6e98dc6ecca1e02b7cfc8a"
   end
 
   resource "grc" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/grc/aspell6-grc-0.02-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/grc/aspell6-grc-0.02-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/grc/aspell6-grc-0.02-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/grc/aspell6-grc-0.02-0.tar.bz2"
     sha256 "2214883e2b9883f360b090948afd2cb0687bc6bba4e1e98011fb8c8d4a42b9ff"
   end
 
   resource "gu" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/gu/aspell6-gu-0.03-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/gu/aspell6-gu-0.03-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/gu/aspell6-gu-0.03-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/gu/aspell6-gu-0.03-0.tar.bz2"
     sha256 "432c125acc6a86456061dcd47018df4318a117be9f7c09a590979243ad448311"
   end
 
   resource "gv" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/gv/aspell-gv-0.50-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/gv/aspell-gv-0.50-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/gv/aspell-gv-0.50-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/gv/aspell-gv-0.50-0.tar.bz2"
     sha256 "bbe626feb5c81c1b7e7d3199d558bc5c560b2d4aef377d0e4b4227ae3c7176e6"
   end
 
   resource "he" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/he/aspell6-he-1.0-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/he/aspell6-he-1.0-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/he/aspell6-he-1.0-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/he/aspell6-he-1.0-0.tar.bz2"
     sha256 "d64dabac9f40ca9e632a8eee40fc01c7d18a2c699d8f9742000fadd2e15b708d"
   end
 
   resource "hi" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/hi/aspell6-hi-0.02-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/hi/aspell6-hi-0.02-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/hi/aspell6-hi-0.02-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/hi/aspell6-hi-0.02-0.tar.bz2"
     sha256 "da0778c46716f4209da25195294139c2f5e6031253381afa4f81908fc9193a37"
   end
 
   resource "hil" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/hil/aspell5-hil-0.11-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/hil/aspell5-hil-0.11-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/hil/aspell5-hil-0.11-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/hil/aspell5-hil-0.11-0.tar.bz2"
     sha256 "570a374fd0b97943bc6893cf25ac7b23da815120842a80144e2c7ee8b41388e8"
   end
 
   resource "hr" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/hr/aspell-hr-0.51-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/hr/aspell-hr-0.51-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/hr/aspell-hr-0.51-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/hr/aspell-hr-0.51-0.tar.bz2"
     sha256 "2ac4030354d7961e45d63b46e06e59248d59cc70dfc9e1d8ee0ae21d9c774a25"
   end
 
   resource "hsb" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/hsb/aspell6-hsb-0.02-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/hsb/aspell6-hsb-0.02-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/hsb/aspell6-hsb-0.02-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/hsb/aspell6-hsb-0.02-0.tar.bz2"
     sha256 "8d9f2ae428c7754a922ce6a7ef23401bc65f6f1909aec5077975077b3edc222e"
   end
 
   resource "hu" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/hu/aspell6-hu-0.99.4.2-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/hu/aspell6-hu-0.99.4.2-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/hu/aspell6-hu-0.99.4.2-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/hu/aspell6-hu-0.99.4.2-0.tar.bz2"
     sha256 "3335a7b45cf9774bccf03740fbddeb7ec4752dd87178fa93f92d4c71e3f236b5"
   end
 
   resource "hus" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/hus/aspell6-hus-0.03-1.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/hus/aspell6-hus-0.03-1.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/hus/aspell6-hus-0.03-1.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/hus/aspell6-hus-0.03-1.tar.bz2"
     sha256 "6d28f371d1a172439395d56d2d5ce8f27c617de03f847f02643dfd79dd8df425"
   end
 
   resource "hy" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/hy/aspell6-hy-0.10.0-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/hy/aspell6-hy-0.10.0-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/hy/aspell6-hy-0.10.0-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/hy/aspell6-hy-0.10.0-0.tar.bz2"
     sha256 "2dea8d0093a3b8373cc97703dca2979b285f71916181d1a20db70bea28c2bcf0"
   end
 
   resource "ia" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/ia/aspell-ia-0.50-1.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/ia/aspell-ia-0.50-1.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/ia/aspell-ia-0.50-1.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/ia/aspell-ia-0.50-1.tar.bz2"
     sha256 "5797cb59606d007cf8fe5b9ec435de0d63b2d0e0d391ed8850ef8aa3f4bb0c2f"
   end
 
   resource "id" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/id/aspell5-id-1.2-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/id/aspell5-id-1.2-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/id/aspell5-id-1.2-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/id/aspell5-id-1.2-0.tar.bz2"
     sha256 "523912082848d891746dbb233f2ddb2cdbab6750dc76c38b3f6e000c9eb37308"
   end
 
   resource "it" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/it/aspell6-it-2.2_20050523-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/it/aspell6-it-2.2_20050523-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/it/aspell6-it-2.2_20050523-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/it/aspell6-it-2.2_20050523-0.tar.bz2"
     sha256 "3b19dc709924783c8d87111aa9653dc6c000e845183778abee750215d83aaebd"
   end
 
   resource "kn" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/kn/aspell6-kn-0.01-1.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/kn/aspell6-kn-0.01-1.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/kn/aspell6-kn-0.01-1.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/kn/aspell6-kn-0.01-1.tar.bz2"
     sha256 "cb010b34a712f853fa53c4618cb801704b9f76c72db9390009ba914e3a075383"
   end
 
   resource "ku" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/ku/aspell5-ku-0.20-1.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/ku/aspell5-ku-0.20-1.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/ku/aspell5-ku-0.20-1.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/ku/aspell5-ku-0.20-1.tar.bz2"
     sha256 "968f76418c991dc004a1cc3d8cd07b58fb210b6ad506106857ed2d97274a6a27"
   end
 
   resource "ky" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/ky/aspell6-ky-0.01-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/ky/aspell6-ky-0.01-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/ky/aspell6-ky-0.01-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/ky/aspell6-ky-0.01-0.tar.bz2"
     sha256 "e10f2f25b44b71e30fa1ea9c248c04543c688845a734d0b9bdc65a2bbd16fb4f"
   end
 
   resource "la" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/la/aspell6-la-20020503-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/la/aspell6-la-20020503-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/la/aspell6-la-20020503-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/la/aspell6-la-20020503-0.tar.bz2"
     sha256 "d486b048d1c3056d3a555744584a81873a63ecd4641f04e8b7bf9910b98d2985"
   end
 
   resource "lt" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/lt/aspell6-lt-1.2.1-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/lt/aspell6-lt-1.2.1-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/lt/aspell6-lt-1.2.1-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/lt/aspell6-lt-1.2.1-0.tar.bz2"
     sha256 "f6f53b6e418c22f63e1a70b8bc77bc66912bc1afd40cf98dc026d110d26452ab"
   end
 
   resource "lv" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/lv/aspell6-lv-0.5.5-1.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/lv/aspell6-lv-0.5.5-1.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/lv/aspell6-lv-0.5.5-1.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/lv/aspell6-lv-0.5.5-1.tar.bz2"
     sha256 "3c30e206ea562b2e759fb7467680e1a01d5deec5edbd66653c83184550d1fb8a"
   end
 
   resource "mg" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/mg/aspell5-mg-0.03-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/mg/aspell5-mg-0.03-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/mg/aspell5-mg-0.03-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/mg/aspell5-mg-0.03-0.tar.bz2"
     sha256 "5182f832e1630ceef5711a83b530fb583ffe04f28cc042d195b5c6b2d25cb041"
   end
 
   resource "mi" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/mi/aspell-mi-0.50-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/mi/aspell-mi-0.50-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/mi/aspell-mi-0.50-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/mi/aspell-mi-0.50-0.tar.bz2"
     sha256 "beee1e33baf6301e3ffc56558c84c3e7d29622541b232c1aea1e91d12ebd7d89"
   end
 
   resource "mk" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/mk/aspell-mk-0.50-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/mk/aspell-mk-0.50-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/mk/aspell-mk-0.50-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/mk/aspell-mk-0.50-0.tar.bz2"
     sha256 "15fc2380fb673d2003d8075d8cef2b0dbb4d30b430587ad459257681904d9971"
   end
 
   resource "ml" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/ml/aspell6-ml-0.03-1.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/ml/aspell6-ml-0.03-1.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/ml/aspell6-ml-0.03-1.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/ml/aspell6-ml-0.03-1.tar.bz2"
     sha256 "e4cd551e558b6d26e4db58e051eeca3d893fc2c4e7fce90a022af247422096fd"
   end
 
   resource "mn" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/mn/aspell6-mn-0.06-2.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/mn/aspell6-mn-0.06-2.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/mn/aspell6-mn-0.06-2.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/mn/aspell6-mn-0.06-2.tar.bz2"
     sha256 "2f1b6edd48b82cd9b99b9262d5635f72271c062ef4e772b90388dfc48a4f1294"
   end
 
   resource "mr" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/mr/aspell6-mr-0.10-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/mr/aspell6-mr-0.10-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/mr/aspell6-mr-0.10-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/mr/aspell6-mr-0.10-0.tar.bz2"
     sha256 "d3a35a40bee0234a5b388375485ab8bf0ba8edbf3b0a82e2c2f76a40a8586f33"
   end
 
   resource "ms" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/ms/aspell-ms-0.50-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/ms/aspell-ms-0.50-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/ms/aspell-ms-0.50-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/ms/aspell-ms-0.50-0.tar.bz2"
     sha256 "3cc4e3537bb0f455ce58b4d2fa84b03dc678e0153536a41dee1a3a7623dc246f"
   end
 
   resource "mt" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/mt/aspell-mt-0.50-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/mt/aspell-mt-0.50-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/mt/aspell-mt-0.50-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/mt/aspell-mt-0.50-0.tar.bz2"
     sha256 "e00fcaad60a90cfed687ba02f62be8c27b8650457dd3c5bdcb064b476da059b4"
   end
 
   resource "nds" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/nds/aspell6-nds-0.01-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/nds/aspell6-nds-0.01-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/nds/aspell6-nds-0.01-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/nds/aspell6-nds-0.01-0.tar.bz2"
     sha256 "ce381e869def56e54a31f965df518deca0e6f12238859650fcb115623f8772da"
   end
 
   resource "nl" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/nl/aspell-nl-0.50-2.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/nl/aspell-nl-0.50-2.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/nl/aspell-nl-0.50-2.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/nl/aspell-nl-0.50-2.tar.bz2"
     sha256 "440e0b7df8c5903d728221fe4ba88a74658ce14c8bb04b290c41402dfd41cb39"
   end
 
   resource "nn" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/nn/aspell-nn-0.50.1-1.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/nn/aspell-nn-0.50.1-1.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/nn/aspell-nn-0.50.1-1.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/nn/aspell-nn-0.50.1-1.tar.bz2"
     sha256 "ac6610540c7e134f09cbebbd148f9316bef27bc491e377638ef4e2950b2d5370"
   end
 
   resource "ny" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/ny/aspell5-ny-0.01-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/ny/aspell5-ny-0.01-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/ny/aspell5-ny-0.01-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/ny/aspell5-ny-0.01-0.tar.bz2"
     sha256 "176f970f6ba3bb448c7e946fa8d209eb4da7138ac6899af7731a98c7b6484b3e"
   end
 
   resource "or" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/or/aspell6-or-0.03-1.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/or/aspell6-or-0.03-1.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/or/aspell6-or-0.03-1.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/or/aspell6-or-0.03-1.tar.bz2"
     sha256 "d6ffa369f8918d74cdea966112bc5cb700e09dca5ac6b968660cfc22044ef24f"
   end
 
   resource "pa" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/pa/aspell6-pa-0.01-1.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/pa/aspell6-pa-0.01-1.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/pa/aspell6-pa-0.01-1.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/pa/aspell6-pa-0.01-1.tar.bz2"
     sha256 "c7f3abb1c5efe62e072ca8bef44b0d0506501bbb7b48ced1d0d95f10e61fc945"
   end
 
   resource "pl" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/pl/aspell6-pl-6.0_20061121-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/pl/aspell6-pl-6.0_20061121-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/pl/aspell6-pl-6.0_20061121-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/pl/aspell6-pl-6.0_20061121-0.tar.bz2"
     sha256 "017741fcb70a885d718c534160c9de06b03cc72f352879bd106be165e024574d"
   end
 
   resource "pt_BR" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/pt_BR/aspell6-pt_BR-20131030-12-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/pt_BR/aspell6-pt_BR-20131030-12-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/pt_BR/aspell6-pt_BR-20131030-12-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/pt_BR/aspell6-pt_BR-20131030-12-0.tar.bz2"
     sha256 "eb0d99db0b5d5c442133a88bddfe96dd252c0c3df3da36e9326c241dc4bc14f7"
   end
 
   resource "pt_PT" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/pt_PT/aspell6-pt_PT-20190329-1-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/pt_PT/aspell6-pt_PT-20190329-1-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/pt_PT/aspell6-pt_PT-20190329-1-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/pt_PT/aspell6-pt_PT-20190329-1-0.tar.bz2"
     sha256 "e5708b890c2afff51276a6cc276af5e6b3b8a026db75eda48b58124f2368a051"
   end
 
   resource "qu" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/qu/aspell6-qu-0.02-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/qu/aspell6-qu-0.02-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/qu/aspell6-qu-0.02-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/qu/aspell6-qu-0.02-0.tar.bz2"
     sha256 "80977629b8425bda7ffd951628d23a6793a457f4948151c71ff9e0bff5073f01"
   end
 
   resource "ro" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/ro/aspell5-ro-3.3-2.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/ro/aspell5-ro-3.3-2.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/ro/aspell5-ro-3.3-2.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/ro/aspell5-ro-3.3-2.tar.bz2"
     sha256 "53c38b7668a540cf90ddca11c007ce812d2ad86bd11c2c43a08da9e06392683d"
   end
 
   resource "ru" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/ru/aspell6-ru-0.99f7-1.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/ru/aspell6-ru-0.99f7-1.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/ru/aspell6-ru-0.99f7-1.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/ru/aspell6-ru-0.99f7-1.tar.bz2"
     sha256 "5c29b6ccce57bc3f7c4fb0510d330446b9c769e59c92bdfede27333808b6e646"
   end
 
   resource "rw" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/rw/aspell-rw-0.50-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/rw/aspell-rw-0.50-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/rw/aspell-rw-0.50-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/rw/aspell-rw-0.50-0.tar.bz2"
     sha256 "3406102e0e33344b6eae73dbfaf86d8e411b7c97775827a6db79c943ce43f081"
   end
 
   resource "sc" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/sc/aspell5-sc-1.0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/sc/aspell5-sc-1.0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/sc/aspell5-sc-1.0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/sc/aspell5-sc-1.0.tar.bz2"
     sha256 "591ae22f712b472182b41b8bc97dce1e5ecd240c75eccc25f59ab15c60be8742"
   end
 
   resource "sk" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/sk/aspell6-sk-2.01-2.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/sk/aspell6-sk-2.01-2.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/sk/aspell6-sk-2.01-2.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/sk/aspell6-sk-2.01-2.tar.bz2"
     sha256 "c6a80a2989c305518e0d71af1196b7484fda26fe53be4e49eec7b15b76a860a6"
   end
 
   resource "sl" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/sl/aspell-sl-0.50-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/sl/aspell-sl-0.50-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/sl/aspell-sl-0.50-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/sl/aspell-sl-0.50-0.tar.bz2"
     sha256 "e566d127f7130da2df7b1f4f4cb4bc51932517b0c24299f84498ba325e6133d1"
   end
 
   resource "sr" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/sr/aspell6-sr-0.02.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/sr/aspell6-sr-0.02.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/sr/aspell6-sr-0.02.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/sr/aspell6-sr-0.02.tar.bz2"
     sha256 "705e58fb390633c89c4cb224a1cfb34e67e09496448f7adc6500494b6e009289"
   end
 
   resource "sv" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/sv/aspell-sv-0.51-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/sv/aspell-sv-0.51-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/sv/aspell-sv-0.51-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/sv/aspell-sv-0.51-0.tar.bz2"
     sha256 "9b70573c9c8cf76f5cdb6abcdfb834a754bbaa1efd7d6f57f47b8a91a19c5c0a"
   end
 
   resource "sw" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/sw/aspell-sw-0.50-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/sw/aspell-sw-0.50-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/sw/aspell-sw-0.50-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/sw/aspell-sw-0.50-0.tar.bz2"
     sha256 "7ed51f107dc57a7b3555f20d1cee2903275d63e022b055ea6b6409d9e081f297"
   end
 
   resource "ta" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/ta/aspell6-ta-20040424-1.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/ta/aspell6-ta-20040424-1.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/ta/aspell6-ta-20040424-1.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/ta/aspell6-ta-20040424-1.tar.bz2"
     sha256 "52f552f1a2c0fc53ed4eac75990ff75bccf3d5f1440ca3d948d96eafe5f3486a"
   end
 
   resource "te" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/te/aspell6-te-0.01-2.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/te/aspell6-te-0.01-2.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/te/aspell6-te-0.01-2.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/te/aspell6-te-0.01-2.tar.bz2"
     sha256 "3682638a757a65afcc770e565e68347e8eb7be94052d9d6eff64fc767e7fec5d"
   end
 
   resource "tet" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/tet/aspell5-tet-0.1.1.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/tet/aspell5-tet-0.1.1.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/tet/aspell5-tet-0.1.1.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/tet/aspell5-tet-0.1.1.tar.bz2"
     sha256 "9dd546c9c48f42085e3c17f22c8e6d46e56f3ea9c4618b933c642a091df1c09e"
   end
 
   resource "tk" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/tk/aspell5-tk-0.01-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/tk/aspell5-tk-0.01-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/tk/aspell5-tk-0.01-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/tk/aspell5-tk-0.01-0.tar.bz2"
     sha256 "86f24209cab61a54ed85ad3020915d8ce1dec13fbfe012f1bf1d648825696a0b"
   end
 
   resource "tl" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/tl/aspell5-tl-0.02-1.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/tl/aspell5-tl-0.02-1.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/tl/aspell5-tl-0.02-1.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/tl/aspell5-tl-0.02-1.tar.bz2"
     sha256 "48b65d2c6886f353d1e1756a93bcd4d8ab2b88b021176c25dfdb5d8bcf348acd"
   end
 
   resource "tn" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/tn/aspell5-tn-1.0.1-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/tn/aspell5-tn-1.0.1-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/tn/aspell5-tn-1.0.1-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/tn/aspell5-tn-1.0.1-0.tar.bz2"
     sha256 "41a0c20e1d2acaa28a647d74b40778e491815566019f79e7049621f40d3bbd60"
   end
 
   resource "tr" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/tr/aspell-tr-0.50-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/tr/aspell-tr-0.50-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/tr/aspell-tr-0.50-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/tr/aspell-tr-0.50-0.tar.bz2"
     sha256 "0bc6530e5eebf8b2b53f1e8add596c62099173f62b9baa6b3efaa86752bdfb4a"
   end
 
   resource "uk" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/uk/aspell6-uk-1.4.0-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/uk/aspell6-uk-1.4.0-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/uk/aspell6-uk-1.4.0-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/uk/aspell6-uk-1.4.0-0.tar.bz2"
     sha256 "35f9a7e840c1272706bc6dd172bc9625cbd843d021094da8598a6abba525f18c"
   end
 
   resource "uz" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/uz/aspell6-uz-0.6-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/uz/aspell6-uz-0.6-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/uz/aspell6-uz-0.6-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/uz/aspell6-uz-0.6-0.tar.bz2"
     sha256 "2281c1fc7fe2411f02d25887c8a68eaa2965df3cd25f5ff06d31787a3de5e369"
   end
 
   resource "vi" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/vi/aspell6-vi-0.01.1-1.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/vi/aspell6-vi-0.01.1-1.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/vi/aspell6-vi-0.01.1-1.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/vi/aspell6-vi-0.01.1-1.tar.bz2"
     sha256 "3cd85d53bb62b0d104cb5c03e142c3bbe1ad64329d7beae057854816dc7e7c17"
   end
 
   resource "wa" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/wa/aspell-wa-0.50-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/wa/aspell-wa-0.50-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/wa/aspell-wa-0.50-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/wa/aspell-wa-0.50-0.tar.bz2"
     sha256 "5a17aa8aa37afbcc8f52336476670b93cba16462bcb89dd46b80f4d9cfe73fe4"
   end
 
   resource "yi" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/yi/aspell6-yi-0.01.1-1.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/yi/aspell6-yi-0.01.1-1.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/yi/aspell6-yi-0.01.1-1.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/yi/aspell6-yi-0.01.1-1.tar.bz2"
     sha256 "9879d35a5b0b86f8e217601568480f2f634bc8b7a97341e9e80b0d40a8202856"
   end
 
   resource "zu" do
-    url "https://ftp.gnu.org/gnu/aspell/dict/zu/aspell-zu-0.50-0.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/aspell/dict/zu/aspell-zu-0.50-0.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/aspell/dict/zu/aspell-zu-0.50-0.tar.bz2"
+    mirror "https://ftp.gnu.org/aspell/dict/zu/aspell-zu-0.50-0.tar.bz2"
     sha256 "3fa255cd0b20e6229a53df972fd3c5ed8481db11cfd0347dd3da629bbb7a6796"
   end
 

--- a/Formula/a/autoconf-archive.rb
+++ b/Formula/a/autoconf-archive.rb
@@ -1,8 +1,8 @@
 class AutoconfArchive < Formula
   desc "Collection of over 500 reusable autoconf macros"
   homepage "https://savannah.gnu.org/projects/autoconf-archive/"
-  url "https://ftp.gnu.org/gnu/autoconf-archive/autoconf-archive-2024.10.16.tar.xz"
-  mirror "https://ftpmirror.gnu.org/autoconf-archive/autoconf-archive-2024.10.16.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/autoconf-archive/autoconf-archive-2024.10.16.tar.xz"
+  mirror "https://ftp.gnu.org/autoconf-archive/autoconf-archive-2024.10.16.tar.xz"
   sha256 "7bcd5d001916f3a50ed7436f4f700e3d2b1bade3ed803219c592d62502a57363"
   license "GPL-3.0-or-later"
 

--- a/Formula/a/autoconf.rb
+++ b/Formula/a/autoconf.rb
@@ -1,8 +1,8 @@
 class Autoconf < Formula
   desc "Automatic configure script builder"
   homepage "https://www.gnu.org/software/autoconf/"
-  url "https://ftp.gnu.org/gnu/autoconf/autoconf-2.72.tar.gz"
-  mirror "https://ftpmirror.gnu.org/autoconf/autoconf-2.72.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/autoconf/autoconf-2.72.tar.gz"
+  mirror "https://ftp.gnu.org/autoconf/autoconf-2.72.tar.gz"
   sha256 "afb181a76e1ee72832f6581c0eddf8df032b83e2e0239ef79ebedc4467d92d6e"
   license all_of: [
     "GPL-3.0-or-later",

--- a/Formula/a/autoconf@2.13.rb
+++ b/Formula/a/autoconf@2.13.rb
@@ -1,8 +1,8 @@
 class AutoconfAT213 < Formula
   desc "Automatic configure script builder"
   homepage "https://www.gnu.org/software/autoconf/"
-  url "https://ftp.gnu.org/gnu/autoconf/autoconf-2.13.tar.gz"
-  mirror "https://ftpmirror.gnu.org/autoconf/autoconf-2.13.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/autoconf/autoconf-2.13.tar.gz"
+  mirror "https://ftp.gnu.org/autoconf/autoconf-2.13.tar.gz"
   sha256 "f0611136bee505811e9ca11ca7ac188ef5323a8e2ef19cffd3edb3cf08fd791e"
   license "GPL-2.0-or-later"
 

--- a/Formula/a/autoconf@2.69.rb
+++ b/Formula/a/autoconf@2.69.rb
@@ -1,8 +1,8 @@
 class AutoconfAT269 < Formula
   desc "Automatic configure script builder"
   homepage "https://www.gnu.org/software/autoconf/"
-  url "https://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz"
-  mirror "https://ftpmirror.gnu.org/autoconf/autoconf-2.69.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz"
+  mirror "https://ftp.gnu.org/autoconf/autoconf-2.69.tar.gz"
   sha256 "954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969"
   license all_of: [
     "GPL-3.0-or-later",

--- a/Formula/a/autogen.rb
+++ b/Formula/a/autogen.rb
@@ -1,8 +1,8 @@
 class Autogen < Formula
   desc "Automated text file generator"
   homepage "https://autogen.sourceforge.net/"
-  url "https://ftp.gnu.org/gnu/autogen/rel5.18.16/autogen-5.18.16.tar.xz"
-  mirror "https://ftpmirror.gnu.org/autogen/rel5.18.16/autogen-5.18.16.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/autogen/rel5.18.16/autogen-5.18.16.tar.xz"
+  mirror "https://ftp.gnu.org/autogen/rel5.18.16/autogen-5.18.16.tar.xz"
   sha256 "f8a13466b48faa3ba99fe17a069e71c9ab006d9b1cfabe699f8c60a47d5bb49a"
   license "GPL-3.0-or-later"
   revision 2

--- a/Formula/a/automake.rb
+++ b/Formula/a/automake.rb
@@ -1,8 +1,8 @@
 class Automake < Formula
   desc "Tool for generating GNU Standards-compliant Makefiles"
   homepage "https://www.gnu.org/software/automake/"
-  url "https://ftp.gnu.org/gnu/automake/automake-1.18.1.tar.xz"
-  mirror "https://ftpmirror.gnu.org/automake/automake-1.18.1.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/automake/automake-1.18.1.tar.xz"
+  mirror "https://ftp.gnu.org/automake/automake-1.18.1.tar.xz"
   sha256 "168aa363278351b89af56684448f525a5bce5079d0b6842bd910fdd3f1646887"
   license "GPL-2.0-or-later"
 

--- a/Formula/b/bash.rb
+++ b/Formula/b/bash.rb
@@ -5,8 +5,8 @@ class Bash < Formula
   head "https://git.savannah.gnu.org/git/bash.git", branch: "master"
 
   stable do
-    url "https://ftp.gnu.org/gnu/bash/bash-5.3.tar.gz"
-    mirror "https://ftpmirror.gnu.org/bash/bash-5.3.tar.gz"
+    url "https://ftpmirror.gnu.org/gnu/bash/bash-5.3.tar.gz"
+    mirror "https://ftp.gnu.org/bash/bash-5.3.tar.gz"
     mirror "https://mirrors.kernel.org/gnu/bash/bash-5.3.tar.gz"
     mirror "https://mirrors.ocf.berkeley.edu/gnu/bash/bash-5.3.tar.gz"
     sha256 "0d5cd86965f869a26cf64f4b71be7b96f90a3ba8b3d74e27e8e9d9d5550f31ba"
@@ -28,8 +28,8 @@ class Bash < Formula
 
     patch_checksum_pairs.each_slice(2) do |p, checksum|
       patch :p0 do
-        url "https://ftp.gnu.org/gnu/bash/bash-5.3-patches/bash53-#{p}"
-        mirror "https://ftpmirror.gnu.org/bash/bash-5.3-patches/bash53-#{p}"
+        url "https://ftpmirror.gnu.org/gnu/bash/bash-5.3-patches/bash53-#{p}"
+        mirror "https://ftp.gnu.org/bash/bash-5.3-patches/bash53-#{p}"
         mirror "https://mirrors.kernel.org/gnu/bash/bash-5.3-patches/bash53-#{p}"
         mirror "https://mirrors.ocf.berkeley.edu/gnu/bash/bash-5.3-patches/bash53-#{p}"
         sha256 checksum
@@ -40,7 +40,7 @@ class Bash < Formula
   # We're not using `url :stable` here because we need `url` to be a string
   # when we use it in the `strategy` block.
   livecheck do
-    url "https://ftp.gnu.org/gnu/bash/?C=M&O=D"
+    url "https://ftpmirror.gnu.org/gnu/bash/?C=M&O=D"
     regex(/href=.*?bash[._-]v?(\d+(?:\.\d+)+)\.t/i)
     strategy :gnu do |page, regex|
       # Match versions from files

--- a/Formula/b/bc.rb
+++ b/Formula/b/bc.rb
@@ -1,8 +1,8 @@
 class Bc < Formula
   desc "Arbitrary precision numeric processing language"
   homepage "https://www.gnu.org/software/bc/"
-  url "https://ftp.gnu.org/gnu/bc/bc-1.08.2.tar.gz"
-  mirror "https://ftpmirror.gnu.org/bc/bc-1.08.2.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/bc/bc-1.08.2.tar.gz"
+  mirror "https://ftp.gnu.org/bc/bc-1.08.2.tar.gz"
   sha256 "ae470fec429775653e042015edc928d07c8c3b2fc59765172a330d3d87785f86"
   license "GPL-3.0-or-later"
 

--- a/Formula/b/berkeley-db@5.rb
+++ b/Formula/b/berkeley-db@5.rb
@@ -32,8 +32,8 @@ class BerkeleyDbAT5 < Formula
   resource "automake" do
     on_linux do
       on_arm do
-        url "https://ftp.gnu.org/gnu/automake/automake-1.16.5.tar.xz"
-        mirror "https://ftpmirror.gnu.org/automake/automake-1.16.5.tar.xz"
+        url "https://ftpmirror.gnu.org/gnu/automake/automake-1.16.5.tar.xz"
+        mirror "https://ftp.gnu.org/automake/automake-1.16.5.tar.xz"
         sha256 "f01d58cd6d9d77fbdca9eb4bbd5ead1988228fdb73d6f7a201f5f8d6b118b469"
       end
     end

--- a/Formula/b/binutils.rb
+++ b/Formula/b/binutils.rb
@@ -1,8 +1,8 @@
 class Binutils < Formula
   desc "GNU binary tools for native development"
   homepage "https://www.gnu.org/software/binutils/binutils.html"
-  url "https://ftp.gnu.org/gnu/binutils/binutils-2.45.tar.bz2"
-  mirror "https://ftpmirror.gnu.org/binutils/binutils-2.45.tar.bz2"
+  url "https://ftpmirror.gnu.org/gnu/binutils/binutils-2.45.tar.bz2"
+  mirror "https://ftp.gnu.org/binutils/binutils-2.45.tar.bz2"
   sha256 "1393f90db70c2ebd785fb434d6127f8888c559d5eeb9c006c354b203bab3473e"
   license all_of: ["GPL-2.0-or-later", "GPL-3.0-or-later", "LGPL-2.0-or-later", "LGPL-3.0-only"]
 

--- a/Formula/b/bison.rb
+++ b/Formula/b/bison.rb
@@ -2,8 +2,8 @@ class Bison < Formula
   desc "Parser generator"
   homepage "https://www.gnu.org/software/bison/"
   # X.Y.9Z are beta releases that sometimes get accidentally uploaded to the release FTP
-  url "https://ftp.gnu.org/gnu/bison/bison-3.8.2.tar.xz"
-  mirror "https://ftpmirror.gnu.org/bison/bison-3.8.2.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/bison/bison-3.8.2.tar.xz"
+  mirror "https://ftp.gnu.org/bison/bison-3.8.2.tar.xz"
   sha256 "9bba0214ccf7f1079c5d59210045227bcf619519840ebfa80cd3849cff5a5bf2"
   license "GPL-3.0-or-later"
   version_scheme 1

--- a/Formula/b/bison@2.7.rb
+++ b/Formula/b/bison@2.7.rb
@@ -1,8 +1,8 @@
 class BisonAT27 < Formula
   desc "Parser generator"
   homepage "https://www.gnu.org/software/bison/"
-  url "https://ftp.gnu.org/gnu/bison/bison-2.7.1.tar.gz"
-  mirror "https://ftpmirror.gnu.org/bison/bison-2.7.1.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/bison/bison-2.7.1.tar.gz"
+  mirror "https://ftp.gnu.org/bison/bison-2.7.1.tar.gz"
   sha256 "08e2296b024bab8ea36f3bb3b91d071165b22afda39a17ffc8ff53ade2883431"
   license "GPL-3.0-or-later"
   revision 1

--- a/Formula/c/cflow.rb
+++ b/Formula/c/cflow.rb
@@ -1,8 +1,8 @@
 class Cflow < Formula
   desc "Generate call graphs from C code"
   homepage "https://www.gnu.org/software/cflow/"
-  url "https://ftp.gnu.org/gnu/cflow/cflow-1.8.tar.bz2"
-  mirror "https://ftpmirror.gnu.org/cflow/cflow-1.8.tar.bz2"
+  url "https://ftpmirror.gnu.org/gnu/cflow/cflow-1.8.tar.bz2"
+  mirror "https://ftp.gnu.org/cflow/cflow-1.8.tar.bz2"
   sha256 "8321627b55b6c7877f6a43fcc6f9f846a94b1476a081a035465f7a78d3499ab8"
   license "GPL-3.0-or-later"
 

--- a/Formula/c/coreutils.rb
+++ b/Formula/c/coreutils.rb
@@ -1,8 +1,8 @@
 class Coreutils < Formula
   desc "GNU File, Shell, and Text utilities"
   homepage "https://www.gnu.org/software/coreutils/"
-  url "https://ftp.gnu.org/gnu/coreutils/coreutils-9.7.tar.xz"
-  mirror "https://ftpmirror.gnu.org/coreutils/coreutils-9.7.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/coreutils/coreutils-9.7.tar.xz"
+  mirror "https://ftp.gnu.org/coreutils/coreutils-9.7.tar.xz"
   sha256 "e8bb26ad0293f9b5a1fc43fb42ba970e312c66ce92c1b0b16713d7500db251bf"
   license "GPL-3.0-or-later"
 

--- a/Formula/c/cpio.rb
+++ b/Formula/c/cpio.rb
@@ -1,8 +1,8 @@
 class Cpio < Formula
   desc "Copies files into or out of a cpio or tar archive"
   homepage "https://www.gnu.org/software/cpio/"
-  url "https://ftp.gnu.org/gnu/cpio/cpio-2.15.tar.bz2"
-  mirror "https://ftpmirror.gnu.org/cpio/cpio-2.15.tar.bz2"
+  url "https://ftpmirror.gnu.org/gnu/cpio/cpio-2.15.tar.bz2"
+  mirror "https://ftp.gnu.org/cpio/cpio-2.15.tar.bz2"
   sha256 "937610b97c329a1ec9268553fb780037bcfff0dcffe9725ebc4fd9c1aa9075db"
   license "GPL-3.0-or-later"
 

--- a/Formula/c/cppi.rb
+++ b/Formula/c/cppi.rb
@@ -1,8 +1,8 @@
 class Cppi < Formula
   desc "Indent C preprocessor directives to reflect their nesting"
   homepage "https://www.gnu.org/software/cppi/"
-  url "https://ftp.gnu.org/gnu/cppi/cppi-1.18.tar.xz"
-  mirror "https://ftpmirror.gnu.org/cppi/cppi-1.18.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/cppi/cppi-1.18.tar.xz"
+  mirror "https://ftp.gnu.org/cppi/cppi-1.18.tar.xz"
   sha256 "12a505b98863f6c5cf1f749f9080be3b42b3eac5a35b59630e67bea7241364ca"
   license "GPL-3.0-or-later"
 

--- a/Formula/c/cvs.rb
+++ b/Formula/c/cvs.rb
@@ -6,13 +6,13 @@
 class Cvs < Formula
   desc "Version control system"
   homepage "https://www.nongnu.org/cvs/"
-  url "https://ftp.gnu.org/non-gnu/cvs/source/feature/1.12.13/cvs-1.12.13.tar.bz2"
+  url "https://ftpmirror.gnu.org/non-gnu/cvs/source/feature/1.12.13/cvs-1.12.13.tar.bz2"
   sha256 "78853613b9a6873a30e1cc2417f738c330e75f887afdaf7b3d0800cb19ca515e"
   license all_of: ["GPL-2.0-or-later", "LGPL-2.0-or-later"]
   revision 4
 
   livecheck do
-    url "https://ftp.gnu.org/non-gnu/cvs/source/feature/"
+    url "https://ftpmirror.gnu.org/non-gnu/cvs/source/feature/"
     regex(%r{href=.*?v?(\d+(?:\.\d+)+)/}i)
   end
 

--- a/Formula/d/datamash.rb
+++ b/Formula/d/datamash.rb
@@ -1,8 +1,8 @@
 class Datamash < Formula
   desc "Tool to perform numerical, textual & statistical operations"
   homepage "https://www.gnu.org/software/datamash/"
-  url "https://ftp.gnu.org/gnu/datamash/datamash-1.9.tar.gz"
-  mirror "https://ftpmirror.gnu.org/datamash/datamash-1.9.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/datamash/datamash-1.9.tar.gz"
+  mirror "https://ftp.gnu.org/datamash/datamash-1.9.tar.gz"
   sha256 "f382ebda03650dd679161f758f9c0a6cc9293213438d4a77a8eda325aacb87d2"
   license "GPL-3.0-or-later"
 

--- a/Formula/d/ddd.rb
+++ b/Formula/d/ddd.rb
@@ -1,8 +1,8 @@
 class Ddd < Formula
   desc "Graphical front-end for command-line debuggers"
   homepage "https://www.gnu.org/software/ddd/"
-  url "https://ftp.gnu.org/gnu/ddd/ddd-3.4.1.tar.gz"
-  mirror "https://ftpmirror.gnu.org/ddd/ddd-3.4.1.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/ddd/ddd-3.4.1.tar.gz"
+  mirror "https://ftp.gnu.org/ddd/ddd-3.4.1.tar.gz"
   sha256 "b87517a6c3f9611566347e283a2cf931fa369919b553536a2235e63402f4ee89"
   license all_of: [
     "GPL-3.0-or-later",

--- a/Formula/d/ddrescue.rb
+++ b/Formula/d/ddrescue.rb
@@ -1,8 +1,8 @@
 class Ddrescue < Formula
   desc "GNU data recovery tool"
   homepage "https://www.gnu.org/software/ddrescue/ddrescue.html"
-  url "https://ftp.gnu.org/gnu/ddrescue/ddrescue-1.29.1.tar.lz"
-  mirror "https://ftpmirror.gnu.org/ddrescue/ddrescue-1.29.1.tar.lz"
+  url "https://ftpmirror.gnu.org/gnu/ddrescue/ddrescue-1.29.1.tar.lz"
+  mirror "https://ftp.gnu.org/ddrescue/ddrescue-1.29.1.tar.lz"
   sha256 "ddd7d45df026807835a2ec6ab9c365df2ef19e8de1a50ffe6886cd391e04dd75"
   license "GPL-2.0-or-later"
 

--- a/Formula/d/deja-gnu.rb
+++ b/Formula/d/deja-gnu.rb
@@ -1,8 +1,8 @@
 class DejaGnu < Formula
   desc "Framework for testing other programs"
   homepage "https://www.gnu.org/software/dejagnu/"
-  url "https://ftp.gnu.org/gnu/dejagnu/dejagnu-1.6.3.tar.gz"
-  mirror "https://ftpmirror.gnu.org/dejagnu/dejagnu-1.6.3.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/dejagnu/dejagnu-1.6.3.tar.gz"
+  mirror "https://ftp.gnu.org/dejagnu/dejagnu-1.6.3.tar.gz"
   sha256 "87daefacd7958b4a69f88c6856dbd1634261963c414079d0c371f589cd66a2e3"
   license "GPL-3.0-or-later"
 

--- a/Formula/d/diction.rb
+++ b/Formula/d/diction.rb
@@ -1,8 +1,8 @@
 class Diction < Formula
   desc "GNU diction and style"
   homepage "https://www.gnu.org/software/diction/"
-  url "https://ftp.gnu.org/gnu/diction/diction-1.11.tar.gz"
-  mirror "https://ftpmirror.gnu.org/diction/diction-1.11.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/diction/diction-1.11.tar.gz"
+  mirror "https://ftp.gnu.org/diction/diction-1.11.tar.gz"
   sha256 "35c2f1bf8ddf0d5fa9f737ffc8e55230736e5d850ff40b57fdf5ef1d7aa024f6"
   license "GPL-3.0-or-later"
 

--- a/Formula/d/diffutils.rb
+++ b/Formula/d/diffutils.rb
@@ -1,8 +1,8 @@
 class Diffutils < Formula
   desc "File comparison utilities"
   homepage "https://www.gnu.org/software/diffutils/"
-  url "https://ftp.gnu.org/gnu/diffutils/diffutils-3.12.tar.xz"
-  mirror "https://ftpmirror.gnu.org/diffutils/diffutils-3.12.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/diffutils/diffutils-3.12.tar.xz"
+  mirror "https://ftp.gnu.org/diffutils/diffutils-3.12.tar.xz"
   sha256 "7c8b7f9fc8609141fdea9cece85249d308624391ff61dedaf528fcb337727dfd"
   license "GPL-3.0-or-later"
 

--- a/Formula/d/direvent.rb
+++ b/Formula/d/direvent.rb
@@ -1,8 +1,8 @@
 class Direvent < Formula
   desc "Monitors events in the file system directories"
   homepage "https://www.gnu.org.ua/software/direvent/direvent.html"
-  url "https://ftp.gnu.org/gnu/direvent/direvent-5.4.tar.gz"
-  mirror "https://ftpmirror.gnu.org/direvent/direvent-5.4.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/direvent/direvent-5.4.tar.gz"
+  mirror "https://ftp.gnu.org/direvent/direvent-5.4.tar.gz"
   sha256 "1dbbc6192aab67e345725148603d570c6a2828380c964215762af91524d795ba"
   license "GPL-3.0-or-later"
 

--- a/Formula/e/ed.rb
+++ b/Formula/e/ed.rb
@@ -1,8 +1,8 @@
 class Ed < Formula
   desc "Classic UNIX line editor"
   homepage "https://www.gnu.org/software/ed/ed.html"
-  url "https://ftp.gnu.org/gnu/ed/ed-1.22.1.tar.lz"
-  mirror "https://ftpmirror.gnu.org/ed/ed-1.22.1.tar.lz"
+  url "https://ftpmirror.gnu.org/gnu/ed/ed-1.22.1.tar.lz"
+  mirror "https://ftp.gnu.org/ed/ed-1.22.1.tar.lz"
   sha256 "1af541116796d6b9e4b66ef9c45ddce0e15a19ed62bfca362ccd7d472cc1c8fb"
   license "GPL-3.0-or-later"
 

--- a/Formula/e/emacs.rb
+++ b/Formula/e/emacs.rb
@@ -1,8 +1,8 @@
 class Emacs < Formula
   desc "GNU Emacs text editor"
   homepage "https://www.gnu.org/software/emacs/"
-  url "https://ftp.gnu.org/gnu/emacs/emacs-30.1.tar.xz"
-  mirror "https://ftpmirror.gnu.org/emacs/emacs-30.1.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/emacs/emacs-30.1.tar.xz"
+  mirror "https://ftp.gnu.org/emacs/emacs-30.1.tar.xz"
   sha256 "6ccac1ae76e6af93c6de1df175e8eb406767c23da3dd2a16aa67e3124a6f138f"
   license "GPL-3.0-or-later"
 

--- a/Formula/e/enscript.rb
+++ b/Formula/e/enscript.rb
@@ -1,8 +1,8 @@
 class Enscript < Formula
   desc "Convert text to Postscript, HTML, or RTF, with syntax highlighting"
   homepage "https://www.gnu.org/software/enscript/"
-  url "https://ftp.gnu.org/gnu/enscript/enscript-1.6.6.tar.gz"
-  mirror "https://ftpmirror.gnu.org/enscript/enscript-1.6.6.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/enscript/enscript-1.6.6.tar.gz"
+  mirror "https://ftp.gnu.org/enscript/enscript-1.6.6.tar.gz"
   sha256 "6d56bada6934d055b34b6c90399aa85975e66457ac5bf513427ae7fc77f5c0bb"
   license "GPL-3.0-or-later"
   revision 1

--- a/Formula/f/findutils.rb
+++ b/Formula/f/findutils.rb
@@ -1,8 +1,8 @@
 class Findutils < Formula
   desc "Collection of GNU find, xargs, and locate"
   homepage "https://www.gnu.org/software/findutils/"
-  url "https://ftp.gnu.org/gnu/findutils/findutils-4.10.0.tar.xz"
-  mirror "https://ftpmirror.gnu.org/findutils/findutils-4.10.0.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/findutils/findutils-4.10.0.tar.xz"
+  mirror "https://ftp.gnu.org/findutils/findutils-4.10.0.tar.xz"
   sha256 "1387e0b67ff247d2abde998f90dfbf70c1491391a59ddfecb8ae698789f0a4f5"
   license "GPL-3.0-or-later"
 

--- a/Formula/f/freedink.rb
+++ b/Formula/f/freedink.rb
@@ -1,7 +1,7 @@
 class Freedink < Formula
   desc "Portable version of the Dink Smallwood game engine"
   homepage "https://www.gnu.org/software/freedink/"
-  url "https://ftp.gnu.org/gnu/freedink/freedink-109.6.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/freedink/freedink-109.6.tar.gz"
   sha256 "5e0b35ac8f46d7bb87e656efd5f9c7c2ac1a6c519a908fc5b581e52657981002"
   license "GPL-3.0-or-later"
   revision 1
@@ -41,7 +41,7 @@ class Freedink < Formula
   depends_on "sdl2_ttf"
 
   resource "freedink-data" do
-    url "https://ftp.gnu.org/gnu/freedink/freedink-data-1.08.20190120.tar.gz"
+    url "https://ftpmirror.gnu.org/gnu/freedink/freedink-data-1.08.20190120.tar.gz"
     sha256 "715f44773b05b73a9ec9b62b0e152f3f281be1a1512fbaaa386176da94cffb9d"
   end
 

--- a/Formula/f/freeipmi.rb
+++ b/Formula/f/freeipmi.rb
@@ -1,8 +1,8 @@
 class Freeipmi < Formula
   desc "In-band and out-of-band IPMI (v1.5/2.0) software"
   homepage "https://www.gnu.org/software/freeipmi/"
-  url "https://ftp.gnu.org/gnu/freeipmi/freeipmi-1.6.15.tar.gz"
-  mirror "https://ftpmirror.gnu.org/freeipmi/freeipmi-1.6.15.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/freeipmi/freeipmi-1.6.15.tar.gz"
+  mirror "https://ftp.gnu.org/freeipmi/freeipmi-1.6.15.tar.gz"
   sha256 "d6929c354639f5ce75b5b1897e8b366eb63625c23e5c4590a7aea034fe2b8caf"
   license "GPL-3.0-or-later"
 

--- a/Formula/g/gawk.rb
+++ b/Formula/g/gawk.rb
@@ -1,8 +1,8 @@
 class Gawk < Formula
   desc "GNU awk utility"
   homepage "https://www.gnu.org/software/gawk/"
-  url "https://ftp.gnu.org/gnu/gawk/gawk-5.3.1.tar.xz"
-  mirror "https://ftpmirror.gnu.org/gawk/gawk-5.3.1.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/gawk/gawk-5.3.1.tar.xz"
+  mirror "https://ftp.gnu.org/gawk/gawk-5.3.1.tar.xz"
   sha256 "694db764812a6236423d4ff40ceb7b6c4c441301b72ad502bb5c27e00cd56f78"
   license "GPL-3.0-or-later"
   head "https://git.savannah.gnu.org/git/gawk.git", branch: "master"

--- a/Formula/g/gcc.rb
+++ b/Formula/g/gcc.rb
@@ -5,8 +5,8 @@ class Gcc < Formula
   head "https://gcc.gnu.org/git/gcc.git", branch: "master"
 
   stable do
-    url "https://ftp.gnu.org/gnu/gcc/gcc-15.1.0/gcc-15.1.0.tar.xz"
-    mirror "https://ftpmirror.gnu.org/gcc/gcc-15.1.0/gcc-15.1.0.tar.xz"
+    url "https://ftpmirror.gnu.org/gnu/gcc/gcc-15.1.0/gcc-15.1.0.tar.xz"
+    mirror "https://ftp.gnu.org/gcc/gcc-15.1.0/gcc-15.1.0.tar.xz"
     sha256 "e2b09ec21660f01fecffb715e0120265216943f038d0e48a9868713e54f06cea"
 
     # Branch from the Darwin maintainer of GCC, with a few generic fixes and

--- a/Formula/g/gcc@10.rb
+++ b/Formula/g/gcc@10.rb
@@ -1,8 +1,8 @@
 class GccAT10 < Formula
   desc "GNU compiler collection"
   homepage "https://gcc.gnu.org/"
-  url "https://ftp.gnu.org/gnu/gcc/gcc-10.5.0/gcc-10.5.0.tar.xz"
-  mirror "https://ftpmirror.gnu.org/gcc/gcc-10.5.0/gcc-10.5.0.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/gcc/gcc-10.5.0/gcc-10.5.0.tar.xz"
+  mirror "https://ftp.gnu.org/gcc/gcc-10.5.0/gcc-10.5.0.tar.xz"
   sha256 "25109543fdf46f397c347b5d8b7a2c7e5694a5a51cce4b9c6e1ea8a71ca307c1"
   license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }
 

--- a/Formula/g/gcc@11.rb
+++ b/Formula/g/gcc@11.rb
@@ -2,8 +2,8 @@ class GccAT11 < Formula
   desc "GNU compiler collection"
   homepage "https://gcc.gnu.org/"
   # TODO: Remove maximum_macos if Xcode 16 support is added to https://github.com/iains/gcc-11-branch
-  url "https://ftp.gnu.org/gnu/gcc/gcc-11.5.0/gcc-11.5.0.tar.xz"
-  mirror "https://ftpmirror.gnu.org/gcc/gcc-11.5.0/gcc-11.5.0.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/gcc/gcc-11.5.0/gcc-11.5.0.tar.xz"
+  mirror "https://ftp.gnu.org/gcc/gcc-11.5.0/gcc-11.5.0.tar.xz"
   sha256 "a6e21868ead545cf87f0c01f84276e4b5281d672098591c1c896241f09363478"
   license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }
 

--- a/Formula/g/gcc@12.rb
+++ b/Formula/g/gcc@12.rb
@@ -2,8 +2,8 @@ class GccAT12 < Formula
   desc "GNU compiler collection"
   homepage "https://gcc.gnu.org/"
   # TODO: Remove maximum_macos if Xcode 16 support is added to https://github.com/iains/gcc-12-branch
-  url "https://ftp.gnu.org/gnu/gcc/gcc-12.4.0/gcc-12.4.0.tar.xz"
-  mirror "https://ftpmirror.gnu.org/gcc/gcc-12.4.0/gcc-12.4.0.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/gcc/gcc-12.4.0/gcc-12.4.0.tar.xz"
+  mirror "https://ftp.gnu.org/gcc/gcc-12.4.0/gcc-12.4.0.tar.xz"
   sha256 "704f652604ccbccb14bdabf3478c9511c89788b12cb3bbffded37341916a9175"
   license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }
 

--- a/Formula/g/gcc@13.rb
+++ b/Formula/g/gcc@13.rb
@@ -1,8 +1,8 @@
 class GccAT13 < Formula
   desc "GNU compiler collection"
   homepage "https://gcc.gnu.org/"
-  url "https://ftp.gnu.org/gnu/gcc/gcc-13.4.0/gcc-13.4.0.tar.xz"
-  mirror "https://ftpmirror.gnu.org/gcc/gcc-13.4.0/gcc-13.4.0.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/gcc/gcc-13.4.0/gcc-13.4.0.tar.xz"
+  mirror "https://ftp.gnu.org/gcc/gcc-13.4.0/gcc-13.4.0.tar.xz"
   sha256 "9c4ce6dbb040568fdc545588ac03c5cbc95a8dbf0c7aa490170843afb59ca8f5"
   license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }
 

--- a/Formula/g/gcc@14.rb
+++ b/Formula/g/gcc@14.rb
@@ -1,8 +1,8 @@
 class GccAT14 < Formula
   desc "GNU compiler collection"
   homepage "https://gcc.gnu.org/"
-  url "https://ftp.gnu.org/gnu/gcc/gcc-14.3.0/gcc-14.3.0.tar.xz"
-  mirror "https://ftpmirror.gnu.org/gcc/gcc-14.3.0/gcc-14.3.0.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/gcc/gcc-14.3.0/gcc-14.3.0.tar.xz"
+  mirror "https://ftp.gnu.org/gcc/gcc-14.3.0/gcc-14.3.0.tar.xz"
   sha256 "e0dc77297625631ac8e50fa92fffefe899a4eb702592da5c32ef04e2293aca3a"
   license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }
 

--- a/Formula/g/gcc@9.rb
+++ b/Formula/g/gcc@9.rb
@@ -1,8 +1,8 @@
 class GccAT9 < Formula
   desc "GNU compiler collection"
   homepage "https://gcc.gnu.org/"
-  url "https://ftp.gnu.org/gnu/gcc/gcc-9.5.0/gcc-9.5.0.tar.xz"
-  mirror "https://ftpmirror.gnu.org/gcc/gcc-9.5.0/gcc-9.5.0.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/gcc/gcc-9.5.0/gcc-9.5.0.tar.xz"
+  mirror "https://ftp.gnu.org/gcc/gcc-9.5.0/gcc-9.5.0.tar.xz"
   sha256 "27769f64ef1d4cd5e2be8682c0c93f9887983e6cfd1a927ce5a0a2915a95cf8f"
   license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }
 

--- a/Formula/g/gdb.rb
+++ b/Formula/g/gdb.rb
@@ -1,8 +1,8 @@
 class Gdb < Formula
   desc "GNU debugger"
   homepage "https://www.gnu.org/software/gdb/"
-  url "https://ftp.gnu.org/gnu/gdb/gdb-16.3.tar.xz"
-  mirror "https://ftpmirror.gnu.org/gdb/gdb-16.3.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/gdb/gdb-16.3.tar.xz"
+  mirror "https://ftp.gnu.org/gdb/gdb-16.3.tar.xz"
   sha256 "bcfcd095528a987917acf9fff3f1672181694926cc18d609c99d0042c00224c5"
   license "GPL-3.0-or-later"
   head "https://sourceware.org/git/binutils-gdb.git", branch: "master"

--- a/Formula/g/gdbm.rb
+++ b/Formula/g/gdbm.rb
@@ -1,8 +1,8 @@
 class Gdbm < Formula
   desc "GNU database manager"
   homepage "https://www.gnu.org.ua/software/gdbm/"
-  url "https://ftp.gnu.org/gnu/gdbm/gdbm-1.26.tar.gz"
-  mirror "https://ftpmirror.gnu.org/gdbm/gdbm-1.26.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/gdbm/gdbm-1.26.tar.gz"
+  mirror "https://ftp.gnu.org/gdbm/gdbm-1.26.tar.gz"
   sha256 "6a24504a14de4a744103dcb936be976df6fbe88ccff26065e54c1c47946f4a5e"
   license "GPL-3.0-or-later"
 

--- a/Formula/g/gengetopt.rb
+++ b/Formula/g/gengetopt.rb
@@ -1,8 +1,8 @@
 class Gengetopt < Formula
   desc "Generate C code to parse command-line arguments via getopt_long"
   homepage "https://www.gnu.org/software/gengetopt/"
-  url "https://ftp.gnu.org/gnu/gengetopt/gengetopt-2.23.tar.xz"
-  mirror "https://ftpmirror.gnu.org/gengetopt/gengetopt-2.23.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/gengetopt/gengetopt-2.23.tar.xz"
+  mirror "https://ftp.gnu.org/gengetopt/gengetopt-2.23.tar.xz"
   sha256 "b941aec9011864978dd7fdeb052b1943535824169d2aa2b0e7eae9ab807584ac"
   license "GPL-3.0-or-later"
 

--- a/Formula/g/gettext.rb
+++ b/Formula/g/gettext.rb
@@ -1,8 +1,8 @@
 class Gettext < Formula
   desc "GNU internationalization (i18n) and localization (l10n) library"
   homepage "https://www.gnu.org/software/gettext/"
-  url "https://ftp.gnu.org/gnu/gettext/gettext-0.26.tar.gz"
-  mirror "https://ftpmirror.gnu.org/gettext/gettext-0.26.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/gettext/gettext-0.26.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/gettext/gettext-0.26.tar.gz"
   mirror "http://ftp.gnu.org/gnu/gettext/gettext-0.26.tar.gz"
   sha256 "39acf4b0371e9b110b60005562aace5b3631fed9b1bb9ecccfc7f56e58bb1d7f"
   license "GPL-3.0-or-later"

--- a/Formula/g/gforth.rb
+++ b/Formula/g/gforth.rb
@@ -1,7 +1,7 @@
 class Gforth < Formula
   desc "Implementation of the ANS Forth language"
   homepage "https://www.gnu.org/software/gforth/"
-  url "https://ftp.gnu.org/gnu/gforth/gforth-0.7.3.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/gforth/gforth-0.7.3.tar.gz"
   sha256 "2f62f2233bf022c23d01c920b1556aa13eab168e3236b13352ac5e9f18542bb0"
   license "GPL-3.0-or-later"
   revision 3

--- a/Formula/g/glibc.rb
+++ b/Formula/g/glibc.rb
@@ -43,8 +43,8 @@ end
 class Glibc < Formula
   desc "GNU C Library"
   homepage "https://www.gnu.org/software/libc/"
-  url "https://ftp.gnu.org/gnu/glibc/glibc-2.35.tar.gz"
-  mirror "https://ftpmirror.gnu.org/gnu/glibc/glibc-2.35.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/glibc/glibc-2.35.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/glibc/glibc-2.35.tar.gz"
   sha256 "3e8e0c6195da8dfbd31d77c56fb8d99576fb855fafd47a9e0a895e51fd5942d4"
   license all_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later"]
   revision 1

--- a/Formula/g/glibc@2.13.rb
+++ b/Formula/g/glibc@2.13.rb
@@ -62,8 +62,8 @@ end
 class GlibcAT213 < Formula
   desc "GNU C Library"
   homepage "https://www.gnu.org/software/libc/"
-  url "https://ftp.gnu.org/gnu/glibc/glibc-2.13.tar.gz"
-  mirror "https://ftpmirror.gnu.org/gnu/glibc/glibc-2.13.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/glibc/glibc-2.13.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/glibc/glibc-2.13.tar.gz"
   sha256 "bd90d6119bcc2898befd6e1bbb2cb1ed3bb1c2997d5eaa6fdbca4ee16191a906"
   license all_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later"]
   revision 1

--- a/Formula/g/glibc@2.17.rb
+++ b/Formula/g/glibc@2.17.rb
@@ -62,8 +62,8 @@ end
 class GlibcAT217 < Formula
   desc "GNU C Library"
   homepage "https://www.gnu.org/software/libc/"
-  url "https://ftp.gnu.org/gnu/glibc/glibc-2.17.tar.gz"
-  mirror "https://ftpmirror.gnu.org/gnu/glibc/glibc-2.17.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/glibc/glibc-2.17.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/glibc/glibc-2.17.tar.gz"
   sha256 "a3b2086d5414e602b4b3d5a8792213feb3be664ffc1efe783a829818d3fca37a"
   license all_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later"]
 

--- a/Formula/g/global.rb
+++ b/Formula/g/global.rb
@@ -4,8 +4,8 @@ class Global < Formula
 
   desc "Source code tag system"
   homepage "https://www.gnu.org/software/global/"
-  url "https://ftp.gnu.org/gnu/global/global-6.6.14.tar.gz"
-  mirror "https://ftpmirror.gnu.org/global/global-6.6.14.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/global/global-6.6.14.tar.gz"
+  mirror "https://ftp.gnu.org/global/global-6.6.14.tar.gz"
   sha256 "f6e7fd0b68aed292e85bb686616baf6551d5c9424adcddca11d808ba318cb320"
   license "GPL-3.0-or-later"
 

--- a/Formula/g/glpk.rb
+++ b/Formula/g/glpk.rb
@@ -1,8 +1,8 @@
 class Glpk < Formula
   desc "Library for Linear and Mixed-Integer Programming"
   homepage "https://www.gnu.org/software/glpk/"
-  url "https://ftp.gnu.org/gnu/glpk/glpk-5.0.tar.gz"
-  mirror "https://ftpmirror.gnu.org/glpk/glpk-5.0.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/glpk/glpk-5.0.tar.gz"
+  mirror "https://ftp.gnu.org/glpk/glpk-5.0.tar.gz"
   sha256 "4a1013eebb50f728fc601bdd833b0b2870333c3b3e5a816eeba921d95bec6f15"
   license "GPL-3.0-or-later"
 

--- a/Formula/g/gmp.rb
+++ b/Formula/g/gmp.rb
@@ -2,7 +2,7 @@ class Gmp < Formula
   desc "GNU multiple precision arithmetic library"
   homepage "https://gmplib.org/"
   # gmplib.org blocks GitHub server IPs, so it should not be the primary URL
-  url "https://ftp.gnu.org/gnu/gmp/gmp-6.3.0.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/gmp/gmp-6.3.0.tar.xz"
   mirror "https://gmplib.org/download/gmp/gmp-6.3.0.tar.xz"
   sha256 "a3c2b80201b89e68616f4ad30bc66aee4927c3ce50e33929ca819d5c43538898"
   license any_of: ["LGPL-3.0-or-later", "GPL-2.0-or-later"]

--- a/Formula/g/gnu-apl.rb
+++ b/Formula/g/gnu-apl.rb
@@ -1,8 +1,8 @@
 class GnuApl < Formula
   desc "GNU implementation of the programming language APL"
   homepage "https://www.gnu.org/software/apl/"
-  url "https://ftp.gnu.org/gnu/apl/apl-1.9.tar.gz"
-  mirror "https://ftpmirror.gnu.org/apl/apl-1.9.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/apl/apl-1.9.tar.gz"
+  mirror "https://ftp.gnu.org/apl/apl-1.9.tar.gz"
   sha256 "291867f1b1937693abb57be7d9a37618b0376e3e2709574854a7bbe52bb28eb8"
   license "GPL-3.0-or-later"
 

--- a/Formula/g/gnu-barcode.rb
+++ b/Formula/g/gnu-barcode.rb
@@ -1,8 +1,8 @@
 class GnuBarcode < Formula
   desc "Convert text strings to printed bars"
   homepage "https://www.gnu.org/software/barcode/"
-  url "https://ftp.gnu.org/gnu/barcode/barcode-0.99.tar.gz"
-  mirror "https://ftpmirror.gnu.org/barcode/barcode-0.99.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/barcode/barcode-0.99.tar.gz"
+  mirror "https://ftp.gnu.org/barcode/barcode-0.99.tar.gz"
   sha256 "7c031cf3eb811242f53664379aebbdd9fae0b7b26b5e5d584c31a9f338154b64"
   license "GPL-3.0-or-later"
 

--- a/Formula/g/gnu-chess.rb
+++ b/Formula/g/gnu-chess.rb
@@ -1,8 +1,8 @@
 class GnuChess < Formula
   desc "Chess-playing program"
   homepage "https://www.gnu.org/software/chess/"
-  url "https://ftp.gnu.org/gnu/chess/gnuchess-6.2.11.tar.gz"
-  mirror "https://ftpmirror.gnu.org/chess/gnuchess-6.2.11.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/chess/gnuchess-6.2.11.tar.gz"
+  mirror "https://ftp.gnu.org/chess/gnuchess-6.2.11.tar.gz"
   sha256 "d81140eea5c69d14b0cfb63816d4b4c9e18fba51f5267de5b1539f468939e9bd"
   license "GPL-3.0-or-later"
 
@@ -32,11 +32,11 @@ class GnuChess < Formula
   depends_on "readline"
 
   resource "book" do
-    url "https://ftp.gnu.org/gnu/chess/book_1.02.pgn.gz"
+    url "https://ftpmirror.gnu.org/gnu/chess/book_1.02.pgn.gz"
     sha256 "deac77edb061a59249a19deb03da349cae051e52527a6cb5af808d9398d32d44"
 
     livecheck do
-      url "https://ftp.gnu.org/gnu/chess/"
+      url "https://ftpmirror.gnu.org/gnu/chess/"
       regex(/href=.*?book[._-]v?(\d+(?:\.\d+)+\.pgn)/i)
     end
   end

--- a/Formula/g/gnu-complexity.rb
+++ b/Formula/g/gnu-complexity.rb
@@ -1,8 +1,8 @@
 class GnuComplexity < Formula
   desc "Measures complexity of C source"
   homepage "https://www.gnu.org/software/complexity/"
-  url "https://ftp.gnu.org/gnu/complexity/complexity-1.13.tar.xz"
-  mirror "https://ftpmirror.gnu.org/complexity/complexity-1.13.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/complexity/complexity-1.13.tar.xz"
+  mirror "https://ftp.gnu.org/complexity/complexity-1.13.tar.xz"
   sha256 "80a625a87ee7c17fed02fb39482a7946fc757f10d8a4ffddc5372b4c4b739e67"
   license "GPL-3.0-or-later"
 

--- a/Formula/g/gnu-go.rb
+++ b/Formula/g/gnu-go.rb
@@ -1,8 +1,8 @@
 class GnuGo < Formula
   desc "Plays the game of Go"
   homepage "https://www.gnu.org/software/gnugo/gnugo.html"
-  url "https://ftp.gnu.org/gnu/gnugo/gnugo-3.8.tar.gz"
-  mirror "https://ftpmirror.gnu.org/gnugo/gnugo-3.8.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/gnugo/gnugo-3.8.tar.gz"
+  mirror "https://ftp.gnu.org/gnugo/gnugo-3.8.tar.gz"
   sha256 "da68d7a65f44dcf6ce6e4e630b6f6dd9897249d34425920bfdd4e07ff1866a72"
   # The `:cannot_represent` is for src/gtp.* which is similar to ICU license if
   # SPDX allowed replacing `this software ... (the "Software")` with `file gtp.c`

--- a/Formula/g/gnu-indent.rb
+++ b/Formula/g/gnu-indent.rb
@@ -1,8 +1,8 @@
 class GnuIndent < Formula
   desc "C code prettifier"
   homepage "https://www.gnu.org/software/indent/"
-  url "https://ftp.gnu.org/gnu/indent/indent-2.2.13.tar.gz"
-  mirror "https://ftpmirror.gnu.org/indent/indent-2.2.13.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/indent/indent-2.2.13.tar.gz"
+  mirror "https://ftp.gnu.org/indent/indent-2.2.13.tar.gz"
   sha256 "9e64634fc4ce6797b204bcb8897ce14fdd0ab48ca57696f78767c59cae578095"
   license "GPL-3.0-or-later"
 

--- a/Formula/g/gnu-sed.rb
+++ b/Formula/g/gnu-sed.rb
@@ -1,8 +1,8 @@
 class GnuSed < Formula
   desc "GNU implementation of the famous stream editor"
   homepage "https://www.gnu.org/software/sed/"
-  url "https://ftp.gnu.org/gnu/sed/sed-4.9.tar.xz"
-  mirror "https://ftpmirror.gnu.org/sed/sed-4.9.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/sed/sed-4.9.tar.xz"
+  mirror "https://ftp.gnu.org/sed/sed-4.9.tar.xz"
   sha256 "6e226b732e1cd739464ad6862bd1a1aba42d7982922da7a53519631d24975181"
   license "GPL-3.0-or-later"
 

--- a/Formula/g/gnu-shogi.rb
+++ b/Formula/g/gnu-shogi.rb
@@ -1,8 +1,8 @@
 class GnuShogi < Formula
   desc "Japanese Chess"
   homepage "https://www.gnu.org/software/gnushogi/"
-  url "https://ftp.gnu.org/gnu/gnushogi/gnushogi-1.4.2.tar.gz"
-  mirror "https://ftpmirror.gnu.org/gnushogi/gnushogi-1.4.2.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/gnushogi/gnushogi-1.4.2.tar.gz"
+  mirror "https://ftp.gnu.org/gnushogi/gnushogi-1.4.2.tar.gz"
   sha256 "1ecc48a866303c63652552b325d685e7ef5e9893244080291a61d96505d52b29"
   license "GPL-3.0-or-later"
 

--- a/Formula/g/gnu-smalltalk.rb
+++ b/Formula/g/gnu-smalltalk.rb
@@ -5,8 +5,8 @@ class GnuSmalltalk < Formula
   revision 10
 
   stable do
-    url "https://ftp.gnu.org/gnu/smalltalk/smalltalk-3.2.5.tar.xz"
-    mirror "https://ftpmirror.gnu.org/smalltalk/smalltalk-3.2.5.tar.xz"
+    url "https://ftpmirror.gnu.org/gnu/smalltalk/smalltalk-3.2.5.tar.xz"
+    mirror "https://ftp.gnu.org/smalltalk/smalltalk-3.2.5.tar.xz"
     sha256 "819a15f7ba8a1b55f5f60b9c9a58badd6f6153b3f987b70e7b167e7755d65acc"
 
     # Backport fix to support ARM macOS and fix build with Xcode 15+

--- a/Formula/g/gnu-tar.rb
+++ b/Formula/g/gnu-tar.rb
@@ -1,8 +1,8 @@
 class GnuTar < Formula
   desc "GNU version of the tar archiving utility"
   homepage "https://www.gnu.org/software/tar/"
-  url "https://ftp.gnu.org/gnu/tar/tar-1.35.tar.gz"
-  mirror "https://ftpmirror.gnu.org/tar/tar-1.35.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/tar/tar-1.35.tar.gz"
+  mirror "https://ftp.gnu.org/tar/tar-1.35.tar.gz"
   sha256 "14d55e32063ea9526e057fbf35fcabd53378e769787eff7919c3755b02d2b57e"
   license "GPL-3.0-or-later"
 

--- a/Formula/g/gnu-time.rb
+++ b/Formula/g/gnu-time.rb
@@ -1,8 +1,8 @@
 class GnuTime < Formula
   desc "GNU implementation of time utility"
   homepage "https://www.gnu.org/software/time/"
-  url "https://ftp.gnu.org/gnu/time/time-1.9.tar.gz"
-  mirror "https://ftpmirror.gnu.org/time/time-1.9.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/time/time-1.9.tar.gz"
+  mirror "https://ftp.gnu.org/time/time-1.9.tar.gz"
   sha256 "fbacf0c81e62429df3e33bda4cee38756604f18e01d977338e23306a3e3b521e"
   license "GPL-3.0-or-later"
 

--- a/Formula/g/gnu-typist.rb
+++ b/Formula/g/gnu-typist.rb
@@ -1,8 +1,8 @@
 class GnuTypist < Formula
   desc "GNU typing tutor"
   homepage "https://www.gnu.org/software/gtypist/"
-  url "https://ftp.gnu.org/gnu/gtypist/gtypist-2.10.1.tar.xz"
-  mirror "https://ftpmirror.gnu.org/gtypist/gtypist-2.10.1.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/gtypist/gtypist-2.10.1.tar.xz"
+  mirror "https://ftp.gnu.org/gtypist/gtypist-2.10.1.tar.xz"
   sha256 "ca618054e91f1ed5ef043fcc43500bbad701c959c31844d4688ff22849ac252d"
   license "GPL-3.0-or-later"
 

--- a/Formula/g/gnu-units.rb
+++ b/Formula/g/gnu-units.rb
@@ -1,8 +1,8 @@
 class GnuUnits < Formula
   desc "GNU unit conversion tool"
   homepage "https://www.gnu.org/software/units/"
-  url "https://ftp.gnu.org/gnu/units/units-2.24.tar.gz"
-  mirror "https://ftpmirror.gnu.org/units/units-2.24.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/units/units-2.24.tar.gz"
+  mirror "https://ftp.gnu.org/units/units-2.24.tar.gz"
   sha256 "1e502c4edfacf20b29284716c72e5ddb51a495a2365d7b03e7960494c4a0c902"
   license "GPL-3.0-or-later"
 

--- a/Formula/g/gnu-which.rb
+++ b/Formula/g/gnu-which.rb
@@ -2,8 +2,8 @@ class GnuWhich < Formula
   desc "GNU implementation of which utility"
   # Previous homepage is dead. Have linked to the GNU Projects page for now.
   homepage "https://savannah.gnu.org/projects/which/"
-  url "https://ftp.gnu.org/gnu/which/which-2.23.tar.gz"
-  mirror "https://ftpmirror.gnu.org/which/which-2.23.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/which/which-2.23.tar.gz"
+  mirror "https://ftp.gnu.org/which/which-2.23.tar.gz"
   sha256 "a2c558226fc4d9e4ce331bd2fd3c3f17f955115d2c00e447618a4ef9978a2a73"
   license "GPL-3.0-or-later"
 

--- a/Formula/g/gnucobol.rb
+++ b/Formula/g/gnucobol.rb
@@ -1,8 +1,8 @@
 class Gnucobol < Formula
   desc "COBOL85-202x compiler supporting lots of dialect specific extensions"
   homepage "https://gnucobol.sourceforge.io/"
-  url "https://ftp.gnu.org/gnu/gnucobol/gnucobol-3.2.tar.xz"
-  mirror "https://ftpmirror.gnu.org/gnucobol/gnucobol-3.2.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/gnucobol/gnucobol-3.2.tar.xz"
+  mirror "https://ftp.gnu.org/gnucobol/gnucobol-3.2.tar.xz"
   sha256 "3bb48af46ced4779facf41fdc2ee60e4ccb86eaa99d010b36685315df39c2ee2"
   license "GPL-3.0-or-later"
 

--- a/Formula/g/gnunet.rb
+++ b/Formula/g/gnunet.rb
@@ -1,8 +1,8 @@
 class Gnunet < Formula
   desc "Framework for distributed, secure and privacy-preserving applications"
   homepage "https://gnunet.org/"
-  url "https://ftp.gnu.org/gnu/gnunet/gnunet-0.24.3.tar.gz"
-  mirror "https://ftpmirror.gnu.org/gnunet/gnunet-0.24.3.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/gnunet/gnunet-0.24.3.tar.gz"
+  mirror "https://ftp.gnu.org/gnunet/gnunet-0.24.3.tar.gz"
   sha256 "5b06897b0e84489bbb438278ec73e4362442b2e05a63e40023ec1d0cccc6c576"
   license "AGPL-3.0-or-later"
 

--- a/Formula/g/gpatch.rb
+++ b/Formula/g/gpatch.rb
@@ -1,8 +1,8 @@
 class Gpatch < Formula
   desc "Apply a diff file to an original"
   homepage "https://savannah.gnu.org/projects/patch/"
-  url "https://ftp.gnu.org/gnu/patch/patch-2.8.tar.xz"
-  mirror "https://ftpmirror.gnu.org/patch/patch-2.8.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/patch/patch-2.8.tar.xz"
+  mirror "https://ftp.gnu.org/patch/patch-2.8.tar.xz"
   sha256 "f87cee69eec2b4fcbf60a396b030ad6aa3415f192aa5f7ee84cad5e11f7f5ae3"
   license "GPL-3.0-or-later"
 

--- a/Formula/g/gperf.rb
+++ b/Formula/g/gperf.rb
@@ -1,8 +1,8 @@
 class Gperf < Formula
   desc "Perfect hash function generator"
   homepage "https://www.gnu.org/software/gperf/"
-  url "https://ftp.gnu.org/gnu/gperf/gperf-3.3.tar.gz"
-  mirror "https://ftpmirror.gnu.org/gperf/gperf-3.3.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/gperf/gperf-3.3.tar.gz"
+  mirror "https://ftp.gnu.org/gperf/gperf-3.3.tar.gz"
   sha256 "fd87e0aba7e43ae054837afd6cd4db03a3f2693deb3619085e6ed9d8d9604ad8"
   license "GPL-3.0-or-later"
 

--- a/Formula/g/grep.rb
+++ b/Formula/g/grep.rb
@@ -1,8 +1,8 @@
 class Grep < Formula
   desc "GNU grep, egrep and fgrep"
   homepage "https://www.gnu.org/software/grep/"
-  url "https://ftp.gnu.org/gnu/grep/grep-3.12.tar.xz"
-  mirror "https://ftpmirror.gnu.org/grep/grep-3.12.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/grep/grep-3.12.tar.xz"
+  mirror "https://ftp.gnu.org/grep/grep-3.12.tar.xz"
   sha256 "2649b27c0e90e632eadcd757be06c6e9a4f48d941de51e7c0f83ff76408a07b9"
   license "GPL-3.0-or-later"
 

--- a/Formula/g/groff.rb
+++ b/Formula/g/groff.rb
@@ -1,8 +1,8 @@
 class Groff < Formula
   desc "GNU troff text-formatting system"
   homepage "https://www.gnu.org/software/groff/"
-  url "https://ftp.gnu.org/gnu/groff/groff-1.23.0.tar.gz"
-  mirror "https://ftpmirror.gnu.org/groff/groff-1.23.0.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/groff/groff-1.23.0.tar.gz"
+  mirror "https://ftp.gnu.org/groff/groff-1.23.0.tar.gz"
   sha256 "6b9757f592b7518b4902eb6af7e54570bdccba37a871fddb2d30ae3863511c13"
   license "GPL-3.0-or-later"
   revision 1

--- a/Formula/g/gsasl.rb
+++ b/Formula/g/gsasl.rb
@@ -1,8 +1,8 @@
 class Gsasl < Formula
   desc "SASL library command-line interface"
   homepage "https://www.gnu.org/software/gsasl/"
-  url "https://ftp.gnu.org/gnu/gsasl/gsasl-2.2.2.tar.gz"
-  mirror "https://ftpmirror.gnu.org/gsasl/gsasl-2.2.2.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/gsasl/gsasl-2.2.2.tar.gz"
+  mirror "https://ftp.gnu.org/gsasl/gsasl-2.2.2.tar.gz"
   sha256 "41e8e442648eccaf6459d9ad93d4b18530b96c8eaf50e3f342532ef275eff3ba"
   license "GPL-3.0-or-later"
 

--- a/Formula/g/gsl.rb
+++ b/Formula/g/gsl.rb
@@ -1,8 +1,8 @@
 class Gsl < Formula
   desc "Numerical library for C and C++"
   homepage "https://www.gnu.org/software/gsl/"
-  url "https://ftp.gnu.org/gnu/gsl/gsl-2.8.tar.gz"
-  mirror "https://ftpmirror.gnu.org/gsl/gsl-2.8.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/gsl/gsl-2.8.tar.gz"
+  mirror "https://ftp.gnu.org/gsl/gsl-2.8.tar.gz"
   sha256 "6a99eeed15632c6354895b1dd542ed5a855c0f15d9ad1326c6fe2b2c9e423190"
   license "GPL-3.0-or-later"
 

--- a/Formula/g/guile.rb
+++ b/Formula/g/guile.rb
@@ -1,8 +1,8 @@
 class Guile < Formula
   desc "GNU Ubiquitous Intelligent Language for Extensions"
   homepage "https://www.gnu.org/software/guile/"
-  url "https://ftp.gnu.org/gnu/guile/guile-3.0.10.tar.xz"
-  mirror "https://ftpmirror.gnu.org/guile/guile-3.0.10.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/guile/guile-3.0.10.tar.xz"
+  mirror "https://ftp.gnu.org/guile/guile-3.0.10.tar.xz"
   sha256 "bd7168517fd526333446d4f7ab816527925634094fbd37322e17e2b8d8e76388"
   license "LGPL-3.0-or-later"
 

--- a/Formula/g/gzip.rb
+++ b/Formula/g/gzip.rb
@@ -1,8 +1,8 @@
 class Gzip < Formula
   desc "Popular GNU data compression program"
   homepage "https://www.gnu.org/software/gzip/"
-  url "https://ftp.gnu.org/gnu/gzip/gzip-1.14.tar.gz"
-  mirror "https://ftpmirror.gnu.org/gzip/gzip-1.14.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/gzip/gzip-1.14.tar.gz"
+  mirror "https://ftp.gnu.org/gzip/gzip-1.14.tar.gz"
   sha256 "613d6ea44f1248d7370c7ccdeee0dd0017a09e6c39de894b3c6f03f981191c6b"
   license "GPL-3.0-or-later"
 

--- a/Formula/h/hello.rb
+++ b/Formula/h/hello.rb
@@ -1,7 +1,7 @@
 class Hello < Formula
   desc "Program providing model for GNU coding standards and practices"
   homepage "https://www.gnu.org/software/hello/"
-  url "https://ftp.gnu.org/gnu/hello/hello-2.12.2.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/hello/hello-2.12.2.tar.gz"
   sha256 "5a9a996dc292cc24dcf411cee87e92f6aae5b8d13bd9c6819b4c7a9dce0818ab"
   license "GPL-3.0-or-later"
 

--- a/Formula/h/help2man.rb
+++ b/Formula/h/help2man.rb
@@ -1,8 +1,8 @@
 class Help2man < Formula
   desc "Automatically generate simple man pages"
   homepage "https://www.gnu.org/software/help2man/"
-  url "https://ftp.gnu.org/gnu/help2man/help2man-1.49.3.tar.xz"
-  mirror "https://ftpmirror.gnu.org/help2man/help2man-1.49.3.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/help2man/help2man-1.49.3.tar.xz"
+  mirror "https://ftp.gnu.org/help2man/help2man-1.49.3.tar.xz"
   sha256 "4d7e4fdef2eca6afe07a2682151cea78781e0a4e8f9622142d9f70c083a2fd4f"
   license "GPL-3.0-or-later"
   revision 3

--- a/Formula/i/i386-elf-gdb.rb
+++ b/Formula/i/i386-elf-gdb.rb
@@ -1,8 +1,8 @@
 class I386ElfGdb < Formula
   desc "GNU debugger for i386-elf cross development"
   homepage "https://www.gnu.org/software/gdb/"
-  url "https://ftp.gnu.org/gnu/gdb/gdb-16.3.tar.xz"
-  mirror "https://ftpmirror.gnu.org/gdb/gdb-16.3.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/gdb/gdb-16.3.tar.xz"
+  mirror "https://ftp.gnu.org/gdb/gdb-16.3.tar.xz"
   sha256 "bcfcd095528a987917acf9fff3f1672181694926cc18d609c99d0042c00224c5"
   license "GPL-3.0-or-later"
   head "https://sourceware.org/git/binutils-gdb.git", branch: "master"

--- a/Formula/i/i686-elf-binutils.rb
+++ b/Formula/i/i686-elf-binutils.rb
@@ -1,8 +1,8 @@
 class I686ElfBinutils < Formula
   desc "GNU Binutils for i686-elf cross development"
   homepage "https://www.gnu.org/software/binutils/"
-  url "https://ftp.gnu.org/gnu/binutils/binutils-2.45.tar.bz2"
-  mirror "https://ftpmirror.gnu.org/binutils/binutils-2.45.tar.bz2"
+  url "https://ftpmirror.gnu.org/gnu/binutils/binutils-2.45.tar.bz2"
+  mirror "https://ftp.gnu.org/binutils/binutils-2.45.tar.bz2"
   sha256 "1393f90db70c2ebd785fb434d6127f8888c559d5eeb9c006c354b203bab3473e"
   license "GPL-3.0-or-later"
 

--- a/Formula/i/i686-elf-gcc.rb
+++ b/Formula/i/i686-elf-gcc.rb
@@ -1,8 +1,8 @@
 class I686ElfGcc < Formula
   desc "GNU compiler collection for i686-elf"
   homepage "https://gcc.gnu.org"
-  url "https://ftp.gnu.org/gnu/gcc/gcc-15.2.0/gcc-15.2.0.tar.xz"
-  mirror "https://ftpmirror.gnu.org/gcc/gcc-15.2.0/gcc-15.2.0.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/gcc/gcc-15.2.0/gcc-15.2.0.tar.xz"
+  mirror "https://ftp.gnu.org/gcc/gcc-15.2.0/gcc-15.2.0.tar.xz"
   sha256 "438fd996826b0c82485a29da03a72d71d6e3541a83ec702df4271f6fe025d24e"
   license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }
 

--- a/Formula/i/i686-elf-grub.rb
+++ b/Formula/i/i686-elf-grub.rb
@@ -1,7 +1,7 @@
 class I686ElfGrub < Formula
   desc "GNU GRUB bootloader for i686-elf"
   homepage "https://savannah.gnu.org/projects/grub"
-  url "https://ftp.gnu.org/gnu/grub/grub-2.12.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/grub/grub-2.12.tar.xz"
   mirror "https://mirrors.ocf.berkeley.edu/gnu/grub/grub-2.12.tar.xz"
   sha256 "f3c97391f7c4eaa677a78e090c7e97e6dc47b16f655f04683ebd37bef7fe0faa"
   license "GPL-3.0-or-later"

--- a/Formula/i/idutils.rb
+++ b/Formula/i/idutils.rb
@@ -1,8 +1,8 @@
 class Idutils < Formula
   desc "ID database and query tools"
   homepage "https://www.gnu.org/software/idutils/"
-  url "https://ftp.gnu.org/gnu/idutils/idutils-4.6.tar.xz"
-  mirror "https://ftpmirror.gnu.org/idutils/idutils-4.6.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/idutils/idutils-4.6.tar.xz"
+  mirror "https://ftp.gnu.org/idutils/idutils-4.6.tar.xz"
   sha256 "8181f43a4fb62f6f0ccf3b84dbe9bec71ecabd6dfdcf49c6b5584521c888aac2"
   license "GPL-3.0-or-later"
   revision 1

--- a/Formula/i/inetutils.rb
+++ b/Formula/i/inetutils.rb
@@ -1,8 +1,8 @@
 class Inetutils < Formula
   desc "GNU utilities for networking"
   homepage "https://www.gnu.org/software/inetutils/"
-  url "https://ftp.gnu.org/gnu/inetutils/inetutils-2.6.tar.xz"
-  mirror "https://ftpmirror.gnu.org/inetutils/inetutils-2.6.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/inetutils/inetutils-2.6.tar.xz"
+  mirror "https://ftp.gnu.org/inetutils/inetutils-2.6.tar.xz"
   sha256 "68bedbfeaf73f7d86be2a7d99bcfbd4093d829f52770893919ae174c0b2357ca"
   license "GPL-3.0-or-later"
 

--- a/Formula/k/kawa.rb
+++ b/Formula/k/kawa.rb
@@ -1,8 +1,8 @@
 class Kawa < Formula
   desc "Programming language for Java (implementation of Scheme)"
   homepage "https://www.gnu.org/software/kawa/"
-  url "https://ftp.gnu.org/gnu/kawa/kawa-3.1.1.zip"
-  mirror "https://ftpmirror.gnu.org/kawa/kawa-3.1.1.zip"
+  url "https://ftpmirror.gnu.org/gnu/kawa/kawa-3.1.1.zip"
+  mirror "https://ftp.gnu.org/kawa/kawa-3.1.1.zip"
   sha256 "dab1f41da968191fc68be856f133e3d02ce65d2dbd577a27e0490f18ca00fa22"
   license "MIT"
   revision 1

--- a/Formula/l/lightning.rb
+++ b/Formula/l/lightning.rb
@@ -1,8 +1,8 @@
 class Lightning < Formula
   desc "Generates assembly language code at run-time"
   homepage "https://www.gnu.org/software/lightning/"
-  url "https://ftp.gnu.org/gnu/lightning/lightning-2.2.3.tar.gz"
-  mirror "https://ftpmirror.gnu.org/lightning/lightning-2.2.3.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/lightning/lightning-2.2.3.tar.gz"
+  mirror "https://ftp.gnu.org/lightning/lightning-2.2.3.tar.gz"
   sha256 "c045c7a33a00affbfeb11066fa502c03992e474a62ba95977aad06dbc14c6829"
   license "GPL-3.0-or-later"
   revision 1

--- a/Formula/lib/libextractor.rb
+++ b/Formula/lib/libextractor.rb
@@ -1,8 +1,8 @@
 class Libextractor < Formula
   desc "Library to extract meta data from files"
   homepage "https://www.gnu.org/software/libextractor/"
-  url "https://ftp.gnu.org/gnu/libextractor/libextractor-1.13.tar.gz"
-  mirror "https://ftpmirror.gnu.org/libextractor/libextractor-1.13.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/libextractor/libextractor-1.13.tar.gz"
+  mirror "https://ftp.gnu.org/libextractor/libextractor-1.13.tar.gz"
   sha256 "bb8f312c51d202572243f113c6b62d8210301ab30cbaee604f9837d878cdf755"
   license "GPL-3.0-or-later"
 

--- a/Formula/lib/libffcall.rb
+++ b/Formula/lib/libffcall.rb
@@ -1,8 +1,8 @@
 class Libffcall < Formula
   desc "GNU Foreign Function Interface library"
   homepage "https://www.gnu.org/software/libffcall/"
-  url "https://ftp.gnu.org/gnu/libffcall/libffcall-2.5.tar.gz"
-  mirror "https://ftpmirror.gnu.org/gnu/libffcall/libffcall-2.5.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/libffcall/libffcall-2.5.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/libffcall/libffcall-2.5.tar.gz"
   sha256 "7f422096b40498b1389093955825f141bb67ed6014249d884009463dc7846879"
   license "GPL-2.0-or-later"
 

--- a/Formula/lib/libgccjit.rb
+++ b/Formula/lib/libgccjit.rb
@@ -5,8 +5,8 @@ class Libgccjit < Formula
   head "https://gcc.gnu.org/git/gcc.git", branch: "master"
 
   stable do
-    url "https://ftp.gnu.org/gnu/gcc/gcc-15.1.0/gcc-15.1.0.tar.xz"
-    mirror "https://ftpmirror.gnu.org/gcc/gcc-15.1.0/gcc-15.1.0.tar.xz"
+    url "https://ftpmirror.gnu.org/gnu/gcc/gcc-15.1.0/gcc-15.1.0.tar.xz"
+    mirror "https://ftp.gnu.org/gcc/gcc-15.1.0/gcc-15.1.0.tar.xz"
     sha256 "e2b09ec21660f01fecffb715e0120265216943f038d0e48a9868713e54f06cea"
 
     # Branch from the Darwin maintainer of GCC, with a few generic fixes and

--- a/Formula/lib/libiconv.rb
+++ b/Formula/lib/libiconv.rb
@@ -1,8 +1,8 @@
 class Libiconv < Formula
   desc "Conversion library"
   homepage "https://www.gnu.org/software/libiconv/"
-  url "https://ftp.gnu.org/gnu/libiconv/libiconv-1.18.tar.gz"
-  mirror "https://ftpmirror.gnu.org/libiconv/libiconv-1.18.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/libiconv/libiconv-1.18.tar.gz"
+  mirror "https://ftp.gnu.org/libiconv/libiconv-1.18.tar.gz"
   sha256 "3b08f5f4f9b4eb82f151a7040bfd6fe6c6fb922efe4b1659c66ea933276965e8"
   license all_of: ["GPL-3.0-or-later", "LGPL-2.0-or-later"]
 

--- a/Formula/lib/libidn.rb
+++ b/Formula/lib/libidn.rb
@@ -1,8 +1,8 @@
 class Libidn < Formula
   desc "International domain name library"
   homepage "https://www.gnu.org/software/libidn/"
-  url "https://ftp.gnu.org/gnu/libidn/libidn-1.43.tar.gz"
-  mirror "https://ftpmirror.gnu.org/libidn/libidn-1.43.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/libidn/libidn-1.43.tar.gz"
+  mirror "https://ftp.gnu.org/libidn/libidn-1.43.tar.gz"
   sha256 "bdc662c12d041b2539d0e638f3a6e741130cdb33a644ef3496963a443482d164"
   license any_of: ["GPL-2.0-or-later", "LGPL-3.0-or-later"]
 

--- a/Formula/lib/libidn2.rb
+++ b/Formula/lib/libidn2.rb
@@ -1,8 +1,8 @@
 class Libidn2 < Formula
   desc "International domain name library (IDNA2008, Punycode and TR46)"
   homepage "https://www.gnu.org/software/libidn/#libidn2"
-  url "https://ftp.gnu.org/gnu/libidn/libidn2-2.3.8.tar.gz"
-  mirror "https://ftpmirror.gnu.org/libidn/libidn2-2.3.8.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/libidn/libidn2-2.3.8.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/libidn/libidn2-2.3.8.tar.gz"
   mirror "http://ftp.gnu.org/gnu/libidn/libidn2-2.3.8.tar.gz"
   sha256 "f557911bf6171621e1f72ff35f5b1825bb35b52ed45325dcdee931e5d3c0787a"
   license all_of: [

--- a/Formula/lib/libmicrohttpd.rb
+++ b/Formula/lib/libmicrohttpd.rb
@@ -1,8 +1,8 @@
 class Libmicrohttpd < Formula
   desc "Light HTTP/1.1 server library"
   homepage "https://www.gnu.org/software/libmicrohttpd/"
-  url "https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-1.0.2.tar.gz"
-  mirror "https://ftpmirror.gnu.org/libmicrohttpd/libmicrohttpd-1.0.2.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/libmicrohttpd/libmicrohttpd-1.0.2.tar.gz"
+  mirror "https://ftp.gnu.org/libmicrohttpd/libmicrohttpd-1.0.2.tar.gz"
   sha256 "df324fcd0834175dab07483133902d9774a605bfa298025f69883288fd20a8c7"
   license "LGPL-2.1-or-later"
 

--- a/Formula/lib/libmpc.rb
+++ b/Formula/lib/libmpc.rb
@@ -1,8 +1,8 @@
 class Libmpc < Formula
   desc "C library for the arithmetic of high precision complex numbers"
   homepage "https://www.multiprecision.org/"
-  url "https://ftp.gnu.org/gnu/mpc/mpc-1.3.1.tar.gz"
-  mirror "https://ftpmirror.gnu.org/mpc/mpc-1.3.1.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/mpc/mpc-1.3.1.tar.gz"
+  mirror "https://ftp.gnu.org/mpc/mpc-1.3.1.tar.gz"
   sha256 "ab642492f5cf882b74aa0cb730cd410a81edcdbec895183ce930e706c1c759b8"
   license "LGPL-3.0-or-later"
 

--- a/Formula/lib/libosip.rb
+++ b/Formula/lib/libosip.rb
@@ -1,8 +1,8 @@
 class Libosip < Formula
   desc "Implementation of the eXosip2 stack"
   homepage "https://www.gnu.org/software/osip/"
-  url "https://ftp.gnu.org/gnu/osip/libosip2-5.3.1.tar.gz"
-  mirror "https://ftpmirror.gnu.org/osip/libosip2-5.3.1.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/osip/libosip2-5.3.1.tar.gz"
+  mirror "https://ftp.gnu.org/osip/libosip2-5.3.1.tar.gz"
   sha256 "fe82fe841608266ac15a5c1118216da00c554d5006e2875a8ac3752b1e6adc79"
   license "LGPL-2.1-or-later"
 

--- a/Formula/lib/libsigsegv.rb
+++ b/Formula/lib/libsigsegv.rb
@@ -1,8 +1,8 @@
 class Libsigsegv < Formula
   desc "Library for handling page faults in user mode"
   homepage "https://www.gnu.org/software/libsigsegv/"
-  url "https://ftp.gnu.org/gnu/libsigsegv/libsigsegv-2.15.tar.gz"
-  mirror "https://ftpmirror.gnu.org/libsigsegv/libsigsegv-2.15.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/libsigsegv/libsigsegv-2.15.tar.gz"
+  mirror "https://ftp.gnu.org/libsigsegv/libsigsegv-2.15.tar.gz"
   sha256 "036855660225cb3817a190fc00e6764ce7836051bacb48d35e26444b8c1729d9"
   license "GPL-2.0-or-later"
 

--- a/Formula/lib/libtasn1.rb
+++ b/Formula/lib/libtasn1.rb
@@ -1,8 +1,8 @@
 class Libtasn1 < Formula
   desc "ASN.1 structure parser library"
   homepage "https://www.gnu.org/software/libtasn1/"
-  url "https://ftp.gnu.org/gnu/libtasn1/libtasn1-4.20.0.tar.gz"
-  mirror "https://ftpmirror.gnu.org/libtasn1/libtasn1-4.20.0.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/libtasn1/libtasn1-4.20.0.tar.gz"
+  mirror "https://ftp.gnu.org/libtasn1/libtasn1-4.20.0.tar.gz"
   sha256 "92e0e3bd4c02d4aeee76036b2ddd83f0c732ba4cda5cb71d583272b23587a76c"
   license "LGPL-2.1-or-later"
 

--- a/Formula/lib/libtool.rb
+++ b/Formula/lib/libtool.rb
@@ -1,8 +1,8 @@
 class Libtool < Formula
   desc "Generic library support script"
   homepage "https://www.gnu.org/software/libtool/"
-  url "https://ftp.gnu.org/gnu/libtool/libtool-2.5.4.tar.xz"
-  mirror "https://ftpmirror.gnu.org/libtool/libtool-2.5.4.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/libtool/libtool-2.5.4.tar.xz"
+  mirror "https://ftp.gnu.org/libtool/libtool-2.5.4.tar.xz"
   sha256 "f81f5860666b0bc7d84baddefa60d1cb9fa6fceb2398cc3baca6afaa60266675"
   license "GPL-2.0-or-later"
 

--- a/Formula/lib/libunistring.rb
+++ b/Formula/lib/libunistring.rb
@@ -1,8 +1,8 @@
 class Libunistring < Formula
   desc "C string library for manipulating Unicode strings"
   homepage "https://www.gnu.org/software/libunistring/"
-  url "https://ftp.gnu.org/gnu/libunistring/libunistring-1.3.tar.gz"
-  mirror "https://ftpmirror.gnu.org/libunistring/libunistring-1.3.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/libunistring/libunistring-1.3.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/libunistring/libunistring-1.3.tar.gz"
   mirror "http://ftp.gnu.org/gnu/libunistring/libunistring-1.3.tar.gz"
   sha256 "8ea8ccf86c09dd801c8cac19878e804e54f707cf69884371130d20bde68386b7"
   license any_of: ["GPL-2.0-only", "LGPL-3.0-or-later"]

--- a/Formula/lib/libxmi.rb
+++ b/Formula/lib/libxmi.rb
@@ -1,8 +1,8 @@
 class Libxmi < Formula
   desc "C/C++ function library for rasterizing 2D vector graphics"
   homepage "https://www.gnu.org/software/libxmi/"
-  url "https://ftp.gnu.org/gnu/libxmi/libxmi-1.2.tar.gz"
-  mirror "https://ftpmirror.gnu.org/libxmi/libxmi-1.2.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/libxmi/libxmi-1.2.tar.gz"
+  mirror "https://ftp.gnu.org/libxmi/libxmi-1.2.tar.gz"
   sha256 "9d56af6d6c41468ca658eb6c4ba33ff7967a388b606dc503cd68d024e08ca40d"
   license "GPL-2.0-only"
 

--- a/Formula/m/m4.rb
+++ b/Formula/m/m4.rb
@@ -1,8 +1,8 @@
 class M4 < Formula
   desc "Macro processing language"
   homepage "https://www.gnu.org/software/m4/"
-  url "https://ftp.gnu.org/gnu/m4/m4-1.4.20.tar.xz"
-  mirror "https://ftpmirror.gnu.org/m4/m4-1.4.20.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/m4/m4-1.4.20.tar.xz"
+  mirror "https://ftp.gnu.org/m4/m4-1.4.20.tar.xz"
   sha256 "e236ea3a1ccf5f6c270b1c4bb60726f371fa49459a8eaaebc90b216b328daf2b"
   license "GPL-3.0-or-later"
 

--- a/Formula/m/m68k-elf-binutils.rb
+++ b/Formula/m/m68k-elf-binutils.rb
@@ -1,8 +1,8 @@
 class M68kElfBinutils < Formula
   desc "GNU Binutils for m68k-elf cross development"
   homepage "https://www.gnu.org/software/binutils/"
-  url "https://ftp.gnu.org/gnu/binutils/binutils-2.45.tar.bz2"
-  mirror "https://ftpmirror.gnu.org/binutils/binutils-2.45.tar.bz2"
+  url "https://ftpmirror.gnu.org/gnu/binutils/binutils-2.45.tar.bz2"
+  mirror "https://ftp.gnu.org/binutils/binutils-2.45.tar.bz2"
   sha256 "1393f90db70c2ebd785fb434d6127f8888c559d5eeb9c006c354b203bab3473e"
   license "GPL-3.0-or-later"
 

--- a/Formula/m/m68k-elf-gcc.rb
+++ b/Formula/m/m68k-elf-gcc.rb
@@ -1,8 +1,8 @@
 class M68kElfGcc < Formula
   desc "GNU compiler collection m68k-elf"
   homepage "https://gcc.gnu.org"
-  url "https://ftp.gnu.org/gnu/gcc/gcc-15.2.0/gcc-15.2.0.tar.xz"
-  mirror "https://ftpmirror.gnu.org/gcc/gcc-15.2.0/gcc-15.2.0.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/gcc/gcc-15.2.0/gcc-15.2.0.tar.xz"
+  mirror "https://ftp.gnu.org/gcc/gcc-15.2.0/gcc-15.2.0.tar.xz"
   sha256 "438fd996826b0c82485a29da03a72d71d6e3541a83ec702df4271f6fe025d24e"
   license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }
 

--- a/Formula/m/mailutils.rb
+++ b/Formula/m/mailutils.rb
@@ -1,8 +1,8 @@
 class Mailutils < Formula
   desc "Swiss Army knife of email handling"
   homepage "https://mailutils.org/"
-  url "https://ftp.gnu.org/gnu/mailutils/mailutils-3.20.tar.gz"
-  mirror "https://ftpmirror.gnu.org/mailutils/mailutils-3.20.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/mailutils/mailutils-3.20.tar.gz"
+  mirror "https://ftp.gnu.org/mailutils/mailutils-3.20.tar.gz"
   sha256 "d10ee65ba391d6463952d8a81551f8a6e667538ee8587b3c801137e657087d4c"
   license "GPL-3.0-or-later"
 

--- a/Formula/m/make.rb
+++ b/Formula/m/make.rb
@@ -1,8 +1,8 @@
 class Make < Formula
   desc "Utility for directing compilation"
   homepage "https://www.gnu.org/software/make/"
-  url "https://ftp.gnu.org/gnu/make/make-4.4.1.tar.lz"
-  mirror "https://ftpmirror.gnu.org/make/make-4.4.1.tar.lz"
+  url "https://ftpmirror.gnu.org/gnu/make/make-4.4.1.tar.lz"
+  mirror "https://ftp.gnu.org/make/make-4.4.1.tar.lz"
   sha256 "8814ba072182b605d156d7589c19a43b89fc58ea479b9355146160946f8cf6e9"
   license "GPL-3.0-only"
 

--- a/Formula/m/mdk.rb
+++ b/Formula/m/mdk.rb
@@ -1,8 +1,8 @@
 class Mdk < Formula
   desc "GNU MIX development kit"
   homepage "https://www.gnu.org/software/mdk/mdk.html"
-  url "https://ftp.gnu.org/gnu/mdk/v1.3.0/mdk-1.3.0.tar.gz"
-  mirror "https://ftpmirror.gnu.org/mdk/v1.3.0/mdk-1.3.0.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/mdk/v1.3.0/mdk-1.3.0.tar.gz"
+  mirror "https://ftp.gnu.org/mdk/v1.3.0/mdk-1.3.0.tar.gz"
   sha256 "8b1e5dd7f47b738cb966ef717be92a501494d9ba6d87038f09e8fa29101b132e"
   license "GPL-3.0-or-later"
   revision 1

--- a/Formula/m/mingw-w64.rb
+++ b/Formula/m/mingw-w64.rb
@@ -34,14 +34,14 @@ class MingwW64 < Formula
   uses_from_macos "zlib"
 
   resource "binutils" do
-    url "https://ftp.gnu.org/gnu/binutils/binutils-2.44.tar.bz2"
-    mirror "https://ftpmirror.gnu.org/binutils/binutils-2.44.tar.bz2"
+    url "https://ftpmirror.gnu.org/gnu/binutils/binutils-2.44.tar.bz2"
+    mirror "https://ftp.gnu.org/binutils/binutils-2.44.tar.bz2"
     sha256 "f66390a661faa117d00fab2e79cf2dc9d097b42cc296bf3f8677d1e7b452dc3a"
   end
 
   resource "gcc" do
-    url "https://ftp.gnu.org/gnu/gcc/gcc-15.1.0/gcc-15.1.0.tar.xz"
-    mirror "https://ftpmirror.gnu.org/gcc/gcc-15.1.0/gcc-15.1.0.tar.xz"
+    url "https://ftpmirror.gnu.org/gnu/gcc/gcc-15.1.0/gcc-15.1.0.tar.xz"
+    mirror "https://ftp.gnu.org/gcc/gcc-15.1.0/gcc-15.1.0.tar.xz"
     sha256 "e2b09ec21660f01fecffb715e0120265216943f038d0e48a9868713e54f06cea"
   end
 

--- a/Formula/m/mit-scheme.rb
+++ b/Formula/m/mit-scheme.rb
@@ -1,14 +1,14 @@
 class MitScheme < Formula
   desc "MIT/GNU Scheme development tools and runtime library"
   homepage "https://www.gnu.org/software/mit-scheme/"
-  url "https://ftp.gnu.org/gnu/mit-scheme/stable.pkg/12.1/mit-scheme-12.1-svm1-64le.tar.gz"
-  mirror "https://ftpmirror.gnu.org/gnu/mit-scheme/stable.pkg/12.1/mit-scheme-12.1-svm1-64le.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/mit-scheme/stable.pkg/12.1/mit-scheme-12.1-svm1-64le.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/mit-scheme/stable.pkg/12.1/mit-scheme-12.1-svm1-64le.tar.gz"
   sha256 "2c5b5bf1f44c7c2458da79c0943e082ae37f1752c7d9d1ce0a61f7afcbf04304"
   license "GPL-2.0-or-later"
   revision 1
 
   livecheck do
-    url "https://ftp.gnu.org/gnu/mit-scheme/stable.pkg/?C=M&O=D"
+    url "https://ftpmirror.gnu.org/gnu/mit-scheme/stable.pkg/?C=M&O=D"
     regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]}i)
     strategy :page_match
   end

--- a/Formula/m/moe.rb
+++ b/Formula/m/moe.rb
@@ -1,8 +1,8 @@
 class Moe < Formula
   desc "Console text editor for ISO-8859 and ASCII"
   homepage "https://www.gnu.org/software/moe/moe.html"
-  url "https://ftp.gnu.org/gnu/moe/moe-1.15.tar.lz"
-  mirror "https://ftpmirror.gnu.org/moe/moe-1.15.tar.lz"
+  url "https://ftpmirror.gnu.org/gnu/moe/moe-1.15.tar.lz"
+  mirror "https://ftp.gnu.org/moe/moe-1.15.tar.lz"
   sha256 "41f8c8b099ce3047945ca4e097a60d9243e9c73fbb268c194a12da8b0d9f0a66"
   license "GPL-2.0-or-later"
 

--- a/Formula/m/mpfr.rb
+++ b/Formula/m/mpfr.rb
@@ -1,8 +1,8 @@
 class Mpfr < Formula
   desc "C library for multiple-precision floating-point computations"
   homepage "https://www.mpfr.org/"
-  url "https://ftp.gnu.org/gnu/mpfr/mpfr-4.2.2.tar.xz"
-  mirror "https://ftpmirror.gnu.org/mpfr/mpfr-4.2.2.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/mpfr/mpfr-4.2.2.tar.xz"
+  mirror "https://ftp.gnu.org/mpfr/mpfr-4.2.2.tar.xz"
   sha256 "b67ba0383ef7e8a8563734e2e889ef5ec3c3b898a01d00fa0a6869ad81c6ce01"
   license "LGPL-3.0-or-later"
   head "https://gitlab.inria.fr/mpfr/mpfr.git", branch: "master"

--- a/Formula/m/mtools.rb
+++ b/Formula/m/mtools.rb
@@ -1,8 +1,8 @@
 class Mtools < Formula
   desc "Tools for manipulating MSDOS files"
   homepage "https://www.gnu.org/software/mtools/"
-  url "https://ftp.gnu.org/gnu/mtools/mtools-4.0.49.tar.gz"
-  mirror "https://ftpmirror.gnu.org/mtools/mtools-4.0.49.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/mtools/mtools-4.0.49.tar.gz"
+  mirror "https://ftp.gnu.org/mtools/mtools-4.0.49.tar.gz"
   sha256 "10cd1111da87bf2400a380c1639a6cba8bfb937a24f9c51f5f88d393ae5f6f76"
   license "GPL-3.0-or-later"
 

--- a/Formula/n/ncurses.rb
+++ b/Formula/n/ncurses.rb
@@ -1,10 +1,10 @@
 class Ncurses < Formula
   desc "Text-based UI library"
   homepage "https://invisible-island.net/ncurses/announce.html"
-  url "https://ftp.gnu.org/gnu/ncurses/ncurses-6.5.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/ncurses/ncurses-6.5.tar.gz"
   mirror "https://invisible-mirror.net/archives/ncurses/ncurses-6.5.tar.gz"
   mirror "ftp://ftp.invisible-island.net/ncurses/ncurses-6.5.tar.gz"
-  mirror "https://ftpmirror.gnu.org/ncurses/ncurses-6.5.tar.gz"
+  mirror "https://ftp.gnu.org/ncurses/ncurses-6.5.tar.gz"
   sha256 "136d91bc269a9a5785e5f9e980bc76ab57428f604ce3e5a5a90cebc767971cc6"
   license "MIT"
 

--- a/Formula/n/nettle.rb
+++ b/Formula/n/nettle.rb
@@ -1,8 +1,8 @@
 class Nettle < Formula
   desc "Low-level cryptographic library"
   homepage "https://www.lysator.liu.se/~nisse/nettle/"
-  url "https://ftp.gnu.org/gnu/nettle/nettle-3.10.2.tar.gz"
-  mirror "https://ftpmirror.gnu.org/nettle/nettle-3.10.2.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/nettle/nettle-3.10.2.tar.gz"
+  mirror "https://ftp.gnu.org/nettle/nettle-3.10.2.tar.gz"
   sha256 "fe9ff51cb1f2abb5e65a6b8c10a92da0ab5ab6eaf26e7fc2b675c45f1fb519b5"
   license any_of: ["GPL-2.0-or-later", "LGPL-3.0-or-later"]
 

--- a/Formula/o/ocp.rb
+++ b/Formula/o/ocp.rb
@@ -52,7 +52,7 @@ class Ocp < Formula
 
   # pin to 15.0.6 to use precompiled fonts
   resource "unifont" do
-    url "https://ftp.gnu.org/gnu/unifont/unifont-15.0.06/unifont-15.0.06.tar.gz"
+    url "https://ftpmirror.gnu.org/gnu/unifont/unifont-15.0.06/unifont-15.0.06.tar.gz"
     sha256 "36668eb1326d22e1466b94b3929beeafd10b9838bf3d41f4e5e3b52406ae69f1"
   end
 

--- a/Formula/o/ocrad.rb
+++ b/Formula/o/ocrad.rb
@@ -1,8 +1,8 @@
 class Ocrad < Formula
   desc "Optical character recognition (OCR) program"
   homepage "https://www.gnu.org/software/ocrad/"
-  url "https://ftp.gnu.org/gnu/ocrad/ocrad-0.29.tar.lz"
-  mirror "https://ftpmirror.gnu.org/ocrad/ocrad-0.29.tar.lz"
+  url "https://ftpmirror.gnu.org/gnu/ocrad/ocrad-0.29.tar.lz"
+  mirror "https://ftp.gnu.org/ocrad/ocrad-0.29.tar.lz"
   sha256 "11200cc6b0b7ba16884a72dccb58ef694f7aa26cd2b2041e555580f064d2d9e9"
   license "GPL-2.0-or-later"
 

--- a/Formula/o/octave.rb
+++ b/Formula/o/octave.rb
@@ -1,8 +1,8 @@
 class Octave < Formula
   desc "High-level interpreted language for numerical computing"
   homepage "https://octave.org/index.html"
-  url "https://ftp.gnu.org/gnu/octave/octave-9.4.0.tar.xz"
-  mirror "https://ftpmirror.gnu.org/octave/octave-9.4.0.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/octave/octave-9.4.0.tar.xz"
+  mirror "https://ftp.gnu.org/octave/octave-9.4.0.tar.xz"
   sha256 "fff911909ef79f95ba244dab5b8c1cb8c693a6c447d31deabb53994f17cb7b3d"
   license "GPL-3.0-or-later"
   revision 1

--- a/Formula/p/parallel.rb
+++ b/Formula/p/parallel.rb
@@ -1,8 +1,8 @@
 class Parallel < Formula
   desc "Shell command parallelization utility"
   homepage "https://savannah.gnu.org/projects/parallel/"
-  url "https://ftp.gnu.org/gnu/parallel/parallel-20250722.tar.bz2"
-  mirror "https://ftpmirror.gnu.org/parallel/parallel-20250722.tar.bz2"
+  url "https://ftpmirror.gnu.org/gnu/parallel/parallel-20250722.tar.bz2"
+  mirror "https://ftp.gnu.org/parallel/parallel-20250722.tar.bz2"
   sha256 "91a81ff4129cdf5ad3c3c45ec033e75f2bbea5447f4b6813a0d8cfe8e5c7843b"
   license "GPL-3.0-or-later"
   version_scheme 1

--- a/Formula/p/plotutils.rb
+++ b/Formula/p/plotutils.rb
@@ -1,8 +1,8 @@
 class Plotutils < Formula
   desc "C/C++ function library for exporting 2-D vector graphics"
   homepage "https://www.gnu.org/software/plotutils/"
-  url "https://ftp.gnu.org/gnu/plotutils/plotutils-2.6.tar.gz"
-  mirror "https://ftpmirror.gnu.org/plotutils/plotutils-2.6.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/plotutils/plotutils-2.6.tar.gz"
+  mirror "https://ftp.gnu.org/plotutils/plotutils-2.6.tar.gz"
   sha256 "4f4222820f97ca08c7ea707e4c53e5a3556af4d8f1ab51e0da6ff1627ff433ab"
   license "GPL-3.0-or-later"
   revision 1

--- a/Formula/p/poke.rb
+++ b/Formula/p/poke.rb
@@ -1,7 +1,7 @@
 class Poke < Formula
   desc "Extensible editor for structured binary data"
   homepage "https://jemarch.net/poke"
-  url "https://ftp.gnu.org/gnu/poke/poke-4.3.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/poke/poke-4.3.tar.gz"
   sha256 "a84cb9175d50d45a411f2481fd0662b83cb32ce517316b889cfb570819579373"
   license "GPL-3.0-or-later"
 

--- a/Formula/p/proxygen.rb
+++ b/Formula/p/proxygen.rb
@@ -38,8 +38,8 @@ class Proxygen < Formula
   # FIXME: Build script is not compatible with gperf 3.2
   resource "gperf" do
     on_linux do
-      url "https://ftp.gnu.org/gnu/gperf/gperf-3.1.tar.gz"
-      mirror "https://ftpmirror.gnu.org/gperf/gperf-3.1.tar.gz"
+      url "https://ftpmirror.gnu.org/gnu/gperf/gperf-3.1.tar.gz"
+      mirror "https://ftp.gnu.org/gperf/gperf-3.1.tar.gz"
       sha256 "588546b945bba4b70b6a3a616e80b4ab466e3f33024a352fc2198112cdbb3ae2"
     end
   end

--- a/Formula/p/pth.rb
+++ b/Formula/p/pth.rb
@@ -1,8 +1,8 @@
 class Pth < Formula
   desc "GNU Portable THreads"
   homepage "https://www.gnu.org/software/pth/"
-  url "https://ftp.gnu.org/gnu/pth/pth-2.0.7.tar.gz"
-  mirror "https://ftpmirror.gnu.org/pth/pth-2.0.7.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/pth/pth-2.0.7.tar.gz"
+  mirror "https://ftp.gnu.org/pth/pth-2.0.7.tar.gz"
   sha256 "72353660c5a2caafd601b20e12e75d865fd88f6cf1a088b306a3963f0bc77232"
   license "LGPL-2.1-or-later"
 

--- a/Formula/r/rcs.rb
+++ b/Formula/r/rcs.rb
@@ -1,8 +1,8 @@
 class Rcs < Formula
   desc "GNU revision control system"
   homepage "https://www.gnu.org/software/rcs/"
-  url "https://ftp.gnu.org/gnu/rcs/rcs-5.10.1.tar.lz"
-  mirror "https://ftpmirror.gnu.org/rcs/rcs-5.10.1.tar.lz"
+  url "https://ftpmirror.gnu.org/gnu/rcs/rcs-5.10.1.tar.lz"
+  mirror "https://ftp.gnu.org/rcs/rcs-5.10.1.tar.lz"
   sha256 "43ddfe10724a8b85e2468f6403b6000737186f01e60e0bd62fde69d842234cc5"
   license "GPL-3.0-or-later"
 

--- a/Formula/r/readline.rb
+++ b/Formula/r/readline.rb
@@ -1,8 +1,8 @@
 class Readline < Formula
   desc "Library for command-line editing"
   homepage "https://tiswww.case.edu/php/chet/readline/rltop.html"
-  url "https://ftp.gnu.org/gnu/readline/readline-8.3.tar.gz"
-  mirror "https://ftpmirror.gnu.org/readline/readline-8.3.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/readline/readline-8.3.tar.gz"
+  mirror "https://ftp.gnu.org/readline/readline-8.3.tar.gz"
   version "8.3.1"
   sha256 "fe5383204467828cd495ee8d1d3c037a7eba1389c22bc6a041f627976f9061cc"
   license "GPL-3.0-or-later"
@@ -21,8 +21,8 @@ class Readline < Formula
 
   patch_checksum_pairs.each_slice(2) do |p, checksum|
     patch :p0 do
-      url "https://ftp.gnu.org/gnu/readline/readline-8.3-patches/readline83-#{p}"
-      mirror "https://ftpmirror.gnu.org/readline/readline-8.3-patches/readline83-#{p}"
+      url "https://ftpmirror.gnu.org/gnu/readline/readline-8.3-patches/readline83-#{p}"
+      mirror "https://ftp.gnu.org/readline/readline-8.3-patches/readline83-#{p}"
       sha256 checksum
     end
   end

--- a/Formula/r/recutils.rb
+++ b/Formula/r/recutils.rb
@@ -1,8 +1,8 @@
 class Recutils < Formula
   desc "Tools to work with human-editable, plain text data files"
   homepage "https://www.gnu.org/software/recutils/"
-  url "https://ftp.gnu.org/gnu/recutils/recutils-1.9.tar.gz"
-  mirror "https://ftpmirror.gnu.org/gnu/recutils/recutils-1.9.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/recutils/recutils-1.9.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/recutils/recutils-1.9.tar.gz"
   sha256 "6301592b0020c14b456757ef5d434d49f6027b8e5f3a499d13362f205c486e0e"
   license "GPL-3.0-or-later"
 

--- a/Formula/r/riscv64-elf-binutils.rb
+++ b/Formula/r/riscv64-elf-binutils.rb
@@ -1,8 +1,8 @@
 class Riscv64ElfBinutils < Formula
   desc "GNU Binutils for riscv64-elf cross development"
   homepage "https://www.gnu.org/software/binutils/"
-  url "https://ftp.gnu.org/gnu/binutils/binutils-2.45.tar.bz2"
-  mirror "https://ftpmirror.gnu.org/binutils/binutils-2.45.tar.bz2"
+  url "https://ftpmirror.gnu.org/gnu/binutils/binutils-2.45.tar.bz2"
+  mirror "https://ftp.gnu.org/binutils/binutils-2.45.tar.bz2"
   sha256 "1393f90db70c2ebd785fb434d6127f8888c559d5eeb9c006c354b203bab3473e"
   license "GPL-3.0-or-later"
 

--- a/Formula/r/riscv64-elf-gcc.rb
+++ b/Formula/r/riscv64-elf-gcc.rb
@@ -1,8 +1,8 @@
 class Riscv64ElfGcc < Formula
   desc "GNU compiler collection for riscv64-elf"
   homepage "https://gcc.gnu.org"
-  url "https://ftp.gnu.org/gnu/gcc/gcc-15.2.0/gcc-15.2.0.tar.xz"
-  mirror "https://ftpmirror.gnu.org/gcc/gcc-15.2.0/gcc-15.2.0.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/gcc/gcc-15.2.0/gcc-15.2.0.tar.xz"
+  mirror "https://ftp.gnu.org/gcc/gcc-15.2.0/gcc-15.2.0.tar.xz"
   sha256 "438fd996826b0c82485a29da03a72d71d6e3541a83ec702df4271f6fe025d24e"
   license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }
 

--- a/Formula/r/riscv64-elf-gdb.rb
+++ b/Formula/r/riscv64-elf-gdb.rb
@@ -1,8 +1,8 @@
 class Riscv64ElfGdb < Formula
   desc "GNU debugger for riscv64-elf cross development"
   homepage "https://www.gnu.org/software/gdb/"
-  url "https://ftp.gnu.org/gnu/gdb/gdb-16.3.tar.xz"
-  mirror "https://ftpmirror.gnu.org/gdb/gdb-16.3.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/gdb/gdb-16.3.tar.xz"
+  mirror "https://ftp.gnu.org/gdb/gdb-16.3.tar.xz"
   sha256 "bcfcd095528a987917acf9fff3f1672181694926cc18d609c99d0042c00224c5"
   license "GPL-3.0-or-later"
   head "https://sourceware.org/git/binutils-gdb.git", branch: "master"

--- a/Formula/r/rush.rb
+++ b/Formula/r/rush.rb
@@ -1,8 +1,8 @@
 class Rush < Formula
   desc "GNU's Restricted User SHell"
   homepage "https://www.gnu.org.ua/software/rush/"
-  url "https://ftp.gnu.org/gnu/rush/rush-2.4.tar.xz"
-  mirror "https://ftpmirror.gnu.org/rush/rush-2.4.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/rush/rush-2.4.tar.xz"
+  mirror "https://ftp.gnu.org/rush/rush-2.4.tar.xz"
   sha256 "fa95af9d2c7b635581841cc27a1d27af611f60dd962113a93d23a8874aa060f4"
   license "GPL-3.0-or-later"
 

--- a/Formula/s/screen.rb
+++ b/Formula/s/screen.rb
@@ -1,8 +1,8 @@
 class Screen < Formula
   desc "Terminal multiplexer with VT100/ANSI terminal emulation"
   homepage "https://www.gnu.org/software/screen/"
-  url "https://ftp.gnu.org/gnu/screen/screen-5.0.1.tar.gz"
-  mirror "https://ftpmirror.gnu.org/screen/screen-5.0.1.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/screen/screen-5.0.1.tar.gz"
+  mirror "https://ftp.gnu.org/screen/screen-5.0.1.tar.gz"
   sha256 "2dae36f4db379ffcd14b691596ba6ec18ac3a9e22bc47ac239789ab58409869d"
   license "GPL-3.0-or-later"
   head "https://git.savannah.gnu.org/git/screen.git", branch: "master"

--- a/Formula/s/shepherd.rb
+++ b/Formula/s/shepherd.rb
@@ -1,8 +1,8 @@
 class Shepherd < Formula
   desc "Service manager that looks after the herd of system services"
   homepage "https://www.gnu.org/software/shepherd/"
-  url "https://ftp.gnu.org/gnu/shepherd/shepherd-1.0.6.tar.gz"
-  mirror "https://ftpmirror.gnu.org/shepherd/shepherd-1.0.6.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/shepherd/shepherd-1.0.6.tar.gz"
+  mirror "https://ftp.gnu.org/shepherd/shepherd-1.0.6.tar.gz"
   sha256 "fc74dfda499a695e650fc5839d39ad538e2e323949b8904afcfaffa34171be33"
   license "GPL-3.0-or-later"
 

--- a/Formula/s/shtool.rb
+++ b/Formula/s/shtool.rb
@@ -1,8 +1,8 @@
 class Shtool < Formula
   desc "GNU's portable shell tool"
   homepage "https://www.gnu.org/software/shtool/"
-  url "https://ftp.gnu.org/gnu/shtool/shtool-2.0.8.tar.gz"
-  mirror "https://ftpmirror.gnu.org/shtool/shtool-2.0.8.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/shtool/shtool-2.0.8.tar.gz"
+  mirror "https://ftp.gnu.org/shtool/shtool-2.0.8.tar.gz"
   sha256 "1298a549416d12af239e9f4e787e6e6509210afb49d5cf28eb6ec4015046ae19"
   license "GPL-2.0-or-later"
 

--- a/Formula/s/source-highlight.rb
+++ b/Formula/s/source-highlight.rb
@@ -1,8 +1,8 @@
 class SourceHighlight < Formula
   desc "Source-code syntax highlighter"
   homepage "https://www.gnu.org/software/src-highlite/"
-  url "https://ftp.gnu.org/gnu/src-highlite/source-highlight-3.1.9.tar.gz"
-  mirror "https://ftpmirror.gnu.org/src-highlite/source-highlight-3.1.9.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/src-highlite/source-highlight-3.1.9.tar.gz"
+  mirror "https://ftp.gnu.org/src-highlite/source-highlight-3.1.9.tar.gz"
   sha256 "3a7fd28378cb5416f8de2c9e77196ec915145d44e30ff4e0ee8beb3fe6211c91"
   license "GPL-3.0-or-later"
   revision 6

--- a/Formula/s/stow.rb
+++ b/Formula/s/stow.rb
@@ -1,8 +1,8 @@
 class Stow < Formula
   desc "Organize software neatly under a single directory tree (e.g. /usr/local)"
   homepage "https://www.gnu.org/software/stow/"
-  url "https://ftp.gnu.org/gnu/stow/stow-2.4.1.tar.gz"
-  mirror "https://ftpmirror.gnu.org/stow/stow-2.4.1.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/stow/stow-2.4.1.tar.gz"
+  mirror "https://ftp.gnu.org/stow/stow-2.4.1.tar.gz"
   sha256 "2a671e75fc207303bfe86a9a7223169c7669df0a8108ebdf1a7fe8cd2b88780b"
   license "GPL-3.0-or-later"
 

--- a/Formula/t/texinfo.rb
+++ b/Formula/t/texinfo.rb
@@ -1,8 +1,8 @@
 class Texinfo < Formula
   desc "Official documentation format of the GNU project"
   homepage "https://www.gnu.org/software/texinfo/"
-  url "https://ftp.gnu.org/gnu/texinfo/texinfo-7.2.tar.xz"
-  mirror "https://ftpmirror.gnu.org/texinfo/texinfo-7.2.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/texinfo/texinfo-7.2.tar.xz"
+  mirror "https://ftp.gnu.org/texinfo/texinfo-7.2.tar.xz"
   sha256 "0329d7788fbef113fa82cb80889ca197a344ce0df7646fe000974c5d714363a6"
   license "GPL-3.0-or-later"
 

--- a/Formula/u/unrtf.rb
+++ b/Formula/u/unrtf.rb
@@ -1,8 +1,8 @@
 class Unrtf < Formula
   desc "RTF to other formats converter"
   homepage "https://www.gnu.org/software/unrtf/"
-  url "https://ftp.gnu.org/gnu/unrtf/unrtf-0.21.10.tar.gz"
-  mirror "https://ftpmirror.gnu.org/unrtf/unrtf-0.21.10.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/unrtf/unrtf-0.21.10.tar.gz"
+  mirror "https://ftp.gnu.org/unrtf/unrtf-0.21.10.tar.gz"
   sha256 "b49f20211fa69fff97d42d6e782a62d7e2da670b064951f14bbff968c93734ae"
   license "GPL-3.0-or-later"
   head "https://hg.savannah.gnu.org/hgweb/unrtf/", using: :hg

--- a/Formula/v/vcdimager.rb
+++ b/Formula/v/vcdimager.rb
@@ -1,8 +1,8 @@
 class Vcdimager < Formula
   desc "(Super) video CD authoring solution"
   homepage "https://www.gnu.org/software/vcdimager/"
-  url "https://ftp.gnu.org/gnu/vcdimager/vcdimager-2.0.1.tar.gz"
-  mirror "https://ftpmirror.gnu.org/vcdimager/vcdimager-2.0.1.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/vcdimager/vcdimager-2.0.1.tar.gz"
+  mirror "https://ftp.gnu.org/vcdimager/vcdimager-2.0.1.tar.gz"
   sha256 "67515fefb9829d054beae40f3e840309be60cda7d68753cafdd526727758f67a"
   license "GPL-2.0-or-later"
   revision 2

--- a/Formula/w/wdiff.rb
+++ b/Formula/w/wdiff.rb
@@ -1,8 +1,8 @@
 class Wdiff < Formula
   desc "Display word differences between text files"
   homepage "https://www.gnu.org/software/wdiff/"
-  url "https://ftp.gnu.org/gnu/wdiff/wdiff-1.2.2.tar.gz"
-  mirror "https://ftpmirror.gnu.org/wdiff/wdiff-1.2.2.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/wdiff/wdiff-1.2.2.tar.gz"
+  mirror "https://ftp.gnu.org/wdiff/wdiff-1.2.2.tar.gz"
   sha256 "34ff698c870c87e6e47a838eeaaae729fa73349139fc8db12211d2a22b78af6b"
   license "GPL-3.0-or-later"
   revision 2

--- a/Formula/w/wget.rb
+++ b/Formula/w/wget.rb
@@ -1,7 +1,7 @@
 class Wget < Formula
   desc "Internet file retriever"
   homepage "https://www.gnu.org/software/wget/"
-  url "https://ftp.gnu.org/gnu/wget/wget-1.25.0.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/wget/wget-1.25.0.tar.gz"
   sha256 "766e48423e79359ea31e41db9e5c289675947a7fcf2efdcedb726ac9d0da3784"
   license "GPL-3.0-or-later"
 

--- a/Formula/w/wget2.rb
+++ b/Formula/w/wget2.rb
@@ -1,7 +1,7 @@
 class Wget2 < Formula
   desc "Successor of GNU Wget, a file and recursive website downloader"
   homepage "https://gitlab.com/gnuwget/wget2"
-  url "https://ftp.gnu.org/gnu/wget/wget2-2.2.0.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/wget/wget2-2.2.0.tar.gz"
   sha256 "2b3b9c85b7fb26d33ca5f41f1f8daca71838d869a19b406063aa5c655294d357"
   license "GPL-3.0-or-later"
   revision 1

--- a/Formula/x/x86_64-elf-binutils.rb
+++ b/Formula/x/x86_64-elf-binutils.rb
@@ -1,8 +1,8 @@
 class X8664ElfBinutils < Formula
   desc "GNU Binutils for x86_64-elf cross development"
   homepage "https://www.gnu.org/software/binutils/"
-  url "https://ftp.gnu.org/gnu/binutils/binutils-2.45.tar.bz2"
-  mirror "https://ftpmirror.gnu.org/binutils/binutils-2.45.tar.bz2"
+  url "https://ftpmirror.gnu.org/gnu/binutils/binutils-2.45.tar.bz2"
+  mirror "https://ftp.gnu.org/binutils/binutils-2.45.tar.bz2"
   sha256 "1393f90db70c2ebd785fb434d6127f8888c559d5eeb9c006c354b203bab3473e"
   license "GPL-3.0-or-later"
 

--- a/Formula/x/x86_64-elf-gcc.rb
+++ b/Formula/x/x86_64-elf-gcc.rb
@@ -1,8 +1,8 @@
 class X8664ElfGcc < Formula
   desc "GNU compiler collection for x86_64-elf"
   homepage "https://gcc.gnu.org"
-  url "https://ftp.gnu.org/gnu/gcc/gcc-15.2.0/gcc-15.2.0.tar.xz"
-  mirror "https://ftpmirror.gnu.org/gcc/gcc-15.2.0/gcc-15.2.0.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/gcc/gcc-15.2.0/gcc-15.2.0.tar.xz"
+  mirror "https://ftp.gnu.org/gcc/gcc-15.2.0/gcc-15.2.0.tar.xz"
   sha256 "438fd996826b0c82485a29da03a72d71d6e3541a83ec702df4271f6fe025d24e"
   license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }
 

--- a/Formula/x/x86_64-elf-gdb.rb
+++ b/Formula/x/x86_64-elf-gdb.rb
@@ -1,8 +1,8 @@
 class X8664ElfGdb < Formula
   desc "GNU debugger for x86_64-elf cross development"
   homepage "https://www.gnu.org/software/gdb/"
-  url "https://ftp.gnu.org/gnu/gdb/gdb-16.3.tar.xz"
-  mirror "https://ftpmirror.gnu.org/gdb/gdb-16.3.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/gdb/gdb-16.3.tar.xz"
+  mirror "https://ftp.gnu.org/gdb/gdb-16.3.tar.xz"
   sha256 "bcfcd095528a987917acf9fff3f1672181694926cc18d609c99d0042c00224c5"
   license "GPL-3.0-or-later"
   head "https://sourceware.org/git/binutils-gdb.git", branch: "master"

--- a/Formula/x/x86_64-elf-grub.rb
+++ b/Formula/x/x86_64-elf-grub.rb
@@ -1,7 +1,7 @@
 class X8664ElfGrub < Formula
   desc "GNU GRUB bootloader for x86_64-elf"
   homepage "https://savannah.gnu.org/projects/grub"
-  url "https://ftp.gnu.org/gnu/grub/grub-2.12.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/grub/grub-2.12.tar.xz"
   mirror "https://mirrors.ocf.berkeley.edu/gnu/grub/grub-2.12.tar.xz"
   sha256 "f3c97391f7c4eaa677a78e090c7e97e6dc47b16f655f04683ebd37bef7fe0faa"
   license "GPL-3.0-or-later"
@@ -35,7 +35,7 @@ class X8664ElfGrub < Formula
   uses_from_macos "python" => :build
 
   resource "unifont" do
-    url "https://ftp.gnu.org/gnu/unifont/unifont-16.0.02/unifont-16.0.02.pcf.gz", using: :nounzip
+    url "https://ftpmirror.gnu.org/gnu/unifont/unifont-16.0.02/unifont-16.0.02.pcf.gz", using: :nounzip
     mirror "https://mirrors.ocf.berkeley.edu/gnu/unifont/unifont-16.0.02/unifont-16.0.02.pcf.gz"
     version "16.0.02"
     sha256 "02a3fe11994d3cdaf1d4bd5d2b6b609735e6823e01764ae83b704e02ec2f640d"

--- a/Formula/x/x86_64-linux-gnu-binutils.rb
+++ b/Formula/x/x86_64-linux-gnu-binutils.rb
@@ -1,8 +1,8 @@
 class X8664LinuxGnuBinutils < Formula
   desc "GNU Binutils for x86_64-linux-gnu cross development"
   homepage "https://www.gnu.org/software/binutils/binutils.html"
-  url "https://ftp.gnu.org/gnu/binutils/binutils-2.45.tar.bz2"
-  mirror "https://ftpmirror.gnu.org/binutils/binutils-2.45.tar.bz2"
+  url "https://ftpmirror.gnu.org/gnu/binutils/binutils-2.45.tar.bz2"
+  mirror "https://ftp.gnu.org/binutils/binutils-2.45.tar.bz2"
   sha256 "1393f90db70c2ebd785fb434d6127f8888c559d5eeb9c006c354b203bab3473e"
   license "GPL-3.0-or-later"
 

--- a/Formula/x/xboard.rb
+++ b/Formula/x/xboard.rb
@@ -1,8 +1,8 @@
 class Xboard < Formula
   desc "Graphical user interface for chess"
   homepage "https://www.gnu.org/software/xboard/"
-  url "https://ftp.gnu.org/gnu/xboard/xboard-4.9.1.tar.gz"
-  mirror "https://ftpmirror.gnu.org/xboard/xboard-4.9.1.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/xboard/xboard-4.9.1.tar.gz"
+  mirror "https://ftp.gnu.org/xboard/xboard-4.9.1.tar.gz"
   sha256 "2b2e53e8428ad9b6e8dc8a55b3a5183381911a4dae2c0072fa96296bbb1970d6"
   license "GPL-3.0-or-later"
   revision 4

--- a/Formula/x/xorriso.rb
+++ b/Formula/x/xorriso.rb
@@ -1,8 +1,8 @@
 class Xorriso < Formula
   desc "ISO9660+RR manipulation tool"
   homepage "https://www.gnu.org/software/xorriso/"
-  url "https://ftp.gnu.org/gnu/xorriso/xorriso-1.5.6.pl02.tar.gz"
-  mirror "https://ftpmirror.gnu.org/xorriso/xorriso-1.5.6.pl02.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/xorriso/xorriso-1.5.6.pl02.tar.gz"
+  mirror "https://ftp.gnu.org/xorriso/xorriso-1.5.6.pl02.tar.gz"
   version "1.5.6.pl02"
   sha256 "786f9f5df9865cc5b0c1fecee3d2c0f5e04cab8c9a859bd1c9c7ccd4964fdae1"
   license "GPL-2.0-or-later"

--- a/Formula/x/xshogi.rb
+++ b/Formula/x/xshogi.rb
@@ -1,8 +1,8 @@
 class Xshogi < Formula
   desc "X11 interface for GNU Shogi"
   homepage "https://www.gnu.org/software/gnushogi/"
-  url "https://ftp.gnu.org/gnu/gnushogi/xshogi-1.4.2.tar.gz"
-  mirror "https://ftpmirror.gnu.org/gnushogi/xshogi-1.4.2.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/gnushogi/xshogi-1.4.2.tar.gz"
+  mirror "https://ftp.gnu.org/gnushogi/xshogi-1.4.2.tar.gz"
   sha256 "2e2f1145e3317143615a764411178f538bd54945646b14fc2264aaeaa105dab6"
   license "GPL-3.0-or-later"
   revision 1

--- a/Formula/z/zile.rb
+++ b/Formula/z/zile.rb
@@ -4,8 +4,8 @@ class Zile < Formula
   # Before bumping to a new version, check the NEWS file to make sure it is a
   # stable release: https://git.savannah.gnu.org/cgit/zile.git/plain/NEWS
   # For context, see: https://github.com/Homebrew/homebrew-core/issues/67379
-  url "https://ftp.gnu.org/gnu/zile/zile-2.6.4.tar.gz"
-  mirror "https://ftpmirror.gnu.org/zile/zile-2.6.4.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/zile/zile-2.6.4.tar.gz"
+  mirror "https://ftp.gnu.org/zile/zile-2.6.4.tar.gz"
   sha256 "d5d44b85cb490643d0707e1a2186f3a32998c2f6eabaa9481479b65caeee57c0"
   license "GPL-3.0-or-later"
   version_scheme 1


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Update formula URLs to prefer ftpmirror.gnu.org over ftp.gnu.org as suggested by GNU.

Requires https://github.com/Homebrew/brew/pull/20461 to be merged first.

Fixes https://github.com/Homebrew/brew/issues/20456.
