### PR TITLE
infisical: update livecheck due to moved repo

### DIFF
--- a/Formula/i/infisical.rb
+++ b/Formula/i/infisical.rb
@@ -1,15 +1,10 @@
 class Infisical < Formula
   desc "CLI for Infisical"
   homepage "https://infisical.com/docs/cli/overview"
-  url "https://github.com/Infisical/infisical/archive/refs/tags/infisical-cli/v0.41.90.tar.gz"
-  sha256 "c246439c7a60e57f332d0ffd478110441498e6f266ba21865f78dde328244350"
+  url "https://github.com/Infisical/cli/archive/refs/tags/v0.42.4.tar.gz"
+  sha256 "cfc03e7cf93e1d0eb0a8d24ce38e7feb16107e523f7fddc14d8a0eedab8276ec"
   license "MIT"
-  head "https://github.com/Infisical/infisical.git", branch: "main"
-
-  livecheck do
-    url :stable
-    regex(%r{^infisical-cli/v?(\d+(?:\.\d+)+)$}i)
-  end
+  head "https://github.com/Infisical/cli.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "391fba831818f9ef3af511809edbff6f3271fcbbbec1b6ccf2f38d5ebac72885"
@@ -24,13 +19,11 @@ class Infisical < Formula
   depends_on "go" => :build
 
   def install
-    cd "cli" do
-      ldflags = %W[
-        -s -w
-        -X github.com/Infisical/infisical-merge/packages/util.CLI_VERSION=#{version}
-      ]
-      system "go", "build", *std_go_args(ldflags:)
-    end
+    ldflags = %W[
+      -s -w
+      -X github.com/Infisical/infisical-merge/packages/util.CLI_VERSION=#{version}
+    ]
+    system "go", "build", *std_go_args(ldflags:)
   end
 
   test do

--- a/Formula/i/infisical.rb
+++ b/Formula/i/infisical.rb
@@ -7,13 +7,11 @@ class Infisical < Formula
   head "https://github.com/Infisical/cli.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "391fba831818f9ef3af511809edbff6f3271fcbbbec1b6ccf2f38d5ebac72885"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "5bc1e0e921d86036c42a16800918e0208c0c83a0db7943bacd467651a55888af"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "5bc1e0e921d86036c42a16800918e0208c0c83a0db7943bacd467651a55888af"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "5bc1e0e921d86036c42a16800918e0208c0c83a0db7943bacd467651a55888af"
-    sha256 cellar: :any_skip_relocation, sonoma:        "93966e5d89d6773c2ea5aa40d1ed1ae9b061ad26430fbfad933e3bfe0d71bc44"
-    sha256 cellar: :any_skip_relocation, ventura:       "93966e5d89d6773c2ea5aa40d1ed1ae9b061ad26430fbfad933e3bfe0d71bc44"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1b7580328aa751528593135df1a464611d3e1d2559f7dfa33ff60c5d5e417884"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "c84998b7c4308436d41bb7d4227c85a300a04f25b095e8e26f032ba5c6e16304"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "c84998b7c4308436d41bb7d4227c85a300a04f25b095e8e26f032ba5c6e16304"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "c84998b7c4308436d41bb7d4227c85a300a04f25b095e8e26f032ba5c6e16304"
+    sha256 cellar: :any_skip_relocation, sonoma:        "8a01c4205ee1b0622f297ca52e4253d44fda81dfc9ec5e714e6129002af35103"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "139bee269fc8dfff13b6cdaaeecc05a13fc2eebaf448bf2a0eeb28ee441e8aff"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We've moved the Infisical CLI repository from https://github.com/Infiscial/infisical, to it's own standalone repository at https://github.com/Infisical/cli. This move has caused homebrew to stop automatically syncing new CLI versions.