### PR TITLE
yaze-ag: update urls

### DIFF
--- a/Formula/y/yaze-ag.rb
+++ b/Formula/y/yaze-ag.rb
@@ -1,7 +1,7 @@
 class YazeAg < Formula
   desc "Yet Another Z80 Emulator (by AG)"
-  homepage "https://www.mathematik.uni-ulm.de/users/ag/yaze-ag/"
-  url "https://www.mathematik.uni-ulm.de/users/ag/yaze-ag/devel/yaze-ag-2.51.3.tar.gz"
+  homepage "https://agl.yaze-ag.de/"
+  url "https://agl.yaze-ag.de/devel/yaze-ag-2.51.3.tar.gz"
   sha256 "2b0a90c3bf3a27574b0427cf4579dc2347b371bec3fea5739e1527edf74b2809"
   license "GPL-2.0-or-later"
 


### PR DESCRIPTION
Looking at archived copy of site: https://web.archive.org/web/20221202120348/https://www.mathematik.uni-ulm.de/users/ag/yaze-ag/README-2.51.3.html

It mentions this domain which was originally a redirect
```
You will find yaze-ag-2.51.3 under

	http://yaze-ag.de

	   it's a redirect to

	http://www.mathematik.uni-ulm.de/users/ag/yaze-ag/

	ftp://ag-yaze:yaze@xylopia-upload.mathematik.uni-ulm.de
```

Now it redirects to:
```console
❯ curl -IL http://yaze-ag.de
HTTP/1.1 301 Moved Permanently
Date: Thu, 11 Sep 2025 19:58:44 GMT
Server: Apache/2.4.41
Location: https://www.yaze-ag.de/
Content-Type: text/html; charset=iso-8859-1

HTTP/1.1 200 OK
Date: Thu, 11 Sep 2025 19:58:45 GMT
Server: Apache/2.4.41
Upgrade: h2,h2c
Connection: Upgrade
Last-Modified: Sat, 03 May 2025 15:29:41 GMT
ETag: "a8-6343cef8b657f"
Accept-Ranges: bytes
Content-Length: 168
Vary: Accept-Encoding
Content-Type: text/html
```