### PR TITLE
xdg-ninja: support XN_PROGRAMS_DIR override

### DIFF
--- a/Formula/x/xdg-ninja.rb
+++ b/Formula/x/xdg-ninja.rb
@@ -7,8 +7,8 @@ class XdgNinja < Formula
   head "https://github.com/b3nj5m1n/xdg-ninja.git", branch: "main"
 
   bottle do
-    rebuild 2
-    sha256 cellar: :any_skip_relocation, all: "5d767e8e08cd29ca7a383288a46aa3ece6f66eefe8cdabeb103a3f882ededfb9"
+    rebuild 3
+    sha256 cellar: :any_skip_relocation, all: "1fe099d79ef105b5a0272c820ccc1c774807c554c3e5e3bf180205afa50703ec"
   end
 
   depends_on "glow"

--- a/Formula/x/xdg-ninja.rb
+++ b/Formula/x/xdg-ninja.rb
@@ -17,7 +17,10 @@ class XdgNinja < Formula
   def install
     pkgshare.install "programs/"
     pkgshare.install "xdg-ninja.sh" => "xdg-ninja"
-    (bin/"xdg-ninja").write_env_script(pkgshare/"xdg-ninja", XN_PROGRAMS_DIR: pkgshare/"programs")
+    (bin/"xdg-ninja").write_env_script(
+      pkgshare/"xdg-ninja",
+      XN_PROGRAMS_DIR: "${XN_PROGRAMS_DIR:-#{pkgshare}/programs}",
+    )
     man1.install "man/xdg-ninja.1"
   end
 


### PR DESCRIPTION
Support local override of XN_PROGRAMS_DIR.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
