### PR TITLE
node@22: remove deprecated `-ld_classic`

### DIFF
--- a/Formula/n/node@22.rb
+++ b/Formula/n/node@22.rb
@@ -47,7 +47,7 @@ class NodeAT22 < Formula
   uses_from_macos "zlib"
 
   on_macos do
-    depends_on "llvm" => [:build, :test] if DevelopmentTools.clang_build_version <= 1100
+    depends_on "llvm" => :build if DevelopmentTools.clang_build_version <= 1100
   end
 
   fails_with :clang do
@@ -59,9 +59,6 @@ class NodeAT22 < Formula
 
   def install
     ENV.llvm_clang if OS.mac? && (DevelopmentTools.clang_build_version <= 1100)
-
-    # The new linker crashed during LTO due to high memory usage.
-    ENV.append "LDFLAGS", "-Wl,-ld_classic" if DevelopmentTools.clang_build_version >= 1500
 
     # make sure subprocesses spawned by make are using our Python 3
     ENV["PYTHON"] = which("python3.13")


### PR DESCRIPTION
Want to check on state of ld to reduce deprecated ld_classic usage.

May try tuning parallelism if needed. As reference point the previous run https://github.com/Homebrew/homebrew-core/actions/runs/17310189134 ~ 2.5 hours

---

No issues so far:
- https://github.com/Homebrew/homebrew-core/actions/runs/17702022293/job/50309647606?pr=240900