### PR TITLE
conda-lock: fix test

### DIFF
--- a/Formula/c/conda-lock.rb
+++ b/Formula/c/conda-lock.rb
@@ -20,6 +20,7 @@ class CondaLock < Formula
   end
 
   depends_on "rust" => :build # for pydantic
+  depends_on "micromamba" => :test
   depends_on "certifi"
   depends_on "cffi"
   depends_on "libyaml"
@@ -308,7 +309,8 @@ class CondaLock < Formula
       dependencies:
         - python=3.13
     YAML
-    system bin/"conda-lock", "-p", "osx-64", "-p", "osx-arm64"
+    system bin/"conda-lock", "-p", "osx-64", "-p", "osx-arm64",
+                             "--conda", Formula["micromamba"].opt_bin/"mamba"
     assert_path_exists testpath/"conda-lock.yml"
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

conda-lock uses ensureconda [^1] to fetch and install a standalone micromamba, but the micromamba binary depends on a libpython3.13.dylib that's unavailable in the test environment. Let's tell conda-lock to use our micromamba instead.

[^1]: https://github.com/conda-incubator/ensureconda
