### PR TITLE
libusrsctp: fix build with CMake 4.0+

### DIFF
--- a/Formula/lib/libusrsctp.rb
+++ b/Formula/lib/libusrsctp.rb
@@ -1,11 +1,21 @@
 class Libusrsctp < Formula
   desc "Portable SCTP userland stack"
   homepage "https://github.com/sctplab/usrsctp"
-  url "https://github.com/sctplab/usrsctp/archive/refs/tags/0.9.5.0.tar.gz"
-  sha256 "260107caf318650a57a8caa593550e39bca6943e93f970c80d6c17e59d62cd92"
   license "BSD-3-Clause"
   revision 1
   head "https://github.com/sctplab/usrsctp.git", branch: "master"
+
+  stable do
+    url "https://github.com/sctplab/usrsctp/archive/refs/tags/0.9.5.0.tar.gz"
+    sha256 "260107caf318650a57a8caa593550e39bca6943e93f970c80d6c17e59d62cd92"
+
+    # Fix minimum required version to configure with CMake 4
+    # Remove with `stable` block on next release.
+    patch do
+      url "https://github.com/sctplab/usrsctp/commit/7569d2ce1e8658534369ad9726ca62139211db84.patch?full_index=1"
+      sha256 "6d37314f524ff301546f1e53b605dd276837a984545c6dc1cb21ad87cbd49f6b"
+    end
+  end
 
   no_autobump! because: :requires_manual_review
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
