### PR TITLE
glui: attempt to fix test failure

### DIFF
--- a/Formula/g/glui.rb
+++ b/Formula/g/glui.rb
@@ -48,6 +48,7 @@ class Glui < Formula
         #include <cassert>
         #include <GL/glui.h>
         int main() {
+          glutDisplayFunc([](){});
           GLUI *glui = GLUI_Master.create_glui("GLUI");
           assert(glui != nullptr);
           return 0;
@@ -63,6 +64,7 @@ class Glui < Formula
         #include <GL/glut.h>
         int main(int argc, char **argv) {
           glutInit(&argc, argv);
+          glutDisplayFunc([](){});
           GLUI *glui = GLUI_Master.create_glui("GLUI");
           assert(glui != nullptr);
           return 0;


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Trying to fix the following failure encountered while bottling for Tahoe:

    ==> ./a.out
    2025-09-11 14:01:12.502 a.out[7764:19153] GLUT Warning: The following is a new check for GLUT 3.0; update your code.
    2025-09-11 14:01:12.502 a.out[7764:19153] GLUT Fatal Error: redisplay needed for window 1, but no display callback.
    Error: glui: failed

I could not reproduce the CI faiure locally so can't guarantee this works. But we could try setting a display callback and see if it fixes it.
