### PR TITLE
hivex: change workaround to avoid deprecated `-ld_classic`

### DIFF
--- a/Formula/h/hivex.rb
+++ b/Formula/h/hivex.rb
@@ -33,8 +33,9 @@ class Hivex < Formula
   end
 
   def install
-    # Use `-ld_classic` to work around `-Wl,-M` usage
-    ENV.append "LDFLAGS", "-Wl,-ld_classic" if DevelopmentTools.clang_build_version >= 1500
+    # Work around `-Wl,-M` usage. This was fixed in parent project (libguestfs) but not yet in hivex
+    # https://github.com/libguestfs/libguestfs/commit/e17d794d11090b2f221bfd93acb6a8da046a2540
+    inreplace "configure", '"-Wl,-M -Wl,"', '"-Wl,-map -Wl,"' if DevelopmentTools.clang_build_version >= 1500
 
     args = %w[
       --disable-ocaml


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
