### PR TITLE
elf2uf2-rs: Fix compatibility with latest Rust

### DIFF
--- a/Formula/e/elf2uf2-rs.rb
+++ b/Formula/e/elf2uf2-rs.rb
@@ -24,6 +24,12 @@ class Elf2uf2Rs < Formula
     depends_on "systemd" # for libudev
   end
 
+  # Fix compatibility issues with latest Rust: https://github.com/JoNil/elf2uf2-rs/issues/40, https://github.com/JoNil/elf2uf2-rs/pull/41
+  patch do
+    url "https://github.com/JoNil/elf2uf2-rs/commit/c1639b9e8bcaaaab653f9fa0e358fed0e8a7ce76.patch?full_index=1"
+    sha256 "3bbcfa39c01bd705f7b021c1e5117bd9a91fa51c4c13c998a43ba17adf9616a7"
+  end
+
   def install
     system "cargo", "install", *std_cargo_args
     (pkgshare/"examples").install Dir.glob("*.elf")

--- a/Formula/e/elf2uf2-rs.rb
+++ b/Formula/e/elf2uf2-rs.rb
@@ -8,13 +8,14 @@ class Elf2uf2Rs < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "b2502c3b12665d304fc3f016c68eef40119b4b529867d67cc26fb641e844b5de"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "4cd37371cbeb7dd6be732e6db993b226dea3dc7fbbd2c321e81665c68c6de036"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "5e0726aed0c347586d3a4eef4b49ce9ef93d2560f31ae686f48381babae5f508"
-    sha256 cellar: :any_skip_relocation, sonoma:        "592612fe9e209df4f432354b7cc471f83a41ab679a13ce2ab904dd1431ffd9ab"
-    sha256 cellar: :any_skip_relocation, ventura:       "5942db8bcb33f094ba359873643e78f39ec73e12e2b85fdc076a4abbb63ab08d"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "bee91ffd1bed1d4f42d0eb45e4c21539b1f8089710b08d007d00a1090bfb352d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "85a5d2a22806dbd123281e4ab4d9f078ae31a81c29f0ad10ee199e4fc7375e5b"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "6e82da1e4bda8f4e9b96a224bd39f0fa553df1f2b2f5685e3d26ea8d36db64ae"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "ad84d3c1063a64c46201c1f3848ae783cf238e63dd215470e908642153d4eadd"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "9d8ad586061ca0882a16789b7242c86801e76389e525657ba1864ea33084dae9"
+    sha256 cellar: :any_skip_relocation, sonoma:        "b49813f898c7f808ceb5ec486e6336e5c05e78ac6eb28835eb19b25c2a12e56e"
+    sha256 cellar: :any_skip_relocation, ventura:       "459684a3cb259a2aba995e088130a2f9724c1589a7cbd11e9e4380ba1238024b"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "fb8bd88d07dec80d7314766dd10b94d6ea0d9e3f1fd60129528549745da19c4e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "41046fe0f99aac047708fdb2204bb12220625173156e477322e7bd13f09c27e8"
   end
 
   depends_on "rust" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

There has been a change in the elf header generated by rustc, those files are
now rejected as invalid by elf2uf2-rs.

This commit includes a patch to consider the new ABI valid as well.

https://github.com/JoNil/elf2uf2-rs/issues/40
https://github.com/JoNil/elf2uf2-rs/pull/41

(I couldn't build this locally yet, as brew is hanging with a `mdfind` child process indefinitely)