### PR TITLE
universal_binary_allowlist: remove versioned formulae

### DIFF
--- a/audit_exceptions/universal_binary_allowlist.json
+++ b/audit_exceptions/universal_binary_allowlist.json
@@ -1,13 +1,4 @@
 [
   "llvm",
-  "llvm@12",
-  "llvm@13",
-  "llvm@14",
-  "llvm@15",
-  "llvm@16",
-  "llvm@17",
-  "llvm@18",
-  "llvm@19",
-  "llvm@20",
   "swift"
 ]


### PR DESCRIPTION
We can remove these after Homebrew/brew#20538 is merged.
