### PR TITLE
libunistring: fix iconv support on Tahoe

### DIFF
--- a/Formula/lib/libunistring.rb
+++ b/Formula/lib/libunistring.rb
@@ -23,10 +23,11 @@ class Libunistring < Formula
     # This is also why we skip `make check`.
     # https://github.com/coreutils/gnulib/commit/bab130878fe57086921fa7024d328341758ed453
     # https://savannah.gnu.org/bugs/?65686
-    ENV["am_cv_func_iconv_works"] = "yes" if OS.mac? && [:sequoia, :tahoe].include?(MacOS.version)
+    use_iconv_workaround = OS.mac? && MacOS.version >= :sonoma
+    ENV["am_cv_func_iconv_works"] = "yes" if use_iconv_workaround
     system "./configure", "--disable-silent-rules", *std_configure_args
     system "make"
-    system "make", "check" if !OS.mac? || MacOS.version < :sonoma || MacOS.version > :tahoe
+    system "make", "check" unless use_iconv_workaround
     system "make", "install"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We didn't actually turn on iconv support on Tahoe due to an oversight [^1]. This fixes it.

[^1]: https://github.com/Homebrew/homebrew-core/pull/237544/files#r2346877107
