### PR TITLE
libsbol: workaround for CMake 4

### DIFF
--- a/Formula/lib/libsbol.rb
+++ b/Formula/lib/libsbol.rb
@@ -27,14 +27,28 @@ class Libsbol < Formula
   uses_from_macos "curl"
   uses_from_macos "libxslt"
 
+  on_macos do
+    # Fails with Apple Clang 1700+ / LLVM Clang 19+
+    # include/sbol/property.h:135:71: error: member access into incomplete type 'SBOLObject'
+    depends_on "llvm@18" => [:build, :test] if DevelopmentTools.clang_build_version >= 1700
+  end
+
   def install
+    if ENV.compiler == :clang && DevelopmentTools.clang_build_version >= 1700
+      inreplace "source/CMakeLists.txt", 'set(CMAKE_OSX_ARCHITECTURES "x86_64")', ""
+      ENV["CC"] = Formula["llvm@18"].opt_bin/"clang"
+      ENV["CXX"] = Formula["llvm@18"].opt_bin/"clang++"
+    end
+
     # upstream issue: https://github.com/SynBioDex/libSBOL/issues/215
     inreplace "source/CMakeLists.txt", "measure.h", "measurement.h"
 
-    args = std_cmake_args
-    args << "-DSBOL_BUILD_SHARED=TRUE"
-    args << "-DRAPTOR_INCLUDE_DIR=#{Formula["raptor"].opt_include}/raptor2"
-    args << "-DRASQAL_INCLUDE_DIR=#{Formula["rasqal"].opt_include}"
+    args = %W[
+      -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+      -DSBOL_BUILD_SHARED=ON
+      -DRAPTOR_INCLUDE_DIR=#{Formula["raptor"].opt_include}/raptor2
+      -DRASQAL_INCLUDE_DIR=#{Formula["rasqal"].opt_include}
+    ]
 
     if OS.mac? && (sdk = MacOS.sdk_path_if_needed)
       args << "-DCURL_LIBRARY=#{sdk}/usr/lib/libcurl.tbd"
@@ -42,12 +56,16 @@ class Libsbol < Formula
       args << "-DLIBXSLT_LIBRARIES=#{sdk}/usr/lib/libxslt.tbd"
     end
 
-    system "cmake", "-S", ".", "-B", "build", *args
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
   end
 
   test do
+    if ENV.compiler == :clang && DevelopmentTools.clang_build_version >= 1700
+      ENV["CXX"] = Formula["llvm@18"].opt_bin/"clang++"
+    end
+
     (testpath/"test.cpp").write <<~CPP
       #include "sbol/sbol.h"
 
@@ -60,7 +78,6 @@ class Libsbol < Formula
       }
     CPP
     system ENV.cxx, "test.cpp", "-o", "test", "-std=c++11",
-                    "-I/System/Library/Frameworks/Python.framework/Headers",
                     "-I#{Formula["raptor"].opt_include}/raptor2",
                     "-I#{include}", "-L#{lib}",
                     "-L#{Formula["jsoncpp"].opt_lib}",


### PR DESCRIPTION
Still fails for me locally on Tahoe so want to check if this fails on other OS.

---

Using LLVM 18 for now as code needs to be refactored a bit, maybe moving some parts of property.h to a cpp file.

Given lack of upstream activity, may just deprecate soon.