### PR TITLE
keepassc: remove redundant manpage installation

### DIFF
--- a/Formula/k/keepassc.rb
+++ b/Formula/k/keepassc.rb
@@ -33,7 +33,6 @@ class Keepassc < Formula
 
   def install
     virtualenv_install_with_resources
-    man1.install_symlink libexec.glob("share/man/man1/*.1")
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

These are already installed in the venv [at `share/man/man1/`](https://github.com/raymontag/keepassc/blob/1.8.2/setup.py#L23) and thus linked by [`virtualenv_install_with_resources`](https://github.com/Homebrew/brew/blob/9219495eb0a66e7559a03759d6c859148c19c617/Library/Homebrew/language/python.rb#L440-L444)
