### PR TITLE
keeper-commander: depend on `pillow`

### DIFF
--- a/Formula/k/keeper-commander.rb
+++ b/Formula/k/keeper-commander.rb
@@ -24,18 +24,12 @@ class KeeperCommander < Formula
   depends_on "certifi"
   depends_on "cryptography"
   depends_on "ffmpeg"
-  depends_on "freetype"
-  depends_on "jpeg-turbo"
-  depends_on "libtiff"
   depends_on "libvpx"
   depends_on "libyaml"
-  depends_on "little-cms2"
   depends_on "opus"
+  depends_on "pillow"
   depends_on "python@3.13"
   depends_on "srtp"
-  depends_on "webp"
-
-  uses_from_macos "zlib"
 
   on_macos do
     depends_on "openssl@3"
@@ -199,11 +193,6 @@ class KeeperCommander < Formula
   resource "packaging" do
     url "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz"
     sha256 "d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"
-  end
-
-  resource "pillow" do
-    url "https://files.pythonhosted.org/packages/f3/0d/d0d6dea55cd152ce3d6767bb38a8fc10e33796ba4ba210cbab9354b6d238/pillow-11.3.0.tar.gz"
-    sha256 "3828ee7586cd0b2091b6209e5ad53e20d0649bbe87164a459d0676e035e8f523"
   end
 
   resource "prompt-toolkit" do

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -514,7 +514,7 @@
     "exclude_packages": ["certifi", "cryptography"]
   },
   "keeper-commander": {
-    "exclude_packages": ["certifi", "cryptography"]
+    "exclude_packages": ["certifi", "cryptography", "pillow"]
   },
   "keepkey-agent": {
     "exclude_packages": ["cryptography"],


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Also, remove the dependencies that are likely due to the `pillow`
resource.
