### PR TITLE
vulsio-gost: backport fix for fetching Debian CVE DB

### DIFF
--- a/Formula/v/vulsio-gost.rb
+++ b/Formula/v/vulsio-gost.rb
@@ -18,6 +18,12 @@ class VulsioGost < Formula
 
   conflicts_with "gost", because: "both install `gost` binaries"
 
+  # Backport fix for fetching Debian CVE DB
+  patch do
+    url "https://github.com/vulsio/gost/commit/e609fd898e22ce4e75f09e90e0a2c4fef7671111.patch?full_index=1"
+    sha256 "9eeed9c0a0e1b4ca38176851207556d6f51d0e9f0b53819e846fef3d1acaf84d"
+  end
+
   def install
     ldflags = %W[
       -s -w

--- a/Formula/v/vulsio-gost.rb
+++ b/Formula/v/vulsio-gost.rb
@@ -6,12 +6,13 @@ class VulsioGost < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "c503f4dcbf1a4aa65ca07d40d600f9bdfb1cc528f20360561cf54615be0a85dd"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "c503f4dcbf1a4aa65ca07d40d600f9bdfb1cc528f20360561cf54615be0a85dd"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "c503f4dcbf1a4aa65ca07d40d600f9bdfb1cc528f20360561cf54615be0a85dd"
-    sha256 cellar: :any_skip_relocation, sonoma:        "aa84053bee3db2caaff971039516194598656d39371a3dc312913c34aa61e40a"
-    sha256 cellar: :any_skip_relocation, ventura:       "aa84053bee3db2caaff971039516194598656d39371a3dc312913c34aa61e40a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5d45c94dac320f5b899e6bfdff44fb024b1acc85ebead4e3cd80d5103dfc62d4"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "c4a53e4b807b85cf00e833102650028ff9e0033dd04b61a28d4e23fdec98732f"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "c4a53e4b807b85cf00e833102650028ff9e0033dd04b61a28d4e23fdec98732f"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "c4a53e4b807b85cf00e833102650028ff9e0033dd04b61a28d4e23fdec98732f"
+    sha256 cellar: :any_skip_relocation, sonoma:        "b9d48f771f5f28f6ebcdde2751feb98855dcdae0e95d026ae72e7787309f2835"
+    sha256 cellar: :any_skip_relocation, ventura:       "b9d48f771f5f28f6ebcdde2751feb98855dcdae0e95d026ae72e7787309f2835"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "993bf1845ac3db8067ac54af6625a966217ce79b75c5a029e214da48076d0a52"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Needs new bottles 