### PR TITLE
manticoresearch: update livecheck

### DIFF
--- a/Formula/m/manticoresearch.rb
+++ b/Formula/m/manticoresearch.rb
@@ -15,11 +15,9 @@ class Manticoresearch < Formula
 
   # There can be a notable gap between when a version is tagged and a
   # corresponding release is created, so we check the "latest" release instead
-  # of the Git tags. The upstream version scheme uses an even-numbered patch to
-  # indicate stable versions.
+  # of the Git tags.
   livecheck do
     url :stable
-    regex(/^v?(\d+(?:\.\d+)+\.\d*[02468])$/i)
     strategy :github_latest
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `manticoresearch` uses the `GithubLatest` strategy but it returns an `Unable to get versions` error because the regex only matches versions with an even-numbered patch (which 13.6.7 does not have). Everything I've seen upstream suggests that 13.6.7 is the newest stable version, so removing this restriction seems appropriate to me at this point.