### PR TITLE
adaptivecpp: use brew `llvm` only on Linux

### DIFF
--- a/Formula/a/adaptivecpp.rb
+++ b/Formula/a/adaptivecpp.rb
@@ -17,8 +17,9 @@ class Adaptivecpp < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "boost"
-  depends_on "llvm"
+  depends_on "boost" # needed to use collective_execution_engine.hpp
+
+  uses_from_macos "llvm"
   uses_from_macos "python"
 
   on_macos do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Features that need LLVM lib is only enabled on Linux.

Boost isn't linked, but part of installed headers do include it so keeping it as runtime dependency as we don't split out `-dev` portion.