### PR TITLE
mismatched_binary_allowlist: add preevy x86_64 ELF files

### DIFF
--- a/audit_exceptions/mismatched_binary_allowlist.json
+++ b/audit_exceptions/mismatched_binary_allowlist.json
@@ -7,6 +7,7 @@
   "i686-elf-grub": "lib/i686-elf/grub/i386-pc/*",
   "lima": "share/lima/lima-guestagent.Linux-*",
   "picotool": "share/picotool/*.elf",
+  "preevy": "libexec/lib/node_modules/preevy/node_modules/@preevy/compose-tunnel-agent/out/*.node",
   "prestodb": "libexec/bin/procname/Linux-*/libprocname.so",
   "qemu": "share/qemu/*",
   "x86_64-elf-grub": "lib/x86_64-elf/grub/i386-pc/*"


### PR DESCRIPTION
https://www.npmjs.com/package/@preevy/compose-tunnel-agent includes pre-built x86_64 ELF files to be used in Docker container.
