### PR TITLE
dash-mpd-cli 0.2.27 (new formula)

### DIFF
--- a/Formula/d/dash-mpd-cli.rb
+++ b/Formula/d/dash-mpd-cli.rb
@@ -6,6 +6,12 @@ class DashMpdCli < Formula
   license "MIT"
   head "https://github.com/emarsden/dash-mpd-cli.git", branch: "main"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_sonoma: "7114a3a27fb5dac5d261bd2093ab61ba5a3f6616e248cbe4bd84cbbe40b901f0"
+    sha256 cellar: :any_skip_relocation, sonoma:       "f96174fd46c1142421281112246e56f809a785e9aecf5f7cf89e20d4d961b055"
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "9ad451329d0d7739fa06ae39c29c1e4e37eec28aa7c344665b5d55ec8d76122c"
+  end
+
   depends_on "protobuf" => :build
   depends_on "rust" => :build
   depends_on "bento4"

--- a/Formula/d/dash-mpd-cli.rb
+++ b/Formula/d/dash-mpd-cli.rb
@@ -1,0 +1,30 @@
+class DashMpdCli < Formula
+  desc "Download media content from a DASH-MPEG or DASH-WebM MPD manifest"
+  homepage "https://emarsden.github.io/dash-mpd-cli/"
+  url "https://github.com/emarsden/dash-mpd-cli/archive/refs/tags/v0.2.27.tar.gz"
+  sha256 "01a4a513ddebdc9affed8f6e51575df7b7bc2bcdeb785f8e321c84b46c94eb63"
+  license "MIT"
+  head "https://github.com/emarsden/dash-mpd-cli.git", branch: "main"
+
+  depends_on "protobuf" => :build
+  depends_on "rust" => :build
+  depends_on "bento4"
+  depends_on "ffmpeg"
+  depends_on "mkvtoolnix"
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    resource "testfile" do
+      url "https://storage.googleapis.com/shaka-demo-assets/angel-one-widevine/dash.mpd"
+      sha256 "4fb9ea292aba0db94ddfe8c941b8423d98decb51dca851afbc203e409bd487d4"
+    end
+
+    dash_manifest_url = resource("testfile").url
+
+    output = shell_output("#{bin}/dash-mpd-cli --simulate --verbose #{dash_manifest_url} 2>&1")
+    assert_match "video avc1.4d401f       |  7493 Kbps |   768x576", output.chomp
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Adds [dash-mpd-cli](https://github.com/emarsden/dash-mpd-cli), a command line application for downloading media content from a DASH MPD file, as used for on-demand replay of TV content and video streaming services.