### PR TITLE
openapi 1.6.1 (new formula)  (replacement for #235707)

### DIFF
--- a/Formula/o/openapi.rb
+++ b/Formula/o/openapi.rb
@@ -1,0 +1,31 @@
+class Openapi < Formula
+  desc "CLI tools for working with OpenAPI, Arazzo and Overlay specifications"
+  homepage "https://github.com/speakeasy-api/openapi"
+  url "https://github.com/speakeasy-api/openapi/archive/refs/tags/v1.6.1.tar.gz"
+  sha256 "2d1cb22b79b515ba0faefdb721b2d199f8094d76badb671ead88bd1454e76e10"
+  license "MIT"
+  head "https://github.com/speakeasy-api/openapi.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = %W[
+      -s -w
+      -X main.version=#{version}
+      -X main.commit=#{stable.specs[:revision]}
+      -X main.date=#{time.iso8601}
+    ]
+    system "go", "build", *std_go_args(ldflags:), "./cmd/openapi"
+
+    generate_completions_from_executable(bin/"openapi", "completion", shells: [:bash, :zsh, :fish, :pwsh])
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/openapi --version")
+
+    system bin/"openapi", "spec", "bootstrap", "test-api.yaml"
+    assert_path_exists testpath/"test-api.yaml"
+
+    system bin/"openapi", "spec", "validate", "test-api.yaml"
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Introduces the openapi CLI tool with extensive utilities for working with the suite of OpenAPI documents
