### PR TITLE
nuxi 3.28.0 (new formula)

### DIFF
--- a/Formula/n/nuxi.rb
+++ b/Formula/n/nuxi.rb
@@ -6,6 +6,10 @@ class Nuxi < Formula
   license "MIT"
   head "https://github.com/nuxt/cli.git", branch: "main"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, all: "cffdd16982be5e0ca7bd122e21b50a21b34717b8d53811b54f70f7c37822f1b8"
+  end
+
   depends_on "node"
 
   def install

--- a/Formula/n/nuxi.rb
+++ b/Formula/n/nuxi.rb
@@ -1,0 +1,32 @@
+class Nuxi < Formula
+  desc "Nuxt CLI (nuxi) for creating and managing Nuxt projects"
+  homepage "https://github.com/nuxt/cli"
+  url "https://registry.npmjs.org/nuxi/-/nuxi-3.28.0.tgz"
+  sha256 "2f4872aedf175d81390f273ac892aa0c045b2cd911e7c10893da556f6ca285d9"
+  license "MIT"
+  head "https://github.com/nuxt/cli.git", branch: "main"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    # Both aliases should be present and report the same version
+    assert_match version.to_s, shell_output("#{bin}/nuxi --version")
+    assert_match version.to_s, shell_output("#{bin}/nuxt --version")
+
+    # Perform a minimal project initialization in the temporary testpath
+    ENV["CI"] = "1"
+    target = testpath/"nuxi-tmp"
+    output = shell_output(
+      "#{bin}/nuxt init . --cwd #{target} -f --no-install --packageManager npm --gitInit -M --preferOffline",
+    )
+    assert_predicate target, :directory?
+    assert_predicate target/".git", :directory?
+    assert_path_exists target/"package.json"
+    assert_match "npm run dev", output
+  end
+end


### PR DESCRIPTION
Add Nuxt framework via npm package with npm livecheck and offline-safe tests (version, binaries, help).

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
