### PR TITLE
xeol: turn off brew specific test

### DIFF
--- a/Formula/x/xeol.rb
+++ b/Formula/x/xeol.rb
@@ -18,6 +18,10 @@ class Xeol < Formula
   depends_on "go" => :build
 
   def install
+    # Turn off homebrew specific database checks
+    # Issue ref: https://github.com/xeol-io/xeol/issues/568
+    inreplace "xeol/db/curator.go", "isBrewTest == \"1\"", "isBrewTest == \"999\""
+
     ldflags = %W[
       -s -w
       -X main.version=#{version}


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
