### PR TITLE
xeol: test EOL database status

### DIFF
--- a/Formula/x/xeol.rb
+++ b/Formula/x/xeol.rb
@@ -38,7 +38,13 @@ class Xeol < Formula
   test do
     assert_match version.to_s, shell_output("#{bin}/xeol version")
 
-    output = shell_output("#{bin}/xeol alpine:latest")
+    output = shell_output("#{bin}/xeol db update 2>&1")
+    assert_match "EOL database updated to latest version!", output
+
+    output = shell_output("#{bin}/xeol db status 2>&1")
+    assert_match "Status:    valid", output
+
+    output = shell_output("#{bin}/xeol alpine:latest 2>&1")
     assert_match "no EOL software has been found", output
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Test after failure in
* https://github.com/Homebrew/homebrew-core/pull/226636

Reported upstream:
* https://github.com/xeol-io/xeol/issues/568