### PR TITLE
libpulsar: add workaround for Protobuf 30+ and upstream issue ref

### DIFF
--- a/Formula/lib/libpulsar.rb
+++ b/Formula/lib/libpulsar.rb
@@ -22,7 +22,7 @@ class Libpulsar < Formula
   depends_on "pkgconf" => :build
 
   depends_on "openssl@3"
-  depends_on "protobuf@29"
+  depends_on "protobuf"
   depends_on "snappy"
   depends_on "zstd"
 
@@ -34,6 +34,9 @@ class Libpulsar < Formula
     url "https://raw.githubusercontent.com/Homebrew/formula-patches/93a4bb54004417c3742ca0e41183c662d9f417f5/libpulsar/asio.patch"
     sha256 "519ecb20d3721575a916f45e7e0d382ae61de38ceaee23b53b97c7b4fcdbc019"
   end
+
+  # Workaround for Protobuf 30+, issue ref: https://github.com/apache/pulsar-client-cpp/issues/478
+  patch :DATA
 
   def install
     args = %W[
@@ -64,3 +67,20 @@ class Libpulsar < Formula
     system "./test"
   end
 end
+
+__END__
+diff --git a/lib/ProtobufNativeSchema.cc b/lib/ProtobufNativeSchema.cc
+index 5cddf74..4bf45cf 100644
+--- a/lib/ProtobufNativeSchema.cc
++++ b/lib/ProtobufNativeSchema.cc
+@@ -39,8 +39,8 @@ SchemaInfo createProtobufNativeSchema(const google::protobuf::Descriptor* descri
+     }
+ 
+     const auto fileDescriptor = descriptor->file();
+-    const std::string rootMessageTypeName = descriptor->full_name();
+-    const std::string rootFileDescriptorName = fileDescriptor->name();
++    const std::string rootMessageTypeName = std::string(descriptor->full_name());
++    const std::string rootFileDescriptorName = std::string(fileDescriptor->name());
+ 
+     FileDescriptorSet fileDescriptorSet;
+     internalCollectFileDescriptors(fileDescriptor, fileDescriptorSet);

--- a/Formula/lib/libpulsar.rb
+++ b/Formula/lib/libpulsar.rb
@@ -8,13 +8,14 @@ class Libpulsar < Formula
   revision 3
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "127f23ea8cfe8361eda6419a782f1a30e574319c59f7daddaaf5e80fda4448c4"
-    sha256 cellar: :any,                 arm64_sonoma:  "0672f509cd6452e0a3b0a704406a417c53ee08feb013fe871c339431a349fd93"
-    sha256 cellar: :any,                 arm64_ventura: "ccebb44c06c890b4c1c628c724fa0d2c32b0f5ad5bcca8bd4f681869b3458bc7"
-    sha256 cellar: :any,                 sonoma:        "b171543333bd0b44c7091dc1ae5690645ef766695e17b8a0bd6d9861ad69e7f4"
-    sha256 cellar: :any,                 ventura:       "9235b7618d27f2ac474bc0500d814dba9003448eaf4228eb630fed8b927402d9"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "0972785e45e4ea72ed90a0274df98a5019407745dd521c172700e5b0d44a7c64"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1ecd9b3a9368874cecaf30395dbee90e153639f7294333ba4f465e226af5a896"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "e17b813a73dafc0a88d4436a4744603800c8870903063514fca333015a7fc16f"
+    sha256 cellar: :any,                 arm64_sonoma:  "5637122aa767f1c09b5ffdfa5e3bc369fffc912de7db35440a74ac97503fbb7c"
+    sha256 cellar: :any,                 arm64_ventura: "dc2072aa142a8a4f21414bdace24121bddad5ac6667fc32b412f9ac0d2630837"
+    sha256 cellar: :any,                 sonoma:        "5627ec90bc03294b80d60a042510795b9cc6bad0b3273eac96d247915aff09f2"
+    sha256 cellar: :any,                 ventura:       "5758ca49c4efbd0b6f24fe5ca5321290e03e8557e02eb2050001d1a4dc1c23ac"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "452cc1e4ef67eb9f3b58f0d62ccb4ad90f5b8b4b9f5ee971a7d99c704f87fd19"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "14127de62a4698ecbc3718c904786ae2bfc009c309d6c5bf10a86ad4d4454ec1"
   end
 
   depends_on "boost" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Waiting on response to upstream issue (https://github.com/apache/pulsar-client-cpp/issues/478) before opening PR.

For now just applying a simple workaround which matches Protobuf's own modifications (https://github.com/protocolbuffers/protobuf/commit/d1990d968a54176eb9f4229abe7f7c97ece50cec).