### PR TITLE
pgvector: add `postgresql@18`, drop `postgresql@14`

### DIFF
--- a/Formula/p/pgvector.rb
+++ b/Formula/p/pgvector.rb
@@ -6,14 +6,13 @@ class Pgvector < Formula
   license "PostgreSQL"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "2c264eeffe1086c33dbe07d1c3cbe33ff8ac4f658969d8010213cd05c885d54c"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "01dff5d03be54305b71a6aac9eaaf3fd5e4d1f315ed0fa1dd830aebdf5e75746"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "b7e99e6267e9e0686af80ccab22c764b1010cbaeaf2c026ad591a41c0d7fe870"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "ef33203fe058a76976309bac1bbec7ca55e352241eac2f74f71621466533d977"
-    sha256 cellar: :any_skip_relocation, sonoma:        "92462244cffe391b566a0eae47a7cd5c48d43b4d4b2708ae4d54b9e8d2a52b2a"
-    sha256 cellar: :any_skip_relocation, ventura:       "04e8b84a206d48f8622d53ff2021373b81356d6c95104f6d49399656602b4784"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "7a6fa66bd919c746f9d58432fc43982bee2f4d3eb0cf197715fe997f4293071d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "aaab7b23e670c2db2ba871a2130001c2ee7448d21e0911b7b28d68fa0ce1c78a"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "71331f9fce25247c15fa2b8c38ff776c396bedec8f157e6a55b4a8a4df8a3bf7"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "020d8b756ac7ec0fc1a3bc098585d5c51135ca16aab20ce1adf24e6c41322938"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "4ba83ebac1b5836c368e3b5b9409650a3a8b75afd13281066bfe9e3b66b5c6c7"
+    sha256 cellar: :any_skip_relocation, sonoma:        "b004e0e298b7cf38af96444ab2282d577595cd982176d143fbde704d22998354"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "cd82274ea8b8c03b811de6db28adc8e3d313daf53b2fb3270046ce4277ed277c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "37f45074367bb109411982def1e757518d7ec77f2c22a3df5544d910226b92d8"
   end
 
   depends_on "postgresql@17" => [:build, :test]

--- a/Formula/p/pgvector.rb
+++ b/Formula/p/pgvector.rb
@@ -16,14 +16,16 @@ class Pgvector < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "aaab7b23e670c2db2ba871a2130001c2ee7448d21e0911b7b28d68fa0ce1c78a"
   end
 
-  depends_on "postgresql@14" => [:build, :test]
   depends_on "postgresql@17" => [:build, :test]
+  depends_on "postgresql@18" => [:build, :test]
 
   def postgresqls
     deps.map(&:to_formula).sort_by(&:version).filter { |f| f.name.start_with?("postgresql@") }
   end
 
   def install
+    odie "Too many postgresql dependencies!" if postgresqls.count > 2
+
     postgresqls.each do |postgresql|
       ENV["PG_CONFIG"] = postgresql.opt_bin/"pg_config"
       system "make"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

No revision bump so users on `postgresql@14` can still use extension until next formula release while users on `postgresql@18` can reinstall to get support.

Policy discussed in #245698. This matches what we do for Python.

Users can always use a custom tap to create formulae for other versions.