### PR TITLE
mp3blaster: add `libvorbis` due to linkage

### DIFF
--- a/Formula/m/mp3blaster.rb
+++ b/Formula/m/mp3blaster.rb
@@ -28,6 +28,10 @@ class Mp3blaster < Formula
 
   uses_from_macos "ncurses"
 
+  on_linux do
+    depends_on "libvorbis"
+  end
+
   def install
     if DevelopmentTools.clang_build_version >= 1700
       # Fix to error: constant expression evaluates to -1 which cannot be narrowed to type 'unsigned int'


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-core/actions/runs/18040802617/job/51341007502#step:4:21767

```
==> brew linkage --cached --test --strict mp3blaster
==> FAILED
Full linkage --cached --test --strict mp3blaster output
  Indirect dependencies with linkage:
    libvorbis
```