### PR TITLE
flang: use Ninja to scale down compile jobs

### DIFF
--- a/Formula/f/flang.rb
+++ b/Formula/f/flang.rb
@@ -21,6 +21,7 @@ class Flang < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "ninja" => :build
   depends_on "llvm"
 
   # Keep broken symlink if `llvm` has been unlinked on Linux.
@@ -38,6 +39,7 @@ class Flang < Formula
     relative_resource_dir = resource_dir.relative_path_from(llvm.prefix.realpath)
 
     common_args = %W[
+      -GNinja
       -DBUILD_SHARED_LIBS=ON
       -DLLVM_DIR=#{llvm.opt_lib}/cmake/llvm
       -DLLVM_ENABLE_FATLTO=ON
@@ -49,6 +51,7 @@ class Flang < Formula
       -DFLANG_INCLUDE_TESTS=OFF
       -DFLANG_REPOSITORY_STRING=#{tap&.issues_url}
       -DFLANG_VENDOR=#{tap&.user}
+      -DLLVM_RAM_PER_COMPILE_JOB=5000
       -DLLVM_TOOL_OPENMP_BUILD=ON
       -DLLVM_USE_SYMLINKS=ON
       -DMLIR_DIR=#{llvm.opt_lib}/cmake/mlir
@@ -83,21 +86,18 @@ class Flang < Formula
     # https://github.com/llvm/llvm-project/blob/main/flang-rt/CMakeLists.txt#L120-L130
     lib.install_symlink (prefix/relative_resource_dir).glob("**/#{shared_library("*")}")
 
-    if OS.linux?
-      # Allow flang -flto to work on Linux as it expects library relative to driver.
-      # The HOMEBREW_PREFIX path is used so that `brew link` skips creating a symlink.
-      lib.install_symlink HOMEBREW_PREFIX/"lib/LLVMgold.so"
-      return
-    end
+    # Allow flang -flto to work on Linux as it expects library relative to driver.
+    # The HOMEBREW_PREFIX path is used so that `brew link` skips creating a symlink.
+    lib.install_symlink HOMEBREW_PREFIX/"lib/LLVMgold.so" if OS.linux?
 
     libexec.install bin.children
     bin.install_symlink libexec.children
 
     # Help `flang` driver find `libLTO.dylib` and runtime libraries
-    (libexec/"flang.cfg").atomic_write <<~CONFIG
-      -Wl,-lto_library,#{llvm.opt_lib}/libLTO.dylib
-      -resource-dir=#{llvm.opt_prefix/relative_resource_dir}
-    CONFIG
+    # TODO: Try using CLANG_RESOURCE_DIR when building `llvm`
+    configs = ["-resource-dir=#{llvm.opt_prefix/relative_resource_dir}"]
+    configs << "-Wl,-lto_library,#{llvm.opt_lib}/libLTO.dylib" if OS.mac?
+    (libexec/"flang.cfg").atomic_write "#{configs.join("\n")}\n"
   end
 
   test do


### PR DESCRIPTION
Trying out Ninja again and may retry tuning memory so see if it there is any improvement on arm64 Sequoia.

Baseline:
* `make` (total core parallel) took about 3 hours (15-arm64) and 1 hour (14 / linux)

Runner `brew install` time. Approx. cores for 16GB arm64 runner

| | CPU | RAM | Run 1 | Run 2 | Run 3 |
| --- | --- | --- | --- | --- | --- |
| GiB/compile job | | | 5 (3 cores) | 5 (3 cores) | 6 (2 cores) |
| GiB/link job | | | 10 (1 core) | N/A | N/A |
| Limited steps | | | Flang, RT | Flang | Flang |
| Linux x86_64    | 4 | 16 | 01:00:53 |  01:00:37 | 01:00:04 |
| macOS 14-x86_64 | 6 | 64 | 01:27:07 | 01:19:25 | 01:05:17 |
| macOS 13-x86_64 | 6 | 64 | 01:01:21 | 01:13:51 | 00:47:34 |
| macOS 15-arm64  | 4 | 16 | 01:29:47 | 01:16:15 | 01:21:17 |
| macOS 14-arm64  | 4 | 16 | 01:12:24 | 01:11:49 | 01:16:03 |
| macOS 13-arm64  | 4 | 16 | 01:26:23 | 01:18:31 | 01:17:14 |

Just using ninja or ninja with single link job had worse build time.


---

~~Afterward, will explore options to handle resource-dir for arm64 Linux~~

1. Easiest would be using the flang.cfg on all OS.
2. ~~Could try rebuilding LLVM with relative resource-dir, e.g. `opt_lib.relative_path_from(bin)/"clang"/version.major`~~

Just going to apply flang.cfg for now and try changes in future PR.