### PR TITLE
libcds: remove `boost` dependency

### DIFF
--- a/Formula/lib/libcds.rb
+++ b/Formula/lib/libcds.rb
@@ -25,13 +25,12 @@ class Libcds < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "boost"
 
   def install
     # Change the install library directory for x86_64 arch to `lib`
     inreplace "CMakeLists.txt", "set(LIB_SUFFIX \"64\")", ""
 
-    system "cmake", "-S", ".", "-B", "_build", *std_cmake_args
+    system "cmake", "-S", ".", "-B", "_build", "-DCMAKE_POLICY_VERSION_MINIMUM=3.5", *std_cmake_args
     system "cmake", "--build", "_build"
     system "cmake", "--install", "_build"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Boost dependency not needed since 2.3.3 -   https://github.com/khizmax/libcds/commit/76e98406c70a05d92ffa3a1f62e0e43ca947faf5

Remaining Boost atomics feature is not enabled by default.