### PR TITLE
zig anyzig: add conflict each other

### DIFF
--- a/Formula/a/anyzig.rb
+++ b/Formula/a/anyzig.rb
@@ -16,9 +16,9 @@ class Anyzig < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "1d68a435c3c52c8d944409175fe05f977932382420388bda1f341edb3270d6cc"
   end
 
-  keg_only "it conflicts with zig"
-
   depends_on "zig@0.14" => :build
+
+  conflicts_with "zig", because: "both install `zig` binaries"
 
   def install
     args = %W[-Dforce-version=v#{version.to_s.tr(".", "_")}]

--- a/Formula/z/zig.rb
+++ b/Formula/z/zig.rb
@@ -31,6 +31,8 @@ class Zig < Formula
     depends_on "zstd"
   end
 
+  conflicts_with "anyzig", because: "both install `zig` binaries"
+
   # https://github.com/Homebrew/homebrew-core/issues/209483
   skip_clean "lib/zig/libc/darwin/libSystem.tbd"
 


### PR DESCRIPTION
[Follow up](https://github.com/Homebrew/homebrew-core/pull/233392#discussion_r2275996139) to see if we can properly declare the conflict between these two formulas and remove the `keg_only` attribute from the new anyzig formula.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
