### PR TITLE
qt@5: deprecate on 2026-05-19

### DIFF
--- a/Formula/p/poppler-qt5.rb
+++ b/Formula/p/poppler-qt5.rb
@@ -21,6 +21,8 @@ class PopplerQt5 < Formula
 
   keg_only "it conflicts with poppler"
 
+  deprecate! date: "2026-05-19", because: "is for end-of-life Qt 5"
+
   depends_on "cmake" => :build
   depends_on "gobject-introspection" => :build
   depends_on "pkgconf" => :build

--- a/Formula/p/pyqt@5.rb
+++ b/Formula/p/pyqt@5.rb
@@ -14,6 +14,8 @@ class PyqtAT5 < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "4f6a880862f2f69cc6fad70b2e6ca750bdfe8bb19ad41d41568cdeb4497d7278"
   end
 
+  deprecate! date: "2026-05-19", because: "is for end-of-life Qt 5"
+
   depends_on "pyqt-builder" => :build
   depends_on "python@3.13"
   depends_on "qt@5"

--- a/Formula/q/qt@5.rb
+++ b/Formula/q/qt@5.rb
@@ -30,6 +30,20 @@ class QtAT5 < Formula
 
   keg_only :versioned_formula
 
+  # Deprecating on expected date of Qt 5.15.19 open-source release which is
+  # planned for 1 year after the commercial release date of 2025-05-19[^1].
+  # Standard support officially ended on 2025-05-26 and Qt5 is now in EoS[^2].
+  # Any new CVEs found are no longer being fixed since commercial release.
+  # Also, we rely on Linux distro patches and they are planning removal too,
+  # e.g. Alpine[^3], Gentoo[^4] and Ubuntu[^5].
+  #
+  # [^1]: https://www.qt.io/blog/commercial-lts-qt-5.15.19-released
+  # [^2]: https://www.qt.io/blog/extended-security-maintenance-for-qt-5.15-begins-may-2025
+  # [^3]: https://gitlab.alpinelinux.org/alpine/aports/-/issues/17114
+  # [^4]: https://bugs.gentoo.org/948836
+  # [^5]: https://discourse.ubuntu.com/t/removing-qt-5-from-ubuntu-before-the-release-of-26-04-lts/49296
+  deprecate! date: "2026-05-19", because: :unsupported
+
   depends_on "ninja" => :build
   depends_on "node" => :build
   depends_on "pkgconf" => :build

--- a/Formula/q/qwt-qt5.rb
+++ b/Formula/q/qwt-qt5.rb
@@ -24,6 +24,8 @@ class QwtQt5 < Formula
 
   keg_only "it conflicts with qwt"
 
+  deprecate! date: "2026-05-19", because: "is for end-of-life Qt 5"
+
   depends_on "qt@5"
 
   # Update designer plugin linking back to qwt framework/lib after install


### PR DESCRIPTION
Deprecating on expected date of Qt 5.15.19 open-source release which is planned for 1 year after the commercial release date of 2025-05-19[^1]. Standard support officially ended on 2025-05-26 and Qt5 is now in EoS[^2]. Any new CVEs found are no longer being fixed since commercial release. Also, we rely on Linux distro patches and they are planning removal too, e.g. Alpine[^3], Gentoo[^4] and Ubuntu[^5].

Deprecation date will give dependents an extra 1 year to migrate while being installable and another year in disabled state before removal.

[^1]: https://www.qt.io/blog/commercial-lts-qt-5.15.19-released
[^2]: https://www.qt.io/blog/extended-security-maintenance-for-qt-5.15-begins-may-2025
[^3]: https://gitlab.alpinelinux.org/alpine/aports/-/issues/17114
[^4]: https://bugs.gentoo.org/948836
[^5]: https://discourse.ubuntu.com/t/removing-qt-5-from-ubuntu-before-the-release-of-26-04-lts/49296

---

### TODO
- [x] `suil` - #235491 / https://gitlab.com/lv2/suil/-/issues/11
- [ ] `morpheus`
- [ ] `qsoas`

### Tracking dependents that just need a new release
- [ ] `carla` - Qt6 in HEAD, planned for 2.6 release (e.g. https://github.com/falkTX/Carla/commit/6f4b8b45de1ea5aedd6f0916450ea31798db3732)
- [ ] `mgba` - Qt6 in HEAD, planned for 0.11 release (e.g. https://github.com/mgba-emu/mgba/commit/1179d218e7094b40ce5666df0a7c2d083cb96504)
- [ ] `qdmr` - Qt6 in devel, planned for 0.13 release, https://github.com/hmatuschek/qdmr/issues/592

### Tracking issues/PRs with recent upstream maintainer activity
- [ ] `gnuradio` - https://github.com/gnuradio/gnuradio/issues/7708 / https://github.com/gnuradio/gnuradio/pull/7883
- [ ] `inspectrum` - https://github.com/miek/inspectrum/issues/240
- [ ] `qjson` - https://github.com/flavio/qjson/issues/122 / https://github.com/flavio/qjson/pull/125

### Deprecating dependents with low activity (#235330)
- [x] `color-code` - last release on 2023-11-20. long release cycles, e.g. 8 years for 0.8.5 -> 0.8.7. no means of contact
- [x] `qtads` - https://github.com/realnc/qtads/pull/21 (no review in 2 years), last release on 2023-05-17, last commit on 2023-05-19, low installs: `install: 8 (30 days), 39 (90 days), 305 (365 days)`
- [x] `tarsnap-gui` - last release on 2018-08-23, low installs: `install: 3 (30 days), 26 (90 days), 176 (365 days)`
- [x] `dspdfviewer` - last release on 2016-09-13, last commit on 2023-04-27

### Deprecating Qt5-specific formulae (this PR)
- [x] `poppler-qt5` - same deprecation date
- [x] `pyqt@5` - same deprecation date
- [x] `qwt-qt5` - same deprecation date
- [x] `pyside@2` - disabled

### Backporting support
- [x] `colmap` - #235624 - https://github.com/colmap/colmap/pull/3597
