### PR TITLE
llgo: simplify

### DIFF
--- a/Formula/l/llgo.rb
+++ b/Formula/l/llgo.rb
@@ -36,7 +36,8 @@ class Llgo < Formula
   end
 
   def find_dep(name)
-    deps.map(&:to_formula).find { |f| f.name.match?(/^#{name}(@\d+)?$/) }
+    deps.find { |f| f.name.match?(/^#{name}(@\d+(\.\d+)*)?$/) }
+        .to_formula
   end
 
   def install
@@ -63,7 +64,8 @@ class Llgo < Formula
 
     libexec.install "LICENSE", "README.md", "go.mod", "go.sum", "runtime"
 
-    path_deps = %w[lld llvm go@1.24 pkgconf].map { |name| find_dep(name).opt_bin }
+    path_deps = %w[lld go pkgconf].map { |name| find_dep(name).opt_bin }
+    path_deps << llvm.opt_bin
     script_env = { PATH: "#{path_deps.join(":")}:$PATH" }
 
     if OS.linux?
@@ -81,7 +83,7 @@ class Llgo < Formula
   end
 
   test do
-    go = find_dep("go@1.24")
+    go = find_dep("go")
     goos = shell_output("#{go.opt_bin}/go env GOOS").chomp
     goarch = shell_output("#{go.opt_bin}/go env GOARCH").chomp
     assert_equal "llgo v#{version} #{goos}/#{goarch}", shell_output("#{bin}/llgo version").chomp


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- adjust regex in `find_dep` so it can find a versioned Go dependency
- call `#to_formula` last, since this is a relatively expensive
  operation
- reuse the existing `llvm` Formula object created earlier, instead of
  invoking `find_dep` to return another one.

The adjustments to `find_dep` mean that we don't have to make multiple
changes throughout the formula when adjusting the `go` dependency.

CC @luoliwoshang
