### PR TITLE
protozero 1.8.1 (new formula)

### DIFF
--- a/Formula/lib/libosmium.rb
+++ b/Formula/lib/libosmium.rb
@@ -6,7 +6,8 @@ class Libosmium < Formula
   license "BSL-1.0"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "02ce13c6248f0566b846579f0325c94f2e2385e9f00c7163b04b27636304ce57"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "648276b37fc4f1358b665c6f68308b6387f5069e6726cb8eb0e6cec73a4a108e"
   end
 
   depends_on "boost" => :build

--- a/Formula/lib/libosmium.rb
+++ b/Formula/lib/libosmium.rb
@@ -11,16 +11,12 @@ class Libosmium < Formula
 
   depends_on "boost" => :build
   depends_on "cmake" => :build
+  depends_on "protozero" => :build
   depends_on "lz4"
 
   uses_from_macos "bzip2"
   uses_from_macos "expat"
   uses_from_macos "zlib"
-
-  resource "protozero" do
-    url "https://github.com/mapbox/protozero/archive/refs/tags/v1.8.0.tar.gz"
-    sha256 "d95ca543fc42bd22b8c4bce1e6d691ce1711eda4b4910f7863449e6517fade6b"
-  end
 
   # Backport support for CMake 4
   patch do
@@ -29,16 +25,16 @@ class Libosmium < Formula
   end
 
   def install
-    resource("protozero").stage { libexec.install "include" }
-
     args = %W[
+      -DBUILD_EXAMPLES=OFF
+      -DBUILD_WITH_CCACHE=OFF
       -DINSTALL_GDALCPP=ON
       -DINSTALL_UTFCPP=ON
-      -DPROTOZERO_INCLUDE_DIR=#{libexec}/include
+      -DPROTOZERO_INCLUDE_DIR=#{Formula["protozero"].opt_include}
     ]
 
+    # We only install headers, so we can skip `cmake --build`.
     system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
-    system "cmake", "--build", "build"
     system "cmake", "--install", "build"
   end
 

--- a/Formula/p/protozero.rb
+++ b/Formula/p/protozero.rb
@@ -5,6 +5,10 @@ class Protozero < Formula
   sha256 "6c7a896f1dc08435e8cd4f3780ff688cd0bfce6890599b755f6f3cb36398dc25"
   license "BSD-2-Clause"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, all: "0e5449eeed0e64413afe0b49e9bbc162c0a5c9a1d2e91e992adf5c281413ad5a"
+  end
+
   depends_on "cmake" => :build
 
   def install

--- a/Formula/p/protozero.rb
+++ b/Formula/p/protozero.rb
@@ -1,0 +1,21 @@
+class Protozero < Formula
+  desc "Minimalist protocol buffer decoder and encoder in C++"
+  homepage "https://github.com/mapbox/protozero"
+  url "https://github.com/mapbox/protozero/archive/refs/tags/v1.8.1.tar.gz"
+  sha256 "6c7a896f1dc08435e8cd4f3780ff688cd0bfce6890599b755f6f3cb36398dc25"
+  license "BSD-2-Clause"
+
+  depends_on "cmake" => :build
+
+  def install
+    # We only install headers, so we can skip `cmake --build`.
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    system "cmake", "--install", "build"
+    pkgshare.install "tools"
+  end
+
+  test do
+    system ENV.cxx, "-std=c++14", "-I#{include}", pkgshare/"tools/pbf-decoder.cpp", "-o", "pbf-decoder"
+    assert_empty pipe_output("./pbf-decoder -", "")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This can be used to replace the `protozero` resource in `libosmium`.

- **protozero 1.8.1 (new formula)**
- **libosmium: use `protozero` formula**
