### PR TITLE
mpremote: fix all bottle

### DIFF
--- a/Formula/m/mpremote.rb
+++ b/Formula/m/mpremote.rb
@@ -27,9 +27,9 @@ class Mpremote < Formula
     virtualenv_install_with_resources
 
     # Build an `:all` bottle.
-    usr_local_files = %w[
+    usr_local_files = %W[
       platformdirs/unix.py
-      platformdirs-4.3.8.dist-info/METADATA
+      platformdirs-#{resource("platformdirs").version}.dist-info/METADATA
     ].map { |file| libexec/Language::Python.site_packages("python3")/file }
     inreplace usr_local_files, "/usr/local", HOMEBREW_PREFIX
 

--- a/Formula/m/mpremote.rb
+++ b/Formula/m/mpremote.rb
@@ -8,7 +8,8 @@ class Mpremote < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "ef937462df64160d0b412a69a2b19f27c51fb781fc936cedc167a97691a2a168"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "b12a460088c523aec51a337f3ff11978d2a06ba58800f5e2b902a39d88717c5a"
   end
 
   depends_on "python@3.13"

--- a/disabled_new_usr_local_relocation_formulae.json
+++ b/disabled_new_usr_local_relocation_formulae.json
@@ -1,4 +1,5 @@
 [
   "abi3audit",
-  "meson"
+  "meson",
+  "mpremote"
 ]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

In the last PR, this bottle is cached with `disabled_new_usr_local_relocation_formulae` and so it is actually required to build `:all` bottle. And improve the version param for METADATA.