### PR TITLE
qt@5: add `ENV.runtime_cpu_detection` on arm64 linux

### DIFF
--- a/Formula/q/qt@5.rb
+++ b/Formula/q/qt@5.rb
@@ -319,6 +319,9 @@ class QtAT5 < Formula
         -webengine-webp
       ]
 
+      # Chromium in QtWebEngine needs hardware CRC32 support via `-march=armv8-a+crc`
+      ENV.runtime_cpu_detection if Hardware::CPU.arm?
+
       # Homebrew-specific workaround to ignore spurious linker warnings on Linux.
       inreplace "qtwebengine/src/3rdparty/chromium/build/config/compiler/BUILD.gn",
                 "fatal_linker_warnings = true",

--- a/style_exceptions/runtime_cpu_detection_allowlist.json
+++ b/style_exceptions/runtime_cpu_detection_allowlist.json
@@ -39,6 +39,7 @@
   "postgresql@18",
   "pytorch",
   "qt",
+  "qt@5",
   "spades",
   "spidermonkey",
   "svt-av1",


### PR DESCRIPTION
Chromium needs CRC32 support (i.e. `-march=armv8-a+crc`):
```
[8920/24007] /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/shims/linux/super/g++ -MMD -MF obj/third_party/crc32c/crc32c_arm64/crc32c_arm64.o.d -DUSE_UDEV -DUSE_AURA=1 -DUSE_NSS_CERTS=1 -DUSE_OZONE=1 -DOFFICIAL_BUILD -DTOOLKIT_QT -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -DNO_UNWIND_TABLES -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -DNDEBUG -DNVALGRIND -DDYNAMIC_ANNOTATIONS_ENABLED=0 -DBYTE_ORDER_BIG_ENDIAN=0 -DCRC32C_TESTS_BUILT_WITH_GLOG=0 -DHAVE_MM_PREFETCH=0 -DHAVE_SSE42=0 -DHAVE_BUILTIN_PREFETCH=1 -DHAVE_ARM64_CRC32C=1 -DHAVE_STRONG_GETAUXVAL=1 -DHAVE_WEAK_GETAUXVAL=1 -Igen -I../../3rdparty/chromium -I../../3rdparty/chromium/third_party/crc32c/config -I../../3rdparty/chromium/third_party/crc32c/src/include -march=armv8-a+crc+crypto -fno-strict-aliasing --param=ssp-buffer-size=4 -fstack-protector -fno-unwind-tables -fno-asynchronous-unwind-tables -fPIC -pipe -pthread -Wall -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -Wno-unused-local-typedefs -Wno-maybe-uninitialized -Wno-deprecated-declarations -fno-delete-null-pointer-checks -Wno-comments -Wno-packed-not-aligned -Wno-dangling-else -Wno-missing-field-initializers -Wno-unused-parameter -O2 -fno-ident -fdata-sections -ffunction-sections -fno-omit-frame-pointer -g0 -fvisibility=hidden -std=gnu++17 -Wno-narrowing -Wno-class-memaccess -Wno-attributes -Wno-class-memaccess -Wno-subobject-linkage -Wno-invalid-offsetof -Wno-return-type -Wno-deprecated-copy -fno-exceptions -fno-rtti -fvisibility-inlines-hidden -c ../../3rdparty/chromium/third_party/crc32c/src/src/crc32c_arm64.cc -o obj/third_party/crc32c/crc32c_arm64/crc32c_arm64.o
FAILED: [code=1] obj/third_party/crc32c/crc32c_arm64/crc32c_arm64.o 
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/shims/linux/super/g++ -MMD -MF obj/third_party/crc32c/crc32c_arm64/crc32c_arm64.o.d -DUSE_UDEV -DUSE_AURA=1 -DUSE_NSS_CERTS=1 -DUSE_OZONE=1 -DOFFICIAL_BUILD -DTOOLKIT_QT -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -DNO_UNWIND_TABLES -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -DNDEBUG -DNVALGRIND -DDYNAMIC_ANNOTATIONS_ENABLED=0 -DBYTE_ORDER_BIG_ENDIAN=0 -DCRC32C_TESTS_BUILT_WITH_GLOG=0 -DHAVE_MM_PREFETCH=0 -DHAVE_SSE42=0 -DHAVE_BUILTIN_PREFETCH=1 -DHAVE_ARM64_CRC32C=1 -DHAVE_STRONG_GETAUXVAL=1 -DHAVE_WEAK_GETAUXVAL=1 -Igen -I../../3rdparty/chromium -I../../3rdparty/chromium/third_party/crc32c/config -I../../3rdparty/chromium/third_party/crc32c/src/include -march=armv8-a+crc+crypto -fno-strict-aliasing --param=ssp-buffer-size=4 -fstack-protector -fno-unwind-tables -fno-asynchronous-unwind-tables -fPIC -pipe -pthread -Wall -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -Wno-unused-local-typedefs -Wno-maybe-uninitialized -Wno-deprecated-declarations -fno-delete-null-pointer-checks -Wno-comments -Wno-packed-not-aligned -Wno-dangling-else -Wno-missing-field-initializers -Wno-unused-parameter -O2 -fno-ident -fdata-sections -ffunction-sections -fno-omit-frame-pointer -g0 -fvisibility=hidden -std=gnu++17 -Wno-narrowing -Wno-class-memaccess -Wno-attributes -Wno-class-memaccess -Wno-subobject-linkage -Wno-invalid-offsetof -Wno-return-type -Wno-deprecated-copy -fno-exceptions -fno-rtti -fvisibility-inlines-hidden -c ../../3rdparty/chromium/third_party/crc32c/src/src/crc32c_arm64.cc -o obj/third_party/crc32c/crc32c_arm64/crc32c_arm64.o
In file included from ../../3rdparty/chromium/third_party/crc32c/src/src/crc32c_arm64.cc:21:
/usr/lib/gcc/aarch64-linux-gnu/12/include/arm_acle.h: In function ‘uint32_t crc32c::ExtendArm64(uint32_t, const uint8_t*, size_t)’:
/usr/lib/gcc/aarch64-linux-gnu/12/include/arm_acle.h:197:1: error: inlining failed in call to ‘always_inline’ ‘uint32_t __crc32cd(uint32_t, uint64_t)’: target specific option mismatch
  197 | __crc32cd (uint32_t __a, uint64_t __b)
      | ^~~~~~~~~
../../3rdparty/chromium/third_party/crc32c/src/src/crc32c_arm64.cc:94:21: note: called from here
   94 |     crc ^= __crc32cd(0, t0);
      |            ~~~~~~~~~^~~~~~~
```

---


EDIT: Change worked for arm64 linux
https://github.com/Homebrew/homebrew-core/actions/runs/18081327677/job/51445127985?pr=246110#step:4:70

Waiting for Intel runners to finish to make sure CPUID check is okay, which gets triggered even if `ENV.runtime_cpu_detection` is only set on arm64 linux.