### PR TITLE
aspell: backport fix

### DIFF
--- a/Formula/a/aspell.rb
+++ b/Formula/a/aspell.rb
@@ -555,6 +555,12 @@ class Aspell < Formula
     sha256 "3fa255cd0b20e6229a53df972fd3c5ed8481db11cfd0347dd3da629bbb7a6796"
   end
 
+  # Backport fix for newer Apple Clang and GCC 15
+  patch do
+    url "https://github.com/GNUAspell/aspell/commit/ee6cbb12ff36a1e6618d7388a78dd4e0a2b44041.patch?full_index=1"
+    sha256 "96e6b23947744e5d1374640a38cf20ec541b64c00a063cbed6d1fcc3e3fc19ee"
+  end
+
   # const problems with llvm: https://www.freebsd.org/cgi/query-pr.cgi?pr=180565&cat=
   patch :DATA
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Based on commit message, this may help with https://github.com/Homebrew/homebrew-core/issues/236818#issuecomment-3273969247
```
  In file included from modules/speller/default/readonly_ws.cpp:51:
  modules/speller/default/vector_hash-t.hpp:186:43: error: no member named 'e' in 'VectorHashTable<Parms>'
    186 |     for (iterator i = begin(); i != this->e; ++i, ++this->_size);
        |                                     ~~~~  ^
  modules/speller/default/vector_hash-t.hpp:186:59: error: no member named '_size' in 'VectorHashTable<Parms>'; did you mean 'size_'?
    186 |     for (iterator i = begin(); i != this->e; ++i, ++this->_size);
        |                                                           ^~~~~
        |                                                           size_
  modules/speller/default/vector_hash.hpp:182:17: note: 'size_' declared here
    182 |     size_type   size_;
        |                 ^
```