### PR TITLE
ayatana-ido: remove `gettext` dependency on Linux

### DIFF
--- a/Formula/a/ayatana-ido.rb
+++ b/Formula/a/ayatana-ido.rb
@@ -20,14 +20,17 @@ class AyatanaIdo < Formula
   depends_on "gobject-introspection" => :build
   depends_on "pkgconf" => [:build, :test]
   depends_on "vala" => :build
-  depends_on "at-spi2-core"
   depends_on "cairo"
   depends_on "gdk-pixbuf"
-  depends_on "gettext"
   depends_on "glib"
   depends_on "gtk+3"
-  depends_on "harfbuzz"
   depends_on "pango"
+
+  on_macos do
+    depends_on "at-spi2-core"
+    depends_on "gettext"
+    depends_on "harfbuzz"
+  end
 
   def install
     args = %w[-DENABLE_TESTS=OFF]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

From https://github.com/Homebrew/homebrew-core/actions/runs/16470887391/job/46562938318#step:5:173
```
==> brew linkage --cached ayatana-ido
System libraries:
  /lib/x86_64-linux-gnu/libc.so.6
  /lib/x86_64-linux-gnu/libm.so.6
Homebrew libraries:
  /home/linuxbrew/.linuxbrew/opt/cairo/lib/libcairo.so.2 (cairo)
  /home/linuxbrew/.linuxbrew/opt/gdk-pixbuf/lib/libgdk_pixbuf-2.0.so.0 (gdk-pixbuf)
  /home/linuxbrew/.linuxbrew/opt/glib/lib/libgio-2.0.so.0 (glib)
  /home/linuxbrew/.linuxbrew/opt/glib/lib/libglib-2.0.so.0 (glib)
  /home/linuxbrew/.linuxbrew/opt/glib/lib/libgobject-2.0.so.0 (glib)
  /home/linuxbrew/.linuxbrew/opt/gtk+3/lib/libgdk-3.so.0 (gtk+3)
  /home/linuxbrew/.linuxbrew/opt/gtk+3/lib/libgtk-3.so.0 (gtk+3)
  /home/linuxbrew/.linuxbrew/opt/pango/lib/libpango-1.0.so.0 (pango)
  /home/linuxbrew/.linuxbrew/opt/pango/lib/libpangocairo-1.0.so.0 (pango)
Dependencies with no linkage:
  at-spi2-core
```
