### PR TITLE
openldap: use macOS cyrus-sasl to avoid mixing versions

### DIFF
--- a/Formula/o/openldap.rb
+++ b/Formula/o/openldap.rb
@@ -25,10 +25,10 @@ class Openldap < Formula
 
   keg_only :provided_by_macos
 
-  depends_on "cyrus-sasl"
   depends_on "openssl@3"
 
   uses_from_macos "mandoc" => :build
+  uses_from_macos "cyrus-sasl"
 
   on_linux do
     depends_on "util-linux"

--- a/Formula/o/openldap.rb
+++ b/Formula/o/openldap.rb
@@ -14,13 +14,14 @@ class Openldap < Formula
   end
 
   bottle do
-    sha256 arm64_sequoia: "a1dc03b12f5d087bf8eca0c017483a45548a88ad62e27e0c0efe499f19cf57ff"
-    sha256 arm64_sonoma:  "fc1c7897033c6869b7bcc0e9e7589c7e2dc1bcda9f1939bc571f6afc9586b97f"
-    sha256 arm64_ventura: "2940262081277489fbb0b6187269efb4dca69ad6000b1793ce2e67a8fcce5513"
-    sha256 sonoma:        "6360ceeaf23775210ee3c9f739ff8d7b3cd83b2dfce7bf7ae4cd69065b3ec544"
-    sha256 ventura:       "f3da0ae98808e034485d22f56185b01715e544387d6d5a61df4f7cd4dadb2930"
-    sha256 arm64_linux:   "56958d2700c221fd98383fc04078a18e3f9b28afae795c2b15b0cb5fcba10b62"
-    sha256 x86_64_linux:  "79ace347f02583cfe9e64e4e28b96a965b5b4a96d98db2ce0d746be4ad5da3b9"
+    rebuild 1
+    sha256 arm64_sequoia: "248a79f1498bbff0644cb1980d1efabf399d71f4251df230b7e6161d14482309"
+    sha256 arm64_sonoma:  "e1e547e9f5a91f21715853710892d69d0356947128b15a9ae16c7b69b2c8222c"
+    sha256 arm64_ventura: "bacfcb76abf64fb280a1e845abc7ef842aa8ddaafb3c7b1a4b68e7e9cd66161d"
+    sha256 sonoma:        "8845255968f6ce00273b24b4ec963913900cd33179ee6a5b8e29b887f84364bd"
+    sha256 ventura:       "77370c7be27839f6b1c67b6594ede02919dafe3ce30760eddd033b382b38785c"
+    sha256 arm64_linux:   "d6aa23170013b357b634255d980bf589fc5104f38536e99a524ffbdd20dd17e7"
+    sha256 x86_64_linux:  "6593c993b1e061f4f5bd11a3a0a98cdb64244d35a12d0787797daaaa9ea4cb47"
   end
 
   keg_only :provided_by_macos

--- a/Formula/p/percona-server@8.0.rb
+++ b/Formula/p/percona-server@8.0.rb
@@ -23,13 +23,13 @@ class PerconaServerAT80 < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 arm64_sequoia: "d8df21ad76f4ddbdc8ee644760d831924c90c00abb21c24a2c26303b0ac1bf32"
-    sha256 arm64_sonoma:  "690b006463e92d616234415e230cdaf6e293ea0e765bc538463eb30bdea32c50"
-    sha256 arm64_ventura: "b02ed11fca9afd5765fe6e33373d63b48671b7ba0c7fb2059419931cbb5e71e3"
-    sha256 sonoma:        "22888edc54ae46453c3551eb977608d22fea2a693f4c8a1ba70bf22b92a2e8e6"
-    sha256 ventura:       "0f0895e5f979043bd0a804e65ac631cbdf3fa234025374f84375d83d3566892d"
-    sha256 arm64_linux:   "312611e2585a8048685bb7808ddf13cddc64c5fb1dcba3f901d6d0c0971ae531"
-    sha256 x86_64_linux:  "6f3e36a2588494df0da6d4e421530974f1387fc4777efaada067df4a342475a6"
+    sha256 arm64_sequoia: "3eed8303b8842a9387d698b7e28b7fed5030a0f26d1ef48fbd1c2db998dc3e78"
+    sha256 arm64_sonoma:  "efe604f23093e3b617ecfb843c9b1eef30dfcd9cdbb56807f759a2bc711ab23c"
+    sha256 arm64_ventura: "3f6e7796a2836f1acae4f19d146c89e81d84b1fa2b373136742408f9f580084d"
+    sha256 sonoma:        "58c116fa49bc7467eae2b13513aa9e409ed3e3e2157f1f4f2341a8ec06f20b65"
+    sha256 ventura:       "203d62185a91e5cd10b59dc78e06626050b81304e95834208350afdaa180cf14"
+    sha256 arm64_linux:   "572e1744e47cc0d2838b056cc0a90c848c8b37582edcfb222bb258a7fb5f0dd5"
+    sha256 x86_64_linux:  "7dabd8dc9a0414296a8363912968b0f61f89fe05e023dd3c543e1c0a2e003bf3"
   end
 
   keg_only :versioned_formula

--- a/Formula/p/percona-server@8.0.rb
+++ b/Formula/p/percona-server@8.0.rb
@@ -4,6 +4,7 @@ class PerconaServerAT80 < Formula
   url "https://downloads.percona.com/downloads/Percona-Server-8.0/Percona-Server-8.0.43-34/source/tarball/percona-server-8.0.43-34.tar.gz"
   sha256 "4469b5e3873559f366eb632c7c231e01aa700c1b9c13cce869085dbe1ec9203e"
   license "BSD-3-Clause"
+  revision 1
 
   livecheck do
     url "https://www.percona.com/products-api.php", post_form: {


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Added in 
- #234674

But we usually don't use brew `cyrus-sasl` on macOS. Previously 0 usage:
```console
❯ brew uses cyrus-sasl --eval-all | wc -l
       1
❯ brew uses cyrus-sasl --eval-all
openldap
```

`percona-server` is one example where 2 different SASL are in dependency tree which may cause problems.