### PR TITLE
gradle: depend on openjdk again

### DIFF
--- a/Formula/g/gradle.rb
+++ b/Formula/g/gradle.rb
@@ -1,7 +1,6 @@
 class Gradle < Formula
   desc "Open-source build automation tool based on the Groovy and Kotlin DSL"
   homepage "https://www.gradle.org/"
-  # TODO: Switch to `openjdk` 25 when 9.1.0 is released.
   url "https://services.gradle.org/distributions/gradle-9.1.0-all.zip"
   sha256 "b84e04fa845fecba48551f425957641074fcc00a88a84d2aae5808743b35fc85"
   license "Apache-2.0"
@@ -16,12 +15,12 @@ class Gradle < Formula
   end
 
   # https://github.com/gradle/gradle/blob/master/platforms/documentation/docs/src/docs/userguide/releases/compatibility.adoc
-  depends_on "openjdk@21"
+  depends_on "openjdk"
 
   def install
     rm(Dir["bin/*.bat"])
     libexec.install %w[bin docs lib src]
-    env = Language::Java.overridable_java_home_env("21")
+    env = Language::Java.overridable_java_home_env
     (bin/"gradle").write_env_script libexec/"bin/gradle", env
   end
 

--- a/Formula/g/gradle.rb
+++ b/Formula/g/gradle.rb
@@ -11,7 +11,8 @@ class Gradle < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "e13126cd6030f1b0939f0ffd9f2b22b1cc2640631d96ff6076093bcd6f0fa839"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "ab0ce18f9ede373b7008766383c6a87f353d1578a9256ac752e899f12682d9a8"
   end
 
   # https://github.com/gradle/gradle/blob/master/platforms/documentation/docs/src/docs/userguide/releases/compatibility.adoc


### PR DESCRIPTION
follow-up to #244418

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
