### PR TITLE
git-gui: backport upstream patches

### DIFF
--- a/Formula/g/git-gui.rb
+++ b/Formula/g/git-gui.rb
@@ -12,7 +12,7 @@ class GitGui < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "703a593f09c0c37610e2c1bb236014392246c749cfed9e80a9ba0d66e3a3ba1c"
+    sha256 cellar: :any_skip_relocation, all: "a4823322be76e03f41e1794f18b149121cb335cb67da4e865157f940abef11e4"
   end
 
   depends_on "tcl-tk"

--- a/Formula/g/git-gui.rb
+++ b/Formula/g/git-gui.rb
@@ -4,7 +4,7 @@ class GitGui < Formula
   url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.51.0.tar.xz"
   sha256 "60a7c2251cc2e588d5cd87bae567260617c6de0c22dca9cdbfc4c7d2b8990b62"
   license "GPL-2.0-only"
-  revision 1
+  revision 2
   head "https://github.com/git/git.git", branch: "master"
 
   livecheck do
@@ -16,6 +16,19 @@ class GitGui < Formula
   end
 
   depends_on "tcl-tk"
+
+  # Fix gitk's right click and scrolling behavior with Tcl/Tk 9.
+  # Remove both when included in https://github.com/git/git/tree/#{tag}/gitk-git
+  patch do
+    url "https://github.com/j6t/gitk/commit/7c06c19e66e7654031eb50b72fd79c380fa54158.patch?full_index=1"
+    sha256 "5ffaf1f1377a593079a6e1f4d55babfec5ef000552027f65bae157cc42ca4b75"
+    directory "gitk-git"
+  end
+  patch do
+    url "https://github.com/j6t/gitk/commit/432669914b2fb812bc62e3b52176a8bfc8e4d667.patch?full_index=1"
+    sha256 "3b750defc0406f5799645d25f01f56dc5750b0dd534e4073a1e1b01f53e2061f"
+    directory "gitk-git"
+  end
 
   def install
     # build verbosely


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

These patches fix gitk's right click [^1] and scrolling behavior [^2] with Tcl/Tk 9. I'm bumping the revision number since this seems to be affecting a nontrivial number of users according to issue reports and analytics [^3].

Fixes https://github.com/Homebrew/homebrew-core/commit/8688881f23287b4ba0f47eec7f3d422808608ff2#commitcomment-164727427. Fixes https://github.com/Homebrew/homebrew-core/issues/234735. Fixes https://github.com/Homebrew/homebrew-core/issues/235488.

[^1]: https://github.com/j6t/gitk/pull/30
[^2]: https://github.com/j6t/gitk/pull/32
[^3]: https://formulae.brew.sh/formula/git-gui
