### PR TITLE
regal: Update source location

### DIFF
--- a/Formula/r/regal.rb
+++ b/Formula/r/regal.rb
@@ -1,10 +1,10 @@
 class Regal < Formula
   desc "Linter and language server for Rego"
-  homepage "https://docs.styra.com/regal"
-  url "https://github.com/StyraInc/regal/archive/refs/tags/v0.35.1.tar.gz"
+  homepage "https://www.openpolicyagent.org/projects/regal"
+  url "https://github.com/open-policy-agent/regal/archive/refs/tags/v0.35.1.tar.gz"
   sha256 "49bfa9e94f66fffebe963c886686cdf7a202f7d4fbe6ed59b02d13e0bd0e3fc3"
   license "Apache-2.0"
-  head "https://github.com/StyraInc/regal.git", branch: "main"
+  head "https://github.com/open-policy-agent/regal.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "6439d599a24d1ab0885f6d082d7621b444b064ca0dcbb9e29f44fd1b8c33329e"
@@ -18,6 +18,8 @@ class Regal < Formula
   depends_on "go" => :build
 
   def install
+    odie "Update ldflags" if build.stable? && version > "0.35.1"
+
     ldflags = %W[
       -s -w
       -X github.com/styrainc/regal/pkg/version.Version=#{version}


### PR DESCRIPTION
Regal has been donated to the CNCF OPA org and now should be installed from the new location.

More details in this blog: https://blog.openpolicyagent.org/note-from-teemu-tim-and-torin-to-the-open-policy-agent-community-2dbbfe494371

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
