### PR TITLE
onnxruntime: apply Fedora workaround to fix using `onnx` formula

### DIFF
--- a/Formula/o/onnx.rb
+++ b/Formula/o/onnx.rb
@@ -9,12 +9,12 @@ class Onnx < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any, arm64_tahoe:   "3883ea6e80ead51e5d9097a01b18eb136a21dfcfe7019d8dacebe5015e128ef8"
-    sha256 cellar: :any, arm64_sequoia: "9682feab99a890a29d73ecee50511e6028315dc8567cb34db516c0bb79f6a450"
-    sha256 cellar: :any, arm64_sonoma:  "4507a220a631084813e999892eab70bddfb006919dd7b29bd183ab23855dac63"
-    sha256 cellar: :any, sonoma:        "95855fd2e9e3e78bf73a3fe128fdb41fb7009fa59b346264c857c087bd6fc75b"
-    sha256               arm64_linux:   "0060a099854db318934b3e5dc7d021cc53a88defd92e5f69c12808d719438c99"
-    sha256               x86_64_linux:  "d892372bc745cd60572e55bf2e90441e982413b63766b0eebe1b256e4d131515"
+    sha256 cellar: :any, arm64_tahoe:   "81b64f196d68c01bb740a53aae9f7c9e088b240a741389f5a5d676cb01cbc7ae"
+    sha256 cellar: :any, arm64_sequoia: "ff2c5310746525e6bc79ba0b7cbe8ce08ad826cccb3c7f937970ff342295fdc7"
+    sha256 cellar: :any, arm64_sonoma:  "56f97c1ccabbd67c20a3c6d1c4c1733bc228a018e90e6db51c69f7ea051e642d"
+    sha256 cellar: :any, sonoma:        "2dad70397d478bb86df821d42c2ce0fe195b789c3dc156868e6f208c4188438a"
+    sha256               arm64_linux:   "d81d331edfa586d1904fd3fd47f99f254967bd89de1a63bef07745b32a83066c"
+    sha256               x86_64_linux:  "962b238222306fb53e1581df8d1474e1b6bcfd0dcce0cc895cdf21862bf1aeb3"
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/o/onnx.rb
+++ b/Formula/o/onnx.rb
@@ -4,7 +4,7 @@ class Onnx < Formula
   url "https://github.com/onnx/onnx/archive/refs/tags/v1.17.0.tar.gz"
   sha256 "8d5e983c36037003615e5a02d36b18fc286541bf52de1a78f6cf9f32005a820e"
   license "Apache-2.0"
-  revision 7
+  revision 8
 
   no_autobump! because: :requires_manual_review
 
@@ -22,6 +22,16 @@ class Onnx < Formula
   depends_on "protobuf"
 
   uses_from_macos "python" => :build
+
+  # Apply Fedora's workaround to allow `onnxruntime` to use `onnx` built without
+  # ONNX_DISABLE_STATIC_REGISTRATION[^1]. We can't use this option as it will
+  # break functionality for any dependents/users expecting the default behavior.
+  #
+  # [^1]: https://github.com/microsoft/onnxruntime/issues/8556#issuecomment-1006091632
+  patch do
+    url "https://src.fedoraproject.org/rpms/onnx/raw/4de8a450afd87b1ba1931f50d841e9c50b63d8a0/f/0004-Add-fixes-for-use-with-onnxruntime.patch"
+    sha256 "d9ddb735c065fd5dae11ab79371e62bdcca157a6d2a7705cc83ee612abeaaa98"
+  end
 
   def install
     args = %W[

--- a/Formula/o/onnxruntime.rb
+++ b/Formula/o/onnxruntime.rb
@@ -5,7 +5,7 @@ class Onnxruntime < Formula
       tag:      "v1.22.2",
       revision: "5630b081cd25e4eccc7516a652ff956e51676794"
   license "MIT"
-  revision 3
+  revision 4
 
   livecheck do
     url :stable
@@ -58,9 +58,20 @@ class Onnxruntime < Formula
     end
   end
 
-  # Workaround for Abseil >= 20250814.0 which removed absl::low_level_hash[^1].
-  # Upstream only supports using vendored deps which we bypass.
-  # [^1]: https://github.com/abseil/abseil-cpp/commit/2ea5334068f11664a71d1d9dfb9a475482fa05f5
+  # Workaround for Abseil >= 20250814.0 which removed absl::low_level_hash.
+  # Issue ref: https://github.com/microsoft/onnxruntime/issues/25815
+  patch do
+    url "https://src.fedoraproject.org/rpms/onnxruntime/raw/1e041e70baa51b4661c16ec5446daab332937cb4/f/abseil-cpp-20250814.patch"
+    sha256 "9b0bf4fda2acf486907005e781f68c56b47c0b05cc2a2cff04c891f2d35b92f9"
+  end
+
+  # Apply Fedora's workaround[^1] to allow `onnxruntime` to use `onnx` built without
+  # ONNX_DISABLE_STATIC_REGISTRATION[^2]. We can't use this option as it will
+  # break functionality for any dependents/users expecting the default behavior.
+  # The main alternative is to build a bundled copy of `onnx`.
+  #
+  # [^1]: https://src.fedoraproject.org/rpms/onnxruntime/blob/rawhide/f/0013-onnx-onnxruntime-fix.patch
+  # [^2]: https://github.com/microsoft/onnxruntime/issues/8556#issuecomment-1006091632
   patch :DATA
 
   def install
@@ -95,30 +106,92 @@ class Onnxruntime < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~C
-      #include <onnxruntime/onnxruntime_c_api.h>
-      #include <stdio.h>
-      int main()
-      {
-        printf("%s\\n", OrtGetApiBase()->GetVersionString());
+    # Modified copy of upstream's testcase at
+    # https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/test/wasm/test_inference.cc
+    (testpath/"test.cc").write <<~CPP
+      // Copyright (c) Microsoft Corporation. All rights reserved.
+      // Licensed under the MIT License.
+
+      #include <cassert>
+      #include <iostream>
+      #include <onnxruntime/onnxruntime_cxx_api.h>
+
+      int main(void) {
+        Ort::Env ort_env;
+        Ort::Session session{ort_env, "mul_1.onnx", Ort::SessionOptions{nullptr}};
+        auto memory_info = Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
+
+        std::array<float, 6> input_data{1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+        std::array<int64_t, 2> input_shape{3, 2};
+        Ort::Value input_tensor = Ort::Value::CreateTensor<float>(memory_info,
+                                                                  input_data.data(), input_data.size(),
+                                                                  input_shape.data(), input_shape.size());
+
+        std::array<float, 6> output_data{};
+        std::array<int64_t, 2> output_shape{3, 2};
+        Ort::Value output_tensor = Ort::Value::CreateTensor<float>(memory_info,
+                                                                   output_data.data(), output_data.size(),
+                                                                   output_shape.data(), output_shape.size());
+
+        const char* input_names[] = {"X"};
+        const char* output_names[] = {"Y"};
+
+        session.Run(Ort::RunOptions{nullptr}, input_names, &input_tensor, 1, output_names, &output_tensor, 1);
+
+        std::array<float, 6> expected_data{1.0f, 4.0f, 9.0f, 16.0f, 25.0f, 36.0f};
+        std::vector<int64_t> expected_shape{3, 2};
+
+        auto type_info = output_tensor.GetTensorTypeAndShapeInfo();
+        assert(type_info.GetShape() == expected_shape);
+        auto total_len = type_info.GetElementCount();
+        assert(total_len == expected_data.size());
+
+        float* result = output_tensor.GetTensorMutableData<float>();
+        for (size_t i = 0; i != total_len; ++i) {
+          assert(expected_data[i] == result[i]);
+        }
+
+        std::cout << Ort::GetVersionString();
         return 0;
       }
-    C
-    system ENV.cc, "-I#{include}", "test.c", "-L#{lib}", "-lonnxruntime", "-o", "test"
-    assert_equal version, shell_output("./test").strip
+    CPP
+
+    require "base64"
+    mul_1_onnx = "CAMSBmNoZW50YTpwChUKAVgKAVcSAVkaBW11bF8xIgNNdWwSCG11bCB0ZXN" \
+                 "0KiMIAwgCEAEiGAAAgD8AAABAAABAQAAAgEAAAKBAAADAQEIBV1oTCgFYEg" \
+                 "4KDAgBEggKAggDCgIIAmITCgFZEg4KDAgBEggKAggDCgIIAkIECgAQBw=="
+    (testpath/"mul_1.onnx").write Base64.decode64(mul_1_onnx)
+
+    system ENV.cxx, "-std=c++17", "-I#{include}", "test.cc", "-L#{lib}", "-lonnxruntime", "-o", "test"
+    assert_equal version, shell_output("./test 2>&1")
   end
 end
 
 __END__
-diff --git a/cmake/external/abseil-cpp.cmake b/cmake/external/abseil-cpp.cmake
-index 427e77a524..feb2eb26f1 100644
---- a/cmake/external/abseil-cpp.cmake
-+++ b/cmake/external/abseil-cpp.cmake
-@@ -119,7 +119,6 @@ absl::absl_check
- absl::hash_function_defaults
- absl::function_ref
- absl::city
--absl::low_level_hash
- absl::fixed_array
- absl::variant
- absl::meta
+diff --git a/onnxruntime/core/session/onnxruntime_c_api.cc b/onnxruntime/core/session/onnxruntime_c_api.cc
+index b60d97e38f..6951642edb 100644
+--- a/onnxruntime/core/session/onnxruntime_c_api.cc
++++ b/onnxruntime/core/session/onnxruntime_c_api.cc
+@@ -45,6 +45,8 @@
+ #include "core/session/ort_env.h"
+ #include "core/session/utils.h"
+ 
++#include "onnx/onnxruntime_fix.h"
++
+ #if defined(USE_CUDA) || defined(USE_CUDA_PROVIDER_INTERFACE)
+ #include "core/providers/cuda/cuda_provider_factory.h"
+ #include "core/providers/cuda/cuda_execution_provider_info.h"
+@@ -3094,6 +3096,13 @@ ORT_API(const char*, OrtApis::GetBuildInfoString) {
+ }
+ 
+ const OrtApiBase* ORT_API_CALL OrtGetApiBase(void) NO_EXCEPTION {
++  class RunONNXRuntimeFix {
++   public:
++    RunONNXRuntimeFix() {
++      onnx::ONNXRuntimeFix::disableStaticRegistration();
++    }
++  };
++  static RunONNXRuntimeFix runONNXRuntimeFix;
+   return &ort_api_base;
+ }
+ 

--- a/Formula/o/onnxruntime.rb
+++ b/Formula/o/onnxruntime.rb
@@ -13,12 +13,12 @@ class Onnxruntime < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "0f2608db9217fb1be7c5655c143e168c93a7900bb3001dde9c010d6a509a92ee"
-    sha256 cellar: :any,                 arm64_sequoia: "f2dc7dd6cef41f70d6c3dfa6fa1c6ad389bcb2b520e33b04b6584f31e60570e4"
-    sha256 cellar: :any,                 arm64_sonoma:  "f84931d36b5ac7f7886ea7445e739d1f47f57d38a9aa252b50a5968f95f29e35"
-    sha256 cellar: :any,                 sonoma:        "3cd8140298f1805652ff697c687bac97fe70cf42a80963f9cca6391fe6e89609"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "79923938f5a5540c0c4246d3532aa9fddd740ccb5b1d1e333790c932c6935c9c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "832dd4b443be46d4f66e90c49bbbe7c3b7f8dadfe9c2a1ec8e33b527193733cd"
+    sha256 cellar: :any,                 arm64_tahoe:   "012b01908123c5e122d51d13e06c6b9259af934ff42cf8c63a917feef53ce1de"
+    sha256 cellar: :any,                 arm64_sequoia: "6778af32f255d948bc23dca0ec47d893cc87b6e30f4f5cda237c9fe7324622b5"
+    sha256 cellar: :any,                 arm64_sonoma:  "8be8e2fbc11c023f0550237b905ef7603a20c7c6334fc418e64062f326e3d6ef"
+    sha256 cellar: :any,                 sonoma:        "e6938e93e1aff60b0267187359e6f731c1abaa8ba222ea19faecc14431563bda"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "014bc0e3ad88055e062667ba68784f5dc87d56f9ecaf4ca6e9792ebab3831c0f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8ce1a4a6216412a1625a7b6168762a9ae9acf9836f6209397d3dff4368441e1d"
   end
 
   depends_on "boost" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Closes #245956