### PR TITLE
formulae: remove unsupported clang build

### DIFF
--- a/Formula/g/gdb.rb
+++ b/Formula/g/gdb.rb
@@ -48,14 +48,6 @@ class Gdb < Formula
     depends_on "guile"
   end
 
-  fails_with :clang do
-    build 800
-    cause <<~EOS
-      probe.c:63:28: error: default initialization of an object of const type
-      'const any_static_probe_ops' without a user-provided default constructor
-    EOS
-  end
-
   def install
     # Fix `error: use of undeclared identifier 'command_style'`
     inreplace "gdb/darwin-nat.c", "#include \"cli/cli-cmds.h\"",

--- a/Formula/p/percona-server.rb
+++ b/Formula/p/percona-server.rb
@@ -58,12 +58,6 @@ class PerconaServer < Formula
 
   conflicts_with "mariadb", "mysql", because: "percona, mariadb, and mysql install the same binaries"
 
-  # https://github.com/percona/percona-server/blob/8.4/cmake/os/Darwin.cmake
-  fails_with :clang do
-    build 999
-    cause "Requires Apple Clang 10.0 or newer"
-  end
-
   # https://github.com/percona/percona-server/blob/8.4/cmake/os/Linux.cmake
   fails_with :gcc do
     version "9"

--- a/Formula/p/percona-server@8.0.rb
+++ b/Formula/p/percona-server@8.0.rb
@@ -58,12 +58,6 @@ class PerconaServerAT80 < Formula
     depends_on "libtirpc"
   end
 
-  # https://github.com/percona/percona-server/blob/8.0/cmake/os/Darwin.cmake
-  fails_with :clang do
-    build 999
-    cause "Requires Apple Clang 10.0 or newer"
-  end
-
   # https://github.com/percona/percona-server/blob/Percona-Server-#{version}/cmake/boost.cmake
   resource "boost" do
     url "https://downloads.sourceforge.net/project/boost/boost/1.77.0/boost_1_77_0.tar.bz2"

--- a/Formula/x/x264.rb
+++ b/Formula/x/x264.rb
@@ -51,18 +51,8 @@ class X264 < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "4ec18379e16e4e5fd740518dd8964472392725b10dcde1e726f02a34bcba813e"
   end
 
-  on_macos do
-    depends_on "gcc" if DevelopmentTools.clang_build_version <= 902
-  end
-
   on_intel do
     depends_on "nasm" => :build
-  end
-
-  # https://code.videolan.org/videolan/x264/-/commit/b5bc5d69c580429ff716bafcd43655e855c31b02
-  fails_with :clang do
-    build 902
-    cause "Stack realignment requires newer Clang"
   end
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
