### PR TITLE
buildapp pgloader: workaround to avoid corrupted Linux bottle

### DIFF
--- a/Formula/b/buildapp.rb
+++ b/Formula/b/buildapp.rb
@@ -10,17 +10,13 @@ class Buildapp < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    rebuild 2
-    sha256 arm64_tahoe:    "571d55ab5313212cfa48bb6a522581f47368c8c6f56985c54316627c09a0694e"
-    sha256 arm64_sequoia:  "25eba8ba9388bbf422a7a5f14e2db9f1ea8d9e9add5cd58aecb3ea6a97f7eb83"
-    sha256 arm64_sonoma:   "4cd0afa49db04a858b694e03cb247d5fc67b5c73b082725032364102b6e24973"
-    sha256 arm64_ventura:  "41ce31edf3763b06c08acd06abfcfaecec13bfa0487d876ca37019f2aea85ead"
-    sha256 arm64_monterey: "071a97e829ed1ca27927b7bb4539a552cc1a26f671f83d23cad621ad13b3cb4a"
-    sha256 sonoma:         "d54e9bdbef32deb80e6dcf9ad7089ae433e9594fd3fc8df6e1ae50065a8e2857"
-    sha256 ventura:        "e74370d3c6b1367de4d8edcee76878f8a380d7728f43f18cf4e2b28d6acb609e"
-    sha256 monterey:       "8c4d8793f2467b30a89079fd58099a79d331794d3667949736b91542279d1b6c"
-    sha256 arm64_linux:    "2c2711b913dccab60c2f0273493426a2e98c007b736711685387a4b33423cf65"
-    sha256 x86_64_linux:   "4642b29de810bdc8d7c9d5e1ea678c5f366dee7a3dd6ca48523dd36af4f559ea"
+    rebuild 3
+    sha256 arm64_tahoe:   "1b91e415cf7ddeab7dc5585efe5b7e58d4798f336ae19bd8c33ebd4d24b19e58"
+    sha256 arm64_sequoia: "a424c9298996d720b76dd934de8ba4f8fb90f30b05ab3a8f2916ff351bbe8318"
+    sha256 arm64_sonoma:  "3c6c239c61b755cf08e189979db5dfc599111067973befc8fa7155986a2d2e6f"
+    sha256 sonoma:        "e832088898a11ef56ff0b5000b5166df15e600d78da05b7061b1917ff932c90e"
+    sha256 arm64_linux:   "25b50dc88f92ffa69a1ca5f768b1b50338b37f3ff32078a93492e29b3f66b56b"
+    sha256 x86_64_linux:  "7fd612c69baa9387a3790c750c5fc8eb3a7c9787e9107cf7fb200aeb3d184f3b"
   end
 
   depends_on "sbcl"

--- a/Formula/p/pgloader.rb
+++ b/Formula/p/pgloader.rb
@@ -15,17 +15,13 @@ class Pgloader < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_tahoe:    "cc07415eedb3e46c7e7826846ed4bc9027e246db81ede0fac1041b0a157dc660"
-    sha256 cellar: :any,                 arm64_sequoia:  "cb7f5d7b24d71a33f540c1deac860c14ac23a722ea8d090dcee236d323fb91c7"
-    sha256 cellar: :any,                 arm64_sonoma:   "e9e988b590421ba3ebbf60331db3cb54d713d3629e53905218cdfe677d83190b"
-    sha256 cellar: :any,                 arm64_ventura:  "66c38d5680137c97900e8bc0345212df6ef9c246688263d27a1612f0c68362a3"
-    sha256 cellar: :any,                 arm64_monterey: "368d8f4b75362e444098030d8a7de45e09c495d501037a679670a1349bc366a8"
-    sha256 cellar: :any,                 sonoma:         "4b2bb7c9ae9bd104768e44181fcb9536928d5d37a20a39b66dd29d3446eecef8"
-    sha256 cellar: :any,                 ventura:        "8abc681975f40539f48f3444ffee0d6028080ee7dfbff23a69d2d1ad283079cd"
-    sha256 cellar: :any,                 monterey:       "52cdba8d7bf8f2a836eeba8b6e2eae1521d95a31a0203edb0f5ae9b1a05ae394"
-    sha256 cellar: :any_skip_relocation, arm64_linux:    "cbd685f4531bdf498e069785d26e5944ee7f25a505c9e6f3e5a9a41d2a6d2dbe"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b3066fd9fdb9548c8e1d3f6bb445017b0da557e00247d72bb8c2cafc4aed41d3"
+    rebuild 2
+    sha256 cellar: :any,                 arm64_tahoe:   "f5baa53cabbdcdba97c61a8734543b06ffecf1edfb6a072fffe33673b6adda14"
+    sha256 cellar: :any,                 arm64_sequoia: "0b51ea7384a8623316882a7e4ca9fd5a67fd290fc2cea4f37e1b202b565a33cf"
+    sha256 cellar: :any,                 arm64_sonoma:  "02643e311b7153fc874298fc931b1a685a2cacee774b094807ca907938d1d778"
+    sha256 cellar: :any,                 sonoma:        "b3e66db5bd5d27ebb26eb4afad56169753c690f85606abcd28855f15eafbf5b2"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "9dad60ccd17c70c50388e58642587f660497c819d964544cb59ef9a80f942133"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3383d6eb3b97d354416fa7257bf7beafbbaa14d671dc285e44cf6b2c0116356b"
   end
 
   depends_on "buildapp" => :build


### PR DESCRIPTION
Current Linux bottles are broken because we skipped the test, i.e. "Can't find sbcl.core" should not be ignored (no bottles is better than broken bottles here as it will trigger source building a functional binary)

This uses a hack to avoid patchelf corruption. There really is no way to handle this cleanly on Homebrew/core side. It needs support in Homebrew/brew perhaps via a skip patchelf DSL or by detecting non-standard executables (same for Bazel and a few other formulae).