### PR TITLE
pcapplusplus: Disable building unit tests during install.

### DIFF
--- a/Formula/p/pcapplusplus.rb
+++ b/Formula/p/pcapplusplus.rb
@@ -20,6 +20,7 @@ class Pcapplusplus < Formula
   def install
     cmake_args = %w[
       -DPCAPPP_BUILD_EXAMPLES=OFF
+      -DPCAPPP_BUILD_TESTS=OFF
     ]
 
     system "cmake", "-S", ".", "-B", "build", *cmake_args, *std_cmake_args


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
The PcapPlusPlus unit tests are not exported or used during the install process, so building them is unnecessary.