### PR TITLE
urlscan: remove redundant manpage installation, add head

### DIFF
--- a/Formula/u/urlscan.rb
+++ b/Formula/u/urlscan.rb
@@ -6,6 +6,7 @@ class Urlscan < Formula
   url "https://files.pythonhosted.org/packages/af/95/4c28f3cfdb866f9a6e301fbafedb0e537dd40c8cf9d33872e67ed38ec1d2/urlscan-1.0.7.tar.gz"
   sha256 "041b932f94cb1e2e8dbb20f43322da85cb483be328fa10477c6e5e96a89891c3"
   license "GPL-2.0-or-later"
+  head "https://github.com/firecat53/urlscan.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "f06e24ee723a5d356f9b82a54abf7c29f3104c509865c4a014d948f306b73bed"
@@ -25,8 +26,6 @@ class Urlscan < Formula
 
   def install
     virtualenv_install_with_resources
-
-    man1.install "urlscan.1"
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

This is already installed in the venv [at `share/man/man1/`](https://github.com/firecat53/urlscan/blob/1.0.7/pyproject.toml#L60) and thus linked by [`virtualenv_install_with_resources`](https://github.com/Homebrew/brew/blob/9219495eb0a66e7559a03759d6c859148c19c617/Library/Homebrew/language/python.rb#L440-L444)
