### PR TITLE
dnscrypt-wrapper: workaround for arm64 macOS

### DIFF
--- a/Formula/d/dnscrypt-wrapper.rb
+++ b/Formula/d/dnscrypt-wrapper.rb
@@ -21,11 +21,10 @@ class DnscryptWrapper < Formula
   depends_on "libevent"
   depends_on "libsodium"
 
-  on_macos do
-    depends_on arch: :x86_64 # https://github.com/cofyc/dnscrypt-wrapper/issues/177
-  end
-
   def install
+    # Workaround for arm64 macOS, https://github.com/cofyc/dnscrypt-wrapper/issues/177
+    inreplace "compat.h", "#define HAVE_BACKTRACE 1", "" if OS.mac? && Hardware::CPU.arm?
+
     system "make", "configure"
     system "./configure", "--prefix=#{prefix}"
     system "make"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
