### PR TITLE
c3c: deprecate due to checksum mismatch

### DIFF
--- a/Formula/c/c3c.rb
+++ b/Formula/c/c3c.rb
@@ -24,6 +24,11 @@ class C3c < Formula
     sha256               x86_64_linux:  "2d484624c26dbcdc838dac9e68fc1fa591cfb197f409177263ac8219fb74dede"
   end
 
+  # We are unable to rebuild bottles as url has a checksum mismatch and
+  # upstream has not responded to https://github.com/c3lang/c3c/issues/2425
+  # This can be removed if upstream confirms retag or in future release
+  deprecate! date: "2025-08-25", because: :checksum_mismatch
+
   depends_on "cmake" => :build
   depends_on "lld"
   depends_on "llvm"


### PR DESCRIPTION
Unable to proceed in #234396 as upstream has not responded.

Moving `c3c` to deprecated as we will be unable to rebuild bottles until we get confirmation. Existing bottles will be broken once LLVM 21 PR is done (release date is planned tomorrow so likely in 2 days).

Deprecation message should output:
> Deprecated because it was built with an initially released source file that had a different checksum than the current one. Upstream's repository might have been compromised. We can re-package this once upstream has confirmed that they retagged their release! It will be disabled on 2026-08-25.

---

Users who see this should request upstream to confirm retag to keep formula in Homebrew/core
