### PR TITLE
veilid 0.4.8 (rebuild)

### DIFF
--- a/Formula/v/veilid.rb
+++ b/Formula/v/veilid.rb
@@ -7,7 +7,7 @@ class Veilid < Formula
   head "https://gitlab.com/veilid/veilid.git", branch: "main"
 
   bottle do
-    rebuild 1
+    rebuild 2
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "224049716b76f63659cc8dfbce9816253c2014135156bdb82cf4bf2e45060168"
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "c0dfdd88564f4c28c64587507cd3c0582e8101a2b9e59a379c83e5b1847b5b1c"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "e496dcb522e3488234d4601c8f41ae5e1baddf820dc7b1841ba68ee9bc55c52f"


### PR DESCRIPTION
The `arm64_tahoe` bottle is on `0.4.8`, but the other bottles are on `0.4.7`. I'm guessing it was a mistake to revert the bottles to `0.4.7`.

See the weird history here: https://github.com/Homebrew/homebrew-core/commits/ce5059a92789c6085d5db153cb03aa77a60794a3/Formula/v/veilid.rb

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
