### PR TITLE
gambit-scheme: upstream recommended optimizations

### DIFF
--- a/Formula/g/gambit-scheme.rb
+++ b/Formula/g/gambit-scheme.rb
@@ -41,18 +41,19 @@ class GambitScheme < Formula
     # -O1 is recommended over -O2 by upstream using recent GCC versions[^1].
     # Similar tests on macOS 15 show -O1 outperforming both -Os and -O2.
     # [^1]: https://github.com/gambit/gambit/blob/v4.9.7/INSTALL.txt#L99-L101
-    ENV.O1
+    # ENV.O1
 
     args = %W[
       --prefix=#{prefix}
       --docdir=#{doc}
       --infodir=#{info}
       --enable-default-runtime-options=f8,-8,t8
-      --enable-dynamic-clib
       --enable-openssl
       --enable-single-host
-      --enable-trust-c-tco
     ]
+    # TODO: test following
+    # --enable-dynamic-clib
+    # --enable-trust-c-tco
 
     system "./configure", *args
     system "make"

--- a/Formula/g/gambit-scheme.rb
+++ b/Formula/g/gambit-scheme.rb
@@ -37,23 +37,24 @@ class GambitScheme < Formula
   fails_with :clang
 
   def install
+    ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
+    # -O1 is recommended over -O2 by upstream using recent GCC versions[^1].
+    # Similar tests on macOS 15 show -O1 outperforming both -Os and -O2.
+    # [^1]: https://github.com/gambit/gambit/blob/v4.9.7/INSTALL.txt#L99-L101
+    ENV.O1
+
     args = %W[
       --prefix=#{prefix}
       --docdir=#{doc}
       --infodir=#{info}
-      --enable-single-host
       --enable-default-runtime-options=f8,-8,t8
+      --enable-dynamic-clib
       --enable-openssl
+      --enable-single-host
+      --enable-trust-c-tco
     ]
 
     system "./configure", *args
-
-    # Fixed in gambit HEAD, but they haven't cut a release
-    inreplace "config.status" do |s|
-      s.gsub! %r{/usr/local/opt/openssl(@\d(\.\d)?)?}, Formula["openssl@3"].opt_prefix
-    end
-    system "./config.status"
-
     system "make"
     ENV.deparallelize
     system "make", "install"

--- a/Formula/g/gambit-scheme.rb
+++ b/Formula/g/gambit-scheme.rb
@@ -37,7 +37,8 @@ class GambitScheme < Formula
   fails_with :clang
 
   def install
-    ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
+    # ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
+
     # -O1 is recommended over -O2 by upstream using recent GCC versions[^1].
     # Similar tests on macOS 15 show -O1 outperforming both -Os and -O2.
     # [^1]: https://github.com/gambit/gambit/blob/v4.9.7/INSTALL.txt#L99-L101
@@ -56,6 +57,13 @@ class GambitScheme < Formula
     # --enable-trust-c-tco
 
     system "./configure", *args
+
+    # Fixed in gambit HEAD, but they haven't cut a release
+    inreplace "config.status" do |s|
+      s.gsub! %r{/usr/local/opt/openssl(@\d(\.\d)?)?}, Formula["openssl@3"].opt_prefix
+    end
+    system "./config.status"
+
     system "make"
     ENV.deparallelize
     system "make", "install"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`--enable-dynamic-clib` and  `--enable-trust-c-tco` are recommended by upstream and have some performance improvement from local testing.
* https://github.com/gambit/gambit/blob/master/configure.ac#L3906-L3914
  ```ac
  **************************************************************************
  ***                                                                    ***
  *** The option "--enable-dynamic-clib" was not specified to the        ***
  *** configure script.  The Gambit system will compile correctly but    ***
  *** typically dynamically compiled modules will be less optimized than ***
  *** when "--enable-dynamic-clib" is specified.  This option may not    ***
  *** work on some operating systems.                                    ***
  ***                                                                    ***
  **************************************************************************
  ```
* https://github.com/gambit/gambit/blob/master/configure.ac#L4053-L4068
  ```
  **************************************************************************
  ***                                                                    ***
  *** The GNU GCC compiler that is being used supports the command line  ***
  *** option "-foptimize-sibling-calls" so it probably supports TCO      ***
  *** sufficiently well to allow the use of the "--enable-trust-c-tco"   ***
  *** configure option, which was not specified to the configure script. ***
  *** The Gambit system will compile correctly but the executables may   ***
  *** run slower than when "--enable-trust-c-tco" is specified.  One way ***
  *** to check if "--enable-trust-c-tco" works is to try that option and ***
  *** then see if there is a segmentation violation (stack overflow)     ***
  *** when the system is built with a "make".  If the build completes    ***
  *** without error, specifically the last phase of the "make" that      ***
  *** builds the modules, then it is very likely that C TCO can be       ***
  *** trusted.                                                           ***
  ***                                                                    ***
  **************************************************************************
  ```

`-O1` is also recommended and does perform better (at least on arm64 macOS) than `-O2` and `-Os`