### PR TITLE
gh: fix typo in manpage installation path

### DIFF
--- a/Formula/g/gh.rb
+++ b/Formula/g/gh.rb
@@ -47,7 +47,7 @@ class Gh < Formula
       system "make", "bin/gh", "manpages"
     end
     bin.install "bin/gh"
-    man1.install builpath.glob("share/man/man1/gh*.1")
+    man1.install buildpath.glob("share/man/man1/gh*.1")
     generate_completions_from_executable(bin/"gh", "completion", "-s")
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/pull/237619#issuecomment-3281066145
