### PR TITLE
aoj-cli 1.0.0 (new formula)

### DIFF
--- a/Formula/a/aoj-cli.rb
+++ b/Formula/a/aoj-cli.rb
@@ -1,0 +1,28 @@
+class AojCli < Formula
+  desc "Command-line interface for Aizu Online Judge (AOJ)"
+  homepage "https://github.com/YuminosukeSato/AOJ-cli"
+  url "https://github.com/YuminosukeSato/AOJ-cli/archive/refs/tags/v1.0.0.tar.gz"
+  sha256 "8558c5e7285b7d3cf406018018b6b637a3298f209cf1761455d4ad1d550d0e47"
+  license "MIT"
+  head "https://github.com/YuminosukeSato/AOJ-cli.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args(ldflags: "-s -w"), "./cmd/aojcli"
+
+    # Rename the binary to 'aoj'
+    bin.install "aojcli" => "aoj"
+
+    # Generate shell completions if available
+    generate_completions_from_executable(bin/"aoj", "completion") if (bin/"aoj").exist?
+  end
+
+  test do
+    # Test the binary exists and runs
+    assert_match "AOJ CLI", shell_output("#{bin}/aoj --help")
+
+    # Test basic functionality without requiring network
+    assert_match "Usage:", shell_output("#{bin}/aoj --help")
+  end
+end


### PR DESCRIPTION
## Description
Command-line interface for Aizu Online Judge (AOJ), inspired by atcoder-cli.

AOJ CLI streamlines competitive programming workflow by providing authentication, problem downloading, local testing, and direct submission to AOJ from the terminal.

## Checklist
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`?
- [x] Have you run `brew audit --strict <formula>` and addressed any errors?
- [x] Have you run `brew test <formula>` and ensured the test passes?

## Notes
First submission of AOJ CLI to Homebrew Core.
Project repository: https://github.com/YuminosukeSato/AOJ-cli