### PR TITLE
opencode 0.10.3

### DIFF
--- a/Formula/o/opencode.rb
+++ b/Formula/o/opencode.rb
@@ -6,11 +6,11 @@ class Opencode < Formula
   license "MIT"
 
   bottle do
-    sha256                               arm64_tahoe:   "0d28b28c9477340068d577d364db37b48761666d2ae66db84dd4bde7d41b7561"
-    sha256                               arm64_sequoia: "0d28b28c9477340068d577d364db37b48761666d2ae66db84dd4bde7d41b7561"
-    sha256                               arm64_sonoma:  "0d28b28c9477340068d577d364db37b48761666d2ae66db84dd4bde7d41b7561"
-    sha256 cellar: :any_skip_relocation, sonoma:        "9c62505672272fde147e9fd381942e26c4f4ff0d22e416e37845d188a91b58d9"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "fec74305d1df263346c50beab22f1e267310ad53763753ebae2200ad00dc2ca6"
+    sha256                               arm64_tahoe:   "9a480117d29144343de2db50959e5f7015205529003f16401247878021b23abd"
+    sha256                               arm64_sequoia: "9a480117d29144343de2db50959e5f7015205529003f16401247878021b23abd"
+    sha256                               arm64_sonoma:  "9a480117d29144343de2db50959e5f7015205529003f16401247878021b23abd"
+    sha256 cellar: :any_skip_relocation, sonoma:        "f33c283061cbcd0d3db4a34d4e23b5cb3d8f32c473202d825d73c0ba2d1b1eef"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "94723eb7f265bc52f565ba9ab2df331e1712bef1e3e69a090881686ba84c6bd2"
   end
 
   depends_on "node"

--- a/Formula/o/opencode.rb
+++ b/Formula/o/opencode.rb
@@ -1,8 +1,8 @@
 class Opencode < Formula
   desc "AI coding agent, built for the terminal"
   homepage "https://opencode.ai"
-  url "https://registry.npmjs.org/opencode-ai/-/opencode-ai-0.10.1.tgz"
-  sha256 "588f195583e7e00d269405e12f6a3cdfbb136be30edda645c5c235434ec65e20"
+  url "https://registry.npmjs.org/opencode-ai/-/opencode-ai-0.10.3.tgz"
+  sha256 "250310735f8908b96a2ceb09b92a8206222872a1f63ef9c311774bb7d79351f1"
   license "MIT"
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

livecheck uses the `Npm` strategy to check for new versions of `opencode` but the strategy is currently broken, so the autobump workflow is failing to update related formulae to new versions that are available. This manually updates `opencode` to 0.10.3, using CI-skip-livecheck to allow this to pass CI while my [brew PR to fix `Npm`](https://github.com/Homebrew/brew/pull/20734) is pending review.

[CI-skip-livecheck shouldn't be used to avoid a broken check under normal circumstances (an existing check should be fixed or a working `livecheck` block added) but a fix is coming for `Npm`, so I'm fine with using this as a workaround to merge version updates in the interim time.]