### PR TITLE
libparserutils: fix test

### DIFF
--- a/Formula/lib/libparserutils.rb
+++ b/Formula/lib/libparserutils.rb
@@ -37,7 +37,7 @@ class Libparserutils < Formula
 
   test do
     system ENV.cc, pkgshare/"test/cscodec-utf8.c", "-I#{include}", "-L#{lib}", "-lparserutils", "-o", "cscodec-utf8"
-    output = shell_output(testpath/"cscodec-utf8 #{pkgshare}/test/data/cscodec-utf8/UTF-8-test.txt")
+    output = shell_output("#{testpath}/cscodec-utf8 #{pkgshare}/test/data/cscodec-utf8/UTF-8-test.txt")
     assert_match "PASS", output
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fixes: `Minitest::Assertion: Pathname '/private/tmp/libparserutils-test-20250910-8235-v6u7a9/cscodec-utf8 /opt/homebrew/Cellar/libparserutils/0.2.5/share/libparserutils/test/data/cscodec-utf8/UTF-8-test.txt' does not exist!.`
