### PR TITLE
hypopg pg_partman pg_cron postgresql-hll wal2json: add `postgresql@18`, drop `postgresql@14`

### DIFF
--- a/Formula/h/hypopg.rb
+++ b/Formula/h/hypopg.rb
@@ -11,14 +11,13 @@ class Hypopg < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "59d61a40ee46c35533398e2a711ede66458f2616268dd74e34ba04c56109d7b9"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e319bf2b836a72e560bcb3496f80917f29cb2d9a4243580a0c1487f7e4b7c9da"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "e641b2c2df8ca7f8a6b2c882b42f820f24a3e9326a3605dcfeb97770149889e8"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "8cfe4430907140af1fe4e26ab9ab97c0180e570b7d9c55d1c03932ca050e0566"
-    sha256 cellar: :any_skip_relocation, sonoma:        "f1f748e156c8e3fc1ef64c3d0741df3d8f69cc1c7fd8468576db210b6bdb92f8"
-    sha256 cellar: :any_skip_relocation, ventura:       "37dda840487b942c69f32b88347fbb57f279ee780e385a5a8d6ab653d09e70c3"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "593f3fcf8179281606f2dd9e22248ad010cea256dac2a17d567660bf0b93ce0a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "21cc0571fc75444925050a5856e02b3100ca1e5698adcaddf21b6dde1f269d42"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "62a5a0b0c592109dbfd59cc2ed251cfc61139444fa11dd43c6a813bf5721dc05"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "fdeda4712d8f810bbef1018e34bc93f250736e7d06b52c46237fb72f0203d6b6"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "5944371d52b74079759b3c1697219a83afa8668897d99727d3a8178915d4a0d8"
+    sha256 cellar: :any_skip_relocation, sonoma:        "489ad1c03c7445f390a0b5343368138b5e7f9fcd09f2d93cb2788b77d82c02f9"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "85797620c0d3f1115917e23044e64b4526d2913b15044a6156d3c69037ca23d7"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5a2cf8d3428a7e9e63c750f8fe2d45a5d0235c0b88d661089e1bc72bfcebff68"
   end
 
   depends_on "postgresql@17" => [:build, :test]

--- a/Formula/h/hypopg.rb
+++ b/Formula/h/hypopg.rb
@@ -21,14 +21,16 @@ class Hypopg < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "21cc0571fc75444925050a5856e02b3100ca1e5698adcaddf21b6dde1f269d42"
   end
 
-  depends_on "postgresql@14" => [:build, :test]
   depends_on "postgresql@17" => [:build, :test]
+  depends_on "postgresql@18" => [:build, :test]
 
   def postgresqls
     deps.map(&:to_formula).sort_by(&:version).filter { |f| f.name.start_with?("postgresql@") }
   end
 
   def install
+    odie "Too many postgresql dependencies!" if postgresqls.count > 2
+
     postgresqls.each do |postgresql|
       ENV["PG_CONFIG"] = postgresql.opt_bin/"pg_config"
       system "make"

--- a/Formula/p/pg_cron.rb
+++ b/Formula/p/pg_cron.rb
@@ -16,8 +16,8 @@ class PgCron < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "c7206a1fa1242bbed6b486da83c12b373da497bf3ccaa72d81ba0d0dd6db55b5"
   end
 
-  depends_on "postgresql@14" => [:build, :test]
   depends_on "postgresql@17" => [:build, :test]
+  depends_on "postgresql@18" => [:build, :test]
   depends_on "libpq"
 
   on_macos do
@@ -30,6 +30,8 @@ class PgCron < Formula
   end
 
   def install
+    odie "Too many postgresql dependencies!" if postgresqls.count > 2
+
     # Work around for ld: Undefined symbols: _libintl_ngettext
     # Issue ref: https://github.com/citusdata/pg_cron/issues/269
     ENV["PG_LDFLAGS"] = "-lintl" if OS.mac?

--- a/Formula/p/pg_cron.rb
+++ b/Formula/p/pg_cron.rb
@@ -6,14 +6,13 @@ class PgCron < Formula
   license "PostgreSQL"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "db8a7bfe281044697f5f7b0835b95052e1ed0fb3688c673b6d65efbf1f047d78"
-    sha256 cellar: :any,                 arm64_sequoia: "937e5bc2845b6ccf62c19823c03b39678ece0efd0c2834d81aa56795b0ba7199"
-    sha256 cellar: :any,                 arm64_sonoma:  "a14743988807d045690aa9cfbc58d58b2f2f431e1951ddfa41547a55296043e8"
-    sha256 cellar: :any,                 arm64_ventura: "8de0b4c5f4177977f2de2db6ab5fb3047d38d4233836b98a5ade1a45427436ef"
-    sha256 cellar: :any,                 sonoma:        "9fd83573a717b2ccdc615bf0dc196be9ebb33c3f4a614e3fcdfda0bf8503341f"
-    sha256 cellar: :any,                 ventura:       "6e2af376fd0565ccff721ae6cb9f3f7e399c78e494b18008ef2291927cc6dd1a"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "66babf31f827196051d5f074ccaa9538d26c361908b4a9037a29ce39d657cdc1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c7206a1fa1242bbed6b486da83c12b373da497bf3ccaa72d81ba0d0dd6db55b5"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "09735afcd85669a8b3c460864d987b45a85efa861b23d13d091d0a3044b9d65e"
+    sha256 cellar: :any,                 arm64_sequoia: "c6248b364e481b21ca81bfc63776271f8f3eda1ed42971b88c6b1b6cf87db682"
+    sha256 cellar: :any,                 arm64_sonoma:  "8f312f0971c68d69201ee2d4ed3b544c0572a4d36a2ebbc9ba8c5785ca20a556"
+    sha256 cellar: :any,                 sonoma:        "8eb54aed1bdff05c61bda87a5d30ec13beed7e14539eee17f9450748f67680bb"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "56feed3b8e5d423e83dc9218a3a17432e819b16fdd1045b7584593649fa3952d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "58fc98446a6b2f23b701b53c391b8c4d052cbea137b0ea7e8fa7ff398bfe509a"
   end
 
   depends_on "postgresql@17" => [:build, :test]

--- a/Formula/p/pg_partman.rb
+++ b/Formula/p/pg_partman.rb
@@ -21,14 +21,16 @@ class PgPartman < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "35d4cb1858223e0a1b0badd91bc8d83393da2fcd30d9609bef6285d8fe5fef3c"
   end
 
-  depends_on "postgresql@14" => [:build, :test]
   depends_on "postgresql@17" => [:build, :test]
+  depends_on "postgresql@18" => [:build, :test]
 
   def postgresqls
     deps.map(&:to_formula).sort_by(&:version).filter { |f| f.name.start_with?("postgresql@") }
   end
 
   def install
+    odie "Too many postgresql dependencies!" if postgresqls.count > 2
+
     postgresqls.each do |postgresql|
       ENV["PG_CONFIG"] = postgresql.opt_bin/"pg_config"
 

--- a/Formula/p/pg_partman.rb
+++ b/Formula/p/pg_partman.rb
@@ -11,14 +11,13 @@ class PgPartman < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "99cbe1b5a499e361d0e5fce55c8bbf3896b10430c23c71d57111d48af8a6fc85"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "bc8d0101a41b8462c808e3b89ced8cf4c35abd2859da258810f45c7cc3d08eab"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "fbb25523f90c489a1d3e960c72a5e25e2015203f076b422979105d4237548fa7"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "da418435f548516e2c08d7152618cba4944c05ea97e7a6caf885d392367d6b1f"
-    sha256 cellar: :any_skip_relocation, sonoma:        "4ff364c6122dd2f76874efa3993473d44c1875a9af05f87ac2b6162e0d3c3081"
-    sha256 cellar: :any_skip_relocation, ventura:       "d354534be1f5892af69af5ad223d00864f39f49a1a05a161a45c32440f51bb87"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "514b8f6796d0853c9dee95b01cae31d554351c999f1ebbc989553d0572fe833a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "35d4cb1858223e0a1b0badd91bc8d83393da2fcd30d9609bef6285d8fe5fef3c"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "9aa872814097e24a5251c1ff5b9c1962958f480ecb159a6ae80632bbd8be2ada"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "237456de81b9e9656dd9de9e54311e51ab859cabf251db79bcd0001ca727d6f2"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "3360bd68ca5d0297445da2ae315fe2e5d59edb5df7490550081d0f80794174b3"
+    sha256 cellar: :any_skip_relocation, sonoma:        "1925b115886c4c53d4f52d18cee74d07617ee927a795eb48cac622f7948e4bf1"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "ab848f61fc5c01cf74a13c5c340412fa9cc3a8e0e00f38f101abfc46ff251c40"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b712bdf503c41e4fbbbcd9e7aced208586c7b52525cf6104c6fc58799b94eded"
   end
 
   depends_on "postgresql@17" => [:build, :test]

--- a/Formula/p/postgresql-hll.rb
+++ b/Formula/p/postgresql-hll.rb
@@ -18,14 +18,16 @@ class PostgresqlHll < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "87c9b558987de3f251c0339c3427bf6e0c8172b887a697048b13b7cb0710e4de"
   end
 
-  depends_on "postgresql@14" => [:build, :test]
   depends_on "postgresql@17" => [:build, :test]
+  depends_on "postgresql@18" => [:build, :test]
 
   def postgresqls
     deps.map(&:to_formula).sort_by(&:version).filter { |f| f.name.start_with?("postgresql@") }
   end
 
   def install
+    odie "Too many postgresql dependencies!" if postgresqls.count > 2
+
     postgresqls.each do |postgresql|
       ENV["PG_CONFIG"] = postgresql.opt_bin/"pg_config"
       system "make"

--- a/Formula/p/postgresql-hll.rb
+++ b/Formula/p/postgresql-hll.rb
@@ -8,14 +8,13 @@ class PostgresqlHll < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "8513d2e8cbc044030d8c601a0feb76db6b908f7418376262a2f1fe9aeba40f35"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "27480a860a6ad43655bbc46261a3802ea26252038b3c0ada7900d7727654248d"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "7c452476e1fa061eff0b1e1ed08ded91385d0ea266b47173ecac203e009ddcc4"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "7eff2df8ade96abbf8b6ea92b187994a875ef21491f57628b67b3e17524a896b"
-    sha256 cellar: :any_skip_relocation, sonoma:        "ef85b1da74c48d8c1338dd3ba819f728d3c10ff0e2eb9df0144b684741bdcd55"
-    sha256 cellar: :any_skip_relocation, ventura:       "f02c71f284135ed072743b270584d958183d8951c85faa42472dc0c602748b5f"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "01e309e288fe1c16b2b47e4ec6ea57bc17da8d41bda3f49bbd869ef6aa62fd16"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "87c9b558987de3f251c0339c3427bf6e0c8172b887a697048b13b7cb0710e4de"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "f2127db4c57a1859e589e8d6b073846c921403023651fa7b7dc307976555bd0a"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "68222bf3940f01f6e0fdb678793550e891216642508fda81c9d00399829299f6"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "99fef7555b3537c04f99342845460b847e89986f7cb48f6f66365734cd3aa2ee"
+    sha256 cellar: :any_skip_relocation, sonoma:        "ecbb627cf1d27c957afb6cdb6f7a3ecc7249ece09ff377686d7c1b6eeaa26fce"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "538f2f44bca1e662c992bbc06a506159aaea51a1c409da1ed1eea86e863f688d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "52f63b4a80e968c0633065248096e6579ab64aba28a8f6f04ea6633a72d85565"
   end
 
   depends_on "postgresql@17" => [:build, :test]

--- a/Formula/w/wal2json.rb
+++ b/Formula/w/wal2json.rb
@@ -25,14 +25,16 @@ class Wal2json < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "44d6b43deefc69fbd0cb1df19957d8f827d74f49693d43ddd2df058ebb3bfb1f"
   end
 
-  depends_on "postgresql@14" => [:build, :test]
   depends_on "postgresql@17" => [:build, :test]
+  depends_on "postgresql@18" => [:build, :test]
 
   def postgresqls
     deps.map(&:to_formula).sort_by(&:version).filter { |f| f.name.start_with?("postgresql@") }
   end
 
   def install
+    odie "Too many postgresql dependencies!" if postgresqls.count > 2
+
     postgresqls.each do |postgresql|
       system "make", "install", "USE_PGXS=1",
                                 "PG_CONFIG=#{postgresql.opt_bin}/pg_config",

--- a/Formula/w/wal2json.rb
+++ b/Formula/w/wal2json.rb
@@ -14,15 +14,13 @@ class Wal2json < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "e3c2d30a2b8630f06c70f9fffc6e975f067cbd71b007240eca145b5fcb61d6c0"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "ec43557186dc322d7e038dbc6a9d2062296a13f8830952bbdb0c72d154c8a70b"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "0d9b4650f924f544a650ba786967a754b29a4971868b3dbd5ba9f47abd44f6cb"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "03a5c4a6e4048d088a5a23aed0251a4cf05f86d271eb23f8c681c139f6336672"
-    sha256 cellar: :any_skip_relocation, sonoma:        "4e53de38eccaf3a9a23587ea164b8723f68648c84d3c3017d362823daaacd113"
-    sha256 cellar: :any_skip_relocation, ventura:       "1ac11a6eb237df8ffab44e8a903925e0896628a3ba78b31b919ea6a61d1b54e6"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "d86989d3fc89bd67beea43908aeff1306132d88234f93e24aa2a9a952dd9ba33"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "44d6b43deefc69fbd0cb1df19957d8f827d74f49693d43ddd2df058ebb3bfb1f"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "6df07eb3b4c76fd3a26aabbd3d9512f2018ca40991a213805b3d97a359e6bbea"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "0cd88f515f6d34e3aeb5ecbf7ef5a869639b032373512e8eb6d68b58e9b3b2af"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "79300555385707acce8e526b38f75d91445f7bf43ad8dcc4b3d51083edd29a82"
+    sha256 cellar: :any_skip_relocation, sonoma:        "1bd372e6fe5bf4532c35eea95a8da392cca051f40fb43eb2721a6d8669375eb0"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "98ff83a1fd6e9730c36c443fd57824831f83b48d426836a33e6a98e94b70647b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b73b0d8f8d95d485c6a5b8e9bc0ccf357292d8ca232ca6708cba79cb0875a7e9"
   end
 
   depends_on "postgresql@17" => [:build, :test]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

No revision bump so users on `postgresql@14` can still use extension until next formula release while users on `postgresql@18` can reinstall to get support.

Policy discussed in #245698. This matches what we do for Python.

Users can always use a custom tap to create formulae for other versions.