### PR TITLE
clazy 1.16

### DIFF
--- a/Formula/c/clazy.rb
+++ b/Formula/c/clazy.rb
@@ -1,10 +1,9 @@
 class Clazy < Formula
   desc "Qt oriented static code analyzer"
   homepage "https://www.kdab.com/"
-  url "https://download.kde.org/stable/clazy/1.15/src/clazy-1.15.tar.xz"
-  sha256 "43189460b366ea3126242878c36ee8a403e37ec4baef7e61ccfa124b1414e7a9"
+  url "https://download.kde.org/stable/clazy/1.16/src/clazy-v1.16.tar.xz"
+  sha256 "0fa9e9ce54969edfb2c831815b724be9ab89c41ac3a40c0033c558173c4c302b"
   license "LGPL-2.0-or-later"
-  revision 1
   head "https://invent.kde.org/sdk/clazy.git", branch: "master"
 
   livecheck do


### PR DESCRIPTION
clazy 1.16

---

https://github.com/Homebrew/homebrew-core/actions/runs/17531260363/job/49788517475#step:6:2573