### PR TITLE
vercel-cli 48.1.0

### DIFF
--- a/Formula/v/vercel-cli.rb
+++ b/Formula/v/vercel-cli.rb
@@ -6,12 +6,12 @@ class VercelCli < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "400dfa71a0dfcb6bcf8fc9ae02f0de439842c5623375a367d541a8152651e177"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "400dfa71a0dfcb6bcf8fc9ae02f0de439842c5623375a367d541a8152651e177"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "400dfa71a0dfcb6bcf8fc9ae02f0de439842c5623375a367d541a8152651e177"
-    sha256 cellar: :any_skip_relocation, sonoma:        "edf7efc0781ad6faf8b621fafbd6af1d9f802bd538e9345706e08e6eed21b5a6"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "f5a857ef5f1dedaa6a329c7f2e4fd83e36fb2c43d3ac31869d93fcf85b07545f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "ff433e0c655a5266a56eeb18a2776ca8daeb5c47e07af2de56f1e93575ac8b29"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "0e33c0b17fbebaf1e9376399708b5f6bc9af07539dded43e703508dbd6f1f85e"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "0e33c0b17fbebaf1e9376399708b5f6bc9af07539dded43e703508dbd6f1f85e"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "0e33c0b17fbebaf1e9376399708b5f6bc9af07539dded43e703508dbd6f1f85e"
+    sha256 cellar: :any_skip_relocation, sonoma:        "7258a78895ff4ebc598d74dd063c8e43e11a0bac8491236142775fac320bb875"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "650e33fe3994b2aa6cdf7221865ac56b0a9d26cb7c9a3c7342dfc15fef2c2a97"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "787d5e9b816e3c744e94f6039930b9486378e44b3ba65b6f5573406d7873566b"
   end
 
   depends_on "node"

--- a/Formula/v/vercel-cli.rb
+++ b/Formula/v/vercel-cli.rb
@@ -1,8 +1,8 @@
 class VercelCli < Formula
   desc "Command-line interface for Vercel"
   homepage "https://vercel.com/home"
-  url "https://registry.npmjs.org/vercel/-/vercel-48.0.3.tgz"
-  sha256 "0294b779bd61276f2339446a6e7fc7e89cb32d46cf45146b9f51b28615681c56"
+  url "https://registry.npmjs.org/vercel/-/vercel-48.1.0.tgz"
+  sha256 "8e0c38ba67b03322abbc2e6000f86700348fa1cb69aeabb361a605ad905bb1fe"
   license "Apache-2.0"
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

livecheck uses the `Npm` strategy to check for new versions of `vercel-cli` but the strategy is currently broken, so the autobump workflow is failing to update related formulae to new versions that are available. This manually updates `vercel-cli` to 48.1.0, using CI-skip-livecheck to allow this to pass CI while my [brew PR to fix `Npm`](https://github.com/Homebrew/brew/pull/20734) is pending review.

[CI-skip-livecheck shouldn't be used to avoid a broken check under normal circumstances (an existing check should be fixed or a working `livecheck` block added) but a fix is coming for `Npm`, so I'm fine with using this as a workaround to merge version updates in the interim time.]