### PR TITLE
formulae: use brew `tcl-tk`

### DIFF
--- a/Formula/g/gensio.rb
+++ b/Formula/g/gensio.rb
@@ -22,8 +22,7 @@ class Gensio < Formula
   depends_on "glib"
   depends_on "openssl@3"
   depends_on "python@3.13"
-
-  uses_from_macos "tcl-tk"
+  depends_on "tcl-tk"
 
   on_macos do
     depends_on "gettext"
@@ -42,13 +41,15 @@ class Gensio < Formula
   end
 
   def install
+    tcltk = Formula["tcl-tk"]
     args = %W[
       --disable-silent-rules
       --with-python=#{which(python3)}
       --with-pythoninstall=#{lib}/gensio-python
+      --with-tclcflags=-I#{tcltk.opt_include}/tcl-tk
+      --with-tcllibs=-ltcl#{tcltk.version.major_minor}
       --sysconfdir=#{etc}
     ]
-    args << "--with-tclcflags=-I#{HOMEBREW_PREFIX}/include/tcl-tk" if OS.linux?
 
     system "./configure", *args, *std_configure_args
     system "make", "install"

--- a/Formula/g/gensio.rb
+++ b/Formula/g/gensio.rb
@@ -6,13 +6,14 @@ class Gensio < Formula
   license all_of: ["LGPL-2.1-only", "GPL-2.0-only", "Apache-2.0"]
 
   bottle do
-    sha256 arm64_sequoia: "55f26f4519d626685977d8698f239dd144b28d5dff6f2bd08182335f6026af4d"
-    sha256 arm64_sonoma:  "a26e4a132a4f4099ce49f56c17b7c24f0e509a9e944ef54634151b10c02657dc"
-    sha256 arm64_ventura: "e2a24dac5ea15c6235327c5028e8ed34e59e09c64e35830e1f7f4b699c3e5987"
-    sha256 sonoma:        "74eced1fc82f3d172aee5eef3194d8e5e401f160fd1554c85c3352f6bf305ecf"
-    sha256 ventura:       "f76906e1351966419ed1617b3cba3fa43ab37f1b9dd4d4dc2547f15604336325"
-    sha256 arm64_linux:   "7849c953dc4d197d70ecc835d47b25e7de0f0cd51a2b02b163570ab79fbe0dcd"
-    sha256 x86_64_linux:  "f0654ac13d972321059009c5d0b971b3c7a7206239bc6db5045125e0a04b283e"
+    rebuild 1
+    sha256 arm64_sequoia: "f457b2ff887d4185b42cdbc10d84add3917d22ca11fae4e1ee20a2ada1e9521c"
+    sha256 arm64_sonoma:  "96b46ed061f5e25c0c311f12d382d0a23b4122ac01fbe0bf3f0a75d30271c24e"
+    sha256 arm64_ventura: "49728197d847378132c23682ab2de37655f4b4839f350ef761377d78aa98f72c"
+    sha256 sonoma:        "2d0c0744dbe3bccca04aa55874165036386436b400aac7a9f008d62780f3e0a3"
+    sha256 ventura:       "d84654ff3a63796d51f6cc4ce1dcb5029f12a66f6d246f111ac6e0db533d009d"
+    sha256 arm64_linux:   "1516dd344ba741c695f5f8294ae74022e0206eda6e5aa5a869ba005630977fcc"
+    sha256 x86_64_linux:  "9b133b00d37f8aa4ddf4c924f67f39444d16e6def67fcdbb010f7ae49d015dd2"
   end
 
   depends_on "go" => :build

--- a/Formula/l/lmod.rb
+++ b/Formula/l/lmod.rb
@@ -18,10 +18,10 @@ class Lmod < Formula
   depends_on "luarocks" => :build
   depends_on "pkgconf" => :build
   depends_on "lua"
+  depends_on "tcl-tk"
 
   uses_from_macos "bc" => :build
   uses_from_macos "libxcrypt"
-  uses_from_macos "tcl-tk"
 
   on_macos do
     depends_on "gnu-sed" => :build
@@ -56,14 +56,8 @@ class Lmod < Formula
       end
     end
 
-    # pkgconf cannot find tcl-tk on Linux correctly, so we manually set the include and libs
-    if OS.linux?
-      tcltk_version = Formula["tcl-tk"].version.major_minor
-      ENV["TCL_INCLUDE"] = "-I#{Formula["tcl-tk"].opt_include}/tcl-tk"
-      ENV["TCL_LIBS"] = "-L#{Formula["tcl-tk"].opt_lib} -ltcl#{tcltk_version} -ltclstub"
-      # Homebrew installed tcl-tk library has major_minor version suffix
-      inreplace "configure", "'' tcl tcl8.8 tcl8.7 tcl8.6 tcl8.5", "'' tcl#{tcltk_version}"
-    end
+    # configure overrides PKG_CONFIG_PATH with TCL_PKG_CONFIG_DIR value
+    ENV["TCL_PKG_CONFIG_DIR"] = ENV["PKG_CONFIG_PATH"]
 
     system "./configure", "--with-siteControlPrefix=yes", "--prefix=#{prefix}"
     system "make", "install"

--- a/Formula/l/lmod.rb
+++ b/Formula/l/lmod.rb
@@ -6,13 +6,14 @@ class Lmod < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "9b164d43ee500e18db4a6825c4fda3afcec4a2f4853c86b297c7194682060453"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "8a9c22f9aed882d9afe5c908ce9e470816b53c196fb9f540120dcffad65f7acf"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "03d9898710ed5f2b0685e3af511a8cd34096c184ee6e186f0c71386954daf764"
-    sha256 cellar: :any_skip_relocation, sonoma:        "3a5c1a0da19418f9ebb35ab2f0ebd16e540159049d3cb65e04e899e3467f184d"
-    sha256 cellar: :any_skip_relocation, ventura:       "5daf6eedb6fb9d6a9bbb38b748a89804a5d2ae240f52b4653d3ede867e740339"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "4dcc3fdada7572417c6af563f9ed6c59a98d505f15c1e573d0435e6470fc5966"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "ae7591aac670b9ea9e60e47aa0b663f63dd35378298f41753b4fe46e57f0dd35"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "025d09bbc64a285b582e8ae3a1f1dc1dc029a5e83e9a100dbc2bb6a83695f422"
+    sha256 cellar: :any,                 arm64_sonoma:  "dae512dba1cb2c26c1e5e07b046a581eb651e02aa92bb1c101e4fcbad1bb7c6d"
+    sha256 cellar: :any,                 arm64_ventura: "7e7a83d356066fe87d3798607691016c45966c2debae433677141af6c9f83517"
+    sha256 cellar: :any,                 sonoma:        "6192004664e5475b60f9a14a12b9012cb42777275d6aa7df8076f69cce8d9f2a"
+    sha256 cellar: :any,                 ventura:       "76b8f0313de66fd290caa09032f9d28e2561320fafa35c1134c70fe2bfbd3248"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "d0ea4d91ccfb9d5bd3d8f357566100a9dff646b50ea67fd1a11805005eef58bd"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3772266e5febfe4581baec559e0128755c09144595290265c5b7ef034aac543e"
   end
 
   depends_on "luarocks" => :build

--- a/Formula/s/sqlite-analyzer.rb
+++ b/Formula/s/sqlite-analyzer.rb
@@ -13,14 +13,14 @@ class SqliteAnalyzer < Formula
   no_autobump! because: :incompatible_version_format
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "9e8f648f174b1c820f49e926b0b72232ea62753c13c7ed3b399940435bee7dc4"
-    sha256 cellar: :any,                 arm64_sonoma:  "c082ffe72e06051e9643e26936e640466836992fc3dd27608e23e570fe5e0151"
-    sha256 cellar: :any,                 arm64_ventura: "29be04dc1dbc47c0f16c96765389d9dd81530bd1c17b27a05058ee1aec254024"
-    sha256 cellar: :any,                 sequoia:       "dd57fd9f41ef2bfe9e21f7f00185a818b45c03f4b84e42e7b3b3378b6b046e11"
-    sha256 cellar: :any,                 sonoma:        "4ea08b67282f32d4e657301b6d0fdfcf50acd3ee2b3406a4ec783c847a113cdd"
-    sha256 cellar: :any,                 ventura:       "91030d1ca9685939bc35f65fb7ab65d5c34655b3cba243eb32c4b3a1a80880d8"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "cc80e06640fead3520cf6623e6385bdf7065defce848d8c983c7e06b4c625d03"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "84bb4ebf263f3e396a44870a6510a14688f203927f196199d81e72c00e66e0d5"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "983c929529debfa69afd99dc23a7025dbe681a100fafa0f20c08ef3b144310cb"
+    sha256 cellar: :any,                 arm64_sonoma:  "8c6c0770b134f712086b1fc259c469428b2cb214a11737d1ed7b46acec77bbf7"
+    sha256 cellar: :any,                 arm64_ventura: "2a4457aa0b6bd51662221422b09993d9a9adf6d8d5d6a8ca8d066820b6734ae1"
+    sha256 cellar: :any,                 sonoma:        "9ea7789c685af83f51e33619c920b963605cb39dbbb8f872b135fad0b32122ec"
+    sha256 cellar: :any,                 ventura:       "b76902ea0ea66727d276c099b81003714783bf48fa4535cf12bd2200dcca0b5b"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "ec05b4e264b7c5477bf2daa0f9b860d04548699383f231eef61816472cc937b3"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "69276f619b21ed65f21da3db17842b02c0355b0e05a3db2bc8119001cb673122"
   end
 
   depends_on "tcl-tk"

--- a/Formula/s/sqlite-analyzer.rb
+++ b/Formula/s/sqlite-analyzer.rb
@@ -23,19 +23,15 @@ class SqliteAnalyzer < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "84bb4ebf263f3e396a44870a6510a14688f203927f196199d81e72c00e66e0d5"
   end
 
+  depends_on "tcl-tk"
   uses_from_macos "sqlite" => :test
-  uses_from_macos "tcl-tk"
+
+  on_macos do
+    depends_on "libtommath"
+  end
 
   def install
-    tcl = if OS.mac?
-      MacOS.sdk_path/"System/Library/Frameworks/Tcl.framework"
-    else
-      Formula["tcl-tk"].opt_lib
-    end
-
-    system "./configure", "--disable-debug",
-                          "--with-tcl=#{tcl}",
-                          "--prefix=#{prefix}"
+    system "./configure", "--with-tcl=#{Formula["tcl-tk"].opt_lib}", *std_configure_args
     system "make", "sqlite3_analyzer"
     bin.install "sqlite3_analyzer"
   end

--- a/Formula/w/weechat.rb
+++ b/Formula/w/weechat.rb
@@ -29,10 +29,10 @@ class Weechat < Formula
   depends_on "perl"
   depends_on "python@3.13"
   depends_on "ruby"
+  depends_on "tcl-tk"
   depends_on "zstd"
 
   uses_from_macos "curl"
-  uses_from_macos "tcl-tk"
   uses_from_macos "zlib"
 
   on_macos do
@@ -41,18 +41,18 @@ class Weechat < Formula
   end
 
   def install
+    tcltk = Formula["tcl-tk"]
     args = %W[
       -DENABLE_MAN=ON
       -DENABLE_GUILE=OFF
       -DCA_FILE=#{Formula["gnutls"].pkgetc}/cert.pem
       -DENABLE_JAVASCRIPT=OFF
       -DENABLE_PHP=OFF
+      -DTCL_INCLUDE_PATH=#{tcltk.opt_include}/tcl-tk
+      -DTCL_LIBRARY=#{tcltk.opt_lib/shared_library("libtcl#{tcltk.version.major_minor}")}
+      -DTK_INCLUDE_PATH=#{tcltk.opt_include}/tcl-tk
+      -DTK_LIBRARY=#{tcltk.opt_lib/shared_library("libtcl#{tcltk.version.major}tk#{tcltk.version.major_minor}")}
     ]
-
-    if OS.linux?
-      args << "-DTCL_INCLUDE_PATH=#{Formula["tcl-tk"].opt_include}/tcl-tk"
-      args << "-DTK_INCLUDE_PATH=#{Formula["tcl-tk"].opt_include}/tcl-tk"
-    end
 
     system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
     system "cmake", "--build", "build"

--- a/Formula/w/weechat.rb
+++ b/Formula/w/weechat.rb
@@ -7,13 +7,14 @@ class Weechat < Formula
   head "https://github.com/weechat/weechat.git", branch: "main"
 
   bottle do
-    sha256 arm64_sequoia: "cc4e5e1bf923e7661a853e31f11ee85bdd34f18c52dc58fb930078ecd92f0101"
-    sha256 arm64_sonoma:  "97d570fc05deee3831ee139a1b6c1d41160e9379b235d4f10eaaaaf18c043632"
-    sha256 arm64_ventura: "8bbb387e517c2515170dc58c490a405607bb176c96444a61e692f5ab5d457adb"
-    sha256 sonoma:        "9cfa39417c7dc72603d6441222302f62bde372ba7159ba804ca5258daad59224"
-    sha256 ventura:       "8fe8019d2bc46c6513b11f6135acbc6b861f3460973fc165a86f2fb9c1fd617d"
-    sha256 arm64_linux:   "50332a7573a9ea88d10b5447d599b0e03d584727bbda5e6d7c9e9363660cc81f"
-    sha256 x86_64_linux:  "1072c047689580fe404dae14f28c0bbe0d32dd08fe5d40ad76c2b8b0cc4468c0"
+    rebuild 1
+    sha256 arm64_sequoia: "49b2099f0a1e8a5e1e0956d2f12091b1795501ecaaf566c60434ea37f7af67d0"
+    sha256 arm64_sonoma:  "f71b979b629e34ab7ed293804d603a38f1655684c74b8aacf7ee1db8f3e2ca14"
+    sha256 arm64_ventura: "71284c1d91c338d6b7260c4f06357fe25da1422d4861a335a2238e1df9dd55ef"
+    sha256 sonoma:        "6ff2ebd94b1c5bea8605da2365e9ff974daa36aad3e58146b43eb2c182f9e156"
+    sha256 ventura:       "531a5daea68fdc0dd410737affe69b03642071f1ebfddea578018a0ac2d766aa"
+    sha256 arm64_linux:   "49a72bb5ba4b5344db4c4cdabe7b4f15d5370a1e506481271065b26526e74bee"
+    sha256 x86_64_linux:  "e69a378a9363872ac7f63fd65c909394493286ee770207741b86415352349ac8"
   end
 
   depends_on "asciidoctor" => :build

--- a/Formula/y/yosys.rb
+++ b/Formula/y/yosys.rb
@@ -7,13 +7,14 @@ class Yosys < Formula
   head "https://github.com/YosysHQ/yosys.git", branch: "main"
 
   bottle do
-    sha256 arm64_sequoia: "33f7b02c67d9f1cfe91f13702d3404a5d9b6f55bed1c2fddb51bccd87bac5af9"
-    sha256 arm64_sonoma:  "c19a16733b085d014f30a259db52bacf1344d5cbd274e918e0febdd0da8427af"
-    sha256 arm64_ventura: "4b5329d0ee1c92bc16aeea600b566b9586e4e37f214eeb252916629052aab3fa"
-    sha256 sonoma:        "d1485783574a4736647e675f6c59ea4bf0fa0816377fae64a2093260491b34bf"
-    sha256 ventura:       "32818da322b5a9fb9e220f8a71f79fb5d942abe93b1c75c92ed343ba2cc98be7"
-    sha256 arm64_linux:   "f6bbc6913e93dcb3446c6238348fbf52b35f2ee0169b923feb276b9f85f22186"
-    sha256 x86_64_linux:  "e781387b0b2c8ae49077ce07d0d12cbab593c58e9d5465f7bf555609926ff73f"
+    rebuild 1
+    sha256 arm64_sequoia: "0fbba5b942612395e4515a3cc8fc66532f954c6873538362094d3c249b1d1353"
+    sha256 arm64_sonoma:  "96c88c062cddb7dcf27305120030f0eba4c4163d02ed939c68e0764f5cc95fca"
+    sha256 arm64_ventura: "0f39a258ef3bbab82f71f2dd1f699e71c4fcfaf1a4df4ffc352ac69e52a5deea"
+    sha256 sonoma:        "57660b57cfbf67d94c1f775470f1e6a8ed4d13e143ca7615454a28c2bb2241c4"
+    sha256 ventura:       "8b257260ddc652a20272b4885e79875b4f674811df993085e8023ec960be3b4f"
+    sha256 arm64_linux:   "7c782b74b00f9ae2a354244609a478fcf0f3dc2059617975ba225524ba3fa89f"
+    sha256 x86_64_linux:  "95e0144c88ee718da54c6de5f79f91f9566945352967ef75eb9bc60b879512dc"
   end
 
   depends_on "bison" => :build

--- a/Formula/y/yosys.rb
+++ b/Formula/y/yosys.rb
@@ -18,17 +18,14 @@ class Yosys < Formula
 
   depends_on "bison" => :build
   depends_on "pkgconf" => :build
+  depends_on "libtommath"
   depends_on "readline"
+  depends_on "tcl-tk"
 
   uses_from_macos "flex"
   uses_from_macos "libffi", since: :catalina
   uses_from_macos "python"
-  uses_from_macos "tcl-tk"
   uses_from_macos "zlib"
-
-  on_linux do
-    depends_on "libtommath"
-  end
 
   def install
     ENV.append "LINKFLAGS", "-L#{Formula["readline"].opt_lib}"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Try switching to brew `tcl-tk`. Related to discussion in #236366 and Apple deprecated/planned-removal status of system Tcl.