### PR TITLE
liquibase 4.33.0

### DIFF
--- a/Formula/l/liquibase.rb
+++ b/Formula/l/liquibase.rb
@@ -1,10 +1,9 @@
 class Liquibase < Formula
   desc "Library for database change tracking"
   homepage "https://www.liquibase.org/"
-  url "https://github.com/liquibase/liquibase/releases/download/v4.33.0/liquibase-4.33.0.tar.gz"
+  url "https://package.liquibase.com/downloads/liquibase/homebrew/liquibase-4.33.0.tar.gz"
   sha256 "689acfcdc97bad0d4c150d1efab9c851e251b398cb3d6326f75e8aafe40ed578"
   license "Apache-2.0"
-  revision 1
 
   livecheck do
     url :stable
@@ -14,8 +13,13 @@ class Liquibase < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, all: "222519225b5374762241360ed0c6720d11f31a6b996c2df9268fe321bf7917aa"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "41c94aa6826f3ffb843e01817c8b60b79ea54e9c61536539524b8611254d2a66"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "41c94aa6826f3ffb843e01817c8b60b79ea54e9c61536539524b8611254d2a66"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "41c94aa6826f3ffb843e01817c8b60b79ea54e9c61536539524b8611254d2a66"
+    sha256 cellar: :any_skip_relocation, sonoma:        "309ba6ac0f42635065a35a15b2ea2cb996851246b0483d84266cdd9d9c3119c4"
+    sha256 cellar: :any_skip_relocation, ventura:       "309ba6ac0f42635065a35a15b2ea2cb996851246b0483d84266cdd9d9c3119c4"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "41c94aa6826f3ffb843e01817c8b60b79ea54e9c61536539524b8611254d2a66"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "41c94aa6826f3ffb843e01817c8b60b79ea54e9c61536539524b8611254d2a66"
   end
 
   depends_on "openjdk"
@@ -25,9 +29,8 @@ class Liquibase < Formula
 
     chmod 0755, "liquibase"
     libexec.install Dir["*"]
-    bash_completion.install libexec/"lib/liquibase_autocomplete.sh" => "liquibase"
-    zsh_completion.install libexec/"lib/liquibase_autocomplete.zsh" => "_liquibase"
     (bin/"liquibase").write_env_script libexec/"liquibase", Language::Java.overridable_java_home_env
+    (libexec/"lib").install_symlink Dir["#{libexec}/sdk/lib-sdk/slf4j*"]
   end
 
   def caveats


### PR DESCRIPTION
Switch to the canonical package URL (package.liquibase.com) for fetching Liquibase. Checksum verification and extraction remain unchanged. No functional impact—this simplifies maintenance and decouples the build from the storage backend.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
