### PR TITLE
gource: remove ENV.libcxx

### DIFF
--- a/Formula/g/gource.rb
+++ b/Formula/g/gource.rb
@@ -42,8 +42,6 @@ class Gource < Formula
   end
 
   def install
-    ENV.cxx11
-
     # Workaround for Boost 1.89.0 as upstream commit requires regenerating configure
     # https://github.com/acaudwell/Gource/commit/1b4e37d71506e6ad19f15190907852978507fc6a
     if build.stable?
@@ -51,9 +49,7 @@ class Gource < Formula
       ENV["with_boost_system"] = "no"
     end
 
-    # clang on Mt. Lion will try to build against libstdc++,
-    # despite -std=gnu++0x
-    ENV.libcxx
+    ENV.cxx11
     ENV.append "LDFLAGS", "-pthread" if OS.linux?
 
     system "autoreconf", "--force", "--install", "--verbose" if build.head?


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Try removing some ancient Apple libstdc++ stuff