### PR TITLE
blueprint-compiler: fix references to python3

### DIFF
--- a/Formula/b/blueprint-compiler.rb
+++ b/Formula/b/blueprint-compiler.rb
@@ -1,10 +1,13 @@
 class BlueprintCompiler < Formula
+  include Language::Python::Shebang
+  include Language::Python::Virtualenv
+
   desc "Markup language and compiler for GTK 4 user interfaces"
   homepage "https://gnome.pages.gitlab.gnome.org/blueprint-compiler/"
-  url "https://gitlab.gnome.org/GNOME/blueprint-compiler.git",
-      tag:      "v0.18.0",
-      revision: "07c9c9df9cd1b6b4454ecba21ee58211e9144a4b"
+  url "https://gitlab.gnome.org/GNOME/blueprint-compiler/-/archive/0.18.0/blueprint-compiler-0.18.0.tar.gz"
+  sha256 "51aa472ecd7bd4b32b8baa7ae6768b19810793d4a2a1aba39c5b31b0170cb258"
   license "LGPL-3.0-or-later"
+  revision 1
   head "https://gitlab.gnome.org/GNOME/blueprint-compiler.git", branch: "main"
 
   bottle do
@@ -17,15 +20,19 @@ class BlueprintCompiler < Formula
 
   depends_on "gtk4"
   depends_on "pygobject3"
+  depends_on "python@3.13"
 
   def install
-    # Workaround for python binding location
-    files = %w[meson.build docs/meson.build]
-    inreplace files, "py.get_install_dir()", "'#{Language::Python.site_packages("python3")}'"
+    python3 = "python3.13"
+    venv = virtualenv_create(libexec, python3)
 
-    system "meson", "setup", "build", *std_meson_args
+    system "meson", "setup", "build", "-Dpython.platlibdir=#{venv.site_packages}",
+                                      "-Dpython.purelibdir=#{venv.site_packages}",
+                                      *std_meson_args
     system "meson", "compile", "-C", "build", "--verbose"
     system "meson", "install", "-C", "build"
+
+    rewrite_shebang python_shebang_rewrite_info(venv.root/"bin/python"), *bin.children
   end
 
   test do

--- a/Formula/b/blueprint-compiler.rb
+++ b/Formula/b/blueprint-compiler.rb
@@ -11,8 +11,7 @@ class BlueprintCompiler < Formula
   head "https://gitlab.gnome.org/GNOME/blueprint-compiler.git", branch: "main"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, all: "cce13a7d26edd2be79f5a2de5ed261edf0bab59b19c7600d6e4ed0c1368a1eb6"
+    sha256 cellar: :any_skip_relocation, all: "2421f6d9a9b639e63bd93add35e7dd08fea14c137dfda9a4f5133de82f183e83"
   end
 
   depends_on "meson" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Test fails in #245931 when switching the default python
