### PR TITLE
various: modify `no_autobump!` stanza

### DIFF
--- a/Formula/l/logtalk.rb
+++ b/Formula/l/logtalk.rb
@@ -12,7 +12,7 @@ class Logtalk < Formula
     regex(/Latest stable version:.*?v?(\d+(?:\.\d+)+)/i)
   end
 
-  no_autobump! because: :requires_manual_review
+  no_autobump! because: :bumped_by_upstream
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "b8d1adc6b8dad0f9e778bbec53705202dea06b84105c501ad53979bc2140cd29"

--- a/Formula/m/meilisearch.rb
+++ b/Formula/m/meilisearch.rb
@@ -13,6 +13,8 @@ class Meilisearch < Formula
     strategy :github_latest
   end
 
+  no_autobump! because: :bumped_by_upstream
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "841f096e70d2270e9a317e5d7c1e19a636c7e3aa3b3c9de49dd27a3392858e8e"
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "749923b3a193d318ef09a50bfe2a71d2e2496c5e1773972c57b59f67989d32bf"

--- a/Formula/p/packetry.rb
+++ b/Formula/p/packetry.rb
@@ -5,8 +5,6 @@ class Packetry < Formula
   sha256 "158cd25536c6d4feab2b9e76fcbb4174fdb2fd6fb1c309775a3b2efbe84db33b"
   license "BSD-3-Clause"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "7b44a327337008bac85d41e08c6c01d443ec193d25671791275bb846fbb49a98"
     sha256 cellar: :any,                 arm64_sequoia: "96b22357843f520ea804060b1a2016ca1597d2944bd9ba421ee18cb4400aed5f"

--- a/Formula/p/phrase-cli.rb
+++ b/Formula/p/phrase-cli.rb
@@ -5,7 +5,7 @@ class PhraseCli < Formula
   sha256 "407ae4113852e949ab7418d515879bfd71beec58739a01355f6c631fa0dcb1c7"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
+  no_autobump! because: :bumped_by_upstream
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "0e9852fd561d87376838c75b1b002e6013a4ee28b82a02a3f7dfda9d5af7f350"

--- a/Formula/u/unciv.rb
+++ b/Formula/u/unciv.rb
@@ -10,6 +10,8 @@ class Unciv < Formula
     regex(/^v?(\d+(?:\.\d+)+(?:[._-]?patch\d*)?)$/i)
   end
 
+  no_autobump! because: :bumped_by_upstream
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "65d683fb47f383768046cf27b8122ca9eb79952db26e05cce2fe30e63985b259"
   end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
logtalk, meilisearch, phrase-cli, and unciv are bumped by upstream using github actions

packetry can be added to autobump list