### PR TITLE
privatebin-cli 2.1.1 (new formula)

### DIFF
--- a/Formula/p/privatebin-cli.rb
+++ b/Formula/p/privatebin-cli.rb
@@ -1,0 +1,25 @@
+class PrivatebinCli < Formula
+  desc "CLI for creating and managing PrivateBin pastes"
+  homepage "https://github.com/gearnode/privatebin"
+  url "https://github.com/gearnode/privatebin/archive/refs/tags/v2.1.1.tar.gz"
+  sha256 "eb143ed6d2ab88d66e615c5a98fb2c3f8b0ee5a8394590b68ddbf59bfb2c39d3"
+  license "ISC"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = %W[
+      -s -w
+      -X main.version=#{version}
+      -X main.commit=#{tap.user}
+      -X main.date=#{time.iso8601}
+    ]
+    system "go", "build", *std_go_args(ldflags: ldflags, output: bin/"privatebin"), "./cmd/privatebin"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/privatebin --version")
+
+    assert_match "Error: cannot load configuration", shell_output("#{bin}/privatebin create foo 2>&1", 1)
+  end
+end

--- a/Formula/p/privatebin-cli.rb
+++ b/Formula/p/privatebin-cli.rb
@@ -5,6 +5,14 @@ class PrivatebinCli < Formula
   sha256 "eb143ed6d2ab88d66e615c5a98fb2c3f8b0ee5a8394590b68ddbf59bfb2c39d3"
   license "ISC"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "bb4c13c2f9ea53f51675c8647c55767c74939837c097578ba38d3039e4c2d7c4"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "bb4c13c2f9ea53f51675c8647c55767c74939837c097578ba38d3039e4c2d7c4"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "bb4c13c2f9ea53f51675c8647c55767c74939837c097578ba38d3039e4c2d7c4"
+    sha256 cellar: :any_skip_relocation, sonoma:        "e91653fc6b2105a834846e498a97865246f173e20a1cc48e30fb2fa2f7b8d192"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0bbee2ff0b938abdcb16eeeeafb7b33a77123df28a3615574488104c186cf847"
+  end
+
   depends_on "go" => :build
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

--

I understand that the contributing guidelines generally discourage project maintainers from submitting formulae for their own projects. However, since packages for this project are already provided by others on Ubuntu, Debian, and Arch Linux, I’d really like to have it on Homebrew as well at least for my own use. I also know several macOS users who would love to see it available there. As the maintainer for over 4 years, I think having a Homebrew formula would make the project more accessible for the macOS community.