### PR TITLE
sevenzip: build and install 7z.so alongside 7zz

### DIFF
--- a/Formula/s/sevenzip.rb
+++ b/Formula/s/sevenzip.rb
@@ -15,13 +15,14 @@ class Sevenzip < Formula
   no_autobump! because: :incompatible_version_format
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "7fc707e54e639a99f4bb1041dcdb981890b80711023d5d86122ad6f2fc75e9a6"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "3254fd85c69624613c4d2473bf0962cd0a6da95426db4103e7085a2eb6fb6523"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "98b39cffa36a599b640eba229458461a1b9658b5a6ce1495ed9c06194ab7701d"
-    sha256 cellar: :any_skip_relocation, sonoma:        "1de5040b9b80f5711eda3f3dc75555c5b6a2eda7d20eea1a8d6ec56ab3583c62"
-    sha256 cellar: :any_skip_relocation, ventura:       "93471f3ededabe6868538922a8268bef618ba992f2504826c37a391e3f7e3271"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "7503b0032b2724f7244f8fbf56be566bb31450973a120ea8a3380decf5b2c7e9"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "18a9255bc26eba7518647e9ed69790864aaa3e0d16bb932856c318b468fab9f8"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "164df59691f0b22b908312d7352a048c348fbc5ca0f4cb01e90a0d588436af26"
+    sha256 cellar: :any,                 arm64_sonoma:  "061da1460500f02df5cd42a12f5301f76b7b4684fb75a76e590278b84445396c"
+    sha256 cellar: :any,                 arm64_ventura: "640b7a4fe0208c77a79dd47d960f52b3f2e75d618615e16708b644220b6943df"
+    sha256 cellar: :any,                 sonoma:        "eb1f49451241d795505ed4c2d42d67a6f994cda22f151cf3acc51db6c52100a3"
+    sha256 cellar: :any,                 ventura:       "0764395d3853ff416c9b5b1d94578cd0a2c6a29b7ba7875066ecc36d70d156b9"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "38ddcf4c4583824aa90ee0efaee9a5a9c3b51f30fc11f5406afcd8b59ce1983f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "bdacdbbc0f28b2915b38c8e27d3a59ce64d7b5a23db36ad29f8f8fb5fc3dbdaa"
   end
 
   def install

--- a/Formula/s/sevenzip.rb
+++ b/Formula/s/sevenzip.rb
@@ -25,20 +25,24 @@ class Sevenzip < Formula
   end
 
   def install
+    mac_suffix = Hardware::CPU.intel? ? "x64" : Hardware::CPU.arch
+    mk_suffix, directory = if OS.mac?
+      ["mac_#{mac_suffix}", "m_#{mac_suffix}"]
+    else
+      ["gcc", "g"]
+    end
     cd "CPP/7zip/Bundles/Alone2" do
-      mac_suffix = Hardware::CPU.intel? ? "x64" : Hardware::CPU.arch
-      mk_suffix, directory = if OS.mac?
-        ["mac_#{mac_suffix}", "m_#{mac_suffix}"]
-      else
-        ["gcc", "g"]
-      end
-
       system "make", "-f", "../../cmpl_#{mk_suffix}.mak", "DISABLE_RAR_COMPRESS=1"
 
       # Cherry pick the binary manually. This should be changed to something
       # like `make install' if the upstream adds an install target.
       # See: https://sourceforge.net/p/sevenzip/discussion/45797/thread/1d5b04f2f1/
       bin.install "b/#{directory}/7zz"
+    end
+    cd "CPP/7zip/Bundles/Format7zF" do
+      system "make", "-f", "../../cmpl_#{mk_suffix}.mak", "DISABLE_RAR_COMPRESS=1"
+      lib.install "b/#{directory}/7z.so"
+      lib.install_symlink "7z.so" => shared_library("lib7z")
     end
   end
 
@@ -47,5 +51,63 @@ class Sevenzip < Formula
     system bin/"7zz", "a", "-t7z", "foo.7z", "foo.txt"
     system bin/"7zz", "e", "foo.7z", "-oout"
     assert_equal "hello world!\n", (testpath/"out/foo.txt").read
+
+    (testpath/"test7z.c").write <<~EOS
+      #include <stdint.h>
+      #include <stdio.h>
+      #include <string.h>
+
+      typedef int32_t HRESULT;
+      #define S_OK ((HRESULT)0L)
+      #define SUCCEEDED(hr) (((HRESULT)(hr)) >= 0)
+
+      typedef uint16_t VARTYPE;
+      #define VT_UI4 19
+
+      typedef struct tagPROPVARIANT {
+        VARTYPE vt;
+        uint16_t wReserved1;
+        uint16_t wReserved2;
+        uint16_t wReserved3;
+        union {
+          uint32_t ulVal;
+          int32_t  lVal;
+          uint64_t uhVal;
+          int64_t  hVal;
+          int16_t  iVal;
+          uint16_t uiVal;
+          char     cVal;
+          unsigned char bVal;
+          int      intVal;
+          unsigned int uintVal;
+        };
+      } PROPVARIANT;
+
+      typedef int PROPID;
+
+      HRESULT GetModuleProp(PROPID propID, PROPVARIANT *value);
+
+      int main(void) {
+        PROPVARIANT val;
+        memset(&val, 0, sizeof(val));
+
+        HRESULT hr = GetModuleProp(1, &val); // 1 = kVersion
+
+        if (!SUCCEEDED(hr) || val.vt != VT_UI4) {
+          printf("GetModuleProp failed\\n");
+          return 1;
+        }
+
+        unsigned major = val.ulVal >> 16;
+        unsigned minor = val.ulVal & 0xFFFF;
+
+        printf("%02u.%02u", major, minor);
+        return 0;
+      }
+    EOS
+
+    system ENV.cc, "test7z.c", "-L#{lib}", "-l7z", "-o", "test7z"
+    output = shell_output("./test7z").strip
+    assert_equal version.to_s, output
   end
 end


### PR DESCRIPTION
This adds building and installing the 7z.so shared library alongside the existing 7zz binary. Useful for software that dynamically loads 7-Zip codecs and formats. This makes the formula more complete without affecting current CLI users.
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
