### PR TITLE
zelda-login 2.1.0 (new formula)

### DIFF
--- a/Formula/z/zelda-login.rb
+++ b/Formula/z/zelda-login.rb
@@ -1,0 +1,57 @@
+class ZeldaLogin < Formula
+  desc "Play Zelda's secret sound when opening a new terminal window"
+  homepage "https://github.com/quitequinn/ZeldaLogin"
+  url "https://github.com/quitequinn/ZeldaLogin/archive/v2.1.0.tar.gz"
+  sha256 "bc679cdbcd49dfa4f1e678b175798cbe3cde7f60d605cf823c266603998a70b6"
+  license "MIT"
+  head "https://github.com/quitequinn/ZeldaLogin.git", branch: "master"
+
+  depends_on "curl"
+
+  def install
+    # Install the audio file to share directory
+    (share/"zelda-login").install "zelda-secret.mp3"
+    
+    # Install the installer script
+    bin.install "install.sh" => "zelda-login-install"
+    
+    # Install configuration examples
+    (share/"zelda-login/configs").install Dir["configs/*"]
+    
+    # Install documentation
+    (share/"doc/zelda-login").install "README.md", "PACKAGE_MANAGERS.md"
+  end
+
+  def caveats
+    <<~EOS
+      Zelda Login has been installed but not yet configured.
+
+      To set up terminal audio:
+        zelda-login-install
+
+      To configure for specific shells:
+        # Bash
+        echo 'afplay #{share}/zelda-login/zelda-secret.mp3 > /dev/null 2>&1 &' >> ~/.bash_profile
+        
+        # Zsh  
+        echo 'afplay #{share}/zelda-login/zelda-secret.mp3 > /dev/null 2>&1 &' >> ~/.zshrc
+
+      See example configs in: #{share}/zelda-login/configs/
+
+      To uninstall completely:
+        1. Remove the audio command from your shell config
+        2. brew uninstall zelda-login
+    EOS
+  end
+
+  test do
+    # Test that the audio file exists
+    assert_predicate share/"zelda-login/zelda-secret.mp3", :exist?
+    
+    # Test that the installer script is executable
+    assert_predicate bin/"zelda-login-install", :executable?
+    
+    # Test that we can run the installer with --version
+    system bin/"zelda-login-install", "--version"
+  end
+end

--- a/Formula/z/zelda-login.rb
+++ b/Formula/z/zelda-login.rb
@@ -4,9 +4,7 @@ class ZeldaLogin < Formula
   url "https://github.com/quitequinn/ZeldaLogin/archive/v2.1.0.tar.gz"
   sha256 "bc679cdbcd49dfa4f1e678b175798cbe3cde7f60d605cf823c266603998a70b6"
   license "MIT"
-  head "https://github.com/quitequinn/ZeldaLogin.git", branch: "master"
-
-  depends_on "curl"
+  head "https://github.com/quitequinn/ZeldaLogin.git", branch: "main"
 
   def install
     # Install the audio file to share directory
@@ -19,7 +17,7 @@ class ZeldaLogin < Formula
     (share/"zelda-login/configs").install Dir["configs/*"]
     
     # Install documentation
-    (share/"doc/zelda-login").install "README.md", "PACKAGE_MANAGERS.md"
+    (share/"doc/zelda-login").install "README.md", "PACKAGE_MANAGERS.md" if (buildpath/"README.md").exist?
   end
 
   def caveats
@@ -48,10 +46,10 @@ class ZeldaLogin < Formula
     # Test that the audio file exists
     assert_predicate share/"zelda-login/zelda-secret.mp3", :exist?
     
-    # Test that the installer script is executable
+    # Test that the installer script is executable  
     assert_predicate bin/"zelda-login-install", :executable?
     
     # Test that we can run the installer with --version
-    system bin/"zelda-login-install", "--version"
+    assert_match version.to_s, shell_output("#{bin}/zelda-login-install --version")
   end
 end


### PR DESCRIPTION
## Summary
Adds **Zelda Login** - Play Zelda's secret door sound when opening a new terminal window.

## Features
- Cross-platform support (macOS/Linux)
- Non-blocking audio playback 
- Multi-shell compatibility (bash/zsh/fish)
- Automatic configuration with zelda-login-install
- Professional installer with version support

## Testing
✅ Tested via custom tap: `brew tap quitequinn/zelda-login && brew install zelda-login`
✅ Installation verified on macOS
✅ Non-blocking audio confirmed
✅ Shell configuration works properly

Source: https://github.com/quitequinn/ZeldaLogin

## Checklist
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?