### PR TITLE
nanobind: fix test

### DIFF
--- a/Formula/n/nanobind.rb
+++ b/Formula/n/nanobind.rb
@@ -52,7 +52,7 @@ class Nanobind < Formula
       cmake_minimum_required(VERSION 3.27)
       project(test_nanobind)
 
-      find_package(Python #{python_version} COMPONENTS Interpreter Development.Module REQUIRED)
+      find_package(Python #{python_version} EXACT COMPONENTS Interpreter Development.Module REQUIRED)
 
       if(FIND_NANOBIND_USING_PYTHON)
         execute_process(


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Test fails when updating `python3` to 3.14: https://github.com/Homebrew/homebrew-core/actions/runs/18054150691/job/51382481571?pr=245931

> -- Found Python: /home/linuxbrew/.linuxbrew/bin/python3.14 (found suitable version "3.14.0", minimum required is "3.13") found components: Interpreter Development.Module

Tell `find_package` that we need 3.13, not >=3.13
