### PR TITLE
wumpus: use `:does_not_build` to avoid bottle tracking

### DIFF
--- a/Formula/w/wumpus.rb
+++ b/Formula/w/wumpus.rb
@@ -22,7 +22,8 @@ class Wumpus < Formula
   end
 
   # checksum got changed and no response from upstream, https://gitlab.com/esr/wumpus/-/issues/2
-  deprecate! date: "2025-09-12", because: :unmaintained
+  deprecate! date: "2025-09-12", because: :does_not_build
+  disable! date: "2026-09-12", because: :does_not_build
 
   def install
     system "make"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We still track deprecated formulae in mbm unless `:does_not_build` is used.

Probably should also add `:checksum_mismatch` to skip list