### PR TITLE
color-code dspdfviewer qtads tarsnap-gui: deprecate on 2026-05-19

### DIFF
--- a/Formula/c/color-code.rb
+++ b/Formula/c/color-code.rb
@@ -23,6 +23,10 @@ class ColorCode < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "dd2a46ae5f69b106738617bd41d8fe1d2a71a34dcb876850ac1c698b4ca09496"
   end
 
+  # No means of contact or public tracker page to discuss/view Qt 6 status.
+  # Can undeprecate if new release with Qt 6 support is available.
+  deprecate! date: "2026-05-19", because: "needs end-of-life Qt 5"
+
   depends_on "cmake" => :build
   depends_on "qt@5"
 

--- a/Formula/d/dspdfviewer.rb
+++ b/Formula/d/dspdfviewer.rb
@@ -18,6 +18,10 @@ class Dspdfviewer < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "ca5f6fc6b6b9ddbaa85c87107317aba3bf14fd5a9c0824460efeb612e34be2ae"
   end
 
+  # Last release on 2016-09-13, last commit on 2023-04-27.
+  # Can undeprecate if new release with Qt 6 support is available.
+  deprecate! date: "2026-05-19", because: "needs end-of-life Qt 5"
+
   depends_on "cmake" => :build
   depends_on "gobject-introspection" => :build
   depends_on "pkgconf" => :build

--- a/Formula/q/qtads.rb
+++ b/Formula/q/qtads.rb
@@ -26,6 +26,11 @@ class Qtads < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "251840532a70387d1007ab9a992bb9f6e8d6c543133fc19d5d41b0dd81c822a5"
   end
 
+  # Last release on 2023-05-17, last commit on 2023-05-19.
+  # PR for Qt 6 open since 2023-10-28: https://github.com/realnc/qtads/pull/21
+  # Can undeprecate if new release with Qt 6 support is available.
+  deprecate! date: "2026-05-19", because: "needs end-of-life Qt 5"
+
   depends_on "pkgconf" => :build
   depends_on "fluid-synth"
   depends_on "libsndfile"

--- a/Formula/t/tarsnap-gui.rb
+++ b/Formula/t/tarsnap-gui.rb
@@ -24,6 +24,10 @@ class TarsnapGui < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "97b8a8c25cd8383218b698725c2a88cbdb55f161188de94df95406514573d34c"
   end
 
+  # Last release on 2018-08-23
+  # Can undeprecate if new release with Qt 6 support is available.
+  deprecate! date: "2026-05-19", because: "needs end-of-life Qt 5"
+
   depends_on "qt@5"
   depends_on "tarsnap"
 


### PR DESCRIPTION
Aligning deprecation with Qt5 for dependents that may be unmaintained or have low activity (i.e. higher chance of still being on Qt5 when we hit deprecation date):
- #235319

Still looking at other dependents.