### PR TITLE
abpoa: add livecheck using github_releases

### DIFF
--- a/Formula/a/abpoa.rb
+++ b/Formula/a/abpoa.rb
@@ -6,6 +6,12 @@ class Abpoa < Formula
   license "MIT"
   head "https://github.com/yangao07/abPOA.git", branch: "main"
 
+  livecheck do
+    url :stable
+    strategy :github_releases
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   no_autobump! because: :requires_manual_review
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
livecheck: add GitHub releases strategy

- Add a `livecheck` block for `abpoa` using `github_releases` with a numeric-tag regex.
- Verified locally:
  - `brew livecheck abpoa --debug` 
  - `brew style abpoa` 
  - `brew audit --strict --online abpoa` 
- `no_autobump!` remains; this only improves version detection.
