### PR TITLE
roxctl: update livecheck

### DIFF
--- a/Formula/r/roxctl.rb
+++ b/Formula/r/roxctl.rb
@@ -6,9 +6,12 @@ class Roxctl < Formula
   license "Apache-2.0"
   head "https://github.com/stackrox/stackrox.git", branch: "master"
 
+  # Upstream maintains multiple major/minor versions and the "latest" release
+  # may be for a lower version, so we have to check multiple releases to
+  # identify the highest version.
   livecheck do
     url :stable
-    strategy :github_latest
+    strategy :github_releases
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `roxctl` uses the `GithubLatest` strategy but it's currently returning 4.6.9 as newest instead of 4.8.2. 4.6.9 was released after 4.8.2 and marked as "latest", so we can't rely on the "latest" release always being the highest version due to upstream creating releases for multiple major/minor versions in an indeterminate order.

This addresses the issue by updating the `livecheck` block to use the `GithubReleases` strategy, which finds the highest version from recent releases. I checked for upstream pages that may link to the latest versions in a more lightweight fashion but didn't find any alternatives.