### PR TITLE
kargo: set go as a build dependency

### DIFF
--- a/Formula/k/kargo.rb
+++ b/Formula/k/kargo.rb
@@ -16,7 +16,7 @@ class Kargo < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "b2893968509018b83fc242040d95a8cee6b989fb597d630275cca72c4a832dd0"
   end
 
-  depends_on "go"
+  depends_on "go" => :build
 
   def install
     ldflags = %W[


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The kargo formula doesn't mark go as a build dependency, resulting in go being installed even when you're not building from source. Go isn't needed as a runtime dependency.