### PR TITLE
vtk: remove `tcl-tk` as not feature not enabled

### DIFF
--- a/Formula/v/vtk.rb
+++ b/Formula/v/vtk.rb
@@ -43,7 +43,6 @@ class Vtk < Formula
 
   uses_from_macos "expat"
   uses_from_macos "libxml2"
-  uses_from_macos "tcl-tk"
   uses_from_macos "zlib"
 
   on_linux do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

No linkage:
- https://github.com/Homebrew/homebrew-core/actions/runs/17332290756/job/49241148708#step:4:173
- https://github.com/Homebrew/homebrew-core/actions/runs/17332290756/job/49241148669#step:5:178

`VTK_USE_TK` is OFF by default - https://github.com/Kitware/VTK/blob/v9.5.1/CMake/vtkWrapSettings.cmake#L46