### PR TITLE
ca-certificates: fix ASCII encoding error in post-install

### DIFF
--- a/Formula/c/ca-certificates.rb
+++ b/Formula/c/ca-certificates.rb
@@ -96,7 +96,8 @@ class CaCertificates < Formula
     end
 
     # Now process Mozilla certificates we downloaded.
-    pem_certificates_list = (pkgshare/"cacert.pem").read
+    # Read as raw bytes to avoid locale-dependent encoding errors
+    pem_certificates_list = (pkgshare/"cacert.pem").binread.force_encoding(Encoding::ASCII_8BIT)
     pem_certificates = pem_certificates_list.scan(
       /-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----/m,
     )
@@ -121,7 +122,8 @@ class CaCertificates < Formula
   end
 
   def load_certificates_from_file(file_path, trusted_certificates, fingerprints, certificate_type)
-    certificates_list = file_path.read
+    # Read as raw bytes to avoid locale-dependent encoding errors
+    certificates_list = file_path.binread.force_encoding(Encoding::ASCII_8BIT)
     certificates = certificates_list.scan(
       /-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----/m,
     )
@@ -169,8 +171,7 @@ class CaCertificates < Formula
     (pkgetc/"cert.pem").atomic_write(trusted_certificates.join("\n") << "\n")
     ohai "CA certificates have been bootstrapped from the system CA store."
   ensure
-    # FIXME: the steps above can fail. We should handle them properly.
-    # https://github.com/Homebrew/homebrew-core/issues/233206
+    # Ensure a PEM file always exists, even if the method exits early or fails
     cp pkgshare/"cacert.pem", pkgetc/"cert.pem" unless (pkgetc/"cert.pem").exist?
   end
 

--- a/Formula/c/ca-certificates.rb
+++ b/Formula/c/ca-certificates.rb
@@ -11,8 +11,8 @@ class CaCertificates < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, all: "80f4508a2a5711fcabeeaafdeebb88c9eec6b0e834e75f47b837ffe3da60c7d3"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, all: "e74a63e172f75fe700f74875b91217668065af5dd8f6f624315fa9e7f890be40"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

## Summary
Fixes `ArgumentError: invalid byte sequence in US-ASCII` that occurs during `ca-certificates` post-install on systems with US-ASCII locale when certificate files contain UTF-8 characters (e.g. German umlauts in certificate comments).

## Changes
- Treats certificate data as raw bytes to avoid locale-dependent encoding conflicts
- Preserves existing certificate parsing functionality

Fixes #233206

## Testing
Verified the fix using an AI-generated Docker-based reproducer script to test both reproduction and validation of the fix.

**Test original bug:**
```bash
curl -o homebrew-ca-certificates-reproducer.sh https://gist.githubusercontent.com/ypfaff/7fa7114360f7d5102954cf0173b8df30/raw/homebrew-ca-certificates-reproducer.sh
chmod +x homebrew-ca-certificates-reproducer.sh
docker run --rm -it -v "$PWD:/work" ubuntu:22.04 bash -c "/work/homebrew-ca-certificates-reproducer.sh"
```

**Test with fix:**
```bash
docker run --rm -it \
  -e FORK_URL="https://github.com/ypfaff/homebrew-core.git" \
  -e FORK_BRANCH="fix-ca-certificates-ascii-encoding" \
  -v "$PWD:/work" ubuntu:22.04 \
  bash -c "/work/homebrew-ca-certificates-reproducer.sh"
```

**Results:**
- Before fix: Fails with ArgumentError: invalid byte sequence in US-ASCII
- After fix: Completes successfully, creates valid certificate bundle

**Reproducer Script Output (Before Fix):**
```
=== ATTEMPTING POSTINSTALL WITH ASCII LOCALE ===
This should trigger: ArgumentError: invalid byte sequence in US-ASCII

+ env -i HOME=/home/linuxbrew PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin LC_ALL=C LANG=C HOMEBREW_DEVELOPER=1 HOMEBREW_DEBUG=1 brew postinstall -vd ca-certificates
+ tee /home/linuxbrew/postinstall-debug.log
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb (Formulary::FromAPILoader): loading ca-certificates
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb (Formulary::FromAPILoader): loading homebrew/core/ca-certificates
==> Postinstalling ca-certificates
Warning: The post-install step did not complete successfully
==> An exception occurred within a child process:
  ArgumentError: invalid byte sequence in US-ASCII
/home/linuxbrew/.linuxbrew/opt/ca-certificates/.brew/ca-certificates.rb:120:in 'String#scan'
/home/linuxbrew/.linuxbrew/opt/ca-certificates/.brew/ca-certificates.rb:120:in 'Formulary::FormulaNamespace649b4458bed66144f08b4931e4866dcd4c3746149a747e53d33b0dc669268214::CaCertificates#load_certificates_from_file'
/home/linuxbrew/.linuxbrew/opt/ca-certificates/.brew/ca-certificates.rb:162:in 'Formulary::FormulaNamespace649b4458bed66144f08b4931e4866dcd4c3746149a747e53d33b0dc669268214::CaCertificates#linux_post_install'
/home/linuxbrew/.linuxbrew/opt/ca-certificates/.brew/ca-certificates.rb:21:in 'Formulary::FormulaNamespace649b4458bed66144f08b4931e4866dcd4c3746149a747e53d33b0dc669268214::CaCertificates#post_install'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:1423:in 'block (2 levels) in Formula#run_post_install'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:1268:in 'Formula#with_logging'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.5.12434/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.5.12434/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.5.12434/lib/types/private/methods/_methods.rb:277:in 'block in Formula#_on_method_added'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:1422:in 'block in Formula#run_post_install'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/extend/kernel.rb:263:in 'Kernel#with_env'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:1418:in 'Formula#run_post_install'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.5.12434/lib/types/private/methods/call_validation.rb:282:in 'UnboundMethod#bind_call'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.5.12434/lib/types/private/methods/call_validation.rb:282:in 'T::Private::Methods::CallValidation.validate_call'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle/ruby/3.4.0/gems/sorbet-runtime-0.5.12434/lib/types/private/methods/_methods.rb:277:in 'block in Formula#_on_method_added'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/postinstall.rb:32:in '<main>'
You can try again using:
  brew postinstall ca-certificates
+ set +x

=== POSTINSTALL FAILED (EXPECTED) ===
Check /home/linuxbrew/postinstall-debug.log for full details

✓ Successfully reproduced the encoding bug!
Found 'invalid byte sequence' error in output
```

**Reproducer Script Output (After Fix):**
```
==> Fetching downloads for: ca-certificates
==> Fetching ca-certificates
==> Downloading https://curl.se/ca/cacert-2025-08-12.pem
######################################################################### 100.0%
==> Reinstalling ca-certificates
Loaded 146 system certificates
Loaded 12 Mozilla certificates
==> CA certificates have been bootstrapped from the system CA store.
==> Caveats
CA certificates have been bootstrapped from both the Mozilla CA store and the system CA store at

  /etc/ssl/certs/ca-certificates.crt

if this path exists and is readable.
==> Summary
🍺  /home/linuxbrew/.linuxbrew/Cellar/ca-certificates/2025-08-12: 4 files, 248.5KB, built in 1 second
==> Running `brew cleanup ca-certificates`...
Disable this behaviour by setting `HOMEBREW_NO_INSTALL_CLEANUP=1`.
Hide these hints with `HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).
==> No outdated dependents to upgrade!
[INFO] ca-certificates installation completed
[INFO] Configuring ASCII-only environment to trigger the bug...
[DEBUG] Hidden locale command to force ASCII fallback
[INFO] Reproducing ca-certificates postinstall bug...
=== REPRODUCTION ENVIRONMENT ===
Homebrew version: Homebrew 4.6.6
Brew cache: /home/linuxbrew/.cache/Homebrew
Logs root: /home/linuxbrew/.cache/Homebrew/Logs
locale command: hidden (this triggers the ASCII fallback)

=== ATTEMPTING POSTINSTALL WITH ASCII LOCALE ===
This should trigger: ArgumentError: invalid byte sequence in US-ASCII

+ env -i HOME=/home/linuxbrew PATH=/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin LC_ALL=C LANG=C HOMEBREW_DEVELOPER=1 HOMEBREW_DEBUG=1 brew postinstall -vd ca-certificates
+ tee /home/linuxbrew/postinstall-debug.log
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb (Formulary::FromAPILoader): loading ca-certificates
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb (Formulary::FromAPILoader): loading homebrew/core/ca-certificates
==> Postinstalling ca-certificates
Loaded 146 system certificates
Loaded 12 Mozilla certificates
==> CA certificates have been bootstrapped from the system CA store.
+ set +x

=== POSTINSTALL SUCCEEDED ===
✓ No encoding error detected - the bug appears to be fixed!
```
