### PR TITLE
kdoctools: fix metadata, resolving homepage 404

### DIFF
--- a/Formula/k/kdoctools.rb
+++ b/Formula/k/kdoctools.rb
@@ -1,6 +1,6 @@
 class Kdoctools < Formula
   desc "Create documentation from DocBook"
-  homepage "https://api.kde.org/frameworks/kdoctools/html/index.html"
+  homepage "https://l10n.kde.org/docs/doc-primer/"
   url "https://download.kde.org/stable/frameworks/6.18/kdoctools-6.18.0.tar.xz"
   sha256 "e73ddb2dfb1b061e02d37861ef58c2d58daf1817e1ce543737ff7abf284bc984"
   license all_of: [


### PR DESCRIPTION
Trivial metadata change, fixing a 404 on bitrotted homepage URL - highlighted in https://github.com/Homebrew/homebrew-core/issues/139929#issuecomment-3314367014, tagged with [<kbd>help wanted</kbd>](https://github.com/Homebrew/homebrew-core/issues?q=label%3A%22help%20wanted%22) label. 

Since `kdoctools` is a techwriting tool (suite), and its git repo is already mentioned in `head "https://invent.kde.org/frameworks/kdoctools.git"` - I'm pointing the homepage to KDE l10n guide. It has a section that explains usage of `checkXML` & `meinproc` tools, both shipped within `kdoctools` package.

Because it's only a metadata change, I'll trust its testing to the CI.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
