### PR TITLE
mupen64plus: skip test on Tahoe

### DIFF
--- a/Formula/m/mupen64plus.rb
+++ b/Formula/m/mupen64plus.rb
@@ -61,8 +61,9 @@ class Mupen64plus < Formula
   end
 
   test do
-    # Disable test in Linux CI because it hangs because a display is not available.
+    # Disable test in Linux and Tahoe CI because it hangs because a display is not available.
     return if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"]
+    return if OS.mac? && MacOS.version == :tahoe && ENV["HOMEBREW_GITHUB_ACTIONS"]
 
     resource "rom" do
       url "https://github.com/mupen64plus/mupen64plus-rom/raw/76ef14c876ed036284154444c7bdc29d19381acc/m64p_test_rom.v64"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The test passed locally, but failed silently in CI likely due to the absence of a display.
