### PR TITLE
regal: Update ldflags for new source repo

### DIFF
--- a/Formula/r/regal.rb
+++ b/Formula/r/regal.rb
@@ -18,14 +18,19 @@ class Regal < Formula
   depends_on "go" => :build
 
   def install
-    odie "Update ldflags" if build.stable? && version > "0.35.1"
-
+    # the source repo for this project has changed from styrainc/regal to
+    # open-policy-agent/regal. This is needed to do the correct assignments for
+    # all versions.
     ldflags = %W[
       -s -w
       -X github.com/styrainc/regal/pkg/version.Version=#{version}
       -X github.com/styrainc/regal/pkg/version.Commit=#{tap.user}
       -X github.com/styrainc/regal/pkg/version.Timestamp=#{time.iso8601}
       -X github.com/styrainc/regal/pkg/version.Hostname=#{tap.user}
+      -X github.com/open-policy-agent/regal/pkg/version.Version=#{version}
+      -X github.com/open-policy-agent/regal/pkg/version.Commit=#{tap.user}
+      -X github.com/open-policy-agent/regal/pkg/version.Timestamp=#{time.iso8601}
+      -X github.com/open-policy-agent/regal/pkg/version.Hostname=#{tap.user}
     ]
     system "go", "build", *std_go_args(ldflags:)
 


### PR DESCRIPTION
This updates the setting of ldflags to work regardless of the underlying package (either using the old version for pre 0.35.1 or the new open-policy-agent location).

Following the recommendation on https://github.com/Homebrew/homebrew-core/pull/236565.

I expect the automated updated for http://github.com/open-policy-agent/regal/releases/tag/v0.36.1 will come in separately with the digests etc.