### PR TITLE
pact-cli 1.77.0 (new formula)

### DIFF
--- a/Formula/p/pact-cli.rb
+++ b/Formula/p/pact-cli.rb
@@ -26,5 +26,6 @@ class PactCli < Formula
 
   test do
     assert_match version.to_s, shell_output("#{bin}/#{name} version")
+    assert_match "Connection refused", shell_output("#{bin}/#{name} list-pacticipants --broker-base-url=https://localhost 2>&1", 1)
   end
 end

--- a/Formula/p/pact-cli.rb
+++ b/Formula/p/pact-cli.rb
@@ -26,6 +26,7 @@ class PactCli < Formula
 
   test do
     assert_match version.to_s, shell_output("#{bin}/#{name} version")
-    assert_match "Connection refused", shell_output("#{bin}/#{name} list-pacticipants --broker-base-url=https://localhost 2>&1", 1)
+    assert_match "Connection refused",
+                 shell_output("#{bin}/#{name} list-pacticipants --broker-base-url=https://localhost 2>&1", 1)
   end
 end

--- a/Formula/p/pact-cli.rb
+++ b/Formula/p/pact-cli.rb
@@ -1,0 +1,30 @@
+class PactCli < Formula
+  desc "CLI client for the Pact Broker"
+  homepage "https://github.com/pact-foundation/pact_broker-client"
+  url "https://github.com/pact-foundation/pact_broker-client/archive/refs/tags/v1.77.0.tar.gz"
+  sha256 "a7f333afee6eae511c177256a284fc30d7b236bc4ab715107303d99353555664"
+  license "MIT"
+
+  depends_on "ruby"
+
+  def install
+    ENV["BUNDLE_VERSION"] = "system"
+    ENV["GEM_HOME"] = libexec
+
+    inreplace "pact-broker-client.gemspec",
+              /`git ls-files`.split.*$/,
+              'Dir["lib/**/*", "bin/*", "README*", "LICENSE*"]'
+
+    system "bundle", "config", "set", "without", "development", "test"
+    system "bundle", "install"
+    system "gem", "build", "pact-broker-client.gemspec"
+    system "gem", "install", "pact_broker-client-#{version}.gem"
+
+    bin.install libexec/"bin/pact-broker" => name.to_s
+    bin.env_script_all_files(libexec/"bin", GEM_HOME: ENV["GEM_HOME"])
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/#{name} version")
+  end
+end


### PR DESCRIPTION
Add a formula for pact-cli, a CLI client for the Pact Broker.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
-----
Notes
`brew audit --new` doesn't pass due to `depends_on "ruby"` which is necessary due to macOS ruby being outdated for `pact-cli`.