### PR TITLE
faircamp: remove `gettext` dependency on Linux

### DIFF
--- a/Formula/f/faircamp.rb
+++ b/Formula/f/faircamp.rb
@@ -19,11 +19,14 @@ class Faircamp < Formula
   depends_on "pkgconf" => :build
   depends_on "rust" => :build
   depends_on "ffmpeg"
-  depends_on "gettext"
   depends_on "glib"
   depends_on "opus"
   depends_on "vips"
   depends_on "xz"
+
+  on_macos do
+    depends_on "gettext"
+  end
 
   def install
     # libvips is a runtime dependency, the brew install location is
@@ -51,11 +54,11 @@ class Faircamp < Formula
     system bin/"faircamp", "--catalog-dir", catalog_dir, "--build-dir", output_dir
 
     assert_path_exists output_dir/"favicon.svg"
-    assert_path_exists output_dir/"album"/"index.html"
-    assert_path_exists output_dir/"album"/"cover_1.jpg"
-    assert_path_exists output_dir/"album"/"1"/"opus-96"/"8zjo5mMqlmM"/"01 Track01.opus"
-    assert_path_exists output_dir/"album"/"2"/"opus-96"/"visBSotimzQ"/"02 Track02.opus"
-    assert_path_exists output_dir/"album"/"1"/"mp3-v5"/"tbscAvvooxg"/"01 Track01.mp3"
-    assert_path_exists output_dir/"album"/"2"/"mp3-v5"/"d3t6L5fUbXg"/"02 Track02.mp3"
+    assert_path_exists output_dir/"album/index.html"
+    assert_path_exists output_dir/"album/cover_1.jpg"
+    assert_path_exists output_dir/"album/1/opus-96/8zjo5mMqlmM/01 Track01.opus"
+    assert_path_exists output_dir/"album/2/opus-96/visBSotimzQ/02 Track02.opus"
+    assert_path_exists output_dir/"album/1/mp3-v5/tbscAvvooxg/01 Track01.mp3"
+    assert_path_exists output_dir/"album/2/mp3-v5/d3t6L5fUbXg/02 Track02.mp3"
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/actions/runs/17344616918/job/49243027940#step:5:173
```
==> brew linkage --cached faircamp
System libraries:
  /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
  /lib/x86_64-linux-gnu/libc.so.6
  /lib/x86_64-linux-gnu/libm.so.6
Homebrew libraries:
  /home/linuxbrew/.linuxbrew/opt/gcc/lib/gcc/current/libgcc_s.so.1 (gcc)
  /home/linuxbrew/.linuxbrew/opt/glib/lib/libglib-2.0.so.0 (glib)
  /home/linuxbrew/.linuxbrew/opt/glib/lib/libgobject-2.0.so.0 (glib)
  /home/linuxbrew/.linuxbrew/opt/opus/lib/libopus.so.0 (opus)
  /home/linuxbrew/.linuxbrew/opt/vips/lib/libvips.so.42 (vips)
  /home/linuxbrew/.linuxbrew/opt/xz/lib/liblzma.so.5 (xz)
```