### PR TITLE
cubejs-cli 1.3.70

### DIFF
--- a/Formula/c/cubejs-cli.rb
+++ b/Formula/c/cubejs-cli.rb
@@ -6,12 +6,12 @@ class CubejsCli < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "64db9c611fe1fb7dee255d806e88b2c5db1f9c0ead1c02d0426e758be4f8d93e"
-    sha256 cellar: :any,                 arm64_sequoia: "e2dfdb6ba0337ccd434626f0b6d600b615d1dd70042f8de9a0ed126234087b65"
-    sha256 cellar: :any,                 arm64_sonoma:  "e2dfdb6ba0337ccd434626f0b6d600b615d1dd70042f8de9a0ed126234087b65"
-    sha256 cellar: :any,                 sonoma:        "bba8a3606e27dd6739cc42c3060b90428c28f5e787c2bba01f8e3859df4a473b"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "061c385e9b4e2b15660d54e224d6b8004af396c99b5b25e8c51714aacdfcad56"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2a4c6bcc03f9c488dd9373e5b5e5ad22489d26e7dbff73cd1b024d87020499f4"
+    sha256 cellar: :any,                 arm64_tahoe:   "8a16d342573cb90e39401dfd9f4fdfd9b29a6637ef6177b498a0ce79f09eca27"
+    sha256 cellar: :any,                 arm64_sequoia: "c74b51159c010578c693b94b54c1c2cc17b3fa40484649cecc309ca9f87db669"
+    sha256 cellar: :any,                 arm64_sonoma:  "c74b51159c010578c693b94b54c1c2cc17b3fa40484649cecc309ca9f87db669"
+    sha256 cellar: :any,                 sonoma:        "ccd2a7c63593e9ef77a6b12a1832186f23cf9208c30a8f9d3a4875b0bc4270da"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "ef9dd6b3e7932aaac4a26de8d211a2794901e5792bfa467f6f0444f2c1525d2d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "451c0b58a9a9ebdf40619bb771f8f137c295552e345780b54446569996e570b8"
   end
 
   depends_on "node"

--- a/Formula/c/cubejs-cli.rb
+++ b/Formula/c/cubejs-cli.rb
@@ -1,8 +1,8 @@
 class CubejsCli < Formula
   desc "Cube.js command-line interface"
   homepage "https://cube.dev/"
-  url "https://registry.npmjs.org/cubejs-cli/-/cubejs-cli-1.3.69.tgz"
-  sha256 "ece1ebf34867c5e0123e6d94ec2c5efc09357137fa8cd7f8d49f76c915e1eb39"
+  url "https://registry.npmjs.org/cubejs-cli/-/cubejs-cli-1.3.70.tgz"
+  sha256 "a69ea8ef05369c0170fc452415499e40e24469070d1a07b877eeff35bb3e57a9"
   license "Apache-2.0"
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

livecheck uses the `Npm` strategy to check for new versions of `cubejs-cli` but the strategy is currently broken, so the autobump workflow is failing to update related formulae to new versions that are available. This manually updates `cubejs-cli` to 1.3.70, using CI-skip-livecheck to allow this to pass CI while my [brew PR to fix `Npm`](https://github.com/Homebrew/brew/pull/20734) is pending review.

[CI-skip-livecheck shouldn't be used to avoid a broken check under normal circumstances (an existing check should be fixed or a working `livecheck` block added) but a fix is coming for `Npm`, so I'm fine with using this as a workaround to merge version updates in the interim time.]