### PR TITLE
openjdk: help find Metal on macOS

### DIFF
--- a/Formula/o/openjdk.rb
+++ b/Formula/o/openjdk.rb
@@ -124,6 +124,8 @@ class Openjdk < Formula
         --with-freetype-include=#{Formula["freetype"].opt_include}
         --with-freetype-lib=#{Formula["freetype"].opt_lib}
         --with-sysroot=#{MacOS.sdk_path}
+        METAL=#{MacOS::Xcode.toolchain_path/"usr/bin/metal"}
+        METALLIB=#{MacOS::Xcode.toolchain_path/"usr/bin/metal"}
       ]
     else
       %W[


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Should help to fix:

    configure: error: XCode tool 'metal' neither found in path nor with xcrun
