### PR TITLE
node@lts: new alias for node@22

### DIFF
--- a/Aliases/node@lts
+++ b/Aliases/node@lts
@@ -1,0 +1,1 @@
+../Formula/n/node@22.rb


### PR DESCRIPTION
This change introduces the `node@lts` alias, pointing it to the `node@22` formula. This provides users with a stable and convenient way to install the latest LTS version by simply running `brew install node@lts`.

At any moment there's only one 'active' LTS release, it currently being v22. Please see https://nodejs.org/en/about/previous-releases#nodejs-releases for more details.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
