### PR TITLE
python2exe 0.1.0 (new formula)

### DIFF
--- a/Formula/python2exe.rb
+++ b/Formula/python2exe.rb
@@ -6,7 +6,7 @@ class Python2exe < Formula
   license "MIT"
   head "https://github.com/planetminguez/Python2ExeInC.git", branch: "main"
 
-  depends_on "python@3.12"
+  depends_on "python@3.13"
 
   def install
     system "make", "CC=#{ENV.cc}", "PREFIX=#{prefix}", "PYTHON_EXECUTABLE=#{Formula["python@3.12"].opt_bin}/python3"

--- a/Formula/python2exe.rb
+++ b/Formula/python2exe.rb
@@ -1,10 +1,10 @@
 class Python2exe < Formula
   desc "Convert Python scripts into native executables via a generated C wrapper"
-  homepage "https://github.com/planetminguez/homebrew-tools"
-  url "https://github.com/planetminguez/homebrew-tools/archive/refs/tags/v0.1.0.tar.gz"
-  sha256 "ef04859472d3d11e2289bc322c7026a241e32d15add2db0524b507eb6fcd5102"
+  homepage "https://github.com/planetminguez/Python2ExeInC"
+  url "https://github.com/planetminguez/Python2ExeInC/archive/refs/tags/v0.1.0.tar.gz"
+  sha256 "a71df5fdaedb7f189f59496b58a6cd48421e4952ba6ed54f68cc0d2cd9d6d0ac"
   license "MIT"
-  head "https://github.com/planetminguez/homebrew-tools.git", branch: "main"
+  head "https://github.com/planetminguez/Python2ExeInC.git", branch: "main"
 
   depends_on "python@3.12"
 
@@ -19,7 +19,7 @@ class Python2exe < Formula
       import sys
       print("hello")
       if len(sys.argv) > 1:
-          print(sys.argv[1])
+        print(sys.argv[1])
     PY
 
     system bin/"python2exe", testpath/"hello.py"
@@ -30,4 +30,3 @@ class Python2exe < Formula
     assert_match "world", output
   end
 end
-

--- a/Formula/python2exe.rb
+++ b/Formula/python2exe.rb
@@ -1,0 +1,33 @@
+class Python2exe < Formula
+  desc "Convert Python scripts into native executables via a generated C wrapper"
+  homepage "https://github.com/planetminguez/homebrew-tools"
+  url "https://github.com/planetminguez/homebrew-tools/archive/refs/tags/v0.1.0.tar.gz"
+  sha256 "ef04859472d3d11e2289bc322c7026a241e32d15add2db0524b507eb6fcd5102"
+  license "MIT"
+  head "https://github.com/planetminguez/homebrew-tools.git", branch: "main"
+
+  depends_on "python@3.12"
+
+  def install
+    system "make", "CC=#{ENV.cc}", "PREFIX=#{prefix}", "PYTHON_EXECUTABLE=#{Formula["python@3.12"].opt_bin}/python3"
+    bin.install "python2exe"
+  end
+
+  test do
+    (testpath/"hello.py").write <<~PY
+      #!/usr/bin/env python3
+      import sys
+      print("hello")
+      if len(sys.argv) > 1:
+          print(sys.argv[1])
+    PY
+
+    system bin/"python2exe", testpath/"hello.py"
+    assert_path_exists testpath/"hello"
+
+    output = shell_output("#{testpath}/hello world").strip
+    assert_match "hello", output
+    assert_match "world", output
+  end
+end
+


### PR DESCRIPTION
Add python2exe formula: converts Python scripts into native executables by embedding the script in a generated C wrapper that invokes Homebrew's Python at runtime. Includes a functional test.