### PR TITLE
e2b 2.2.1

### DIFF
--- a/Formula/e/e2b.rb
+++ b/Formula/e/e2b.rb
@@ -1,8 +1,8 @@
 class E2b < Formula
   desc "CLI to manage E2B sandboxes and templates"
   homepage "https://e2b.dev"
-  url "https://registry.npmjs.org/@e2b/cli/-/cli-2.2.0.tgz"
-  sha256 "83df3e415a1673011489821f8e284d77ca4c73c412d1ce55472987aed204e2a6"
+  url "https://registry.npmjs.org/@e2b/cli/-/cli-2.2.1.tgz"
+  sha256 "429acf483c1f324e1dbd08136bccf5cecb6f608d36b1a3176ab88738daf8f80b"
   license "Apache-2.0"
 
   bottle do

--- a/Formula/e/e2b.rb
+++ b/Formula/e/e2b.rb
@@ -6,7 +6,7 @@ class E2b < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "44b7cbab37592a75fd8aacb7a7908c37bc9ded621d35225abb78eb1e27d1647c"
+    sha256 cellar: :any_skip_relocation, all: "b1526ab3d7a4ae329c4823c2bdac69695cf9a5e65ced8ab5a4206b685c43e095"
   end
 
   depends_on "node"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

livecheck uses the `Npm` strategy to check for new versions of `e2b` but the strategy is currently broken, so the autobump workflow is failing to update related formulae to new versions that are available. This manually updates `e2b` to 2.2.1, using CI-skip-livecheck to allow this to pass CI while my [brew PR to fix `Npm`](https://github.com/Homebrew/brew/pull/20734) is pending review.

[CI-skip-livecheck shouldn't be used to avoid a broken check under normal circumstances (an existing check should be fixed or a working `livecheck` block added) but a fix is coming for `Npm`, so I'm fine with using this as a workaround to merge version updates in the interim time.]