### PR TITLE
ffmpeg@7: fix `livecheck`

### DIFF
--- a/Formula/f/ffmpeg@7.rb
+++ b/Formula/f/ffmpeg@7.rb
@@ -9,7 +9,7 @@ class FfmpegAT7 < Formula
 
   livecheck do
     url "https://ffmpeg.org/download.html"
-    regex(/href=.*?ffmpeg[._-]v?(7\.(?:\.\d+)+)\.t/i)
+    regex(/href=.*?ffmpeg[._-]v?(7(?:\.\d+)+)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Follow-up to #234498.
