### PR TITLE
bazel bazel@7: only pour arm64 linux bottle on default prefix

### DIFF
--- a/Formula/b/bazel.rb
+++ b/Formula/b/bazel.rb
@@ -28,15 +28,16 @@ class Bazel < Formula
   uses_from_macos "zip"
 
   on_linux do
-    # Workaround for "/usr/bin/ld.gold: internal error in try_fix_erratum_843419_optimized"
-    # Issue ref: https://sourceware.org/bugzilla/show_bug.cgi?id=31182
     on_arm do
+      # Workaround for "/usr/bin/ld.gold: internal error in try_fix_erratum_843419_optimized"
+      # Issue ref: https://sourceware.org/bugzilla/show_bug.cgi?id=31182
       depends_on "lld" => :build
-    end
 
-    on_intel do
       # We use a workaround to prevent modification of the `bazel-real` binary
       # but this means brew cannot rewrite paths for non-default prefix
+      pour_bottle? only_if: :default_prefix
+    end
+    on_intel do
       pour_bottle? only_if: :default_prefix
     end
   end

--- a/Formula/b/bazel@7.rb
+++ b/Formula/b/bazel@7.rb
@@ -32,9 +32,12 @@ class BazelAT7 < Formula
   uses_from_macos "zip"
 
   on_linux do
+    # We use a workaround to prevent modification of the `bazel-real` binary
+    # but this means brew cannot rewrite paths for non-default prefix
+    on_arm do
+      pour_bottle? only_if: :default_prefix
+    end
     on_intel do
-      # We use a workaround to prevent modification of the `bazel-real` binary
-      # but this means brew cannot rewrite paths for non-default prefix
       pour_bottle? only_if: :default_prefix
     end
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

DSL does not allow `pour_bottle` directly under `on_linux` so need per arch