### PR TITLE
gemini-cli 0.5.5

### DIFF
--- a/Formula/g/gemini-cli.rb
+++ b/Formula/g/gemini-cli.rb
@@ -1,8 +1,8 @@
 class GeminiCli < Formula
   desc "Interact with Google Gemini AI models from the command-line"
   homepage "https://github.com/google-gemini/gemini-cli"
-  url "https://registry.npmjs.org/@google/gemini-cli/-/gemini-cli-0.5.4.tgz"
-  sha256 "4c272d3be5653bcb31ea9fbd1637c7f3f7e81da91f70b8f3e0072c1c961f57cc"
+  url "https://registry.npmjs.org/@google/gemini-cli/-/gemini-cli-0.5.5.tgz"
+  sha256 "9d55b51440e997096616e4c9e295665edc900583f1c762a122ffb872e759c06d"
   license "Apache-2.0"
 
   bottle do

--- a/Formula/g/gemini-cli.rb
+++ b/Formula/g/gemini-cli.rb
@@ -6,11 +6,11 @@ class GeminiCli < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256                               arm64_tahoe:   "b1340a7dd580e2576693145e11955e7a8500d6f35aae56e34ad9b2ae2aed4205"
-    sha256                               arm64_sequoia: "44d893aacab0a7f41ec357af5119d1b8b49c5e593defacf1c58e8762c19b07e9"
-    sha256                               arm64_sonoma:  "6cdf56c0bb54d51c0f7f2beab93e21115f55030ecb964d4f4a3a8119fdcd7168"
-    sha256                               sonoma:        "3d7152f9cc7378553aed2eff47f75e46069035e57b567f88e5238bf34d40fd1b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "83da20006021298f43990fac780fd100adfbf4cec24c6d054c9858c9711ba3dc"
+    sha256                               arm64_tahoe:   "0ddc031a913011d38967b126c958e6b0f159fb0fff959c96b299ae895b74059c"
+    sha256                               arm64_sequoia: "45fd86d0f680ba9f92a916358d304e03718cd9592a4891cade1fb8e92019a882"
+    sha256                               arm64_sonoma:  "a7f2b6f67f93ec90b6a344b37063155e6f21f77240ad078123bf50d16eb7a6bb"
+    sha256                               sonoma:        "7dde4d20efddc9201829be9e84917bcb5907dd49193eb20a27b9929ebfc9a087"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "87212a8fb266bf6851894ac061c3dbcc747784b0d8348c332635f1212691c0a3"
   end
 
   depends_on "node"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

livecheck uses the `Npm` strategy to check for new versions of `gemini-cli` but the strategy is currently broken, so the autobump workflow is failing to update related formulae to new versions that are available. This manually updates `gemini-cli` to 0.5.5, using CI-skip-livecheck to allow this to pass CI while my [brew PR to fix `Npm`](https://github.com/Homebrew/brew/pull/20734) is pending review.

[CI-skip-livecheck shouldn't be used to avoid a broken check under normal circumstances (an existing check should be fixed or a working `livecheck` block added) but a fix is coming for `Npm`, so I'm fine with using this as a workaround to merge version updates in the interim time.]

Closes #244969 (which was originally a version bump PR for 0.5.4), as we won't need a `livecheck` block for this after the `Npm` changes are merged.