### PR TITLE
libtiff: avoid opportunistic linkage to `libdeflate`

### DIFF
--- a/Formula/lib/libtiff.rb
+++ b/Formula/lib/libtiff.rb
@@ -29,6 +29,7 @@ class Libtiff < Formula
     args = %W[
       --prefix=#{prefix}
       --disable-dependency-tracking
+      --disable-libdeflate
       --disable-webp
       --enable-zstd
       --enable-lzma


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Should help users needing to source-build: https://github.com/orgs/Homebrew/discussions/6435