### PR TITLE
nebula: update config ref in service

### DIFF
--- a/Formula/n/nebula.rb
+++ b/Formula/n/nebula.rb
@@ -27,7 +27,7 @@ class Nebula < Formula
   end
 
   service do
-    run [opt_bin/"nebula", "-config", etc/"nebula/config.yml"]
+    run [opt_bin/"nebula", "-config", etc/"nebula/"]
     keep_alive true
     require_root true
     log_path var/"log/nebula.log"

--- a/Formula/n/nebula.rb
+++ b/Formula/n/nebula.rb
@@ -7,14 +7,13 @@ class Nebula < Formula
   head "https://github.com/slackhq/nebula.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "3d738fd69c42ab18ecc2a660f83c79bfb373ca7c81ef8b09ce462b7f0fc47b6f"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e6f59a4f872d1473f2f7cf18926ab14b7d8bbccb5bb892e6c872c11a6b43ec21"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "e6f59a4f872d1473f2f7cf18926ab14b7d8bbccb5bb892e6c872c11a6b43ec21"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "e6f59a4f872d1473f2f7cf18926ab14b7d8bbccb5bb892e6c872c11a6b43ec21"
-    sha256 cellar: :any_skip_relocation, sonoma:        "24965ddda6baddc380d6adf41afa33988b5114723016f1af555f822f5bd4d08d"
-    sha256 cellar: :any_skip_relocation, ventura:       "24965ddda6baddc380d6adf41afa33988b5114723016f1af555f822f5bd4d08d"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "55c9c2784a48e6e192efd609244aea588ae89c142ca68ddfc93b2c3b43c38025"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "06cc496be659b9958ef4368e2773e270a91a8be32ba41f9054471eba7b503be4"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "9ea5bd56ad2d80258cd1c953579638bd57c792bf8718bdf1f3764d311debbe38"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "9ea5bd56ad2d80258cd1c953579638bd57c792bf8718bdf1f3764d311debbe38"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "9ea5bd56ad2d80258cd1c953579638bd57c792bf8718bdf1f3764d311debbe38"
+    sha256 cellar: :any_skip_relocation, sonoma:        "ce40df53bf659aaf6c0a11e829566209a47b9e88034d9bb60153911475122118"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "485047208e47cf11bf919f48f7da6bde8d9cd2dc6119e711d552f84d70888417"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "dff95a5f73806f67554cdef5fb8b2b380df586e5320235a7ad58ee24f878512d"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
Redo of https://github.com/Homebrew/homebrew-core/pull/244744.

Update the nebula service to search the nebula config folder for config files / config folders.

If passed a folder for config, nebula will look within the folder and descend into children of that folder looking for config files, and then will sort them lexically: [slackhq/nebula@5cccd39/config/config.go#L41-L62](https://github.com/slackhq/nebula/blob/5cccd394656ab223ca58dc937400f00013fe442a/config/config.go#L41-L62)

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
