### PR TITLE
perl-xml-parser: fix manpage installation

### DIFF
--- a/Formula/p/perl-xml-parser.rb
+++ b/Formula/p/perl-xml-parser.rb
@@ -25,10 +25,10 @@ class PerlXmlParser < Formula
 
   def install
     system "perl", "Makefile.PL", "INSTALL_BASE=#{prefix}"
-    system "make", "PERL5LIB=#{ENV["PERL5LIB"]}"
+    system "make"
     system "make", "install"
 
-    man.install prefix/"man"
+    share.install prefix/"man"
     perl_version = Formula["perl"].version.major_minor.to_s
     site_perl = lib/"perl5/site_perl"/perl_version
     (lib/"perl5").find do |pn|

--- a/Formula/p/perl-xml-parser.rb
+++ b/Formula/p/perl-xml-parser.rb
@@ -9,14 +9,14 @@ class PerlXmlParser < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "6652df7d2ee4241d47bd7696f6b6b063ce31cfca2d922f5be08adb4364df9952"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "4219900b1c2f9105cefb7e34c0d2d8ef42dee9696881a46646a58a4ed83f339d"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "6d8331557430f37f003b838ab9dce30073e0876bddacaa1dbc07aed0ab2c3e2d"
-    sha256 cellar: :any_skip_relocation, sonoma:        "636cdbf8bf30e94da13d51d4785cf3c4bd578338cc5f84c2b219a26b788886f4"
-    sha256 cellar: :any_skip_relocation, ventura:       "9876b8022ee76c8f4b100bc392c04c7fc65975b2a2b08cd24edb7057fe6d1419"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "428b10afda30e79f0fd6a06f9eadbfe784c00ab92a2add9c25f4ff8ab1eb4cef"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "7b353076b4fc4b713b7ae09fd42468ff3f77bed5ac08106c7558d4dd3347316e"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "743f65ac327d1c467d9e4f82fa910d19ae383c858073846009aca35322f9e64e"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "ca54e86b76d10069e88fb814728f36ddc091cfda3dcffb38e68c6ec656d05cc5"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "5dc622c5856a89a675ab3a23aed3158434a6a7196d9b95b19b82f4371d1f50c7"
+    sha256 cellar: :any_skip_relocation, sonoma:        "4b5a25de8d14214ec9102591fe6812ee2674e0c3e1e6bd2e4f094690298ba55b"
+    sha256 cellar: :any_skip_relocation, ventura:       "1f11e49aeb5e4927c4fdd2a3f23096b655b06146a34ac2c3275a0967eccc882d"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "ea6d38240ddf5f5c8c1d8a170d3f609e5c575f6218400779d9fee264434b6eb1"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "fee8525a0657759385a896976246e5e8d65c948bcc81276c6edc1fe7c72a0a15"
   end
 
   # macOS Perl already has the XML::Parser module


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Doing `man.install` installs the manpages in `share/man/man`, which is
not correct.

While we're here, let's remove the unneeded `PERL5LIB` (because
`ENV["PERL5LIB"]` is not set here).
