### PR TITLE
mbpoll: fix cmake 4 compatibility

### DIFF
--- a/Formula/m/mbpoll.rb
+++ b/Formula/m/mbpoll.rb
@@ -22,6 +22,13 @@ class Mbpoll < Formula
   depends_on "pkgconf" => :build
   depends_on "libmodbus"
 
+  # Workaround for CMake 4 compatibility
+  # PR ref: https://github.com/epsilonrt/mbpoll/pull/95
+  patch do
+    url "https://github.com/epsilonrt/mbpoll/commit/baad0efca89f0d8fe370591283d87a6e8e7dee4c.patch?full_index=1"
+    sha256 "75cb9265a30218159d11e6dbda81aa17484d96721f71e22072639d490a7f95d2"
+  end
+
   def install
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args
     system "cmake", "--build", "build"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
