### PR TITLE
util-linux: fix build, add LDFLAGS="-lm" on Linux

### DIFF
--- a/Formula/u/util-linux.rb
+++ b/Formula/u/util-linux.rb
@@ -107,8 +107,10 @@ class UtilLinux < Formula
     end
 
     system "./configure", *args, *std_configure_args
-    ENV.append "LDFLAGS", "-lm" if OS.linux?
-    system "make", "install"
+
+    install_args = []
+    install_args << "LDFLAGS=-lm" if OS.linux?
+    system "make", "install", *install_args
   end
 
   def caveats


### PR DESCRIPTION
This was attempted in #214529, but not actually fixed. This changes the approach from an environment variable to a `make` command argument. [Full explanation in discussion.](https://github.com/orgs/Homebrew/discussions/5421#discussioncomment-14260165)

Closes https://github.com/orgs/Homebrew/discussions/5421

-----

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

<details>
<summary>Install & test results</summary>

```shell
$ brew uninstall --force util-linux

$ brew install --build-from-source util-linux --only-dependencies
...

$ HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source util-linux
==> Fetching downloads for: util-linux
==> Fetching util-linux
==> Downloading https://github.com/util-linux/util-linux/commit/45f943a4b36f59814cf5a735e4975f2252afac26.patch?full_index=1
Already downloaded: /home/jacktose/.cache/Homebrew/downloads/6044fe7f1f251a5ea2f51e816024257d0306b1f0a96600daefa42791decd657e--45f943a4b36f59814cf5a735e4975f2252afac26.patch
==> Downloading https://github.com/util-linux/util-linux/commit/565eb6370c76721bbd0d7fa292d9315a6856f627.patch?full_index=1
Already downloaded: /home/jacktose/.cache/Homebrew/downloads/0ce740c8bfb56ee839b57801f29c447b0623e6d4dc85a7e393f7a8b9e61b5aa0--565eb6370c76721bbd0d7fa292d9315a6856f627.patch
==> Downloading https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.41/util-linux-2.41.1.tar.xz
Already downloaded: /home/jacktose/.cache/Homebrew/downloads/fb2bf25e6a14d80fc8745c951ab9a77c73feb7f56c1b520f00f2f4b3bc39d0fe--util-linux-2.41.1.tar.xz
==> Patching
==> Applying 45f943a4b36f59814cf5a735e4975f2252afac26.patch
==> Applying 565eb6370c76721bbd0d7fa292d9315a6856f627.patch
==> autoreconf --force --install --verbose
==> ./configure --disable-silent-rules --disable-asciidoc --with-bashcompletiondir=/home/linuxbrew/.linuxbrew/Cellar/util-linux/2.41.1_1/etc/bash_completion.d --disable-use-tty-group --disable-kill --without-s
==> make install
🍺  /home/linuxbrew/.linuxbrew/Cellar/util-linux/2.41.1_1: 447 files, 26.2MB, built in 38 seconds
==> Running `brew cleanup util-linux`...
Disable this behaviour by setting `HOMEBREW_NO_INSTALL_CLEANUP=1`.
Hide these hints with `HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).
Removing: /home/jacktose/.cache/Homebrew/util-linux_bottle_manifest--2.40.4... (17.5KB)
Removing: /home/jacktose/.cache/Homebrew/util-linux--2.41.1.tar.xz... (9.2MB)
Removing: /home/jacktose/.cache/Homebrew/util-linux--patch--3945234bcfbf4d9126e92b4f808029971ab26330618da53671941ba1a52d8427.patch... (634B)
Removing: /home/jacktose/.cache/Homebrew/util-linux--patch--b372a7578ff397787f37e1aa1c03c8299c9b3e3f7ab8620c4af68c93ab2103b5.patch... (1.5KB)
==> No outdated dependents to upgrade!
==> Caveats
Bash completion has been installed to:
  /home/linuxbrew/.linuxbrew/etc/bash_completion.d
==> Installation times
util-linux               36.797 s

$ brew test util-linux
==> Testing util-linux
==> /home/linuxbrew/.linuxbrew/Cellar/util-linux/2.41.1_1/bin/namei -lx /usr

$ brew audit --strict util-linux

$ brew style util-linux

1 file inspected, no offenses detected
```
</details>

[gist logs](https://gist.github.com/jacktose/af12c9a030aa05c2963e7af13b6ee9b3)

-----

Alternatives: @cho-m is working on a more general fix in #235571. If that's accepted and solves this issue (I'll be thrilled and) we won't need this, nor #214529.
I suggest merging this simple fix now, then backing out both when #235571 lands.
(If you don't want this fix now, I suggest backing out #214529, and I'll just keep my `brew edit util-linux` version until the general fix lands.)