### PR TITLE
zx 8.8.2

### DIFF
--- a/Formula/z/zx.rb
+++ b/Formula/z/zx.rb
@@ -1,8 +1,8 @@
 class Zx < Formula
   desc "Tool for writing better scripts"
   homepage "https://google.github.io/zx/"
-  url "https://registry.npmjs.org/zx/-/zx-8.8.1.tgz"
-  sha256 "50025fb3748232b1facea458c4b07a671e0b9893880c7b573e33dbc7ccf8b102"
+  url "https://registry.npmjs.org/zx/-/zx-8.8.2.tgz"
+  sha256 "e20ac3cab7727310974791120d9cafd8c7664b717a003344320bb6b2b22f1df6"
   license "Apache-2.0"
 
   bottle do

--- a/Formula/z/zx.rb
+++ b/Formula/z/zx.rb
@@ -6,7 +6,7 @@ class Zx < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "bdd6fb9a017f89677cfeb86efb81afdd1d81d60b5e48e7acf197ca89ff5db3ad"
+    sha256 cellar: :any_skip_relocation, all: "647992c8adb1506959ec24a0230e18af2e0af0a63008d404dbd62e78c035da8d"
   end
 
   depends_on "node"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

livecheck uses the `Npm` strategy to check for new versions of `zx` but the strategy is currently broken, so the autobump workflow is failing to update related formulae to new versions that are available. This manually updates `zx` to 8.8.2, using CI-skip-livecheck to allow this to pass CI while my [brew PR to fix `Npm`](https://github.com/Homebrew/brew/pull/20734) is pending review.

[CI-skip-livecheck shouldn't be used to avoid a broken check under normal circumstances (an existing check should be fixed or a working `livecheck` block added) but a fix is coming for `Npm`, so I'm fine with using this as a workaround to merge version updates in the interim time.]