### PR TITLE
formulae: remove unneeded `since: :catalina`

### DIFF
--- a/Formula/g/grafana.rb
+++ b/Formula/g/grafana.rb
@@ -23,7 +23,7 @@ class Grafana < Formula
   depends_on "node@22" => :build
   depends_on "yarn" => :build
 
-  uses_from_macos "python" => :build, since: :catalina
+  uses_from_macos "python" => :build
   uses_from_macos "zlib"
 
   on_linux do

--- a/Formula/i/inko.rb
+++ b/Formula/i/inko.rb
@@ -40,7 +40,7 @@ class Inko < Formula
 
   depends_on "rust" => :build
 
-  uses_from_macos "libffi", since: :catalina
+  uses_from_macos "libffi"
 
   def install
     # Avoid statically linking to LLVM

--- a/Formula/k/ki18n.rb
+++ b/Formula/k/ki18n.rb
@@ -31,7 +31,7 @@ class Ki18n < Formula
   depends_on "iso-codes"
   depends_on "qt"
 
-  uses_from_macos "python" => :build, since: :catalina
+  uses_from_macos "python" => :build
 
   def install
     args = %W[

--- a/Formula/lib/libsndfile.rb
+++ b/Formula/lib/libsndfile.rb
@@ -29,7 +29,7 @@ class Libsndfile < Formula
   depends_on "mpg123"
   depends_on "opus"
 
-  uses_from_macos "python" => :build, since: :catalina
+  uses_from_macos "python" => :build
 
   def install
     args = %W[

--- a/Formula/m/micropython.rb
+++ b/Formula/m/micropython.rb
@@ -19,7 +19,7 @@ class Micropython < Formula
   end
 
   depends_on "pkgconf" => :build
-  uses_from_macos "libffi", since: :catalina
+  uses_from_macos "libffi"
   uses_from_macos "python" # Requires libffi v3 closure API
 
   def install

--- a/Formula/m/molten-vk.rb
+++ b/Formula/m/molten-vk.rb
@@ -95,7 +95,7 @@ class MoltenVk < Formula
   depends_on xcode: ["11.7", :build]
   depends_on :macos # Linux does not have a Metal implementation. Not implied by the line above.
 
-  uses_from_macos "python" => :build, since: :catalina
+  uses_from_macos "python" => :build
 
   def install
     resources.each do |res|

--- a/Formula/n/neovide.rb
+++ b/Formula/n/neovide.rb
@@ -20,7 +20,7 @@ class Neovide < Formula
   depends_on "neovim"
 
   uses_from_macos "llvm" => :build
-  uses_from_macos "python" => :build, since: :catalina
+  uses_from_macos "python" => :build
 
   on_macos do
     depends_on "cargo-bundle" => :build

--- a/Formula/n/ninja.rb
+++ b/Formula/n/ninja.rb
@@ -23,7 +23,7 @@ class Ninja < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "13cca961d30a825d800c714dfc04932d916b08127ac866c37fc99a7072e22003"
   end
 
-  uses_from_macos "python" => [:build, :test], since: :catalina
+  uses_from_macos "python" => [:build, :test]
 
   def install
     system "python3", "configure.py", "--bootstrap", "--verbose", "--with-python=python3"

--- a/Formula/n/node.rb
+++ b/Formula/n/node.rb
@@ -35,7 +35,7 @@ class Node < Formula
   depends_on "uvwasi"
   depends_on "zstd"
 
-  uses_from_macos "python", since: :catalina
+  uses_from_macos "python"
   uses_from_macos "zlib"
 
   on_macos do

--- a/Formula/n/node@18.rb
+++ b/Formula/n/node@18.rb
@@ -32,7 +32,7 @@ class NodeAT18 < Formula
   depends_on "libuv"
   depends_on "openssl@3"
 
-  uses_from_macos "python", since: :catalina
+  uses_from_macos "python"
   uses_from_macos "zlib"
 
   on_macos do

--- a/Formula/o/ocrmypdf.rb
+++ b/Formula/o/ocrmypdf.rb
@@ -32,7 +32,7 @@ class Ocrmypdf < Formula
   depends_on "tesseract"
   depends_on "unpaper"
 
-  uses_from_macos "libffi", since: :catalina
+  uses_from_macos "libffi"
   uses_from_macos "libxml2", since: :ventura
   uses_from_macos "libxslt"
 

--- a/Formula/p/p11-kit.rb
+++ b/Formula/p/p11-kit.rb
@@ -29,7 +29,7 @@ class P11Kit < Formula
   depends_on "ca-certificates"
   depends_on "libtasn1"
 
-  uses_from_macos "libffi", since: :catalina
+  uses_from_macos "libffi"
 
   def install
     # https://bugs.freedesktop.org/show_bug.cgi?id=91602#c1

--- a/Formula/p/passenger.rb
+++ b/Formula/p/passenger.rb
@@ -25,7 +25,7 @@ class Passenger < Formula
   uses_from_macos "xz" => :build
   uses_from_macos "curl"
   uses_from_macos "libxcrypt"
-  uses_from_macos "ruby", since: :catalina
+  uses_from_macos "ruby"
   uses_from_macos "zlib"
 
   def install

--- a/Formula/p/ppsspp.rb
+++ b/Formula/p/ppsspp.rb
@@ -38,7 +38,7 @@ class Ppsspp < Formula
   depends_on "snappy"
   depends_on "zstd"
 
-  uses_from_macos "python" => :build, since: :catalina
+  uses_from_macos "python" => :build
   uses_from_macos "zlib"
 
   on_macos do

--- a/Formula/r/r.rb
+++ b/Formula/r/r.rb
@@ -38,7 +38,7 @@ class R < Formula
 
   uses_from_macos "bzip2"
   uses_from_macos "curl"
-  uses_from_macos "libffi", since: :catalina
+  uses_from_macos "libffi"
   uses_from_macos "zlib"
 
   on_macos do

--- a/Formula/r/rakudo-star.rb
+++ b/Formula/r/rakudo-star.rb
@@ -31,7 +31,7 @@ class RakudoStar < Formula
   depends_on "zstd"
 
   uses_from_macos "perl" => :build
-  uses_from_macos "libffi", since: :catalina
+  uses_from_macos "libffi"
   uses_from_macos "libxml2"
 
   on_macos do

--- a/Formula/s/sagittarius-scheme.rb
+++ b/Formula/s/sagittarius-scheme.rb
@@ -22,7 +22,7 @@ class SagittariusScheme < Formula
   depends_on "openssl@3"
   depends_on "unixodbc"
 
-  uses_from_macos "libffi", since: :catalina
+  uses_from_macos "libffi"
   uses_from_macos "zlib"
 
   def install

--- a/Formula/s/simgrid.rb
+++ b/Formula/s/simgrid.rb
@@ -27,7 +27,7 @@ class Simgrid < Formula
   depends_on "boost"
   depends_on "graphviz"
 
-  uses_from_macos "python", since: :catalina
+  uses_from_macos "python"
 
   def install
     # Avoid superenv shim references

--- a/Formula/s/spirv-tools.rb
+++ b/Formula/s/spirv-tools.rb
@@ -27,7 +27,7 @@ class SpirvTools < Formula
 
   depends_on "cmake" => :build
 
-  uses_from_macos "python" => :build, since: :catalina
+  uses_from_macos "python" => :build
 
   resource "spirv-headers" do
     # revision number could be found as `spirv_headers_revision` in `./DEPS`


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
