### PR TITLE
cassandra-cpp-driver: fix cmake 4 compatibility

### DIFF
--- a/Formula/c/cassandra-cpp-driver.rb
+++ b/Formula/c/cassandra-cpp-driver.rb
@@ -34,9 +34,15 @@ class CassandraCppDriver < Formula
   end
 
   def install
-    system "cmake", "-S", ".", "-B", "build",
-                    "-DLIBUV_ROOT_DIR=#{Formula["libuv"].opt_prefix}",
-                    *std_cmake_args
+    # Fix to error: Unsupported compiler: AppleClang
+    inreplace "CMakeLists.txt", 'STREQUAL "Clang"', 'STREQUAL "AppleClang"' if OS.mac?
+
+    # Workaround for CMake 4 compatibility
+    args = %W[
+      -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+      -DLIBUV_ROOT_DIR=#{Formula["libuv"].opt_prefix}
+    ]
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
