### PR TITLE
plakar: remove agent service

### DIFF
--- a/Formula/p/plakar.rb
+++ b/Formula/p/plakar.rb
@@ -25,21 +25,12 @@ class Plakar < Formula
     system "go", "build", *std_go_args(ldflags: "-s -w")
   end
 
-  service do
-    run [opt_bin/"plakar", "agent", "-foreground"]
-    keep_alive true
-  end
-
   test do
     assert_match version.to_s, shell_output("#{bin}/plakar version")
 
     repo = testpath/"plakar"
-    system bin/"plakar", "at", repo, "create", "-plaintext", "-no-compression"
+    system bin/"plakar", "-no-agent", "at", repo, "create", "-plaintext", "-no-compression"
     assert_path_exists repo
-
-    # Skip linux CI test as test due to `failed to run the agent` error
-    return if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"]
-
-    assert_match "Repository", shell_output("#{bin}/plakar at #{repo} info")
+    assert_match "Repository", shell_output("#{bin}/plakar -no-agent at #{repo} info")
   end
 end

--- a/Formula/p/plakar.rb
+++ b/Formula/p/plakar.rb
@@ -11,12 +11,13 @@ class Plakar < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "dd541aab41faafda34ff5082ce43ef9f2d3f3638f9ec79bcb66a62b9eb14c9e7"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "f25f9d87c90cdb9242a19cc7fda93243ce679192c8a603f2db59b60ac4af5e84"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "c09440d6f94f6f52a39bd0de9458e6588b953d0a82f3b0a020d82302d47bb8c2"
-    sha256 cellar: :any_skip_relocation, sonoma:        "92be32f8055c7ae5b881a44631db8e14d892cf304563a610a01f8b34fe4db34e"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "702d95c9ec88a775b5d7618bab78ad9faa2b62f82147d398369f2e4f0d9aecbc"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "39b25bd2cb6cfba3f2c7749f5fefbbbd1d2afbe1bdf72a6b15f7fd9da980851c"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "05bfe0625daf8826181764459e8ba36f86d02227ff06467690c152f95e145667"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "818e741785d9ca4725d714652740c4131c89beab5f34505b939e5d475df9e092"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "e7284fbb3ee7b602f5d9165e3ffc9985d35951794453e59484e895b19ba9c09b"
+    sha256 cellar: :any_skip_relocation, sonoma:        "31c706033abcc1c17a781556c587efba6a71d7123c115a40667a9ecbbee8cc4e"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "ee546b3ea5d384ad040ddbeed9dcc559c12d751eba775428bda076030ea7404a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "601a6eb18db4e0fa7b509056e7a5a774eee4db3db44af7beff75914815b4aa5e"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
With v1.0.4, it is no longer necessary (or possible) to start the plakar agent.


- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
