### PR TITLE
otf2: update homepage, livecheck

### DIFF
--- a/Formula/o/otf2.rb
+++ b/Formula/o/otf2.rb
@@ -1,12 +1,12 @@
 class Otf2 < Formula
   desc "Open Trace Format 2 file handling library"
-  homepage "https://www.vi-hps.org/projects/score-p/"
+  homepage "https://www.vi-hps.org/projects/score-p/overview/overview.html"
   url "https://perftools.pages.jsc.fz-juelich.de/cicd/otf2/tags/otf2-3.1.1/otf2-3.1.1.tar.gz"
   sha256 "5a4e013a51ac4ed794fe35c55b700cd720346fda7f33ec84c76b86a5fb880a6e"
   license "BSD-3-Clause"
 
   livecheck do
-    url :homepage
+    url "https://www.vi-hps.org/projects/score-p/download/download.html"
     regex(/href=.*?otf2[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `otf2` is giving an `Unable to get versions` error, as the homepage redirects to the overview page and that doesn't contain an `otf2` tarball link. This updates the `livecheck` block URL to check the download page, which is where the `otf2` tarball link is found. Besides that, this updates the `homepage` URL to resolve the redirection.