### PR TITLE
neverest: deprecate as both stable and head do not build

### DIFF
--- a/Formula/n/neverest.rb
+++ b/Formula/n/neverest.rb
@@ -16,6 +16,8 @@ class Neverest < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "42967910c00046d764d281458105af646720163beb854aa14aa8740fbd54ee8f"
   end
 
+  deprecate! date: "2025-09-20", because: :does_not_build
+
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Can be undeprecated if fixed upstream.