### PR TITLE
dbus: fix launchd item management

### DIFF
--- a/Formula/d/dbus.rb
+++ b/Formula/d/dbus.rb
@@ -15,13 +15,13 @@ class Dbus < Formula
   end
 
   bottle do
-    sha256 arm64_sequoia: "b03c304cbecc18a7fd132a24aac4ae0245a731b72ea7ce819353397cd0e05b2c"
-    sha256 arm64_sonoma:  "540c1301f304a5da43ba2f1af7cff5ae6bbac3b28169f59d76741ec8105ea1ee"
-    sha256 arm64_ventura: "55db2782d19df3356835e0f71b1edff1c9aad20084df237154760f7f73e21d0a"
-    sha256 sonoma:        "cc14d4e58379b1c86bf51ce3ccb4a56ddf0808de29483cce83f5190c3dc0509b"
-    sha256 ventura:       "a1e1ee9afdc8c822751f93d7513e08681546f851bc1df5a815841c881621605e"
-    sha256 arm64_linux:   "b255e2237e533be133b8b637b8bc8425f754ba7a23bcdcf71a3634c5d4d79b4c"
-    sha256 x86_64_linux:  "32d15b5c8ddfdbd62a0a232aed447ebc0311ab3812d6f08c6fde4af08dcb3af3"
+    sha256 arm64_sequoia: "5a51451acabb5ae56b5682e88a82dfa43cc6a2b653ca068198546bb72324bd0c"
+    sha256 arm64_sonoma:  "1be729814991108cc593bb8472e376947898f8bf94b73271c2238c329514a3ba"
+    sha256 arm64_ventura: "29098b5b3f154677a61c30b402b17fe2912e9efe1cd7917ee6ae754209fe1f29"
+    sha256 sonoma:        "438a1da22c323246b958e0fbc63c5e7405dba77e9274809ebd73ab8c886a19d7"
+    sha256 ventura:       "2f10ec74399e7ffb843022aa22bf11b088ab6b00d34da46d623fca78900f166b"
+    sha256 arm64_linux:   "f636ed77fc07ab232ec75012b8b5a69cee10f8f239d48b1d5622baa83d9d9d7e"
+    sha256 x86_64_linux:  "42841a5373f596cbccd52b4cf3eae4f3ec6a853309b14e36e869a7030fabd21a"
   end
 
   depends_on "docbook" => :build

--- a/Formula/d/dbus.rb
+++ b/Formula/d/dbus.rb
@@ -6,7 +6,8 @@ class Dbus < Formula
   mirror "https://deb.debian.org/debian/pool/main/d/dbus/dbus_1.16.2.orig.tar.xz"
   sha256 "0ba2a1a4b16afe7bceb2c07e9ce99a8c2c3508e5dec290dbb643384bd6beb7e2"
   license any_of: ["AFL-2.1", "GPL-2.0-or-later"]
-  head "https://gitlab.freedesktop.org/dbus/dbus.git", branch: "master"
+  revision 1
+  head "https://gitlab.freedesktop.org/dbus/dbus.git", branch: "main"
 
   livecheck do
     url "https://dbus.freedesktop.org/releases/dbus/"
@@ -34,6 +35,10 @@ class Dbus < Formula
   uses_from_macos "python" => :build
   uses_from_macos "expat"
 
+  # Remove deprecated keys from launchd plist.
+  # PR ref: https://gitlab.freedesktop.org/dbus/dbus/-/merge_requests/179
+  patch :DATA
+
   def install
     # Fix the TMPDIR to one D-Bus doesn't reject due to odd symbols
     ENV["TMPDIR"] = "/tmp"
@@ -47,7 +52,8 @@ class Dbus < Formula
       -Dmodular_tests=disabled
     ]
 
-    args << "-Dlaunchd_agent_dir=#{lib}/Library/LaunchAgents" if OS.mac?
+    args << "-Dlaunchd_agent_dir=#{prefix}" << "-Ddbus_user=daemon" if OS.mac?
+    inreplace "bus/org.freedesktop.dbus-session.plist.in", "@DBUS_DAEMONDIR@", opt_bin
 
     # rpath is not set for meson build
     ENV.append "LDFLAGS", "-Wl,-rpath,#{lib}"
@@ -55,6 +61,11 @@ class Dbus < Formula
     system "meson", "setup", "build", *args, *std_meson_args
     system "meson", "compile", "-C", "build", "--verbose"
     system "meson", "install", "-C", "build"
+
+    # Manually create plist for system bus service
+    (prefix/"org.freedesktop.dbus-system.plist").write system_plist if OS.mac?
+    mkdir etc/"dbus-1/system.d"
+    mkdir etc/"dbus-1/session.d"
   end
 
   def post_install
@@ -65,17 +76,18 @@ class Dbus < Formula
   def caveats
     on_macos do
       <<~EOS
-        To load #{name} at startup, activate the included Launch Agent:
+        To start the session bus now and at login:
 
-          sudo cp #{lib}/Library/LaunchAgents/org.freedesktop.dbus-session.plist /Library/LaunchAgents
-          sudo chmod 644 /Library/LaunchAgents/org.freedesktop.dbus-session.plist
-          sudo launchctl load -w /Library/LaunchAgents/org.freedesktop.dbus-session.plist
+          brew services start dbus
 
-        If this is an upgrade and you already have the Launch Agent loaded, you
-        have to unload the Launch Agent before reinstalling it:
+        To start the system bus now and on boot, install and activate the included daemon:
 
-          sudo launchctl unload -w /Library/LaunchAgents/org.freedesktop.dbus-session.plist
-          sudo rm /Library/LaunchAgents/org.freedesktop.dbus-session.plist
+          sudo cp -f $(brew --prefix dbus)/org.freedesktop.dbus-system.plist /Library/LaunchDaemons
+          sudo launchctl bootstrap system /Library/LaunchDaemons/org.freedesktop.dbus-system.plist
+
+        If the daemon is already installed and running, restart it:
+
+          sudo launchctl kickstart -k system/org.freedesktop.dbus-system
       EOS
     end
   end
@@ -84,7 +96,64 @@ class Dbus < Formula
     name macos: "org.freedesktop.dbus-session"
   end
 
+  def system_plist
+    <<~PLIST
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+      <dict>
+        <key>Label</key>
+        <string>org.freedesktop.dbus-system</string>
+        <key>KeepAlive</key>
+        <dict>
+          <key>SuccessfulExit</key>
+          <false/>
+        </dict>
+        <key>ProgramArguments</key>
+        <array>
+          <string>#{opt_bin}/dbus-daemon</string>
+          <string>--nofork</string>
+          <string>--system</string>
+          <string>--nopidfile</string>
+        </array>
+        <key>Sockets</key>
+        <dict>
+          <key>unix_domain_listener</key>
+          <dict>
+            <key>SockPathName</key>
+            <string>#{var}/run/dbus/system_bus_socket</string>
+            <key>SockPathMode</key>
+            <integer>511</integer>
+          </dict>
+        </dict>
+      </dict>
+      </plist>
+    PLIST
+  end
+
   test do
-    system bin/"dbus-daemon", "--version"
+    assert_match version.to_s, shell_output("#{bin}/dbus-daemon --version")
   end
 end
+
+__END__
+diff --git a/bus/org.freedesktop.dbus-session.plist.in b/bus/org.freedesktop.dbus-session.plist.in
+index 40ff370..3c77fa9 100644
+--- a/bus/org.freedesktop.dbus-session.plist.in
++++ b/bus/org.freedesktop.dbus-session.plist.in
+@@ -5,15 +5,6 @@
+ 	<key>Label</key>
+ 	<string>org.freedesktop.dbus-session</string>
+ 
+-	<key>ServiceIPC</key>
+-	<true/>
+-
+-	<!-- Please uncomment on 10.4; OnDemand doesn't work properly there. -->
+-	<!--
+-	<key>OnDemand</key>
+-	<false />
+-	-->
+-
+ 	<key>ProgramArguments</key>
+ 	<array>
+ 		<string>@DBUS_DAEMONDIR@/dbus-daemon</string>


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fixes for these issues with `dbus`:

- moves the supplied launchd plist into the formula prefix, where it needs to be for `brew services` to see it. (Only a half dozen formulae currently supply their own plists.) Fixes https://github.com/zbentley/dbus-osx-examples/issues/4.
- patches out deprecated plist keys. This patch was removed in its [last version bump](https://github.com/Homebrew/homebrew-core/pull/209163), but the [associated merge request](https://gitlab.freedesktop.org/dbus/dbus/-/merge_requests/179) hasn't been completed.
- since the provided plist is only for the session bus, this supplies an additional plist for the system bus and adjusts the instructions to show how to manually enable it, since `brew services` doesn't currently support managing multiple services from a single formula.
