### PR TITLE
octave scipy: remove `cxxstdlib_check`

### DIFF
--- a/Formula/o/octave.rb
+++ b/Formula/o/octave.rb
@@ -79,9 +79,6 @@ class Octave < Formula
     depends_on "mesa-glu"
   end
 
-  # Dependencies use Fortran, leading to spurious messages about GCC
-  cxxstdlib_check :skip
-
   def install
     system "./bootstrap" if build.head?
     args = [

--- a/Formula/s/scipy.rb
+++ b/Formula/s/scipy.rb
@@ -30,8 +30,6 @@ class Scipy < Formula
     depends_on "patchelf" => :build
   end
 
-  cxxstdlib_check :skip
-
   def pythons
     deps.map(&:to_formula)
         .select { |f| f.name.start_with?("python@") }


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Testing if we can remove this as it doesn't seem to do anything since https://github.com/Homebrew/brew/commit/04abc51d1f2c8b0ab35bfd340afe5414925b7ac8