### PR TITLE
adjfind 0.1.1 (new formula)

### DIFF
--- a/Formula/a/adjfind.rb
+++ b/Formula/a/adjfind.rb
@@ -1,0 +1,34 @@
+class Adjfind < Formula
+  desc "C++ program with specialized path finding algorithms for adjacency/proximity"
+  homepage "https://github.com/zwang-geog/AdjFind"
+  url "https://github.com/zwang-geog/AdjFind/archive/refs/tags/v0.1.1.tar.gz"
+  sha256 "4cc45499380590e6cb5e13b56a54d1f91f02f5241944b1f79d8a8a4c31ff9850"
+  license "MIT"
+
+  depends_on "cmake" => :build
+  depends_on "boost"
+  depends_on "gdal"
+
+  def install
+    # Create build directory
+    mkdir "build" do
+      # Configure with CMake
+      system "cmake", "..",
+             "-DCMAKE_BUILD_TYPE=Release",
+             "-DCMAKE_INSTALL_PREFIX=#{prefix}",
+             "-DCMAKE_POSITION_INDEPENDENT_CODE=ON",
+             *std_cmake_args
+
+      # Build
+      system "cmake", "--build", ".", "--config", "Release"
+
+      # Install
+      system "cmake", "--install", "."
+    end
+  end
+
+  test do
+    # Test that the executable runs and shows help
+    system bin/"adjfind", "--help"
+  end
+end


### PR DESCRIPTION
A C++ program containing specialized path finding algorithms related to adjacency/proximity.

Supports three main modes:
- Road Segmentation Mode: Determines which service points are closest to each road segment using network distance
- Neighboring Points Mode: Identifies nearest neighboring service points along road networks
- Structure Access Mode: Computes shortest unobstructed paths from building corners to road networks

Built with CMake, requires GDAL and Boost Geometry library.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
