### PR TITLE
chapel ispc: use `llvm@20`

### DIFF
--- a/Formula/c/chapel.rb
+++ b/Formula/c/chapel.rb
@@ -6,6 +6,7 @@ class Chapel < Formula
   url "https://github.com/chapel-lang/chapel/releases/download/2.5.0/chapel-2.5.0.tar.gz"
   sha256 "020220ca9bf52b9f416e9a029bdc465bb1f635c1e274c6ca3c18d1f83e41fce1"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/chapel-lang/chapel.git", branch: "main"
 
   no_autobump! because: :bumped_by_upstream
@@ -24,7 +25,7 @@ class Chapel < Formula
   depends_on "gmp"
   depends_on "hwloc"
   depends_on "jemalloc"
-  depends_on "llvm"
+  depends_on "llvm@20"
   depends_on "pkgconf"
   depends_on "python@3.13"
 

--- a/Formula/c/chapel.rb
+++ b/Formula/c/chapel.rb
@@ -12,13 +12,13 @@ class Chapel < Formula
   no_autobump! because: :bumped_by_upstream
 
   bottle do
-    sha256 arm64_sequoia: "a5a93684662e89ab9bd90ae07a4c9a58ad81ec04259c7c81a9cfad561f67da0b"
-    sha256 arm64_sonoma:  "68b76ffbc83f9e5a7bd12092339d44b3ea14e6dca0be102de3feb00eff507dfc"
-    sha256 arm64_ventura: "cc3bf308763816d2da9a7a195f386aafde8df3b3ac8d5291171484273a12d18d"
-    sha256 sonoma:        "5aa538418e487a2e0962b12462c8f4d9bd4cd8b7a3e13395e4b938ea650a657a"
-    sha256 ventura:       "262872aa45e49d3829b9c08305573325bbed47e6a9bae88662ba6d5c3555fa7e"
-    sha256 arm64_linux:   "bcd47a3df6d01f14709be8036d1f7984eecfb37b32713869e535c32f4e829ea1"
-    sha256 x86_64_linux:  "baaa4df00345e3dc085e17754379f709b72f186bf00e6c68418baafa1ec59e3f"
+    sha256 arm64_sequoia: "c240bd5999904238afbe1c5c337c730b42d30912c029e87febdb819d4d165ad0"
+    sha256 arm64_sonoma:  "96d857a9f7ae365f1ff09e228921ee8cab38ad5543a03ebbba87588bae914416"
+    sha256 arm64_ventura: "191d300a56ed3ab0fdea1471b0cd219f1c9d03466a312515a02a8f6091830bd9"
+    sha256 sonoma:        "ae4692a15c2ef296206e6dbc9130a95905aeae1cb2729f730e252b1953974dcf"
+    sha256 ventura:       "1549c04130d6700f3bc3371940c21a326dd3627802d9d24e8e0f6b349424aaa1"
+    sha256 arm64_linux:   "aae1218cbf6324e4f65d4ed4be62add0bed2ac45187e5fe6f27fc4dbe5e1905f"
+    sha256 x86_64_linux:  "9e343ae0af8a7173e152e84f154d30812840e88008bf9781ada2428f4a902150"
   end
 
   depends_on "cmake"

--- a/Formula/i/ispc.rb
+++ b/Formula/i/ispc.rb
@@ -4,6 +4,7 @@ class Ispc < Formula
   url "https://github.com/ispc/ispc/archive/refs/tags/v1.28.0.tar.gz"
   sha256 "207a0552d184c65f3d971ca4be8b53b4f25ebda843df0fc893569ce0b7f07043"
   license "BSD-3-Clause"
+  revision 1
 
   # Upstream sometimes creates releases that use a stable tag (e.g., `v1.2.3`)
   # but are labeled as "pre-release" on GitHub, so it's necessary to use the
@@ -26,7 +27,7 @@ class Ispc < Formula
   depends_on "bison" => :build
   depends_on "cmake" => :build
   depends_on "flex" => :build
-  depends_on "llvm"
+  depends_on "llvm@20"
 
   uses_from_macos "python" => :build
 

--- a/Formula/i/ispc.rb
+++ b/Formula/i/ispc.rb
@@ -15,13 +15,13 @@ class Ispc < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "e87b28254925524504f62c40db1cb09c4ce922b97a489d904c222655b70f4216"
-    sha256 cellar: :any,                 arm64_sonoma:  "fd18a7344087f35316fc39c8c0c254884a7329865c09b2fe66f5ad6baa9ba064"
-    sha256 cellar: :any,                 arm64_ventura: "5dde22fbc1cb48f9587271df0a81df3aa1479dc0c393ce42a3c89017d8938353"
-    sha256 cellar: :any,                 sonoma:        "43b272fa3f1cc2bd73b14cc5fda9f979ae37523d508b6cc9074b5103cd8afc13"
-    sha256 cellar: :any,                 ventura:       "47a7f98f565cd3a5506d3c9597bc01f4503779c7cebbfdd3ebc1850ad136fd67"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "1aa38595f6b4980e2f11944f1949b57ff782e4d29c6170cff4654660ea47a835"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "fa2ab8a0339a6e7c424955934160abd9b911c74f24217b242fa5905911848cf8"
+    sha256 cellar: :any,                 arm64_sequoia: "712267cbcd1d9ccf7945f8ead6702067e6663b4c5006982045c67c9902e3d83f"
+    sha256 cellar: :any,                 arm64_sonoma:  "30f8f5032a40279f5ad8cda3e786771a7a33d0c759a3d73d9a6e1dd32e92588f"
+    sha256 cellar: :any,                 arm64_ventura: "fa2dda37e14d6ab496a3f1f2703c5ba0e18959b7e3b29337cc53755e330e071c"
+    sha256 cellar: :any,                 sonoma:        "0e1ac09de1832ec69ffde6e885e902271b83973b31a15f00119f1b70b4b41b30"
+    sha256 cellar: :any,                 ventura:       "798bed2aeb38cc4e7008add47c267f3149ed4b383031dc32480a3795e9158048"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "ce5b72785e2c3a0d6de3c004d8199e7b05e77aa19d2fc28f9dedee2cac8d6e66"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0d55df7677ad255f667ef148dafe9bb66e836b706f55faff618bb92de4bf2d7c"
   end
 
   depends_on "bison" => :build


### PR DESCRIPTION
Blocked until 
- #234240

---

`chapel` has hard limit https://github.com/chapel-lang/chapel/blob/main/util/chplenv/chpl_llvm.py#L16-L20

`ispc` first failed locally due to new availability-detected feature (https://github.com/llvm/llvm-project/commit/17d05695388128353662fbb80bbb7a13d172b41d). Even after trying to link to LLVM's `libc++`, seeing a failure finding generated core.isph:
```
stdlib/stdlib.ispc:15:10: fatal error: cannot open file 'stdlib/core.isph': No such file or directory
   15 | #include "core.isph"
      |          ^
make[2]: *** [share/ispc/stdlib_generic_i1x4_aarch64_unix.bc] Error 2
make[1]: *** [CMakeFiles/generic-stdlib-bc.dir/all] Error 2
```