### PR TITLE
jemalloc: build with aarch64 64K support, skip livecheck

### DIFF
--- a/Formula/j/jemalloc.rb
+++ b/Formula/j/jemalloc.rb
@@ -11,18 +11,14 @@ class Jemalloc < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia:  "e5e0394bcc4feeb5db140387352090773761aebe3ff8ae42faf4990b2360fec6"
-    sha256 cellar: :any,                 arm64_sonoma:   "f70f02aa2f1b858ed5e5cef84a271efeaaa27e79f266844997aab95daa66a7fa"
-    sha256 cellar: :any,                 arm64_ventura:  "33e0c3fbe56642e081018a9674df734d34afdc35af7d03f5dd2b484a804555e3"
-    sha256 cellar: :any,                 arm64_monterey: "b7ef9abad498e6eb53fb476fde4396fc9ab99a23092ea14bcf576548e198f9bd"
-    sha256 cellar: :any,                 arm64_big_sur:  "b24e4a9413b347397a10ebc9a7a2d309d88c0f9479c1cdebe6c302acba9a43a9"
-    sha256 cellar: :any,                 sonoma:         "cb1d95640b85ec863d457722af363119b9a16274ce6f9e968f939fcf85bdd350"
-    sha256 cellar: :any,                 ventura:        "66b5f3a4c4ad9f7801e6ad2e76d1586e7b57e2cc64b24c2684dd1c2af8bc82f3"
-    sha256 cellar: :any,                 monterey:       "27ae29c02d718c38ee5f623c3ef08ad3530a6fd3595d16d2ddadd6552bf32c12"
-    sha256 cellar: :any,                 big_sur:        "72aef17aa140b457400c4f2b74d0473bf1160616c3df7cb8604ac2bf734afea5"
-    sha256 cellar: :any,                 catalina:       "3f5cf334d16ab432bf210c7e171510d0edcd834f939b57bddfd428af5ed248ae"
-    sha256 cellar: :any_skip_relocation, arm64_linux:    "9a0c9835c0efd14f2e79a8ce59ef17cd0ba160f50db1f359e4a690b4f43abd6a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "240b20cc078b21d90c32bd34447952b9b464958b1858ae109f168558993f9278"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "10573a40eb77f7ded7ce5825c5f03e3daf53ae04bd01670341418652bc84f0d6"
+    sha256 cellar: :any,                 arm64_sonoma:  "d6eb24407abe8727ef33a295a9685ffbc3c89cd4772c95768575b76dc52d03e7"
+    sha256 cellar: :any,                 arm64_ventura: "63744266dcd09077be2d6803f4f22b19826f9f088282f16ac227d580c6731be9"
+    sha256 cellar: :any,                 sonoma:        "aad0662c3aa09d15cdff15575506efa347c8ea2d83fbd7b62d18df87c6825175"
+    sha256 cellar: :any,                 ventura:       "8979f7acc83f0ac5c7d90b5071ed90b7f60a54237d2f9c43b0e8be6e5520494b"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "397758abcc63244fc47ab9183027c9817c37d1d84620cb836049440de3a83147"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "463bbcc1146e18ce0221638a152c6ee3f4820dc27b48b8cc1a39350778fca22d"
   end
 
   head do

--- a/Formula/j/jemalloc.rb
+++ b/Formula/j/jemalloc.rb
@@ -5,7 +5,10 @@ class Jemalloc < Formula
   sha256 "2db82d1e7119df3e71b7640219b6dfe84789bc0537983c3b7ac4f7189aecfeaa"
   license "BSD-2-Clause"
 
-  no_autobump! because: :requires_manual_review
+  # TODO: See if Meta continues releases https://github.com/facebook/jemalloc/discussions/7
+  livecheck do
+    skip "archived, see https://jasone.github.io/2025/06/12/jemalloc-postmortem/"
+  end
 
   bottle do
     sha256 cellar: :any,                 arm64_sequoia:  "e5e0394bcc4feeb5db140387352090773761aebe3ff8ae42faf4990b2360fec6"
@@ -35,6 +38,7 @@ class Jemalloc < Formula
       --prefix=#{prefix}
       --with-jemalloc-prefix=
     ]
+    args << "--with-lg-page=16" if Hardware::CPU.arch == :arm64 && OS.linux?
 
     if build.head?
       args << "--with-xslroot=#{Formula["docbook-xsl"].opt_prefix}/docbook-xsl"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Same as Fedora https://src.fedoraproject.org/rpms/jemalloc/blob/rawhide/f/jemalloc.spec#_44
```spec
%ifarch ppc64 ppc64le aarch64
%define lg_page --with-lg-page=16
%endif
```

No idea on fork status yet. Maybe Meta/Facebook will take ownership or another organization will fork it. 

Still need to keep as other formulae use it.