### PR TITLE
nox: build all bottle

### DIFF
--- a/Formula/n/nox.rb
+++ b/Formula/n/nox.rb
@@ -35,18 +35,18 @@ class Nox < Formula
   end
 
   resource "dependency-groups" do
-    url "https://files.pythonhosted.org/packages/b4/57/cd53c3e335eafbb0894449af078e2b71db47e9939ce2b45013e5a9fe89b7/dependency_groups-1.3.0.tar.gz"
-    sha256 "5b9751d5d98fbd6dfd038a560a69c8382e41afcbf7ffdbcc28a2a3f85498830f"
+    url "https://files.pythonhosted.org/packages/62/55/f054de99871e7beb81935dea8a10b90cd5ce42122b1c3081d5282fdb3621/dependency_groups-1.3.1.tar.gz"
+    sha256 "78078301090517fd938c19f64a53ce98c32834dfe0dee6b88004a569a6adfefd"
   end
 
   resource "distlib" do
-    url "https://files.pythonhosted.org/packages/0d/dd/1bec4c5ddb504ca60fc29472f3d27e8d4da1257a854e1d96742f15c1d02d/distlib-0.3.9.tar.gz"
-    sha256 "a60f20dea646b8a33f3e7772f74dc0b2d0772d2837ee1342a00645c81edf9403"
+    url "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz"
+    sha256 "feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d"
   end
 
   resource "filelock" do
-    url "https://files.pythonhosted.org/packages/0a/10/c23352565a6544bdc5353e0b15fc1c563352101f30e24bf500207a54df9a/filelock-3.18.0.tar.gz"
-    sha256 "adbc88eabb99d2fec8c9c1b229b171f18afa655400173ddc653d5d01501fb9f2"
+    url "https://files.pythonhosted.org/packages/40/bb/0ab3e58d22305b6f5440629d20683af28959bf793d98d11950e305c1c326/filelock-3.19.1.tar.gz"
+    sha256 "66eda1888b0171c998b35be2bcc0f6d75c388a7ce20c3f3f37aa8e96c2dddf58"
   end
 
   resource "packaging" do
@@ -55,13 +55,13 @@ class Nox < Formula
   end
 
   resource "platformdirs" do
-    url "https://files.pythonhosted.org/packages/b6/2d/7d512a3913d60623e7eb945c6d1b4f0bddf1d0b7ada5225274c87e5b53d1/platformdirs-4.3.7.tar.gz"
-    sha256 "eb437d586b6a0986388f0d6f74aa0cde27b48d0e3d66843640bfb6bdcdb6e351"
+    url "https://files.pythonhosted.org/packages/23/e8/21db9c9987b0e728855bd57bff6984f67952bea55d6f75e055c46b5383e8/platformdirs-4.4.0.tar.gz"
+    sha256 "ca753cf4d81dc309bc67b0ea38fd15dc97bc30ce419a7f58d13eb3bf14c4febf"
   end
 
   resource "virtualenv" do
-    url "https://files.pythonhosted.org/packages/38/e0/633e369b91bbc664df47dcb5454b6c7cf441e8f5b9d0c250ce9f0546401e/virtualenv-20.30.0.tar.gz"
-    sha256 "800863162bcaa5450a6e4d721049730e7f2dae07720e0902b0e4040bd6f9ada8"
+    url "https://files.pythonhosted.org/packages/1c/14/37fcdba2808a6c615681cd216fecae00413c9dab44fb2e57805ecf3eaee3/virtualenv-20.34.0.tar.gz"
+    sha256 "44815b2c9dee7ed86e387b842a84f20b93f7f417f95886ca1996a72a4138eb1a"
   end
 
   def install
@@ -70,6 +70,11 @@ class Nox < Formula
 
     generate_completions_from_executable(libexec/"bin/register-python-argcomplete", "nox",
                                          shell_parameter_format: :arg)
+
+    # Build an `:all` bottle by replacing comments
+    site_packages = libexec/Language::Python.site_packages("python3")
+    file = site_packages/"argcomplete-#{resource("argcomplete").version}.dist-info/METADATA"
+    inreplace file, "/opt/homebrew/bin/bash", "$HOMEBREW_PREFIX/bin/bash"
   end
 
   test do

--- a/Formula/n/nox.rb
+++ b/Formula/n/nox.rb
@@ -8,13 +8,8 @@ class Nox < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "3e2714259195a768dc9390d04a0d2f9f0bcc1a1bd6cad293b3865a0b305eac9b"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "3e2714259195a768dc9390d04a0d2f9f0bcc1a1bd6cad293b3865a0b305eac9b"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "3e2714259195a768dc9390d04a0d2f9f0bcc1a1bd6cad293b3865a0b305eac9b"
-    sha256 cellar: :any_skip_relocation, sonoma:        "f9718d5d586aad781bf74f6808694ffe294b2e7ef40e07bd185ced9c9831531c"
-    sha256 cellar: :any_skip_relocation, ventura:       "f9718d5d586aad781bf74f6808694ffe294b2e7ef40e07bd185ced9c9831531c"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "8fe7df1af903820f571e1d6b1c08449a743f06e9908e1bcd6005eed4225a0140"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8fe7df1af903820f571e1d6b1c08449a743f06e9908e1bcd6005eed4225a0140"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "dfe6707c09a9fed17147b7876d9682feb20eea8f2b1ef95169b36bca661492a3"
   end
 
   depends_on "python@3.13"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
`platformdirs` updated and now it will build all bottle.

`argcomplete`

```diff
--- nox--2025.5.1.arm64_ventura.bottle.1.tar
+++ nox--2025.5.1.ventura.bottle.1.tar
─ nox/2025.5.1/libexec/lib/python3.13/site-packages/argcomplete-3.6.2.dist-info/METADATA
@@ -263,15 +263,15 @@
 Additionally, completion is activated for scripts run as ``python <script>`` and ``python -m <module>``. If you're using
 multiple Python versions on the same system, the version being used to run the script must have argcomplete installed.
 
 .. admonition:: Bash version compatibility
 
  When using bash, global completion requires bash support for ``complete -D``, which was introduced in bash 4.2. Since
  Mac OS ships with an outdated version of Bash (3.2), you can either use zsh or install a newer version of bash using
- `Homebrew <http://brew.sh/>`_ (``brew install bash`` - you will also need to add ``@@HOMEBREW_PREFIX@@/bin/bash`` to
+ `Homebrew <http://brew.sh/>`_ (``brew install bash`` - you will also need to add ``/opt/homebrew/bin/bash`` to
```