### PR TITLE
gh-manager-cli 1.12.0 (new formula)

### DIFF
--- a/Formula/g/gh-manager-cli.rb
+++ b/Formula/g/gh-manager-cli.rb
@@ -1,0 +1,20 @@
+require "language/node"
+
+class GhManagerCli < Formula
+  desc "Interactive CLI to manage GitHub repositories"
+  homepage "https://github.com/wiiiimm/gh-manager-cli"
+  url "https://registry.npmjs.org/gh-manager-cli/-/gh-manager-cli-1.12.0.tgz"
+  sha256 "3fabcb5e3c106c1a5568e13b4a1df06bd61edb9fb8606f8f8d095de686caa0ac"
+  license "MIT"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/gh-manager-cli --version")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`?
- [x] Have you run `brew audit --new-formula <formula>` (for new formulae)?
- [x] Have you run `brew test <formula>`?

This PR adds gh-manager-cli, an interactive terminal UI for managing GitHub repositories built with Ink (React for CLIs).

- **Homepage**: https://github.com/wiiiimm/gh-manager-cli
- **npm package**: https://www.npmjs.com/package/gh-manager-cli
- **Description**: Interactive CLI to manage GitHub repositories with features like sorting, filtering, archiving, and fork syncing
- **Source**: npm tarball using Language::Node standard installation
- **Dependencies**: node
- **Test**: Uses `--version` flag (no network required)

The formula has been tested locally on macOS ARM64 (Apple Silicon) and all tests pass.