### PR TITLE
mp3blaster: fix build with newer clang

### DIFF
--- a/Formula/m/mp3blaster.rb
+++ b/Formula/m/mp3blaster.rb
@@ -28,6 +28,13 @@ class Mp3blaster < Formula
   uses_from_macos "ncurses"
 
   def install
+    if DevelopmentTools.clang_build_version >= 1700
+      # Fix to error: constant expression evaluates to -1 which cannot be narrowed to type 'unsigned int'
+      ENV.append_to_cflags "-Wno-c++11-narrowing"
+      # Fix to error: :invalid suffix on literal; C++11 requires a space between literal and identifier
+      ENV.append_to_cflags "-Wno-reserved-user-defined-literal"
+    end
+
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--disable-silent-rules",


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
