### PR TITLE
dysk: no longer linux-only

### DIFF
--- a/Formula/d/dysk.rb
+++ b/Formula/d/dysk.rb
@@ -7,8 +7,14 @@ class Dysk < Formula
   head "https://github.com/Canop/dysk.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_linux:  "cb4dbe53d55835f0c424093e5cae7ce5dad518ea2b0ab985f7cb2dda482f3f7a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "6ffd24f271b68440a0073e8c722c3110864a60e3101bf9c616184dbb240a3e8a"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "69a722cf0f7880bff7c8a4eca3e7f548ca41e19698cba2a74ccee9b6a7f46e4d"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "2d4c4933d05dca6f4f754772b515ca38ee3871f626437a8ec59c0f4619138df7"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "f45d5c56bc93ca60b8b5020aaeb7629dcee9769fb6537b8acdc67f2ee4bbfe8a"
+    sha256 cellar: :any_skip_relocation, sonoma:        "25b57d97916d4dd66fd5074cfb1a782ee5627b8356299566f348ab4be0632c02"
+    sha256 cellar: :any_skip_relocation, ventura:       "5cf1ee234654544f941a84fe880427e1db26d2d1a9337704eb05c8ae008c5eca"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "e07f4e51836f75c1270a082e6e3ccdc3ec3f410797e6ca0469486d8834292d41"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "06ab30e421110c934b66a51778c2df4522e6ba89f25d98f5bd5b7148e28dd3a6"
   end
 
   depends_on "rust" => :build

--- a/Formula/d/dysk.rb
+++ b/Formula/d/dysk.rb
@@ -12,7 +12,6 @@ class Dysk < Formula
   end
 
   depends_on "rust" => :build
-  depends_on :linux
 
   def install
     system "cargo", "install", *std_cargo_args


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
-----

As of 3.0.0, dysk now also works on macOS.