### PR TITLE
x265: enable alpha

### DIFF
--- a/Formula/x/x265.rb
+++ b/Formula/x/x265.rb
@@ -38,6 +38,7 @@ class X265 < Formula
     ENV.runtime_cpu_detection
     # Build based off the script at ./build/linux/multilib.sh
     args = %W[
+      -DENABLE_ALPHA=ON
       -DLINKED_10BIT=ON
       -DLINKED_12BIT=ON
       -DEXTRA_LINK_FLAGS=-L.
@@ -47,6 +48,7 @@ class X265 < Formula
     args << "-DENABLE_SVE2=OFF" if OS.linux? && Hardware::CPU.arm?
     args << "-DCMAKE_POLICY_VERSION_MINIMUM=3.5" # FIXME: Workaround for CMake 4.
     high_bit_depth_args = %w[
+      -DENABLE_ALPHA=ON
       -DHIGH_BIT_DEPTH=ON -DEXPORT_C_API=OFF
       -DENABLE_SHARED=OFF -DENABLE_CLI=OFF
     ]


### PR DESCRIPTION
Complement [FFmpeg 8.x added support to x265 with alpha](https://trac.ffmpeg.org/ticket/7965#comment:21).

Added Cmake `-DENABLE_ALPHA=ON` flag for 8, 10, and 12-bit encoding.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
