### PR TITLE
ncmpcpp: replace Boost 1.89 workaround with upstreamed patch

### DIFF
--- a/Formula/n/ncmpcpp.rb
+++ b/Formula/n/ncmpcpp.rb
@@ -32,11 +32,15 @@ class Ncmpcpp < Formula
 
   uses_from_macos "curl"
 
-  def install
-    # Workaround for Boost 1.89.0 until fixed upstream.
-    # Issue ref: https://github.com/ncmpcpp/ncmpcpp/issues/633
-    ENV["boost_cv_lib_system"] = "yes"
+  # Apply open PR to fix build with Boost 1.89.0.
+  # PR ref: https://github.com/ncmpcpp/ncmpcpp/pull/636
+  # Issue ref: https://github.com/ncmpcpp/ncmpcpp/issues/633
+  patch do
+    url "https://github.com/ncmpcpp/ncmpcpp/commit/f67d350aa9beb2abdd12c429e97ae919e5b3102c.patch?full_index=1"
+    sha256 "7fa67adf722fec69793f9aa53398195294402bb09519e7bd99b388b7f99a5e59"
+  end
 
+  def install
     ENV.append "LDFLAGS", "-liconv" if OS.mac?
     ENV.prepend "LDFLAGS", "-L#{Formula["readline"].opt_lib}"
     ENV.prepend "CPPFLAGS", "-I#{Formula["readline"].opt_include}"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Replacing my workaround with upstreamed patch.