### PR TITLE
gradle@8: switch to `openjdk@21`

### DIFF
--- a/Formula/g/gradle@8.rb
+++ b/Formula/g/gradle@8.rb
@@ -12,7 +12,7 @@ class GradleAT8 < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "f1eae3a15f69a395246d590a2affefb1c30b1bca61f00996490ca76ce8965eb1"
+    sha256 cellar: :any_skip_relocation, all: "2626c2bf646f7ad9f6b9c192968e30b25e1226e7ff40659b695ab6b10513191f"
   end
 
   keg_only :versioned_formula

--- a/Formula/g/gradle@8.rb
+++ b/Formula/g/gradle@8.rb
@@ -4,6 +4,7 @@ class GradleAT8 < Formula
   url "https://services.gradle.org/distributions/gradle-8.14.3-all.zip"
   sha256 "ed1a8d686605fd7c23bdf62c7fc7add1c5b23b2bbc3721e661934ef4a4911d7c"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     url "https://gradle.org/releases/"
@@ -17,17 +18,13 @@ class GradleAT8 < Formula
   keg_only :versioned_formula
 
   # https://github.com/gradle/gradle/blob/master/platforms/documentation/docs/src/docs/userguide/releases/compatibility.adoc
-  depends_on "openjdk"
+  depends_on "openjdk@21"
 
   def install
     rm(Dir["bin/*.bat"])
     libexec.install %w[bin docs lib src]
-    env = Language::Java.overridable_java_home_env
+    env = Language::Java.overridable_java_home_env("21")
     (bin/"gradle").write_env_script libexec/"bin/gradle", env
-
-    # Ensure we have uniform bottles.
-    inreplace libexec/"src/jvm-services/org/gradle/jvm/toolchain/internal/LinuxInstallationSupplier.java",
-              "/usr/local", HOMEBREW_PREFIX
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

In preparation for `openjdk` 25 (#243689). This version does not support Java 25.
