### PR TITLE
zsh-completions: update test

### DIFF
--- a/Formula/z/zsh-completions.rb
+++ b/Formula/z/zsh-completions.rb
@@ -58,11 +58,10 @@ class ZshCompletions < Formula
 
   test do
     (testpath/"test.zsh").write <<~SHELL
-      fpath=(#{pkgshare} $fpath)
-      autoload _ack
-      which _ack
+      fpath=(#{pkgshare})
+      autoload -R _afew
+      which _afew
     SHELL
-
-    assert_match(/^_ack/, shell_output("zsh test.zsh"))
+    assert_match(/^_afew/, shell_output("zsh test.zsh"))
   end
 end


### PR DESCRIPTION
Test will now fail if referenced completion is missing: previously it would pass even when given a non-existant completion script to check.

Test using a completion that is still part of package: corrected test would have failed, since `_ack` was removed from this package years ago.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
