### PR TITLE
qtbase qtsvg ... 6.9.3 (new formula)

### DIFF
--- a/Formula/q/qtbase.rb
+++ b/Formula/q/qtbase.rb
@@ -20,6 +20,14 @@ class Qtbase < Formula
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
+  bottle do
+    sha256 cellar: :any,                 arm64_tahoe:   "031dc8feea7e91068bad640f2384309b5d73983f5e13b63fd41019a492365d6a"
+    sha256 cellar: :any,                 arm64_sequoia: "f81cd92620f9a76049a118e983b68141d469825828fbc317e04c4449c3e7066d"
+    sha256 cellar: :any,                 arm64_sonoma:  "73404da080f30f866f0edd489527ed879a06a2a956f59c6ed52d47c7e32668f5"
+    sha256 cellar: :any,                 sonoma:        "6a51ae0cf024a196bba21a5ba75bf7d4c35aedcdae23476ff2f948cecb3602a9"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "28447cd1dc3f8930358e067866bc3b68c24f26ab5a19ba7bd7d22e8978924a42"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "ninja" => :build
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/q/qtbase.rb
+++ b/Formula/q/qtbase.rb
@@ -1,0 +1,263 @@
+class Qtbase < Formula
+  desc "Cross-platform application and UI framework"
+  homepage "https://www.qt.io/"
+  url "https://download.qt.io/official_releases/qt/6.9/6.9.3/submodules/qtbase-everywhere-src-6.9.3.tar.xz"
+  mirror "https://qt.mirror.constant.com/archive/qt/6.9/6.9.3/submodules/qtbase-everywhere-src-6.9.3.tar.xz"
+  mirror "https://mirrors.ukfast.co.uk/sites/qt.io/archive/qt/6.9/6.9.3/submodules/qtbase-everywhere-src-6.9.3.tar.xz"
+  sha256 "c5a1a2f660356ec081febfa782998ae5ddbc5925117e64f50e4be9cd45b8dc6e"
+  license all_of: [
+    { any_of: ["LGPL-3.0-only", "GPL-2.0-only", "GPL-3.0-only"] },
+    { "GPL-3.0-only" => { with: "Qt-GPL-exception-1.0" } }, # qmake
+    "BSD-3-Clause", # *.cmake
+    "GFDL-1.3-no-invariants-only", # *.qdoc
+  ]
+  head "https://code.qt.io/qt/qtbase.git", branch: "dev"
+
+  # The first-party website doesn't make version information readily available,
+  # so we check the `head` repository tags instead.
+  livecheck do
+    url :head
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
+  depends_on "cmake" => [:build, :test]
+  depends_on "ninja" => :build
+  depends_on "pkgconf" => [:build, :test]
+  depends_on "vulkan-headers" => [:build, :test]
+  depends_on xcode: :build
+
+  depends_on "brotli"
+  depends_on "dbus"
+  depends_on "double-conversion"
+  depends_on "freetype"
+  depends_on "glib"
+  depends_on "harfbuzz"
+  depends_on "icu4c@77"
+  depends_on "jpeg-turbo"
+  depends_on "libb2"
+  depends_on "libpng"
+  depends_on "md4c"
+  depends_on "openssl@3"
+  depends_on "pcre2"
+  depends_on "zstd"
+
+  uses_from_macos "cups"
+  uses_from_macos "krb5"
+  uses_from_macos "sqlite"
+  uses_from_macos "zlib"
+
+  on_macos do
+    depends_on "molten-vk" => :build
+  end
+
+  on_linux do
+    depends_on "fontconfig"
+    depends_on "gdk-pixbuf"
+    depends_on "gtk+3"
+    depends_on "libdrm"
+    depends_on "libice"
+    depends_on "libsm"
+    depends_on "libx11"
+    depends_on "libxcb"
+    depends_on "libxkbcommon"
+    depends_on "mesa"
+    depends_on "pango"
+    depends_on "systemd"
+    depends_on "xcb-util-cursor"
+    depends_on "xcb-util-image"
+    depends_on "xcb-util-keysyms"
+    depends_on "xcb-util-renderutil"
+    depends_on "xcb-util-wm"
+  end
+
+  def install
+    # Allow -march options to be passed through, as Qt builds
+    # arch-specific code with runtime detection of capabilities:
+    # https://bugreports.qt.io/browse/QTBUG-113391
+    ENV.runtime_cpu_detection
+
+    # Remove bundled libraries
+    rm_r(%w[
+      src/3rdparty/double-conversion
+      src/3rdparty/freetype
+      src/3rdparty/harfbuzz-ng
+      src/3rdparty/libjpeg
+      src/3rdparty/libpng
+      src/3rdparty/md4c
+      src/3rdparty/pcre2
+      src/3rdparty/sqlite
+      src/3rdparty/xcb
+      src/3rdparty/zlib
+    ])
+
+    # The install prefix is HOMEBREW_PREFIX so that modules can be installed in separate formulae
+    cmake_args = std_cmake_args(install_prefix: HOMEBREW_PREFIX, find_framework: "FIRST") + %W[
+      -DCMAKE_STAGING_PREFIX=#{prefix}
+      -DINSTALL_ARCHDATADIR=share/qt
+      -DINSTALL_DATADIR=share/qt
+      -DINSTALL_EXAMPLESDIR=share/qt/examples
+      -DINSTALL_MKSPECSDIR=share/qt/mkspecs
+      -DINSTALL_TESTSDIR=share/qt/tests
+
+      -DFEATURE_sql_mysql=OFF
+      -DFEATURE_sql_odbc=OFF
+      -DFEATURE_sql_psql=OFF
+
+      -DFEATURE_openssl_linked=ON
+      -DFEATURE_pkg_config=ON
+      -DFEATURE_system_doubleconversion=ON
+      -DFEATURE_system_freetype=ON
+      -DFEATURE_system_harfbuzz=ON
+      -DFEATURE_system_jpeg=ON
+      -DFEATURE_system_libb2=ON
+      -DFEATURE_system_pcre2=ON
+      -DFEATURE_system_png=ON
+      -DFEATURE_system_sqlite=ON
+      -DFEATURE_system_zlib=ON
+      -DQT_ALLOW_SYMLINK_IN_PATHS=ON
+    ]
+
+    cmake_args += if OS.mac?
+      # Workaround to support relocatable installs in Homebrew's symlink directory structure.
+      inreplace "cmake/QtQmakeHelpers.cmake",
+                'set(QT_CONFIGURE_LIBLOCATION_TO_PREFIX_PATH "${from_lib_location_to_prefix}")',
+                "set(QT_CONFIGURE_LIBLOCATION_TO_PREFIX_PATH \"#{HOMEBREW_PREFIX.relative_path_from(lib)}\")"
+
+      # Cannoy deploy to version later than 14, due to functions obsoleted in macOS 15.0
+      # https://bugreports.qt.io/browse/QTBUG-128900
+      deploy = [MacOS.version, MacOSVersion.from_symbol(:sonoma)].min
+
+      %W[
+        -DCMAKE_OSX_DEPLOYMENT_TARGET=#{deploy}.0
+        -DFEATURE_relocatable=ON
+        -DQT_NO_APPLE_SDK_AND_XCODE_CHECK=ON
+      ]
+    else
+      # FIXME: Unable to use workaround for relocatable installs as paths are resolved relative
+      # to absolutePath() rather than canonicalPath(). This can break based on order of RPATH.
+      # https://github.com/qt/qtbase/blob/v6.9.2/src/corelib/global/qlibraryinfo.cpp#L304
+      %w[
+        -DFEATURE_relocatable=OFF
+        -DFEATURE_xcb=ON
+        -DFEATURE_system_xcb_xinput=ON
+      ]
+    end
+
+    system "cmake", "-S", ".", "-B", "build", "-G", "Ninja", *cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+
+    # Some config scripts will only find Qt in a "Frameworks" folder
+    frameworks.install_symlink lib.glob("*.framework") if OS.mac?
+
+    inreplace lib/"cmake/Qt6/qt.toolchain.cmake", "#{Superenv.shims_path}/", ""
+
+    # Install a qtversion.xml to ease integration with QtCreator
+    # As far as we can tell, there is no ability to make the Qt buildsystem
+    # generate this and it's in the Qt source tarball at all.
+    # Multiple people on StackOverflow have asked for this and it's a pain
+    # to add Qt to QtCreator (the official IDE) without it.
+    # Given Qt upstream seems extremely unlikely to accept this: let's ship our
+    # own version.
+    # If you read this and you can eliminate it or upstream it: please do!
+    # More context in https://github.com/Homebrew/homebrew-core/pull/124923
+    (share/"qtcreator/QtProject/qtcreator/qtversion.xml").write <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE QtCreatorQtVersions>
+      <qtcreator>
+      <data>
+        <variable>QtVersion.0</variable>
+        <valuemap type="QVariantMap">
+        <value type="int" key="Id">1</value>
+        <value type="QString" key="Name">Qt %{Qt:Version} (#{HOMEBREW_PREFIX})</value>
+        <value type="QString" key="QMakePath">#{opt_bin}/qmake</value>
+        <value type="QString" key="QtVersion.Type">Qt4ProjectManager.QtVersion.Desktop</value>
+        <value type="QString" key="autodetectionSource"></value>
+        <value type="bool" key="isAutodetected">false</value>
+        </valuemap>
+      </data>
+      <data>
+        <variable>Version</variable>
+        <value type="int">1</value>
+      </data>
+      </qtcreator>
+    XML
+  end
+
+  def caveats
+    <<~CAVEATS
+      You can add Homebrew's Qt to QtCreator's "Qt Versions" in:
+        Preferences > Qt Versions > Link with Qt...
+      pressing "Choose..." and selecting as the Qt installation path:
+        #{HOMEBREW_PREFIX}
+    CAVEATS
+  end
+
+  test do
+    modules = %w[Core Gui Widgets Sql Concurrent Network]
+
+    (testpath/"CMakeLists.txt").write <<~CMAKE
+      cmake_minimum_required(VERSION 4.0)
+      project(test VERSION 1.0.0 LANGUAGES CXX)
+      set(CMAKE_AUTOMOC ON)
+      set(CMAKE_AUTORCC ON)
+      set(CMAKE_AUTOUIC ON)
+      find_package(Qt6 REQUIRED COMPONENTS #{modules.join(" ")})
+      add_executable(test main.cpp)
+      target_link_libraries(test PRIVATE Qt6::#{modules.join(" Qt6::")})
+    CMAKE
+
+    (testpath/"test.pro").write <<~QMAKE
+      QT      += #{modules.join(" ").downcase}
+      TARGET   = test
+      CONFIG  += console
+      CONFIG  -= app_bundle
+      TEMPLATE = app
+      SOURCES += main.cpp
+      INCLUDEPATH += #{Formula["vulkan-headers"].opt_include}
+    QMAKE
+
+    (testpath/"main.cpp").write <<~CPP
+      #undef QT_NO_DEBUG
+      #include <QCoreApplication>
+      #include <QImageReader>
+      #include <QtSql>
+      #include <QVulkanInstance>
+
+      int main(int argc, char *argv[]) {
+        QCoreApplication app(argc, argv);
+        Q_ASSERT(QSqlDatabase::isDriverAvailable("QSQLITE"));
+        const auto &list = QImageReader::supportedImageFormats();
+        QVulkanInstance inst;
+        // See https://github.com/actions/runner-images/issues/1779
+        // if (!inst.create())
+        //   qFatal("Failed to create Vulkan instance: %d", inst.errorCode());
+        for (const char* fmt : {"bmp", "cur", "gif", "ico", "jpeg", "jpg", "pbm", "pgm", "png", "ppm", "xbm", "xpm"}) {
+          Q_ASSERT(list.contains(fmt));
+        }
+        return 0;
+      }
+    CPP
+
+    ENV["LC_ALL"] = "en_US.UTF-8"
+    ENV["QT_QPA_PLATFORM"] = "minimal" if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"]
+
+    system "cmake", "-S", ".", "-B", "cmake"
+    system "cmake", "--build", "cmake"
+    system "./cmake/test"
+
+    ENV.delete "CPATH" if OS.mac?
+    mkdir "qmake" do
+      system bin/"qmake", testpath/"test.pro"
+      system "make"
+      system "./test"
+    end
+
+    flags = shell_output("pkgconf --cflags --libs Qt6#{modules.join(" Qt6")}").chomp.split
+    system ENV.cxx, "-std=c++17", "main.cpp", "-o", "test", *flags
+    system "./test"
+
+    # Check QT_INSTALL_PREFIX is HOMEBREW_PREFIX to support split formulae
+    assert_equal HOMEBREW_PREFIX.to_s, shell_output("#{bin}/qmake -query QT_INSTALL_PREFIX").chomp
+  end
+end

--- a/Formula/q/qtconnectivity.rb
+++ b/Formula/q/qtconnectivity.rb
@@ -1,0 +1,97 @@
+class Qtconnectivity < Formula
+  desc "Provides access to Bluetooth hardware"
+  homepage "https://www.qt.io/"
+  url "https://download.qt.io/official_releases/qt/6.9/6.9.3/submodules/qtconnectivity-everywhere-src-6.9.3.tar.xz"
+  mirror "https://qt.mirror.constant.com/archive/qt/6.9/6.9.3/submodules/qtconnectivity-everywhere-src-6.9.3.tar.xz"
+  mirror "https://mirrors.ukfast.co.uk/sites/qt.io/archive/qt/6.9/6.9.3/submodules/qtconnectivity-everywhere-src-6.9.3.tar.xz"
+  sha256 "e21bba5efb174c4456c5e5a7b4d52bba1ee62dfb4509bcff73fdfad9cb1dd7f5"
+  license all_of: [
+    { any_of: ["LGPL-3.0-only", "GPL-2.0-only", "GPL-3.0-only"] },
+    "BSD-3-Clause", # *.cmake
+  ]
+  head "https://code.qt.io/qt/qtconnectivity.git", branch: "dev"
+
+  livecheck do
+    formula "qtbase"
+  end
+
+  depends_on "cmake" => [:build, :test]
+  depends_on "ninja" => :build
+  depends_on "pkgconf" => :test
+
+  depends_on "qtbase"
+
+  uses_from_macos "pcsc-lite"
+
+  on_linux do
+    depends_on "pkgconf" => :build
+    depends_on "bluez"
+  end
+
+  def install
+    args = ["-DCMAKE_STAGING_PREFIX=#{prefix}"]
+    args << "-DQT_NO_APPLE_SDK_AND_XCODE_CHECK=ON" if OS.mac?
+
+    system "cmake", "-S", ".", "-B", "build", "-G", "Ninja",
+                    *args, *std_cmake_args(install_prefix: HOMEBREW_PREFIX, find_framework: "FIRST")
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+
+    # Some config scripts will only find Qt in a "Frameworks" folder
+    frameworks.install_symlink lib.glob("*.framework") if OS.mac?
+  end
+
+  test do
+    # NOTE: On macOS we cannot run executable as it requires Bluetooth permissions via interactive prompt
+    run_executable = !OS.mac?
+
+    (testpath/"CMakeLists.txt").write <<~CMAKE
+      cmake_minimum_required(VERSION 4.0)
+      project(test VERSION 1.0.0 LANGUAGES CXX)
+      find_package(Qt6 REQUIRED COMPONENTS Bluetooth)
+      add_executable(test main.cpp)
+      target_link_libraries(test PRIVATE Qt6::Bluetooth)
+    CMAKE
+
+    (testpath/"test.pro").write <<~QMAKE
+      QT      += bluetooth
+      TARGET   = test
+      CONFIG  += console
+      CONFIG  -= app_bundle
+      TEMPLATE = app
+      SOURCES += main.cpp
+    QMAKE
+
+    (testpath/"main.cpp").write <<~CPP
+      #undef QT_NO_DEBUG
+      #include <QBluetoothLocalDevice>
+      #include <QDebug>
+
+      int main(void) {
+        QBluetoothLocalDevice localDevice;
+        if (localDevice.isValid()) {
+          qInfo() << localDevice.name();
+        }
+        return 0;
+      }
+    CPP
+
+    ENV["LC_ALL"] = "en_US.UTF-8"
+    ENV["QT_QPA_PLATFORM"] = "minimal" if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"]
+
+    system "cmake", "-S", ".", "-B", "cmake"
+    system "cmake", "--build", "cmake"
+    system "./cmake/test" if run_executable
+
+    ENV.delete "CPATH" if OS.mac?
+    mkdir "qmake" do
+      system Formula["qtbase"].bin/"qmake", testpath/"test.pro"
+      system "make"
+      system "./test" if run_executable
+    end
+
+    flags = shell_output("pkgconf --cflags --libs Qt6Bluetooth").chomp.split
+    system ENV.cxx, "-std=c++17", "main.cpp", "-o", "test", *flags
+    system "./test" if run_executable
+  end
+end

--- a/Formula/q/qtconnectivity.rb
+++ b/Formula/q/qtconnectivity.rb
@@ -15,6 +15,14 @@ class Qtconnectivity < Formula
     formula "qtbase"
   end
 
+  bottle do
+    sha256 cellar: :any,                 arm64_tahoe:   "46990ccc8f093045c2062b4ce93ef453ec9a4b37789f96b22c32b425e3ff6f8b"
+    sha256 cellar: :any,                 arm64_sequoia: "fd9521753c641880c1c195936787a70ad33023c6c481d990e11db44e04e68a4e"
+    sha256 cellar: :any,                 arm64_sonoma:  "9309787fa0b27c8a7a17be3a317cf413d8c7db8cdb46b643f6813ca7e40f18c5"
+    sha256 cellar: :any,                 sonoma:        "0561107aa7d4c025cd48aec78034789d7629eb5ca918ee3e251c1e9bbaed9925"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "49aab37a8f1da9d6b8a68b690d75877f8a5c48265b3dd7dd67e5d0f930059ee5"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "ninja" => :build
   depends_on "pkgconf" => :test

--- a/Formula/q/qtdeclarative.rb
+++ b/Formula/q/qtdeclarative.rb
@@ -1,0 +1,61 @@
+class Qtdeclarative < Formula
+  desc "QML, Qt Quick and several related modules"
+  homepage "https://www.qt.io/"
+  url "https://download.qt.io/official_releases/qt/6.9/6.9.3/submodules/qtdeclarative-everywhere-src-6.9.3.tar.xz"
+  mirror "https://qt.mirror.constant.com/archive/qt/6.9/6.9.3/submodules/qtdeclarative-everywhere-src-6.9.3.tar.xz"
+  mirror "https://mirrors.ukfast.co.uk/sites/qt.io/archive/qt/6.9/6.9.3/submodules/qtdeclarative-everywhere-src-6.9.3.tar.xz"
+  sha256 "5a071b227229afbf5c976b7b59a0d850818d06ae861fcdf6d690351ca3f8a260"
+  license all_of: [
+    { any_of: ["LGPL-3.0-only", "GPL-2.0-only", "GPL-3.0-only"] },
+    { "GPL-3.0-only" => { with: "Qt-GPL-exception-1.0" } }, # qml
+    "BSD-2-Clause", # masm
+    "BSD-3-Clause", # *.cmake
+  ]
+  head "https://code.qt.io/qt/qtdeclarative.git", branch: "dev"
+
+  livecheck do
+    formula "qtbase"
+  end
+
+  depends_on "cmake" => :build
+  depends_on "ninja" => :build
+  depends_on "qtlanguageserver" => :build
+  depends_on "qtshadertools" => :build
+  depends_on "vulkan-headers" => :build
+
+  depends_on "qtbase"
+  depends_on "qtsvg"
+
+  uses_from_macos "python" => :build
+
+  def install
+    args = ["-DCMAKE_STAGING_PREFIX=#{prefix}"]
+    args << "-DQT_NO_APPLE_SDK_AND_XCODE_CHECK=ON" if OS.mac?
+
+    system "cmake", "-S", ".", "-B", "build", "-G", "Ninja",
+                    *args, *std_cmake_args(install_prefix: HOMEBREW_PREFIX, find_framework: "FIRST")
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+
+    # Some config scripts will only find Qt in a "Frameworks" folder
+    frameworks.install_symlink lib.glob("*.framework") if OS.mac?
+  end
+
+  test do
+    # https://github.com/qt/qtdeclarative/blob/dev/tests/auto/qml/qqmlapplicationengine/testapp/immediateQuit.qml
+    (testpath/"immediateQuit.qml").write <<~QML
+      import QtQml
+      import QtQuick
+      QtObject {
+        Component.onCompleted: {
+          console.log("End: " + Qt.application.arguments[1]);
+          Qt.quit()
+        }
+      }
+    QML
+
+    ENV["LC_ALL"] = "en_US.UTF-8"
+    ENV["QT_QPA_PLATFORM"] = "minimal" if OS.linux?
+    assert_match "qml: End: immediateQuit.qml", shell_output("#{bin}/qml immediateQuit.qml 2>&1")
+  end
+end

--- a/Formula/q/qtdeclarative.rb
+++ b/Formula/q/qtdeclarative.rb
@@ -17,6 +17,14 @@ class Qtdeclarative < Formula
     formula "qtbase"
   end
 
+  bottle do
+    sha256                               arm64_tahoe:   "01c719a27a1fa9961ded9a195e326468d7c5a9c3ab5462eb10cd553539e62b0e"
+    sha256                               arm64_sequoia: "4073f5e4d88bcc78c24f38d8ba11fb9d474b70c0fec3a76c7997108ac50241c8"
+    sha256                               arm64_sonoma:  "830c76d0e22f0d7ecc800f1d26b920fd65bc5f5ef3b6e219267e7c673d1534dc"
+    sha256 cellar: :any,                 sonoma:        "d4f34e19e1e6ce6dd7452dea1cb4b42bf39c7e3e7d6f7b73e42cf72a5635f53e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "25c2ae6327941d10525bec6b4596b92239bcccd7a6468b522579ae410a1c0e03"
+  end
+
   depends_on "cmake" => :build
   depends_on "ninja" => :build
   depends_on "qtlanguageserver" => :build

--- a/Formula/q/qtimageformats.rb
+++ b/Formula/q/qtimageformats.rb
@@ -15,6 +15,14 @@ class Qtimageformats < Formula
     formula "qtbase"
   end
 
+  bottle do
+    sha256 cellar: :any,                 arm64_tahoe:   "9f36e8943686802d046651f233ff63386c126443cd3bd9bd92e55940e1a93124"
+    sha256 cellar: :any,                 arm64_sequoia: "4730520a5ffe2a0dc02b4037bbb073cae05e5b8926ca9786cb76cfb03e6da177"
+    sha256 cellar: :any,                 arm64_sonoma:  "9e8c7cc840f05e1babafbcb767e5e5ed6e47d5cd48d2592579a09910d1b02894"
+    sha256 cellar: :any,                 sonoma:        "87cd8046387e13613f6b04d1d60d3c45340cc16201db30f32f9e4c45113f7fd8"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "6bc7a304fcdfb672f8205bbfc268dc9bddb35a5ee6bf58ffdb329aa4fc0bd4ef"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "ninja" => :build
   depends_on "pkgconf" => :test

--- a/Formula/q/qtimageformats.rb
+++ b/Formula/q/qtimageformats.rb
@@ -1,0 +1,101 @@
+class Qtimageformats < Formula
+  desc "Plugins for additional image formats: TIFF, MNG, TGA, WBMP"
+  homepage "https://www.qt.io/"
+  url "https://download.qt.io/official_releases/qt/6.9/6.9.3/submodules/qtimageformats-everywhere-src-6.9.3.tar.xz"
+  mirror "https://qt.mirror.constant.com/archive/qt/6.9/6.9.3/submodules/qtimageformats-everywhere-src-6.9.3.tar.xz"
+  mirror "https://mirrors.ukfast.co.uk/sites/qt.io/archive/qt/6.9/6.9.3/submodules/qtimageformats-everywhere-src-6.9.3.tar.xz"
+  sha256 "4fb26bdbfbd4b8e480087896514e11c33aba7b6b39246547355ea340c4572ffe"
+  license all_of: [
+    { any_of: ["LGPL-3.0-only", "GPL-2.0-only", "GPL-3.0-only"] },
+    "BSD-3-Clause", # *.cmake
+  ]
+  head "https://code.qt.io/qt/qtimageformats.git", branch: "dev"
+
+  livecheck do
+    formula "qtbase"
+  end
+
+  depends_on "cmake" => [:build, :test]
+  depends_on "ninja" => :build
+  depends_on "pkgconf" => :test
+
+  depends_on "jasper"
+  depends_on "jpeg-turbo"
+  depends_on "libmng"
+  depends_on "libtiff"
+  depends_on "qtbase"
+  depends_on "webp"
+
+  def install
+    rm_r("src/3rdparty")
+
+    args = %W[
+      -DCMAKE_STAGING_PREFIX=#{prefix}
+      -DFEATURE_system_tiff=ON
+      -DFEATURE_system_webp=ON
+    ]
+    args << "-DQT_NO_APPLE_SDK_AND_XCODE_CHECK=ON" if OS.mac?
+
+    system "cmake", "-S", ".", "-B", "build", "-G", "Ninja",
+                    *args, *std_cmake_args(install_prefix: HOMEBREW_PREFIX, find_framework: "FIRST")
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+
+    # Some config scripts will only find Qt in a "Frameworks" folder
+    frameworks.install_symlink lib.glob("*.framework") if OS.mac?
+  end
+
+  test do
+    (testpath/"CMakeLists.txt").write <<~CMAKE
+      cmake_minimum_required(VERSION 4.0)
+      project(test VERSION 1.0.0 LANGUAGES CXX)
+      find_package(Qt6 REQUIRED COMPONENTS Gui)
+      add_executable(test main.cpp)
+      target_link_libraries(test PRIVATE Qt6::Gui)
+    CMAKE
+
+    (testpath/"test.pro").write <<~QMAKE
+      QT      += gui
+      TARGET   = test
+      CONFIG  += console
+      CONFIG  -= app_bundle
+      TEMPLATE = app
+      SOURCES += main.cpp
+    QMAKE
+
+    (testpath/"main.cpp").write <<~CPP
+      #undef QT_NO_DEBUG
+      #include <QImageReader>
+
+      int main(void) {
+        const auto &list = QImageReader::supportedImageFormats();
+        for(const char* fmt : {"icns", "jp2", "tga", "tif", "tiff", "wbmp", "webp"}) {
+          Q_ASSERT(list.contains(fmt));
+        }
+      #ifdef __APPLE__
+        Q_ASSERT(list.contains("heic"));
+        Q_ASSERT(list.contains("heif"));
+      #endif
+        return 0;
+      }
+    CPP
+
+    ENV["LC_ALL"] = "en_US.UTF-8"
+    ENV["QT_QPA_PLATFORM"] = "minimal" if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"]
+
+    system "cmake", "-S", ".", "-B", "cmake"
+    system "cmake", "--build", "cmake"
+    system "./cmake/test"
+
+    ENV.delete "CPATH" if OS.mac?
+    mkdir "qmake" do
+      system Formula["qtbase"].bin/"qmake", testpath/"test.pro"
+      system "make"
+      system "./test"
+    end
+
+    flags = shell_output("pkgconf --cflags --libs Qt6Gui").chomp.split
+    system ENV.cxx, "-std=c++17", "main.cpp", "-o", "test", *flags
+    system "./test"
+  end
+end

--- a/Formula/q/qtlanguageserver.rb
+++ b/Formula/q/qtlanguageserver.rb
@@ -1,0 +1,87 @@
+class Qtlanguageserver < Formula
+  desc "Implementation of the Language Server Protocol and JSON-RPC"
+  homepage "https://www.qt.io/"
+  url "https://download.qt.io/official_releases/qt/6.9/6.9.3/submodules/qtlanguageserver-everywhere-src-6.9.3.tar.xz"
+  mirror "https://qt.mirror.constant.com/archive/qt/6.9/6.9.3/submodules/qtlanguageserver-everywhere-src-6.9.3.tar.xz"
+  mirror "https://mirrors.ukfast.co.uk/sites/qt.io/archive/qt/6.9/6.9.3/submodules/qtlanguageserver-everywhere-src-6.9.3.tar.xz"
+  sha256 "c8e8a6c4f8cb25626922e78f398b13b02eea21c4cc5525ffc2a0da7469369d33"
+  license all_of: [
+    { any_of: ["LGPL-3.0-only", "GPL-2.0-only", "GPL-3.0-only"] },
+    "BSD-3-Clause", # *.cmake
+  ]
+  head "https://code.qt.io/qt/qtlanguageserver.git", branch: "dev"
+
+  livecheck do
+    formula "qtbase"
+  end
+
+  depends_on "cmake" => [:build, :test]
+  depends_on "ninja" => :build
+
+  depends_on "qtbase"
+
+  def install
+    args = ["-DCMAKE_STAGING_PREFIX=#{prefix}"]
+    args << "-DQT_NO_APPLE_SDK_AND_XCODE_CHECK=ON" if OS.mac?
+
+    system "cmake", "-S", ".", "-B", "build", "-G", "Ninja",
+                    *args, *std_cmake_args(install_prefix: HOMEBREW_PREFIX, find_framework: "FIRST")
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+
+    # Some config scripts will only find Qt in a "Frameworks" folder
+    frameworks.install_symlink lib.glob("*.framework") if OS.mac?
+  end
+
+  test do
+    (testpath/"CMakeLists.txt").write <<~CMAKE
+      cmake_minimum_required(VERSION 4.0)
+      project(test VERSION 1.0.0 LANGUAGES CXX)
+      find_package(Qt6 REQUIRED COMPONENTS JsonRpcPrivate)
+      add_executable(test main.cpp)
+      target_link_libraries(test PRIVATE Qt6::JsonRpcPrivate)
+    CMAKE
+
+    (testpath/"test.pro").write <<~QMAKE
+      QT      += jsonrpc_private
+      TARGET   = test
+      CONFIG  += console
+      CONFIG  -= app_bundle
+      TEMPLATE = app
+      SOURCES += main.cpp
+    QMAKE
+
+    (testpath/"main.cpp").write <<~CPP
+      #undef QT_NO_DEBUG
+      #include <QtJsonRpc/private/qjsonrpctransport_p.h>
+      #include <QtJsonRpc/private/qjsonrpcprotocol_p.h>
+
+      class TestTransport : public QJsonRpcTransport {
+      public:
+        void sendMessage(const QJsonDocument &) final {}
+        void receiveData(const QByteArray &) final {}
+      };
+
+      int main(void) {
+        QJsonRpcProtocol protocol;
+        TestTransport transport;
+        protocol.setTransport(&transport);
+        return 0;
+      }
+    CPP
+
+    ENV["LC_ALL"] = "en_US.UTF-8"
+    ENV["QT_QPA_PLATFORM"] = "minimal" if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"]
+
+    system "cmake", "-S", ".", "-B", "cmake"
+    system "cmake", "--build", "cmake"
+    system "./cmake/test"
+
+    ENV.delete "CPATH" if OS.mac?
+    mkdir "qmake" do
+      system Formula["qtbase"].bin/"qmake", testpath/"test.pro"
+      system "make"
+      system "./test"
+    end
+  end
+end

--- a/Formula/q/qtlanguageserver.rb
+++ b/Formula/q/qtlanguageserver.rb
@@ -15,6 +15,14 @@ class Qtlanguageserver < Formula
     formula "qtbase"
   end
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "0d4229ffcdccf46c7de6c85f6c172fe4d32e98c4de97eac26308d325d101285e"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "224eff3ca1a5461c2e30e2a2ce2e08255c5ef59e6e155a101fd76f89f0ce3658"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "1e70336d46487107ec97a74126f4abe4fb81eb376f1fbb44194ee330b690330c"
+    sha256 cellar: :any_skip_relocation, sonoma:        "c02e42a854bdce647fbdbee94996bd4ef0527d55768b1a724279d003a4589a66"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f88fd9cdb6fde0da393d684f91fd8d80a7edbbbcce56d33a8131ffa838f464f5"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "ninja" => :build
 

--- a/Formula/q/qtpositioning.rb
+++ b/Formula/q/qtpositioning.rb
@@ -17,6 +17,14 @@ class Qtpositioning < Formula
     formula "qtbase"
   end
 
+  bottle do
+    sha256 cellar: :any,                 arm64_tahoe:   "0527cd554ef27823760fc1b58b749f484c2a54da05745188b6e8da6fd8505667"
+    sha256 cellar: :any,                 arm64_sequoia: "752f8c9bddbc745cb99897f30d918b7bbf5481faf19031df5af6d6fa7034953b"
+    sha256 cellar: :any,                 arm64_sonoma:  "6d51d148e6cc63c0b1a0178fae03dbc5f1b7f231fe27904f87449eca158e1564"
+    sha256 cellar: :any,                 sonoma:        "939737840db8646bcf700862955b1037d7fc15c3e63ec249973b4ffe97c8f637"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8d21a7d8372cbd1fe44966d5eba3fab9f189d8331c504249e905e36bf1430189"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "ninja" => :build
   depends_on "pkgconf" => :test

--- a/Formula/q/qtpositioning.rb
+++ b/Formula/q/qtpositioning.rb
@@ -1,0 +1,87 @@
+class Qtpositioning < Formula
+  desc "Provides access to position, satellite info and area monitoring classes"
+  homepage "https://www.qt.io/"
+  url "https://download.qt.io/official_releases/qt/6.9/6.9.3/submodules/qtpositioning-everywhere-src-6.9.3.tar.xz"
+  mirror "https://qt.mirror.constant.com/archive/qt/6.9/6.9.3/submodules/qtpositioning-everywhere-src-6.9.3.tar.xz"
+  mirror "https://mirrors.ukfast.co.uk/sites/qt.io/archive/qt/6.9/6.9.3/submodules/qtpositioning-everywhere-src-6.9.3.tar.xz"
+  sha256 "0c87c980f704c17aadaf0bf8a03845dd0a60cc0313be24bd7b5b90685d5835b4"
+  license all_of: [
+    { any_of: ["LGPL-3.0-only", "GPL-2.0-only", "GPL-3.0-only"] },
+    "BSD-3-Clause", # bundled poly2tri; *.cmake
+    "BSL-1.0",      # bundled clipper
+    "MIT",          # bundled clip2tri
+  ]
+  head "https://code.qt.io/qt/qtpositioning.git", branch: "dev"
+
+  livecheck do
+    formula "qtbase"
+  end
+
+  depends_on "cmake" => [:build, :test]
+  depends_on "ninja" => :build
+  depends_on "pkgconf" => :test
+
+  depends_on "qtbase"
+  depends_on "qtdeclarative"
+  depends_on "qtserialport"
+
+  def install
+    args = ["-DCMAKE_STAGING_PREFIX=#{prefix}"]
+    args << "-DQT_NO_APPLE_SDK_AND_XCODE_CHECK=ON" if OS.mac?
+
+    system "cmake", "-S", ".", "-B", "build", "-G", "Ninja",
+                    *args, *std_cmake_args(install_prefix: HOMEBREW_PREFIX, find_framework: "FIRST")
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+
+    # Some config scripts will only find Qt in a "Frameworks" folder
+    frameworks.install_symlink lib.glob("*.framework") if OS.mac?
+  end
+
+  test do
+    (testpath/"CMakeLists.txt").write <<~CMAKE
+      cmake_minimum_required(VERSION 4.0)
+      project(test VERSION 1.0.0 LANGUAGES CXX)
+      find_package(Qt6 REQUIRED COMPONENTS Positioning)
+      add_executable(test main.cpp)
+      target_link_libraries(test PRIVATE Qt6::Positioning)
+    CMAKE
+
+    (testpath/"test.pro").write <<~QMAKE
+      QT      += positioning
+      TARGET   = test
+      CONFIG  += console
+      CONFIG  -= app_bundle
+      TEMPLATE = app
+      SOURCES += main.cpp
+    QMAKE
+
+    (testpath/"main.cpp").write <<~CPP
+      #undef QT_NO_DEBUG
+      #include <QGeoPositionInfoSource>
+
+      int main(void) {
+        Q_ASSERT(QGeoPositionInfoSource::availableSources().contains("nmea"));
+        return 0;
+      }
+    CPP
+
+    ENV["LC_ALL"] = "en_US.UTF-8"
+    ENV["QT_QPA_PLATFORM"] = "minimal" if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"]
+
+    system "cmake", "-S", ".", "-B", "cmake"
+    system "cmake", "--build", "cmake"
+    system "./cmake/test"
+
+    ENV.delete "CPATH" if OS.mac?
+    mkdir "qmake" do
+      system Formula["qtbase"].bin/"qmake", testpath/"test.pro"
+      system "make"
+      system "./test"
+    end
+
+    flags = shell_output("pkgconf --cflags --libs Qt6Positioning").chomp.split
+    system ENV.cxx, "-std=c++17", "main.cpp", "-o", "test", *flags
+    system "./test"
+  end
+end

--- a/Formula/q/qtserialport.rb
+++ b/Formula/q/qtserialport.rb
@@ -1,0 +1,92 @@
+class Qtserialport < Formula
+  desc "Provides classes to interact with hardware and virtual serial ports"
+  homepage "https://www.qt.io/"
+  url "https://download.qt.io/official_releases/qt/6.9/6.9.3/submodules/qtserialport-everywhere-src-6.9.3.tar.xz"
+  mirror "https://qt.mirror.constant.com/archive/qt/6.9/6.9.3/submodules/qtserialport-everywhere-src-6.9.3.tar.xz"
+  mirror "https://mirrors.ukfast.co.uk/sites/qt.io/archive/qt/6.9/6.9.3/submodules/qtserialport-everywhere-src-6.9.3.tar.xz"
+  sha256 "4b18ec030ff2644698c3f5c776894d8ffe5d3174c964d9bd8668429c943e8298"
+  license all_of: [
+    { any_of: ["LGPL-3.0-only", "GPL-2.0-only", "GPL-3.0-only"] },
+    "BSD-3-Clause", # *.cmake
+  ]
+  head "https://code.qt.io/qt/qtserialport.git", branch: "dev"
+
+  livecheck do
+    formula "qtbase"
+  end
+
+  depends_on "cmake" => [:build, :test]
+  depends_on "ninja" => :build
+  depends_on "pkgconf" => :test
+
+  depends_on "qtbase"
+
+  on_linux do
+    depends_on "pkgconf" => :build
+    depends_on "systemd"
+  end
+
+  def install
+    args = ["-DCMAKE_STAGING_PREFIX=#{prefix}"]
+    args << "-DQT_NO_APPLE_SDK_AND_XCODE_CHECK=ON" if OS.mac?
+
+    system "cmake", "-S", ".", "-B", "build", "-G", "Ninja",
+                    *args, *std_cmake_args(install_prefix: HOMEBREW_PREFIX, find_framework: "FIRST")
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+
+    # Some config scripts will only find Qt in a "Frameworks" folder
+    frameworks.install_symlink lib.glob("*.framework") if OS.mac?
+  end
+
+  test do
+    (testpath/"CMakeLists.txt").write <<~CMAKE
+      cmake_minimum_required(VERSION 4.0)
+      project(test VERSION 1.0.0 LANGUAGES CXX)
+      find_package(Qt6 REQUIRED COMPONENTS SerialPort)
+      add_executable(test main.cpp)
+      target_link_libraries(test PRIVATE Qt6::SerialPort)
+    CMAKE
+
+    (testpath/"test.pro").write <<~QMAKE
+      QT      += serialport
+      TARGET   = test
+      CONFIG  += console
+      CONFIG  -= app_bundle
+      TEMPLATE = app
+      SOURCES += main.cpp
+    QMAKE
+
+    (testpath/"main.cpp").write <<~'CPP'
+      #undef QT_NO_DEBUG
+      #include <QSerialPortInfo>
+      #include <QDebug>
+
+      int main(void) {
+        const auto serialPortInfos = QSerialPortInfo::availablePorts();
+        for (const QSerialPortInfo &portInfo : serialPortInfos) {
+          qDebug() << "Port:" << portInfo.portName() << "\n"
+                   << "Location:" << portInfo.systemLocation() << "\n";
+        }
+      }
+    CPP
+
+    ENV["LC_ALL"] = "en_US.UTF-8"
+    ENV["QT_QPA_PLATFORM"] = "minimal" if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"]
+
+    system "cmake", "-S", ".", "-B", "cmake"
+    system "cmake", "--build", "cmake"
+    system "./cmake/test"
+
+    ENV.delete "CPATH" if OS.mac?
+    mkdir "qmake" do
+      system Formula["qtbase"].bin/"qmake", testpath/"test.pro"
+      system "make"
+      system "./test"
+    end
+
+    flags = shell_output("pkgconf --cflags --libs Qt6SerialPort").chomp.split
+    system ENV.cxx, "-std=c++17", "main.cpp", "-o", "test", *flags
+    system "./test"
+  end
+end

--- a/Formula/q/qtserialport.rb
+++ b/Formula/q/qtserialport.rb
@@ -15,6 +15,14 @@ class Qtserialport < Formula
     formula "qtbase"
   end
 
+  bottle do
+    sha256 cellar: :any,                 arm64_tahoe:   "a8a89abf674c18356e224b863c50ef93de9443c4c00f4988a54c3a1719f1b184"
+    sha256 cellar: :any,                 arm64_sequoia: "e73491d79f3318f356bbedfdf194b30e24d4591c3c7e0daa3556d1977b812607"
+    sha256 cellar: :any,                 arm64_sonoma:  "be4b0ebdc65e7f9c6162d08e86db40e90923bb6c70907591533f39c107e582b9"
+    sha256 cellar: :any,                 sonoma:        "6c03a8b4fb34e06d80abdab55dc6821dbb7b04d7f508b980af32681e3ef91f02"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c6f4079925529e453d07694d63aa22a15a19cec659cce192559a3857832d67c9"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "ninja" => :build
   depends_on "pkgconf" => :test

--- a/Formula/q/qtshadertools.rb
+++ b/Formula/q/qtshadertools.rb
@@ -1,0 +1,63 @@
+class Qtshadertools < Formula
+  desc "Provides tools for the cross-platform Qt shader pipeline"
+  homepage "https://www.qt.io/"
+  url "https://download.qt.io/official_releases/qt/6.9/6.9.3/submodules/qtshadertools-everywhere-src-6.9.3.tar.xz"
+  mirror "https://qt.mirror.constant.com/archive/qt/6.9/6.9.3/submodules/qtshadertools-everywhere-src-6.9.3.tar.xz"
+  mirror "https://mirrors.ukfast.co.uk/sites/qt.io/archive/qt/6.9/6.9.3/submodules/qtshadertools-everywhere-src-6.9.3.tar.xz"
+  sha256 "629804ee86a35503e4b616f9ab5175caef3da07bd771cf88a24da3b5d4284567"
+  license all_of: [
+    { any_of: ["LGPL-3.0-only", "GPL-2.0-only", "GPL-3.0-only"] },
+    { "GPL-3.0-only" => { with: "Qt-GPL-exception-1.0" } }, # qsb
+    { all_of: ["Apache-2.0", "MIT-Khronos-old"] }, # bundled SPIRV-Cross
+    { all_of: ["BSD-3-Clause", "MIT-Khronos-old", "Apache-2.0", "AML-glslang",
+               "GPL-3.0-or-later" => { with: "Bison-exception-2.2" }] }, # bundled glslang
+    "BSD-3-Clause", # *.cmake
+  ]
+  head "https://code.qt.io/qt/qtshadertools.git", branch: "dev"
+
+  livecheck do
+    formula "qtbase"
+  end
+
+  depends_on "cmake" => :build
+  depends_on "ninja" => :build
+
+  depends_on "qtbase"
+
+  def install
+    args = ["-DCMAKE_STAGING_PREFIX=#{prefix}"]
+    args << "-DQT_NO_APPLE_SDK_AND_XCODE_CHECK=ON" if OS.mac?
+
+    system "cmake", "-S", ".", "-B", "build", "-G", "Ninja",
+                    *args, *std_cmake_args(install_prefix: HOMEBREW_PREFIX, find_framework: "FIRST")
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+
+    # Some config scripts will only find Qt in a "Frameworks" folder
+    frameworks.install_symlink lib.glob("*.framework") if OS.mac?
+  end
+
+  test do
+    (testpath/"shader.frag").write <<~GLSL
+      #version 440
+
+      layout(location = 0) in vec2 v_texcoord;
+      layout(location = 0) out vec4 fragColor;
+      layout(binding = 1) uniform sampler2D tex;
+
+      layout(std140, binding = 0) uniform buf {
+        float uAlpha;
+      };
+
+      void main() {
+        vec4 c = texture(tex, v_texcoord);
+        fragColor = vec4(c.rgb, uAlpha);
+      }
+    GLSL
+
+    ENV["LC_ALL"] = "en_US.UTF-8"
+    system bin/"qsb", "--output", "shader.frag.qsb", "shader.frag"
+    assert_path_exists testpath/"shader.frag.qsb"
+    assert_match "Shader 0: SPIR-V 100", shell_output("#{bin}/qsb --dump shader.frag.qsb")
+  end
+end

--- a/Formula/q/qtshadertools.rb
+++ b/Formula/q/qtshadertools.rb
@@ -19,6 +19,14 @@ class Qtshadertools < Formula
     formula "qtbase"
   end
 
+  bottle do
+    sha256 cellar: :any,                 arm64_tahoe:   "bb579540bf38f45c33f8608e40022c7000e682eb4186d84264f8f240770a4e85"
+    sha256 cellar: :any,                 arm64_sequoia: "205156158b29aa23357605ad9e2be6a4d784641dbf2dd42ac6d69107375ca84d"
+    sha256 cellar: :any,                 arm64_sonoma:  "1e54af54279cb0d96388f878e4f8ffb4f1b46a22ef0ae292b86a5631b951b377"
+    sha256 cellar: :any,                 sonoma:        "21f5464d71410117011e6035ab999264e902d90d28c91649d42b2aaded0f3830"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "de225d737f69ffacd8b1b130fa55dc1c6e844e5df18d876c73653821a947cc5a"
+  end
+
   depends_on "cmake" => :build
   depends_on "ninja" => :build
 

--- a/Formula/q/qtsvg.rb
+++ b/Formula/q/qtsvg.rb
@@ -1,0 +1,89 @@
+class Qtsvg < Formula
+  desc "Classes for displaying the contents of SVG files"
+  homepage "https://www.qt.io/"
+  url "https://download.qt.io/official_releases/qt/6.9/6.9.3/submodules/qtsvg-everywhere-src-6.9.3.tar.xz"
+  mirror "https://qt.mirror.constant.com/archive/qt/6.9/6.9.3/submodules/qtsvg-everywhere-src-6.9.3.tar.xz"
+  mirror "https://mirrors.ukfast.co.uk/sites/qt.io/archive/qt/6.9/6.9.3/submodules/qtsvg-everywhere-src-6.9.3.tar.xz"
+  sha256 "db76aa3358cbbe6fce7da576ff4669cb9801920188c750d3b12783bbe97026e2"
+  license all_of: [
+    { any_of: ["LGPL-3.0-only", "GPL-2.0-only", "GPL-3.0-only"] },
+    "BSD-3-Clause", # *.cmake
+  ]
+  head "https://code.qt.io/qt/qtsvg.git", branch: "dev"
+
+  livecheck do
+    formula "qtbase"
+  end
+
+  depends_on "cmake" => [:build, :test]
+  depends_on "ninja" => :build
+  depends_on "pkgconf" => :test
+
+  depends_on "qtbase"
+
+  uses_from_macos "zlib"
+
+  def install
+    args = ["-DCMAKE_STAGING_PREFIX=#{prefix}"]
+    args << "-DQT_NO_APPLE_SDK_AND_XCODE_CHECK=ON" if OS.mac?
+
+    system "cmake", "-S", ".", "-B", "build", "-G", "Ninja",
+                    *args, *std_cmake_args(install_prefix: HOMEBREW_PREFIX, find_framework: "FIRST")
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+
+    # Some config scripts will only find Qt in a "Frameworks" folder
+    frameworks.install_symlink lib.glob("*.framework") if OS.mac?
+  end
+
+  test do
+    (testpath/"CMakeLists.txt").write <<~CMAKE
+      cmake_minimum_required(VERSION 4.0)
+      project(test VERSION 1.0.0 LANGUAGES CXX)
+      find_package(Qt6 REQUIRED COMPONENTS Svg)
+      add_executable(test main.cpp)
+      target_link_libraries(test PRIVATE Qt6::Svg)
+    CMAKE
+
+    (testpath/"test.pro").write <<~QMAKE
+      QT      += svg
+      TARGET   = test
+      CONFIG  += console
+      CONFIG  -= app_bundle
+      TEMPLATE = app
+      SOURCES += main.cpp
+    QMAKE
+
+    (testpath/"main.cpp").write <<~CPP
+      #undef QT_NO_DEBUG
+      #include <QImageReader>
+      #include <QtSvg>
+
+      int main(void) {
+        QSvgGenerator generator;
+        const auto &list = QImageReader::supportedImageFormats();
+        Q_ASSERT(list.contains("svg"));
+        Q_ASSERT(list.contains("svgz"));
+        return 0;
+      }
+    CPP
+
+    ENV["LC_ALL"] = "en_US.UTF-8"
+    ENV["QT_QPA_PLATFORM"] = "minimal" if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"]
+
+    system "cmake", "-S", ".", "-B", "cmake"
+    system "cmake", "--build", "cmake"
+    system "./cmake/test"
+
+    ENV.delete "CPATH" if OS.mac?
+    mkdir "qmake" do
+      system Formula["qtbase"].bin/"qmake", testpath/"test.pro"
+      system "make"
+      system "./test"
+    end
+
+    flags = shell_output("pkgconf --cflags --libs Qt6Svg").chomp.split
+    system ENV.cxx, "-std=c++17", "main.cpp", "-o", "test", *flags
+    system "./test"
+  end
+end

--- a/Formula/q/qtsvg.rb
+++ b/Formula/q/qtsvg.rb
@@ -15,6 +15,14 @@ class Qtsvg < Formula
     formula "qtbase"
   end
 
+  bottle do
+    sha256 cellar: :any,                 arm64_tahoe:   "1b999d5ec5374d07bf0bd9054bbfa07e5c99600a2a66ac1443a60f82db322ca8"
+    sha256 cellar: :any,                 arm64_sequoia: "1c957a3056610a7c6df750b38cb77e1f36be981755f8c6b13be05fd5bd9c0b15"
+    sha256 cellar: :any,                 arm64_sonoma:  "207ffa2660c6101fcdaeb82fb96f3f4fe01908c0c8e5d5768857ed74dfaca5cb"
+    sha256 cellar: :any,                 sonoma:        "25d2a966b420dedf3c935cb08339b4b57bc0fccf3e9c6e21f754cd82fdb6e819"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0520e7c62d0c903d2bd5a75c5e8493ea13e0f21b0dd8d72c96e5f65a17509eee"
+  end
+
   depends_on "cmake" => [:build, :test]
   depends_on "ninja" => :build
   depends_on "pkgconf" => :test

--- a/style_exceptions/runtime_cpu_detection_allowlist.json
+++ b/style_exceptions/runtime_cpu_detection_allowlist.json
@@ -40,6 +40,7 @@
   "pytorch",
   "qt",
   "qt@5",
+  "qtbase",
   "spades",
   "spidermonkey",
   "svt-av1",


### PR DESCRIPTION
- qtbase 6.9.3 (new formula)
- qtsvg 6.9.3 (new formula)
- qtimageformats 6.9.3 (new formula)
- qtshadertools 6.9.3 (new formula)
- qtlanguageserver 6.9.3 (new formula)
- qtdeclarative 6.9.3 (new formula)
- qtconnectivity 6.9.3 (new formula)
- qtserialport 6.9.3 (new formula)
- qtpositioning 6.9.3 (new formula)

---

Updated these from my old PR #209644 and now trying staging branch.

Other changes to `qtbase` on top of `qt` formula:
* More accurate license, though not exhaustive (can do a follow up later on).
* Remove bundled libraries before build to avoid any possible usage
* `-DFEATURE_openssl_linked=ON` to include in linkage rather than dynamically loading it.
* `-DQT_NO_APPLE_SDK_AND_XCODE_CHECK=ON` as this should handle `-DQT_FORCE_WARN_APPLE_SDK_AND_XCODE_CHECK=ON` for older OS and also avoid warning on newer OS like Tahoe. The check isn't useful for us.
* Restore relocatable install on macOS. Not available on Linux due to how upstream code uses absolute rather than real paths.

TBD:
* Naming scheme

---

<details>
<summary>TODO for future PRs</summary>

- [ ] `qt3d`
- [ ] `qt5compat`
- [ ] `qtcharts`
- [ ] `qtdatavis3d`
- [ ] `qtdoc`
- [ ] `qtgraphs`
- [ ] `qtgrpc`
- [ ] `qthttpserver`
- [ ] `qtlocation`
- [ ] `qtlottie`
- [ ] `qtmultimedia`
- [ ] `qtnetworkauth`
- [ ] `qtquick3d`
- [ ] `qtquick3dphysics`
- [ ] `qtquickeffectmaker`
- [ ] `qtquicktimeline`
- [ ] `qtremoteobjects`
- [ ] `qtscxml`
- [ ] `qtsensors`
- [ ] `qtserialbus`
- [ ] `qtspeech`
- [ ] `qttools`
- [ ] `qttranslations`
- [ ] `qtvirtualkeyboard`
- [ ] `qtwayland`
- [ ] `qtwebchannel`
- [ ] `qtwebengine`
- [ ] `qtwebsockets`
- [ ] `qtwebview`
</details>