### PR TITLE
Revert watchman 2025.08.18.00 (and dependencies)

### DIFF
--- a/Formula/e/edencommon.rb
+++ b/Formula/e/edencommon.rb
@@ -1,9 +1,10 @@
 class Edencommon < Formula
   desc "Shared library for Watchman and Eden projects"
   homepage "https://github.com/facebookexperimental/edencommon"
-  url "https://github.com/facebookexperimental/edencommon/archive/refs/tags/v2025.08.18.00.tar.gz"
-  sha256 "ec857fadf3c3b8746cca3a3031f9c3dec8243f36f1f6baf51b1194b1081ac0e7"
+  url "https://github.com/facebookexperimental/edencommon/archive/refs/tags/v2025.08.11.00.tar.gz"
+  sha256 "25b5bd103e6450fe8e357fb76544c2816f1db405bb302a6f9f7a9386b5eb2d52"
   license "MIT"
+  revision 1
   head "https://github.com/facebookexperimental/edencommon.git", branch: "main"
 
   bottle do

--- a/Formula/f/fb303.rb
+++ b/Formula/f/fb303.rb
@@ -1,8 +1,8 @@
 class Fb303 < Formula
   desc "Thrift functions for querying information from a service"
   homepage "https://github.com/facebook/fb303"
-  url "https://github.com/facebook/fb303/archive/refs/tags/v2025.08.18.00.tar.gz"
-  sha256 "d3495010adb466b612f233c2731ba6089d39be3fc8581aa99da9db4bf7d30017"
+  url "https://github.com/facebook/fb303/archive/refs/tags/v2025.08.11.00.tar.gz"
+  sha256 "69123178f5e00c0a507a82dc5cd33ff81300ee3a50d7951425d9f5931ee8fbbd"
   license "Apache-2.0"
   head "https://github.com/facebook/fb303.git", branch: "main"
 
@@ -25,6 +25,12 @@ class Fb303 < Formula
   depends_on "gflags"
   depends_on "glog"
   depends_on "openssl@3"
+
+  # CMAKE_CXX_STANDARD to 20, should remove in next release
+  patch do
+    url "https://github.com/facebook/fb303/commit/ac1a8c3fb522f8a08d96ba831818912e18d565d9.patch?full_index=1"
+    sha256 "f048ae3b053822114fd692967cf7b8e8f0b362711699e65007c406b31d67550f"
+  end
 
   def install
     shared_args = ["-DBUILD_SHARED_LIBS=ON", "-DCMAKE_INSTALL_RPATH=#{rpath}"]

--- a/Formula/f/fbthrift.rb
+++ b/Formula/f/fbthrift.rb
@@ -1,9 +1,10 @@
 class Fbthrift < Formula
   desc "Facebook's branch of Apache Thrift, including a new C++ server"
   homepage "https://github.com/facebook/fbthrift"
-  url "https://github.com/facebook/fbthrift/archive/refs/tags/v2025.08.18.00.tar.gz"
-  sha256 "2bf208b198bf7ad55d404a8863ff5092ce0ad6f0d8693877cacb72db16b44772"
+  url "https://github.com/facebook/fbthrift/archive/refs/tags/v2025.08.11.00.tar.gz"
+  sha256 "e3abde5a00cd7b52db21f4097d5a2c8b32ab8e17071e795c0af27991410d0dde"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/facebook/fbthrift.git", branch: "main"
 
   bottle do

--- a/Formula/f/fizz.rb
+++ b/Formula/f/fizz.rb
@@ -1,8 +1,8 @@
 class Fizz < Formula
   desc "C++14 implementation of the TLS-1.3 standard"
   homepage "https://github.com/facebookincubator/fizz"
-  url "https://github.com/facebookincubator/fizz/releases/download/v2025.08.18.00/fizz-v2025.08.18.00.tar.gz"
-  sha256 "16e94add30d6e15373483c65350290512d2c234e18fcdf1411ae4394d37c1fbc"
+  url "https://github.com/facebookincubator/fizz/releases/download/v2025.08.11.00/fizz-v2025.08.11.00.tar.gz"
+  sha256 "4b488cb4e3cff707081c286ae96bfa93250c8f53ab1a4e8b56cc55943f7c782b"
   license "BSD-3-Clause"
   head "https://github.com/facebookincubator/fizz.git", branch: "main"
 

--- a/Formula/f/folly.rb
+++ b/Formula/f/folly.rb
@@ -1,9 +1,10 @@
 class Folly < Formula
   desc "Collection of reusable C++ library artifacts developed at Facebook"
   homepage "https://github.com/facebook/folly"
-  url "https://github.com/facebook/folly/archive/refs/tags/v2025.08.18.00.tar.gz"
-  sha256 "54df42979bb9d0445e8cc84752116d929b924ae05de2d20ea7c033ec5c44d911"
+  url "https://github.com/facebook/folly/archive/refs/tags/v2025.08.11.00.tar.gz"
+  sha256 "a5cdbf0e8b5198a0f0e863e9f9e3c35b30a78b189c2cd2f300d2d3ca67c0aa3f"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/facebook/folly.git", branch: "main"
 
   bottle do

--- a/Formula/m/mvfst.rb
+++ b/Formula/m/mvfst.rb
@@ -1,9 +1,10 @@
 class Mvfst < Formula
   desc "QUIC transport protocol implementation"
   homepage "https://github.com/facebook/mvfst"
-  url "https://github.com/facebook/mvfst/archive/refs/tags/v2025.08.18.00.tar.gz"
-  sha256 "8906b8e7e517a5676d1ab1288ca0566e4bbaa87f484af258c9e2f59e682be91b"
+  url "https://github.com/facebook/mvfst/archive/refs/tags/v2025.08.11.00.tar.gz"
+  sha256 "9d475c425e658e7d2d55911856b47acf6c5cde9bf64ee4d9b380b1363a4c2f8b"
   license "MIT"
+  revision 1
   head "https://github.com/facebook/mvfst.git", branch: "main"
 
   bottle do

--- a/Formula/p/proxygen.rb
+++ b/Formula/p/proxygen.rb
@@ -1,9 +1,10 @@
 class Proxygen < Formula
   desc "Collection of C++ HTTP libraries"
   homepage "https://github.com/facebook/proxygen"
-  url "https://github.com/facebook/proxygen/releases/download/v2025.08.18.00/proxygen-v2025.08.18.00.tar.gz"
-  sha256 "01286d48007a578b3b9964e2f065a07f296de50d8ddac2fdc6fe54bb2145fbba"
+  url "https://github.com/facebook/proxygen/releases/download/v2025.08.11.00/proxygen-v2025.08.11.00.tar.gz"
+  sha256 "adcb875fda718aa62fe47dc9b25c45c65632ccec583452f302624619a164e44f"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/facebook/proxygen.git", branch: "main"
 
   bottle do
@@ -29,11 +30,20 @@ class Proxygen < Formula
   depends_on "wangle"
   depends_on "zstd"
 
-  uses_from_macos "gperf" => :build
+  # TODO: uses_from_macos "gperf" => :build
   uses_from_macos "python" => :build
   uses_from_macos "zlib"
 
   conflicts_with "hq", because: "both install `hq` binaries"
+
+  # FIXME: Build script is not compatible with gperf 3.2
+  resource "gperf" do
+    on_linux do
+      url "https://ftpmirror.gnu.org/gnu/gperf/gperf-3.1.tar.gz"
+      mirror "https://ftp.gnu.org/gnu/gperf/gperf-3.1.tar.gz"
+      sha256 "588546b945bba4b70b6a3a616e80b4ab466e3f33024a352fc2198112cdbb3ae2"
+    end
+  end
 
   # Fix build with Boost 1.89.0, pr ref: https://github.com/facebook/proxygen/pull/570
   patch do
@@ -42,6 +52,14 @@ class Proxygen < Formula
   end
 
   def install
+    if OS.linux?
+      resource("gperf").stage do
+        system "./configure", *std_configure_args(prefix: buildpath/"gperf")
+        system "make", "install"
+        ENV.prepend_path "PATH", buildpath/"gperf/bin"
+      end
+    end
+
     args = ["-DBUILD_SHARED_LIBS=ON", "-DCMAKE_INSTALL_RPATH=#{rpath}"]
     if OS.mac?
       args += [

--- a/Formula/w/wangle.rb
+++ b/Formula/w/wangle.rb
@@ -1,9 +1,10 @@
 class Wangle < Formula
   desc "Modular, composable client/server abstractions framework"
   homepage "https://github.com/facebook/wangle"
-  url "https://github.com/facebook/wangle/archive/refs/tags/v2025.08.18.00.tar.gz"
-  sha256 "f2fa29f52fb4810b211d2f6f5321e3c706118b8e46e977501fda414cd7e2b70c"
+  url "https://github.com/facebook/wangle/archive/refs/tags/v2025.08.11.00.tar.gz"
+  sha256 "42d51131ec0b6ec5bc96a43e81a4e85daaabba357f1e3b4d9f2c9f254b01b517"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/facebook/wangle.git", branch: "main"
 
   bottle do
@@ -47,12 +48,18 @@ class Wangle < Formula
   end
 
   test do
+    # libsodium has no CMake file but fizz runs `find_dependency(Sodium)` so fetch a copy from mvfst
+    resource "FindSodium.cmake" do
+      url "https://raw.githubusercontent.com/facebook/mvfst/v2024.09.02.00/cmake/FindSodium.cmake"
+      sha256 "39710ab4525cf7538a66163232dd828af121672da820e1c4809ee704011f4224"
+    end
+    (testpath/"cmake").install resource("FindSodium.cmake")
+
     (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 3.5)
       project(Echo LANGUAGES CXX)
       set(CMAKE_CXX_STANDARD 17)
 
-      list(APPEND CMAKE_MODULE_PATH "#{Formula["fizz"].opt_libexec}/cmake")
       find_package(gflags REQUIRED)
       find_package(folly CONFIG REQUIRED)
       find_package(fizz CONFIG REQUIRED)

--- a/Formula/w/watchman.rb
+++ b/Formula/w/watchman.rb
@@ -3,9 +3,10 @@ class Watchman < Formula
 
   desc "Watch files and take action when they change"
   homepage "https://github.com/facebook/watchman"
-  url "https://github.com/facebook/watchman/archive/refs/tags/v2025.08.18.00.tar.gz"
-  sha256 "71a4208ed35dc655199580ed1acb2908033bb512f9c3a9714681fb9b644c61f5"
+  url "https://github.com/facebook/watchman/archive/refs/tags/v2025.08.11.00.tar.gz"
+  sha256 "f9493050fdc5384c92d18f5445e73b3ebca80fe262c5af9e0c70044e56fd96de"
   license "MIT"
+  revision 1
   head "https://github.com/facebook/watchman.git", branch: "main"
 
   bottle do


### PR DESCRIPTION
This reverts commit 7ebb3ff790a647055949e5f4662cc45228d17bb8, reversing changes made to 4d98891ae1df1d2207d880801194a62649f04aea.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This reverts https://github.com/Homebrew/homebrew-core/pull/233972 as this version is significantly broken: https://github.com/facebook/watchman/issues/1298
