### PR TITLE
formulae: remove linux-headers dep

### DIFF
--- a/Formula/a/atop.rb
+++ b/Formula/a/atop.rb
@@ -14,7 +14,6 @@ class Atop < Formula
   depends_on "pkgconf" => :build
   depends_on "glib"
   depends_on :linux
-  depends_on "linux-headers@5.15"
   depends_on "ncurses"
   depends_on "zlib"
 

--- a/Formula/d/dosbox-x.rb
+++ b/Formula/d/dosbox-x.rb
@@ -49,7 +49,6 @@ class DosboxX < Formula
   end
 
   on_linux do
-    depends_on "linux-headers@5.15" => :build
     depends_on "alsa-lib"
     depends_on "libx11"
     depends_on "libxrandr"

--- a/Formula/f/fastfetch.rb
+++ b/Formula/f/fastfetch.rb
@@ -41,7 +41,6 @@ class Fastfetch < Formula
     depends_on "libx11" => :build
     depends_on "libxcb" => :build
     depends_on "libxrandr" => :build
-    depends_on "linux-headers@5.15" => :build
     depends_on "mesa" => :build
     depends_on "opencl-icd-loader" => :build
     depends_on "pulseaudio" => :build

--- a/Formula/g/git.rb
+++ b/Formula/g/git.rb
@@ -29,7 +29,6 @@ class Git < Formula
   uses_from_macos "zlib", since: :high_sierra
 
   on_linux do
-    depends_on "linux-headers@5.15" => :build
     depends_on "openssl@3" # Uses CommonCrypto on macOS
   end
 

--- a/Formula/i/iptables.rb
+++ b/Formula/i/iptables.rb
@@ -15,7 +15,6 @@ class Iptables < Formula
     sha256 x86_64_linux: "4de49c1ece1a24f6f72d8290a3d1b4f875a94b9a277640f65faf3258e578a6da"
   end
 
-  depends_on "linux-headers@5.15" => :build
   depends_on "pkgconf" => :build
   depends_on "libmnl"
   depends_on "libnetfilter_conntrack"
@@ -26,7 +25,6 @@ class Iptables < Formula
   depends_on "nftables"
 
   def install
-    ENV.append "CFLAGS", "-I#{Formula["linux-headers@5.15"].opt_include}"
     system "./configure", "--disable-silent-rules",
                           "--enable-bpf-compiler",
                           "--enable-devel",

--- a/Formula/t/task.rb
+++ b/Formula/t/task.rb
@@ -26,7 +26,6 @@ class Task < Formula
   depends_on "rust" => :build
 
   on_linux do
-    depends_on "linux-headers@5.15" => :build
     depends_on "readline"
     depends_on "util-linux"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Try removing `linux-headers` dependency. 