### PR TITLE
postgis pgrouting: add `postgresql@18`, drop `postgresql@14`

### DIFF
--- a/Formula/p/pgrouting.rb
+++ b/Formula/p/pgrouting.rb
@@ -13,13 +13,11 @@ class Pgrouting < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "728c5861fae994633c5a1966ffdc2c391199ce36dd17210e46b9a65ee87de592"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "2d1298e0d55177fa19efd6cc79c0a54733481ac27126ac3fad54495b614b1f08"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "5c019e8d253e0a1242e6faf24ef0dfa5c8e413f9ac6e936b2f62a250b488cdf0"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "ac46316a8e7440784db41c6047fff8603b29d46ee19e89a5b0cb08c53ee31ac9"
-    sha256 cellar: :any_skip_relocation, sonoma:        "6db98cc05d362db522ebda306baaf618c5750a4813e90fb0c14cac5c1b1c55db"
-    sha256 cellar: :any_skip_relocation, ventura:       "1f839ae39b9725eda43fff5fdb29b9aaa8421fe00ff3274512ca025bb7134f6b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "6ea9fd403a6b1f28bdda54dc537dc60173056cf163f8efb7258f4a69a9f9ffc4"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "635b794cef3d095e2dd87b630953c191bdfa2773ed0bec3c6c308ca2891b50ef"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "a726b05d0bb7a9e9595b56ab81382ead5cdffe5e1b5a4c87f615f362f3420549"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "7cbfdcd6a1ebbff590ba6d8891e6771d374cb648600cbe7ddf8c5c349956e309"
+    sha256 cellar: :any_skip_relocation, sonoma:        "4c5e7218e0d1621047793dfb8085bfd2229c4d581f50a226434b6e51d1556874"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "761046a6b81bde4e46bffc7c7e07f79a2a4167ee2162fcf150be89abb2aa8f0f"
   end
 
   depends_on "boost" => :build

--- a/Formula/p/pgrouting.rb
+++ b/Formula/p/pgrouting.rb
@@ -4,6 +4,7 @@ class Pgrouting < Formula
   url "https://github.com/pgRouting/pgrouting/releases/download/v3.8.0/pgrouting-3.8.0.tar.gz"
   sha256 "b8a5f0472934fdf7cda3fb4754d01945378d920cdaddc01f378617ddbb9c447f"
   license "GPL-2.0-or-later"
+  revision 1
   head "https://github.com/pgRouting/pgrouting.git", branch: "main"
 
   livecheck do
@@ -23,8 +24,8 @@ class Pgrouting < Formula
 
   depends_on "boost" => :build
   depends_on "cmake" => :build
-  depends_on "postgresql@14" => [:build, :test]
   depends_on "postgresql@17" => [:build, :test]
+  depends_on "postgresql@18" => [:build, :test]
   depends_on "postgis"
 
   def postgresqls
@@ -32,6 +33,8 @@ class Pgrouting < Formula
   end
 
   def install
+    odie "Too many postgresql dependencies!" if postgresqls.count > 2
+
     ENV["DESTDIR"] = buildpath/"stage"
 
     postgresqls.each do |postgresql|

--- a/Formula/p/postgis.rb
+++ b/Formula/p/postgis.rb
@@ -4,6 +4,7 @@ class Postgis < Formula
   url "https://download.osgeo.org/postgis/source/postgis-3.6.0.tar.gz"
   sha256 "8caffef4b457ed70d5328bf4e5a21f9306b06c271662e03e1a65d30090e5f25f"
   license "GPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url "https://download.osgeo.org/postgis/source/"
@@ -29,8 +30,8 @@ class Postgis < Formula
   end
 
   depends_on "pkgconf" => :build
-  depends_on "postgresql@14" => [:build, :test]
   depends_on "postgresql@17" => [:build, :test]
+  depends_on "postgresql@18" => [:build, :test]
 
   depends_on "gdal"
   depends_on "geos"
@@ -55,6 +56,8 @@ class Postgis < Formula
   end
 
   def install
+    odie "Too many postgresql dependencies!" if postgresqls.count > 2
+
     # C++17 is required.
     ENV.append "CXXFLAGS", "-std=c++17"
     # Avoid linking to libc++ on Linux due to indirect LLVM dependency

--- a/Formula/p/postgis.rb
+++ b/Formula/p/postgis.rb
@@ -12,13 +12,11 @@ class Postgis < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "693ea3521c4e928a74d28db1b42f5534f55495cef49a412fefc1145d82016ed9"
-    sha256 cellar: :any,                 arm64_sequoia: "35b1d86a5ac4dea6594c5c67fb72e09cb2704cfa258733db2d0bc4d38b11fc67"
-    sha256 cellar: :any,                 arm64_sonoma:  "2dd9280503bda0eb56904637d66ae582290ece6c9db6f0db2294b8c307cb7c61"
-    sha256 cellar: :any,                 arm64_ventura: "72993a0b8b3820ee52fcc8a3a929332e3e4de1e70e5c2bee63720d489c339796"
-    sha256 cellar: :any,                 sonoma:        "a284f0f5f15998ea9173c5035c87efeb3c123624141036ebb9122f9ab86780a5"
-    sha256 cellar: :any,                 ventura:       "41d888377f765111bdc1a32825e322d29cb0444c28dfd5b360978a4880fe877a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f4fcaa64330866bdfd815c06a06b1149965a9740ee75dc2dc9ab6a3aacf819e9"
+    sha256 cellar: :any,                 arm64_tahoe:   "ba758c3bad80ee44b6337f6740a40de629192060aa0b93539ad8ba7516705313"
+    sha256 cellar: :any,                 arm64_sequoia: "3dc689d8882df3c1b0313a8ec6e92a5e80e2f87c04dfac28e801beffeffce2c0"
+    sha256 cellar: :any,                 arm64_sonoma:  "80a134d70401385c85762b5c7c4faf1d47f4b7860fb599bcaa63519419e2188f"
+    sha256 cellar: :any,                 sonoma:        "25f5e7b840c1279fb3e68e790879456ed668c273c786ca10691e22198e011380"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "32d430c1056caaea59d67c5a796ccf310454487eb885c69201ee23a591a31d08"
   end
 
   head do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Unlike other PRs, need revision bump as `pgrouting` depends on `postgis` so can end up with mismatched versions here.

Policy discussed in #245698. This matches what we do for Python.

Users can always use a custom tap to create formulae for other versions.