### PR TITLE
binutils: symlink ld.so.conf

### DIFF
--- a/Formula/b/binutils.rb
+++ b/Formula/b/binutils.rb
@@ -24,6 +24,8 @@ class Binutils < Formula
   uses_from_macos "bison" => :build
   uses_from_macos "zlib"
 
+  skip_clean "etc/ld.so.conf"
+
   link_overwrite "bin/dwp"
 
   def install
@@ -61,9 +63,13 @@ class Binutils < Formula
       bin_files = bin.children.select(&:elf?)
       system "strip", *bin_files, *lib.glob("*.a")
     end
+
+    # Allow ld to find brew glibc. A broken symlink falls back to /etc/ld.so.conf
+    (prefix/"etc").install_symlink etc/"ld.so.conf" if OS.linux?
   end
 
   test do
     assert_match "Usage:", shell_output("#{bin}/strings #{bin}/strings")
+    assert_predicate prefix/"etc/ld.so.conf", :symlink? if OS.linux?
   end
 end

--- a/Formula/b/binutils.rb
+++ b/Formula/b/binutils.rb
@@ -7,13 +7,14 @@ class Binutils < Formula
   license all_of: ["GPL-2.0-or-later", "GPL-3.0-or-later", "LGPL-2.0-or-later", "LGPL-3.0-only"]
 
   bottle do
-    sha256 arm64_sequoia: "4f7274b8d53163dc1d8dc2b18cc2c7eff75d5efd01db222e7d8bd5f3f05af2c2"
-    sha256 arm64_sonoma:  "bcf972b443b276ee59fc94a4c5c84b54d7702ef6bab66b55c811420eaf548dcd"
-    sha256 arm64_ventura: "db7f43289bcfffe3c70abef62a1a641671ae8fefb858b654161f7914109286fa"
-    sha256 sonoma:        "dfb68055c0d2bddab0e17ab861d76be558877d5f3d960c826fb26a0d59eede14"
-    sha256 ventura:       "a1821fba84ee3cbaab966febef3bedc05dc1c1327fadeb768c2f19790c97bf10"
-    sha256 arm64_linux:   "f2b26e219cd1a37afbd7743be40ce71525604979d0f7bcdc63fbbce016f4cd4d"
-    sha256 x86_64_linux:  "0b5a67a3cfd1779c829a131f38895e1b6c755c57187510cf998f77d4d3a7ddd7"
+    rebuild 1
+    sha256 arm64_sequoia: "3fb936ff0d64e4bc3530ab07f83417f5dea8c098549ec506f19f1c6ae4962cb6"
+    sha256 arm64_sonoma:  "1a6356d10575b843eafe84253ba51c147334239b37e02d99288d998466912471"
+    sha256 arm64_ventura: "4a1b661cba6a910e35d0691d2d1dda1ed6337e212fb6237a6189dfa99bb45888"
+    sha256 sonoma:        "fb94a53dfab0618b68dcf429dfcd54d5854f74bff87225dc2f6465d9bb278f07"
+    sha256 ventura:       "96dcff59ccbb203e0fa8ccb7a36bc9eaba8fe6a63010bbb77f1238df951bce78"
+    sha256 arm64_linux:   "9d452137d4cfe39d4edbf7e9ae47389039345a3ac6ec85e9b3bcdca6911f3b75"
+    sha256 x86_64_linux:  "a6a1fca273e6ac2ed2309c0f0c4180cf10fae283bc303c58da8ce3771598c1b3"
   end
 
   keg_only "it shadows the host toolchain"


### PR DESCRIPTION
Fixes https://github.com/orgs/Homebrew/discussions/5421. No revision bump as very small number of users impacted. Those that need fix can `brew postinstall binutils` or `brew reinstall binutils`.

An alternative fix is adding `-rpath-link` via cc shim, i.e. change https://github.com/Homebrew/brew/blob/main/Library/Homebrew/shims/super/cc#L374
```rb
args << "#{wl}-rpath-link=#{@opt}/#{versioned_glibc_dep}/lib" if versioned_glibc_dep
```
maybe to
```rb
args << if versioned_glibc_dep
  "#{wl}-rpath-link=#{@opt}/#{versioned_glibc_dep}/lib"
else
  "#{wl}-rpath-link=#{@opt}/glibc/lib"
end
```

Though this does apply it when `glibc` is installed but not really needed. Would be better to constrain based on whether brew `glibc` is in dependency tree.

---

For analysis of issue, looking at ld man page[^1], the shared libraries' libraries seem to be resolved in order of
1. `-rpath-link`
2. `-rpath`
3. `export LD_RUN_PATH=...` (skip) - only if (1) and (2) are not used which is never in brew
4. SunOS ... (skip)
5. `export LD_LIBRARY_PATH=...` (skip) - usually not used in brew
6. `DT_RUNPATH` or `DT_RPATH` - these don't include `glibc`
7. /etc/ld.so.conf - this looks like where we are finding system glibc rather than brew glibc

Binutils does prioritize `<prefix>/etc/ld.so.conf` over `/etc/ld.so.conf` at https://sourceware.org/git/?p=binutils-gdb.git;a=blob;f=ld/ldelf.c;h=f4f27fc3873440398ff85a403e8b98a834e5697c;hb=HEAD#l946
```c
      tmppath = concat (ld_sysroot, prefix, "/etc/ld.so.conf",
			(const char *) NULL);
      if (!ldelf_parse_ld_so_conf (&info, tmppath))
	{
	  free (tmppath);
	  tmppath = concat (ld_sysroot, "/etc/ld.so.conf",
			    (const char *) NULL);
	  ldelf_parse_ld_so_conf (&info, tmppath);
	}
```

[^1]: https://man.archlinux.org/man/ld.1.en#rpath