### PR TITLE
jtbl: build all bottle

### DIFF
--- a/Formula/j/jtbl.rb
+++ b/Formula/j/jtbl.rb
@@ -28,6 +28,10 @@ class Jtbl < Formula
   def install
     virtualenv_install_with_resources
     man1.install "man/jtbl.1"
+
+    # Build an `:all` bottle
+    packages = libexec/Language::Python.site_packages("python3")
+    inreplace packages/"jtbl-#{version}.dist-info/METADATA", "/usr/local/Cellar", "#{HOMEBREW_PREFIX}/Cellar"
   end
 
   test do

--- a/Formula/j/jtbl.rb
+++ b/Formula/j/jtbl.rb
@@ -8,14 +8,8 @@ class Jtbl < Formula
   license "MIT"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "d36c946d8efc31ba345e4b8933c3b460034df431373eb632837778ade53378ec"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "d36c946d8efc31ba345e4b8933c3b460034df431373eb632837778ade53378ec"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "d36c946d8efc31ba345e4b8933c3b460034df431373eb632837778ade53378ec"
-    sha256 cellar: :any_skip_relocation, sonoma:        "6070ec308bdd9b1030b07c7dd4846bb5b09bd268879b21aeeb352453d1fe0f8f"
-    sha256 cellar: :any_skip_relocation, ventura:       "6070ec308bdd9b1030b07c7dd4846bb5b09bd268879b21aeeb352453d1fe0f8f"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "ebc3fe830e2fe701963c723a4fdfb96e8a9acbedb5a1ec4588b66067466d7172"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d36c946d8efc31ba345e4b8933c3b460034df431373eb632837778ade53378ec"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, all: "649e15e7c82c20e93b6227e694bcf623dd7e289efe6920fa00bd19d4747e49fd"
   end
 
   depends_on "python@3.13"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
METADATA comment contains some example of homebrew python path and so replace it.

```diff
--- 2476d9df3ba754b75b1db598dd856c0072d9447c14851f9dc5f5e9e534a5dfaa--jtbl--1.6.0.arm64_sonoma.bottle.1.tar
+++ c874246303c5859439c4d95b4da1f10aad137d394848490dab50198d1b03f75a--jtbl--1.6.0.sonoma.bottle.1.tar
─ jtbl/1.6.0/libexec/lib/python3.13/site-packages/jtbl-1.6.0.dist-info/METADATA
@@ -283,14 +283,14 @@
 The `-n` option disables wrapping and overrides the `--cols` and `-t` options.
 
 This can be useful to present a nicely non-wrapped table of infinite width in combination with `less -S`:
 \`\`\`
 $ jc ps aux | jtbl -n | less -S
 user                  pid        vsz     rss  tt    stat    started    time       command
 ------------------  -----  ---------  ------  ----  ------  ---------  ---------  ---------------------------------------------------
-joeuser             34029    4277364   24800  s000  S+      9:28AM     0:00.27    /usr/local/Cellar/python/3.7.6_1/Frameworks/Python....
-joeuser             34030    4283136   17104  s000  S+      9:28AM     0:00.20    /usr/local/Cellar/python/3.7.6_1/Frameworks/Python....
+joeuser             34029    4277364   24800  s000  S+      9:28AM     0:00.27    @@HOMEBREW_CELLAR@@/python/3.7.6_1/Frameworks/Python....
+joeuser             34030    4283136   17104  s000  S+      9:28AM     0:00.20    @@HOMEBREW_CELLAR@@/python/3.7.6_1/Frameworks/Python....
 joeuser               481    5728568  189328        S       17Apr20    21:46.52   /Applications/Utilities/Terminal.app/Contents/MacOS...
```