### PR TITLE
fs-uae: add workaround for newer clang

### DIFF
--- a/Formula/f/fs-uae.rb
+++ b/Formula/f/fs-uae.rb
@@ -28,7 +28,7 @@ class FsUae < Formula
   end
 
   head do
-    url "https://github.com/FrodeSolheim/fs-uae.git", branch: "master"
+    url "https://github.com/FrodeSolheim/fs-uae.git", branch: "main"
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build
@@ -58,6 +58,10 @@ class FsUae < Formula
 
   def install
     system "./bootstrap" if build.head?
+
+    # Workaround for newer Clang
+    ENV.append_to_cflags "-Wno-c++11-narrowing" if DevelopmentTools.clang_build_version >= 1400
+
     system "./configure", "--disable-silent-rules", *std_configure_args
     mkdir "gen"
     system "make"


### PR DESCRIPTION
fs-uae: add workaround for newer clang

---

```
  src/blkdev.cpp:758:40: error: non-constant-expression cannot be narrowed from type 'int' to 'uae_u8' (aka 'unsigned char') in initializer list [-Wc++11-narrowing]
    758 |                 uae_u8 cmd[10] = {0x4b,0,0,0,0,0,0,0,paused?0:1,0};
        |                                                      ^~~~~~~~~~
  src/blkdev.cpp:758:40: note: insert an explicit cast to silence this issue
    758 |                 uae_u8 cmd[10] = {0x4b,0,0,0,0,0,0,0,paused?0:1,0};
        |                                                      ^~~~~~~~~~
        |                                                      static_cast<uae_u8>( )
```