### PR TITLE
sundials: remove `gcc` dependency, replace deprecated args

### DIFF
--- a/Formula/s/sundials.rb
+++ b/Formula/s/sundials.rb
@@ -21,23 +21,20 @@ class Sundials < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "gcc" # for gfortran
   depends_on "open-mpi"
   depends_on "openblas"
   depends_on "suite-sparse"
-
-  uses_from_macos "libpcap"
 
   def install
     blas = "-L#{Formula["openblas"].opt_lib} -lopenblas"
     args = %W[
       -DBUILD_SHARED_LIBS=ON
-      -DKLU_ENABLE=ON
+      -DENABLE_KLU=ON
+      -DENABLE_LAPACK=ON
+      -DENABLE_MPI=ON
       -DKLU_LIBRARY_DIR=#{Formula["suite-sparse"].opt_lib}
       -DKLU_INCLUDE_DIR=#{Formula["suite-sparse"].opt_include}/suitesparse
-      -DLAPACK_ENABLE=ON
       -DLAPACK_LIBRARIES=#{blas};#{blas}
-      -DMPI_ENABLE=ON
     ]
 
     system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Can't find where `libpcap` was used.

GCC doesn't seem to be used as Fortran and OpenMP features are disabled by default.

Replace deprecated args like `MPI_ENABLE`: https://github.com/LLNL/sundials/blob/v7.3.0/cmake/SundialsDeprecated.cmake#L33-L40