### PR TITLE
oterm: depend on `pillow`

### DIFF
--- a/Formula/o/oterm.rb
+++ b/Formula/o/oterm.rb
@@ -8,13 +8,14 @@ class Oterm < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "7be96b3339212c657723c0dd622bc96fd432e692e47510580b5dc0917e92fafd"
-    sha256 cellar: :any,                 arm64_sonoma:  "531577059a3879d64e34f52f20612fabe52302693a44c50067011cf8828419b6"
-    sha256 cellar: :any,                 arm64_ventura: "43abe5834465f6d6f4510ca274cb95524896984ecde25f0a686fc9df0946135c"
-    sha256 cellar: :any,                 sonoma:        "ba0852947a91c1c93aaba5022222b912ddc39b562521c51c5a878f3cdfa29c66"
-    sha256 cellar: :any,                 ventura:       "8779492763097e745099e49df488183681c2f2b7e45ca63346771981b1dcbe1b"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "ea1a5a07755837ebed6aa1c2473ccb89f16c818a1c1938394eab0f4db53d8005"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f534585a1f86cc183927bb2ff5b70d47b62860a3405f1cec132d18ef2604ca30"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "8aee3915adbe42c2aa6fb2dc1ae2419f06394bec3e2f338935149c8fcf890b7f"
+    sha256 cellar: :any,                 arm64_sonoma:  "0b51e91a8859b2a2d5c6a45d8c8cab94b7042584043d5c33f61015e0f2cb1dcd"
+    sha256 cellar: :any,                 arm64_ventura: "861b11b0b378f7493eacc5fdda5a336a4d5ea1494bdc2e3e44879e3b2fb87bdf"
+    sha256 cellar: :any,                 sonoma:        "122e7773955c9776650a9a12a30c359165b3768696863372daf559457ea15923"
+    sha256 cellar: :any,                 ventura:       "7e8e5e232b8136695c8a7ba2725c15caae7c5649fa88d271bd6c80b4b949ba43"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "15dcca427cede18febebc34a536dba44a9548477d5a151a8fc6c6b59cc43c8bf"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1e34c9c421ac326104d96491416dc5ce0cb472d2ba60e3a4c19b346a970fbee2"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/o/oterm.rb
+++ b/Formula/o/oterm.rb
@@ -22,12 +22,7 @@ class Oterm < Formula
   depends_on "certifi"
   depends_on "cffi"
   depends_on "cryptography"
-  depends_on "freetype"
-  depends_on "jpeg-turbo"
-  depends_on "libraqm"
-  depends_on "libtiff"
-  depends_on "little-cms2"
-  depends_on "openjpeg"
+  depends_on "pillow"
   depends_on "pycparser"
   depends_on "python@3.13"
 
@@ -151,11 +146,6 @@ class Oterm < Formula
   resource "packaging" do
     url "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz"
     sha256 "d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"
-  end
-
-  resource "pillow" do
-    url "https://files.pythonhosted.org/packages/f3/0d/d0d6dea55cd152ce3d6767bb38a8fc10e33796ba4ba210cbab9354b6d238/pillow-11.3.0.tar.gz"
-    sha256 "3828ee7586cd0b2091b6209e5ad53e20d0649bbe87164a459d0676e035e8f523"
   end
 
   resource "platformdirs" do

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -674,7 +674,7 @@
     "exclude_packages": ["certifi"]
   },
   "oterm": {
-    "exclude_packages": ["certifi", "cffi", "cryptography", "pycparser"]
+    "exclude_packages": ["certifi", "cffi", "cryptography", "pillow", "pycparser"]
   },
   "otterdog": {
     "exclude_packages": ["certifi", "cryptography"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Also, remove the dependencies that are likely due to the `pillow`
resource.