### PR TITLE
io: backport commits to build on arm64 macOS and avoid deprecation

### DIFF
--- a/Formula/i/io.rb
+++ b/Formula/i/io.rb
@@ -9,6 +9,39 @@ class Io < Formula
     url "https://github.com/IoLanguage/io/archive/refs/tags/2017.09.06.tar.gz"
     sha256 "9ac5cd94bbca65c989cd254be58a3a716f4e4f16480f0dc81070457aa353c217"
 
+    # Backport commits to build on arm64
+    on_macos do
+      on_arm do
+        # Backport CMake changes to cleanly apply later commits
+        patch do
+          url "https://github.com/IoLanguage/io/commit/27d3900e8a88d0ee45773666a5a257ca735eb0b0.patch?full_index=1"
+          sha256 "937ba88cecf017b19791b13e8f721060b91af319ba753463b40353a56d6fa99d"
+        end
+        patch do
+          url "https://github.com/IoLanguage/io/commit/27e87f614992df745d894b5190c95180baf9cf4b.patch?full_index=1"
+          sha256 "142761908bc1cb2e04c442e1d97397f39b063d64d10079750b396316280ccf7e"
+        end
+        patch do
+          url "https://github.com/IoLanguage/io/commit/72c8a7ec1e0711ba54754b17def08e3fdcea4f66.patch?full_index=1"
+          sha256 "634ded26ac1e1015ec1ece869c7311ec1db7639b6c6bfb976f74c7617c7b417f"
+        end
+        patch do
+          url "https://github.com/IoLanguage/io/commit/b200c7f0e0f899a19d576852e931badb542f37a7.patch?full_index=1"
+          sha256 "85f942c3b25238ab722d26944ff2c11d8e55cd6c3d4373e8121c2a31d1fe1fd5"
+        end
+
+        # Backport some clang-format whitespace changes from
+        # https://github.com/IoLanguage/io/commit/158ee62d2551ceffcc1a34616baa38794e59e21f
+        patch :DATA
+
+        # Backport support for arm64
+        patch do
+          url "https://github.com/IoLanguage/io/commit/bb5fa48fc272e0e8febda40c0f9f6c85cd788a60.patch?full_index=1"
+          sha256 "b6f1100606dc2539abdd0707fe6a578cd7e462db7f70d192a9613860e67bf760"
+        end
+      end
+    end
+
     # Backport fix for Linux build
     patch do
       url "https://github.com/IoLanguage/io/commit/92fe8304c55b84a17b0624613a7006e85a0128a2.patch?full_index=1"
@@ -16,7 +49,10 @@ class Io < Formula
     end
 
     # build patch for sysctl.h as glibc 2.32 removed <sys/sysctl.h>
-    patch :DATA
+    patch do
+      url "https://github.com/IoLanguage/io/commit/9f3e4d87b6d4c1bf583134d55d1cf92d3464c49f.patch?full_index=1"
+      sha256 "2ee70f5e61d1b798bea172fb357381c7781eecd465714de7ad56c56fd89f5c1c"
+    end
   end
 
   no_autobump! because: :requires_manual_review
@@ -35,22 +71,20 @@ class Io < Formula
 
   uses_from_macos "libxml2"
 
-  on_macos do
-    depends_on arch: :x86_64 # https://github.com/IoLanguage/io/issues/465
-  end
-
   def install
     ENV.deparallelize
 
     # FSF GCC needs this to build the ObjC bridge
     ENV.append_to_cflags "-fobjc-exceptions"
 
-    inreplace "CMakeLists.txt" do |s|
-      # Turn off all add-ons in main cmake file
-      s.gsub! "add_subdirectory(addons)", "#add_subdirectory(addons)" if build.stable?
-      # Allow building on non-x86_64 platforms
-      # Ref: https://github.com/IoLanguage/io/issues/450 / https://github.com/IoLanguage/io/issues/474
-      s.gsub! 'SET(CMAKE_C_FLAGS "-msse2")', "" unless Hardware::CPU.intel?
+    if build.stable?
+      inreplace "CMakeLists.txt" do |s|
+        # Turn off all add-ons in main cmake file
+        s.gsub! "add_subdirectory(addons)", "#add_subdirectory(addons)"
+        # Allow building on non-x86_64 platforms
+        # Ref: https://github.com/IoLanguage/io/issues/450 / https://github.com/IoLanguage/io/issues/474
+        s.gsub! 'SET(CMAKE_C_FLAGS "-msse2")', "" if OS.linux? && !Hardware::CPU.intel?
+      end
     end
 
     args = %W[
@@ -66,25 +100,60 @@ class Io < Formula
   end
 
   test do
-    (testpath/"test.io").write <<~EOS
+    (testpath/"test.io").write <<~IO
       "it works!" println
-    EOS
+    IO
 
     assert_equal "it works!\n", shell_output("#{bin}/io test.io")
   end
 end
 
 __END__
-diff --git a/libs/iovm/source/IoSystem.c b/libs/iovm/source/IoSystem.c
-index a6234f7..af3a975 100755
---- a/libs/iovm/source/IoSystem.c
-+++ b/libs/iovm/source/IoSystem.c
-@@ -22,7 +22,7 @@ Contains methods related to the IoVM.
- #if defined(__NetBSD__) || defined(__OpenBSD__)
- # include <sys/param.h>
+diff --git a/libs/coroutine/source/Coro.c b/libs/coroutine/source/Coro.c
+index 88951158..25219b47 100644
+--- a/libs/coroutine/source/Coro.c
++++ b/libs/coroutine/source/Coro.c
+@@ -70,9 +70,7 @@ typedef struct CallbackBlock
  #endif
--#ifndef __CYGWIN__
-+#if defined(HAVE_SYS_SYSCTL_H) && !defined(__GLIBC__)
- # include <sys/sysctl.h>
+ } CallbackBlock;
+ 
+-
+-Coro *Coro_new(void)
+-{
++Coro *Coro_new(void) {
+ 	Coro *self = (Coro *)io_calloc(1, sizeof(Coro));
+ 	self->requestedStackSize = CORO_DEFAULT_STACK_SIZE;
+ 	self->allocatedStackSize = 0;
+diff --git a/libs/coroutine/source/taskimpl.h b/libs/coroutine/source/taskimpl.h
+index e3742315..8b871b29 100644
+--- a/libs/coroutine/source/taskimpl.h
++++ b/libs/coroutine/source/taskimpl.h
+@@ -106,17 +106,17 @@ extern	void		makecontext(ucontext_t*, void(*)(), int, ...);
  #endif
+ 
+ #if defined(__APPLE__)
+-#	define mcontext libthread_mcontext
+-#	define mcontext_t libthread_mcontext_t
+-#	define ucontext libthread_ucontext
+-#	define ucontext_t libthread_ucontext_t
+-#	if defined(__i386__)
+-#		include "386-ucontext.h"
+-#	elif defined(__x86_64__)
+-#		include "amd64-ucontext.h"
+-#	else
+-#		include "power-ucontext.h"
+-#	endif
++#define mcontext libthread_mcontext
++#define mcontext_t libthread_mcontext_t
++#define ucontext libthread_ucontext
++#define ucontext_t libthread_ucontext_t
++#if defined(__i386__)
++#include "386-ucontext.h"
++#elif defined(__x86_64__)
++#include "amd64-ucontext.h"
++#else
++#include "power-ucontext.h"
++#endif
  #endif
+ 
+ #if defined(__OpenBSD__)


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Backport `:DATA` patch is for whitespace changes:
```diff
diff --git a/libs/coroutine/source/Coro.c b/libs/coroutine/source/Coro.c
index 88951158..25219b47 100644
--- a/libs/coroutine/source/Coro.c
+++ b/libs/coroutine/source/Coro.c
@@ -70,9 +70,7 @@ typedef struct CallbackBlock
 #endif
 } CallbackBlock;
 
-
-Coro *Coro_new(void)
-{
+Coro *Coro_new(void) {
 	Coro *self = (Coro *)io_calloc(1, sizeof(Coro));
 	self->requestedStackSize = CORO_DEFAULT_STACK_SIZE;
 	self->allocatedStackSize = 0;
diff --git a/libs/coroutine/source/taskimpl.h b/libs/coroutine/source/taskimpl.h
index e3742315..8b871b29 100644
--- a/libs/coroutine/source/taskimpl.h
+++ b/libs/coroutine/source/taskimpl.h
@@ -106,17 +106,17 @@ extern	void		makecontext(ucontext_t*, void(*)(), int, ...);
 #endif
 
 #if defined(__APPLE__)
-#	define mcontext libthread_mcontext
-#	define mcontext_t libthread_mcontext_t
-#	define ucontext libthread_ucontext
-#	define ucontext_t libthread_ucontext_t
-#	if defined(__i386__)
-#		include "386-ucontext.h"
-#	elif defined(__x86_64__)
-#		include "amd64-ucontext.h"
-#	else
-#		include "power-ucontext.h"
-#	endif
+#define mcontext libthread_mcontext
+#define mcontext_t libthread_mcontext_t
+#define ucontext libthread_ucontext
+#define ucontext_t libthread_ucontext_t
+#if defined(__i386__)
+#include "386-ucontext.h"
+#elif defined(__x86_64__)
+#include "amd64-ucontext.h"
+#else
+#include "power-ucontext.h"
+#endif
 #endif
 
 #if defined(__OpenBSD__)
```