### PR TITLE
portable-ruby: add various formulae.

### DIFF
--- a/Abstract/portable-formula.rb
+++ b/Abstract/portable-formula.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+module PortableFormulaMixin
+  if OS.mac?
+    if Hardware::CPU.arm?
+      TARGET_MACOS = :big_sur
+      TARGET_DARWIN_VERSION = Version.new("20.1.0").freeze
+    else
+      TARGET_MACOS = :catalina
+      TARGET_DARWIN_VERSION = Version.new("19.0.0").freeze
+    end
+
+    CROSS_COMPILING = OS.kernel_version.major != TARGET_DARWIN_VERSION.major
+  end
+
+  def portable_configure_args
+    # Allow cross-compile between Darwin versions
+    if OS.mac? && CROSS_COMPILING
+      cpu = if Hardware::CPU.arm?
+        "aarch64"
+      else
+        "x86_64"
+      end
+      %W[
+        --build=#{cpu}-apple-darwin#{OS.kernel_version}
+        --host=#{cpu}-apple-darwin#{TARGET_DARWIN_VERSION}
+      ]
+    else
+      []
+    end
+  end
+
+  def install
+    if OS.mac?
+      if OS::Mac.version > TARGET_MACOS
+        target_macos_humanized = TARGET_MACOS.to_s.tr("_", " ").split.map(&:capitalize).join(" ")
+
+        opoo <<~EOS
+          You are building portable formula on #{OS::Mac.version}.
+          As result, formula won't be able to work on older macOS versions.
+          It's recommended to build this formula on macOS #{target_macos_humanized}
+          (the oldest version that can run Homebrew).
+        EOS
+      end
+
+      # Always prefer to linking to portable libs.
+      ENV.append "LDFLAGS", "-Wl,-search_paths_first"
+    elsif OS.linux?
+      # reset Linuxbrew env, because we want to build formula against
+      # libraries offered by system (CentOS docker) rather than Linuxbrew.
+      ENV.delete "LDFLAGS"
+      ENV.delete "LIBRARY_PATH"
+      ENV.delete "LD_RUN_PATH"
+      ENV.delete "LD_LIBRARY_PATH"
+      ENV.delete "TERMINFO_DIRS"
+      ENV.delete "HOMEBREW_RPATH_PATHS"
+      ENV.delete "HOMEBREW_DYNAMIC_LINKER"
+
+      # https://github.com/Homebrew/homebrew-portable-ruby/issues/118
+      ENV.append_to_cflags "-fPIC"
+    end
+
+    super
+  end
+
+  def test
+    refute_match(/Homebrew libraries/,
+                 shell_output("#{HOMEBREW_BREW_FILE} linkage #{full_name}"))
+
+    super
+  end
+end
+
+class PortableFormula < Formula
+  desc "Abstract portable formula"
+  homepage "https://github.com/Homebrew/homebrew-portable-ruby"
+
+  def self.inherited(subclass)
+    subclass.class_eval do
+      super
+
+      keg_only "portable formulae are keg-only"
+
+      on_linux do
+        on_intel do
+          depends_on "glibc@2.13" => :build
+        end
+        on_arm do
+          depends_on "glibc@2.17" => :build
+        end
+        depends_on "linux-headers@4.4" => :build
+      end
+
+      prepend PortableFormulaMixin
+    end
+  end
+end

--- a/Formula/p/portable-libffi.rb
+++ b/Formula/p/portable-libffi.rb
@@ -1,0 +1,69 @@
+require File.expand_path("../../Abstract/portable-formula", __dir__)
+
+class PortableLibffi < PortableFormula
+  desc "Portable Foreign Function Interface library"
+  homepage "https://sourceware.org/libffi/"
+  url "https://github.com/libffi/libffi/releases/download/v3.5.2/libffi-3.5.2.tar.gz"
+  sha256 "f3a3082a23b37c293a4fcd1053147b371f2ff91fa7ea1b2a52e335676bac82dc"
+  license "MIT"
+
+  livecheck do
+    formula "libffi"
+  end
+
+  def install
+    system "./configure", *portable_configure_args,
+                          *std_configure_args,
+                          "--enable-static",
+                          "--disable-shared",
+                          "--disable-docs"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"closure.c").write <<~EOS
+      #include <stdio.h>
+      #include <ffi.h>
+      /* Acts like puts with the file given at time of enclosure. */
+      void puts_binding(ffi_cif *cif, unsigned int *ret, void* args[],
+                        FILE *stream)
+      {
+        *ret = fputs(*(char **)args[0], stream);
+      }
+      int main()
+      {
+        ffi_cif cif;
+        ffi_type *args[1];
+        ffi_closure *closure;
+        int (*bound_puts)(char *);
+        int rc;
+        /* Allocate closure and bound_puts */
+        closure = ffi_closure_alloc(sizeof(ffi_closure), &bound_puts);
+        if (closure)
+          {
+            /* Initialize the argument info vectors */
+            args[0] = &ffi_type_pointer;
+            /* Initialize the cif */
+            if (ffi_prep_cif(&cif, FFI_DEFAULT_ABI, 1,
+                             &ffi_type_uint, args) == FFI_OK)
+              {
+                /* Initialize the closure, setting stream to stdout */
+                if (ffi_prep_closure_loc(closure, &cif, puts_binding,
+                                         stdout, bound_puts) == FFI_OK)
+                  {
+                    rc = bound_puts("Hello World!");
+                    /* rc now holds the result of the call to fputs */
+                  }
+              }
+          }
+        /* Deallocate both closure, and bound_puts */
+        ffi_closure_free(closure);
+        return 0;
+      }
+    EOS
+
+    flags = ["-L#{lib}", "-lffi", "-I#{include}"]
+    system ENV.cc, "-o", "closure", "closure.c", *(flags + ENV.cflags.to_s.split)
+    system "./closure"
+  end
+end

--- a/Formula/p/portable-libxcrypt.rb
+++ b/Formula/p/portable-libxcrypt.rb
@@ -1,0 +1,56 @@
+require File.expand_path("../../Abstract/portable-formula", __dir__)
+
+class PortableLibxcrypt < PortableFormula
+  desc "Extended crypt library for descrypt, md5crypt, bcrypt, and others"
+  homepage "https://github.com/besser82/libxcrypt"
+  url "https://github.com/besser82/libxcrypt/releases/download/v4.4.38/libxcrypt-4.4.38.tar.xz"
+  sha256 "80304b9c306ea799327f01d9a7549bdb28317789182631f1b54f4511b4206dd6"
+  license "LGPL-2.1-or-later"
+
+  livecheck do
+    formula "libxcrypt"
+  end
+
+  def install
+    system "./configure", *portable_configure_args,
+                          *std_configure_args,
+                          "--enable-static",
+                          "--disable-shared",
+                          "--disable-obsolete-api",
+                          "--disable-xcrypt-compat-files",
+                          "--disable-failure-tokens",
+                          "--disable-valgrind"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <crypt.h>
+      #include <errno.h>
+      #include <stdio.h>
+      #include <string.h>
+
+      int main()
+      {
+        char *hash = crypt("abc", "$2b$05$abcdefghijklmnopqrstuu");
+
+        if (errno) {
+          fprintf(stderr, "Received error: %s", strerror(errno));
+          return errno;
+        }
+        if (hash == NULL) {
+          fprintf(stderr, "Hash is NULL");
+          return -1;
+        }
+        if (strcmp(hash, "$2b$05$abcdefghijklmnopqrstuuRWUgMyyCUnsDr8evYotXg5ZXVF/HhzS")) {
+          fprintf(stderr, "Unexpected hash output");
+          return -1;
+        }
+
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lcrypt", "-o", "test"
+    system "./test"
+  end
+end

--- a/Formula/p/portable-libyaml.rb
+++ b/Formula/p/portable-libyaml.rb
@@ -1,0 +1,38 @@
+require File.expand_path("../../Abstract/portable-formula", __dir__)
+
+class PortableLibyaml < PortableFormula
+  desc "YAML Parser"
+  homepage "https://github.com/yaml/libyaml"
+  url "https://github.com/yaml/libyaml/releases/download/0.2.5/yaml-0.2.5.tar.gz"
+  sha256 "c642ae9b75fee120b2d96c712538bd2cf283228d2337df2cf2988e3c02678ef4"
+  license "MIT"
+
+  livecheck do
+    formula "libyaml"
+  end
+
+  def install
+    system "./configure", *portable_configure_args,
+                          "--disable-dependency-tracking",
+                          "--prefix=#{prefix}",
+                          "--enable-static",
+                          "--disable-shared"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <yaml.h>
+
+      int main()
+      {
+        yaml_parser_t parser;
+        yaml_parser_initialize(&parser);
+        yaml_parser_delete(&parser);
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lyaml", "-o", "test"
+    system "./test"
+  end
+end

--- a/Formula/p/portable-openssl.rb
+++ b/Formula/p/portable-openssl.rb
@@ -1,0 +1,129 @@
+require File.expand_path("../../Abstract/portable-formula", __dir__)
+
+class PortableOpenssl < PortableFormula
+  desc "Cryptography and SSL/TLS Toolkit"
+  homepage "https://openssl.org/"
+  url "https://github.com/openssl/openssl/releases/download/openssl-3.5.3/openssl-3.5.3.tar.gz"
+  mirror "https://www.openssl.org/source/openssl-3.5.3.tar.gz"
+  mirror "http://fresh-center.net/linux/misc/openssl-3.5.3.tar.gz"
+  sha256 "c9489d2abcf943cdc8329a57092331c598a402938054dc3a22218aea8a8ec3bf"
+  license "Apache-2.0"
+
+  livecheck do
+    url :stable
+    strategy :github_releases do |json, regex|
+      json.filter_map do |release|
+        next if release["draft"] || release["prerelease"]
+
+        match = release["tag_name"]&.match(regex)
+        next if match.blank?
+
+        version = Version.new(match[1])
+        next if version.patch.to_i.zero?
+
+        version
+      end
+    end
+  end
+
+  resource "cacert" do
+    # https://curl.se/docs/caextract.html
+    url "https://curl.se/ca/cacert-2025-09-09.pem"
+    sha256 "f290e6acaf904a4121424ca3ebdd70652780707e28e8af999221786b86bb1975"
+
+    livecheck do
+      url "https://curl.se/ca/cadate.t"
+      regex(/^#define\s+CA_DATE\s+(.+)$/)
+      strategy :page_match do |page, regex|
+        match = page.match(regex)
+        next if match.blank?
+
+        Date.parse(match[1]).iso8601
+      end
+    end
+  end
+
+  def openssldir
+    libexec/"etc/openssl"
+  end
+
+  def arch_args
+    if OS.mac?
+      %W[darwin64-#{Hardware::CPU.arch}-cc enable-ec_nistp_64_gcc_128]
+    elsif Hardware::CPU.intel?
+      if Hardware::CPU.is_64_bit?
+        ["linux-x86_64"]
+      else
+        ["linux-elf"]
+      end
+    elsif Hardware::CPU.arm?
+      if Hardware::CPU.is_64_bit?
+        ["linux-aarch64"]
+      else
+        ["linux-armv4"]
+      end
+    end
+  end
+
+  def configure_args
+    %W[
+      --prefix=#{prefix}
+      --openssldir=#{openssldir}
+      --libdir=#{lib}
+      no-legacy
+      no-module
+      no-shared
+      no-engine
+    ]
+  end
+
+  def install
+    # OpenSSL is not fully portable and certificate paths are backed into the library.
+    # We therefore need to set the certificate path at runtime via an environment variable.
+    # We however don't want to touch _other_ OpenSSL usages, so we change the variable name to differ.
+    inreplace "include/internal/common.h", "\"SSL_CERT_FILE\"", "\"PORTABLE_RUBY_SSL_CERT_FILE\""
+
+    openssldir.mkpath
+    system "perl", "./Configure", *(configure_args + arch_args)
+    system "make"
+    system "make", "test"
+
+    system "make", "install_dev"
+
+    # Ruby doesn't support passing --static to pkg-config.
+    # Unfortunately, this means we need to modify the OpenSSL pc file.
+    # This is a Ruby bug - not an OpenSSL one.
+    inreplace lib/"pkgconfig/libcrypto.pc", "\nLibs.private:", ""
+
+    cacert = resource("cacert")
+    filename = Pathname.new(cacert.url).basename
+    openssldir.install cacert.files(filename => "cert.pem")
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <openssl/evp.h>
+      #include <stdio.h>
+      #include <string.h>
+
+      int main(int argc, char *argv[])
+      {
+        if (argc < 2)
+          return -1;
+
+        unsigned char md[EVP_MAX_MD_SIZE];
+        unsigned int size;
+
+        if (!EVP_Digest(argv[1], strlen(argv[1]), md, &size, EVP_sha256(), NULL))
+          return 1;
+
+        for (unsigned int i = 0; i < size; i++)
+          printf("%02x", md[i]);
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-L#{lib}", "-lcrypto", "-o", "test"
+    assert_equal "717ac506950da0ccb6404cdd5e7591f72018a20cbca27c8a423e9c9e5626ac61",
+                 shell_output("./test 'This is a test string'")
+  end
+end

--- a/Formula/p/portable-ruby.rb
+++ b/Formula/p/portable-ruby.rb
@@ -1,0 +1,193 @@
+require File.expand_path("../../Abstract/portable-formula", __dir__)
+
+class PortableRuby < PortableFormula
+  desc "Powerful, clean, object-oriented scripting language"
+  homepage "https://www.ruby-lang.org/"
+  url "https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.6.tar.gz"
+  sha256 "e3c19ab9e8f41b3723124fbc0114cde7cbf55e65aa9c58c12acd89ec9c0dd1b9"
+  license "Ruby"
+
+  # This regex restricts matching to versions other than X.Y.0.
+  livecheck do
+    formula "ruby"
+    regex(/href=.*?ruby[._-]v?(\d+\.\d+\.(?:(?!0)\d+)(?:\.\d+)*)\.t/i)
+  end
+
+  depends_on "pkgconf" => :build
+  depends_on "portable-libyaml" => :build
+  depends_on "portable-openssl" => :build
+
+  on_linux do
+    depends_on "portable-libffi" => :build
+    depends_on "portable-libxcrypt" => :build
+    depends_on "portable-zlib" => :build
+  end
+
+  resource "msgpack" do
+    url "https://rubygems.org/downloads/msgpack-1.8.0.gem"
+    sha256 "e64ce0212000d016809f5048b48eb3a65ffb169db22238fb4b72472fecb2d732"
+
+    livecheck do
+      url "https://rubygems.org/api/v1/versions/msgpack.json"
+      strategy :json do |json|
+        json.first["number"]
+      end
+    end
+  end
+
+  resource "bootsnap" do
+    url "https://rubygems.org/downloads/bootsnap-1.18.6.gem"
+    sha256 "0ae2393c1e911e38be0f24e9173e7be570c3650128251bf06240046f84a07d00"
+
+    livecheck do
+      url "https://rubygems.org/api/v1/versions/bootsnap.json"
+      strategy :json do |json|
+        json.first["number"]
+      end
+    end
+  end
+
+  # Fix compile on macOS 10.11
+  patch do
+    url "https://github.com/Bo98/ruby/commit/7aec5ca6e8ec13d92307615c32a511e02437d7de.patch?full_index=1"
+    sha256 "644f706bbbb708c2e1d32de65138c335c3710e6d47f86624f9dd98806627e83f"
+  end
+
+  def install
+    # Remove almost all bundled gems and replace with our own set.
+    rm_r ".bundle"
+    allowed_gems = ["debug"]
+    bundled_gems = File.foreach("gems/bundled_gems").select do |line|
+      line.blank? || line.start_with?("#") || allowed_gems.any? { |gem| line.match?(/\A#{Regexp.escape(gem)}\s/) }
+    end
+    rm_r(Dir["gems/*.gem"].reject do |gem_path|
+      gem_basename = File.basename(gem_path)
+      allowed_gems.any? { |gem| gem_basename.match?(/\A#{Regexp.escape(gem)}-\d/) }
+    end)
+    resources.each do |resource|
+      resource.stage "gems"
+      bundled_gems << "#{resource.name} #{resource.version}\n"
+    end
+    File.write("gems/bundled_gems", bundled_gems.join)
+
+    libyaml = Formula["portable-libyaml"]
+    libxcrypt = Formula["portable-libxcrypt"]
+    openssl = Formula["portable-openssl"]
+    libffi = Formula["portable-libffi"]
+    zlib = Formula["portable-zlib"]
+
+    args = portable_configure_args + %W[
+      --prefix=#{prefix}
+      --enable-load-relative
+      --with-static-linked-ext
+      --with-baseruby=#{RbConfig.ruby}
+      --with-out-ext=win32,win32ole
+      --without-gmp
+      --disable-install-doc
+      --disable-install-rdoc
+      --disable-dependency-tracking
+    ]
+
+    # We don't specify OpenSSL as we want it to use the pkg-config, which `--with-openssl-dir` will disable
+    args += %W[
+      --with-libyaml-dir=#{libyaml.opt_prefix}
+    ]
+
+    if OS.linux?
+      ENV["XCFLAGS"] = "-I#{libxcrypt.opt_include}"
+      ENV["XLDFLAGS"] = "-L#{libxcrypt.opt_lib}"
+
+      args += %W[
+        --with-libffi-dir=#{libffi.opt_prefix}
+        --with-zlib-dir=#{zlib.opt_prefix}
+      ]
+
+      # Ensure compatibility with older Ubuntu when built with Ubuntu 22.04
+      args << "MKDIR_P=/bin/mkdir -p"
+
+      # Don't make libruby link to zlib as it means all extensions will require it
+      # It's also not used with the older glibc we use anyway
+      args << "ac_cv_lib_z_uncompress=no"
+    end
+
+    # Append flags rather than override
+    ENV["cflags"] = ENV.delete("CFLAGS")
+    ENV["cppflags"] = ENV.delete("CPPFLAGS")
+    ENV["cxxflags"] = ENV.delete("CXXFLAGS")
+
+    system "./configure", *args
+    system "make", "extract-gems"
+    system "make"
+
+    # Add a helper load path file so bundled gems can be easily used (used by brew's standalone/init.rb)
+    system "make", "ruby.pc"
+    arch = Utils.safe_popen_read("pkg-config", "--variable=arch", "./ruby-#{version.major_minor}.pc").chomp
+    mkdir_p "lib/#{arch}"
+    File.open("lib/#{arch}/portable_ruby_gems.rb", "w") do |file|
+      (Dir["extensions/*/*/*", base: ".bundle"] + Dir["gems/*/lib", base: ".bundle"]).each do |require_path|
+        file.write <<~RUBY
+          $:.unshift "\#{RbConfig::CONFIG["rubylibprefix"]}/gems/\#{RbConfig::CONFIG["ruby_version"]}/#{require_path}"
+        RUBY
+      end
+    end
+
+    system "make", "install"
+
+    abi_version = `#{bin}/ruby -rrbconfig -e 'print RbConfig::CONFIG["ruby_version"]'`
+    abi_arch = `#{bin}/ruby -rrbconfig -e 'print RbConfig::CONFIG["arch"]'`
+
+    if OS.linux?
+      # Don't restrict to a specific GCC compiler binary we used (e.g. gcc-5).
+      inreplace lib/"ruby/#{abi_version}/#{abi_arch}/rbconfig.rb" do |s|
+        s.gsub! ENV.cxx, "c++"
+        s.gsub! ENV.cc, "cc"
+        # Change e.g. `CONFIG["AR"] = "gcc-ar-11"` to `CONFIG["AR"] = "ar"`
+        s.gsub!(/(CONFIG\[".+"\] = )"gcc-(.*)-\d+"/, '\\1"\\2"')
+        # C++ compiler might have been disabled because we break it with glibc@* builds
+        s.sub!(/(CONFIG\["CXX"\] = )"false"/, '\\1"c++"')
+      end
+
+      # Ship libcrypt.a so that building native gems doesn't need system libcrypt installed.
+      cp libxcrypt.lib/"libcrypt.a", lib/"libcrypt.a"
+    end
+
+    libexec.mkpath
+    cp openssl.libexec/"etc/openssl/cert.pem", libexec/"cert.pem"
+    openssl_rb = lib/"ruby/#{abi_version}/openssl.rb"
+    inreplace openssl_rb, "require 'openssl.so'", <<~EOS.chomp
+      ENV["PORTABLE_RUBY_SSL_CERT_FILE"] = ENV["SSL_CERT_FILE"] || File.expand_path("../../libexec/cert.pem", RbConfig.ruby)
+      \\0
+    EOS
+  end
+
+  test do
+    cp_r Dir["#{prefix}/*"], testpath
+    ENV["PATH"] = "/usr/bin:/bin"
+    ruby = (testpath/"bin/ruby").realpath
+    assert_equal version.to_s.split("-").first, shell_output("#{ruby} -e 'puts RUBY_VERSION'").chomp
+    assert_equal ruby.to_s, shell_output("#{ruby} -e 'puts RbConfig.ruby'").chomp
+    assert_equal "3632233996",
+      shell_output("#{ruby} -rzlib -e 'puts Zlib.crc32(\"test\")'").chomp
+    assert_equal " \t\n`><=;|&{(",
+      shell_output("#{ruby} -rreadline -e 'puts Readline.basic_word_break_characters'").chomp
+    assert_equal '{"a" => "b"}',
+      shell_output("#{ruby} -ryaml -e 'puts YAML.load(\"a: b\")'").chomp
+    assert_equal "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      shell_output("#{ruby} -ropenssl -e 'puts OpenSSL::Digest::SHA256.hexdigest(\"\")'").chomp
+    assert_match "200",
+      shell_output("#{ruby} -ropen-uri -e 'URI.open(\"https://google.com\") { |f| puts f.status.first }'").chomp
+    system ruby, "-rrbconfig", "-e", <<~EOS
+      Gem.discover_gems_on_require = false
+      require "portable_ruby_gems"
+      require "debug"
+      require "fiddle"
+      require "bootsnap"
+    EOS
+    system testpath/"bin/gem", "environment"
+    system testpath/"bin/bundle", "init"
+    # install gem with native components
+    system testpath/"bin/gem", "install", "byebug"
+    assert_match "byebug",
+      shell_output("#{testpath}/bin/byebug --version")
+  end
+end

--- a/Formula/p/portable-ruby.rb
+++ b/Formula/p/portable-ruby.rb
@@ -13,6 +13,13 @@ class PortableRuby < PortableFormula
     regex(/href=.*?ruby[._-]v?(\d+\.\d+\.(?:(?!0)\d+)(?:\.\d+)*)\.t/i)
   end
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_big_sur: "695bdce688efbfb42c7087081d1d3e9b360383a68f518f09d5b2e7b1a94732c3"
+    sha256 cellar: :any_skip_relocation, catalina:      "0dd90decb87cf7e1060806536f132187d958410ffa307b23a66b5954c1cf894f"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "bbfaf0e8c22fb545ef914120a6e55b981889c611e97943c728c4974cb9cdf512"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4fda7484ee4de45e40cedd46837622d98f2ae80481ea04935740177d58bbefdc"
+  end
+
   depends_on "pkgconf" => :build
   depends_on "portable-libyaml" => :build
   depends_on "portable-openssl" => :build

--- a/Formula/p/portable-zlib.rb
+++ b/Formula/p/portable-zlib.rb
@@ -1,0 +1,42 @@
+require File.expand_path("../../Abstract/portable-formula", __dir__)
+
+class PortableZlib < PortableFormula
+  desc "General-purpose lossless data-compression library"
+  homepage "https://zlib.net/"
+  url "https://zlib.net/zlib-1.3.1.tar.gz"
+  mirror "https://downloads.sourceforge.net/project/libpng/zlib/1.3.1/zlib-1.3.1.tar.gz"
+  mirror "http://fresh-center.net/linux/misc/zlib-1.3.1.tar.gz"
+  mirror "http://fresh-center.net/linux/misc/legacy/zlib-1.3.1.tar.gz"
+  sha256 "9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23"
+  license "Zlib"
+
+  livecheck do
+    formula "zlib"
+  end
+
+  # https://zlib.net/zlib_how.html
+  resource "test_artifact" do
+    url "https://zlib.net/zpipe.c"
+    version "20051211"
+    sha256 "68140a82582ede938159630bca0fb13a93b4bf1cb2e85b08943c26242cf8f3a6"
+
+    livecheck do
+      skip "Static test artifact"
+    end
+  end
+
+  def install
+    system "./configure", "--static", "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    testpath.install resource("test_artifact")
+    system ENV.cc, "zpipe.c", "-I#{include}", "-L#{lib}", "-lz", "-o", "zpipe"
+
+    touch "foo.txt"
+    output = "./zpipe < foo.txt > foo.txt.z"
+    system output
+    assert File.exist?("foo.txt.z")
+  end
+end


### PR DESCRIPTION
Requires https://github.com/Homebrew/brew/pull/20769 to build correctly.

Setting `CI-syntax-only` until then to avoid breaking things.