### PR TITLE
radare2: Add runtime dependency `pkgconf` to support `r2pm`

### DIFF
--- a/Formula/r/radare2.rb
+++ b/Formula/r/radare2.rb
@@ -21,6 +21,9 @@ class Radare2 < Formula
     sha256 x86_64_linux:  "d890838a320f89e6ec669d9c689a837df4039d37b448190b07a6105b20e2a89f"
   end
 
+  # Required for r2pm (https://github.com/radareorg/radare2-pm/issues/170)
+  depends_on "pkgconf"
+
   def install
     system "./configure", "--prefix=#{prefix}"
     system "make"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Currently `r2pm` will often not work without `pkg-config` available: https://github.com/radareorg/radare2-pm/issues/170