### PR TITLE
pike: fix build on Tahoe

### DIFF
--- a/Formula/p/pike.rb
+++ b/Formula/p/pike.rb
@@ -52,6 +52,9 @@ class Pike < Formula
     # Reported upstream here: https://git.lysator.liu.se/pikelang/pike/-/issues/10082.
     ENV.prepend_path "PATH", Formula["gnu-sed"].libexec/"gnubin" if OS.mac?
 
+    # clang: error: unsupported option '-mrdrnd' for target 'arm64-apple-darwin25.0.0'
+    ENV["pike_cv_option_opt_rdrnd"] = "no" if Hardware::CPU.arm?
+
     configure_args = %W[
       --prefix=#{libexec}
       --with-abi=64


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fixes:

    checking for pkg-config... /opt/homebrew/Library/Homebrew/shims/mac/super/pkg-config
    checking if a pkg-config based libgmp is installed... /opt/homebrew/Library/Homebrew/shims/mac/super/pkg-config: line 12: /opt/homebrew/opt/pkg-config/bin/pkg-config: No such file or directory
    /opt/homebrew/Library/Homebrew/shims/mac/super/pkg-config: line 12: exec: /opt/homebrew/opt/pkg-config/bin/pkg-config: cannot execute: No such file or directory
    no
    checking gmp.h usability... no
    checking gmp.h presence... yes
    configure: WARNING: gmp.h: present but cannot be compiled
    configure: WARNING: gmp.h:     check for missing prerequisite headers?
    configure: WARNING: gmp.h: see the Autoconf documentation
    configure: WARNING: gmp.h:     section "Present But Cannot Be Compiled"
    configure: WARNING: gmp.h: proceeding with the compiler's result
    checking for gmp.h... no
    checking ansi prototype capability... no, giving up...
    make[1]: *** [configure] Error 1
    make: *** [compile] Error 2
