### PR TITLE
dvd+rw-tools: update URLs, remove livecheck

### DIFF
--- a/Formula/d/dvd+rw-tools.rb
+++ b/Formula/d/dvd+rw-tools.rb
@@ -1,14 +1,11 @@
 class DvdxrwTools < Formula
   desc "DVD+-RW/R tools"
-  homepage "https://fy.chalmers.se/~appro/linux/DVD+RW/"
-  url "https://fy.chalmers.se/~appro/linux/DVD+RW/tools/dvd+rw-tools-7.1.tar.gz"
+  # Original URL no longer accessible: https://fy.chalmers.se/~appro/linux/DVD+RW/
+  homepage "https://en.wikipedia.org/wiki/Dvd+rw-tools"
+  url "https://deb.debian.org/debian/pool/main/d/dvd+rw-tools/dvd+rw-tools_7.1.orig.tar.gz"
+  mirror "https://fy.chalmers.se/~appro/linux/DVD+RW/tools/dvd+rw-tools-7.1.tar.gz"
   sha256 "f8d60f822e914128bcbc5f64fbe3ed131cbff9045dca7e12c5b77b26edde72ca"
   license "GPL-2.0-only"
-
-  livecheck do
-    url "https://fy.chalmers.se/~appro/linux/DVD+RW/tools/"
-    regex(/href=.*?dvd\+rw-tools[._-]v?(\d+(?:[.-]\d+)+)\.t/i)
-  end
 
   no_autobump! because: :requires_manual_review
 
@@ -47,6 +44,7 @@ class DvdxrwTools < Formula
   patch :DATA
 
   def install
+    ENV.append "CXXFLAGS", "-Wno-reserved-user-defined-literal" if DevelopmentTools.clang_build_version >= 1700
     bin.mkpath
     man1.mkpath
     system "make", "prefix=#{prefix}", "install"
@@ -61,7 +59,7 @@ index a6a100b..03fc245 100644
 @@ -27,11 +27,13 @@ CXXFLAGS+=$(WARN) -D__unix -O2 -fno-exceptions
  LDLIBS	=-framework CoreFoundation -framework IOKit
  LINK.o	=$(LINK.cc)
- 
+
 +prefix?=/usr
 +
  # to install set-root-uid, `make BIN_MODE=04755 install'...
@@ -72,7 +70,7 @@ index a6a100b..03fc245 100644
 +	install -m $(BIN_MODE) $(CHAIN) $(prefix)/bin
 +	install -m 0644 growisofs.1 $(prefix)/share/man/man1
  ])
- 
+
  ifelse(OS,MINGW32,[
 diff --git a/transport.hxx b/transport.hxx
 index 35a57a7..467ce50 100644
@@ -83,6 +81,6 @@ index 35a57a7..467ce50 100644
  #include <poll.h>
  #include <sys/time.h>
 +#include <limits.h>
- 
+
  inline long getmsecs()
  { struct timeval tv;


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Original URL no longer accessible (https://fy.chalmers.se/ says "This page has been closed"). Dropping livecheck until we see it revive somewhere. Not opting to deprecate/remove yet as the webpage issue is recent (last known good date <2 months ago https://archlinux.org/packages/extra/x86_64/dvd+rw-tools/), and this seems to be an old valuable utility (given it has a long, dedicated Wikipedia article). Could perhaps consider doing so in future when it really increases our maintenance burden.
