### PR TITLE
formulae: remove `:high_sierra` usage

### DIFF
--- a/Formula/a/alure.rb
+++ b/Formula/a/alure.rb
@@ -36,7 +36,7 @@ class Alure < Formula
   # Fix missing unistd include
   # Reported by email to author on 2017-08-25
   patch do
-    on_high_sierra :or_newer do
+    on_macos do
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/eed63e836e/alure/unistd.patch"
       sha256 "7852a7a365f518b12a1afd763a6a80ece88ac7aeea3c9023aa6c1fe46ac5a1ae"
     end

--- a/Formula/b/bison@2.7.rb
+++ b/Formula/b/bison@2.7.rb
@@ -32,7 +32,7 @@ class BisonAT27 < Formula
   uses_from_macos "m4"
 
   patch :p0 do
-    on_high_sierra :or_newer do
+    on_macos do
       url "https://raw.githubusercontent.com/macports/macports-ports/b76d1e48dac/editors/nano/files/secure_snprintf.patch"
       sha256 "57f972940a10d448efbd3d5ba46e65979ae4eea93681a85e1d998060b356e0d2"
     end

--- a/Formula/b/braid.rb
+++ b/Formula/b/braid.rb
@@ -68,7 +68,7 @@ class Braid < Formula
   def install
     ENV["GEM_HOME"] = libexec
     resources.each do |r|
-      next if r.name == "json" && OS.mac? && MacOS.version >= :high_sierra
+      next if r.name == "json" && OS.mac?
 
       r.fetch
       system "gem", "install", r.cached_download, "--ignore-dependencies",

--- a/Formula/c/ccls.rb
+++ b/Formula/c/ccls.rb
@@ -51,7 +51,6 @@ class Ccls < Formula
   depends_on "cmake" => :build
   depends_on "rapidjson" => :build
   depends_on "llvm"
-  depends_on macos: :high_sierra # C++ 17 is required
 
   def llvm
     deps.reject { |d| d.build? || d.test? }

--- a/Formula/c/cmake.rb
+++ b/Formula/c/cmake.rb
@@ -44,9 +44,6 @@ class Cmake < Formula
   # For the GUI application please instead use `brew install --cask cmake`.
 
   def install
-    # Work around "error: no member named 'signbit' in the global namespace"
-    ENV["SDKROOT"] = MacOS.sdk_path if OS.mac? && MacOS.version == :high_sierra
-
     args = %W[
       --prefix=#{prefix}
       --no-system-libs

--- a/Formula/d/dosbox-x.rb
+++ b/Formula/d/dosbox-x.rb
@@ -38,7 +38,6 @@ class DosboxX < Formula
   depends_on "freetype"
   depends_on "libpng"
   depends_on "libslirp"
-  depends_on macos: :high_sierra # needs futimens
   depends_on "sdl2"
 
   uses_from_macos "ncurses"

--- a/Formula/g/gearman.rb
+++ b/Formula/g/gearman.rb
@@ -30,13 +30,6 @@ class Gearman < Formula
   end
 
   def install
-    # Work around "error: no member named 'signbit' in the global namespace"
-    # encountered when trying to detect boost regex in configure
-    if OS.mac? && MacOS.version == :high_sierra
-      ENV.delete("HOMEBREW_SDKROOT")
-      ENV.delete("SDKROOT")
-    end
-
     # https://bugs.launchpad.net/gearmand/+bug/1368926
     Dir["tests/**/*.cc", "libtest/main.cc"].each do |test_file|
       next unless File.read(test_file).include?("std::unique_ptr")

--- a/Formula/g/gist.rb
+++ b/Formula/g/gist.rb
@@ -13,7 +13,7 @@ class Gist < Formula
     sha256 cellar: :any_skip_relocation, all: "8efc350b478d929ecf6de1f41afa0763fccf1efdeed3c16384deb5b4fb8bf66a"
   end
 
-  uses_from_macos "ruby", since: :high_sierra
+  uses_from_macos "ruby"
 
   def install
     system "rake", "install", "prefix=#{prefix}"

--- a/Formula/g/gstreamer.rb
+++ b/Formula/g/gstreamer.rb
@@ -204,9 +204,6 @@ class Gstreamer < Formula
       -Dgst-plugins-rs:sodium-source=system
     ]
 
-    # The apple media plug-in uses API that was added in Mojave
-    args << "-Dgst-plugins-bad:applemedia=disabled" if OS.mac? && MacOS.version <= :high_sierra
-
     # Ban trying to chown to root.
     # https://bugzilla.gnome.org/show_bug.cgi?id=750367
     args << "-Dgstreamer:ptp-helper-permissions=none"

--- a/Formula/h/hashcat.rb
+++ b/Formula/h/hashcat.rb
@@ -28,7 +28,6 @@ class Hashcat < Formula
   end
 
   depends_on "python@3.13" => :build
-  depends_on macos: :high_sierra # Metal implementation requirement
   depends_on "minizip"
   depends_on "xxhash"
 

--- a/Formula/i/idris2.rb
+++ b/Formula/i/idris2.rb
@@ -23,10 +23,6 @@ class Idris2 < Formula
   depends_on "gmp" => :build
   depends_on "chezscheme"
 
-  on_high_sierra :or_older do
-    depends_on "zsh" => :build
-  end
-
   def install
     scheme = Formula["chezscheme"].opt_bin/"chez"
 

--- a/Formula/i/idutils.rb
+++ b/Formula/i/idutils.rb
@@ -29,7 +29,7 @@ class Idutils < Formula
   conflicts_with "coreutils", because: "both install `gid` and `gid.1`"
 
   patch :p0 do
-    on_high_sierra :or_newer do
+    on_macos do
       url "https://raw.githubusercontent.com/macports/macports-ports/b76d1e48dac/editors/nano/files/secure_snprintf.patch"
       sha256 "57f972940a10d448efbd3d5ba46e65979ae4eea93681a85e1d998060b356e0d2"
     end

--- a/Formula/j/jack.rb
+++ b/Formula/j/jack.rb
@@ -51,12 +51,6 @@ class Jack < Formula
   end
 
   def install
-    if OS.mac? && MacOS.version <= :high_sierra
-      # See https://github.com/jackaudio/jack2/issues/640#issuecomment-723022578
-      ENV.append "LDFLAGS", "-Wl,-compatibility_version,1"
-      ENV.append "LDFLAGS", "-Wl,-current_version,#{version}"
-    end
-
     system "python3", "./waf", "configure", "--prefix=#{prefix}"
     system "python3", "./waf", "build"
     system "python3", "./waf", "install"

--- a/Formula/l/lftp.rb
+++ b/Formula/l/lftp.rb
@@ -27,12 +27,6 @@ class Lftp < Formula
   end
 
   def install
-    # Work around "error: no member named 'fpclassify' in the global namespace"
-    if OS.mac? && MacOS.version == :high_sierra
-      ENV.delete("HOMEBREW_SDKROOT")
-      ENV.delete("SDKROOT")
-    end
-
     # Fix compile with newer Clang
     # https://github.com/lavv17/lftp/issues/611
     ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1200

--- a/Formula/l/lolcat.rb
+++ b/Formula/l/lolcat.rb
@@ -26,7 +26,7 @@ class Lolcat < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "8110115e78f3bcb1aca5f3aee73cb81726e59a1293236a780ce99af733a8f524"
   end
 
-  uses_from_macos "ruby", since: :high_sierra
+  uses_from_macos "ruby"
 
   def install
     ENV["GEM_HOME"] = libexec

--- a/Formula/lib/libdrawtext.rb
+++ b/Formula/lib/libdrawtext.rb
@@ -48,7 +48,7 @@ class Libdrawtext < Formula
     font_name = "DejaVuSans"
     font_path = "/usr/share/fonts/truetype/dejavu"
     if OS.mac?
-      ext = "otf" if MacOS.version >= :high_sierra
+      ext = "otf"
       font_name = "LastResort"
       font_path = "/System/Library/Fonts"
     end

--- a/Formula/lib/libsigc++.rb
+++ b/Formula/lib/libsigc++.rb
@@ -22,7 +22,6 @@ class Libsigcxx < Formula
 
   depends_on "meson" => :build
   depends_on "ninja" => :build
-  depends_on macos: :high_sierra # needs C++17
 
   uses_from_macos "m4" => :build
 

--- a/Formula/lib/libzdb.rb
+++ b/Formula/lib/libzdb.rb
@@ -22,7 +22,6 @@ class Libzdb < Formula
   end
 
   depends_on "libpq"
-  depends_on macos: :high_sierra # C++ 17 is required
   depends_on "mariadb-connector-c"
   depends_on "sqlite"
 

--- a/Formula/m/mame.rb
+++ b/Formula/m/mame.rb
@@ -37,8 +37,6 @@ class Mame < Formula
   depends_on "sphinx-doc" => :build
   depends_on "flac"
   depends_on "jpeg-turbo"
-  # Need C++ compiler and standard library support C++17.
-  depends_on macos: :high_sierra
   depends_on "portaudio"
   depends_on "portmidi"
   depends_on "pugixml"

--- a/Formula/o/open-image-denoise.rb
+++ b/Formula/o/open-image-denoise.rb
@@ -17,9 +17,6 @@ class OpenImageDenoise < Formula
 
   depends_on "cmake" => :build
   depends_on "ispc" => :build
-  # clang: error: unknown argument: '-fopenmp-simd'
-  # https://github.com/RenderKit/oidn/issues/35
-  depends_on macos: :high_sierra
   depends_on "tbb"
 
   uses_from_macos "python" => :build

--- a/Formula/o/opensc.rb
+++ b/Formula/o/opensc.rb
@@ -57,10 +57,10 @@ class Opensc < Formula
   end
 
   def caveats
-    on_high_sierra :or_newer do
+    on_macos do
       <<~EOS
-        The OpenSSH PKCS11 smartcard integration will not work from High Sierra
-        onwards. If you need this functionality, unlink this formula, then install
+        The OpenSSH PKCS11 smartcard integration will not work.
+        If you need this functionality, unlink this formula, then install
         the OpenSC cask.
       EOS
     end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
