### PR TITLE
sextractor: update `openblas`'s include dir

### DIFF
--- a/Formula/s/sextractor.rb
+++ b/Formula/s/sextractor.rb
@@ -24,12 +24,16 @@ class Sextractor < Formula
 
   def install
     openblas = Formula["openblas"]
+    # Allow OpenBLAS header migration to subdirectory. Can remove once done
+    openblas_incdir = openblas.include/"openblas"
+    openblas_incdir = openblas.include unless openblas_incdir.exist?
+
     system "./autogen.sh"
-    system "./configure", *std_configure_args,
-           "--disable-silent-rules",
-           "--enable-openblas",
-           "--with-openblas-libdir=#{openblas.lib}",
-           "--with-openblas-incdir=#{openblas.include}"
+    system "./configure", "--disable-silent-rules",
+                          "--enable-openblas",
+                          "--with-openblas-libdir=#{openblas.lib}",
+                          "--with-openblas-incdir=#{openblas_incdir}",
+                          *std_configure_args
     system "make", "install"
     # Remove references to Homebrew shims
     rm Dir["tests/Makefile*"]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Split from #219339 as shouldn't need new bottle.

Seems like CMake defaults to subdirectory. Some distros do use Make and manually set subdirectory like Fedora (https://src.fedoraproject.org/rpms/openblas/blob/rawhide/f/openblas.spec#_433) so to move to subdirectory if we want.