### PR TITLE
pipe-rename: downgrade to 1.6.5

### DIFF
--- a/Formula/p/pipe-rename.rb
+++ b/Formula/p/pipe-rename.rb
@@ -8,13 +8,13 @@ class PipeRename < Formula
   head "https://github.com/marcusbuffett/pipe-rename.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "47e73c28741527cb6a749b35cab379548c2a6c162b5fb7a9cbe599ae17ea85e8"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "f3b8491c9fcb55b9e844f48a2ab727651080e29535e791e1bf36d21ebca6ea78"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "97533ce476e33905239b91dd58378b19c820a22442bf956d0e152a618b6e317c"
-    sha256 cellar: :any_skip_relocation, sonoma:        "b80571f935e8a95fece6633a80b895f0219806caf3103420198e201a16f49fd9"
-    sha256 cellar: :any_skip_relocation, ventura:       "52d774b0aa7e4106dbe9aa1bf8be9093227af2b4045f22ca956359b307ca6107"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "5407430962eaf62383ea116964cb03f03505e1cb9d88f273cde0831c307b9b6e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "eaa61ce9d5ad341d7d8766fe8e188ca6d9adade64178e69443eefb3657ed008e"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "05b5d7a3e3d2800214c3d6c019965abc4c79153e877f9646f0785b731403cd42"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "78ad5f875ea0698f555e7cd1ae0e9cbf3f2288df1a629aea13d73e88d8410868"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "6ead196d4a945b353937da16ba88d97705b9e63359a66a7d1413e84be958728c"
+    sha256 cellar: :any_skip_relocation, sonoma:        "55b14b5cc02d4940996223565bffe107205f002b712b1851759121e32352478b"
+    sha256 cellar: :any_skip_relocation, ventura:       "e78cf189b9daf7abe12c7067ee35d9716e268abe6210014b85ced4aa201c605d"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "76acb0c610a7ca3269b0330affdcfdee2f6549c0fd59883b00bca7bcc61f0393"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "cf3c6d9051347cca1f0a699b770f0acb148b5f079a75bec57e9f1b690360e935"
   end
 
   depends_on "rust" => :build

--- a/Formula/p/pipe-rename.rb
+++ b/Formula/p/pipe-rename.rb
@@ -1,9 +1,10 @@
 class PipeRename < Formula
   desc "Rename your files using your favorite text editor"
   homepage "https://github.com/marcusbuffett/pipe-rename"
-  url "https://github.com/marcusbuffett/pipe-rename/archive/refs/tags/1.6.6.tar.gz"
-  sha256 "bf33a2bba9b2d7ca4b13d35a0e49889ba77d8295314dd187f9709fe5ae6ac629"
+  url "https://github.com/marcusbuffett/pipe-rename/archive/refs/tags/1.6.5.tar.gz"
+  sha256 "bc3cc51e02578e0c56f252e65136dbeb635ffc8468c45b5c38df311cab611b09"
   license "MIT"
+  revision 1
   head "https://github.com/marcusbuffett/pipe-rename.git", branch: "master"
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The 1.6.6 release and tag for `pipe-rename` have been removed upstream, so this downgrades the formula to 1.6.5. The `sha256` has changed between the original 1.6.5 release and now because [upstream re-released 1.6.5 to "include aarch and updated windows binaries"](https://github.com/marcusbuffett/pipe-rename/releases/tag/1.6.5), so this also bumps the `revision` to build new bottles.