### PR TITLE
grafana: backport fix for node 22.18.0

### DIFF
--- a/Formula/g/grafana.rb
+++ b/Formula/g/grafana.rb
@@ -1,10 +1,19 @@
 class Grafana < Formula
   desc "Gorgeous metric visualizations and dashboards for timeseries databases"
   homepage "https://grafana.com"
-  url "https://github.com/grafana/grafana/archive/refs/tags/v12.1.0.tar.gz"
-  sha256 "9e2f3f11eff01f8b86c2c232c6a3c3a32fa303589ea9829538ffc867684a4436"
   license "AGPL-3.0-only"
   head "https://github.com/grafana/grafana.git", branch: "main"
+
+  stable do
+    url "https://github.com/grafana/grafana/archive/refs/tags/v12.1.0.tar.gz"
+    sha256 "9e2f3f11eff01f8b86c2c232c6a3c3a32fa303589ea9829538ffc867684a4436"
+
+    # Backport fix for node 22.18.0
+    patch do
+      url "https://github.com/grafana/grafana/commit/20c14c48f4c7f13610b105d17f54b66d0062b212.patch?full_index=1"
+      sha256 "180ecb3eadb594211479875f9340055b6ccd250ca27eaf00b31e8ff08b15ec1b"
+    end
+  end
 
   livecheck do
     url :stable


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
