### PR TITLE
zsync: add livecheck

### DIFF
--- a/Formula/z/zsync.rb
+++ b/Formula/z/zsync.rb
@@ -9,6 +9,11 @@ class Zsync < Formula
     :public_domain, # librcksum/md4.c, libzsync/sha1.c, zlib/inflate.c
   ]
 
+  livecheck do
+    url "https://zsync.moria.org.uk/downloads"
+    regex(/href=.*?zsync[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "39991c4aa022ce2fe1b3d62b30e2c7e130be4e4e98bf6dca844f28ec8afdfe8d"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "800299bfc82b2ce9970159a2d0efcbe445c74024a357aa4a3c2f8a74c4ed871b"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck uses the `Git` strategy for `zsync` but this doesn't work because the repository doesn't have any tags. This adds a `livecheck` block that checks the first-party download page, which links to the stable tarball.

This was the `livecheck` block we were using before the formula was deprecated (as zsync.moria.org.uk wasn't accessible at the time) and the `livecheck` block was removed. The formula was revived with version 0.6.3 (as the website works again) but the `livecheck` block wasn't restored until now.