### PR TITLE
Generate completion scripts for Swift tools

### DIFF
--- a/Formula/c/create-api.rb
+++ b/Formula/c/create-api.rb
@@ -32,6 +32,7 @@ class CreateApi < Formula
     system "swift", "build", *args, "--configuration", "release"
     bin.install ".build/release/create-api"
     pkgshare.install "Tests/Support/Specs/cookpad.json" => "test-spec.json"
+    generate_completions_from_executable(bin/"create-api", "--generate-completion-script")
   end
 
   test do

--- a/Formula/c/create-api.rb
+++ b/Formula/c/create-api.rb
@@ -10,13 +10,14 @@ class CreateApi < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "3704ccee2566fbffef69ba830037391340cf4211d7ba722735175c8d97de27c6"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "630e2912f2280aeb27c2646cb6af920de7d9c2c5a8c01029bd6d9bfc61ccf823"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "6f1b7204022524efbcc0d5488ace23dad6b074736da5938f5f2044c65466dabf"
-    sha256 cellar: :any_skip_relocation, sonoma:        "cedcc24ae6221316aed18f3231693938d012c99f64af00b4cd53df7c3661c69d"
-    sha256 cellar: :any_skip_relocation, ventura:       "576f78622c10ac452aba62246126c3ccfbb8ad3a684672563ce6d4a1b900a97e"
-    sha256                               arm64_linux:   "c76b87eb0e141e9c261f6bc2c00294a03589280162d3cba551828f2e1e324566"
-    sha256                               x86_64_linux:  "ab24ce8e1aa462a2745d77fd302a183f1f0ceb2d5e820da750f8c1f0667e38d1"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "ad0253916ad9e261c6f172f26a86114522ff41915bc71e8d4db3c85692b4ff55"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "d13191abe5e4a79f12ddb325118fb1d5ad2abeae2269e7a3e6b404d9913584bd"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "8d56775719688b44d0b8425c3662879424a79a337db732cb052006cbc9db988a"
+    sha256 cellar: :any_skip_relocation, sonoma:        "0a285919042a7d87a437dd6baf16cd3cdeb19b957bd655c2f88ffbbca59d3d5c"
+    sha256 cellar: :any_skip_relocation, ventura:       "b6fc15cf43f820ec337a72ebbf119e8837f3bd801d7d06f0125b9aaec2997dfb"
+    sha256                               arm64_linux:   "2abf5d3b403a7046f7ae8d806181047a7820356c4c8c6fc70bd5b55ddbd2263c"
+    sha256                               x86_64_linux:  "958733d65c7aff3b75b64ac6f5a547961d6bc0fa0242e078dddc5686e4a05ded"
   end
 
   depends_on xcode: "13.0"

--- a/Formula/d/dockutil.rb
+++ b/Formula/d/dockutil.rb
@@ -25,6 +25,7 @@ class Dockutil < Formula
   def install
     system "swift", "build", "--disable-sandbox", "--configuration", "release"
     bin.install ".build/release/dockutil"
+    generate_completions_from_executable(bin/"dockutil", "--generate-completion-script")
   end
 
   test do

--- a/Formula/d/dockutil.rb
+++ b/Formula/d/dockutil.rb
@@ -9,13 +9,12 @@ class Dockutil < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "b316cca52f1d2d41b358aae807d3d64996bd1dd6ff44852ac193075fd8eacd73"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "7e0fb8383a52ed1459e9811a121cc5c4105afc61d11d757564e148f72d4b28ce"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "5d8d0e3e19454fc3e958b30f7c1f93bc57cc08f14caa28c2435bbc77504699fc"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "3ccc0b78a56bec0d79cd7aa9249b72cb72330a6065d311041ac9d8415289654c"
-    sha256 cellar: :any_skip_relocation, sonoma:         "e63bf1404297af85f7e5c20d31f23fee13071b66404bf323a19decdf4d898dbe"
-    sha256 cellar: :any_skip_relocation, ventura:        "99b5c036b9ad73b6116ad5656218f55ed97680c6ab5e07921587ba6a10cba74d"
-    sha256 cellar: :any_skip_relocation, monterey:       "0486c78b5e464029ce2669026de258e0bdc13ddbcece77db4e589e118b3e2fb4"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "736b77305847eff297dface1a8e14f35e3c94fd8ce9a68efef0c6d4395abf1f3"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "b89b582646602f45c60de6737a65dc2b21d75393b2543d87be4754b89998e294"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "4d315729e980a1909812bcbf93183b6e745f9cd6ec6c253ac182af052235218f"
+    sha256 cellar: :any_skip_relocation, sonoma:        "23624766ad896d382bf343aeb1b1c46d26f117a8928ab06e3cd3ad29437afacf"
+    sha256 cellar: :any_skip_relocation, ventura:       "4436030a66f240ccfea5317023281dc817ce4bdf0784d52f0c90b536321be629"
   end
 
   depends_on xcode: ["13.0", :build]

--- a/Formula/l/licenseplist.rb
+++ b/Formula/l/licenseplist.rb
@@ -6,11 +6,12 @@ class Licenseplist < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "455aa974e950c7e0f19ea4ae8dc0666a01b663b07eea474fcb515cc20e3cad99"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "7ccc055b2f25c05d5f8f0c236530382463e98ea751b1136958ba8460d7fa7aa7"
-    sha256 cellar: :any,                 arm64_ventura: "d5bb44b8bacf9ef76ab5b2f97ba75586d76c5096c60617547ea76c664ec6e6b4"
-    sha256 cellar: :any_skip_relocation, sonoma:        "88ad0ab2826148ae09d5157e172c44585d974eed16be9c9829bd2453b2dee227"
-    sha256 cellar: :any,                 ventura:       "b2ff6995c345cbcc2eee53878b7740b910c88a3551504f4560ebd9c8c64e8d74"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e54f055c3e29a8aff0f85e950ab1c020a754f0aef9d0cc611dd2ce5805043e68"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "f0b3dcfa0ba7517e413f75da4cc7599fb5e5dd537d6b97441d1c588bd87cfbeb"
+    sha256 cellar: :any,                 arm64_ventura: "8c21ddfdff8381555f285a561c3f510c7ab4fbeda13888fb9f33b0f10846d85a"
+    sha256 cellar: :any_skip_relocation, sonoma:        "703046bd779a84a179d2d9f8b5a47008aa59b589cf541e3c80f43ebd4cdd55ce"
+    sha256 cellar: :any,                 ventura:       "dd3dc64ce46e592dfd9c3ad0b223366ab6556865a5ff2ea3d5392f93a030466e"
   end
 
   depends_on :macos

--- a/Formula/l/licenseplist.rb
+++ b/Formula/l/licenseplist.rb
@@ -20,6 +20,7 @@ class Licenseplist < Formula
   def install
     system "swift", "build", "--disable-sandbox", "--configuration", "release"
     bin.install ".build/release/license-plist"
+    generate_completions_from_executable(bin/"license-plist", "--generate-completion-script")
   end
 
   test do

--- a/Formula/m/mist-cli.rb
+++ b/Formula/m/mist-cli.rb
@@ -7,12 +7,12 @@ class MistCli < Formula
   head "https://github.com/ninxsoft/mist-cli.git", branch: "main"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e3de5cfe1043e9d802d578250bf5ec02386c0e1541c8e6bf8c1f57883bb01155"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "d52878ebf4acd1c8e3462bc7dc477df052682bef4bd8f696a9f2fa83188d403e"
-    sha256 cellar: :any,                 arm64_ventura: "7e304d64f0ef30b675ca7b6fc8df1c3bea09c5f69eaf5cc5ec547d73b9b8a012"
-    sha256 cellar: :any_skip_relocation, sonoma:        "7515d36129473828d4ea0272a182ffb8824ac3ed7c5ecdce65b6633289cc500d"
-    sha256 cellar: :any,                 ventura:       "485d54f96a0ecb0c3739b310b459007a270587746b0187a596da10f04fbbf3c4"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "efc0268da168bdef3957814c3abab5e3becda98958225ce0ab3478a8f7fe2584"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "1a1ea5b8fbae6561a594c3d72706b846a3faaff74ebcf4911bc466f51590bf1b"
+    sha256 cellar: :any,                 arm64_ventura: "c6c0edfdc3f68eabb96bdcf755c9f0ead40dc25394ebdd226a4bb348038e7799"
+    sha256 cellar: :any_skip_relocation, sonoma:        "5bdab24a2100cf79ef66cf23c90c8f7c5b3c12006a60a14af7a4adae2a211921"
+    sha256 cellar: :any,                 ventura:       "9bdc8ca295437ceb51e567998282f24c4b40c82b7a31d07f674f7783e3df80e1"
   end
 
   depends_on :macos

--- a/Formula/m/mist-cli.rb
+++ b/Formula/m/mist-cli.rb
@@ -22,6 +22,7 @@ class MistCli < Formula
   def install
     system "swift", "build", "--disable-sandbox", "--configuration", "release"
     bin.install ".build/release/mist"
+    generate_completions_from_executable(bin/"mist", "--generate-completion-script")
   end
 
   test do

--- a/Formula/m/mockolo.rb
+++ b/Formula/m/mockolo.rb
@@ -25,6 +25,7 @@ class Mockolo < Formula
     end
     system "swift", "build", *args, "-c", "release", "--product", "mockolo"
     bin.install ".build/release/mockolo"
+    generate_completions_from_executable(bin/"mockolo", "--generate-completion-script")
   end
 
   test do

--- a/Formula/m/mockolo.rb
+++ b/Formula/m/mockolo.rb
@@ -6,11 +6,12 @@ class Mockolo < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "b74e8f8747277f43a811197fe8ce144b06b4580a541689dcaf3ce784301b9fdc"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "ab85a94f0caf1fa8d1116376af36f713ecd3c1d18ee29a576aa121329ac9252c"
-    sha256 cellar: :any_skip_relocation, sonoma:        "3bc1c046167b769698f2629375ec0ece777f759e19bcda17f8a708de58eeabc7"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "afd124d827ae8b9a17e7eadeb2a8360758fbf7809e669e5991cd6d3af3c521fa"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "668e2e869b2bfce47c71e3c7b4f66f3b61810b7365a5e13e582645cab44d4dc6"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "18f1b69b192e7aaf2cb57a752c4c9a96c2ea7ab24ce52dce3b138dac2b190599"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "9da1cd6bc134cfd133dc72c56a3120429b8db32a4efab512f113c76f642f58de"
+    sha256 cellar: :any_skip_relocation, sonoma:        "293816ce556079215b9f76165f1d306b2ece74018b4616411cd6086ebc99e291"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "70236713bc4f9f9ede9f42093757fdf3df9b1852e228af98aa614bd463930745"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "476cee56c533c781c86fc767215cfc7ec7515596ef89f6ae473c3aff2927f1cd"
   end
 
   depends_on xcode: ["15.3", :build]

--- a/Formula/p/periphery.rb
+++ b/Formula/p/periphery.rb
@@ -28,6 +28,7 @@ class Periphery < Formula
     end
     system "swift", "build", *args, "--configuration", "release", "--product", "periphery"
     bin.install ".build/release/periphery"
+    generate_completions_from_executable(bin/"periphery", "--generate-completion-script")
   end
 
   test do

--- a/Formula/p/periphery.rb
+++ b/Formula/p/periphery.rb
@@ -7,11 +7,12 @@ class Periphery < Formula
   head "https://github.com/peripheryapp/periphery.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "c314b1a1ce15e2ff50ddab92984142cc48128665bf1fda0f2da5077b7c450ce8"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "1051052582167b3489ae50add5646f8356e991963ab5c133d1b65d900b87ad4c"
-    sha256 cellar: :any_skip_relocation, sonoma:        "85963a0568c0c3b78b5d9dda3a53ff82186a03049b49d977fc57a000d246b8d4"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "3865a7e57f405764e5e4a2fdca11a472e44d3eb6e0606acf4cdfcdde2cbd4871"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c7f6e1fddcebfec563dda91aeefae9a256e42fe5c1065a7e8826fc45b5b9d02e"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e2b0dea494e8bd21ff932fa10fac318cf2ee06c758e6797ecb23f99a6f8d2460"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "400cd8658c47b54ab5060f11df16ee035d1673aa3abd2c0244669121c744d570"
+    sha256 cellar: :any_skip_relocation, sonoma:        "df2656985ae7b056868b3f3acf2de20abd266cbd52d9d5ae31eaae77ea447ea5"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "fb205dd64182f1a1b904bd0187ecb81156bdeb1a38d74476afc9a1bae87654b8"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b4c6039249d029db5538c4d1f96014905f6d01914ecae26a8d0a76af0009fe77"
   end
 
   depends_on xcode: ["16.0", :build]

--- a/Formula/p/progressline.rb
+++ b/Formula/p/progressline.rb
@@ -9,13 +9,14 @@ class Progressline < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "b1ce512768f4802c3951adc6b2dd4add13a71d80ad5e04be15edecf17be6525a"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "77d1ab6f1922dbb9b14f3eed38fe30ddd33fdd5c058564389ec692af11e2a943"
-    sha256 cellar: :any,                 arm64_ventura: "99959093aafeb1bd100e2f720fbfefc377595338d60e004e31f43b50204e5bf1"
-    sha256 cellar: :any_skip_relocation, sonoma:        "4d86284fddc430f9312ff6e74e0ecd510b6d0b34edcdcaca2c4645c4fbf8cd15"
-    sha256 cellar: :any,                 ventura:       "1612ae0bb38a9f3a1897a27b87b14509527208e132d6a9d1c4c238bfd5d518ab"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "e48df80a4b56abf1757d634986174db54dec6d74680a9d6bf65b3847bad0a3f6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8429bc2bf925b50e2794b5e1a192e7a4bc896ea666cea8cd33c235a086872266"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "045e5418e7f4e6b95b5466c1305de384ebe61c46751d945ab9b85e2eff18dd06"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "e4de062267b1d1ee13d97e9b1b9413f8eb6b921fb586a22ec35603de6bc3a799"
+    sha256 cellar: :any,                 arm64_ventura: "0ae3e7443b2d0f26ca6a2707cc5190a8ec2e1a939076fdf4fdd319b37e13fca3"
+    sha256 cellar: :any_skip_relocation, sonoma:        "e1e76d606b4aae24fc61ba66a3a4cc4014efe3390a1bd89f022546bdfaf4ca67"
+    sha256 cellar: :any,                 ventura:       "b9d20a041aa6b083706306d87490f0f831d0747317037c912537ad50f37c2693"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "826e2a32265a039262ed40703e99acbad76a8b4db2762b723a3baecdb997cbd0"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "ff927b499b1881aad2a4f5f0ce1bcc86c72b5b7fc34a0b85303a31928b124105"
   end
 
   uses_from_macos "swift" => :build, since: :sonoma # swift 5.10+

--- a/Formula/p/progressline.rb
+++ b/Formula/p/progressline.rb
@@ -28,6 +28,7 @@ class Progressline < Formula
     end
     system "swift", "build", *args, "--configuration", "release"
     bin.install ".build/release/progressline"
+    generate_completions_from_executable(bin/"progressline", "--generate-completion-script")
   end
 
   test do

--- a/Formula/s/sourcedocs.rb
+++ b/Formula/s/sourcedocs.rb
@@ -56,6 +56,7 @@ class Sourcedocs < Formula
 
     system "swift", "build", *args
     bin.install ".build/release/sourcedocs"
+    generate_completions_from_executable(bin/"sourcedocs", "--generate-completion-script")
   end
 
   test do

--- a/Formula/s/sourcedocs.rb
+++ b/Formula/s/sourcedocs.rb
@@ -8,18 +8,14 @@ class Sourcedocs < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "4914567b0171f3dfcab46315e33232e5c925077268af59ce0ff5955c948dcb6e"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "5461899a0c97729c247703f45eb98a0cf26fc9939ce50eb6fa9543e9f70c6c62"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "fbe4a3e5c3485101486be0639b81cc4799c2dd7e0edf5f528d32a3c0ca6122fa"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "b8757a91d73d96999da362afbc5a5c42c7be949f562cf5569b2bf24853af6ef9"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "1254fb0f47a037f929e579b4a68dd375b0e587d9adb3e876865b6de031d39f46"
-    sha256 cellar: :any_skip_relocation, sonoma:         "9378990038e4d444ca11820d4e41eee737522dc75b7818d7577f4a612ab18bf1"
-    sha256 cellar: :any_skip_relocation, ventura:        "5cf36d5bfe2a9a2770454f21169e5e9c8a5a6b50525ec0a9418c88180706d40c"
-    sha256 cellar: :any_skip_relocation, monterey:       "974904c0b5b4d0d54fe8392c84fe06b3aa23e47fb76f95579f09e5fc94704d2d"
-    sha256 cellar: :any_skip_relocation, big_sur:        "292dbf6713d17716e685ac74c0e9fdbe07038b95bca36f234a94bfe2fffe5aab"
-    sha256 cellar: :any_skip_relocation, catalina:       "56cad5d1e01271614fd93c5ec93b4b7fc7cabb64bef767581bc5ad179ee20a63"
-    sha256                               arm64_linux:    "a5ede432a4cc147f30658c33f26b704e039b102f0c10d6e522296818dbb2bfdd"
-    sha256                               x86_64_linux:   "ebd23518f4371e70e885900d73fdf0ea71a4d30a0695a1dff8fa4d762abfa5e1"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "469c4069a84bcc4e8ed58db567eeca9bb8d13311b0c3b5d289bd61a9d1a09aba"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "b7cb1a6469f057e769fd3ea2e22e2a288b16d42a7b44a3688e1f0787288e6fa2"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "54139f452dcce5a6bb3d42f6483a1ddab9a97705b1b07d89f70333e9a0a770dc"
+    sha256 cellar: :any_skip_relocation, sonoma:        "55d0026d803e708bd167e4817a0f278f0bc0b393103711c0fdc1db59f2ce5063"
+    sha256 cellar: :any_skip_relocation, ventura:       "4b08ada0cacbbfde31cdf88bfc10aba963442a03363844c888c39d9cd6d8862c"
+    sha256                               arm64_linux:   "7698fc8b57805896688c2e9058fb25e4aa7f6189f4252e8d253a02662e98321b"
+    sha256                               x86_64_linux:  "2c97cd8daa81d7c7e546e71cdfdf17db555dee5260d434287266f20edb3a25a6"
   end
 
   depends_on xcode: ["12.0", :build, :test]

--- a/Formula/s/sourcekitten.rb
+++ b/Formula/s/sourcekitten.rb
@@ -24,6 +24,7 @@ class Sourcekitten < Formula
 
   def install
     system "make", "prefix_install", "PREFIX=#{prefix}", "TEMPORARY_FOLDER=#{buildpath}/SourceKitten.dst"
+    generate_completions_from_executable(bin/"sourcekitten", "--generate-completion-script")
   end
 
   test do

--- a/Formula/s/sourcekitten.rb
+++ b/Formula/s/sourcekitten.rb
@@ -8,13 +8,14 @@ class Sourcekitten < Formula
   head "https://github.com/jpsim/SourceKitten.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "34d5a49f50885b3cc0cff8812f6c4770976be709befa058385d404f27487fd06"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "6a68272f86ee89c1dbf1fb19349431a209124f7b2413d6a32152d81dec8978ec"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "07ec2e64a18e5ce87c3511be8ba93f17d162d05c737da4dc5a52c477f6e795a1"
-    sha256 cellar: :any_skip_relocation, sonoma:        "9c64b978d11776e2baa8103bdac80636561f69f157d203411dab05a05c87e294"
-    sha256 cellar: :any_skip_relocation, ventura:       "207bcbf2c8ce58e39afa645836e7798085c39803e9ec1ba728ac80f1b7281713"
-    sha256                               arm64_linux:   "53a805bb690bda85db814fb237af34c3999c8ef3685e9878562b9d0b8a38c355"
-    sha256                               x86_64_linux:  "97515204398c1cd3aec85367e15eba66781a08fbb972aecb2c74a5cafb419ea6"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "44c64e1df133d699d98585b6e1e358c2a3e6ddb330d5d82de43b489c6e8f01bc"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "ac988164695f5e9bf5dbd42e8440601aeff80355022cddcee0e750916fca784d"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "7918e02dcba07a9af1934789a236722bb537b726137ae41652ac7c03bfedc07b"
+    sha256 cellar: :any_skip_relocation, sonoma:        "82ca4f63f693f1d9d2c0faea72ce87456c973d3f802ea38e9f6599e4193741bd"
+    sha256 cellar: :any_skip_relocation, ventura:       "ddcda8cfe8a5762582eb5472f8be3f280c602a6a64f4427aef8c21e4524ea4d5"
+    sha256                               arm64_linux:   "4880dde3f371a7852b5c626c806a9d5da2d18d257a0b671513049cad446d42bd"
+    sha256                               x86_64_linux:  "ecaea860a805bc12aaa65cbfb5928b327645c60a3c62115f3ea33ed40a62a2ec"
   end
 
   depends_on xcode: ["14.0", :build]

--- a/Formula/s/swift-outdated.rb
+++ b/Formula/s/swift-outdated.rb
@@ -26,6 +26,7 @@ class SwiftOutdated < Formula
     end
     system "swift", "build", *args, "-c", "release"
     bin.install ".build/release/swift-outdated"
+    generate_completions_from_executable(bin/"swift-outdated", "--generate-completion-script")
   end
 
   test do

--- a/Formula/s/swift-outdated.rb
+++ b/Formula/s/swift-outdated.rb
@@ -7,13 +7,14 @@ class SwiftOutdated < Formula
   head "https://github.com/kiliankoe/swift-outdated.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "c854d719500ecd9228e4d10a0008da09ac89589a548a5bbc2d92aa2fc5c99281"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "a44bc14904726aa8cf2d4bc15cd3be7b59c7f00ef584cd9b79d7609910c71e09"
-    sha256 cellar: :any,                 arm64_ventura: "d6fa404a960bc8522d91a45bfa9e2d52b7baab491c6c5e0229a13f5a1ece022b"
-    sha256 cellar: :any_skip_relocation, sonoma:        "727817c88b6c5e964dfa2deb2b14b5028364000f4eee8dc8693a982cacc36cf3"
-    sha256 cellar: :any,                 ventura:       "c996f9b83bc6d56580acdc89c83958a30d3ca23adae922d1c4eadfd408906164"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "284ed8674d3a5dbe92d9d0c7068fad398ac559b6ac9696c48687f2eca6d00f02"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "be519ea7c102f4277ca2d217c9eb2275f90c3431205809bc4f99c15620ea2763"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "58aeea76403eca1144530d12d17f6fa5a6948034cb075cb5a3b1014461f0a396"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "59a7de084662bdadeb04796bcd11046d6ee063931e5b01f5ab3792b3486d92a7"
+    sha256 cellar: :any,                 arm64_ventura: "62239578f238bf0236695dad01d98c639260eaca52438a8de0cf2ae86de74510"
+    sha256 cellar: :any_skip_relocation, sonoma:        "6d1604bc3df90d6939ce16b57ef779c57a79f7b84558e6d2512fccb1c6af4e82"
+    sha256 cellar: :any,                 ventura:       "89fb9b983054d10d5a9df8a29be708a4216e1c434d5b981d47c7abb9b791068d"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "7667824b4932a49ee6a49349c37a7806541a872b7320f2aca2216aeb64ced9b1"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "25992defbbb5f13ee4cfadf31b3293691ea40298c8e75ee54bdcdc08556cbdb8"
   end
 
   uses_from_macos "swift" => :build, since: :sonoma # swift 6.0+

--- a/Formula/s/swift-section.rb
+++ b/Formula/s/swift-section.rb
@@ -20,6 +20,7 @@ class SwiftSection < Formula
   def install
     system "swift", "build", "--disable-sandbox", "-c", "release"
     bin.install ".build/release/swift-section"
+    generate_completions_from_executable(bin/"swift-section", "--generate-completion-script")
   end
 
   test do

--- a/Formula/s/swift-section.rb
+++ b/Formula/s/swift-section.rb
@@ -7,7 +7,8 @@ class SwiftSection < Formula
   head "https://github.com/MxIris-Reverse-Engineering/MachOSwiftSection.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "0e0ea2815a7b598314f27fd6106b276e73e2c860df3aae1c650110f8b4601095"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "33bd0561f24b2a832733a8acf0deac577462b2ca382f2a01df72308e75ce141b"
   end
 
   # The Package.swift file requires Swift 5.10 or later.

--- a/Formula/t/tart.rb
+++ b/Formula/t/tart.rb
@@ -38,6 +38,7 @@ class Tart < Formula
     system "swift", "build", "--disable-sandbox", "-c", "release"
     system "/usr/bin/codesign", "-f", "-s", "-", "--entitlement", "Resources/tart.entitlements", ".build/release/tart"
     bin.install ".build/release/tart"
+    generate_completions_from_executable(bin/"tart", "--generate-completion-script")
   end
 
   test do

--- a/Formula/x/xcbeautify.rb
+++ b/Formula/x/xcbeautify.rb
@@ -30,6 +30,7 @@ class Xcbeautify < Formula
     end
     system "swift", "build", *args, "--configuration", "release"
     bin.install ".build/release/xcbeautify"
+    generate_completions_from_executable(bin/"xcbeautify", "--generate-completion-script")
   end
 
   test do

--- a/Formula/x/xcbeautify.rb
+++ b/Formula/x/xcbeautify.rb
@@ -7,13 +7,14 @@ class Xcbeautify < Formula
   head "https://github.com/cpisciotta/xcbeautify.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "ee1f233d52ac4b8541e9bc5bf43b5ee15e5246130bfc500ef248b68ea8e4ad5e"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "5f193dcd43fe565fed28381ebf6f55240d137063507ff96f59dbe3b87091a295"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "e7755f538b36b686e3c71665ead825368a3bdaebb711e95d1e1622b3113b0797"
-    sha256 cellar: :any_skip_relocation, sonoma:        "1db40750e9579e6dc60acc4b35b9c3765620ac1844ffccf016880e777fcc8f4c"
-    sha256 cellar: :any_skip_relocation, ventura:       "b69b9f2f8a36d2912add3c92f20adce091fd4e0ea2fb0a07ece4caffb130b311"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "0f5f5c6a2b24964def0dd4a0d115a44ac141d807b3942238c452fdffd3fb7dd2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "093a34e1852f51b30a4cbe8bebedec15370d91f8180eeb0a55996c63e97977a6"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "45aa6aae0d7a48a05719aa0bd20a3d49d2eb3b602763dbe7fdb20777c57f998e"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "438d03f0c727ad6afdb8364d56abc2e2d61b17b4bca9d2fecba9b676618f9e9a"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "c0b0a8bd11267bec6d150639bdd0a954c663d784f1c1de63e8297a126c01d266"
+    sha256 cellar: :any_skip_relocation, sonoma:        "3b103beb64a4a1c716f761ac978496184e220ede127efc1f44f8084cf62d9b63"
+    sha256 cellar: :any_skip_relocation, ventura:       "d715ace6defcf2422803a14d01623ea3805978a611ba5cc0c9c17d5baaf01ca4"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "dddc7750570072cb5609cc9bf22e88b5867e71633a2fe70aaf347124e545d532"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d81bcec58668fba3b890772640a7d26f456a093379755b548a41bc3e9772f079"
   end
 
   # needs Swift tools version 5.9.0

--- a/Formula/x/xcdiff.rb
+++ b/Formula/x/xcdiff.rb
@@ -8,11 +8,12 @@ class Xcdiff < Formula
   head "https://github.com/bloomberg/xcdiff.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "bd62e3b0b02971f946bea613e95a4ceeb8ab41ede5383518148c542b5908ef04"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "350423748bd984e66f473e60a4545125870b8589807b8d82b01745e0a45cad50"
-    sha256 cellar: :any,                 arm64_ventura: "2ba598baf440f1a76a105f07489776c4e81a1a1803d49c396209e88599e20410"
-    sha256 cellar: :any_skip_relocation, sonoma:        "23083c0664be219b75633a64827762ea19a078b11d76558336df3c82928312e3"
-    sha256 cellar: :any,                 ventura:       "fa904d1ebca63b4ba8e032e8406279535f91bc0f6e62a94edec04ce1f4123950"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "6af8cba695e556e3d1486f1ee108d647d9ff45c69dbe63e66c683830ba8edb34"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "70995592131e0eb7cb495e7b45b0398c2b7e0d37c6ae3b44e30fce1b7151961b"
+    sha256 cellar: :any,                 arm64_ventura: "04a679bb1c3d2e6125594ca56e4c34f48d6d2e7425d15955fbc1d52a8ba916ef"
+    sha256 cellar: :any_skip_relocation, sonoma:        "5520630a6cac7c1e170824dd6fc509beaa446ec8163780ce7f02ca6b49ceb228"
+    sha256 cellar: :any,                 ventura:       "2a302b05ff15c6ffd959cbd6b7306d6a09c76b0318d2902b2f952c9d88cbb870"
   end
 
   depends_on :macos

--- a/Formula/x/xcdiff.rb
+++ b/Formula/x/xcdiff.rb
@@ -24,6 +24,7 @@ class Xcdiff < Formula
     system "make", "update_hash"
     system "swift", "build", "--disable-sandbox", "--configuration", "release"
     bin.install ".build/release/xcdiff"
+    generate_completions_from_executable(bin/"xcdiff", "--generate-completion-script")
   end
 
   test do

--- a/Formula/x/xclogparser.rb
+++ b/Formula/x/xclogparser.rb
@@ -6,13 +6,14 @@ class Xclogparser < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "24152e756e0accf02e58b2e8a27340c7928c108c178a918b94a16b14c83ce7b1"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "84acb208ae9ea2ffc3bd28bf830a43ec4f32f449b455915dfb82fa4489afcac0"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "6564c2ee06346f8cb6a708dc6c6927796f83919798403f2235ef1c6671bdfcc4"
-    sha256 cellar: :any_skip_relocation, sonoma:        "522f1c32a5a4a269a5f530b976648f8485c19c38b8184e13a18e14245f12593a"
-    sha256 cellar: :any_skip_relocation, ventura:       "8a05a80f163e1342eeef5fb1228dd7b10d2f29b5a83c4fd3573a01342999db04"
-    sha256                               arm64_linux:   "d94b3f9875e169fa0cceb79bc62043903fd671778a9e8cf374e678369e625356"
-    sha256                               x86_64_linux:  "4926c5d871fd3162290869816066e8e28f03275240e99b69cb20ec31330fb755"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "622e5798fe8768788e485edcedfec11f6e0fd57e9afbb38e2704d115ff89286b"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "2f12e89a162b46b953fe975af664deb83e59bb554a8b8661bc0390bc0870d778"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "64bddc1054c263b9a69055fd4f6979af194928fc8c2da52d6e5a26aa1d29ca88"
+    sha256 cellar: :any_skip_relocation, sonoma:        "6449046ee960ec4033bb7ea5d021d25967c6a494bfa4d8fccd8e236c748ca0ec"
+    sha256 cellar: :any_skip_relocation, ventura:       "2912ff1525c5e8ecd29fc66c01ea0b0b792e8550b56089d014364351a1dbe3c7"
+    sha256                               arm64_linux:   "958f12eaebc195dce784e46c2518e9d71918476f20caefe2928c0b4b2ffaed09"
+    sha256                               x86_64_linux:  "1a636c81a4dccdf9f84f74eff4abda9baf5da3e3bbd660e961f39a9b1f932a45"
   end
 
   depends_on xcode: "13.0"

--- a/Formula/x/xclogparser.rb
+++ b/Formula/x/xclogparser.rb
@@ -33,6 +33,7 @@ class Xclogparser < Formula
     end
     system "swift", "build", *args, "--configuration", "release"
     bin.install ".build/release/xclogparser"
+    generate_completions_from_executable(bin/"xclogparser", "--generate-completion-script")
   end
 
   test do

--- a/Formula/x/xcresultparser.rb
+++ b/Formula/x/xcresultparser.rb
@@ -22,6 +22,7 @@ class Xcresultparser < Formula
     system "swift", "build", "--disable-sandbox", "--configuration", "release"
     bin.install ".build/release/xcresultparser"
     pkgshare.install "Tests/XcresultparserTests/TestAssets/test.xcresult"
+    generate_completions_from_executable(bin/"xcresultparser", "--generate-completion-script")
   end
 
   test do

--- a/Formula/x/xcresultparser.rb
+++ b/Formula/x/xcresultparser.rb
@@ -7,11 +7,12 @@ class Xcresultparser < Formula
   head "https://github.com/a7ex/xcresultparser.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "5611ac80b73a2e3b80d2031a753f88c719a5aba3ed8971071fd72fa3d56ff520"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "d08e43a313902ca8e9415c071afd632226f73f18ae975564a054b312724c4c80"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "9b0efdb380802a632850cf3245c3eac499bece9f0217dcbd4ee38afc74f80e9f"
-    sha256 cellar: :any_skip_relocation, sonoma:        "e2d94de14b2fc48ffbdeeedf8d4f9d818c1f49393e7f7bc7699672300ad33487"
-    sha256 cellar: :any_skip_relocation, ventura:       "d451ea710acc90edca7d55bc1a0906c581f3f6d8721fa0280893b178ffe1e9e9"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "f576f5ba61ce21d8c490d01e126cd7045e48b12cd5005ffde8ddea8c0404dce8"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "33724a00acf49733e806f2e06d3eb89e2722b5ea8a0ef37a1d8a2b1d58961681"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "98e359f359c24fe7d24a426062239319b704fc1b4544ae19a1af8ed929527487"
+    sha256 cellar: :any_skip_relocation, sonoma:        "8a6d02101985dd1c5b8637230b49ab3d61bbe0042806690269913440b61ca854"
+    sha256 cellar: :any_skip_relocation, ventura:       "0e2890e6c73bfb7fbd301d34f1aab277deddd785afed12933e4168f1e3d3d154"
   end
 
   depends_on xcode: ["15.0", :build]

--- a/Formula/x/xctesthtmlreport.rb
+++ b/Formula/x/xctesthtmlreport.rb
@@ -21,6 +21,7 @@ class Xctesthtmlreport < Formula
   def install
     system "swift", "build", "--disable-sandbox", "-c", "release"
     bin.install ".build/release/xchtmlreport"
+    generate_completions_from_executable(bin/"xchtmlreport", "--generate-completion-script")
   end
 
   test do

--- a/Formula/x/xctesthtmlreport.rb
+++ b/Formula/x/xctesthtmlreport.rb
@@ -7,11 +7,12 @@ class Xctesthtmlreport < Formula
   head "https://github.com/XCTestHTMLReport/XCTestHTMLReport.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "2f891210797be11eff596d4591cfd5a17040edad1f91ab4e82f05810605748ed"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "6ba579e5455f7fcaa0dd5e9f5eebe5ef50d0f8c5e722ea8284cc93acf79d5d6d"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "6ced2a0b67495d2a88bb0c54884826c7803dab81f4a26e9b428be6e9403a7de2"
-    sha256 cellar: :any_skip_relocation, sonoma:        "d6aa6f58167e54283fb1f2fc7f80cbf08024f577d087cae4f46fc764498ede33"
-    sha256 cellar: :any_skip_relocation, ventura:       "110df7a8ab8a1254e30c69397bdca84ba148247d0a9009349a3c36c56c78b088"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "a6befa1b9ad7d3002a8f90f25c0387d6fd95b03f923891d29a759d3ae0119a81"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "3580d4f15dd4fa8865db0f53ed950dfcab35f55070a3888fce5563d2d1a3e139"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "9137f28799e7c82a8f3f6662dd1196c7ceadd780ab6acf2223cddf99de3b6d2b"
+    sha256 cellar: :any_skip_relocation, sonoma:        "79a84112939771f88b58c8f7ef61c7689716ae29bde3bc07061d458b6974b322"
+    sha256 cellar: :any_skip_relocation, ventura:       "03127ae2494f3dcbf1af0c87578aeb1e4fe4a0d04df39262db4b868dbf5754c6"
   end
 
   depends_on :macos


### PR DESCRIPTION
Swift packages using Swift Argument Parser for their CLI should be able to generate completion scripts themselves with the --generate-completion-script.

Not sure if multiple formulae can be updated in a single PR. Let me know if I should rather split them up into separate ones.