### PR TITLE
garble: test with `go@1.24`

### DIFF
--- a/Formula/g/garble.rb
+++ b/Formula/g/garble.rb
@@ -16,7 +16,9 @@ class Garble < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "c0863f7848ea5aa0f24afe53ba523773bfbc732a6082249970c86d2b99d8eee6"
   end
 
-  depends_on "go" => [:build, :test]
+  depends_on "go" => :build
+  # Go version "go1.25.0" is too new; Go linker patches aren't available for go1.25 or later yet
+  depends_on "go@1.24" => :test
   depends_on "git"
 
   def install
@@ -25,6 +27,10 @@ class Garble < Formula
   end
 
   test do
+    go = deps.find { |dep| dep.test? && dep.name.match?(/^go(@\d+(\.\d+)*)?$/) }
+             .to_formula
+    ENV.prepend_path "PATH", go.opt_bin
+
     (testpath/"hello.go").write <<~GO
       package main
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fixes

    Go version "go1.25.0" is too new; Go linker patches aren't available for go1.25 or later yet

See https://github.com/Homebrew/homebrew-core/actions/runs/17061504945/job/48385391639?pr=234049#step:3:112
See #234049.
