### PR TITLE
metabase 0.56.3

### DIFF
--- a/Formula/m/metabase.rb
+++ b/Formula/m/metabase.rb
@@ -1,13 +1,16 @@
 class Metabase < Formula
   desc "Business intelligence report server"
   homepage "https://www.metabase.com/"
-  url "https://downloads.metabase.com/v0.56.2/metabase.jar"
-  sha256 "2440b3458a1918826ed798636b4ef43d5a81e0a31e3a8b706e51f7e24a44ea8f"
+  url "https://downloads.metabase.com/v0.56.3/metabase.jar"
+  sha256 "4fba1db441d0ff2246311e564bb5a56a815ada735969f18ceb7e9791108fd70b"
   license "AGPL-3.0-only"
 
+  # The first-party download page only provides an unversioned link to the
+  # latest OSS jar file. We check the "latest" GitHub release, as the release
+  # body text contains a versioned link to the OSS jar file.
   livecheck do
-    url "https://www.metabase.com/start/oss/jar.html"
-    regex(%r{href=.*?/v?(\d+(?:\.\d+)+)/metabase\.jar}i)
+    url :head
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/m/metabase.rb
+++ b/Formula/m/metabase.rb
@@ -14,7 +14,7 @@ class Metabase < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "8cc28c4c08e03407eca46fb7a8d7a530ea9ebf27b1cd40a51f527eabac21a204"
+    sha256 cellar: :any_skip_relocation, all: "728ed1b6bd8ea2a8f5d8eaf6834ea8801eaf8d24bd0bcf382862703fe2686cf3"
   end
 
   head do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `metabase` to the latest version, 0.56.3.

The existing `livecheck` block for `metabase` is returning an `Unable to get versions` error, as the first-party download page for the OSS jar only contains an unversioned link now (/latest/metabase.jar). This updates the `livecheck` block to use the `GithubLatest` strategy, as the GitHub release body text contains a versioned link to the OSS jar file.