### PR TITLE
ola: configure `olad` service

### DIFF
--- a/Formula/o/ola.rb
+++ b/Formula/o/ola.rb
@@ -29,14 +29,14 @@ class Ola < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    rebuild 1
-    sha256 arm64_sequoia: "bdec6e474a18de3b6d3198aea33920245d9cdabf285bc142b32aafe9a8cd5136"
-    sha256 arm64_sonoma:  "829075716571a9a9bc79c32acee60c5076124e45cf71f22e2110ecefdea74abf"
-    sha256 arm64_ventura: "72a52c9caa891e0e3aa3930f959cf916346d4cbae64abb90d196c338e3b47e29"
-    sha256 sonoma:        "e3a4b0c61c37bcde928fe415fdca94012a61556a47e124842854d1294602c59d"
-    sha256 ventura:       "020535a83d5460524762376c07abd7ac134038f98aead9a63e3c7bdf027b9b71"
-    sha256 arm64_linux:   "afce51d43cc1453c7817aa23a03bf1a90474f682c02c3acea3d1f9c0a8d05091"
-    sha256 x86_64_linux:  "e6404fe986a8605c602a8ad71e19d18a1b8b6ef1bb8c2777295e4d5ac6c12b5d"
+    rebuild 2
+    sha256 arm64_sequoia: "e08cca281744a9ee02b1bfab2f43780807554161d697cfcbf7347b6cdea46f5a"
+    sha256 arm64_sonoma:  "e9f96d87630dc84650379d40e00f7901d6731697b25c6c39991596b5bcadad22"
+    sha256 arm64_ventura: "f8adebde6f2232138e3faf9c7579fba0686c110a75072045c2649f9a40c6e891"
+    sha256 sonoma:        "8ac5181277efbffddb99aa610ddf04631980b5ce7a8fc9bf7b306cfdc02d3422"
+    sha256 ventura:       "6acb4afec8d1583f4dcbb18594ad6178d998f1b5ff6d896b27279bc45a8dbffa"
+    sha256 arm64_linux:   "cc14cca06cfe7361c8b82d08ab9cfb09c42122e368c2f7f2a242dd51585acfd1"
+    sha256 x86_64_linux:  "c32035f4142cd45079be9e508e0afccc5ed2bf7669b29e403342ff090f968f69"
   end
 
   head do

--- a/Formula/o/ola.rb
+++ b/Formula/o/ola.rb
@@ -166,6 +166,11 @@ class Ola < Formula
     EOS
   end
 
+  service do
+    run [opt_bin/"olad", "--no-http-quit"]
+    error_log_path var/"log/olad.log"
+  end
+
   test do
     ENV.prepend_path "PYTHONPATH", extra_python_path
     system bin/"ola_plugin_state", "-h"


### PR DESCRIPTION
Configures the `olad` service that comes with the `ola` formula.

Logging is by default done to `stderr`, thus only `error_log_path` is needed. The default log level is _Warnings_.

The `olad` comes with an HTTP interface. It has a feature for exiting the service by means of making a GET request to the `/quit` path. This results in the `stopped` state for brew, requiring manual intervention using `brew services stop ola` before it can be (re)started. The feature is disabled using the command line argument `--no-http-quit`.

Reference documentation for command line arguments: https://docs.openlighting.org/ola/man/man1/olad.1.html

-----

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
