### PR TITLE
amdatu-bootstrap: deprecate

### DIFF
--- a/Formula/a/amdatu-bootstrap.rb
+++ b/Formula/a/amdatu-bootstrap.rb
@@ -18,7 +18,18 @@ class AmdatuBootstrap < Formula
     sha256 cellar: :any_skip_relocation, all: "0094a50b87c8bf6f25f9fc0e68bcb95a2c46923a240eb83210748a280ee8cd27"
   end
 
+  # Deprecated since:
+  # * No arm64 macOS support: https://docs.brew.sh/Support-Tiers#future-macos-support
+  # * No upstream activity since 2015
+  # * Still needs OpenJDK 8
+  deprecate! date: "2025-09-25", because: :unmaintained
+  disable! date: "2026-09-25", because: :unmaintained
+
   depends_on "openjdk@8"
+
+  on_macos do
+    depends_on arch: :x86_64 # openjdk@8 is not supported on ARM
+  end
 
   def install
     env = Language::Java.java_home_env("1.8")


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Deprecating some OpenJDK 8 dependents. This is unmaintained and has low installs:
```
==> Analytics
install: 0 (30 days), 7 (90 days), 39 (365 days)
install-on-request: 0 (30 days), 7 (90 days), 39 (365 days)
build-error: 0 (30 days)
```