### PR TITLE
telegraf: fix source-build upgrade, remove postinstall

### DIFF
--- a/Formula/t/telegraf.rb
+++ b/Formula/t/telegraf.rb
@@ -12,12 +12,13 @@ class Telegraf < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "32b76c76a211d9f82bc7173c46d3bc596b12df53346c4cbbb3faf8c0f5706433"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "a40ce2bda23e47415765fa64d745fadd422bea9304c74dace38300a609a20b7c"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "3d8a2ef52ec35dfc9aed3c35e265160a90f2bf031e0c5bdd13c887736bb7cd74"
-    sha256 cellar: :any_skip_relocation, sonoma:        "d3ce755689d77fb78b9fb1a22f9985fb0fe8feaf733551446c3a25317c9186c0"
-    sha256 cellar: :any_skip_relocation, ventura:       "1c144191bc4476f02c5e70d9553a6af8895fe8250ac2497e89dc2fd71304130b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3fdd0eadd45c0b3665d84d3788b2efd14e1a0ef6aff993d2208434059af148e0"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "22faf15241c5bdc77af398a4b6feb7183ab9c96e246978b07a4b602fa0b87ebe"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "486e6428641d76fd30562bc1183b07dab0cd2c45f1709cc585b037b7a336e368"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "a4320924da539b6abd7cc3fe06055f98d5d2f23600a665ed5caf71c5281a5bf8"
+    sha256 cellar: :any_skip_relocation, sonoma:        "87932396ddc123a216b95631b570b401f3641ef1d72efe9f95e26d90f8bbca60"
+    sha256 cellar: :any_skip_relocation, ventura:       "c1e21d8d864d44b770ed1126d4a888e7c85da68c07fb3f5d1c130e7663978e86"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "ff2c5639d6f48ee1cf9dd564c1f228f65d8f7e8ada0c39f6767044d654af8f91"
   end
 
   depends_on "go" => :build

--- a/Formula/t/telegraf.rb
+++ b/Formula/t/telegraf.rb
@@ -25,10 +25,9 @@ class Telegraf < Formula
   def install
     ldflags = "-s -w -X github.com/influxdata/telegraf/internal.Version=#{version}"
     system "go", "build", *std_go_args(ldflags:), "./cmd/telegraf"
-    (etc/"telegraf.conf").write Utils.safe_popen_read(bin/"telegraf", "config")
-  end
 
-  def post_install
+    (buildpath/"telegraf.conf").write Utils.safe_popen_read(bin/"telegraf", "config")
+    etc.install "telegraf.conf"
     # Create directory for additional user configurations
     (etc/"telegraf.d").mkpath
   end
@@ -44,7 +43,6 @@ class Telegraf < Formula
   test do
     assert_match version.to_s, shell_output("#{bin}/telegraf --version")
     (testpath/"config.toml").write shell_output("#{bin}/telegraf -sample-config")
-    system bin/"telegraf", "-config", testpath/"config.toml", "-test",
-           "-input-filter", "cpu:mem"
+    system bin/"telegraf", "-config", testpath/"config.toml", "-test", "-input-filter", "cpu:mem"
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Need to use `etc.install` to allow source-build to correctly handle existing file.

Move postinstall into bottle.