### PR TITLE
lsr: remove using argument

### DIFF
--- a/Formula/l/lsr.rb
+++ b/Formula/l/lsr.rb
@@ -2,7 +2,6 @@ class Lsr < Formula
   desc "Ls but with io_uring"
   homepage "https://tangled.sh/@rockorager.dev/lsr"
   url "https://tangled.sh/@rockorager.dev/lsr",
-      using:    :git,
       tag:      "v1.0.0",
       revision: "9bfcae0be1d3ee2db176bb8001c0f46650484249"
   license "MIT"
@@ -16,7 +15,7 @@ class Lsr < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "0044a4cca23cb76a32c0095cee321c50d049007a608ae54155268b0ac30a1213"
   end
 
-  depends_on "zig" => :build
+  depends_on "zig@0.14" => :build # https://tangled.sh/@rockorager.dev/lsr/issues/13
 
   def install
     # Fix illegal instruction errors when using bottles on older CPUs.


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I added support to `DownloadStrategyDetector` for tangled.sh Git URLs (https://github.com/Homebrew/brew/pull/20599), so the `using: :git` argument in the `lsr` formula is (or will be) redundant. This formula would normally fail `brew audit` as a result but the related audit is currently being skipped for `lsr` (it was necessary to be able to merge the related `brew` PR). I've created this as a draft until the aforementioned `DownloadStrategyDetector` change is in a brew release.

Besides that, this modifies the formula to use `zig@14`, as the build will fail with errors otherwise (i.e., `expected function or variable declaration after pub` for `build.zig` lines like `pub usingnamespace @import("src/zeit.zig");` and `pub usingnamespace zzdoc;`).