### PR TITLE
mdcat: use `:does_not_build` to avoid bottle tracking

### DIFF
--- a/Formula/m/mdcat.rb
+++ b/Formula/m/mdcat.rb
@@ -16,7 +16,8 @@ class Mdcat < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "87635e02c1cf4066926983af95ae4b67647749adaf2020687c3b258e3937fc9e"
   end
 
-  deprecate! date: "2025-01-10", because: :repo_archived
+  deprecate! date: "2025-01-10", because: :does_not_build # and :repo_archived
+  disable! date: "2026-01-10", because: :does_not_build
 
   depends_on "asciidoctor" => :build
   depends_on "pkgconf" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/actions/runs/17774671300/job/50519351124#step:4:483

mbm tracker has special handling for `:does_not_build`. 