### PR TITLE
gcc libgccjit: remove `cxxstdlib_check`

### DIFF
--- a/Formula/g/gcc.rb
+++ b/Formula/g/gcc.rb
@@ -61,9 +61,6 @@ class Gcc < Formula
     depends_on "binutils"
   end
 
-  # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
-  cxxstdlib_check :skip
-
   def version_suffix
     if build.head?
       "HEAD"

--- a/Formula/lib/libgccjit.rb
+++ b/Formula/lib/libgccjit.rb
@@ -56,9 +56,6 @@ class Libgccjit < Formula
     end
   end
 
-  # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
-  cxxstdlib_check :skip
-
   def install
     # GCC will suffer build errors if forced to use a particular linker.
     ENV.delete "LD"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Testing if we can remove this as it doesn't seem to do anything since https://github.com/Homebrew/brew/commit/04abc51d1f2c8b0ab35bfd340afe5414925b7ac8

If it works, can handle versioned GCC in syntax only PR.