### PR TITLE
emscripten: run create_entry_points.py

### DIFF
--- a/Formula/e/emscripten.rb
+++ b/Formula/e/emscripten.rb
@@ -25,13 +25,14 @@ class Emscripten < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "01adf988dbf81e8dd05064794b68e3516b8cb42008d38915cce1cb29280f87f4"
-    sha256 cellar: :any,                 arm64_sonoma:  "deac3a8f719f9ebd34cd630a036d25dbe63a68cac4e4d100c91da7901d32c8c9"
-    sha256 cellar: :any,                 arm64_ventura: "148a5b0c6e5f97630e729fd7fcb6a30cd872f8e8c9d56c037e3ae6ba89ab7509"
-    sha256 cellar: :any,                 sonoma:        "003d785030c3b0049930df74982118571ff7c18d3ffa85f6efb1e7db62a1fe79"
-    sha256 cellar: :any,                 ventura:       "74198d66ce8d20ecd245610be311d927af74eed6e0f55091d218c6c3283c0765"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "9e2381da01cc955954d3ca50c345b5fc6482e137f2f52a9bb10b391d624290c5"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2454b1ac1fa70ac432a96dfc4de0b6fa0742f776f78a4a26ae7208af5881c911"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "223d086cff5aadbc101c21de3972c42bb232bf86786731390026a11a41bb81b5"
+    sha256 cellar: :any,                 arm64_sonoma:  "e21e7b7406795befb4875b9d58d0e753028d008779d2f887b3dca4452695df76"
+    sha256 cellar: :any,                 arm64_ventura: "8bf4a5752325353aaf4f54510a6ba47427be9d9557fa1aff23769fe67758200b"
+    sha256 cellar: :any,                 sonoma:        "61f756de6329e8c7cb4e460efc6044bb453d6ccedfd0e6c300925b1a160ee3de"
+    sha256 cellar: :any,                 ventura:       "74946eca531c3a92fdf430c1606a51a478e77f196ea20abcf10bcc510ed20f36"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "a771dfb6a2413ca028fddbedd2c0427c00c5871e335e8cd478722845953c5791"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "114fe23946f18ec2de49925ff4c35f1959817ec1ce8608ad231075a243c1ac5e"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fixes #234170

Replace workaround added in #233579 with generation script which is what the bootstrap script would run (https://github.com/emscripten-core/emscripten/commit/dfd6162eeabe67a79a9a3567cc4b0355f20b2002).

We can't run bootstrap as it will perform npm install without using our DSL and run git submodule operations that won't work without switching source to a git checkout, see https://github.com/emscripten-core/emscripten/blob/main/bootstrap.py#L27-L41
```py
  ('npm packages', [
     'package.json',
     'package-lock.json',
   ], ['npm', 'ci']),
  ('create entry points', [
     'tools/maint/create_entry_points.py',
     'tools/maint/run_python.bat',
     'tools/maint/run_python.sh',
     'tools/maint/run_python.ps1',
   ], [sys.executable, 'tools/maint/create_entry_points.py']),
  ('git submodules', [
     'test/third_party/posixtestsuite/',
     'test/third_party/googletest',
     'test/third_party/wasi-test-suite',
   ], ['git', 'submodule', 'update', '--init']),
```