### PR TITLE
blastem: fix HEAD build with arm64 macOS support

### DIFF
--- a/Formula/b/blastem.rb
+++ b/Formula/b/blastem.rb
@@ -1,11 +1,30 @@
 class Blastem < Formula
   desc "Fast and accurate Genesis emulator"
   homepage "https://www.retrodev.com/blastem/"
-  url "https://www.retrodev.com/repos/blastem/archive/v0.6.2.tar.gz"
-  sha256 "d460632eff7e2753a0048f6bd18e97b9d7c415580c358365ff35ac64af30a452"
   license "GPL-3.0-or-later"
   revision 2
   head "https://www.retrodev.com/repos/blastem", using: :hg
+
+  stable do
+    url "https://www.retrodev.com/repos/blastem/archive/v0.6.2.tar.gz"
+    sha256 "d460632eff7e2753a0048f6bd18e97b9d7c415580c358365ff35ac64af30a452"
+
+    depends_on arch: :x86_64
+
+    # Convert Python 2 script to Python 3. Remove with next release.
+    patch do
+      url "https://www.retrodev.com/repos/blastem/raw-rev/dbbf0100f249"
+      sha256 "e332764bfa08e08e0f9cbbebefe73b88adb99a1e96a77a16a0aeeae827ac72ff"
+    end
+
+    # Fix build with -fno-common which is default in GCC 10+. Remove with next release.
+    patch do
+      on_linux do
+        url "https://www.retrodev.com/repos/blastem/raw-rev/e45a317802bd"
+        sha256 "8f869909df6eb66375eea09dde806422aa007aee073d557b774666f51c2e40dd"
+      end
+    end
+  end
 
   livecheck do
     url "https://www.retrodev.com/repos/blastem/json-tags"
@@ -33,7 +52,6 @@ class Blastem < Formula
   depends_on "pillow" => :build
   depends_on "pkgconf" => :build
   depends_on "python@3.13" => :build
-  depends_on arch: :x86_64
   depends_on "glew"
   depends_on "sdl2"
 
@@ -48,20 +66,6 @@ class Blastem < Formula
     sha256 "9ae0b37bca11cae5cf00e4d47e7225737bdaec4028e4db2a501b4eca7df8639d"
   end
 
-  # Convert Python 2 script to Python 3. Remove with next release.
-  patch do
-    url "https://www.retrodev.com/repos/blastem/raw-rev/dbbf0100f249"
-    sha256 "e332764bfa08e08e0f9cbbebefe73b88adb99a1e96a77a16a0aeeae827ac72ff"
-  end
-
-  # Fix build with -fno-common which is default in GCC 10+. Remove with next release.
-  patch do
-    on_linux do
-      url "https://www.retrodev.com/repos/blastem/raw-rev/e45a317802bd"
-      sha256 "8f869909df6eb66375eea09dde806422aa007aee073d557b774666f51c2e40dd"
-    end
-  end
-
   def install
     resource("vasm").stage do
       system "make", "CPU=m68k", "SYNTAX=mot"
@@ -71,7 +75,7 @@ class Blastem < Formula
 
     # Use imagemagick to convert XCF files instead of xcftools, which is unmaintained and broken.
     # Fix was sent to upstream developer.
-    inreplace "Makefile", "xcf2png $< > $@", "convert $< $@"
+    inreplace "Makefile", "xcf2png $< > $@", "convert $< $@" if build.stable?
 
     system "make", "all", "menu.bin", "HOST_ZLIB=1"
     libexec.install %w[blastem default.cfg menu.bin rom.db shaders]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Helps track formulae that have upstream support for arm64 macOS in preparation for Intel macOS future removal.