### PR TITLE
llvm lld flang wasi-runtimes 21.1.0

### DIFF
--- a/Aliases/lld@21
+++ b/Aliases/lld@21
@@ -1,0 +1,1 @@
+../Formula/l/lld.rb

--- a/Aliases/llvm@21
+++ b/Aliases/llvm@21
@@ -1,0 +1,1 @@
+../Formula/l/llvm.rb

--- a/Formula/a/afl++.rb
+++ b/Formula/a/afl++.rb
@@ -13,13 +13,12 @@ class Aflxx < Formula
   end
 
   bottle do
-    sha256 arm64_sequoia: "4be2a31ddffeee2481371d88fd525f175393815b0322da250bffe14e75fd1a69"
-    sha256 arm64_sonoma:  "fdcfde74d8ab2502051b1ccbe29c72d5518d87b57499d8629eff93f6b80ea026"
-    sha256 arm64_ventura: "55bc5223b24b28b6fbcb40e1cb782a8990fa8c39bea155ea7bfbb6e203eb72e6"
-    sha256 sonoma:        "d52df7a6744ce8dc02e52280ff1803330886e3f38e3a00a2990b67d4291fd38d"
-    sha256 ventura:       "8ae4865731442dec5147643b4bc46d7604fd541d4fb8dbc02ae3cebec4e986f3"
-    sha256 arm64_linux:   "96f8c0deab2753372a3df1434ad7b47e3878008d32473416d69a5b4ea05b2720"
-    sha256 x86_64_linux:  "c7c70958537d3e76775e32c57c8d2d516b182886e988348f3e4dbf6f8d6710e0"
+    sha256 arm64_sequoia: "f2d8c72f3f2caf2583dc9398eff3755e83366104d33af4a8dccb32024269217e"
+    sha256 arm64_sonoma:  "13fd0d4d75c16d02683d30ccf26feedd10334b019b735e290edb50724d3f2dbb"
+    sha256 arm64_ventura: "626c4a4502254103442ca657df6f41ea3f14693d054ea5466eea875c9f7e8375"
+    sha256 ventura:       "39da01c00e47af500cfa1fb500faaf4c2d703b5bc4110b32638c874d5e2f979a"
+    sha256 arm64_linux:   "288b6addabcc7371e593364d06d6cc124409fef97dcaca5458dd48541f49d1c9"
+    sha256 x86_64_linux:  "21c0e7d582386c4451833e3fa518643b8d24dc8526a229e459f4ab5d6d2fde92"
   end
 
   depends_on "coreutils" => :build

--- a/Formula/a/afl++.rb
+++ b/Formula/a/afl++.rb
@@ -5,6 +5,7 @@ class Aflxx < Formula
   version "4.33c"
   sha256 "98903c8036282c8908b1d8cc0d60caf3ea259db4339503a76449b47acce58d1d"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     url :stable

--- a/Formula/a/alive2.rb
+++ b/Formula/a/alive2.rb
@@ -9,13 +9,12 @@ class Alive2 < Formula
   head "https://github.com/AliveToolkit/alive2.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "91de2844001d0f3c72e4dd3d3f9308ff3c52ee4e66e4b70d679bce6cdefb0a68"
-    sha256 cellar: :any,                 arm64_sonoma:  "db9a8607f2f9594345bc25c45792d5bf7fe5dc8310213e19187c85c133e37d34"
-    sha256 cellar: :any,                 arm64_ventura: "a7d5c7fb250c3835929c4254f6552dbad12d8f245c5437a0a4cbcd7cb585f9c3"
-    sha256 cellar: :any,                 sonoma:        "fdd8b62c429b759b4e6883cbca97730d499acf3535216a0236503f9c8ccde13f"
-    sha256 cellar: :any,                 ventura:       "08d5619a9ac5d9b6449997c9dbc51186b784f77bba97eb01d20af8ba6563842f"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "eb4a0454225b275bf9d4db01669b6c3fb5a9792efeb4a559119d7f3db204b77d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f5ec7c86d5e6265387ca2b2bf2689cc1cb136a6881cbae822968e655dc83aa40"
+    sha256 cellar: :any,                 arm64_sequoia: "2b50bddff87ab541451702d2c7d004412b8b10ae2b946a2efba614943cbfef58"
+    sha256 cellar: :any,                 arm64_sonoma:  "c36cbe7db0301802dbaed9106d464e15979f24d842d73ea3d092ee6a74740317"
+    sha256 cellar: :any,                 arm64_ventura: "b414bdbfb3e39fade927d5241a03c78bc05346359d14d72d222819fa79b2b01d"
+    sha256 cellar: :any,                 ventura:       "e7c67408e23dd90ca063cb508dea9060a5f380bbfcb3927481908784872560fd"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "a5c21492b9c865c0b252c360129e047c6d0260180d8d2fe9dc36dfa57aab6c55"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b9fe289bc8cd5bd27db7c60c76084b6b9b72ffe6a1fa5dae9f43ede9367fb4d9"
   end
 
   depends_on "cmake" => :build

--- a/Formula/a/alive2.rb
+++ b/Formula/a/alive2.rb
@@ -5,6 +5,7 @@ class Alive2 < Formula
       tag:      "v21.0",
       revision: "913e1556032ee70a9ebf147b5a0c7e10086b7490"
   license "MIT"
+  revision 1
   head "https://github.com/AliveToolkit/alive2.git", branch: "master"
 
   bottle do
@@ -28,7 +29,12 @@ class Alive2 < Formula
   def install
     # Work around ir/state.cpp:730:40: error: reference to local binding
     # 'src_data' declared in enclosing function 'IR::State::copyUBFromBB'
-    ENV.llvm_clang if OS.mac? && MacOS.version <= :ventura
+    if OS.mac? && MacOS.version <= :ventura
+      ENV.llvm_clang
+      # Also link to LLVM libc++ due to `std::__hash_memory` availability in newer header
+      # https://github.com/llvm/llvm-project/commit/17d05695388128353662fbb80bbb7a13d172b41d
+      ENV.prepend "LDFLAGS", "-L#{Formula["llvm"].opt_lib}/c++ -L#{Formula["llvm"].opt_lib}/unwind -lunwind"
+    end
 
     system "cmake", "-S", ".", "-B", "build", "-DBUILD_LLVM_UTILS=ON", "-DBUILD_TV=ON", *std_cmake_args
     system "cmake", "--build", "build"

--- a/Formula/c/castxml.rb
+++ b/Formula/c/castxml.rb
@@ -26,13 +26,12 @@ class Castxml < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "81fba162f54969e92f8b6e80e1c25f8883b6c577af305bec352cfe160ca6fe1e"
-    sha256 cellar: :any,                 arm64_sonoma:  "f3df454737770552357bfc15b5184b83f995b6eebec8670d200250b626ae2125"
-    sha256 cellar: :any,                 arm64_ventura: "ba53c6ba447c654f0bdf437c776556d36410ff148c956438dfeda34c6f70fed9"
-    sha256 cellar: :any,                 sonoma:        "5d39704e7e6792b2f433184eb3c69697f69bd8f1307f3ed00e1d7f3265a074f7"
-    sha256 cellar: :any,                 ventura:       "d8d9635e8f3cd6d01c59d85d64c49c02b818400a1c22437d82c7bc9779363452"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "49df8d03d192b404f5be478204549916b1bb9e9496075d1515c2c3376b10c0c7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c773dc8de63b455db2dc6f4dd5c3a28cb6042fa82adb8c1282b1fbfbdf815413"
+    sha256 cellar: :any,                 arm64_sequoia: "95fb7d267cd0be30fffb2f28a00e4f4f1783ea8381982819eab564862810922b"
+    sha256 cellar: :any,                 arm64_sonoma:  "16ebcda57fcb0ae900940e1dac9f8a78fea0a3f648849b852d6cebffbaac1b76"
+    sha256 cellar: :any,                 arm64_ventura: "509fc3979f3f7659b316d7414f20701784ccf69cde6a8410405eabd27b0e3e4a"
+    sha256 cellar: :any,                 ventura:       "25974fd36e8a03296b65df304951d4cdd342f6e05b224adcbb474959f15ceb43"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "491484e13a79e529bad359c0cf5cc994583689a2c293e0cd4ba4709a7fd64565"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "26eb128a91be1fcf60d791191f8d62434c745dd0c6f586ea67ad738e63a33e93"
   end
 
   depends_on "cmake" => :build

--- a/Formula/c/castxml.rb
+++ b/Formula/c/castxml.rb
@@ -1,11 +1,24 @@
 class Castxml < Formula
   desc "C-family Abstract Syntax Tree XML Output"
   homepage "https://github.com/CastXML/CastXML"
-  url "https://github.com/CastXML/CastXML/archive/refs/tags/v0.6.11.tar.gz"
-  sha256 "fc5b49f802b67f98ecea10564bc171c660020836a48cecefc416681a2d2e1d3d"
   license "Apache-2.0"
-  revision 1
+  revision 2
   head "https://github.com/CastXML/castxml.git", branch: "master"
+
+  stable do
+    url "https://github.com/CastXML/CastXML/archive/refs/tags/v0.6.11.tar.gz"
+    sha256 "fc5b49f802b67f98ecea10564bc171c660020836a48cecefc416681a2d2e1d3d"
+
+    # Backport support for LLVM 21
+    patch do
+      url "https://github.com/CastXML/CastXML/commit/f4fdb9eebe3a03c8c6479a1cf420761a97e86824.patch?full_index=1"
+      sha256 "33093a62dc22f98ab1f6b44a1eca7a668bc142e870069ea51fa5bbd44627dcae"
+    end
+    patch do
+      url "https://github.com/CastXML/CastXML/commit/e71d56d34d308f410ac6f5493c5622e9701e210f.patch?full_index=1"
+      sha256 "cab3ccec1795d8228a5f784c88b23846e2a90415d084513e9b8f237759a68da6"
+    end
+  end
 
   livecheck do
     url :stable

--- a/Formula/c/ccls.rb
+++ b/Formula/c/ccls.rb
@@ -38,13 +38,12 @@ class Ccls < Formula
   end
 
   bottle do
-    sha256                               arm64_sequoia: "c27b908fad0df43a31ab3773116b623a5fbf118a6952fe107cf1b1ec74298fb9"
-    sha256                               arm64_sonoma:  "c3f51b9b966652326d52e4f70ac9f76679e0f26cdbc217970869017f2496c389"
-    sha256                               arm64_ventura: "d822534f47862b7b9bac59b251e365ff713bb236931a5a91f3d92f8e5a006d49"
-    sha256                               sonoma:        "c55e6b6a3cb802ebc90911280ecc01729aa347818d854e2c2bb7d6fc73e8b7cf"
-    sha256                               ventura:       "2821feb82b94d31af308fb656ac5354a720cf3faccc5aeae4efff119663932a2"
-    sha256                               arm64_linux:   "76bba92dad7dd21c8fb560f4f41f5215043ef1ef8610ed34626a9f7bcdd5521b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8aa50bc118e9e35d8840052839456fb362a603d5e04e210a6b8ae2df9da31423"
+    sha256                               arm64_sequoia: "e9e2dfa3d50fed8794c77ca54c01ab922d40fed4d9e43b7374c1b9982fb1265f"
+    sha256                               arm64_sonoma:  "9a6fb61ff9eee5a3122dfcccdc7d64b0fc63d720e79a4a7c5d60824c0acf7459"
+    sha256                               arm64_ventura: "b12c07bff01f2db44152df2553711dd86848351f0f0d16b372289c90908cc592"
+    sha256                               ventura:       "20517554c04b283944ae28892e0b88139029873a45c45b19895bf4488d4878b0"
+    sha256                               arm64_linux:   "773f2ac0a01f92f7473ddf0fd932d3b8be93efa1c39f261bb51a9cce64eccd40"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f81e657e1923108992eb11bfe532fbc0e6753066924fd7906cc6b713b930e3a3"
   end
 
   depends_on "cmake" => :build

--- a/Formula/c/ccls.rb
+++ b/Formula/c/ccls.rb
@@ -7,7 +7,7 @@ class Ccls < Formula
   #       https://github.com/MaskRay/ccls/issues/786
   #       https://github.com/MaskRay/ccls/issues/895
   license "Apache-2.0"
-  revision 1
+  revision 2
   head "https://github.com/MaskRay/ccls.git", branch: "master"
 
   stable do
@@ -18,6 +18,22 @@ class Ccls < Formula
     patch do
       url "https://github.com/MaskRay/ccls/commit/4331c8958698d42933bf4e132f8a7d61f3cedb8c.patch?full_index=1"
       sha256 "5420b53cf912268688953a2863e86f6b88334ed548852eaedb9f8ce4871ee034"
+    end
+
+    # Backport reformat commit to cleanly apply later patches
+    patch do
+      url "https://github.com/MaskRay/ccls/commit/48f1a006b78944a944cdc0c98fb4b447e19fce7d.patch?full_index=1"
+      sha256 "2fa14b78e00b455138324034f876979f40c34e253b5b254ea794e60a38ac657b"
+    end
+
+    # Backport support for LLVM 21
+    patch do
+      url "https://github.com/MaskRay/ccls/commit/44fb405d00dead04de43891c9818d798f10fc41e.patch?full_index=1"
+      sha256 "40229b6bc013a6daf510b980a7b032bad159f43e95796467705042beeb70fe49"
+    end
+    patch do
+      url "https://github.com/MaskRay/ccls/commit/4427527ed8107719457b5260443e8cad024e446f.patch?full_index=1"
+      sha256 "16ba1cd3c18441054fcc54716e44e013ee01c21b25b796adc480620df511abe0"
     end
   end
 

--- a/Formula/c/clang-uml.rb
+++ b/Formula/c/clang-uml.rb
@@ -4,6 +4,7 @@ class ClangUml < Formula
   url "https://github.com/bkryza/clang-uml/archive/refs/tags/0.6.2.tar.gz"
   sha256 "004540c328699f81abebceb33a4661b548ab3a5f74096da2c025b9971b2b17ff"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/bkryza/clang-uml.git", branch: "master"
 
   bottle do

--- a/Formula/c/clang-uml.rb
+++ b/Formula/c/clang-uml.rb
@@ -8,13 +8,12 @@ class ClangUml < Formula
   head "https://github.com/bkryza/clang-uml.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "bffe298a11ff65c80dec6b020142fc8b6bc902339316ab07dc40d0702008cb5b"
-    sha256 cellar: :any,                 arm64_sonoma:  "050b6a471deca02e968f6422754dad6b8948fa41cec134de0641bd999dca7530"
-    sha256 cellar: :any,                 arm64_ventura: "c408164832471352c12b9a8661a4a30b8e2158268daeea3fca6a564d91d9db57"
-    sha256 cellar: :any,                 sonoma:        "9fb6817ec6239539a1356e3289ec30ee797c7a10f7010e3833fe98cbc81d8bde"
-    sha256 cellar: :any,                 ventura:       "b0c736b7be3eeb4adce9e28d83347dbc815a63062fffd5475e7fd3739f81b42c"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "0a8ea5f5257105ee578172a369d445c8b2d497391bc75128557ec1854ca441c1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5c7cb7625ee43e3c100ab2fb9293f85fb9329f528b36fe96b738482418332efc"
+    sha256 cellar: :any,                 arm64_sequoia: "1aa0e9d5dc458d3bca6664861311b45e3dcc08a38af59064bc73b5d1d0fdb997"
+    sha256 cellar: :any,                 arm64_sonoma:  "9409c54c5f610eac2f82d7da271e3acb10d70779fb0485ef4c91175e19c613ce"
+    sha256 cellar: :any,                 arm64_ventura: "e6d5bd9d6d67fd95d41493d856a64599d93a914698e7f336f36b7deaf1142523"
+    sha256 cellar: :any,                 ventura:       "303669e141b74c565d7908a283ae344ac5df43eb5e12eebd2c4d0cb4bbae9059"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "2607fb8181dff212b77959e57371b6285067db22235a48fba19e0888070bf3d8"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "70c49308718e4d29cc4b6b1670b902e596599a87af20563f1af2da2bf4ba0d94"
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/c/clazy.rb
+++ b/Formula/c/clazy.rb
@@ -13,13 +13,11 @@ class Clazy < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_sequoia: "8e82a24432fe70dbdc57d15a6e000f9965862570357db03f6fa7f24b8b179b9b"
-    sha256 cellar: :any,                 arm64_sonoma:  "e9615987f29c4795cbe367210445d23ac6288a9162f2b14fa16011cf92ca3342"
-    sha256 cellar: :any,                 arm64_ventura: "71125eaff0f77b0ff435fb1a994743c557fb39c411297437f765ddeddf1b8a7b"
-    sha256 cellar: :any,                 sonoma:        "3f5a1d5289b111d1c313034902c77bb56373fac7d4eb93dea8a55c691496c3e4"
-    sha256 cellar: :any,                 ventura:       "1a901cc6580997ddcd7f6d4f5f963c73875edc2dca0b911939b824ccb98731a7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "10e829a29aa7e265e7e1f482a86cef69cb3a45190326475390f00b323af5217b"
+    sha256 cellar: :any,                 arm64_sequoia: "92b3ccdbef548d7966861ace46c31f90af6e8c0c641f68f1a0768fa817c5f862"
+    sha256 cellar: :any,                 arm64_sonoma:  "33da10d4e320a5730af1514d6e00ac84bc8d354b8a6d69a4e2578aa9524b7473"
+    sha256 cellar: :any,                 arm64_ventura: "f6af64aef4696d355d87c6def7d18b3cc7cd6d36a5a2932bccecc3d893371d99"
+    sha256 cellar: :any,                 ventura:       "5152cbc2134bfcb219b9e0c95ec62500910cd775248a8168db30fe09057b8ddc"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1ec42d9e2bb8e000491b657536396520554521bc03cf1d6f41638af98b007e20"
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/c/clazy.rb
+++ b/Formula/c/clazy.rb
@@ -4,6 +4,7 @@ class Clazy < Formula
   url "https://download.kde.org/stable/clazy/1.15/src/clazy-1.15.tar.xz"
   sha256 "43189460b366ea3126242878c36ee8a403e37ec4baef7e61ccfa124b1414e7a9"
   license "LGPL-2.0-or-later"
+  revision 1
   head "https://invent.kde.org/sdk/clazy.git", branch: "master"
 
   livecheck do

--- a/Formula/c/crystal.rb
+++ b/Formula/c/crystal.rb
@@ -2,6 +2,7 @@ class Crystal < Formula
   desc "Fast and statically typed, compiled language with Ruby-like syntax"
   homepage "https://crystal-lang.org/"
   license "Apache-2.0"
+  revision 1
 
   stable do
     # TODO: Replace arm64 linux bootstrap with official when available
@@ -11,6 +12,12 @@ class Crystal < Formula
     resource "shards" do
       url "https://github.com/crystal-lang/shards/archive/refs/tags/v0.19.1.tar.gz"
       sha256 "2a49e7ffa4025e0b3e8774620fa8dbc227d3d1e476211fefa2e8166dcabf82b5"
+    end
+
+    # Backport support for LLVM 21
+    patch do
+      url "https://github.com/crystal-lang/crystal/commit/0e3757edcf7f18c238841e2f2aa659ac302fee4a.patch?full_index=1"
+      sha256 "8f5f9682990a74405f7bbae3b20afcf6bd11f65826204fee77b52b69d0c34925"
     end
   end
 

--- a/Formula/c/crystal.rb
+++ b/Formula/c/crystal.rb
@@ -27,13 +27,13 @@ class Crystal < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "830ca0202f2485716ff43aa76d21b4ed2fd2216cabe004ff5deabcdc3f7b440b"
-    sha256 cellar: :any,                 arm64_sonoma:  "208b835a63003c081562d62818dc565df3d292e96c940447a45e7cd87279e155"
-    sha256 cellar: :any,                 arm64_ventura: "316cb394e5ee50056a7c7199756b7f970c427c867f15f1490c488c78081f2ff5"
-    sha256 cellar: :any,                 sonoma:        "a3312dce8e6e5813e7eee20f06d21bd6e12564502722a6e45ae33237e07ec607"
-    sha256 cellar: :any,                 ventura:       "2219a35b0b16aba257358121210e34237a3d68d228a6c024ce2edcfe483d4e9c"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "b10eb99a47ac85d7c090f9819048e155426b1e3e4a019d0a4fe649217eaf488f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0c2156e8d3e33285ceb109f42e5e189668e468fd605f3e7ad199d627470667f2"
+    sha256 cellar: :any,                 arm64_sequoia: "d760cf41716f2b0f271551e68dd1e98e17e3458972fc2996d4bbff31e61b0203"
+    sha256 cellar: :any,                 arm64_sonoma:  "7a3d36f0fdc462cbdc989e43a08e9cc7cdcb117fe4743b58c9f368e1113f3800"
+    sha256 cellar: :any,                 arm64_ventura: "c7d59e9c315618b57432457d5c36b7e2178000add2e5bddc3b52714d789751d0"
+    sha256 cellar: :any,                 sonoma:        "0f4e14e2aa2f353c0e043fc710b65b7b0887b56670d9066e3edcffc41e38ceaf"
+    sha256 cellar: :any,                 ventura:       "6d977cc2597b8dca70c67ebd1a122af9374bc59ab7802a467724528863087282"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "d6562c2a4d5983795a136efa2ef8d2dafdfb506e970e1c3eda0e1c6cb8057411"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f6f8225076a6174fdf4053dea4983313be0ed11b6a5606027ebe27ac2aa4339c"
   end
 
   head do

--- a/Formula/c/crystalline.rb
+++ b/Formula/c/crystalline.rb
@@ -4,6 +4,7 @@ class Crystalline < Formula
   url "https://github.com/elbywan/crystalline/archive/refs/tags/v0.17.1.tar.gz"
   sha256 "3e8f4c3f41830092300219ef91c3d03e15536774ef18a5395ff6a9fffc27be5b"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 arm64_sequoia: "87a66475cc7c310d5a9ca86451588753fa013793a29647adc860a722d44262b3"

--- a/Formula/c/crystalline.rb
+++ b/Formula/c/crystalline.rb
@@ -7,13 +7,12 @@ class Crystalline < Formula
   revision 1
 
   bottle do
-    sha256 arm64_sequoia: "87a66475cc7c310d5a9ca86451588753fa013793a29647adc860a722d44262b3"
-    sha256 arm64_sonoma:  "55781acbd516f945fa2a882e4791c2eb78eebe8a67c618204dad015d960b93af"
-    sha256 arm64_ventura: "497f4eb216f23ed797a8d23b0430ce78156d865604c2e16d95aa3c7068aef792"
-    sha256 sonoma:        "7633dc8f2abafcfe175aa69a8d85b75b9ce7c95a07a46a24cb4037c81625b035"
-    sha256 ventura:       "2de8e6d021d4fef3cc3f3c896f03ddafc8e0003daccc7fdfb8687968e2b643c2"
-    sha256 arm64_linux:   "7378baeedc88e661685c01cb031a0267dcf6969c071b5d8abcfa23b3a4e9d5e2"
-    sha256 x86_64_linux:  "f99684dd3f96d2888b1429df00c6aef334cf35e5da5a6dab025e3192a57574f2"
+    sha256 arm64_sequoia: "9880d25d405a18e5b15ca3285d636fe7e88c7f8d2c23d475f9d7389d83c7bccb"
+    sha256 arm64_sonoma:  "fa4289ff006887a7cf83a094eb5429785fdedfad7423626de75fd20dbb9e843d"
+    sha256 arm64_ventura: "5e25f739442d1ec0a9c2d246be380a397dfb4eabe27e5c2525f9deb758b37afa"
+    sha256 ventura:       "36692b831edc7d4b9e9fa77f2fc04e36c1accc353ae9dd6ef91d0fbdde501990"
+    sha256 arm64_linux:   "b74e77b5867ae143deb672dbd7387706bcd957c7851845222183c49ad0b914c8"
+    sha256 x86_64_linux:  "28e4ffc22551602bec7b10f5e27f0e4011f8778e651c7bb43fe749d1b229b1ed"
   end
 
   depends_on "bdw-gc"

--- a/Formula/e/enzyme.rb
+++ b/Formula/e/enzyme.rb
@@ -4,6 +4,7 @@ class Enzyme < Formula
   url "https://github.com/EnzymeAD/Enzyme/archive/refs/tags/v0.0.191.tar.gz"
   sha256 "5832f70fdbebc922c45da9e1d49985d96b91d54d12eac8e3f96aee9d3b09eb86"
   license "Apache-2.0" => { with: "LLVM-exception" }
+  revision 1
   head "https://github.com/EnzymeAD/Enzyme.git", branch: "main"
 
   bottle do

--- a/Formula/e/enzyme.rb
+++ b/Formula/e/enzyme.rb
@@ -8,13 +8,12 @@ class Enzyme < Formula
   head "https://github.com/EnzymeAD/Enzyme.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "089be8f214d615b4dcf9024a822a20291efb2964d37353f452ac5ce9d9551588"
-    sha256 cellar: :any,                 arm64_sonoma:  "f70254509f410cb3478f3f8541b8534e7d1b334c0145f790098ee9d9d8665a23"
-    sha256 cellar: :any,                 arm64_ventura: "3e9ca4eeef759d44faed1c2ddfdd6398475a80c762755d9be90ceb21885a7699"
-    sha256 cellar: :any,                 sonoma:        "332406ccc6b5bfaa10653c00ba57282ea38cc162baa0dad982cce0fc985680e3"
-    sha256 cellar: :any,                 ventura:       "f11e1467cd7593372ae7de39e5789ff0ed4a392bc72dd825894cb3a06cabc55c"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "f102b964bff93c876288582b9155ceae54046fb5181fe965c76b5b7369c548a4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "fa188b010c466968b2023b4381786afc8e97db05aaf2795d741e6432bd61a95a"
+    sha256 cellar: :any,                 arm64_sequoia: "69959f569e07029ae82b4fe17a98417f200000bd7c414535242780bc113fece2"
+    sha256 cellar: :any,                 arm64_sonoma:  "1ec0417ae4179cffa6757707f095e6173be5890f647e1368c4874278214efd91"
+    sha256 cellar: :any,                 arm64_ventura: "d3d5e5248586c35809a6d5311e979e58fd249b89f3676af719a793a969e1b62f"
+    sha256 cellar: :any,                 ventura:       "9900d1f9a2a6276b3697b5d977b888230cf473b45d5ac4eb9eafe9fa0a47843f"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "a479085c88737115781d1bb20629f2d189e7932e52202dd2d5e695ca190dfe7d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "dada0144e13fc199f5d470b784964e6bfc588a7f0b928f3053ec43e978250a83"
   end
 
   depends_on "cmake" => :build

--- a/Formula/f/flang.rb
+++ b/Formula/f/flang.rb
@@ -12,13 +12,11 @@ class Flang < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "aa551b929385d0301a2be83757c41c984cdc2fe3091bed40f8afd7d62b943c99"
-    sha256 cellar: :any,                 arm64_sonoma:  "a5618428fa0d17ba2ff82bbd2364347dbdd0860f9f65240c1fa7171c1b03f80f"
-    sha256 cellar: :any,                 arm64_ventura: "95309f672a5e874ebf61cc6e0be57bf31353933ecde87b62ffd620a44830d27a"
-    sha256 cellar: :any,                 sonoma:        "6ab9164f433c8f38ab62c8e7b31fa93ee3242f78a673e0994a6825f3c75cdec4"
-    sha256 cellar: :any,                 ventura:       "61183c878b6d7b0a855001b10ed0164ebfb166636878e8e42f97db0a68a8cf81"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "1033acc769881d4900b6fbdf7958c8edc92e455b73275a2efa876f9616370368"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "7069a55b0af165da0f65d999f463e82df046a21feef1ff075cc25cf7a10f79cf"
+    sha256 cellar: :any,                 arm64_sequoia: "6118c30d25bea2cd21a473be7d6ae0e99a78a6de09552d27de783741a0fcd54b"
+    sha256 cellar: :any,                 arm64_sonoma:  "66e34563beb6bd165d5558e247e91f1dc3eba91f9f796b685b5be63ce1d5f527"
+    sha256 cellar: :any,                 arm64_ventura: "746d426539249714213daf1689fb5de2f3a469e88af91738d1006695369f3ec3"
+    sha256 cellar: :any,                 ventura:       "b495907e8a584fcb9120a768c629439a321e5e8a5e5295d31519a1e2395c6949"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "03c71e3f0d0c9edda50be0ee0b76494d9f20344f565f42ffa38e23dd8c74ceba"
   end
 
   depends_on "cmake" => :build

--- a/Formula/l/lld.rb
+++ b/Formula/l/lld.rb
@@ -12,13 +12,12 @@ class Lld < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "940eb2261de4bcdebfec9b2e65ccabd0816de3e6268a28ff852fb8fc0e0bf2ec"
-    sha256 cellar: :any,                 arm64_sonoma:  "98052466bf93f7bf508b8e75513a1c7ab25a8c61d25a070223c4ab51c219dc10"
-    sha256 cellar: :any,                 arm64_ventura: "66e5f05513416b1d47a9647b4e124c2c8f0d51093d4bc8e8ad806d2f8e9f12ec"
-    sha256 cellar: :any,                 sonoma:        "431d60e5b2244f976a2eea5af897ce6e0424da657b29bbb55331156ecea5f7ed"
-    sha256 cellar: :any,                 ventura:       "a99444524b1084282101c1c7ca94b59b52166b864e01271ac04fa0288bad8f72"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "6b0c1adc936a043862a8545a74fe57c94a911e2d53df083c207edf3c696b58a9"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "adca794c3722595644a6bc85c4b27b57d02e0771c054d0c59bad6c4f3029c9ac"
+    sha256 cellar: :any,                 arm64_sequoia: "d8741d107d61164c194cf5f26579bed4e7aeeab448ec45fe1b1f6882a77864a4"
+    sha256 cellar: :any,                 arm64_sonoma:  "1ad1744b16d99758b4511e355e243327aa6dbc28cf284e6be673790b2e0a249d"
+    sha256 cellar: :any,                 arm64_ventura: "45fb2d3f79ad7f7db4201c902af14002bf169a97bb77b31946b7a4c540052c31"
+    sha256 cellar: :any,                 ventura:       "8f485dc2f5210a4a32b0e5e7b15cb0936b45f7688867318e24ae3cd32edb9b49"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "14fc74d22edcdff422a49363ba938b742efcbe54a86cd4af11b5d2e1401aa745"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4ba7d1788190d6f1566b821e7d0df1d57acfa3ea2cb80ceba011c357daac0505"
   end
 
   depends_on "cmake" => :build

--- a/Formula/l/lld.rb
+++ b/Formula/l/lld.rb
@@ -1,8 +1,8 @@
 class Lld < Formula
   desc "LLVM Project Linker"
   homepage "https://lld.llvm.org/"
-  url "https://github.com/llvm/llvm-project/releases/download/llvmorg-20.1.8/llvm-project-20.1.8.src.tar.xz"
-  sha256 "6898f963c8e938981e6c4a302e83ec5beb4630147c7311183cf61069af16333d"
+  url "https://github.com/llvm/llvm-project/releases/download/llvmorg-21.1.0/llvm-project-21.1.0.src.tar.xz"
+  sha256 "1672e3efb4c2affd62dbbe12ea898b28a451416c7d95c1bd0190c26cbe878825"
   # The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
   license "Apache-2.0" => { with: "LLVM-exception" }
   head "https://github.com/llvm/llvm-project.git", branch: "main"

--- a/Formula/l/llvm.rb
+++ b/Formula/l/llvm.rb
@@ -23,14 +23,13 @@ class Llvm < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_sequoia: "a7947e4272a91b022e167307976e9599de41e8cf637896294bdc051c5856668c"
-    sha256 cellar: :any,                 arm64_sonoma:  "805a28804f44bb699837b0ee6b8df015342ee1aca3bf56d8fafeca5e1826c447"
-    sha256 cellar: :any,                 arm64_ventura: "cbd98cc81a1b461d412464fa0d3178511e7e5dfd18648f24bbd9dfffca5d8915"
-    sha256 cellar: :any,                 sonoma:        "3e9ce8038db104df6f5edd6ad57da00e80e1e507c08ff0a1c543179577eb07c8"
-    sha256 cellar: :any,                 ventura:       "c9dbddb5ede4edd7731c9f64dba627eb948a2fc1e544ce555a4348f0f36398b7"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "44641ca10ffb47ca14f85665b95c871c5d5feebc83c0d2dc8e56dc7ec97da50c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "32c906b0a38077ce39ad7e42533dd754582f09ad8c36b148c7b3d137112d4292"
+    sha256 cellar: :any,                 arm64_sequoia: "4d3228d0eccbd7afdc39804a1eb6fc07cb77967bccc04becee0660364cf25649"
+    sha256 cellar: :any,                 arm64_sonoma:  "56aad5c1eddfab32cffacb73f5507aacb5dffc66b458ae9579cdc9e18f35ef6b"
+    sha256 cellar: :any,                 arm64_ventura: "875aff99943e5628494011c33bcf88df163a6fa9a043a7d86bd54eaa7f2a71d9"
+    sha256 cellar: :any,                 sonoma:        "99300ead6537fb84f5be36de9cef758f633eeb0152a9f49caee35818b27baaa2"
+    sha256 cellar: :any,                 ventura:       "46355a5b5db02271bf1782c157128934fa98d6da839c66e1392ba97479c0315f"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "57c3ea1f7348aad566c462eb209b256116b81e9eb5ba291bef54c9134b8d5a24"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b3bd8ed6898e9e4c18b67da060e8a98d3f31d71c146952fc34606cf31af2506f"
   end
 
   keg_only :provided_by_macos

--- a/Formula/m/mesa.rb
+++ b/Formula/m/mesa.rb
@@ -24,13 +24,12 @@ class Mesa < Formula
   head "https://gitlab.freedesktop.org/mesa/mesa.git", branch: "main"
 
   bottle do
-    sha256 arm64_sequoia: "942831cac5776029a9fe3477e6e482d7ba75cb1e396967630774f26de731b8db"
-    sha256 arm64_sonoma:  "baeb4aff94389aa60efea32cd2d0bc09cead36a07d114f4802148fdb91b29c47"
-    sha256 arm64_ventura: "cc853fb093fac277d04b3f3be70ef9b5f6c79250df2f6aafafbb7106c2f1697d"
-    sha256 sonoma:        "85af72975d668dec712645228e40ade31a531a43e76cd2a6b256ec310e50a2cc"
-    sha256 ventura:       "3b96f1f7cd5fa506a23ff505f97b4476866ad585bb2957ef09b3d36e483b9ab0"
-    sha256 arm64_linux:   "2aef1642b5878efecbd925f1f2e6f95b6da9036ee59d07498346c6d5b51a7a42"
-    sha256 x86_64_linux:  "8c3c073247918d159a09dcabe887ea44ad38716603b604d8655b8fccf0695bc0"
+    sha256 arm64_sequoia: "15f4b8190ca487f1abb1efda11b15fc0203ed0d179bf326103c38290b7306090"
+    sha256 arm64_sonoma:  "c667a02764129fdc163b8de2c1e98b04afd04bff2304c067a023a2e8833bda81"
+    sha256 arm64_ventura: "9acc045e2110cc22e1849752443c2f8d6076aa4c3eb09d8d87d872618d8a5160"
+    sha256 ventura:       "9e2a9f3cdada57344ee5ac090636b458256538115db3a9580a4a4510ee8a63df"
+    sha256 arm64_linux:   "e711b6887fd7ff68d2109291d2fd3a571ec3eee5156cee34ef60cdd5508f9283"
+    sha256 x86_64_linux:  "07b946927b6c98ef900a1955181b35d6cb9441a7c29031e5d9a558cd50b0f1bd"
   end
 
   depends_on "bindgen" => :build

--- a/Formula/n/nvc.rb
+++ b/Formula/n/nvc.rb
@@ -4,6 +4,7 @@ class Nvc < Formula
   url "https://github.com/nickg/nvc/releases/download/r1.17.2/nvc-1.17.2.tar.gz"
   sha256 "f330dc736d579df7ab494ff0853fe8929243c4234f7cc4d1e9df55d2ea41fbfb"
   license "GPL-3.0-or-later"
+  revision 1
 
   bottle do
     sha256 arm64_sequoia: "87e7db44ec8aafac1756149821faae990bcc3e5282e5a59239ba6c93c6dfeeb7"

--- a/Formula/n/nvc.rb
+++ b/Formula/n/nvc.rb
@@ -7,13 +7,12 @@ class Nvc < Formula
   revision 1
 
   bottle do
-    sha256 arm64_sequoia: "87e7db44ec8aafac1756149821faae990bcc3e5282e5a59239ba6c93c6dfeeb7"
-    sha256 arm64_sonoma:  "dad7c6e2513f0c2ddbbf34bd9968e259268948ddbeec50feeb4c55a75d5f32c8"
-    sha256 arm64_ventura: "59b116f5a664999e6fae8e65a540722e141faa6c44eee835912d2f31e862c299"
-    sha256 sonoma:        "7eaff9acd04f346146bf316462bd36550a714894ed6b221525508d5ee761230e"
-    sha256 ventura:       "eadea20f436907344dd4d3d3eccbe2ab863e120987f57074290a83d45b654fc4"
-    sha256 arm64_linux:   "8f1fd6a1a2b8e7db8a98426e6cad67b18985cd9929ab39689895b77fb740f1c7"
-    sha256 x86_64_linux:  "eb1ace5559bf2c5ddb72403203bff511afc53ce2d60dff1d5e9751ef49667d66"
+    sha256 arm64_sequoia: "ffe3f481135377562a65d45bd8af4be3af0dbfe220c8c0c7518fe7e718bef354"
+    sha256 arm64_sonoma:  "cb88c9a86f2e423c2f60a1aba5b9f2b88bf7af8afe97b12974bbd161c17b5cc1"
+    sha256 arm64_ventura: "4e2beabf529215fe2ba4b1f79e2d7027dd6134bc939ad6fbbba5232fec668c34"
+    sha256 ventura:       "50ad0caa4afe6db5591ac5c32d6d25718030f62efe188c0c121ba65d5024d51d"
+    sha256 arm64_linux:   "914f93ec23d9840f826d36c3e160ef66a503ead38b91aafb28c467ea5b9de6e4"
+    sha256 x86_64_linux:  "3f363a64f8ea7290cbcf5cda0aa271dff2979cb018e5743a29786bcbd6dfdd6d"
   end
 
   head do

--- a/Formula/r/rust.rb
+++ b/Formula/r/rust.rb
@@ -2,6 +2,7 @@ class Rust < Formula
   desc "Safe, concurrent, practical language"
   homepage "https://www.rust-lang.org/"
   license any_of: ["Apache-2.0", "MIT"]
+  revision 1
 
   stable do
     url "https://static.rust-lang.org/dist/rustc-1.89.0-src.tar.gz"

--- a/Formula/r/rust.rb
+++ b/Formula/r/rust.rb
@@ -16,13 +16,13 @@ class Rust < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "38b0721c2972bd451bdfe993957241906fcb392098dedec7941a09fd75c708e2"
-    sha256 cellar: :any,                 arm64_sonoma:  "abd100b52c1ea3fd2bb776c500c03fad3f6bdd702aa4c6afd104d043820a46b6"
-    sha256 cellar: :any,                 arm64_ventura: "91ccda04ccff9936169937ffa8119cf161c4c33e9d6fcb93b2292da471d05805"
-    sha256 cellar: :any,                 sonoma:        "748741ad9488d18b0d8291e4b859bb28f391268d4449b102ae8f98e76098736b"
-    sha256 cellar: :any,                 ventura:       "324e15739c6da6bcb32bb38dacf652d0adb0f59115757ba4c35f42d94cf595b1"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "3841d597c369e133d5c42eb02c3a31502044cbe783213b4d6a3ef72f3f9f8d3e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "618553a062a36b80510d23cef0eb3e8bc9ad64231cb56670fc8b0b8f11dccaed"
+    sha256 cellar: :any,                 arm64_sequoia: "9642138cc31f2fe2cc2532c77898f2fa85685c3f351e3d642a8df49c0e103a60"
+    sha256 cellar: :any,                 arm64_sonoma:  "23a6d2569d94ab0dbd2c4fba0e78e8c7e9a9ee8679f750d5e40cb48fbd8d4aac"
+    sha256 cellar: :any,                 arm64_ventura: "79f9adfb4d5cd3986dcad18518c6f7fe7bf24178890616b6a5b293ee12aea9ca"
+    sha256 cellar: :any,                 sonoma:        "685a8652489ba9dd8e9cf06d1be86334066058f9505ceb84ccd272997ea84cf5"
+    sha256 cellar: :any,                 ventura:       "6d62121dd08d01220f5d80060447a4c565f92f6a47e04151ff27596b0baf472a"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "cd050e42618c0a38013d1aa322d7e7896e80edbb66a3b51a173fa3d2d3da2550"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "178586a6f2273dd5f953153075261dba1ad6c3695d9238cd5171f98e679d9e67"
   end
 
   head do

--- a/Formula/s/spirv-headers.rb
+++ b/Formula/s/spirv-headers.rb
@@ -1,10 +1,20 @@
 class SpirvHeaders < Formula
   desc "Headers for SPIR-V"
   homepage "https://github.com/KhronosGroup/SPIRV-Headers"
-  url "https://github.com/KhronosGroup/SPIRV-Headers/archive/refs/tags/vulkan-sdk-1.4.321.0.tar.gz"
-  sha256 "5bbea925663d4cd2bab23efad53874f2718248a73dcaf9dd21dff8cb48e602fc"
   license "MIT"
+  revision 1
   head "https://github.com/KhronosGroup/SPIRV-Headers.git", branch: "main"
+
+  stable do
+    url "https://github.com/KhronosGroup/SPIRV-Headers/archive/refs/tags/vulkan-sdk-1.4.321.0.tar.gz"
+    sha256 "5bbea925663d4cd2bab23efad53874f2718248a73dcaf9dd21dff8cb48e602fc"
+
+    # Backport SPV_INTEL_function_variants for SPIRV LLVM Translator >= 21
+    patch do
+      url "https://github.com/KhronosGroup/SPIRV-Headers/commit/9e3836d7d6023843a72ecd3fbf3f09b1b6747a9e.patch?full_index=1"
+      sha256 "44eff041125f59dce93272be22226ab5e48fe4cf2397e422692d0c8679f40d51"
+    end
+  end
 
   livecheck do
     url :stable

--- a/Formula/s/spirv-headers.rb
+++ b/Formula/s/spirv-headers.rb
@@ -22,7 +22,7 @@ class SpirvHeaders < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "d4e4cb49ae86e01c4659fa3d80db8a2124034ca60f01221fa67cf75bad623241"
+    sha256 cellar: :any_skip_relocation, all: "5fdb11bf7ec105db57352bd5bd8f2865ca8a45d0ca08ad336e82033c5258d52d"
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/s/spirv-llvm-translator.rb
+++ b/Formula/s/spirv-llvm-translator.rb
@@ -1,8 +1,8 @@
 class SpirvLlvmTranslator < Formula
   desc "Tool and a library for bi-directional translation between SPIR-V and LLVM IR"
   homepage "https://github.com/KhronosGroup/SPIRV-LLVM-Translator"
-  url "https://github.com/KhronosGroup/SPIRV-LLVM-Translator/archive/refs/tags/v20.1.5.tar.gz"
-  sha256 "83048509774d865dab7631c887b0673753f59f337256bb56829ea32f30d7584b"
+  url "https://github.com/KhronosGroup/SPIRV-LLVM-Translator/archive/refs/tags/v21.1.0.tar.gz"
+  sha256 "4f7019a06c731daebbc18080db338964002493ead4cfb440fef95d120c50a170"
   license "Apache-2.0" => { with: "LLVM-exception" }
 
   bottle do

--- a/Formula/s/spirv-llvm-translator.rb
+++ b/Formula/s/spirv-llvm-translator.rb
@@ -6,13 +6,12 @@ class SpirvLlvmTranslator < Formula
   license "Apache-2.0" => { with: "LLVM-exception" }
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "97f244193ca29f8f04d91061eec5af361a2ad500cccf6db042acd62b95a4e404"
-    sha256 cellar: :any,                 arm64_sonoma:  "bfbb8ac72c1cac816242462ad7855d382b9948817b726e15f44157701ea02074"
-    sha256 cellar: :any,                 arm64_ventura: "423dbc7c9eafdc35323a1e4b9159b7a2b315007f505c845d3d7f89dc261a4385"
-    sha256 cellar: :any,                 sonoma:        "1fc43505c08f35d00d59e96ad8af93bef3cb47d27e2d4b7875b762ca8303ad4e"
-    sha256 cellar: :any,                 ventura:       "f61beeb55a1433ee58867107294ee1ffccda13ec6d95ef9e247318479b002612"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "32cc58a0975b5d119b8ae4ce6a917f7da1abccc239e6cf1977eef804816a3515"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f5f7b3b3c7c0dfbf665fc92a87f1f607402ce97203406fc82ee72e6bd05bbe6b"
+    sha256 cellar: :any,                 arm64_sequoia: "3bea2165fe9c6efb311333356473424b6bb6271c74add1502d5b26bdb7f5750a"
+    sha256 cellar: :any,                 arm64_sonoma:  "eed9693d15ad1bfdd1d2446a95a8d0649aecb2ef9fe6f1b7e6e714e99401d5b6"
+    sha256 cellar: :any,                 arm64_ventura: "8deefd61c826963f89e93f45c28b0f1bbae6b2eb6fef2bdd6116b2b5f36167d3"
+    sha256 cellar: :any,                 ventura:       "194e3a3a18c5abe679de15088328fe32bcf4436cd784e72ea6fd6a347e9f1ca1"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "e9a3660633b0bf3750482f4ab47d3da95aa4c29d8e623902498e6a29b47876f0"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1b6b6691faf9a480ed428e8ad26ffd48b38493397a98ea3e1a8671fcab56b7ff"
   end
 
   depends_on "cmake" => :build

--- a/Formula/s/symengine.rb
+++ b/Formula/s/symengine.rb
@@ -7,13 +7,12 @@ class Symengine < Formula
   revision 4
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "b413d0e962039cc33ce647e56b64d1e14e0485e9fb03aa9bb05c2a8815f2c77c"
-    sha256 cellar: :any,                 arm64_sonoma:  "6cdebd7e58b3e36fd42c103b87205f01fa93b742dd6e9897c8395a8e4d4ab437"
-    sha256 cellar: :any,                 arm64_ventura: "d7de7b5eaf7484feb69e980f635ca61f6122d08b7781f1e3a56fa61a25629147"
-    sha256 cellar: :any,                 sonoma:        "c7029b46e1429bbb2a98812b47f4f6eb5f604b3fb6c660528b2d33ae536cd22c"
-    sha256 cellar: :any,                 ventura:       "b4245f31edad7985f00376184b29ce8a724ffa572dc6fbc631474783e6831a8c"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "683c421da7e1cd253c511bf8264c315a316ea55416c1b5ea2db0416337bab99c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "08e4246b2c2aaf4cfc1924ffde3e4c4e4f787fdd72306d6eda1b0b922c213d39"
+    sha256 cellar: :any,                 arm64_sequoia: "a0cf67cc7e98d0210e0ad15eb15df2379d949bd235bc106e3035886e462f3c8a"
+    sha256 cellar: :any,                 arm64_sonoma:  "08378ea3146241f35d24c636a298662accb539fbf4dfc8d87354f34121dc1564"
+    sha256 cellar: :any,                 arm64_ventura: "d21da6676835e70716720ce60994aaa9da2572239190d2f81cc1a2d7cc998902"
+    sha256 cellar: :any,                 ventura:       "bb74c79619f0b9482f97e8c413706fb0453cd07cc4133d6fe6ee2cd9a6247b32"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "6af631f2626d92e9c222e48cd4ef7ac1a1896ca66b881f333a5caaecb42adabf"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b5b4460a315a637f02f4c68f666ed15684418ceaef2c575e56c68a268987849f"
   end
 
   depends_on "cereal" => :build

--- a/Formula/s/symengine.rb
+++ b/Formula/s/symengine.rb
@@ -4,7 +4,7 @@ class Symengine < Formula
   url "https://github.com/symengine/symengine/archive/refs/tags/v0.14.0.tar.gz"
   sha256 "11c5f64e9eec998152437f288b8429ec001168277d55f3f5f1df78e3cf129707"
   license "MIT"
-  revision 3
+  revision 4
 
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "b413d0e962039cc33ce647e56b64d1e14e0485e9fb03aa9bb05c2a8815f2c77c"

--- a/Formula/w/wasi-runtimes.rb
+++ b/Formula/w/wasi-runtimes.rb
@@ -11,13 +11,12 @@ class WasiRuntimes < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "6cd664d45755254ce3ae2e19e41e8a81a7a2eb03c47000dae6d026ddd0cb6993"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "1ed3e8da09194c8682c33a5344428709db774efba69d95fb17c155d0effa4724"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "fb6f48eeba18de5e1e65f4c532de1f96715e24aeddb2fdf42828a7ae7b24ecb4"
-    sha256 cellar: :any_skip_relocation, sonoma:        "151407202f74fd0b96c97275e421fcf6f2a0b45abbf105ef83b7303672d99223"
-    sha256 cellar: :any_skip_relocation, ventura:       "ae29e65d5286118494ef89ed92cf9ee3a39dc522298ebe763f7f483ae26a4dc0"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "33a5deda14ed01dfd36a26080c248b14f3f81c7be0e9a87212045024ad283a2b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5aa09804268b9e53b425f98b75f3c621e5f4b42483b6ab93bc25528a21ba9ed7"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "24fe4eed718a3723fbb008cf57655f58553e29849adb759072fa25d19af9e8c9"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "f02ea15ecac55fc983aca5e79b9a1c5aa252e70ab3370bd77425e2fc7fbb8a93"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "7f6803a39e211b559fe1e140e32f1ef0f22137ebaffa18c8e88d520a5b3ddd02"
+    sha256 cellar: :any_skip_relocation, ventura:       "5a5d65b54343ddc8a52ecd1ff979d912fbf2190d79b910835abdcfb3780cfe87"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "1d3068e62daa45b3e525a677354bb74ebdaaea253f8ba8752a83494364c02fb0"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3656184a0fd9609a3d6f1afc73df2b131bc1c063444b0d95678c277cc79a77e1"
   end
 
   depends_on "cmake" => :build

--- a/Formula/w/wasi-runtimes.rb
+++ b/Formula/w/wasi-runtimes.rb
@@ -1,8 +1,8 @@
 class WasiRuntimes < Formula
   desc "Compiler-RT and libc++ runtimes for WASI"
   homepage "https://wasi.dev"
-  url "https://github.com/llvm/llvm-project/releases/download/llvmorg-20.1.8/llvm-project-20.1.8.src.tar.xz"
-  sha256 "6898f963c8e938981e6c4a302e83ec5beb4630147c7311183cf61069af16333d"
+  url "https://github.com/llvm/llvm-project/releases/download/llvmorg-21.1.0/llvm-project-21.1.0.src.tar.xz"
+  sha256 "1672e3efb4c2affd62dbbe12ea898b28a451416c7d95c1bd0190c26cbe878825"
   license "Apache-2.0" => { with: "LLVM-exception" }
   head "https://github.com/llvm/llvm-project.git", branch: "main"
 


### PR DESCRIPTION
~~Trying out a pre-release run to see how many dependents are impacted. Can update to official release once available.~~
Release tagged: https://github.com/llvm/llvm-project/releases/tag/llvmorg-21.1.0
and announced: https://discourse.llvm.org/t/llvm-21-1-0-released/88066

Planned LLVM 21.1.0 release date: **Aug 26th**
https://github.com/llvm/llvm-project/milestone/27

### Formulae changes (beyond revision bump)
- **[llvm]** drop `pstl` runtime - https://github.com/llvm/llvm-project/commit/f8ed45611b75ecac1d459aa6ae3b7051d435abe6
- **[llvm]** reduce jobs to work around OOM error on arm64 linux runner
- **[flang]** replace static with shared libraries on macOS
- **[flang]** move post-installed symlink into bottle
- **[alive]** also link to LLVM libc++ when building with LLVM clang due to `std::__hash_memory` availability in newer header https://github.com/llvm/llvm-project/commit/17d05695388128353662fbb80bbb7a13d172b41d
- **[castxml]** backport LLVM 21 support
- **[ccls]** backport LLVM 21 support
- **[mesa]** add SDKROOT to work around "fatal error: 'stdio.h' file not found"
- **[spirv-headers]** backport https://github.com/KhronosGroup/SPIRV-Headers/commit/9e3836d7d6023843a72ecd3fbf3f09b1b6747a9e

### Rollups
- Closes #232052

### TODO
- [x] add `llvm@20` and `lld@20` - #234240
  - [x] #234396 - #234899
  - [x] #234447
  - [x] #234432
  - [x] #234394
- [x] `flang` - update for runtime, switch to shared libs on macOS
- [x] `llvm` - OOM on arm64 linux
