### PR TITLE
open-ocd: add missing jimtcl build dependency for head build

### DIFF
--- a/Formula/o/open-ocd.rb
+++ b/Formula/o/open-ocd.rb
@@ -32,6 +32,7 @@ class OpenOcd < Formula
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build
+    depends_on "jimtcl" => :build
     depends_on "libtool" => :build
     depends_on "texinfo" => :build
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
There's no existing brew test, but this is just a dependency bugfix