### PR TITLE
dr 0.0.3 (new formula)

### DIFF
--- a/Formula/d/dr.rb
+++ b/Formula/d/dr.rb
@@ -1,0 +1,18 @@
+class Dr < Formula
+  desc "DataRobot command-line interface"
+  homepage "https://github.com/datarobot-oss/cli"
+  url "https://github.com/datarobot-oss/cli/archive/refs/tags/v0.0.3.tar.gz"
+  sha256 "6df4a739dae533ddc30d099d9a34954dcb081aced6e831b01ac2976a96444d80"
+  license :cannot_represent
+  head "https://github.com/datarobot-oss/cli.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", "-ldflags", "-s -w", "-o", bin/"dr"
+  end
+
+  test do
+    system bin/"dr", "version"
+  end
+end


### PR DESCRIPTION
This PR adds in a new formula for the DataRobot CLI, a tool for interacting with DataRobot's application templates.

A note on the selected test:
The documentation specifically [calls out](https://docs.brew.sh/Formula-Cookbook#add-a-test-to-the-formula) a `version` test for a formula as "bad" in most cases. However, because this CLI depends heavily on a user logging into DataRobot for full usage, the `version` test is, unfortunately, the best we have for confirming that the CLI built and installed correctly on a user's computer.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
