### PR TITLE
vulkan-headers 1.4.321.0 (downgrade)

### DIFF
--- a/Formula/v/vulkan-extensionlayer.rb
+++ b/Formula/v/vulkan-extensionlayer.rb
@@ -12,13 +12,13 @@ class VulkanExtensionlayer < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "aa5ca295944b3c100152c8ac997a9a5a322be5a65686e1270bd54c83b1940b36"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "a2053b993eff8b5ed5e0786d776dfb0daeb0c90fcc78963e0a7b4cf0f710661c"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "d1df14370457b3dfe4ef7f4a32153d25329ea721481a4214538aeb6c955e7a17"
-    sha256 cellar: :any_skip_relocation, sonoma:        "1d8e80912889b8536d0956664105e481fa681bfe7a3cec5664bf0d0980c9d05c"
-    sha256 cellar: :any_skip_relocation, ventura:       "208e154424c6fb819d39911292c7d67a86c8ed2f33f50534924a40794ddb3b76"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "6123247d479ae3fd0eff943d0b0cb059d201fbe52fef6e2dfbf1188592210810"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "35d062aa1f79e3cae8dd5de1ca1a5b7b77a3ea31eb1285b6344a281712dfb105"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "4ddf0160cb88f835c9a1197b757fc366fa27a6df2775c15224744c7f3837d490"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "4eeeadeac358017dd128a64ae1c1f0e30930d49e3e6643fcb9f924b7ef5b422f"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "f1cedbea11806339ae081f2082cff16b3a0a1e5003a6885549cdac1dd7906da7"
+    sha256 cellar: :any_skip_relocation, sonoma:        "701f69b976e4530ce5481c7a88ac0dedbd39f2788dbfaefe80866975f527e1fd"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "7c46ee6c4b7967bae8de9537484727900b8dc0eb9960e6513081f733c5b5c25d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "6dfa854a1cee83a1e81c52f3feb304fe641834ff9eaf9724134559ff3a378998"
   end
 
   depends_on "cmake" => :build

--- a/Formula/v/vulkan-extensionlayer.rb
+++ b/Formula/v/vulkan-extensionlayer.rb
@@ -1,14 +1,14 @@
 class VulkanExtensionlayer < Formula
   desc "Layer providing Vulkan features when native support is unavailable"
   homepage "https://github.com/KhronosGroup/Vulkan-ExtensionLayer"
-  url "https://github.com/KhronosGroup/Vulkan-ExtensionLayer/archive/refs/tags/v1.4.321.tar.gz"
-  sha256 "177a356162cfcf47c50cc0f0dcd51630196f171f21d6cefe3fb8b5d514f60d49"
+  url "https://github.com/KhronosGroup/Vulkan-ExtensionLayer/archive/refs/tags/vulkan-sdk-1.4.321.0.tar.gz"
+  sha256 "6104bcd3c81b10e5ad90749d895bd681ff411c0c5de914e53a9aa9f727c43cc8"
   license "Apache-2.0"
   head "https://github.com/KhronosGroup/Vulkan-ExtensionLayer.git", branch: "main"
 
   livecheck do
     url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    regex(/^vulkan-sdk[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do

--- a/Formula/v/vulkan-headers.rb
+++ b/Formula/v/vulkan-headers.rb
@@ -1,14 +1,14 @@
 class VulkanHeaders < Formula
   desc "Vulkan Header files and API registry"
   homepage "https://github.com/KhronosGroup/Vulkan-Headers"
-  url "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v1.4.326.tar.gz"
-  sha256 "19eed9a3f1e96f7fa2a30317f99374103589fba5766f9743ab61265c6889c099"
+  url "https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/vulkan-sdk-1.4.321.0.tar.gz"
+  sha256 "17f8ff30fd79fb7531efcb7c78c02c17a595208d482a150f06836b0ca97ef8f2"
   license "Apache-2.0"
   head "https://github.com/KhronosGroup/Vulkan-Headers.git", branch: "main"
 
   livecheck do
     url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    regex(/^vulkan-sdk[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do

--- a/Formula/v/vulkan-headers.rb
+++ b/Formula/v/vulkan-headers.rb
@@ -12,7 +12,7 @@ class VulkanHeaders < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "910c3ea85bbee4912a862f28a9816d6947e04f879879837c269d26fa1049dca9"
+    sha256 cellar: :any_skip_relocation, all: "caf4628c1bebe36a5eabbd13e178f3d8aa9809e5084a13bbddb220166a409968"
   end
 
   depends_on "cmake" => :build

--- a/Formula/v/vulkan-loader.rb
+++ b/Formula/v/vulkan-loader.rb
@@ -12,16 +12,14 @@ class VulkanLoader < Formula
   end
 
   bottle do
-    sha256               arm64_tahoe:   "7323057105713b203f815fd81eb2703127a2e27395530b55346babf155feb8cc"
-    sha256               arm64_sequoia: "2b3d377d43d59f2576e136e706395c6c64dff5e077fa43c4b0a921b615f635a5"
-    sha256               arm64_sonoma:  "02cdf6f5f443acdb9fc7684ee59fa6ed08c8a92315dcfec18351e0c6cfc85c72"
-    sha256               arm64_ventura: "4b6c12ca6de39603464a9f04cfd27ab7eb17ec0a8f95e2f472c33c468968a556"
-    sha256 cellar: :any, tahoe:         "6bddef382906c090caf881fb9e9ec311636a6ce1438eb5bf1fd951faeb2a2577"
-    sha256 cellar: :any, sequoia:       "ed9de26d11433881f00e9572d7efe2cadf6dece8f520409e6526d0948660fb31"
-    sha256 cellar: :any, sonoma:        "a5c5ca977934fd1c93386194d44066d151f1512b6329d8bffcd1a70eaf823e54"
-    sha256 cellar: :any, ventura:       "6cfb1455dbbe117736114fa04fe097c83d6171d34313ec57812624f1fab66d90"
-    sha256               arm64_linux:   "2565480a9902ab3d3654324ef86dad5654921fb9a51e97d0483a8e503904b05e"
-    sha256               x86_64_linux:  "87d668ca6646b0c3b3becf15e62d19a80a9699bccfcc1ca1d3e94f4722c08e4e"
+    sha256               arm64_tahoe:   "829b502094673c1d93cd47d0d6f15f15c0713e2553c0403dbb43ffbbedd06f4b"
+    sha256               arm64_sequoia: "17a75d4bd3473b078a7adca737eb975374cf3f5d13a625a4d2a9bf7534e59afd"
+    sha256               arm64_sonoma:  "838aa87d6aa49ad722d03773959f4c882a1a1711dce9f96c25658f52ecc55574"
+    sha256 cellar: :any, tahoe:         "3a5fdc3914bdbf62ea713adaa914bfc1949b8d5634418dc4f7462cb67d0af090"
+    sha256 cellar: :any, sequoia:       "e0987e426c2ff59ff188e6a0e82f9381be3d97f8c29fd167b923308d9a36fe2d"
+    sha256 cellar: :any, sonoma:        "eae9057f906f658f584dfb9c4ba030b99468140bd89a7440d65c8eeb251b022e"
+    sha256               arm64_linux:   "5c7d18b7a3cdea079c90c1f57e30d8bfa11336bd091c1f441764853c762819c1"
+    sha256               x86_64_linux:  "f8afa9af215195b1c5e40729857af411149c328834882c0bfb4ab177e31added"
   end
 
   depends_on "cmake" => :build

--- a/Formula/v/vulkan-loader.rb
+++ b/Formula/v/vulkan-loader.rb
@@ -1,14 +1,14 @@
 class VulkanLoader < Formula
   desc "Vulkan ICD Loader"
   homepage "https://github.com/KhronosGroup/Vulkan-Loader"
-  url "https://github.com/KhronosGroup/Vulkan-Loader/archive/refs/tags/v1.4.326.tar.gz"
-  sha256 "86772b60eeef6f510586636b7cf7a0e0eabd9e9920bcabf6e8f3b1c2a634a4cc"
+  url "https://github.com/KhronosGroup/Vulkan-Loader/archive/refs/tags/vulkan-sdk-1.4.321.0.tar.gz"
+  sha256 "9e0315bd13d8def7d130524d0b69d0bef3e967374327ac69dd9c54cd2b716e8f"
   license "Apache-2.0"
   head "https://github.com/KhronosGroup/Vulkan-Loader.git", branch: "main"
 
   livecheck do
     url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    regex(/^vulkan-sdk[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do

--- a/Formula/v/vulkan-profiles.rb
+++ b/Formula/v/vulkan-profiles.rb
@@ -12,14 +12,12 @@ class VulkanProfiles < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "a146ad39c8095554487d7d0f29655d6de4ec87f466b637f4233259515307b803"
-    sha256 cellar: :any,                 arm64_sequoia: "9b2f47521ed8d6bb0f760ba2ebb0e77e5da3a1cb1d5e80abc8f4f17bfb80d5c7"
-    sha256 cellar: :any,                 arm64_sonoma:  "193d300fc5791da66a7a94f18266dc5cafba656e8d6d4f46370424cf4c3625f4"
-    sha256 cellar: :any,                 arm64_ventura: "bc2bd84db62b80afc64cf8d4da30f373382df66d68a4afd0f70787456ff8c2a5"
-    sha256 cellar: :any,                 sonoma:        "4f699181074fba2674c045d940f1c86c2db3158887cd731fc4fba5b6ab7e66c2"
-    sha256 cellar: :any,                 ventura:       "136481e5b164a3ee1998aaca04a561b4355d64ddea997e449575d2a4ffa85402"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "a7c82ce84109308175861ce2c391d6691f4adcddbc2f04336941e3ec3343c712"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "aa1615f62db8bb829459f95ece365850af3775683121512d71055ee2a3f68255"
+    sha256 cellar: :any,                 arm64_tahoe:   "ea471a033493b6daf1505d659eb71f4ebbbb2d144b80fbde436694fa8849c6c8"
+    sha256 cellar: :any,                 arm64_sequoia: "fca13c3157786c674a2e6ad99149b5797673ae2a616400b576cbfa91390b8b01"
+    sha256 cellar: :any,                 arm64_sonoma:  "0f140d2b8bef185399009c74f3413fbcd2cd025366d44a34d5b885e50c05e7fe"
+    sha256 cellar: :any,                 sonoma:        "cc3697f945bb38381a06def249519281c7884342d81a3ede2d1fb0b6049b8183"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "f2ea2920a7a0a8fbd94543e15a798a8ccbadc2cec5bf9b4f4c738be0db279b33"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5fdff2c4e148e5d77d6deea21ac46646213197146cb53ef23c1e22520884f6ad"
   end
 
   depends_on "cmake" => :build

--- a/Formula/v/vulkan-profiles.rb
+++ b/Formula/v/vulkan-profiles.rb
@@ -1,14 +1,14 @@
 class VulkanProfiles < Formula
   desc "Tools for Vulkan profiles"
   homepage "https://github.com/KhronosGroup/Vulkan-Profiles"
-  url "https://github.com/KhronosGroup/Vulkan-Profiles/archive/refs/tags/v1.4.326.tar.gz"
-  sha256 "f7de5da64478c4b26f586302198d714508bfb84b23d0a4fb78fff8ad3bcaa5f6"
+  url "https://github.com/KhronosGroup/Vulkan-Profiles/archive/refs/tags/vulkan-sdk-1.4.321.0.tar.gz"
+  sha256 "83f081e864e3356c193b4b8b12ab431894a4fa2435f94b07fac7d0724587a4e1"
   license "Apache-2.0"
   head "https://github.com/KhronosGroup/Vulkan-Profiles.git", branch: "main"
 
   livecheck do
     url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    regex(/^vulkan-sdk[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do

--- a/Formula/v/vulkan-tools.rb
+++ b/Formula/v/vulkan-tools.rb
@@ -21,14 +21,12 @@ class VulkanTools < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "5a89af679c9a0904b620d61747954b016ef64533f7caf51b08d6938c59b67b9a"
-    sha256 cellar: :any,                 arm64_sequoia: "d5c179bdcd11cb77ef5f3506c504587ed2bd69bae4acac1983dbf1f90587708d"
-    sha256 cellar: :any,                 arm64_sonoma:  "0474cb9353bef73ea16ff4939edc8eff6acb7ff300be4f2c56b7aaea79b236b3"
-    sha256 cellar: :any,                 arm64_ventura: "78760f112086969f24d23ee185129e1ede37eaa4c491749edcd90b53641a1a7c"
-    sha256 cellar: :any,                 sonoma:        "75286ff95c2427d13fe8ba0bcd49afb92164cd97a3d4f1c9e7fa7b1ae71efab7"
-    sha256 cellar: :any,                 ventura:       "5b53f8c0b0355f95e5d813ef4e78770d3d51833bc1c06b35638424324bf77668"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "4c24978d757039ead39e491d22462a175a2650d7a10d458e4eec6bc464ad093e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f9ba847f234d4f2201c0e2fea929c9e49f3b070f1da1201f602e3a7cc1e5aa80"
+    sha256                               arm64_tahoe:   "e9da1e5a385d850e7ae896ccf7f7962444b6e1656300811c8b3ff37d4ea93f52"
+    sha256                               arm64_sequoia: "f8feeeba6366b86abf824fffda14ae21eb7c816505c59183df9e51c61d08e90d"
+    sha256                               arm64_sonoma:  "ee770f9a8f1c75ae812e4bab51923112fb2120a62e9e454ee0d08a5bf6b39484"
+    sha256 cellar: :any,                 sonoma:        "ec203cd8674170349b6aa10e48a954105c50167d6223a7a3f9c44a098df67524"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "4f313e99bf76d1562156644ec78047163a4dd264efb4c1fd359effb1c87449dd"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e745a8b95d4ff0b2e8bc0981fcfae77bad7c39aae256cc9ebe009f33d2e8fdc0"
   end
 
   depends_on "cmake" => :build

--- a/Formula/v/vulkan-tools.rb
+++ b/Formula/v/vulkan-tools.rb
@@ -1,14 +1,23 @@
 class VulkanTools < Formula
   desc "Vulkan utilities and tools"
   homepage "https://github.com/KhronosGroup/Vulkan-Tools"
-  url "https://github.com/KhronosGroup/Vulkan-Tools/archive/refs/tags/v1.4.326.tar.gz"
-  sha256 "f5a6a26704a0ff61d40d608b21b1bec11db385442e6d983b60eb2ca461532ae5"
   license "Apache-2.0"
   head "https://github.com/KhronosGroup/Vulkan-Tools.git", branch: "main"
 
+  stable do
+    url "https://github.com/KhronosGroup/Vulkan-Tools/archive/refs/tags/vulkan-sdk-1.4.321.0.tar.gz"
+    sha256 "f897f76b1fae6b85b567ee86d7bc1ba6f5b1a13d3bfa5fe0f07fdb81609f7b75"
+
+    # Backport fix to build on Linux
+    patch do
+      url "https://github.com/KhronosGroup/Vulkan-Tools/commit/105d6c1fede00c3a9055e5a531ebf3d99bac406e.patch?full_index=1"
+      sha256 "d3dac23d470b81b4de346c8bac377e0bf8fbf67b862be5f020cb2a11f31a6950"
+    end
+  end
+
   livecheck do
     url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    regex(/^vulkan-sdk[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do

--- a/Formula/v/vulkan-utility-libraries.rb
+++ b/Formula/v/vulkan-utility-libraries.rb
@@ -12,16 +12,14 @@ class VulkanUtilityLibraries < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "2d7aeffadc6742b4c6ebc9ee885dc01bdb782a71a4174a7cc676bf5ceb9f5898"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "7ee979f1e6f5e0392a1b00060950851deeeee9df1bc7c5a17499b291986e331d"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "1c6fec58e2c8d29866ea0d68b9744f3d7602526700aff09d20713b31929e8e86"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "7b314de9c02208b43a7ce118f61942ff88e2f406f4a11e45781a069bb9a312a2"
-    sha256 cellar: :any_skip_relocation, tahoe:         "aed0203c02a828719e57032808d0508322e1c943531dee7d8224b83675185c2b"
-    sha256 cellar: :any_skip_relocation, sequoia:       "90bc25ec56389359dfb4c23c7e7b133ac9930e0ca1c0203dd832ac415b046697"
-    sha256 cellar: :any_skip_relocation, sonoma:        "d06011c1c9f4f54792c38f58d78c59a5b776edf778082f6c32612c171eda985b"
-    sha256 cellar: :any_skip_relocation, ventura:       "439b2f225c7f8d8cc75749cff606b943bde3ae21206137fda50104f2bd8c5d3c"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "9bd1599f48a1b0f070fb3f9ad2772b4c5718cb5e6de46f847191dccae8d66c63"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b2464d0b44e1038931d9aa8d76e51fe6acf26e061b762e08cb6252a30b1b1e22"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "a85c2aeb68e87dafbc5a605451b4505609c7016c7a93c09fe0e836a186fda74d"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "f9fb7bdcdb85833797ac77f97d365f44c055aa6007ededd6d48004744840cc59"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "ef214bd78a3a636ba553d6a5cc877ce93383a1206247005044ae8f8d3c6ebcf1"
+    sha256 cellar: :any_skip_relocation, tahoe:         "372c7e5247e6bb51e240f7c7adb239d4df65d5a677c65852588e8731122895ab"
+    sha256 cellar: :any_skip_relocation, sequoia:       "86814d05696e52c3040816dff9791c16cfebc8f56bbc0899c269eb2fbbe1ac94"
+    sha256 cellar: :any_skip_relocation, sonoma:        "8cac2b29c4eb8668deb8139b166ba7227b03e8f665ca50c0e848d8a7c54efdf6"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "3ebfebc41b83ee5a39ca679402a6b627b6ec57ec1bccf5153a61ecd5449f3a87"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "7831b095f97bdbf4a9bcc997984a04f5f391fd54c4ee1c2368a818acae31c27d"
   end
 
   depends_on "cmake" => :build

--- a/Formula/v/vulkan-utility-libraries.rb
+++ b/Formula/v/vulkan-utility-libraries.rb
@@ -1,14 +1,14 @@
 class VulkanUtilityLibraries < Formula
   desc "Utility Libraries for Vulkan"
   homepage "https://github.com/KhronosGroup/Vulkan-Utility-Libraries"
-  url "https://github.com/KhronosGroup/Vulkan-Utility-Libraries/archive/refs/tags/v1.4.326.tar.gz"
-  sha256 "74bc0be35045bc4f3e7dd2b52fbf8141cda7329ab9d4f14c988442bd74f201c8"
+  url "https://github.com/KhronosGroup/Vulkan-Utility-Libraries/archive/refs/tags/vulkan-sdk-1.4.321.0.tar.gz"
+  sha256 "0cb3c19bc1ce3877a69fe00955597684fa7bde569eea633ac735e36dd959768e"
   license "Apache-2.0"
   head "https://github.com/KhronosGroup/Vulkan-Utility-Libraries.git", branch: "main"
 
   livecheck do
     url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    regex(/^vulkan-sdk[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do

--- a/Formula/v/vulkan-validationlayers.rb
+++ b/Formula/v/vulkan-validationlayers.rb
@@ -1,14 +1,14 @@
 class VulkanValidationlayers < Formula
   desc "Vulkan layers that enable developers to verify correct use of the Vulkan API"
   homepage "https://github.com/KhronosGroup/Vulkan-ValidationLayers"
-  url "https://github.com/KhronosGroup/Vulkan-ValidationLayers/archive/refs/tags/v1.4.326.tar.gz"
-  sha256 "41b0a3d5b8a0a1ed395650adfc453b9711ee02c27abdc27845dc58c683d31268"
+  url "https://github.com/KhronosGroup/Vulkan-ValidationLayers/archive/refs/tags/vulkan-sdk-1.4.321.0.tar.gz"
+  sha256 "80f929ac4e9a1810401064fcd3a789a98006c7916b73b215c235a5f538daa5e9"
   license "Apache-2.0"
   head "https://github.com/KhronosGroup/Vulkan-ValidationLayers.git", branch: "main"
 
   livecheck do
     url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    regex(/^vulkan-sdk[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do

--- a/Formula/v/vulkan-validationlayers.rb
+++ b/Formula/v/vulkan-validationlayers.rb
@@ -12,14 +12,12 @@ class VulkanValidationlayers < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "eb4e0918a4afe06ff03661e6443221ef2556d16c2e73c3693739fb9747180181"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "5f56989c5a3b359d448ee2893d2508046a64c285c31b35ea92ad2b33b33ed03b"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "ae729c20f262dffbbd3c31281629e7c26e1fc0236103c21eafda5ad54ccf84e0"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "624ea7227f49f8fd45ea615d30eb1c19444fd8ff5485cbf385179a532a82b616"
-    sha256 cellar: :any_skip_relocation, sonoma:        "e79cb999b73934574c1041deec7b8855714dab93036b8aeae77c0621ad31533b"
-    sha256 cellar: :any_skip_relocation, ventura:       "2a80a4cb4418116ee0662bc814c95f2b919acd4464362c1b378153ac73b0d3dc"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "e1c45bf0c1f281d4cfa08d029f75eea2cf91dc7d5d1f1657d19dea1ff4feec1a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3caf9efe8dd0e9cee6004fa2cf71bf4c732b5d6fe1a075ee3e87d9c5844f01e4"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "284d7b05d954c79f4c27aa28f452163ea57e648c44b8db85540b35a46bf06a30"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "f57178ef7dfc6527b16214898933ba203e0bbeccd89650bdc611cf84c09e97ce"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "00c549edc4baa402feee35f01f77a24dea8dcb3bb1f01cdbebf3fe4d83b7b905"
+    sha256 cellar: :any_skip_relocation, sonoma:        "2efb5adc5ef6fa8fb70a2776a9a9b6e45f593a27fa9b8cdeeb7d36f71fc27481"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "39c19204f8ed834a92729a75a3a30725f81dcb5bfbe4907018a1c146dcf11704"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "7bcec1f2d07ae5e5a51cc0b03728b6c9de3a7b6514c9008447e7c112f5608edd"
   end
 
   depends_on "cmake" => :build

--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -64,6 +64,6 @@
   ["technitium-dns", "technitium-library"],
   ["tmuxinator", "tmuxinator-completion"],
   ["tree-sitter", "tree-sitter-cli"],
-  ["vulkan-headers", "vulkan-loader", "vulkan-profiles", "vulkan-tools", "vulkan-utility-libraries", "vulkan-validationlayers"],
+  ["vulkan-extensionlayer", "vulkan-headers", "vulkan-loader", "vulkan-profiles", "vulkan-tools", "vulkan-utility-libraries", "vulkan-validationlayers"],
   ["wp-cli", "wp-cli-completion"]
 ]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I've been trying to switch us to SDK tags but missed the timing whenever they aligned.

So just downgrading us. Due to extra `.0`, I think we should be able to upload new bottle without revision.

---

The SDK tags are the versions upstream distribute as official releases at https://vulkan.lunarg.com/

From Repology (https://repology.org/project/vulkan-headers/versions), SDK tags are versions used by most major repositories, e.g.
* Alpine
* Arch Linux
* Fedora
* Gentoo
* GNU Guix
* MacPorts
* nixpkgs
* OpenBSD Ports
* Vcpkg
* Void Linux
* Also Debian/Ubuntu but not listed on that page.

While repositories on 1.4.326 include us, Chimera Linux, Exherbo, KaOS, openmamba, Ravenports and Termux.

---

These are better tested with compatibility with other tooling like SPIRV formulae.

Also, if we align SPIRV and Vulkan formulae, then can drop some known_good handling, e.g.
https://github.com/Homebrew/homebrew-core/blob/eab57db0cffa98728407160bd385cd623f7306e5/Formula/v/vulkan-validationlayers.rb#L41-L51