### PR TITLE
protoc-gen-grpc-web: fix test failure

### DIFF
--- a/Formula/p/protoc-gen-grpc-web.rb
+++ b/Formula/p/protoc-gen-grpc-web.rb
@@ -69,7 +69,7 @@ class ProtocGenGrpcWeb < Formula
       import {Test, TestResult} from './test_pb';
     TYPESCRIPT
     system "npm", "install", *std_npm_args(prefix: false), "grpc-web", "@types/google-protobuf"
-    # Specify including lib for `tsc` since `es6` is required for `@types/google-protobuf`.
-    system "tsc", "--lib", "es6", "test.ts"
+    # Include DOM for AbortSignal used by grpc-web 2.x typings; ES level also satisfies @types/google-protobuf.
+    system "tsc", "--lib", "es2021,dom", "test.ts"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This should hopefully resolve test failures spotted at #235241.
