### PR TITLE
inetutils: remove `:high_sierra` usage

### DIFF
--- a/Formula/i/inetutils.rb
+++ b/Formula/i/inetutils.rb
@@ -33,11 +33,7 @@ class Inetutils < Formula
 
   def noshadow
     # List of binaries that do not shadow macOS utils
-    list = %w[dnsdomainname rcp rexec rlogin rsh]
-    on_high_sierra :or_newer do
-      list += %w[ftp telnet]
-    end
-    list
+    %w[dnsdomainname rcp rexec rlogin rsh ftp telnet]
   end
 
   def linux_conflicts
@@ -50,10 +46,10 @@ class Inetutils < Formula
   end
 
   def install
-    system "./configure", *std_configure_args,
-                          "--disable-silent-rules",
+    system "./configure", "--disable-silent-rules",
                           "--with-idn",
-                          "--program-prefix=g"
+                          "--program-prefix=g",
+                          *std_configure_args
     system "make", "SUIDMODE=", "install"
 
     no_conflict = OS.mac? ? noshadow : []


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
