### PR TITLE
Disable AGL framework in wxwidgets

### DIFF
--- a/Formula/w/wxwidgets.rb
+++ b/Formula/w/wxwidgets.rb
@@ -54,6 +54,9 @@ class Wxwidgets < Formula
     %w[catch pcre libwebp].each { |l| rm_r(buildpath/"3rdparty"/l) }
     %w[expat jpeg png tiff zlib].each { |l| rm_r(buildpath/"src"/l) }
 
+    # Work around removal of AGL in Tahoe
+    inreplace "configure", "-framework AGL", ""
+
     args = [
       "--enable-clipboard",
       "--enable-controls",

--- a/Formula/w/wxwidgets@3.2.rb
+++ b/Formula/w/wxwidgets@3.2.rb
@@ -52,6 +52,9 @@ class WxwidgetsAT32 < Formula
     %w[catch pcre].each { |l| rm_r(buildpath/"3rdparty"/l) }
     %w[expat jpeg png tiff zlib].each { |l| rm_r(buildpath/"src"/l) }
 
+    # Work around removal of AGL in Tahoe
+    inreplace "configure", "-framework AGL", ""
+
     args = [
       "--enable-clipboard",
       "--enable-controls",


### PR DESCRIPTION
From the [release notes](https://developer.apple.com/documentation/macos-release-notes/macos-26-release-notes):

> AGL is no longer available in the macOS SDK. AGL was previously used to present OpenGL content in Carbon apps, and Carbon no longer exists in the SDK. AGL symbols now do nothing on 64-bit systems, including Intel x86_64 and Apple Silicon Macs. It is safe to remove any AGL usage and stop linking AGL. OpenGL still remains in the SDK. (153913819)

Reported upstream: https://github.com/wxWidgets/wxWidgets/issues/25798