### PR TITLE
git-gui: use tcl-tk 9

### DIFF
--- a/Formula/g/git-gui.rb
+++ b/Formula/g/git-gui.rb
@@ -4,6 +4,7 @@ class GitGui < Formula
   url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.51.0.tar.xz"
   sha256 "60a7c2251cc2e588d5cd87bae567260617c6de0c22dca9cdbfc4c7d2b8990b62"
   license "GPL-2.0-only"
+  revision 1
   head "https://github.com/git/git.git", branch: "master"
 
   livecheck do
@@ -14,7 +15,7 @@ class GitGui < Formula
     sha256 cellar: :any_skip_relocation, all: "19ad2feb267d2423780971f7f87023f8b2ed6a01d62da5b2a5e6fcc2d18b74b0"
   end
 
-  depends_on "tcl-tk@8"
+  depends_on "tcl-tk"
 
   def install
     # build verbosely
@@ -24,7 +25,7 @@ class GitGui < Formula
     # the git makefiles don't install a .app for git-gui
     # We also tell git to use the homebrew-installed wish binary from tcl-tk.
     # See https://github.com/Homebrew/homebrew-core/issues/36390
-    tcl_bin = Formula["tcl-tk@8"].opt_bin
+    tcl_bin = Formula["tcl-tk"].opt_bin
     args = %W[
       TKFRAMEWORK=/dev/null
       prefix=#{prefix}

--- a/Formula/g/git-gui.rb
+++ b/Formula/g/git-gui.rb
@@ -12,7 +12,7 @@ class GitGui < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "19ad2feb267d2423780971f7f87023f8b2ed6a01d62da5b2a5e6fcc2d18b74b0"
+    sha256 cellar: :any_skip_relocation, all: "703a593f09c0c37610e2c1bb236014392246c749cfed9e80a9ba0d66e3a3ba1c"
   end
 
   depends_on "tcl-tk"


### PR DESCRIPTION
* As of Git v2.51.0 commits `afea2205b4cfccc93bb8633218130c0f602ac929` and `c20408c6b755a6b0fe869586cbba0bd6329978b5` gitk and git gui work with Tcl/Tk 9+
* Remove formula's dependency on `tcl-tk@8` and replace with dependency on `tcl-tk`
* Bump revision to 1 to trigger new bottle creation
* Note : used `tcl-tk` instead of explicitly specifying `tcl-tk@9` (which is an alias for `tcl-tk`)

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
