### PR TITLE
pgroonga: add `postgresql@18`, drop `postgresql@14`

### DIFF
--- a/Formula/p/pgroonga.rb
+++ b/Formula/p/pgroonga.rb
@@ -20,8 +20,8 @@ class Pgroonga < Formula
   end
 
   depends_on "pkgconf" => :build
-  depends_on "postgresql@14" => [:build, :test]
   depends_on "postgresql@17" => [:build, :test]
+  depends_on "postgresql@18" => [:build, :test]
   depends_on "groonga"
 
   def postgresqls
@@ -29,6 +29,8 @@ class Pgroonga < Formula
   end
 
   def install
+    odie "Too many postgresql dependencies!" if postgresqls.count > 2
+
     postgresqls.each do |postgresql|
       with_env(PATH: "#{postgresql.opt_bin}:#{ENV["PATH"]}") do
         system "make"

--- a/Formula/p/pgroonga.rb
+++ b/Formula/p/pgroonga.rb
@@ -11,12 +11,13 @@ class Pgroonga < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "6a0d34a15dfc6e50d4683cf53c2550b1b44f979c79104bd3cdbb63116e7f5499"
-    sha256 cellar: :any,                 arm64_sequoia: "9be6e14234a91733d53540dde22267a8ff42d0e1dfb5ef6260c196b64983c23d"
-    sha256 cellar: :any,                 arm64_sonoma:  "6e8235da975501e02f20faaf99263acb94d298b681eac6ee6cfb9cbb02f1c50c"
-    sha256 cellar: :any,                 sonoma:        "c88d25354070b5f16a3db6312352f967a67f450d24ed5990a76843612573c5e3"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "4a9fce0bb73619d7e104f2a5636fce7d942acb1cef7dd0824a7ff574bc9d4bda"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "cddf003fce89c699dffb8025792d378d2b33077e698c11af59fc7a2db97f281c"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "62030d327ee27e7851dfc83b507d4f0030bf22634c317f078ffd1ea656d9a44d"
+    sha256 cellar: :any,                 arm64_sequoia: "39ec9f2e2ff6a9766dddff6afc9f44ae1e7545f56630e26e599e27580c3cc49a"
+    sha256 cellar: :any,                 arm64_sonoma:  "e6c9a176b813fea1a12c778668da31b49135c3a53249392965f7d297aa815bec"
+    sha256 cellar: :any,                 sonoma:        "7b2e0330558f191ca3b014f417b5d43347b2e7a929b53c6d5a23078df7f9379c"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "7347ac65fb4ae7bbc185c658a8e2d8916a5d284ab55ce1bc47a2d08c1597cc73"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c71d3c7351ac61b308a81ba762e0b2bdb956a4a2409b82e9e2f346eafb5de5e2"
   end
 
   depends_on "pkgconf" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

No revision bump so users on `postgresql@14` can still use extension until next formula release while users on `postgresql@18` can reinstall to get support.

Policy discussed in #245698. This matches what we do for Python.

Users can always use a custom tap to create formulae for other versions.