### PR TITLE
bic: backport arm64 support to avoid deprecation

### DIFF
--- a/Formula/b/bic.rb
+++ b/Formula/b/bic.rb
@@ -8,13 +8,38 @@ class Bic < Formula
     sha256 "553324e39d87df59930d093a264c14176d5e3aaa24cd8bff276531fb94775100"
 
     on_macos do
-      depends_on arch: :x86_64
+      on_arm do
+        # Need to use git archive tarball to apply patches which modify development/CI files
+        url "https://github.com/hexagonal-sun/bic/archive/refs/tags/v1.0.0.tar.gz"
+        sha256 "fa5b9e3ffc955220ab825a749f1987a7a0bd268693c1750a1af6cc1802217547"
+
+        depends_on "autoconf" => :build
+        depends_on "autoconf-archive" => :build
+        depends_on "automake" => :build
+        depends_on "bison" => :build # macOS bison is too outdated, build fails unless gnu bison is used
+        depends_on "libtool" => :build
+        depends_on "pkgconf" => :build
+
+        # Backport to cleanly apply next patch
+        patch do
+          url "https://github.com/hexagonal-sun/bic/commit/97296b610350b3ae6abfb546dcae43fd32a002b3.patch?full_index=1"
+          sha256 "32e732260a974cc48d757c0ed0a457467ed8f88025faf5637feca6e37a6e7788"
+        end
+
+        # Apply all commits from PR https://github.com/hexagonal-sun/bic/pull/49
+        patch do
+          url "https://github.com/hexagonal-sun/bic/compare/631cfb449eec35a2df52eb317f4e9add33c1dea9..7748c44eed2c53ce82b9d45a9f629f68f8cc4f99.patch"
+          sha256 "bf10454ec8fededce5e9688d7ebabc0f74df3d50c24322efc0f4ee215a1879a9"
+        end
+      end
     end
 
     # Backport fix for error: call to undeclared function '__gmp_fprintf'
     patch do
-      url "https://github.com/hexagonal-sun/bic/commit/77f2993cd5b41bfa21fb21636588e459c6aaf45c.patch?full_index=1"
-      sha256 "c7037e4f3b05be997744ccdea0f51786e5eafaddebc131763d5f45745e90cf00"
+      on_intel do
+        url "https://github.com/hexagonal-sun/bic/commit/77f2993cd5b41bfa21fb21636588e459c6aaf45c.patch?full_index=1"
+        sha256 "c7037e4f3b05be997744ccdea0f51786e5eafaddebc131763d5f45745e90cf00"
+      end
     end
   end
 
@@ -38,6 +63,7 @@ class Bic < Formula
     depends_on "automake" => :build
     depends_on "bison" => :build # macOS bison is too outdated, build fails unless gnu bison is used
     depends_on "libtool" => :build
+    depends_on "pkgconf" => :build
 
     uses_from_macos "flex" => :build
     uses_from_macos "libffi"
@@ -50,7 +76,7 @@ class Bic < Formula
   end
 
   def install
-    system "autoreconf", "--force", "--install", "--verbose" if build.head?
+    system "autoreconf", "--force", "--install", "--verbose" if build.head? || (OS.mac? && Hardware::CPU.arm?)
     system "./configure", "--disable-silent-rules", *std_configure_args
     system "make", "install"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
