### PR TITLE
formulae: remove `:high_sierra` usage

### DIFF
--- a/Formula/p/pidgin.rb
+++ b/Formula/p/pidgin.rb
@@ -110,7 +110,6 @@ class Pidgin < Formula
       ENV.append "LDFLAGS", "-Wl,-rpath,#{perl_archlib}/CORE"
     end
 
-    ENV["ac_cv_func_perl_run"] = "yes" if OS.mac? && MacOS.version == :high_sierra
     if DevelopmentTools.clang_build_version >= 1600
       ENV.append_to_cflags "-Wno-incompatible-function-pointer-types -Wno-int-conversion"
     end

--- a/Formula/p/pjproject.rb
+++ b/Formula/p/pjproject.rb
@@ -22,7 +22,6 @@ class Pjproject < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "b0fb2516ec89621fc3622cd52ed7dfa0d814f49f496c32ec6763c2a8f605be66"
   end
 
-  depends_on macos: :high_sierra # Uses Security framework API enum cases introduced in 10.13.4
   depends_on "openssl@3"
 
   def install

--- a/Formula/r/rom-tools.rb
+++ b/Formula/r/rom-tools.rb
@@ -26,13 +26,11 @@ class RomTools < Formula
   depends_on "asio" => :build
   depends_on "pkgconf" => :build
   depends_on "flac"
-  # Need C++ compiler and standard library support C++17.
-  depends_on macos: :high_sierra
   depends_on "sdl2"
   depends_on "utf8proc"
   depends_on "zstd"
 
-  uses_from_macos "python" => :build, since: :catalina
+  uses_from_macos "python" => :build
   uses_from_macos "expat"
   uses_from_macos "zlib"
 

--- a/Formula/s/sfml.rb
+++ b/Formula/s/sfml.rb
@@ -45,11 +45,6 @@ class Sfml < Formula
   end
 
   def install
-    # Fix "fatal error: 'os/availability.h' file not found" on 10.11 and
-    # "error: expected function body after function declarator" on 10.12
-    # Requires the CLT to be the active developer directory if Xcode is installed
-    ENV["SDKROOT"] = MacOS.sdk_path if OS.mac? && MacOS.version <= :high_sierra
-
     # Always remove the "extlibs" to avoid install_name_tool failure
     # (https://github.com/Homebrew/homebrew/pull/35279) but leave the
     # headers that were moved there in https://github.com/SFML/SFML/pull/795

--- a/Formula/s/sfml@2.rb
+++ b/Formula/s/sfml@2.rb
@@ -39,11 +39,6 @@ class SfmlAT2 < Formula
   end
 
   def install
-    # Fix "fatal error: 'os/availability.h' file not found" on 10.11 and
-    # "error: expected function body after function declarator" on 10.12
-    # Requires the CLT to be the active developer directory if Xcode is installed
-    ENV["SDKROOT"] = MacOS.sdk_path if OS.mac? && MacOS.version <= :high_sierra
-
     # Always remove the "extlibs" to avoid install_name_tool failure
     # (https://github.com/Homebrew/homebrew/pull/35279) but leave the
     # headers that were moved there in https://github.com/SFML/SFML/pull/795

--- a/Formula/s/shellinabox.rb
+++ b/Formula/s/shellinabox.rb
@@ -34,8 +34,6 @@ class Shellinabox < Formula
     # https://github.com/shellinabox/shellinabox/issues/518
     ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
-    # Force use of native ptsname_r(), to work around a weird XCode issue on 10.13
-    ENV.append_to_cflags "-DHAVE_PTSNAME_R=1" if OS.mac? && MacOS.version == :high_sierra
     system "autoreconf", "-fiv"
     system "./configure", "--prefix=#{prefix}"
     system "make", "install"

--- a/Formula/s/swiftgen.rb
+++ b/Formula/s/swiftgen.rb
@@ -22,7 +22,7 @@ class Swiftgen < Formula
   depends_on xcode: ["13.3", :build]
   depends_on :macos
 
-  uses_from_macos "ruby" => :build, since: :high_sierra
+  uses_from_macos "ruby" => :build
 
   def install
     # Install bundler (needed for our rake tasks)

--- a/Formula/t/tectonic.rb
+++ b/Formula/t/tectonic.rb
@@ -56,10 +56,7 @@ class Tectonic < Formula
   end
 
   def install
-    if OS.mac?
-      ENV["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version.to_s # needed for CLT-only builds
-      ENV.delete("HOMEBREW_SDKROOT") if MacOS.version == :high_sierra
-    end
+    ENV["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version.to_s if OS.mac? # needed for CLT-only builds
 
     # Ensure that the `openssl` crate picks up the intended library.
     # https://crates.io/crates/openssl#manual-configuration

--- a/Formula/t/texinfo.rb
+++ b/Formula/t/texinfo.rb
@@ -22,7 +22,7 @@ class Texinfo < Formula
   uses_from_macos "ncurses"
   uses_from_macos "perl"
 
-  on_system :linux, macos: :high_sierra_or_older do
+  on_linux do
     depends_on "gettext"
     depends_on "libunistring"
   end

--- a/Formula/u/um.rb
+++ b/Formula/u/um.rb
@@ -25,7 +25,7 @@ class Um < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "c71496a39f88373f2f233b19384bb1ef43e631b280ca0ba51ffcd2838012904f"
   end
 
-  uses_from_macos "ruby", since: :high_sierra
+  uses_from_macos "ruby"
 
   resource "kramdown" do
     url "https://rubygems.org/gems/kramdown-1.17.0.gem"

--- a/Formula/z/zeromq.rb
+++ b/Formula/z/zeromq.rb
@@ -37,12 +37,6 @@ class Zeromq < Formula
   depends_on "libsodium"
 
   def install
-    # Work around "error: no member named 'signbit' in the global namespace"
-    if OS.mac? && MacOS.version == :high_sierra
-      ENV.delete("HOMEBREW_SDKROOT")
-      ENV.delete("SDKROOT")
-    end
-
     ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
 
     # Disable libunwind support due to pkg-config problem


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
