### PR TITLE
apache-arrow: use `llvm@20`, restore GCC build

### DIFF
--- a/Formula/a/apache-arrow.rb
+++ b/Formula/a/apache-arrow.rb
@@ -9,13 +9,13 @@ class ApacheArrow < Formula
   head "https://github.com/apache/arrow.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any, arm64_sequoia: "8fcf225cfa21b562b3623615e9292c7ef6d67b7420f151b6db0dbb8cbec131ed"
-    sha256 cellar: :any, arm64_sonoma:  "ae59bb3e0a40085b9a15db53688919f81723c8654e14f9ae07e2d4bc2d7e86f2"
-    sha256 cellar: :any, arm64_ventura: "93027ec20a5ffb4cee31d6eac8a05e2ed0897ca5258b65dfd888bc74ac99422a"
-    sha256 cellar: :any, sonoma:        "4e9159374a015558ca4adef334853ad51b0b7cba892be8e8edf6ecf80dfa6839"
-    sha256 cellar: :any, ventura:       "4c73cc199a65d6d18a645fbec15e02612ca5579aadfd539dfdf5d75e5dc3af3e"
-    sha256               arm64_linux:   "9c2537470450f3949203d5175494dc13afcc9af2c45715ab2cad62d096966bfe"
-    sha256               x86_64_linux:  "53c384b9f2c18c19ce0fb1d41000be705381446f441af1598693a4a881b1065f"
+    sha256 cellar: :any, arm64_sequoia: "eba5d4c9a454c16ded50064c80bb320f90ba445eca8c77c6017eb7cde2a8c504"
+    sha256 cellar: :any, arm64_sonoma:  "af749d9e8df7978ac004bcf05c38f4a6ba507f104580e2059389135a689cb011"
+    sha256 cellar: :any, arm64_ventura: "fc6d23d58ccc71935689628183b3aa840c66b1ff5b9abeb3b5d7977dd542a716"
+    sha256 cellar: :any, sonoma:        "507bffe11e9ae71a249e4850efe8a456460a76f10de7ad6284bd1c70f5839bba"
+    sha256 cellar: :any, ventura:       "a3b31372594423387c0a0bd459742b59f0514362171bc4d3f62d0747003d3fd2"
+    sha256               arm64_linux:   "f7c33c06cc5a2e7c4150bf09be9768487fa871f330205b3a9f4e711965c03ba1"
+    sha256               x86_64_linux:  "daa359dbdab868134e045b05eea76d9b227cff4137bca8e615b859dbadd28c2c"
   end
 
   depends_on "boost" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

GCC 11 issue was resolved in Protobuf 30 with rollback - https://github.com/protocolbuffers/protobuf/commit/f05e51c08dcac9672f6c89864c4eefed2c5813a1