### PR TITLE
watchman: restore dropped `#include` directives

### DIFF
--- a/Formula/w/watchman.rb
+++ b/Formula/w/watchman.rb
@@ -6,6 +6,7 @@ class Watchman < Formula
   url "https://github.com/facebook/watchman/archive/refs/tags/v2025.08.18.00.tar.gz"
   sha256 "71a4208ed35dc655199580ed1acb2908033bb512f9c3a9714681fb9b644c61f5"
   license "MIT"
+  revision 1
   head "https://github.com/facebook/watchman.git", branch: "main"
 
   bottle do
@@ -40,6 +41,14 @@ class Watchman < Formula
   on_linux do
     depends_on "boost"
     depends_on "libunwind"
+  end
+
+  # Fix incorrectly dropped includes, resulting in watchman becoming unusable
+  # https://github.com/facebook/watchman/issues/1298
+  # https://github.com/facebook/watchman/pull/1300
+  patch do
+    url "https://github.com/facebook/watchman/commit/d97b7fcace5723fd293ae65a59300bf27bc44f1f.patch?full_index=1"
+    sha256 "83f4d6186712410762d44129e969a0616a8442037d7c5ade40741c83648b7944"
   end
 
   def install

--- a/Formula/w/watchman.rb
+++ b/Formula/w/watchman.rb
@@ -10,13 +10,13 @@ class Watchman < Formula
   head "https://github.com/facebook/watchman.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "9102b16f3a0659f3afda719064c65407ef51b01af40201db5ec8790fcbead771"
-    sha256 cellar: :any,                 arm64_sonoma:  "45eccfdf372aa3df36fe9a35850f4fb0de4ae07a11f96863aaf9a01ebfe4900d"
-    sha256 cellar: :any,                 arm64_ventura: "f463e044a8682b0af562488f1d9d1f5e749b675f66847d9b432b6c433cfa5d5a"
-    sha256 cellar: :any,                 sonoma:        "5043af207ef8f352d07db9f1effc7b52562b5cd98e5da80bd66cb84509aa3616"
-    sha256 cellar: :any,                 ventura:       "18f6eec923d0a3d66e6bd7174b3e022d2e02392cfa3e6c9a9b7ee9d5df7bf931"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "102dda32e7f0a9966a8384de37715df87677da5cc62ed37ae8a8277c36557daa"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4b05c4cd66d70c6d3be2630fe704c131afcf4a83c480f3d8baae618f28b29a98"
+    sha256 cellar: :any,                 arm64_sequoia: "33c8b41f5e083990a40b946cb8b41bca372d78db05ee6693a88c1867d7eee861"
+    sha256 cellar: :any,                 arm64_sonoma:  "7f58628c45f84125e6cc31668f6871485e6bdc14d5df36236cba97edb35e19de"
+    sha256 cellar: :any,                 arm64_ventura: "430582daa153397f98c41c1077da70a750810dbc308bc83db71d94a988ae45dd"
+    sha256 cellar: :any,                 sonoma:        "cdbc7b0557cbe592dc87fc4922903c113e0b973bf9981a2568baac4bef456935"
+    sha256 cellar: :any,                 ventura:       "6266cf3f8ce4d790efe1bcfb8f36cf36db187b8bff5b0abd13bbedda03da0ab6"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "41ce4c2e490034768084cfb43d432f194c2c47f461f86cba91773d04ea9375cb"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "ed5a7b0ef2728d9494ce01ab806797bd2110dbbff253670a75fbb02997f6b291"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

See https://github.com/facebook/watchman/issues/1298.

Closes #234268.

~I'll send a PR upstream shortly.~ Upstreamed at facebook/watchman#1300.
