### PR TITLE
ksops: update checksum for 4.4.0 and add github_latest livecheck

### DIFF
--- a/Formula/k/ksops.rb
+++ b/Formula/k/ksops.rb
@@ -2,9 +2,14 @@ class Ksops < Formula
   desc "Flexible Kustomize Plugin for SOPS Encrypted Resources"
   homepage "https://github.com/viaduct-ai/kustomize-sops"
   url "https://github.com/viaduct-ai/kustomize-sops/archive/refs/tags/v4.4.0.tar.gz"
-  sha256 "08891e25bfac225ac90fd6ccc20ec5d8d0dff96222d86eaafeb976d85bb338f0"
+  sha256 "c3c6ce4503cab59a3ee345ba771cee01caccd99d1ee9f3668f58214cd5ef6742"
   license "Apache-2.0"
   head "https://github.com/viaduct-ai/kustomize-sops.git", branch: "master"
+
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
 
   bottle do
     rebuild 1

--- a/Formula/k/ksops.rb
+++ b/Formula/k/ksops.rb
@@ -12,13 +12,11 @@ class Ksops < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "17343452def7526089b16ea57e32f01b1ba172ae97ec5d237733a366befae681"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "17343452def7526089b16ea57e32f01b1ba172ae97ec5d237733a366befae681"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "17343452def7526089b16ea57e32f01b1ba172ae97ec5d237733a366befae681"
-    sha256 cellar: :any_skip_relocation, sonoma:        "bd3f6dc2bfd4bfc5a8fc316bfb69acb96fff9e8e9ce6b486063fea1d22a0eda2"
-    sha256 cellar: :any_skip_relocation, ventura:       "bd3f6dc2bfd4bfc5a8fc316bfb69acb96fff9e8e9ce6b486063fea1d22a0eda2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d4bdbb84f09f2bbd812a349633347fb8f7a0bacf0b1c236337aff59680569195"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "364262faf875534b99ccc31bd7927081d4fe7cd621a76a56c301a6ab67f1a469"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "364262faf875534b99ccc31bd7927081d4fe7cd621a76a56c301a6ab67f1a469"
+    sha256 cellar: :any_skip_relocation, sonoma:        "52792d1cb8bd04bc47e4879360db2941e1baf75858a7c60a70cb9763ebeecfea"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "6db3f9f9fc371dfa67d4fac397b1534af08e6b23ee6009e0eaa9269c101ffd96"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
ksops: update checksum for 4.4.0 and add github_latest livecheck

---

<img width="1290" height="627" alt="image" src="https://github.com/user-attachments/assets/ac23f23d-d2fd-4458-a5c9-c1a4953d7889" />

--- 

also add github_latest livecheck as it happened with 4.3.3 release

- https://github.com/Homebrew/homebrew-core/pull/231395
- https://github.com/viaduct-ai/kustomize-sops/issues/290

----

- #236818