### PR TITLE
speedtest-cli: remove `DeprecatedWarning` message

### DIFF
--- a/Formula/s/speedtest-cli.rb
+++ b/Formula/s/speedtest-cli.rb
@@ -6,7 +6,7 @@ class SpeedtestCli < Formula
   url "https://github.com/sivel/speedtest-cli/archive/refs/tags/v2.1.3.tar.gz"
   sha256 "45e3ca21c3ce3c339646100de18db8a26a27d240c29f1c9e07b6c13995a969be"
   license "Apache-2.0"
-  revision 1
+  revision 2
   head "https://github.com/sivel/speedtest-cli.git", branch: "master"
 
   no_autobump! because: :requires_manual_review
@@ -22,6 +22,15 @@ class SpeedtestCli < Formula
   patch do
     url "https://github.com/sivel/speedtest-cli/commit/22210ca35228f0bbcef75a7c14587c4ecb875ab4.patch?full_index=1"
     sha256 "d0456eb9fded20fb1580dbc6e3bc451a10c3fbcd3441efea66035aa848440c09"
+  end
+
+  # Replace deprecated `datetime.datetime.utcnow()` function with supported
+  # `datetime.datetime.now(datetime.UTC)`
+  #
+  # https://github.com/sivel/speedtest-cli/pull/808
+  patch do
+    url "https://github.com/sivel/speedtest-cli/commit/305dce9bd28e797d32b6b7e4a9239a669ab35322.patch?full_index=1"
+    sha256 "468f7205cedcef51eb95eb565db56d08743c5663b1641be62d9d1247d0845f3b"
   end
 
   def install

--- a/Formula/s/speedtest-cli.rb
+++ b/Formula/s/speedtest-cli.rb
@@ -12,8 +12,7 @@ class SpeedtestCli < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    rebuild 4
-    sha256 cellar: :any_skip_relocation, all: "6add96ed8b9a4a517bbbe21659fb0068c4d6b11da84d858524d221eee60d8448"
+    sha256 cellar: :any_skip_relocation, all: "77a4dc453d1e58aee76c4145eb1e917d7514762cfd76d6014454e4f37b40fec3"
   end
 
   depends_on "python@3.13"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Every time I want to use this package, I see this warning message:
```
/opt/homebrew/bin/speedtest:960: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
  self.timestamp = '%sZ' % datetime.datetime.utcnow().isoformat()
```

It is a bit annoying and may cause issues when new Python versions arrive. As the last commit was 4 years ago, I think it is fair to apply this patch