### PR TITLE
suite-sparse: remove `metis` dependency

### DIFF
--- a/Formula/s/suite-sparse.rb
+++ b/Formula/s/suite-sparse.rb
@@ -30,10 +30,7 @@ class SuiteSparse < Formula
   depends_on "cmake" => :build
   depends_on "gcc" # for gfortran
   depends_on "gmp"
-  depends_on "metis"
   depends_on "mpfr"
-
-  uses_from_macos "m4"
 
   on_macos do
     depends_on "libomp"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Doesn't seem to use external `metis`. Needs changes from internal copy.