### PR TITLE
webtorrent-cli: remove more build files

### DIFF
--- a/Formula/w/webtorrent-cli.rb
+++ b/Formula/w/webtorrent-cli.rb
@@ -6,14 +6,13 @@ class WebtorrentCli < Formula
   license "MIT"
 
   bottle do
-    rebuild 1
-    sha256 arm64_sequoia: "eb96a6e72f8c04344827b1d098938557cc110c58086e09e725bb6baa2c4f5439"
-    sha256 arm64_sonoma:  "e0d8b93558e6684dd9b06357cdaec1bf680f34e825cda653e981674c6c31e796"
-    sha256 arm64_ventura: "abe70e531a96d75b7ce514492dd43605e27b9276d210601f31a32624fe72af8c"
-    sha256 sonoma:        "fbe60e713aca44e2adc2ae4d50f2d93f6053047a90820c3ae620e142916180b0"
-    sha256 ventura:       "3f1f6158f5f07a5fce88a6c6497596da89c17fe438a761332921e4346c227f15"
-    sha256 arm64_linux:   "97429c5667c198d2fdad6ad7545e278cef826f3e160117e6a9c172ad73cce69f"
-    sha256 x86_64_linux:  "c36c64165586a9af662fa923e602821e649bee2a5fda5563c5de109e6429a9c1"
+    rebuild 2
+    sha256 arm64_tahoe:   "4f3bda6aa26bcf929db135e31c3fb3822ef250a7738438b4256c0706abc736b6"
+    sha256 arm64_sequoia: "2455bfe4e4762ecf6d4110b6e3db3160d6b6f7ed455062fea983f230b127b127"
+    sha256 arm64_sonoma:  "89c52aa581dbbf5676cb8fd1e7837f9e7830b35ee33fda3b1dba4b37484b33d7"
+    sha256 sonoma:        "6ba628acde26d8a0b2c90c235cbb4b55739c860781a3974160556e5bfc4169f6"
+    sha256 arm64_linux:   "a44f21e2d862608a8087a7ec516b56d181ebdf61246c2ac7c21d92af9a3b38db"
+    sha256 x86_64_linux:  "9760ecc99259186588ceccdfa3e25a12296ba01b852c2c3411c2c7eeadc3e0ee"
   end
 
   depends_on "cmake" => :build

--- a/Formula/w/webtorrent-cli.rb
+++ b/Formula/w/webtorrent-cli.rb
@@ -31,18 +31,17 @@ class WebtorrentCli < Formula
 
     nm = libexec/"lib/node_modules/webtorrent-cli/node_modules"
 
-    # Delete files that references to the Homebrew shims directory
-    sb = nm/"node-datachannel/build"
-    rm [
-      sb/"CMakeFiles/CMakeConfigureLog.yaml",
-      sb/"CMakeFiles/rules.ninja",
-      sb/"CMakeFiles/#{Formula["cmake"].version}/CMakeCXXCompiler.cmake",
-      sb/"CMakeFiles/#{Formula["cmake"].version}/CMakeCCompiler.cmake",
-      sb/"_deps/libdatachannel-subbuild/CMakeLists.txt",
-      sb/"_deps/libdatachannel-subbuild/libdatachannel-populate-prefix/tmp/libdatachannel-populate-gitclone.cmake",
-      sb/"_deps/libdatachannel-subbuild/libdatachannel-populate-prefix/tmp/libdatachannel-populate-gitupdate.cmake",
-      sb/"CMakeCache.txt",
-    ]
+    # Remove node-datachannel dev dependencies which were installed via
+    # `npm install --ignore-scripts --production=false` to build node-datachannel.node
+    # Also remove prebuild-install which was needed at install time due to install script
+    node_domexception = nm/"node-datachannel/node_modules/node-domexception"
+    rm_r(nm.glob("node-datachannel/node_modules/*") - [node_domexception])
+    odie "node-domexception not found! Check if it is still a dependency." unless node_domexception.exist?
+
+    # Remove node-datachannel CMake build directory other than the final binary
+    node_datachannel_release_dir = nm/"node-datachannel/build/Release"
+    rm_r(nm.glob("node-datachannel/build/*") - [node_datachannel_release_dir])
+    odie "node-datachannel.node not found!" if node_datachannel_release_dir.glob("*.node").empty?
 
     # Remove incompatible pre-built binaries
     os = OS.kernel_name.downcase


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`node-datachannel` at https://github.com/murat-dogan/node-datachannel/blob/v0.12.0/package.json#L38 does:
```
        "install": "prebuild-install -r napi || (npm install --ignore-scripts --production=false && npm run _prebuild)",
```

The `prebuild-install -r napi` is reason why `prebuild-install` is a dependency, but since we use `npm install --build-from-source`, it should be automatically skipped (avoiding prebuild fetching).

Instead, we will hit OR condition that does `npm install --ignore-scripts --production=false` which then installs devDependencies. Since this doesn't use our DSL, it pulls in more prebuilds used to source build `node-datachannel`.

---

Once the binary is built, it doesn't seem to need `prebuild-install` or build files as it just uses path to .node file https://github.com/murat-dogan/node-datachannel/blob/v0.12.0/lib/node-datachannel.js
```js
const nodeDataChannel = require('../build/Release/node_datachannel.node');
```

---

Let's try deleting all the build dependencies for now. Ideally, upstream would use something other than `npm install` like switching to `node-gyp-install` but doesn't matter given `webtorrent-cli` is stuck on an old version of `node-datachannel` for now.