### PR TITLE
libiconv: fix build with new Automake

### DIFF
--- a/Formula/lib/libiconv.rb
+++ b/Formula/lib/libiconv.rb
@@ -20,6 +20,8 @@ class Libiconv < Formula
   depends_on "automake" => :build
   depends_on :macos # is not needed on Linux, where iconv.h is provided by glibc
 
+  uses_from_macos "gperf"
+
   patch do
     url "https://raw.githubusercontent.com/Homebrew/patches/9be2793af/libiconv/patch-utf8mac.diff"
     sha256 "e8128732f22f63b5c656659786d2cf76f1450008f36bcf541285268c66cabeab"
@@ -33,13 +35,20 @@ class Libiconv < Formula
     # Reported at https://savannah.gnu.org/bugs/index.php?66170
     ENV.append_to_cflags "-Wno-incompatible-function-pointer-types" if DevelopmentTools.clang_build_version >= 1500
 
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
-                          "--prefix=#{prefix}",
-                          "--enable-extra-encodings",
-                          "--enable-static",
-                          "--docdir=#{doc}"
-    system "make", "-f", "Makefile.devel", "CFLAGS=#{ENV.cflags}", "CC=#{ENV.cc}"
+    args = %W[
+      --enable-extra-encodings
+      --enable-static
+      --docdir=#{doc}
+    ]
+    system "./configure", *args, *std_configure_args
+
+    make_args = %W[
+      CFLAGS=#{ENV.cflags}
+      CC=#{ENV.cc}
+      ACLOCAL=aclocal
+      AUTOMAKE=automake
+    ]
+    system "make", "-f", "Makefile.devel", *make_args
     system "make", "install"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Also, use `std_configure_args`.
