### PR TITLE
qsoas: workaround for MRuby 3.4.0 and Tahoe

### DIFF
--- a/Formula/q/qsoas.rb
+++ b/Formula/q/qsoas.rb
@@ -36,6 +36,11 @@ class Qsoas < Formula
   uses_from_macos "ruby"
 
   def install
+    # Workaround for MRuby 3.4.0 and to avoid C standard passed to C++ compiler
+    # Issue ref: https://github.com/fourmond/QSoas/issues/5
+    inreplace "src/mruby.cc", "(OP_LOADI,", "(OP_LOADI8,"
+    inreplace "QSoas.pro", "mruby-config --cflags)", "mruby-config --cxxflags)"
+
     gsl = Formula["gsl"].opt_prefix
     qt5 = Formula["qt@5"].opt_prefix
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
