### PR TITLE
gnome-recipes: update patch to a more stable url

### DIFF
--- a/Formula/g/gnome-recipes.rb
+++ b/Formula/g/gnome-recipes.rb
@@ -46,7 +46,7 @@ class GnomeRecipes < Formula
   # Apply Debian patch to support newer libsoup and librest
   # PR ref: https://gitlab.gnome.org/GNOME/recipes/-/merge_requests/47
   patch do
-    url "https://sources.debian.org/data/main/g/gnome-recipes/2.0.4-3/debian/patches/Port-to-libsoup-3.0-and-librest-1.0.patch"
+    url "https://salsa.debian.org/gnome-team/gnome-recipes/-/raw/76a3e12b3a77e76bf0c2bf894481d6b0284dd5af/debian/patches/Port-to-libsoup-3.0-and-librest-1.0.patch"
     sha256 "15a06b277d3961d4a00e71eb37b12f4f63f42c99bc1c1a6c9d9f4ead879d4c32"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
