### PR TITLE
suil: deprecate macOS on 2026-05-19

### DIFF
--- a/Formula/s/suil.rb
+++ b/Formula/s/suil.rb
@@ -28,6 +28,11 @@ class Suil < Formula
   depends_on "lv2"
 
   on_macos do
+    # Can undeprecate if new release with Qt 6 support is available.
+    # Alternatively can just build direct X11 wrapper (libsuil_x11.dylib)
+    # Issue ref: https://gitlab.com/lv2/suil/-/issues/11
+    deprecate! date: "2026-05-19", because: "needs end-of-life Qt 5"
+
     depends_on "qt@5" # cocoa still needs Qt5
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Upstream tracking issue: https://gitlab.com/lv2/suil/-/issues/11 

EDIT: Added a comment that we could just build the direct X11 wrapper (libsuil_x11.dylib). No idea how useful this is without Qt/Gtk but possible via removing dependency (any perhaps `-Dqt6=disabled -Dqt5=disabled` to avoid automatic detection).
