### PR TITLE
formulae: remove unneeded `since: :catalina`

### DIFF
--- a/Formula/a/augustus.rb
+++ b/Formula/a/augustus.rb
@@ -24,7 +24,7 @@ class Augustus < Formula
   depends_on "boost"
   depends_on "htslib"
 
-  uses_from_macos "python" => :build, since: :catalina
+  uses_from_macos "python" => :build
   uses_from_macos "zlib"
 
   def install

--- a/Formula/b/bowtie2.rb
+++ b/Formula/b/bowtie2.rb
@@ -19,7 +19,7 @@ class Bowtie2 < Formula
   end
 
   uses_from_macos "perl"
-  uses_from_macos "python", since: :catalina
+  uses_from_macos "python"
   uses_from_macos "zlib"
 
   on_arm do

--- a/Formula/c/clang-format.rb
+++ b/Formula/c/clang-format.rb
@@ -57,7 +57,7 @@ class ClangFormat < Formula
 
   uses_from_macos "libxml2"
   uses_from_macos "ncurses"
-  uses_from_macos "python", since: :catalina
+  uses_from_macos "python"
   uses_from_macos "zlib"
 
   on_linux do

--- a/Formula/c/cling.rb
+++ b/Formula/c/cling.rb
@@ -29,7 +29,7 @@ class Cling < Formula
 
   depends_on "cmake" => :build
 
-  uses_from_macos "python" => :build, since: :catalina
+  uses_from_macos "python" => :build
   uses_from_macos "libedit"
   uses_from_macos "libxml2"
   uses_from_macos "ncurses"

--- a/Formula/c/cocoapods.rb
+++ b/Formula/c/cocoapods.rb
@@ -19,7 +19,7 @@ class Cocoapods < Formula
 
   depends_on "pkgconf" => :build
   depends_on "ruby"
-  uses_from_macos "libffi", since: :catalina
+  uses_from_macos "libffi"
 
   conflicts_with cask: "cocoapods-app", because: "both install `pod` binaries"
 

--- a/Formula/c/core-lightning.rb
+++ b/Formula/c/core-lightning.rb
@@ -38,7 +38,7 @@ class CoreLightning < Formula
   depends_on "libsodium"
 
   uses_from_macos "jq" => :build, since: :sequoia
-  uses_from_macos "python", since: :catalina
+  uses_from_macos "python"
   uses_from_macos "sqlite"
   uses_from_macos "zlib"
 

--- a/Formula/c/cucumber-ruby.rb
+++ b/Formula/c/cucumber-ruby.rb
@@ -24,7 +24,7 @@ class CucumberRuby < Formula
   depends_on "pkgconf" => :build
   depends_on "ruby"
 
-  uses_from_macos "libffi", since: :catalina
+  uses_from_macos "libffi"
 
   # Runtime dependencies of cucumber
   # List with `gem install --explain cucumber`

--- a/Formula/d/deno.rb
+++ b/Formula/d/deno.rb
@@ -27,7 +27,7 @@ class Deno < Formula
   depends_on "little-cms2"
   depends_on "sqlite" # needs `sqlite3_unlock_notify`
 
-  uses_from_macos "python" => :build, since: :catalina
+  uses_from_macos "python" => :build
   uses_from_macos "libffi"
 
   on_linux do

--- a/Formula/d/dotnet.rb
+++ b/Formula/d/dotnet.rb
@@ -44,7 +44,7 @@ class Dotnet < Formula
   depends_on "icu4c@77"
   depends_on "openssl@3"
 
-  uses_from_macos "python" => :build, since: :catalina
+  uses_from_macos "python" => :build
   uses_from_macos "krb5"
   uses_from_macos "zlib"
 

--- a/Formula/d/dotnet@8.rb
+++ b/Formula/d/dotnet@8.rb
@@ -31,7 +31,7 @@ class DotnetAT8 < Formula
   depends_on "icu4c@77"
   depends_on "openssl@3"
 
-  uses_from_macos "python" => :build, since: :catalina
+  uses_from_macos "python" => :build
   uses_from_macos "krb5"
   uses_from_macos "zlib"
 

--- a/Formula/f/fcitx-remote-for-osx.rb
+++ b/Formula/f/fcitx-remote-for-osx.rb
@@ -24,7 +24,7 @@ class FcitxRemoteForOsx < Formula
   depends_on :macos
 
   # need py3.6+ for f-strings
-  uses_from_macos "python" => :build, since: :catalina
+  uses_from_macos "python" => :build
 
   def install
     system "python3", "build.py", "build", "general"

--- a/Formula/f/fdroidserver.rb
+++ b/Formula/f/fdroidserver.rb
@@ -35,7 +35,7 @@ class Fdroidserver < Formula
   depends_on "rclone"
   depends_on "s3cmd"
 
-  uses_from_macos "libffi", since: :catalina
+  uses_from_macos "libffi"
   uses_from_macos "libxml2", since: :ventura
   uses_from_macos "libxslt"
 

--- a/Formula/f/fpp.rb
+++ b/Formula/f/fpp.rb
@@ -13,7 +13,7 @@ class Fpp < Formula
     sha256 cellar: :any_skip_relocation, all: "3cd7e3e25d729646c8cbb993eaa2c3d517dc128693dcdbc39bd1362c11429390"
   end
 
-  uses_from_macos "python", since: :catalina
+  uses_from_macos "python"
 
   def install
     rm_r(buildpath/"src/tests")

--- a/Formula/g/getmail6.rb
+++ b/Formula/g/getmail6.rb
@@ -19,7 +19,7 @@ class Getmail6 < Formula
     sha256 cellar: :any_skip_relocation, all: "6e0e153c6fb32e3d5b781e90169ccc56a3af19242503cb85ac1f668e29059cd2"
   end
 
-  uses_from_macos "python", since: :catalina
+  uses_from_macos "python"
 
   def install
     files = %w[getmail getmail_fetch getmail_maildir getmail_mbox]

--- a/Formula/g/git-filter-repo.rb
+++ b/Formula/g/git-filter-repo.rb
@@ -12,8 +12,8 @@ class GitFilterRepo < Formula
     sha256 cellar: :any_skip_relocation, all: "774b68744bca239b25b7e82693204f198c6ab1224ded38d8dd33ec1c23c245d8"
   end
 
-  uses_from_macos "git", since: :catalina # git 2.22.0+ is required
-  uses_from_macos "python", since: :catalina
+  uses_from_macos "git"
+  uses_from_macos "python"
 
   def install
     rewrite_shebang detected_python_shebang(use_python_from_path: true), "git-filter-repo"

--- a/Formula/g/git-tools.rb
+++ b/Formula/g/git-tools.rb
@@ -12,7 +12,7 @@ class GitTools < Formula
     sha256 cellar: :any_skip_relocation, all: "ba1a42e203720e6a74dcdfefb2653be957015fbd115415686b119975f111bdb6"
   end
 
-  uses_from_macos "python", since: :catalina
+  uses_from_macos "python"
 
   def install
     rewrite_shebang detected_python_shebang(use_python_from_path: true), "git-restore-mtime"

--- a/Formula/g/gnu-smalltalk.rb
+++ b/Formula/g/gnu-smalltalk.rb
@@ -52,7 +52,7 @@ class GnuSmalltalk < Formula
 
   uses_from_macos "zip" => :build
   uses_from_macos "expat"
-  uses_from_macos "libffi", since: :catalina
+  uses_from_macos "libffi"
   uses_from_macos "zlib"
 
   def install

--- a/Formula/g/gnupg.rb
+++ b/Formula/g/gnupg.rb
@@ -36,7 +36,7 @@ class Gnupg < Formula
 
   uses_from_macos "bzip2"
   uses_from_macos "openldap"
-  uses_from_macos "sqlite", since: :catalina
+  uses_from_macos "sqlite"
   uses_from_macos "zlib"
 
   on_macos do

--- a/Formula/g/gobject-introspection.rb
+++ b/Formula/g/gobject-introspection.rb
@@ -27,7 +27,7 @@ class GobjectIntrospection < Formula
   depends_on "python@3.13"
 
   uses_from_macos "flex" => :build
-  uses_from_macos "libffi", since: :catalina
+  uses_from_macos "libffi"
 
   resource "mako" do
     url "https://files.pythonhosted.org/packages/9e/38/bd5b78a920a64d708fe6bc8e0a2c075e1389d53bef8413725c63ba041535/mako-1.3.10.tar.gz"

--- a/Formula/g/google-java-format.rb
+++ b/Formula/g/google-java-format.rb
@@ -13,7 +13,7 @@ class GoogleJavaFormat < Formula
 
   depends_on "openjdk"
 
-  uses_from_macos "python", since: :catalina
+  uses_from_macos "python"
 
   resource "google-java-format-diff" do
     url "https://raw.githubusercontent.com/google/google-java-format/v1.28.0/scripts/google-java-format-diff.py"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
