### PR TITLE
formulae: remove unsupported clang build

### DIFF
--- a/Formula/e/ettercap.rb
+++ b/Formula/e/ettercap.rb
@@ -59,14 +59,13 @@ class Ettercap < Formula
   depends_on "gtk+3"
   depends_on "libmaxminddb"
   depends_on "libnet"
-  depends_on "ncurses" if DevelopmentTools.clang_build_version >= 1000
+  depends_on "ncurses"
   depends_on "openssl@3"
 
   uses_from_macos "bison" => :build
   uses_from_macos "flex" => :build
   uses_from_macos "curl"
   uses_from_macos "libpcap"
-  uses_from_macos "ncurses"
   uses_from_macos "zlib"
 
   on_macos do

--- a/Formula/g/gcc@10.rb
+++ b/Formula/g/gcc@10.rb
@@ -84,7 +84,7 @@ class GccAT10 < Formula
       args << "--with-system-zlib"
 
       # Xcode 10 dropped 32-bit support
-      args << "--disable-multilib" if DevelopmentTools.clang_build_version >= 1000
+      args << "--disable-multilib"
 
       # System headers may not be in /usr/include
       sdk = MacOS.sdk_path_if_needed

--- a/Formula/g/gcc@9.rb
+++ b/Formula/g/gcc@9.rb
@@ -80,7 +80,7 @@ class GccAT9 < Formula
       args << "--with-system-zlib"
 
       # Xcode 10 dropped 32-bit support
-      args << "--disable-multilib" if DevelopmentTools.clang_build_version >= 1000
+      args << "--disable-multilib"
 
       # Workaround for Xcode 12.5 bug on Intel
       # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100340

--- a/Formula/n/node@16.rb
+++ b/Formula/n/node@16.rb
@@ -36,11 +36,6 @@ class NodeAT16 < Formula
     depends_on "python@3.11"
   end
 
-  fails_with :clang do
-    build 1099
-    cause "Node requires Xcode CLT 11+"
-  end
-
   # Backport support for ICU 76+
   patch do
     url "https://github.com/nodejs/node/commit/81517faceac86497b3c8717837f491aa29a5e0f9.patch?full_index=1"

--- a/Formula/s/sngrep.rb
+++ b/Formula/s/sngrep.rb
@@ -20,11 +20,10 @@ class Sngrep < Formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
-  depends_on "ncurses" if DevelopmentTools.clang_build_version >= 1000
+  depends_on "ncurses"
   depends_on "openssl@3"
 
   uses_from_macos "libpcap"
-  uses_from_macos "ncurses"
 
   def install
     ENV.append_to_cflags "-I#{Formula["ncurses"].opt_include}/ncursesw" if OS.linux?

--- a/Formula/s/sparse.rb
+++ b/Formula/s/sparse.rb
@@ -30,15 +30,6 @@ class Sparse < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "8c282a77e53c828abe22a69af0b1dd9cb124b333344f9be1b0f0f3d0a55a3fb0"
   end
 
-  on_macos do
-    depends_on "gcc" if DevelopmentTools.clang_build_version < 1100
-  end
-
-  fails_with :clang do
-    build 1099
-    cause "error: use of unknown builtin '__builtin_clrsb'"
-  end
-
   def install
     # BSD "install" does not understand the GNU -D flag.
     # Create the parent directories ourselves.

--- a/Formula/z/z3.rb
+++ b/Formula/z/z3.rb
@@ -28,14 +28,6 @@ class Z3 < Formula
   # which does not need Python.
   depends_on "python@3.13" => [:build, :test]
 
-  fails_with :clang do
-    build 1000
-    cause <<~EOS
-      Z3 uses modern C++17 features, which is not supported by Apple's clang until
-      later macOS (10.14).
-    EOS
-  end
-
   def python3
     which("python3.13")
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
