### PR TITLE
sqlmap: build all bottle

### DIFF
--- a/Formula/s/sqlmap.rb
+++ b/Formula/s/sqlmap.rb
@@ -25,19 +25,14 @@ class Sqlmap < Formula
   def install
     libexec.install Dir["*"]
 
-    files = [
-      libexec/"lib/core/dicts.py",
-      libexec/"lib/core/settings.py",
-      libexec/"lib/request/basic.py",
-      libexec/"thirdparty/magic/magic.py",
-    ]
-    inreplace files, "/usr/local", HOMEBREW_PREFIX
-
     %w[sqlmap sqlmapapi].each do |cmd|
       rewrite_shebang detected_python_shebang, libexec/"#{cmd}.py"
       bin.install_symlink libexec/"#{cmd}.py"
       bin.install_symlink bin/"#{cmd}.py" => cmd
     end
+
+    # Build an `:all` bottle
+    inreplace libexec/"thirdparty/magic/magic.py", "/usr/local/Cellar", "#{HOMEBREW_PREFIX}/Cellar"
   end
 
   test do

--- a/Formula/s/sqlmap.rb
+++ b/Formula/s/sqlmap.rb
@@ -9,13 +9,8 @@ class Sqlmap < Formula
   head "https://github.com/sqlmapproject/sqlmap.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "d3502c9c0f94afb1c746b1265a85acbbd5d0b920cae215688aff67c03818f93e"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "d3502c9c0f94afb1c746b1265a85acbbd5d0b920cae215688aff67c03818f93e"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "d3502c9c0f94afb1c746b1265a85acbbd5d0b920cae215688aff67c03818f93e"
-    sha256 cellar: :any_skip_relocation, sonoma:        "0ee62e761154303a0e8b3f93cd1ee0bb3e4aa43ffadf8c74cfa21f4b73bbd046"
-    sha256 cellar: :any_skip_relocation, ventura:       "0ee62e761154303a0e8b3f93cd1ee0bb3e4aa43ffadf8c74cfa21f4b73bbd046"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "cf61512a0d78ff4a5da72eb81e14499c094d9ccab63fadf88878e634e01aa0cd"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "cf61512a0d78ff4a5da72eb81e14499c094d9ccab63fadf88878e634e01aa0cd"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "933d2d0b66f7ed1699d98be08c2726691e23ac457817e5487af3d970ffbcd752"
   end
 
   depends_on "python@3.13"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`basic.py` only have comment block to replace `/usr/local`, so just skip.

```diff
--- 4b766c513bf52ebcb1e4f0f8744495543c6e4ef196b42789db7499123c6d3b84--sqlmap--1.9.8.sonoma.bottle.tar
+++ 9e1997bf87b225837b1c61d55518734ae50d4e4e21ea4cceb65df2270d02b162--sqlmap--1.9.8.arm64_sonoma.bottle.tar=
─ sqlmap/1.9.8/libexec/lib/request/basic.py
@@ -290,15 +290,15 @@
             return None
 
         try:
             if contentEncoding == "deflate":
                 data = io.BytesIO(zlib.decompress(page, -15))  # Reference: http://stackoverflow.com/questions/1089662/python-inflate-and-deflate-implementations
             else:
                 data = gzip.GzipFile("", "rb", 9, io.BytesIO(page))
-                size = struct.unpack("<l", page[-4:])[0]  # Reference: http://pydoc.org/get.cgi/usr/local/lib/python2.5/gzip.py
+                size = struct.unpack("<l", page[-4:])[0]  # Reference: http://pydoc.org/get.cgi/opt/homebrew/lib/python2.5/gzip.py
```