### PR TITLE
p11-kit: update sha for 0.25.9 release

### DIFF
--- a/Formula/p/p11-kit.rb
+++ b/Formula/p/p11-kit.rb
@@ -2,7 +2,7 @@ class P11Kit < Formula
   desc "Library to load and enumerate PKCS#11 modules"
   homepage "https://p11-glue.freedesktop.org"
   url "https://github.com/p11-glue/p11-kit/releases/download/0.25.9/p11-kit-0.25.9.tar.xz"
-  sha256 "f6512a10b2dcf2651cfd57dd767a36c6e44494ab37724c10d4304fe9f0a36497"
+  sha256 "98a96f6602a70206f8073deb5e894b1c8efd76ef53c629ab88815d58273f2561"
   license "BSD-3-Clause"
 
   bottle do


### PR DESCRIPTION
Fix SHA-256

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
