### PR TITLE
zero-install: use system ocaml with opam >= 2.4.0

### DIFF
--- a/Formula/z/zero-install.rb
+++ b/Formula/z/zero-install.rb
@@ -43,8 +43,8 @@ class ZeroInstall < Formula
     ENV["OPAMVERBOSE"] = "1"
     packages = ["./0install.opam", "./0install-solver.opam"]
 
-    system "opam", "init", "--no-setup", "--disable-sandboxing"
-    system "opam", "exec", "--", "opam", "install", *packages, "--deps-only", "-y", "--no-depexts"
+    system "opam", "init", "--compiler=ocaml-system", "--disable-sandboxing", "--no-setup"
+    system "opam", "install", *packages, "--deps-only", "--yes", "--no-depexts"
     system "opam", "exec", "--", "make", "all"
     system "opam", "exec", "--", "dist/install.sh", prefix
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

opam 2.4.0 removed default ocaml-system so restore original behavior. Avoids 2x build time from building another OCaml

Also remove redundant `opam exec` as `opam install` should automatically use `OPAMROOT`. Non opam-commands (e.g.  make) needs the `opam exec`.