### PR TITLE
afm 0.6.0 (new formula)

### DIFF
--- a/Formula/a/afm.rb
+++ b/Formula/a/afm.rb
@@ -1,0 +1,51 @@
+class Afm < Formula
+  desc "macOS server exposing Apple Foundation Models through OpenAI-compatible API"
+  homepage "https://github.com/scouzi1966/maclocal-api"
+  url "https://github.com/scouzi1966/maclocal-api/archive/refs/tags/v0.6.0.tar.gz"
+  sha256 "522665b0b43d4f1d26e6a0c43857444bcc7e11f50530e24ea1b9b0a979a77ab8"
+  license "MIT"
+
+  # Build requirements
+  depends_on xcode: ["16.0", :build]
+
+  # macOS-specific requirements
+  depends_on arch: :arm64 # Apple Silicon only
+  depends_on :macos
+
+  # System requirements - let the build fail gracefully if Foundation Models unavailable
+
+  def install
+    system "swift", "build", "--disable-sandbox", "--configuration", "release"
+    bin.install ".build/release/afm"
+  end
+
+  def caveats
+    <<~EOS
+      afm requires:
+      • macOS Tahoe 26.0+ with Apple Intelligence enabled
+      • Apple Silicon Mac (M1, M2, M3, or M4)
+      • Apple Intelligence enabled in System Settings → Apple Intelligence & Siri
+
+      Note: This formula requires macOS Tahoe (26.0) which limits compatibility
+      to systems with the latest macOS version.
+
+      Usage:
+        afm                    # Start server on default port 9999
+        afm --port 8080        # Custom port
+        afm -s "prompt"        # Single prompt mode
+        echo "text" | afm      # Pipe input support
+    EOS
+  end
+
+  test do
+    # Test version output
+    assert_match version.to_s, shell_output("#{bin}/afm --version")
+
+    # Test help output
+    assert_match "USAGE:", shell_output("#{bin}/afm --help")
+
+    # Test single prompt mode (will fail gracefully if Apple Intelligence not available)
+    output = shell_output("#{bin}/afm -s 'test' 2>&1 || true")
+    assert_match(/Foundation Models|not available|Apple Intelligence/, output)
+  end
+end


### PR DESCRIPTION
# Add afm 0.6.0

## Description

AFM (Apple Foundation Models API) is a macOS server that exposes Apple's Foundation Models through OpenAI-compatible API endpoints, enabling local AI inference with privacy-first design.

## Key Features

- 🔗 **OpenAI API Compatible** - Works with existing OpenAI client libraries
- 📱 **Apple Foundation Models** - Uses Apple's on-device 3B parameter language model  
- 🔒 **Privacy-First** - All processing happens locally on device
- ⚡ **Fast & Lightweight** - No network calls, no API keys required
- 🛠️ **Easy Integration** - Drop-in replacement for OpenAI API endpoints
- 🚰 **CLI Composability** - Accepts piped input from other commands

## System Requirements

- macOS Tahoe 26.0+ with Apple Intelligence enabled
- Apple Silicon Mac (M1, M2, M3, or M4 series)
- Apple Intelligence enabled in System Settings

## Usage Examples

```bash
# Start server (default port 9999)
afm

# Single prompt mode
afm -s "Explain quantum computing"

# Pipe input support
echo "What is the meaning of life?" | afm
git log --oneline | head -5 | afm
```

## API Endpoints

- `POST /v1/chat/completions` - OpenAI-compatible chat completions
- `GET /v1/models` - Available Foundation Models
- `GET /health` - Server health status

## Checklist

- [x] Formula builds without errors
- [x] Formula passes `brew audit --new --formula afm`
- [x] Formula follows Homebrew's style guidelines
- [x] Appropriate system requirements specified
- [x] Test block covers basic functionality
- [x] Caveats explain system requirements
- [x] License matches upstream (MIT)

## Notes

This formula is macOS and Apple Silicon specific due to its dependency on Apple's Foundation Models framework, which is only available on macOS Tahoe 26.0+ with Apple Intelligence enabled. This provides unique functionality that isn't available elsewhere - local Apple Intelligence access via OpenAI-compatible APIs.
