### PR TITLE
opencv: use `4.x` as default branch for head build

### DIFF
--- a/Formula/o/opencv.rb
+++ b/Formula/o/opencv.rb
@@ -40,10 +40,10 @@ class Opencv < Formula
   end
 
   head do
-    url "https://github.com/opencv/opencv.git", branch: "master"
+    url "https://github.com/opencv/opencv.git", branch: "4.x"
 
     resource "contrib" do
-      url "https://github.com/opencv/opencv_contrib.git", branch: "master"
+      url "https://github.com/opencv/opencv_contrib.git", branch: "4.x"
     end
   end
 

--- a/audit_exceptions/head_non_default_branch_allowlist.json
+++ b/audit_exceptions/head_non_default_branch_allowlist.json
@@ -4,6 +4,5 @@
   "libngspice": "master",
   "ngspice": "master",
   "sdl2": "SDL2",
-  "squid": "v6",
-  "opencv": "master"
+  "squid": "v6"
 }


### PR DESCRIPTION
opencv: use `4.x` as default branch for head build

---

followup https://github.com/Homebrew/homebrew-core/pull/235985