### PR TITLE
lunchy: build all bottle

### DIFF
--- a/Formula/l/lunchy.rb
+++ b/Formula/l/lunchy.rb
@@ -9,12 +9,8 @@ class Lunchy < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "0c17a734e1506ea38877dc23b77d843b7975ab2502a459716c1252eb5569d2a4"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "0c17a734e1506ea38877dc23b77d843b7975ab2502a459716c1252eb5569d2a4"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "0c17a734e1506ea38877dc23b77d843b7975ab2502a459716c1252eb5569d2a4"
-    sha256 cellar: :any_skip_relocation, sonoma:        "185916bb389986bfc7c1e52fab8cd544590dd16860271c12a0665131c4d27314"
-    sha256 cellar: :any_skip_relocation, ventura:       "185916bb389986bfc7c1e52fab8cd544590dd16860271c12a0665131c4d27314"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, all: "071a71f4b6716723c0c3de5ce2daa1521e2fb339e009ea0df5e8ba1763a6fd8c"
   end
 
   depends_on :macos

--- a/Formula/l/lunchy.rb
+++ b/Formula/l/lunchy.rb
@@ -31,6 +31,10 @@ class Lunchy < Formula
     bin.env_script_all_files(libexec/"bin", GEM_HOME: ENV["GEM_HOME"])
     bash_completion.install "extras/lunchy-completion.bash" => "lunchy"
     zsh_completion.install "extras/lunchy-completion.zsh" => "_lunchy"
+
+    # Build an `:all` bottle by replacing comment script
+    file = libexec/"gems/lunchy-#{version}/bin/lunchy"
+    inreplace file, "/usr/local/Cellar", "#{HOMEBREW_PREFIX}/Cellar"
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Replace the example `Celler` path in the binary.

```diff
--- lunchy--0.10.4.arm64_sonoma.bottle.2.tar
+++ lunchy--0.10.4.sonoma.bottle.2.tar
─ lunchy/0.10.4/libexec/gems/lunchy-0.10.4/bin/lunchy
@@ -56,15 +56,15 @@
 
 Example:
  lunchy ls
  lunchy ls -l nginx
  lunchy start -w redis
  lunchy stop mongo
  lunchy status mysql
- lunchy install /usr/local/Cellar/redis/2.2.2/io.redis.redis-server.plist
+ lunchy install @@HOMEBREW_CELLAR@@/redis/2.2.2/io.redis.redis-server.plist
  lunchy show redis
  lunchy edit mongo
```