### PR TITLE
linode-cli: prefer formula over vendored resource

### DIFF
--- a/Formula/l/linode-cli.rb
+++ b/Formula/l/linode-cli.rb
@@ -20,6 +20,7 @@ class LinodeCli < Formula
 
   depends_on "certifi"
   depends_on "libyaml"
+  depends_on "pygments"
   depends_on "python@3.13"
 
   resource "anyio" do
@@ -75,11 +76,6 @@ class LinodeCli < Formula
   resource "packaging" do
     url "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz"
     sha256 "d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"
-  end
-
-  resource "pygments" do
-    url "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz"
-    sha256 "636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"
   end
 
   resource "pyyaml" do

--- a/Formula/l/linode-cli.rb
+++ b/Formula/l/linode-cli.rb
@@ -6,7 +6,7 @@ class LinodeCli < Formula
   url "https://files.pythonhosted.org/packages/e8/aa/6be3aadaba64be06cb354b1c7e1a567e77630bce8af7bae2eadfbcc158f7/linode_cli-5.61.0.tar.gz"
   sha256 "702ebcd91b7035c705113edf4e04646028719794cb82b423ad6ed953e3fd8ff3"
   license "BSD-3-Clause"
-  head "https://github.com/linode/linode-cli.git", branch: "main"
+  head "https://github.com/linode/linode-cli.git", branch: "dev"
 
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "18b7fe3bf7f9013354e12959f6ecb20974d60f6a5454095b58ff27b81b31ff08"

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -530,7 +530,7 @@
     "exclude_packages": ["certifi", "cryptography"]
   },
   "linode-cli": {
-    "exclude_packages": ["certifi"]
+    "exclude_packages": ["certifi", "pygments"]
   },
   "litani": {
     "package_name": "",


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
