### PR TITLE
cookcli: build frontend assets

### DIFF
--- a/Formula/c/cookcli.rb
+++ b/Formula/c/cookcli.rb
@@ -15,12 +15,19 @@ class Cookcli < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "aa0f606df53567658253934322d581095af09b97572d5e1a7e4e9c48d97db52f"
   end
 
+  depends_on "node" => :build
   depends_on "rust" => :build
   depends_on "openssl@3"
 
   def install
     ENV["OPENSSL_NO_VENDOR"] = "1"
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
+
+    # Install npm dependencies and build CSS
+    system "npm", "install", *std_npm_args(prefix: false), "--ignore-scripts"
+    system "npm", "run", "build-css"
+
+    # Build and install the binary
     system "cargo", "install", *std_cargo_args
   end
 


### PR DESCRIPTION
Add Node.js build dependency and npm build steps to compile the Tailwind CSS frontend assets during installation. This ensures the web server interface has all required static files when installed via Homebrew.

The formula now:
- Installs npm dependencies with `npm ci`
- Builds CSS with `npm run build-css`
- Installs static assets to pkgshare directory

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
