### PR TITLE
ekg2: add workaround for readline, deprecate as unmaintained

### DIFF
--- a/Formula/e/ekg2.rb
+++ b/Formula/e/ekg2.rb
@@ -59,6 +59,11 @@ class Ekg2 < Formula
     end
   end
 
+  # Original source tarball is gone and we use Fedora copy but they already dropped package.
+  # ekg2 was also removed from other major distros like Debian/Ubuntu and Gentoo.
+  # Last release on 2011-03-17 and last commit on 2019-03-15.
+  deprecate! date: "2025-09-13", because: :unmaintained
+
   depends_on "pkgconf" => :build
   depends_on "openssl@3"
   depends_on "readline"
@@ -70,6 +75,9 @@ class Ekg2 < Formula
       ENV.append_to_cflags "-Wno-incompatible-function-pointer-types"
     end
 
+    # Workaround for newer readline
+    ENV.append_to_cflags "-DWANT_OBSOLETE_TYPEDEFS" if build.stable?
+
     args = %W[
       --enable-unicode
       --with-readline=#{Formula["readline"].opt_prefix}
@@ -77,6 +85,7 @@ class Ekg2 < Formula
       --without-libgadu
       --without-perl
       --without-python
+      --without-nls
     ]
     if OS.linux?
       # Newer ncurses has opaque structures so old plugin code no longer works


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Added workaround for stable release but it will likely stop working in future readline.

Repology shows steady removal: https://repology.org/project/ekg2/history. Will slowly disappear from older Ubuntu as LTS end (around 2030 for 18.04).

Upstream is also discussing archiving repo due to lack of activity.