### PR TITLE
ubertooth: workaround for cmake 4

### DIFF
--- a/Formula/u/ubertooth.rb
+++ b/Formula/u/ubertooth.rb
@@ -26,7 +26,9 @@ class Ubertooth < Formula
   depends_on "libusb"
 
   def install
-    args = ["-DENABLE_PYTHON=OFF"]
+    args = ["-DCMAKE_INSTALL_RPATH=#{rpath}", "-DENABLE_PYTHON=OFF"]
+    # Workaround for CMake 4 until fixed upstream, https://github.com/greatscottgadgets/ubertooth/pull/546
+    args << "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
     # Tell CMake to install udev rules in HOMEBREW_PREFIX/etc on Linux because it defaults to /etc.
     args << "-DUDEV_RULES_PATH=#{etc}/udev/rules.d" unless OS.mac?
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
