### PR TITLE
ansible: add missing tree dependency

### DIFF
--- a/Formula/a/ansible.rb
+++ b/Formula/a/ansible.rb
@@ -28,6 +28,7 @@ class Ansible < Formula
   depends_on "libssh"
   depends_on "libyaml"
   depends_on "python@3.13"
+  depends_on "tree" # for ansible-role-init
 
   uses_from_macos "krb5"
   uses_from_macos "libxml2", since: :ventura


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----


Without tree there is a bug in `ansible-role-init`

```
❯ ansible-role-init test-role
Ansible Role : test-role Creating....
- Role test-role was created successfully
ansible-role-init:4: command not found: tree
```

I would say it could be `recommended` but its not allowed in hombrew-core