### PR TITLE
bdw-gc: simplify `install` method

### DIFF
--- a/Formula/b/bdw-gc.rb
+++ b/Formula/b/bdw-gc.rb
@@ -40,13 +40,11 @@ class BdwGc < Formula
                     *args, *std_cmake_args,
                     "-DBUILD_TESTING=ON" # Pass this *after* `std_cmake_args`
     system "cmake", "--build", "build"
-    if OS.linux? || Hardware::CPU.arm? || MacOS.version > :monterey
-      # Fails on 12-x86_64.
-      system "ctest", "--test-dir", "build",
-                      "--parallel", ENV.make_jobs,
-                      "--rerun-failed",
-                      "--output-on-failure"
-    end
+    system "ctest", "--test-dir", "build",
+                    "--parallel", ENV.make_jobs,
+                    "--rerun-failed",
+                    "--output-on-failure",
+                    "--repeat", "until-pass:3"
     system "cmake", "--install", "build"
 
     system "cmake", "-S", ".", "-B", "build-static", "-DBUILD_SHARED_LIBS=OFF", *args, *std_cmake_args


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I suspect the `ctest` failure referenced there was just a flake, since I
saw a `ctest` failure on 13-x86_64 at #235758 that went away on a
re-run.

Let's just always run `ctest` unconditionally, but pass `--repeat` in
order to automatically rerun flaky tests.
