### PR TITLE
gitui: backport fix for newer Rust

### DIFF
--- a/Formula/g/gitui.rb
+++ b/Formula/g/gitui.rb
@@ -1,10 +1,19 @@
 class Gitui < Formula
   desc "Blazing fast terminal-ui for git written in rust"
   homepage "https://github.com/gitui-org/gitui"
-  url "https://github.com/gitui-org/gitui/archive/refs/tags/v0.27.0.tar.gz"
-  sha256 "55a85f4a3ce97712b618575aa80f3c15ea4004d554e8899669910d7fb4ff6e4b"
   license "MIT"
   head "https://github.com/gitui-org/gitui.git", branch: "master"
+
+  stable do
+    url "https://github.com/gitui-org/gitui/archive/refs/tags/v0.27.0.tar.gz"
+    sha256 "55a85f4a3ce97712b618575aa80f3c15ea4004d554e8899669910d7fb4ff6e4b"
+
+    # Backport fix for newer Rust
+    patch do
+      url "https://github.com/gitui-org/gitui/commit/950e703cab1dd37e3d02e7316ec99cc0dc70513c.patch?full_index=1"
+      sha256 "4e473d73b112a35dd95ba4f379b56cc2bae7e5d142bd5013798ef36f32b65dd0"
+    end
+  end
 
   no_autobump! because: :requires_manual_review
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
