### PR TITLE
tcc: deprecate

### DIFF
--- a/Formula/t/tcc.rb
+++ b/Formula/t/tcc.rb
@@ -27,6 +27,10 @@ class Tcc < Formula
     sha256 x86_64_linux: "053f79a5752554e18ecba168184e48481bce8a2db418a3f9b0de094f9e6d0e4d"
   end
 
+  # Last release on 2017-12-17 and currently only builds on single runner (x86_64 linux).
+  # The HEAD mob branch unmoderated so not ideal to use an arbitrary commit.
+  deprecate! date: "2025-09-16", because: :unsupported
+
   def install
     # Add appropriate include paths for macOS or Linux.
     os_include_path = if OS.mac?


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Don't really see much value in keeping this around.

I've previously added HEAD to try to provide a buildable version. However, HEAD build is now stale and broken.

For users, it is better idea to just keep around in their own tap or pull in via a build system.