### PR TITLE
nzbget: make `inreplace` more efficient

### DIFF
--- a/Formula/n/nzbget.rb
+++ b/Formula/n/nzbget.rb
@@ -8,13 +8,14 @@ class Nzbget < Formula
   head "https://github.com/nzbgetcom/nzbget.git", branch: "develop"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "cfc805d17f2dde8dc172b87ee538357606c927f1883c2375aba80215f9a1a39e"
-    sha256 cellar: :any,                 arm64_sonoma:  "37f1781206860417b05ad5b3c32a4fdbbc4752275df7ab5203c0e06e37fd3991"
-    sha256 cellar: :any,                 arm64_ventura: "f5b3c05a1de78f0c34fd45602518b44591482e6b799b28a0c8fc7c5749d51c82"
-    sha256 cellar: :any,                 sonoma:        "9a06e612b01cb3cb97ba7d4d23e958138a471337f8923d925f816aa513b133b8"
-    sha256 cellar: :any,                 ventura:       "3ef289e522618e695d05761fad0850c5c976589ad0f73a2dba5f773ac7f2b00b"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "7d5757247006ceeefafe36fa98b76ce0c4813d5db6de7b189606c7fe43f5245e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b104a47939a6a6f9ee4a3e24de94941c656c69b21a6e1caced8d6a1e43c33bb7"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "02a229d242fc3773175fc982ce8640bf8e246365612d6c338860b75d0bf4a862"
+    sha256 cellar: :any,                 arm64_sonoma:  "9186bb19216c710bc385133fc2eb04f8e18ba66ab08d86b86e21090bdadef0ab"
+    sha256 cellar: :any,                 arm64_ventura: "4b14901c229483845a2806f26dec7c7096fe6a4cc20e322104b781b685b6868b"
+    sha256                               sonoma:        "69a85d8797a5dc8f39ca9e941d029a46c019e8344df9ecd9e918fda71545b610"
+    sha256                               ventura:       "6c022461281e67314ae48698640a521a506a3d48ac0e3a365d0447ac685f284b"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "b735d3fe4b3b0dca41b27f1aca6762ef95724797c5e1071efc5ec99c845140e3"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "641346d6c0167846bec3f3eebe62e16407a963408644599bf1d6d515e8256048"
   end
 
   depends_on "cmake" => :build

--- a/Formula/n/nzbget.rb
+++ b/Formula/n/nzbget.rb
@@ -31,13 +31,16 @@ class Nzbget < Formula
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
 
-    if OS.mac?
-      # Set upstream's recommended values for file systems without
-      # sparse-file support (e.g., HFS+); see Homebrew/homebrew-core#972
-      inreplace "nzbget.conf", "DirectWrite=yes", "DirectWrite=no"
-      inreplace "nzbget.conf", "ArticleCache=0", "ArticleCache=700"
+    inreplace "nzbget.conf" do |s|
+      if OS.mac?
+        # Set upstream's recommended values for file systems without
+        # sparse-file support (e.g., HFS+); see Homebrew/homebrew-core#972
+        s.gsub! "DirectWrite=yes", "DirectWrite=no"
+        s.gsub! "ArticleCache=0", "ArticleCache=700"
+      end
+
       # Update 7z cmd to match homebrew binary
-      inreplace "nzbget.conf", "SevenZipCmd=7z", "SevenZipCmd=7zz"
+      s.gsub! "SevenZipCmd=7z", "SevenZipCmd=7zz"
     end
 
     etc.install "nzbget.conf"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Let's combine these repeated `inreplace` calls into a single block so we
don't need to open and close `nzbget.conf` repeatedly.

Also, let's keep the replacement of `SevenZipCmd` on Linux too, since
the binary is called `7zz` on Linux too.
