### PR TITLE
gnome_devel_allowlist: update pango version

### DIFF
--- a/audit_exceptions/gnome_devel_allowlist.json
+++ b/audit_exceptions/gnome_devel_allowlist.json
@@ -8,6 +8,6 @@
   "libshumate": "1.3",
   "libxml2": "2.13",
   "libxslt": "1.1",
-  "pango": "1.55",
+  "pango": "1.57",
   "tinysparql": "3.9"
 }


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`audit_exceptions/gnome_devel_allowlist.json` allows pango 1.55 versions (which would otherwise be seen as unstable) but the newest version with an odd-numbered minor is 1.57. This updates the audit exception to allow 1.57 versions, so autobump will be able to update pango to 1.57.0.