### PR TITLE
gdbgui: Allow formula on Apple Silicon as gdb has been fixed for Apple Silicon

### DIFF
--- a/Formula/g/gdbgui.rb
+++ b/Formula/g/gdbgui.rb
@@ -17,10 +17,6 @@ class Gdbgui < Formula
   depends_on "gdb"
   depends_on "python@3.13"
 
-  on_macos do
-    depends_on arch: :x86_64 # gdb is not supported on macOS ARM
-  end
-
   resource "bidict" do
     url "https://files.pythonhosted.org/packages/9a/6e/026678aa5a830e07cd9498a05d3e7e650a4f56a42f267a53d22bcda1bdc9/bidict-0.23.1.tar.gz"
     sha256 "03069d763bc387bbd20e7d49914e75fc4132a41937fa3405417e1a5a2d006d71"

--- a/Formula/g/gdbgui.rb
+++ b/Formula/g/gdbgui.rb
@@ -8,10 +8,14 @@ class Gdbgui < Formula
   license "GPL-3.0-only"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, sonoma:       "8ee30e8ea6b15f70c555bfa1ce141e543ff3b6a3b8294c62ab2e4a5b6e068b61"
-    sha256 cellar: :any_skip_relocation, ventura:      "87dafc3dbe6bac680988b7cf310ede086b94741642eee11a3019b90edbef9dc6"
-    sha256 cellar: :any_skip_relocation, arm64_linux:  "10051a0de1ed423302e53e70bd398568d38355a054d0f3612d846cd470eda4f6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "95cdbe6fd039a1627cae786f3c43ae904bd18b8dc7fc6f3ff607ef625c726552"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "c67e12ece8291f2f109719263e36b593859c8448f6510f95f6364e6971591818"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "5832d02a08e75cf3d21488dcbe98ce1d7349dd8e95b9a5c88e60674093f685ba"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "66a9d628b9d6ded9b1e2e1fe9c9a726f4180ea3ca161bebf24b30a6645f65c85"
+    sha256 cellar: :any_skip_relocation, sonoma:        "55cd8af0d0d7919f27dcb56708c029b06d4c47956455079d88abaa5cc0b607cf"
+    sha256 cellar: :any_skip_relocation, ventura:       "162298ba45e74b9beb055ad822bef2e6decbc68cf350857256e0d50d2e757d08"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "35cfc4af5c6f85e8c96a9f9bae239efac8cd115d8a30474214dba39b21222147"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a59d8311b899344a01c2b2fcf8b65d5fad3c38977da058fa08c85e740386caf6"
   end
 
   depends_on "gdb"


### PR DESCRIPTION
- [X] Have you followed the guidelines for contributing?
- [X] Have you ensured that your commits follow the commit style guide?
- [X] Have you checked that there aren't other open pull requests for the same formula update/change?
- [X] Have you built your formula locally with HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>, where <formula> is the name of the formula you're submitting?
- [X] Is your test running fine brew test <formula>, where <formula> is the name of the formula you're submitting?
- [X] Does your build pass brew audit --strict <formula> (after doing HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>)? If this is a new formula, does it pass brew audit --new <formula>?

-----

This change allows the gdbgui formula on Apple Silicon as gdb has been fixed for Apple Silicon as per 2025-03-13 "gdb: Add Support for Apple Silicon"
https://github.com/Homebrew/homebrew-core/commit/c8feb61a318c6be9e4f0d7ffd37cd39f2a6b753a

Thus installing gdbgui can since then work as it was just the dependency of gdb that did not support Apple Silicon.

This effectively resolves:
 https://github.com/Homebrew/homebrew-core/commit/bc7b86dd415c7b4ce55408875fc14ca07895bd91
 issue: https://github.com/Homebrew/homebrew-core/pull/202897
