### PR TITLE
intltool: make expat indirect dependency

### DIFF
--- a/Formula/i/intltool.rb
+++ b/Formula/i/intltool.rb
@@ -24,7 +24,6 @@ class Intltool < Formula
   uses_from_macos "perl"
 
   on_linux do
-    depends_on "expat"
     depends_on "perl-xml-parser"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Linux repositories specify this as indirect dependency via `perl-xml-parser`:
- https://archlinux.org/packages/extra/any/intltool/
- https://packages.debian.org/sid/intltool