### PR TITLE
cloudformation-guard: add rust 1.89 build patch

### DIFF
--- a/Formula/c/cloudformation-guard.rb
+++ b/Formula/c/cloudformation-guard.rb
@@ -18,6 +18,12 @@ class CloudformationGuard < Formula
 
   depends_on "rust" => :build
 
+  # rust 1.89 build patch, upstream pr ref, https://github.com/aws-cloudformation/cloudformation-guard/pull/650
+  patch do
+    url "https://github.com/aws-cloudformation/cloudformation-guard/commit/e1d2ff2a38345d80004f4b2ffc4da24086b9c520.patch?full_index=1"
+    sha256 "2074bd7c8890f8168993a9c425178ff38414347becc5d25bd6a1f0fdfccfb345"
+  end
+
   def install
     system "cargo", "install", *std_cargo_args(path: "guard")
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- https://github.com/aws-cloudformation/cloudformation-guard/pull/650