### PR TITLE
gtk+: target Sonoma due to obsolete CGWindowListCreateImage

### DIFF
--- a/Formula/g/gtk+.rb
+++ b/Formula/g/gtk+.rb
@@ -28,10 +28,6 @@ class Gtkx < Formula
   end
 
   depends_on "gobject-introspection" => :build
-  # error: 'CGWindowListCreateImage' is unavailable: obsoleted in macOS 15.0 - Please use ScreenCaptureKit instead
-  # NOTE: We could potentially use an older deployment target; however, `gtk+` has been EOL since 2020.
-  # So rather than trying to workaround obsolete APIs, the limit is a deadline to deprecate `gtk+` and dependents.
-  depends_on maximum_macos: [:sonoma, :build]
   depends_on "pkgconf" => [:build, :test]
   depends_on "at-spi2-core"
   depends_on "cairo"
@@ -86,6 +82,9 @@ class Gtkx < Formula
   end
 
   def install
+    # Uses obsolete CGWindowListCreateImage. GTK+ is EOL so won't be updated to ScreenCaptureKit
+    ENV["MACOSX_DEPLOYMENT_TARGET"] = "14.0" if OS.mac? && MacOS.version >= :sequoia
+
     # Work-around for build issue with Xcode 15.3
     if DevelopmentTools.clang_build_version >= 1500
       ENV.append_to_cflags "-Wno-incompatible-function-pointer-types -Wno-implicit-int"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
