### PR TITLE
tiny-remapper: switch to `openjdk@21`

### DIFF
--- a/Formula/t/tiny-remapper.rb
+++ b/Formula/t/tiny-remapper.rb
@@ -13,7 +13,7 @@ class TinyRemapper < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "99a430d8364a495aab6a8d0567737652cc7cd9e64606cb76ba10120eef0c8926"
+    sha256 cellar: :any_skip_relocation, all: "971ac87b9ad46551ec0fa6c3ff9a91d53a904bde4ec6a8835076f604898730a5"
   end
 
   depends_on "openjdk@21"

--- a/Formula/t/tiny-remapper.rb
+++ b/Formula/t/tiny-remapper.rb
@@ -1,9 +1,11 @@
 class TinyRemapper < Formula
   desc "Tiny, efficient tool for remapping JAR files using \"Tiny\"-format mappings"
   homepage "https://fabricmc.net/"
+  # TODO: Check if we can use `openjdk` 25+ when bumping the version.
   url "https://maven.fabricmc.net/net/fabricmc/tiny-remapper/0.11.2/tiny-remapper-0.11.2-fat.jar"
   sha256 "0376b17b92f858956e018da672affb5485c18085db681f9547664996e82b6688"
   license "LGPL-3.0-only"
+  revision 1
 
   livecheck do
     url "https://maven.fabricmc.net/net/fabricmc/tiny-remapper/maven-metadata.xml"
@@ -14,11 +16,16 @@ class TinyRemapper < Formula
     sha256 cellar: :any_skip_relocation, all: "99a430d8364a495aab6a8d0567737652cc7cd9e64606cb76ba10120eef0c8926"
   end
 
-  depends_on "openjdk"
+  depends_on "openjdk@21"
+
+  def openjdk
+    Formula["openjdk@21"]
+  end
 
   def install
     libexec.install "tiny-remapper-#{version}-fat.jar"
-    bin.write_jar_script libexec/"tiny-remapper-#{version}-fat.jar", "tiny-remapper"
+    bin.write_jar_script libexec/"tiny-remapper-#{version}-fat.jar", "tiny-remapper",
+                         java_version: "21"
   end
 
   test do
@@ -46,11 +53,15 @@ class TinyRemapper < Formula
       \tm	()V	method_1234	printMethods
     TINY
 
-    system Formula["openjdk"].bin/"javac", "Main.java"
-    system Formula["openjdk"].bin/"jar", "-cf", "input.jar", "Main.class"
-    assert_match "method method_1234", shell_output("#{Formula["openjdk"].bin}/java -cp input.jar Main")
+    javac = openjdk.opt_bin/"javac"
+    java = openjdk.opt_bin/"java"
+    jar = openjdk.opt_bin/"jar"
+
+    system javac, "Main.java"
+    system jar, "-cf", "input.jar", "Main.class"
+    assert_match "method method_1234", shell_output("#{java} -cp input.jar Main")
 
     system bin/"tiny-remapper", "input.jar", "output.jar", "mappings.tiny", "intermediary", "named"
-    assert_match "method printMethods", shell_output("#{Formula["openjdk"].bin}/java -cp output.jar Main")
+    assert_match "method printMethods", shell_output("#{java} -cp output.jar Main")
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

In preparation for `openjdk` 25 (#243689).
