### PR TITLE
fricas: workaround to avoid corrupted Linux bottles

### DIFF
--- a/Formula/f/fricas.rb
+++ b/Formula/f/fricas.rb
@@ -9,14 +9,13 @@ class Fricas < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "fdc7e5b8b6fb9ed31b3bb661aa50b1761772e87e1506371c5ea49d94468f5dc5"
-    sha256 cellar: :any,                 arm64_sequoia: "7fbe73c52677676edec374061a9889381f7b8dd79d231cd5db743e8b47b83be4"
-    sha256 cellar: :any,                 arm64_sonoma:  "f80b27d9b594c6161a4b882f13cdb0c62f883d42760bb62d8563791d3ce3660b"
-    sha256 cellar: :any,                 arm64_ventura: "e78686fad2f37772d9d575453720622bd63af29ecc888a369672b14f2ca3e1d7"
-    sha256 cellar: :any,                 sonoma:        "716ba2734fc10c1a9540e8b868bfa6ff05c0ff8fa07fc04582808e2c12efb999"
-    sha256 cellar: :any,                 ventura:       "a3737a559b67fb9d5887f00208bf6c56b0e444d8f88be2d627db873c6971fde9"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "22865967ea74382926e358484cef468d9eda01c3b251ee98ac8bdcb0095f47db"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f35e32107cab4e45364c7f07245b562c6a425283ec655a22214a2c6f8302e8a2"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "7c87044d00ac54aed75e3c74024198bfa1334da3cc66e378bb084e9bf34e8b2e"
+    sha256 cellar: :any,                 arm64_sequoia: "6a4986f527a329cda2916c92b2065ae6d41aab08377bf751195b26a88036fd50"
+    sha256 cellar: :any,                 arm64_sonoma:  "c254d2cb770eb7c6796fa9293b06d01c6ffb14be778254ab3a26fc17a8eb8bec"
+    sha256 cellar: :any,                 sonoma:        "9b27da492022588d3d26575fa5f103bfe38f6102679fce800ac4ef9ce8e76343"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "bc084992d8a884fc40ab26b670100ea7aa8e83e91baabb22a9eac3e3687ae9e1"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8412b5815cf0fa53cadd4b4608ba229c84aa50120023fe04279f4e19a9a83360"
   end
 
   depends_on "gmp"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Same as #245173 but not sure which binaries are impacted so just creating a tar archive for all binaries.