### PR TITLE
protoc-gen-grpc-java: fix build on Intel macOS

### DIFF
--- a/Formula/p/protoc-gen-grpc-java.rb
+++ b/Formula/p/protoc-gen-grpc-java.rb
@@ -35,12 +35,11 @@ class ProtocGenGrpcJava < Formula
       s.gsub! ', "-static-libgcc"', ""
     end
 
-    system "gradle", "--no-daemon",
-                     "--stacktrace",
-                     "--debug",
-                     "--project-dir=compiler",
-                     "-PskipAndroid=true",
-                     "java_pluginExecutable"
+    args = %w[--no-daemon --project-dir=compiler -PskipAndroid=true]
+    # Show extra logs for failures other than slow Intel macOS
+    args += %w[--stacktrace --debug] if !OS.mac? || !Hardware::CPU.intel?
+
+    system "gradle", *args, "java_pluginExecutable"
     bin.install "compiler/build/exe/java_plugin/protoc-gen-grpc-java"
 
     pkgshare.install "examples/src/main/proto/helloworld.proto"


### PR DESCRIPTION
PR to work on build failure preventing Intel macOS bottle.