### PR TITLE
wiredtiger vectorscan: remove `ccache` dependency

### DIFF
--- a/Formula/v/vectorscan.rb
+++ b/Formula/v/vectorscan.rb
@@ -17,7 +17,6 @@ class Vectorscan < Formula
   end
 
   depends_on "boost" => :build
-  depends_on "ccache" => :build
   depends_on "cmake" => :build
   depends_on "pcre" => :build # PCRE2 issue: https://github.com/VectorCamp/vectorscan/issues/320
   depends_on "pkgconf" => :build
@@ -25,6 +24,7 @@ class Vectorscan < Formula
 
   def install
     cmake_args = [
+      "-DCCACHE_FOUND=CCACHE_FOUND-NOTFOUND",
       "-DBUILD_STATIC_LIBS=ON",
       "-DBUILD_SHARED_LIBS=ON",
       "-DFAT_RUNTIME=OFF",

--- a/Formula/w/wiredtiger.rb
+++ b/Formula/w/wiredtiger.rb
@@ -20,7 +20,6 @@ class Wiredtiger < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "100e4051caa78dbd63c57f3e0a3be5f0272676e187c191d040068cbaf5c67aa4"
   end
 
-  depends_on "ccache" => :build
   depends_on "cmake" => :build
   depends_on "swig" => :build
   depends_on "lz4"
@@ -35,6 +34,7 @@ class Wiredtiger < Formula
     ENV.runtime_cpu_detection
 
     args = %W[
+      -DCCACHE_FOUND=CCACHE_FOUND-NOTFOUND
       -DHAVE_BUILTIN_EXTENSION_SNAPPY=1
       -DHAVE_BUILTIN_EXTENSION_ZLIB=1
       -DCMAKE_INSTALL_RPATH=#{rpath}


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Also set the CMake cache variable to avoid attempting to find ccache. Also fine without this as it will only output a warning but the message may result in unnecessarily re-adding the dependency.