### PR TITLE
rust: switch to system allocator

### DIFF
--- a/Formula/r/rust.rb
+++ b/Formula/r/rust.rb
@@ -183,7 +183,6 @@ class Rust < Formula
       --disable-cargo-native-static
       --disable-docs
       --disable-lld
-      --set=rust.jemalloc
       --release-description=#{tap.user}
     ]
     if build.head?


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Removes the `--set=rust.jemalloc` overwrite so that the system allocator is used by default. The official rust toolchain uses the system allocator by default [since 2018](https://internals.rust-lang.org/t/jemalloc-was-just-removed-from-the-standard-library/8759).

Using `jemalloc` causes issues on systems that overwrite the allocator using `LD_PRELOAD`. See [discussion](https://github.com/orgs/Homebrew/discussions/6396)
