### PR TITLE
c3c: update checksum and use `llvm@20`

### DIFF
--- a/Formula/c/c3c.rb
+++ b/Formula/c/c3c.rb
@@ -2,8 +2,9 @@ class C3c < Formula
   desc "Compiler for the C3 language"
   homepage "https://github.com/c3lang/c3c"
   url "https://github.com/c3lang/c3c/archive/refs/tags/v0.7.4.tar.gz"
-  sha256 "65bd76c5b418382ccccde468d5cc0a1331ca3bad27f1e1828a43f078d87dcdc0"
+  sha256 "410267a3d771ac4b4d6bcc29be0faf30d4959c24b31f9d1bd00661656072dc2b"
   license "LGPL-3.0-only"
+  revision 1
   head "https://github.com/c3lang/c3c.git", branch: "master"
 
   # Upstream creates releases that use a stable tag (e.g., `v1.2.3`) but are
@@ -24,38 +25,31 @@ class C3c < Formula
     sha256               x86_64_linux:  "2d484624c26dbcdc838dac9e68fc1fa591cfb197f409177263ac8219fb74dede"
   end
 
-  # We are unable to rebuild bottles as url has a checksum mismatch and
-  # upstream has not responded to https://github.com/c3lang/c3c/issues/2425
-  # This can be removed if upstream confirms retag or in future release
-  deprecate! date: "2025-08-25", because: :checksum_mismatch
-
   depends_on "cmake" => :build
-  depends_on "lld"
-  depends_on "llvm"
-  depends_on "zstd"
+  depends_on "lld@20"
+  depends_on "llvm@20"
 
   uses_from_macos "curl"
-  uses_from_macos "zlib"
-
-  # Linking dynamically with LLVM fails with GCC.
-  fails_with :gcc
 
   def install
+    lld = Formula["lld@20"]
+    llvm = Formula["llvm@20"]
+
     args = [
       "-DC3_LINK_DYNAMIC=ON",
       "-DC3_USE_MIMALLOC=OFF",
       "-DC3_USE_TB=OFF",
       "-DCMAKE_POSITION_INDEPENDENT_CODE=ON",
-      "-DLLVM=#{Formula["llvm"].opt_lib/shared_library("libLLVM")}",
-      "-DLLD_COFF=#{Formula["lld"].opt_lib/shared_library("liblldCOFF")}",
-      "-DLLD_COMMON=#{Formula["lld"].opt_lib/shared_library("liblldCommon")}",
-      "-DLLD_ELF=#{Formula["lld"].opt_lib/shared_library("liblldELF")}",
-      "-DLLD_MACHO=#{Formula["lld"].opt_lib/shared_library("liblldMachO")}",
-      "-DLLD_MINGW=#{Formula["lld"].opt_lib/shared_library("liblldMinGW")}",
-      "-DLLD_WASM=#{Formula["lld"].opt_lib/shared_library("liblldWasm")}",
+      "-DLLVM=#{llvm.opt_lib/shared_library("libLLVM")}",
+      "-DLLD_COFF=#{lld.opt_lib/shared_library("liblldCOFF")}",
+      "-DLLD_COMMON=#{lld.opt_lib/shared_library("liblldCommon")}",
+      "-DLLD_ELF=#{lld.opt_lib/shared_library("liblldELF")}",
+      "-DLLD_MACHO=#{lld.opt_lib/shared_library("liblldMachO")}",
+      "-DLLD_MINGW=#{lld.opt_lib/shared_library("liblldMinGW")}",
+      "-DLLD_WASM=#{lld.opt_lib/shared_library("liblldWasm")}",
     ]
+    args << "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON" if OS.linux?
 
-    ENV.append "LDFLAGS", "-lzstd -lz"
     system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
@@ -67,7 +61,6 @@ class C3c < Formula
     libexec.install bin.children
     bin.install_symlink libexec.children.select { |child| child.file? && child.executable? }
     rm_r libexec/"c3c_rt"
-    llvm = Formula["llvm"]
     libexec.install_symlink llvm.opt_lib/"clang"/llvm.version.major/"lib/darwin" => "c3c_rt"
   end
 

--- a/Formula/c/c3c.rb
+++ b/Formula/c/c3c.rb
@@ -16,13 +16,13 @@ class C3c < Formula
   end
 
   bottle do
-    sha256 cellar: :any, arm64_sequoia: "76b4627f508edea70298a5e58202ee3a1fd66ba301f3f27885f4a1d2a5b6a647"
-    sha256 cellar: :any, arm64_sonoma:  "b69907b9904a87266f75f0349d8d3fc3dcce8bcf3fcde23775df61ea5f931ba3"
-    sha256 cellar: :any, arm64_ventura: "b38cb79e6f1e0979bf460127a7c9d1c98f51bc227d5dc0c4a2c850d141b49b01"
-    sha256 cellar: :any, sonoma:        "e76cf7197b9f9de48288b15a2424c154133c5592d8b8ed328dc8b8640ba973b8"
-    sha256 cellar: :any, ventura:       "5ef29f27699fdcf1933d37cac6c4166ae2b2bb9f350d951a2d58887bfc1a81aa"
-    sha256               arm64_linux:   "a0424e7334c780f4eade36b16d794dc9453899bb9f54baeeadbddf00eebde517"
-    sha256               x86_64_linux:  "2d484624c26dbcdc838dac9e68fc1fa591cfb197f409177263ac8219fb74dede"
+    sha256 cellar: :any,                 arm64_sequoia: "6c6831e67b3dad521d8c952587f054c675416f72fe1df21cb5bc6d75a4c4c39b"
+    sha256 cellar: :any,                 arm64_sonoma:  "7cb8c949acc82ab4d2a3f4279e294a353979fda24c427ddba0678cd8f42cc94b"
+    sha256 cellar: :any,                 arm64_ventura: "5b8ba42df1119e4e12ca6d5875fb1a40b575052e8770d01050042bd9481a128f"
+    sha256 cellar: :any,                 sonoma:        "a88eee60a639b90a3affa3d6d53e3f688beaca668ce4e80453da6fd627092a67"
+    sha256 cellar: :any,                 ventura:       "5acba9a1b246a4d3570bb96979c9ed980cec990deabc27085c56b1f07e7b0e98"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "0906c3318ecfc1939351517388b35075a30e80bfce62171ecb2a762bf9f0ddc8"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f323f8a473cdeb8360441d31e160b9026fd5085da47d8a02a3b4318b48378af9"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
Possible re-tag needs confirmation upstream
- https://github.com/c3lang/c3c/issues/2425
- I'm guessing it was re-tagged multiple times as T2[^1] has a 3rd sha256 that doesn't match ours or current tag

On side note, if removing LLVM upper bound check, c3c does build with LLVM 21 but not all tests in testsuite pass so can stay on LLVM 20.
```
- 878/0 test_suite/switch/jump_bugs.c3t: FAILED - Did not compile file test.ll.
- 879/1 test_suite/switch/jump_bug_default.c3t: FAILED - Did not compile file test.ll.
- 880/2 test_suite/switch/enum_jump_switch_and_range.c3t: FAILED - Did not compile file test.ll.
- 882/3 test_suite/switch/jump_bug_nested.c3t: FAILED - Did not compile file test.ll.
- 883/4 test_suite/switch/jump_with_inc.c3t: FAILED - Did not compile file test.ll.
- 885/5 test_suite/switch/simple_jump.c3t: FAILED - Did not compile file simple_jump.ll.
```

[^1]: https://svn.exactcode.de/t2/trunk/package/develop/c3c/c3c.desc