### PR TITLE
cjdns: add rust 1.89 build patch

### DIFF
--- a/Formula/c/cjdns.rb
+++ b/Formula/c/cjdns.rb
@@ -21,6 +21,12 @@ class Cjdns < Formula
   depends_on "node" => :build
   depends_on "rust" => :build
 
+  # rust 1.89 build patch, upstream pr ref, https://github.com/cjdelisle/cjdns/pull/1271
+  patch do
+    url "https://github.com/cjdelisle/cjdns/commit/53007ebb2e18e8052054675f979fcaeea5de0437.patch?full_index=1"
+    sha256 "04b9a820806a5f5318fcedae3335a5c91daeb6a52555d42b9d6120ad41ed177e"
+  end
+
   def install
     system "./do"
     bin.install "cjdroute"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- https://github.com/cjdelisle/cjdns/pull/1271