### PR TITLE
superlu: remove `gcc` dependency

### DIFF
--- a/Formula/s/superlu.rb
+++ b/Formula/s/superlu.rb
@@ -24,7 +24,6 @@ class Superlu < Formula
 
   depends_on "cmake" => :build
   depends_on "pkgconf" => :test
-  depends_on "gcc"
   depends_on "openblas"
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Doesn't seem to have linkage. Could be from 6.0.0 onward commenting out `cmake/XSDKDefaults.cmake`: https://github.com/xiaoyeli/superlu/commit/3cc760f6d934dc52ff60097efdad81fc96d5fd62