### PR TITLE
fontconfig: clean up deps

### DIFF
--- a/Formula/f/fontconfig.rb
+++ b/Formula/f/fontconfig.rb
@@ -29,7 +29,6 @@ class Fontconfig < Formula
 
   uses_from_macos "gperf" => :build
   uses_from_macos "python" => :build, since: :catalina
-  uses_from_macos "bzip2"
   uses_from_macos "expat"
 
   on_macos do
@@ -37,8 +36,6 @@ class Fontconfig < Formula
   end
 
   on_linux do
-    depends_on "gettext" => :build
-    depends_on "json-c" => :build
     depends_on "util-linux"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- `gettext` is already an unconditional `:build` dependency, so there is
  no need to declare it on Linux too.
- `json-c` is only needed for tests, which we disable.
- `bzip2` appears to be unused, and there is no linkage to it. This
  might be from a time when we used `.tar.bz2` tarballs.
