### PR TITLE
attempt-cli: Use correct description

### DIFF
--- a/Formula/a/attempt-cli.rb
+++ b/Formula/a/attempt-cli.rb
@@ -1,5 +1,5 @@
 class AttemptCli < Formula
-  desc "Containerize your dev environments"
+  desc "CLI for retrying fallible commands"
   homepage "https://github.com/MaxBondABE/attempt"
   url "https://github.com/MaxBondABE/attempt/archive/refs/tags/v1.1.0.tar.gz"
   sha256 "59a5a250de15ec14802eec19b6c63de975ccb72d2f205f1402bef94cf30b2f10"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The description for the `attempt-cli` formula as committed in #244339 is "Containerize your dev environments", which has nothing to do with the formula's actual function and was presumably a copy-and paste error.

This replaces it with "A CLI for retrying fallible commands", which is the actual description in the [source repo](https://github.com/MaxBondABE/attempt).