### PR TITLE
workflows: remove `test-bot` Action inputs

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -38,7 +38,6 @@ jobs:
         with:
           core: true
           cask: false
-          test-bot: false
 
       - name: Configure Git user
         uses: Homebrew/actions/git-user-config@main

--- a/.github/workflows/automerge-from-merge-queue.yml
+++ b/.github/workflows/automerge-from-merge-queue.yml
@@ -262,7 +262,6 @@ jobs:
         with:
           core: false
           cask: false
-          test-bot: false
 
       - run: brew pr-publish --branch=main "$PR"
         env:

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -192,7 +192,6 @@ jobs:
         with:
           core: false
           cask: false
-          test-bot: false
 
       - run: brew pr-publish --branch=main "$PR"
         env:

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -44,7 +44,6 @@ jobs:
         with:
           core: false
           cask: false
-          test-bot: false
 
       - name: Determine runners to use for this job
         id: determine-runners
@@ -68,7 +67,6 @@ jobs:
         with:
           core: false
           cask: false
-          test-bot: true
 
       - name: Cleanup runner
         if: matrix.cleanup

--- a/.github/workflows/clean-up-closed-prs.yml
+++ b/.github/workflows/clean-up-closed-prs.yml
@@ -38,7 +38,6 @@ jobs:
         with:
           core: false
           cask: false
-          test-bot: false
 
       - name: Check CI status
         id: check

--- a/.github/workflows/create-replacement-pr.yml
+++ b/.github/workflows/create-replacement-pr.yml
@@ -76,7 +76,6 @@ jobs:
         with:
           core: true
           cask: false
-          test-bot: false
 
       - name: Get reviewers
         id: reviewers

--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -65,7 +65,6 @@ jobs:
         with:
           core: true
           cask: false
-          test-bot: false
 
       - name: Prepare runner matrix
         id: runner-matrix
@@ -218,7 +217,6 @@ jobs:
         with:
           core: true
           cask: false
-          test-bot: false
 
       - name: Download bottles from GitHub Actions
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0

--- a/.github/workflows/dispatch-rebottle.yml
+++ b/.github/workflows/dispatch-rebottle.yml
@@ -70,7 +70,6 @@ jobs:
         with:
           core: true
           cask: false
-          test-bot: false
 
       - name: Determine runners
         id: determine-runners
@@ -153,7 +152,6 @@ jobs:
         with:
           core: true
           cask: false
-          test-bot: false
 
       - name: Download bottles from GitHub Actions
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -306,7 +306,6 @@ jobs:
         with:
           core: true
           cask: false
-          test-bot: false
 
       - name: Configure Git user
         id: git-user-config

--- a/.github/workflows/remove-disabled-packages.yml
+++ b/.github/workflows/remove-disabled-packages.yml
@@ -42,7 +42,6 @@ jobs:
         with:
           core: true
           cask: false
-          test-bot: false
 
       - name: Configure Git user
         id: git-user-config

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -45,7 +45,6 @@ jobs:
         with:
           core: true
           cask: false
-          test-bot: false
 
       - name: Generate matrix
         id: matrix
@@ -117,7 +116,6 @@ jobs:
         with:
           core: true
           cask: false
-          test-bot: false
 
       - name: Install and use Homebrew curl if needed
         if: matrix.curl

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,6 @@ jobs:
         with:
           core: true
           cask: false
-          test-bot: true
           stable: ${{ matrix.stable }}
 
       - name: Cache style cache
@@ -81,7 +80,6 @@ jobs:
         with:
           core: true
           cask: false
-          test-bot: true
 
       - run: brew test-bot --only-formulae-detect
         id: formulae-detect
@@ -199,7 +197,6 @@ jobs:
         with:
           core: true
           cask: false
-          test-bot: false
 
       - name: Determine runners to use for tests job
         id: determine-runners
@@ -326,7 +323,6 @@ jobs:
         with:
           core: true
           cask: false
-          test-bot: false
 
       - name: Determine runners to use for test_deps job
         id: determine-dependent-runners

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -97,7 +97,6 @@ jobs:
         with:
           core: true
           cask: false
-          test-bot: false
 
       - name: Check that bottle block is not modified
         id: bottle-block


### PR DESCRIPTION
`test-bot` has been merged into Homebrew/brew, so these are no longer necessary and output a warning in CI.