### PR TITLE
bc-gh: remove gitea links

### DIFF
--- a/Formula/b/bc-gh.rb
+++ b/Formula/b/bc-gh.rb
@@ -1,7 +1,5 @@
 class BcGh < Formula
   desc "Implementation of Unix dc and POSIX bc with GNU and BSD extensions"
-  # The homepage is https://git.gavinhoward.com/gavin/bc but the Linux CI runner
-  # has issues fetching the Gitea urls so we use the official GitHub mirror instead
   homepage "https://github.com/gavinhoward/bc"
   url "https://github.com/gavinhoward/bc/releases/download/7.0.3/bc-7.0.3.tar.xz"
   sha256 "91eb74caed0ee6655b669711a4f350c25579778694df248e28363318e03c7fc4"
@@ -32,7 +30,7 @@ class BcGh < Formula
   conflicts_with "bc", because: "both install `bc` and `dc` binaries"
 
   def install
-    # https://git.gavinhoward.com/gavin/bc#recommended-optimizations
+    # https://github.com/gavinhoward/bc#recommended-optimizations
     ENV.O3
     ENV.append "CFLAGS", "-flto"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Hosted gitea is no longer available so use GitHub links.