### PR TITLE
python2exe 0.1.0 (new formula)

### DIFF
--- a/Formula/p/python2exe.rb
+++ b/Formula/p/python2exe.rb
@@ -1,0 +1,35 @@
+class Python2exe < Formula
+  desc "Convert Python scripts into native executables via a generated C wrapper"
+  homepage "https://github.com/planetminguez/Python2ExeInC"
+  url "https://github.com/planetminguez/Python2ExeInC/archive/refs/tags/v0.1.0.tar.gz"
+  sha256 "a71df5fdaedb7f189f59496b58a6cd48421e4952ba6ed54f68cc0d2cd9d6d0ac"
+  license "GPL-3.0-or-later"
+  head "https://github.com/planetminguez/Python2ExeInC.git", branch: "main"
+
+  depends_on "python@3.13"
+
+  def install
+    # Build from the subdirectory that contains the Makefile
+    cd "SimplePythonConverter" do
+      system "make", "CC=#{ENV.cc}", "PYTHON_EXECUTABLE=#{Formula["python@3.13"].opt_bin}/python3"
+      system "make", "install", "PREFIX=#{prefix}"
+    end
+  end
+
+  test do
+    (testpath/"hello.py").write <<~PY
+      #!/usr/bin/env python3
+      import sys
+      print("hello")
+      if len(sys.argv) > 1:
+        print(sys.argv[1])
+    PY
+
+    system bin/"python2exe", testpath/"hello.py"
+    assert_path_exists testpath/"hello"
+
+    output = shell_output("#{testpath}/hello world").strip
+    assert_match "hello", output
+    assert_match "world", output
+  end
+end


### PR DESCRIPTION
- **python2exe 0.1.0 (new formula)**
- **Update python2exe formula to use Python2ExeInC v0.1.0 tarball**
- **Update python2exe.rb**
- **python2exe: move to Formula/p and use python@3.13 consistently**
