### PR TITLE
source-highlight: make `boost` build-only

### DIFF
--- a/Formula/s/source-highlight.rb
+++ b/Formula/s/source-highlight.rb
@@ -24,7 +24,7 @@ class SourceHighlight < Formula
     sha256 x86_64_linux:  "09c0f664ede1dd50549c8cae4dd1a57b587c81da49a3f03b5d0b78e33f15a935"
   end
 
-  depends_on "boost"
+  depends_on "boost" => :build
 
   # Fix -flat_namespace being used on Big Sur and later.
   patch do
@@ -34,9 +34,10 @@ class SourceHighlight < Formula
 
   def install
     ENV.cxx11
-    system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}",
-                          "--with-boost=#{Formula["boost"].opt_prefix}"
+    # Avoid linkage to Boost.Regex on macOS
+    ENV.append "LDFLAGS", "-Wl,-dead_strip_dylibs" if OS.mac?
+
+    system "./configure", "--with-boost=#{Formula["boost"].opt_prefix}", *std_configure_args
     system "make", "install"
 
     bash_completion.install "completion/source-highlight"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
