### PR TITLE
samtools: add `zlib` due to linkage

### DIFF
--- a/Formula/s/samtools.rb
+++ b/Formula/s/samtools.rb
@@ -19,6 +19,7 @@ class Samtools < Formula
   depends_on "htslib"
 
   uses_from_macos "ncurses"
+  uses_from_macos "zlib"
 
   def install
     system "./configure", "--prefix=#{prefix}",


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-core/actions/runs/18040802617/job/51341007502#step:4:22527
```
==> brew linkage --cached --test --strict samtools
==> FAILED
Full linkage --cached --test --strict samtools output
  Indirect dependencies with linkage:
    zlib
```