### PR TITLE
Apply patch to fix use of Boost 1.89.0

### DIFF
--- a/Formula/e/ecflow-ui.rb
+++ b/Formula/e/ecflow-ui.rb
@@ -1,8 +1,8 @@
 class EcflowUi < Formula
   desc "User interface for client/server workflow package"
   homepage "https://confluence.ecmwf.int/display/ECFLOW"
-  url "https://confluence.ecmwf.int/download/attachments/8650755/ecFlow-5.14.1-Source.tar.gz"
-  sha256 "6c7b8aa89f8b12a786ba0a175d2b3abc8a524eb7e68b3bdf5a76a0e91a248412"
+  url "https://confluence.ecmwf.int/download/attachments/8650755/ecFlow-5.15.0-Source.tar.gz"
+  sha256 "326ea7dbe436f9435c51616fc3e611f69efc55ae0e0e32c4ded25cfefe9b05fd"
   license "Apache-2.0"
 
   livecheck do

--- a/Formula/e/ecflow-ui.rb
+++ b/Formula/e/ecflow-ui.rb
@@ -25,6 +25,12 @@ class EcflowUi < Formula
 
   uses_from_macos "libxcrypt"
 
+  # Replace boost::asio::deadline_timer since it was removed in Boost 1.89.0
+  patch do
+    url "https://raw.githubusercontent.com/ecmwf/ecflow/refs/heads/brew/patch-5.15.0/releng/brew/patches/5.15.0.patch"
+    sha256 "87c53a3cc96a36a00589ff0ea3bc44b62e56dd4539fda81155d72b5cf84db2a3"
+  end
+
   def install
     args = %w[
       -DECBUILD_LOG_LEVEL=DEBUG


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
