### PR TITLE
media-control: Test with the test command

### DIFF
--- a/Formula/m/media-control.rb
+++ b/Formula/m/media-control.rb
@@ -26,6 +26,7 @@ class MediaControl < Formula
   end
 
   test do
-    system bin/"media-control", "get"
+    assert_match version.to_s, shell_output("#{bin}/media-control version")
+    system bin/"media-control", "test"
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Since version 0.7.0 media-control comes with a `test` command which checks if the MediaRemote framework is still accessible by the tool and consequently if any of the commands will work: https://github.com/ungive/media-control/releases/tag/v0.7.0. This command also runs `get` internally, so the old test is still integrated. Running `test` is better than `get` because it will actually fail, when the MediaRemote framework is inaccessible.

This will also be useful for knowing as early as possible when Apple decides to further gatekeep MediaRemote again, since installing `media-control` will fail for many users and it won't take long for an issue to be opened in the repository by a user.

Closes https://github.com/ungive/media-control/issues/8.