### PR TITLE
whisperkit-cli: Set BUILD_ALL environment variable for cli build

### DIFF
--- a/Formula/w/whisperkit-cli.rb
+++ b/Formula/w/whisperkit-cli.rb
@@ -21,6 +21,7 @@ class WhisperkitCli < Formula
   uses_from_macos "swift"
 
   def install
+    ENV["BUILD_ALL"] = "1"
     system "swift", "build", "-c", "release", "--product", "whisperkit-cli", "--disable-sandbox"
     bin.install ".build/release/whisperkit-cli"
     generate_completions_from_executable(bin/"whisperkit-cli", "--generate-completion-script")

--- a/Formula/w/whisperkit-cli.rb
+++ b/Formula/w/whisperkit-cli.rb
@@ -8,9 +8,10 @@ class WhisperkitCli < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "9f4d70ab8aac4adae190a73fd0877a9be12e9ab9e1a97918f59c09bbd1fdc872"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "c3b8d2e7edbbbaebe36cbcd3c1403edec0e698a24bae2560d37d6b40e8a3b703"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "2d2fc834aca630f85b37c543aed47bc5eb736b12cb3f984035034631411bdab4"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "982007b3ea8e82d10d921b22f42e6194cfa522d436fe7a88bebe90a79c1f1392"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "75d2b956d492974b9dfbd27ee87c379af486b0e66d9a94df24420d7f46385c3b"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "ef2041adae5c4abf8a4e52c9870fae60b06500cd279001866ac5b6dd1a753a33"
   end
 
   depends_on xcode: ["15.0", :build]


### PR DESCRIPTION
Previous PR: https://github.com/Homebrew/homebrew-core/pull/225534

Was [closed](https://github.com/Homebrew/homebrew-core/pull/225534#discussion_r2126302137) due to the feature being pre-release, which has since been merged into main.

BUILD_ALL flag in the code: [argmaxinc/WhisperKit@3a38043/Package.swift#L71-L73](https://github.com/argmaxinc/WhisperKit/blob/3a380435ce1b28c488db301864f9b1de329a63e6/Package.swift#L71-L73)
Documentation for how to use: [argmaxinc/WhisperKit@main/README.md#building-the-server](https://github.com/argmaxinc/WhisperKit/blob/main/README.md?rgh-link-date=2025-09-11T17%3A19%3A40Z#building-the-server)

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
