### PR TITLE
yaml-language-server: downgrade to 1.18.0

### DIFF
--- a/Formula/y/yaml-language-server.rb
+++ b/Formula/y/yaml-language-server.rb
@@ -1,12 +1,12 @@
 class YamlLanguageServer < Formula
   desc "Language Server for Yaml Files"
   homepage "https://github.com/redhat-developer/yaml-language-server"
-  url "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-1.19.0.tgz"
-  sha256 "0f7114bb635cef2ec3803f2e5ea831c456bacb6949a4665747c0ee934ee91b44"
+  url "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-1.18.0.tgz"
+  sha256 "079322c49fa5429f6c7c9edf893236dba70f6a11aaad841623f31c50fd0deaa4"
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "2d4449a1fa027503006876f764a7e05eb16c9c970b858d06193ac1e013d936f0"
+    sha256 cellar: :any_skip_relocation, all: "bafbbb95e8456cfb2c17f213f7a4589c70b869feb3b26c5b3a0840f45e6b189e"
   end
 
   depends_on "node"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`yaml-language-server` was upgraded to 1.19.0, presumably because livecheck's `Npm` strategy reported 1.19.0 as newest. However, 1.19.0 is currently set as the "next" version on npm, whereas 1.18.0 is the "latest" version. This issue will be addressed by changes to the `Npm` strategy's behavior, so this downgrades the formula to 1.18.0 to align with the "latest" npm version. I assume that 1.19.0 will eventually become "latest" but this will save users from installing 1.19.0 in the interim time.

~I'm creating this as a draft until my [brew PR to fix `Npm`](https://github.com/Homebrew/brew/pull/20734) is merged, as that changes the behavior of the strategy to track the "latest" version on npm. The `Npm` strategy hasn't been working in CI but I don't want the autobump workflow to try to upgrade the formula back to 1.19.0 if it suddenly starts working (it probably wouldn't happen due to duplicate PR checking but better safe than sorry).~