### PR TITLE
php: remove gcc dependency for macOS

### DIFF
--- a/Formula/p/php.rb
+++ b/Formula/p/php.rb
@@ -76,21 +76,7 @@ class Php < Formula
   uses_from_macos "libxslt"
   uses_from_macos "zlib"
 
-  on_macos do
-    depends_on "gcc"
-  end
-
-  # https://github.com/Homebrew/homebrew-core/issues/235820
-  # https://clang.llvm.org/docs/UsersManual.html#gcc-extensions-not-implemented-yet
-  fails_with :clang do
-    cause "Performs worse due to lack of general global register variables"
-  end
-
   def install
-    # GCC -Os performs worse than -O1 and significantly worse than -O2/-O3.
-    # We lack a DSL to enable -O2 so just use -O3 which is similar.
-    ENV.O3 if OS.mac?
-
     # buildconf required due to system library linking bug patch
     system "./buildconf", "--force"
 


### PR DESCRIPTION
Removed GCC dependency and Clang failure conditions for macOS.

Reverts https://github.com/Homebrew/homebrew-core/pull/236796

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
