### PR TITLE
bsc: backport TCL 9 support

### DIFF
--- a/Formula/b/bsc.rb
+++ b/Formula/b/bsc.rb
@@ -23,14 +23,13 @@ class Bsc < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "ba525929310367c18e193ffb95e0becc4d9ee009ab746286edf3815db231e5d0"
-    sha256 cellar: :any,                 arm64_sequoia: "023b416fedba9f986345a7b06763995b843fedf2fc45d0428d0f6410fedb8b12"
-    sha256 cellar: :any,                 arm64_sonoma:  "bb8dea8de8ae93ed8c76cbb488ea19645acc76e8aebc3560063024fa381c026a"
-    sha256 cellar: :any,                 arm64_ventura: "5fa279ba7f86d9b0fff2ab75b8d8890b852764e67baeebbcd0125b8c7239825a"
-    sha256 cellar: :any,                 sonoma:        "c8959d3244856dc6562bea2cd1f06ff782195bde78363b1a8dd104176ec6c5f9"
-    sha256 cellar: :any,                 ventura:       "9b975bff3f3232bd26626bc308ccba6d24d433575c88c0b72af4a17059ce4d36"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "de1d37f49533298da63ccbbff21907afbc8952df0ef6ef5d5553a2b720939ae1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "14fba2d067b4da9b16420abf741db79db7eb696f9ff25f629dd205af07409a93"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "7073b1c25d1eaa4e1a03a1bca4671e1d9d5ccdb815cb7271569beb25bbabc9d3"
+    sha256 cellar: :any,                 arm64_sequoia: "028d70a33adfee0459fe3b1e86925ee54496b7e9f3ac58d9d4cc1eab1895724a"
+    sha256 cellar: :any,                 arm64_sonoma:  "398571c528bbc22cf0712375da5568afe655c0822457947036f70f4bf6af7014"
+    sha256 cellar: :any,                 sonoma:        "dea530b42317ecab706119b9a802a9b58d7b9765ec150c3627dc17dbcfcf7150"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "1b7c2c627c3a0d89cb4b3718ef7c9dc90ba7b6ad127537773c2f70f172736c4b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "996a523fc7fd725f0630cd44eb71cc3a0e35b5e0cf71285372077a4c436f5998"
   end
 
   depends_on "autoconf" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Looks like this uses system TCL on macOS - https://github.com/B-Lang-org/bsc/blob/main/platform.sh#L81-L86