### PR TITLE
formulae: remove unneeded `since: :catalina`

### DIFF
--- a/Formula/p/php.rb
+++ b/Formula/p/php.rb
@@ -67,7 +67,7 @@ class Php < Formula
   uses_from_macos "xz" => :build
   uses_from_macos "bzip2"
   uses_from_macos "libedit"
-  uses_from_macos "libffi", since: :catalina
+  uses_from_macos "libffi"
   uses_from_macos "libxml2"
   uses_from_macos "libxslt"
   uses_from_macos "zlib"

--- a/Formula/p/php@8.1.rb
+++ b/Formula/p/php@8.1.rb
@@ -58,7 +58,7 @@ class PhpAT81 < Formula
   uses_from_macos "xz" => :build
   uses_from_macos "bzip2"
   uses_from_macos "libedit"
-  uses_from_macos "libffi", since: :catalina
+  uses_from_macos "libffi"
   uses_from_macos "libxml2"
   uses_from_macos "libxslt"
   uses_from_macos "zlib"

--- a/Formula/p/php@8.2.rb
+++ b/Formula/p/php@8.2.rb
@@ -58,7 +58,7 @@ class PhpAT82 < Formula
   uses_from_macos "xz" => :build
   uses_from_macos "bzip2"
   uses_from_macos "libedit"
-  uses_from_macos "libffi", since: :catalina
+  uses_from_macos "libffi"
   uses_from_macos "libxml2"
   uses_from_macos "libxslt"
   uses_from_macos "zlib"

--- a/Formula/p/php@8.3.rb
+++ b/Formula/p/php@8.3.rb
@@ -55,7 +55,7 @@ class PhpAT83 < Formula
   uses_from_macos "xz" => :build
   uses_from_macos "bzip2"
   uses_from_macos "libedit"
-  uses_from_macos "libffi", since: :catalina
+  uses_from_macos "libffi"
   uses_from_macos "libxml2"
   uses_from_macos "libxslt"
   uses_from_macos "zlib"

--- a/Formula/p/python-freethreading.rb
+++ b/Formula/p/python-freethreading.rb
@@ -32,7 +32,7 @@ class PythonFreethreading < Formula
   uses_from_macos "bzip2"
   uses_from_macos "expat", since: :sequoia
   uses_from_macos "libedit"
-  uses_from_macos "libffi", since: :catalina
+  uses_from_macos "libffi"
   uses_from_macos "libxcrypt"
   uses_from_macos "ncurses"
   uses_from_macos "unzip"

--- a/Formula/p/python@3.10.rb
+++ b/Formula/p/python@3.10.rb
@@ -37,7 +37,7 @@ class PythonAT310 < Formula
 
   uses_from_macos "bzip2"
   uses_from_macos "expat"
-  uses_from_macos "libffi", since: :catalina
+  uses_from_macos "libffi"
   uses_from_macos "libxcrypt"
   uses_from_macos "ncurses"
   uses_from_macos "unzip"

--- a/Formula/p/python@3.11.rb
+++ b/Formula/p/python@3.11.rb
@@ -36,7 +36,7 @@ class PythonAT311 < Formula
   uses_from_macos "bzip2"
   uses_from_macos "expat"
   uses_from_macos "libedit"
-  uses_from_macos "libffi", since: :catalina
+  uses_from_macos "libffi"
   uses_from_macos "libxcrypt"
   uses_from_macos "ncurses"
   uses_from_macos "unzip"

--- a/Formula/p/python@3.12.rb
+++ b/Formula/p/python@3.12.rb
@@ -37,7 +37,7 @@ class PythonAT312 < Formula
   uses_from_macos "bzip2"
   uses_from_macos "expat"
   uses_from_macos "libedit"
-  uses_from_macos "libffi", since: :catalina
+  uses_from_macos "libffi"
   uses_from_macos "libxcrypt"
   uses_from_macos "ncurses"
   uses_from_macos "unzip"

--- a/Formula/p/python@3.13.rb
+++ b/Formula/p/python@3.13.rb
@@ -32,7 +32,7 @@ class PythonAT313 < Formula
   uses_from_macos "bzip2"
   uses_from_macos "expat", since: :sequoia
   uses_from_macos "libedit"
-  uses_from_macos "libffi", since: :catalina
+  uses_from_macos "libffi"
   uses_from_macos "ncurses"
   uses_from_macos "unzip"
   uses_from_macos "zlib"

--- a/Formula/p/python@3.9.rb
+++ b/Formula/p/python@3.9.rb
@@ -37,7 +37,7 @@ class PythonAT39 < Formula
 
   uses_from_macos "bzip2"
   uses_from_macos "expat"
-  uses_from_macos "libffi", since: :catalina
+  uses_from_macos "libffi"
   uses_from_macos "libxcrypt"
   uses_from_macos "ncurses"
   uses_from_macos "unzip"

--- a/Formula/s/src.rb
+++ b/Formula/s/src.rb
@@ -21,7 +21,7 @@ class Src < Formula
 
   depends_on "rcs"
 
-  uses_from_macos "python", since: :catalina
+  uses_from_macos "python"
 
   def install
     ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog" if build.head?

--- a/Formula/t/thrax.rb
+++ b/Formula/t/thrax.rb
@@ -33,7 +33,7 @@ class Thrax < Formula
   depends_on "libtool" => :build
 
   depends_on "openfst"
-  uses_from_macos "python", since: :catalina
+  uses_from_macos "python"
 
   # patch to build with openfst 1.8.4, notified upstream about this patch
   patch :DATA

--- a/Formula/t/txr.rb
+++ b/Formula/t/txr.rb
@@ -24,7 +24,7 @@ class Txr < Formula
 
   uses_from_macos "bison" => :build
   uses_from_macos "flex" => :build
-  uses_from_macos "libffi", since: :catalina
+  uses_from_macos "libffi"
   uses_from_macos "libxcrypt"
   uses_from_macos "zlib"
 

--- a/Formula/v/verilator.rb
+++ b/Formula/v/verilator.rb
@@ -24,7 +24,7 @@ class Verilator < Formula
   uses_from_macos "bison" => :build
   uses_from_macos "flex" => :build
   uses_from_macos "perl"
-  uses_from_macos "python", since: :catalina
+  uses_from_macos "python"
 
   skip_clean "bin" # Allows perl scripts to keep their executable flag
 

--- a/Formula/y/yosys.rb
+++ b/Formula/y/yosys.rb
@@ -24,7 +24,7 @@ class Yosys < Formula
   depends_on "readline"
   depends_on "tcl-tk"
 
-  uses_from_macos "libffi", since: :catalina
+  uses_from_macos "libffi"
   uses_from_macos "python"
   uses_from_macos "zlib"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
