### PR TITLE
libmpeg2: use videolan url as original is gone

### DIFF
--- a/Formula/lib/libmpeg2.rb
+++ b/Formula/lib/libmpeg2.rb
@@ -1,7 +1,8 @@
 class Libmpeg2 < Formula
   desc "Library to decode mpeg-2 and mpeg-1 video streams"
   homepage "https://libmpeg2.sourceforge.io/"
-  url "https://libmpeg2.sourceforge.io/files/libmpeg2-0.5.1.tar.gz"
+  url "https://download.videolan.org/contrib/libmpeg2/libmpeg2-0.5.1.tar.gz"
+  mirror "https://libmpeg2.sourceforge.io/files/libmpeg2-0.5.1.tar.gz"
   sha256 "dee22e893cb5fc2b2b6ebd60b88478ab8556cb3b93f9a0d7ce8f3b61851871d4"
   license "GPL-2.0-or-later"
   revision 1


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I chose VideoLAN url as the SVN repo was hosted on VideoLAN, i.e. https://libmpeg2.sourceforge.io/ has a dead link to https://trac.videolan.org/libmpeg2/browser (probably broken from VideoLAN move to hosting on gitlab instance so now https://code.videolan.org/videolan/libmpeg2)

Using this URL is the same choice as:
* Arch - https://gitlab.archlinux.org/archlinux/packaging/packages/libmpeg2/-/commit/afc577b4e922f69dd3b503de3f97b0f9475d4125
* vcpkg - https://github.com/microsoft/vcpkg/commit/bdd229e13c66fa11acdc0bc8fed8e7474cd24aa5