### PR TITLE
naturaldocs: build all bottle

### DIFF
--- a/Formula/n/naturaldocs.rb
+++ b/Formula/n/naturaldocs.rb
@@ -12,13 +12,8 @@ class Naturaldocs < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "cd5b8ae5f4eb425cfedd08ac4d23b5a5515851257576a0faf77592ba129c4d5c"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "cd5b8ae5f4eb425cfedd08ac4d23b5a5515851257576a0faf77592ba129c4d5c"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "cd5b8ae5f4eb425cfedd08ac4d23b5a5515851257576a0faf77592ba129c4d5c"
-    sha256 cellar: :any_skip_relocation, sonoma:        "cd5b8ae5f4eb425cfedd08ac4d23b5a5515851257576a0faf77592ba129c4d5c"
-    sha256 cellar: :any_skip_relocation, ventura:       "cd5b8ae5f4eb425cfedd08ac4d23b5a5515851257576a0faf77592ba129c4d5c"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "42c3c57a234e360a982c706672b29094dcd6cf848e4854e91c57f852f9d90ba3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "42c3c57a234e360a982c706672b29094dcd6cf848e4854e91c57f852f9d90ba3"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "a439b159358c64b91076716aa62efc0f80cd08938a4a35daa35dd397817a474a"
   end
 
   depends_on "mono"

--- a/Formula/n/naturaldocs.rb
+++ b/Formula/n/naturaldocs.rb
@@ -33,7 +33,7 @@ class Naturaldocs < Formula
       mono #{libexec}/NaturalDocs.exe "$@"
     BASH
 
-    libexec.install_symlink etc/"naturaldocs" => "config"
+    libexec.install_symlink etc/"naturaldocs" => "Config"
 
     libexec.glob("libSQLite.*").each do |f|
       rm f if f.basename.to_s != "libSQLite.#{os}.#{arch}"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

There is a `Config` path already, so macos install conf to that path but linux create another `config` path with lower case.

```diff
--- 13e88fba3cd4677dc68671bd56093ee6a771016f2da723f2410376f36003894e--naturaldocs--2.3.1.arm64_sonoma.bottle.tar
+++ 05641d8e044be5d9f127418183ab612300875abca109495eff24f48332960f04--naturaldocs--2.3.1.x86_64_linux.bottle.tar
─ file list
@@ -5,15 +5,14 @@
 drwxr-xr-x   0        0        0        0 2025-01-31 19:46:02.000000 naturaldocs/2.3.1/bin/
 -r-xr-xr-x   0        0        0       84 2025-01-31 19:46:02.000000 naturaldocs/2.3.1/bin/naturaldocs
 drwxr-xr-x   0        0        0        0 2025-01-31 19:46:02.000000 naturaldocs/2.3.1/libexec/
 drwxr-xr-x   0        0        0        0 2025-01-31 19:46:02.000000 naturaldocs/2.3.1/libexec/Config/
 -rw-r--r--   0        0        0    12989 2025-01-31 19:46:02.000000 naturaldocs/2.3.1/libexec/Config/Comments.txt
 -rw-r--r--   0        0        0     9152 2025-01-31 19:46:02.000000 naturaldocs/2.3.1/libexec/Config/Languages.txt
 -rw-r--r--   0        0        0     3699 2025-01-31 19:46:02.000000 naturaldocs/2.3.1/libexec/Config/Parser.txt
-lrwxrwxrwx   0        0        0        0 2025-01-31 19:46:02.000000 naturaldocs/2.3.1/libexec/Config/naturaldocs -> ../../../../etc/naturaldocs
 drwxr-xr-x   0        0        0        0 2025-01-31 19:46:02.000000 naturaldocs/2.3.1/libexec/Help/
 -rw-r--r--   0        0        0     6613 2025-01-31 19:46:02.000000 naturaldocs/2.3.1/libexec/Help/about.html
 -rw-r--r--   0        0        0    32988 2025-01-31 19:46:02.000000 naturaldocs/2.3.1/libexec/Help/favicon.ico
 drwxr-xr-x   0        0        0        0 2025-01-31 19:46:02.000000 naturaldocs/2.3.1/libexec/Help/features/
 -rw-r--r--   0        0        0     5778 2025-01-31 19:46:02.000000 naturaldocs/2.3.1/libexec/Help/features/comments.html
 drwxr-xr-x   0        0        0        0 2025-01-31 19:46:02.000000 naturaldocs/2.3.1/libexec/Help/features/images/
 -rw-r--r--   0        0        0    21918 2025-01-31 19:46:02.000000 naturaldocs/2.3.1/libexec/Help/features/images/classprototype.png
@@ -205,8 +204,9 @@
 -rw-r--r--   0        0        0    21988 2025-01-31 19:46:02.000000 naturaldocs/2.3.1/libexec/Styles/DefaultJS/NDThemes.js
 -rw-r--r--   0        0        0     3589 2025-01-31 19:46:02.000000 naturaldocs/2.3.1/libexec/Styles/DefaultJS/Style.txt
 drwxr-xr-x   0        0        0        0 2025-01-31 19:46:02.000000 naturaldocs/2.3.1/libexec/Styles/Light/
 -rw-r--r--   0        0        0     3342 2025-01-31 19:46:02.000000 naturaldocs/2.3.1/libexec/Styles/Light/Style.txt
 drwxr-xr-x   0        0        0        0 2025-01-31 19:46:02.000000 naturaldocs/2.3.1/libexec/Translations/
 -rw-r--r--   0        0        0    10782 2025-01-31 19:46:02.000000 naturaldocs/2.3.1/libexec/Translations/NaturalDocs.CLI.default.txt
 -rw-r--r--   0        0        0    44383 2025-01-31 19:46:02.000000 naturaldocs/2.3.1/libexec/Translations/NaturalDocs.Engine.default.txt
+lrwxrwxrwx   0        0        0        0 2025-01-31 19:46:02.000000 naturaldocs/2.3.1/libexec/config -> ../../../../etc/naturaldocs
 -rw-r--r--   0        0        0     1292 2025-01-31 19:46:02.000000 naturaldocs/2.3.1/sbom.spdx.json
```