### PR TITLE
audit_exceptions: add `relicensed_formulae_versions.json`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,16 +9,17 @@
 # Note: @Homebrew/plc does not have write-access to this repository, and therefore cannot be listed in this file.
 
 CODEOWNERS                        @Homebrew/tsc @MikeMcQuaid
-CONTRIBUTING.md                   @Homebrew/tsc @MikeMcQuaid 
-tap_migrations.json               @Homebrew/tsc @MikeMcQuaid 
-.github/ISSUE_TEMPLATE/           @Homebrew/tsc @MikeMcQuaid 
-.github/PULL_REQUEST_TEMPLATE.md  @Homebrew/tsc @MikeMcQuaid 
+CONTRIBUTING.md                   @Homebrew/tsc @MikeMcQuaid
+tap_migrations.json               @Homebrew/tsc @MikeMcQuaid
+.github/ISSUE_TEMPLATE/           @Homebrew/tsc @MikeMcQuaid
+.github/PULL_REQUEST_TEMPLATE.md  @Homebrew/tsc @MikeMcQuaid
 LICENSE.txt                       @Homebrew/tsc @MikeMcQuaid
-.github/workflows/                @Homebrew/core @MikeMcQuaid 
+.github/workflows/                @Homebrew/core @MikeMcQuaid
 .github/workflows/triage.yml      @Homebrew/tsc
 
 audit_exceptions/linux_only_gcc_dependency_allowlist.json               @Homebrew/tsc
 audit_exceptions/permitted_formula_license_mismatches.json              @Homebrew/tsc @MikeMcQuaid
 audit_exceptions/provided_by_macos_depends_on_allowlist.json            @Homebrew/tsc @MikeMcQuaid
-audit_exceptions/universal_binary_allowlist.json                        @Homebrew/tsc @carlocab 
+audit_exceptions/relicensed_formulae_versions.json                      @Homebrew/tsc @MikeMcQuaid
+audit_exceptions/universal_binary_allowlist.json                        @Homebrew/tsc @carlocab
 audit_exceptions/versioned_formula_dependent_conflicts_allowlist.json   @Homebrew/tsc @MikeMcQuaid

--- a/audit_exceptions/relicensed_formulae_versions.json
+++ b/audit_exceptions/relicensed_formulae_versions.json
@@ -1,0 +1,4 @@
+{
+  "liquibase": "5.0.0",
+  "terraform": "1.6"
+}


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
