### PR TITLE
supermodel: update source and homepage

### DIFF
--- a/Formula/s/supermodel.rb
+++ b/Formula/s/supermodel.rb
@@ -1,11 +1,12 @@
 class Supermodel < Formula
   desc "Sega Model 3 arcade emulator"
-  homepage "https://www.supermodel3.com/"
+  homepage "https://github.com/trzy/Supermodel"
   license "GPL-3.0-or-later"
   revision 1
 
   stable do
-    url "https://www.supermodel3.com/Files/Supermodel_0.2a_Src.zip"
+    # Homepage is down, issue ref: https://github.com/trzy/Supermodel/issues/259
+    url "https://cdn.netbsd.org/pub/pkgsrc/distfiles/Supermodel_0.2a_Src.zip"
     sha256 "ecaf3e7fc466593e02cbf824b722587d295a7189654acb8206ce433dcff5497b"
 
     depends_on "sdl12-compat"
@@ -59,7 +60,12 @@ class Supermodel < Formula
         s.gsub! "$(CPPFLAGS)", "$(CPPFLAGS) -std=c++14" if OS.linux?
         # Fix compile with newer Clang.
         if DevelopmentTools.clang_build_version >= 1403
-          s.gsub!(/^COMPILER_FLAGS = /, "\\0 -Wno-implicit-function-declaration ")
+          cxxflags = %w[
+            -Wno-implicit-function-declaration
+            -Wno-reserved-user-defined-literal
+            -Wno-c++11-narrowing
+          ]
+          s.gsub!(/^COMPILER_FLAGS = /, "\\0#{cxxflags.join(" ")} ")
         end
       end
       # Use /usr/local/var/supermodel for saving runtime files


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Since the homepage is down, the only option to download package is from netbsd cdn. Not sure this is correct but just try.