### PR TITLE
hevi: backport support for `zig@0.14`

### DIFF
--- a/Formula/h/hevi.rb
+++ b/Formula/h/hevi.rb
@@ -14,13 +14,29 @@ class Hevi < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "98a58cbce9389c32d13ddf68be6a62b89113000d5ae6f82711174b90cf63174e"
   end
 
-  depends_on "zig" => :build
+  # https://github.com/Arnau478/hevi/commit/6f46f9e6fbcfb7bd331dadbde7f6da48a6679b5c
+  depends_on "zig@0.14" => :build
+
+  # Backport support for Zig 0.14
+  patch do
+    url "https://github.com/Arnau478/hevi/commit/07847bf8c2f05d02756aea1ffce7dd60ad563daf.patch?full_index=1"
+    sha256 "71e992a3183a7fbfa94ac98b12e02fee2f36f4e66b7a60ae78bb699f461edc90"
+  end
+  patch :DATA # https://github.com/Arnau478/hevi/commit/3ef411b8664c8ac7d8296680b2d494f7193a521d
+  patch do
+    url "https://github.com/Arnau478/hevi/commit/830ce7fff48429027c6a527b9c9a53935a212e81.patch?full_index=1"
+    sha256 "9a78d4e64126c0ddc4c2fa84c0f6a163b8dacd41558df564ca4918c4c3454ea8"
+  end
 
   def install
+    # Revert the version update patch
+    inreplace "build.zig.zon", '"2.0.0"', "\"#{version}\""
+
     # Fix illegal instruction errors when using bottles on older CPUs.
     # https://github.com/Homebrew/homebrew-core/issues/92282
     cpu = case Hardware.oldest_cpu
     when :arm_vortex_tempest then "apple_m1" # See `zig targets`.
+    when :armv8 then "xgene1" # Closest to `-march=armv8-a`
     else Hardware.oldest_cpu
     end
 
@@ -34,3 +50,15 @@ class Hevi < Formula
     assert_match "00000000", shell_output("#{bin}/hevi #{test_fixtures("test.pdf")}")
   end
 end
+
+__END__
+--- a/build.zig.zon
++++ b/build.zig.zon
+@@ -1,6 +1,6 @@
+ .{
+     .name = "hevi",
+-    .version = "1.1.0",
++    .version = "2.0.0",
+     .dependencies = .{
+         .ziggy = .{
+             .url = "git+https://github.com/kristoff-it/ziggy#ae30921d8c98970942d3711553aa66ff907482fe",


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
