### PR TITLE
vramsteg: workaround for cmake 4

### DIFF
--- a/Formula/v/vramsteg.rb
+++ b/Formula/v/vramsteg.rb
@@ -4,7 +4,7 @@ class Vramsteg < Formula
   url "https://github.com/GothenburgBitFactory/vramsteg/releases/download/v1.1.0/vramsteg-1.1.0.tar.gz"
   sha256 "9cc82eb195e4673d9ee6151373746bd22513033e96411ffc1d250920801f7037"
   license "MIT"
-  head "https://github.com/GothenburgBitFactory/vramsteg.git", branch: "1.1.1"
+  head "https://github.com/GothenburgBitFactory/vramsteg.git", branch: "develop"
 
   livecheck do
     url "https://gothenburgbitfactory.org"
@@ -35,7 +35,14 @@ class Vramsteg < Formula
   depends_on "cmake" => :build
 
   def install
-    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    # Workaround for CMake 4 until following commit is in a release:
+    # https://github.com/GothenburgBitFactory/vramsteg/commit/b43db620a922b8ee4b8324804aa0fd6150985e03
+    if build.stable?
+      odie "Remove `-DCMAKE_POLICY_VERSION_MINIMUM=3.5`" if version > "1.1.1"
+      args = ["-DCMAKE_POLICY_VERSION_MINIMUM=3.5"]
+    end
+
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
