### PR TITLE
eigen 5.0.0

### DIFF
--- a/Aliases/eigen@5
+++ b/Aliases/eigen@5
@@ -1,0 +1,1 @@
+../Formula/e/eigen.rb

--- a/Formula/a/alpscore.rb
+++ b/Formula/a/alpscore.rb
@@ -4,6 +4,7 @@ class Alpscore < Formula
   url "https://github.com/ALPSCore/ALPSCore/archive/refs/tags/v2.3.2.tar.gz"
   sha256 "bd9b5af0a33acc825ffedfaa0bf794a420ab2b9b50f6a4e634ecbde43ae9cc24"
   license "GPL-2.0-only"
+  revision 1
 
   bottle do
     rebuild 1
@@ -29,9 +30,14 @@ class Alpscore < Formula
 
   # Apply open PR to support Eigen 5.0.0
   # PR ref: https://github.com/ALPSCore/ALPSCore/pull/651
+  # PR ref: https://github.com/ALPSCore/ALPSCore/pull/656
   patch do
-    url "https://github.com/ALPSCore/ALPSCore/commit/0a7952abb3570e48d04d435d7d9d16ecbd06fb2a.patch?full_index=1"
-    sha256 "f007f65367528149ce5c4ad871aea600bbe05dd374c100588d577a07e3a05818"
+    url "https://github.com/ALPSCore/ALPSCore/commit/b2e21ce65b323196f04490c362694f0c30f8cdde.patch?full_index=1"
+    sha256 "8f237373e7a945126e5a1b88d8707ea2d67a263369134d6302205646f35af4e5"
+  end
+  patch do
+    url "https://github.com/ALPSCore/ALPSCore/commit/98a707d2bef2520df1fccfaf132c94ca7c909bb6.patch?full_index=1"
+    sha256 "ad13d526ccbc7f7c90c1bf2895e7bc0143ad8630729d616d391e86d04ffaecd9"
   end
 
   def install

--- a/Formula/a/alpscore.rb
+++ b/Formula/a/alpscore.rb
@@ -7,13 +7,12 @@ class Alpscore < Formula
   revision 1
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_tahoe:   "86681a415ce9b23f7664b88625224dd56d8a55c718e698f2627cf627a34a36a9"
-    sha256 cellar: :any,                 arm64_sequoia: "f2ff9f51f2beb340a170abe4f12766fe64610c553ee3663b114b30e906bd63e6"
-    sha256 cellar: :any,                 arm64_sonoma:  "9dd1b63f515a48f80865690450291d797cda75ac505fb75454c1a86fd50f8c7d"
-    sha256 cellar: :any,                 sonoma:        "f104a219812971245726f55e4c1134f06871b6691f5730d90d6df3b243460410"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "b97b22e40afaa673e367c222e424c8539d73e9c495e8a9e1660b2ff26fa94a2e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f96e68846f519f016c8d6e661a6eebb6f8f2efbe44f8fc2ef6a64715fb825963"
+    sha256 cellar: :any,                 arm64_tahoe:   "c126dec161f1b5f224e3811bfa7725cffc28c07a7353117e732e73a5e98c545c"
+    sha256 cellar: :any,                 arm64_sequoia: "0f73bb0b70e164a8a4ea330153fb90a55704627dbce801fb2256dca62d068352"
+    sha256 cellar: :any,                 arm64_sonoma:  "d400c7a4d8877d42213b712c7ca565dd90810368bfe5f86b70557a8f8d0e2dd3"
+    sha256 cellar: :any,                 sonoma:        "4b977847e01b872501059cd69d19fd82a371b8a89c219967898a6ca48a39332d"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "0ac7f13cd5680672509610183e0d0b9cfce2a443011b1b8eb7d597170eb26496"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "39f48a1bbd7bb2136497962321d05351de1414aed5c6f37e178331cf5aa4d81e"
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/c/ceres-solver.rb
+++ b/Formula/c/ceres-solver.rb
@@ -1,11 +1,21 @@
 class CeresSolver < Formula
   desc "C++ library for large-scale optimization"
   homepage "http://ceres-solver.org/"
-  url "http://ceres-solver.org/ceres-solver-2.2.0.tar.gz"
-  sha256 "48b2302a7986ece172898477c3bcd6deb8fb5cf19b3327bc49969aad4cede82d"
   license "BSD-3-Clause"
-  revision 2
+  revision 3
   head "https://ceres-solver.googlesource.com/ceres-solver.git", branch: "master"
+
+  stable do
+    url "http://ceres-solver.org/ceres-solver-2.2.0.tar.gz"
+    sha256 "48b2302a7986ece172898477c3bcd6deb8fb5cf19b3327bc49969aad4cede82d"
+
+    # Backport support for eigen 5.0.0
+    patch :DATA # https://github.com/ceres-solver/ceres-solver/commit/f0720aeb84ec7bb479fe3618b30fa54981baf8fd
+    patch do
+      url "https://github.com/ceres-solver/ceres-solver/commit/f9b7b6651b108136a16df44d91fb31735645f5a7.patch?full_index=1"
+      sha256 "019006cc850b19b442e108118c599c98b18af8eb06ab37c22e6698c55d55a512"
+    end
+  end
 
   livecheck do
     url "http://ceres-solver.org/installation.html"
@@ -58,3 +68,28 @@ class CeresSolver < Formula
     assert_match "CONVERGENCE", shell_output("./build/helloworld")
   end
 end
+
+__END__
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f53e9981b..af932c6a7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -234,17 +234,9 @@ unset(CERES_COMPILE_OPTIONS)
+ 
+ # Eigen.
+ # Eigen delivers Eigen3Config.cmake since v3.3.3
+-find_package(Eigen3 3.3 REQUIRED)
++find_package(Eigen3 3.3.4 REQUIRED NO_MODULE)
+ if (Eigen3_FOUND)
+   message("-- Found Eigen version ${Eigen3_VERSION}: ${Eigen3_DIR}")
+-  if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64.*|AARCH64.*)" AND
+-      Eigen3_VERSION VERSION_LESS 3.3.4)
+-    # As per issue #289: https://github.com/ceres-solver/ceres-solver/issues/289
+-    # the bundle_adjustment_test will fail for Eigen < 3.3.4 on aarch64.
+-    message(FATAL_ERROR "-- Ceres requires Eigen version >= 3.3.4 on aarch64. "
+-      "Detected version of Eigen is: ${Eigen3_VERSION}.")
+-  endif()
+-
+   if (EIGENSPARSE)
+     message("-- Enabling use of Eigen as a sparse linear algebra library.")
+     list(APPEND CERES_COMPILE_OPTIONS CERES_USE_EIGEN_SPARSE)

--- a/Formula/c/ceres-solver.rb
+++ b/Formula/c/ceres-solver.rb
@@ -25,12 +25,12 @@ class CeresSolver < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "313ed5690a361970bdea14a72c09a8303dc2172b84fc1d8204dbb79b913d00e7"
-    sha256 cellar: :any,                 arm64_sequoia: "4e5508fed469c7de173c44f6875a93e27758aa61a1f3ee0daa1bea279b5703b5"
-    sha256 cellar: :any,                 arm64_sonoma:  "4dc3d66678294486b58e513950109a4d593286eeb02d21b076de35d1aae0d126"
-    sha256 cellar: :any,                 sonoma:        "c17ec0c69c71db298cc62c1447e9c108cbbd8711e676051d7768049ec6614caa"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "ceceda8cfbf36c576474fef71487f756ee03183c20453e1fe25ba304972ee994"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3bf8a2f59441ee79ae0d2fab7a7cfabf6f3aec910c1c2695a215fe673bf7a0c5"
+    sha256 cellar: :any,                 arm64_tahoe:   "81b100c1ef3f92810a9b4f2b9a602b7a1e6b6d7e11a88a677a2886f53fcaccb6"
+    sha256 cellar: :any,                 arm64_sequoia: "dae580fccf96c376fc90bca15973a3375dd56dfe6a3760a19041ec52fc6c621e"
+    sha256 cellar: :any,                 arm64_sonoma:  "66b7cfa4fabfc643db7d86944657198286a8665f2c00302071091680b6fa03b3"
+    sha256 cellar: :any,                 sonoma:        "d997d14192319044b9a573c2d550779dd24c90c574f2c285ca5d705de509f648"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "3dc978b76da56deeec522b9c78fee5348c3d34849704c218cef09c63604aea85"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1e9385fbe9eeb9f92b0a190ad029bbf9aa916d05c8784afcce5f86b307848ac8"
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/e/eigen.rb
+++ b/Formula/e/eigen.rb
@@ -20,7 +20,7 @@ class Eigen < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "64ee1c43cc38e7ceb2efcfacd905212dcb4ffb1434d3833c006cbffdd3a7608c"
+    sha256 cellar: :any_skip_relocation, all: "d0cef7ca9fbd856498d50ee5bd0de3cfb644fb2d49e303c5bd73bfc95cccf05d"
   end
 
   depends_on "cmake" => :build

--- a/Formula/e/eigen.rb
+++ b/Formula/e/eigen.rb
@@ -1,15 +1,13 @@
 class Eigen < Formula
   desc "C++ template library for linear algebra"
   homepage "https://gitlab.com/libeigen/eigen"
-  # TODO: remove LGPL from licenses in 5.0.0
-  url "https://gitlab.com/libeigen/eigen/-/archive/3.4.1/eigen-3.4.1.tar.gz"
-  sha256 "b93c667d1b69265cdb4d9f30ec21f8facbbe8b307cf34c0b9942834c6d4fdbe2"
+  url "https://gitlab.com/libeigen/eigen/-/archive/5.0.0/eigen-5.0.0.tar.gz"
+  sha256 "315c881e19e17542a7d428c5aa37d113c89b9500d350c433797b730cd449c056"
   license all_of: [
     "MPL-2.0",
     "Apache-2.0",   # BFloat16.h
     "BSD-3-Clause", # bindings to BLAS, LAPACKe and MKL
     "Minpack",      # LevenbergMarquardt
-    "LGPL-2.1-only", # IterativeSolvers, removed in 5.0.0
   ]
   head "https://gitlab.com/libeigen/eigen.git", branch: "master"
 
@@ -32,6 +30,7 @@ class Eigen < Formula
       -DEIGEN_BUILD_BLAS=OFF
       -DEIGEN_BUILD_LAPACK=OFF
     ]
+    args << "-DEIGEN_PRERELEASE_VERSION=" if build.stable?
 
     system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
     system "cmake", "--install", "build"
@@ -52,7 +51,7 @@ class Eigen < Formula
         std::cout << m << std::endl;
       }
     CPP
-    system ENV.cxx, "test.cpp", "-I#{include}/eigen3", "-o", "test"
+    system ENV.cxx, "-std=c++14", "test.cpp", "-I#{include}/eigen3", "-o", "test"
     assert_equal %w[3 -1 2.5 1.5], shell_output("./test").split
   end
 end

--- a/Formula/e/eigenpy.rb
+++ b/Formula/e/eigenpy.rb
@@ -25,12 +25,12 @@ class Eigenpy < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "5dba4558782405576b2cb6764135000d9a4cad5cf38e500a4a1f3f8dd612063c"
-    sha256 cellar: :any,                 arm64_sequoia: "95797a7a45aa19440352ab14e0f1920135961f6d435cbb0c9f498c98c4c50581"
-    sha256 cellar: :any,                 arm64_sonoma:  "3a4339729cbcafebc07c2b2ed45aa5f18f02fba8ab78dbbdb9918fcdbb773543"
-    sha256 cellar: :any,                 sonoma:        "a287960361234bde9ee9c17481222d81b4231eb67ec80314a77ae0089ce8df90"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "9abf2e0f4f9b183f5872193216ef47e0370a5a4ba298e61b90288cad3a6320c1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f48af78a3b5b26b468884fdee921e7b2c322defbd51a7a8dfacbc7277f633e1b"
+    sha256 cellar: :any,                 arm64_tahoe:   "4bc4249358018e11dbf082882d5a8d280ff61a6aaaf9dcb02c9731873eb282e2"
+    sha256 cellar: :any,                 arm64_sequoia: "d85e4f6055f6991659dc3f1c891b050d462d194a4e2d31736e347e22634bb640"
+    sha256 cellar: :any,                 arm64_sonoma:  "bac224417799d9a62f1f9593e8104c4c4604ebc28864dbce0575d190d18a9eb9"
+    sha256 cellar: :any,                 sonoma:        "7259543d2fa81a1a80c7f5224e8d08fcbcec8eca95239a0346a679be8158e6ed"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "24dc41bef5374918602dfd3d6cf81a335c9ece6b9dfca174d27d2ea026f4e396"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "9738e55c4291e8105bca2f748b3626600219481daea1c31ab3e2744c92f5ec84"
   end
 
   depends_on "boost" => :build

--- a/Formula/e/eigenpy.rb
+++ b/Formula/e/eigenpy.rb
@@ -1,11 +1,28 @@
 class Eigenpy < Formula
   desc "Python bindings of Eigen library with Numpy support"
   homepage "https://github.com/stack-of-tasks/eigenpy"
-  url "https://github.com/stack-of-tasks/eigenpy/releases/download/v3.12.0/eigenpy-3.12.0.tar.gz"
-  sha256 "e6b7f17e1b7fb61e52447ceee8f47c3fc2c8f9cc4d19317e0467dc71babdb350"
   license "BSD-2-Clause"
-  revision 2
-  head "https://github.com/stack-of-tasks/eigenpy.git", branch: "master"
+  revision 3
+  head "https://github.com/stack-of-tasks/eigenpy.git", branch: "devel"
+
+  stable do
+    url "https://github.com/stack-of-tasks/eigenpy/releases/download/v3.12.0/eigenpy-3.12.0.tar.gz"
+    sha256 "e6b7f17e1b7fb61e52447ceee8f47c3fc2c8f9cc4d19317e0467dc71babdb350"
+
+    # Backport support for eigen 5.0.0
+    patch do
+      url "https://github.com/stack-of-tasks/eigenpy/commit/0bb71c7da9c297a334f2de419df13ba2c7a67312.patch?full_index=1"
+      sha256 "812274fc7fa68e3af3ede5324590aa2e7ae06f264ac1927989dfe6e324374791"
+    end
+    patch do
+      url "https://github.com/stack-of-tasks/eigenpy/commit/a64334c3ddbdd9ffd9f3b65a0b9c1e0d1d2b8c96.patch?full_index=1"
+      sha256 "2110114b6467e5e2889ea55b9e3b2ef5f8cc965a914bfd62d2335e526551d421"
+    end
+    patch do
+      url "https://github.com/stack-of-tasks/eigenpy/commit/2a4adb8af92eebd1dac321010db040797100b91d.patch?full_index=1"
+      sha256 "ef47a99123a391c6d3a7be683d5667b3d2f94562d1b4a6c8284c8acc1928b4c2"
+    end
+  end
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "5dba4558782405576b2cb6764135000d9a4cad5cf38e500a4a1f3f8dd612063c"

--- a/Formula/f/fcl.rb
+++ b/Formula/f/fcl.rb
@@ -1,11 +1,37 @@
 class Fcl < Formula
   desc "Flexible Collision Library"
   homepage "https://flexible-collision-library.github.io/"
-  url "https://github.com/flexible-collision-library/fcl/archive/refs/tags/0.7.0.tar.gz"
-  sha256 "90409e940b24045987506a6b239424a4222e2daf648c86dd146cbcb692ebdcbc"
   license "BSD-3-Clause"
-  revision 1
+  revision 2
   head "https://github.com/flexible-collision-library/fcl.git", branch: "master"
+
+  stable do
+    url "https://github.com/flexible-collision-library/fcl/archive/refs/tags/0.7.0.tar.gz"
+    sha256 "90409e940b24045987506a6b239424a4222e2daf648c86dd146cbcb692ebdcbc"
+
+    # Backport C++ standard changes
+    patch do
+      url "https://github.com/flexible-collision-library/fcl/commit/1257b4183e0ae4890294b0edea780605c2533cfd.patch?full_index=1"
+      sha256 "d3bb6bc82e926d4a89c19064f79b11506fa9899d52c46a482e3f9b41785b1291"
+    end
+
+    # Backport commits to apply subsequent patch
+    patch do
+      url "https://github.com/flexible-collision-library/fcl/commit/beffa1bb54da6686e8167843e051a3f9a2bad6f7.patch?full_index=1"
+      sha256 "ab2058f7316e8ad6e9caa253e94c6f8dcad633ae02473d6353b9003552909525"
+    end
+    patch do
+      url "https://github.com/flexible-collision-library/fcl/commit/3c2b993a0b1a10f888a53cce4f3c73035ab862c3.patch?full_index=1"
+      sha256 "a483773630e9f28c59ace7edacb0a782c9b6a1830514b92e1465ce4828e1111d"
+    end
+
+    # Apply open PR to add cassert includes needed for eigen 5.0.0
+    # PR ref: https://github.com/flexible-collision-library/fcl/pull/649
+    patch do
+      url "https://github.com/flexible-collision-library/fcl/commit/75ad2bc55acefb6c5638ed2730827530b4b7a176.patch?full_index=1"
+      sha256 "6265c1178fe237313e107ae19386d7fc5d69638213d705290ddb61aea0b0fda2"
+    end
+  end
 
   no_autobump! because: :requires_manual_review
 
@@ -29,7 +55,7 @@ class Fcl < Formula
   depends_on "octomap"
 
   def install
-    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    system "cmake", "-S", ".", "-B", "build", "-DCMAKE_CXX_STANDARD=14", *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
   end
@@ -44,7 +70,7 @@ class Fcl < Formula
       }
     CPP
 
-    system ENV.cxx, "test.cpp", "-std=c++11", "-I#{include}",
+    system ENV.cxx, "test.cpp", "-std=c++14", "-I#{include}",
                     "-I#{Formula["eigen"].include}/eigen3",
                     "-L#{lib}", "-lfcl", "-o", "test"
     system "./test"

--- a/Formula/f/fcl.rb
+++ b/Formula/f/fcl.rb
@@ -36,16 +36,12 @@ class Fcl < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:    "bd6336e3163c45d2b6a7966cafc3a3dac0f48919e43e189b52e564684ed2b35c"
-    sha256 cellar: :any,                 arm64_sequoia:  "0ab8eb79ee5ae022e186975198bd18da7cde25c41cb9e52e70366bf20de59e48"
-    sha256 cellar: :any,                 arm64_sonoma:   "6a4d2a1e04f17fb6cf2d7ed92524f09a841c3b212f3ecf22d9dc00dd294bb895"
-    sha256 cellar: :any,                 arm64_ventura:  "d147e210255b79430e8fed2455325c53aa0975c2f081b39c44050c5921efd813"
-    sha256 cellar: :any,                 arm64_monterey: "05d4d212709bccf7dc0f78eb01882937cdfa656ee019b47493baf6c404d33359"
-    sha256 cellar: :any,                 sonoma:         "24a08459f44fe31c2021fe74d4e3cc05dbc32141ad8d941e60c60863229e6635"
-    sha256 cellar: :any,                 ventura:        "06b3d235437c8047c3aa7d3951e15e254a6a81dc45546fb34d8732ddeaac68ba"
-    sha256 cellar: :any,                 monterey:       "199ee80d6917e61d200cb4ce8fd9516542270ce9eefdfb3139d98f203251fade"
-    sha256 cellar: :any_skip_relocation, arm64_linux:    "ba0e24c6cbceb1fde43ffafecf538b4b8b6c45ed1cd361deb12cca64db7136a1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "5840ff43dc2df33f18284bf49f0c29c254d5993d71da5d9939bb18ce316da35d"
+    sha256 cellar: :any,                 arm64_tahoe:   "520b5eb150c605c3d52439c344b97fc921978a7b766141f0deeb000d52a2be6c"
+    sha256 cellar: :any,                 arm64_sequoia: "c3d2ac35822520051226489edef7331201d92857144d64a6fbc16339570bfbd5"
+    sha256 cellar: :any,                 arm64_sonoma:  "84514294768694993849b6182e1c24956c437a05d1b3060033e5fb63590a81b9"
+    sha256 cellar: :any,                 sonoma:        "c940f7e641313fc86f737a53cdee88816a34e0d89b67f626df78144c9d932147"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "8a6759eb4c1576b674bdf4528dc205df0e1ded7d98701282abc1b5868084767b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5213117e4717273be6ea9baf0bccda5ad8ec98a258be6e125b41d151b0cc5e32"
   end
 
   depends_on "cmake" => :build

--- a/Formula/g/g2o.rb
+++ b/Formula/g/g2o.rb
@@ -5,6 +5,7 @@ class G2o < Formula
   version "20241228"
   sha256 "d691ead69184ebbb8256c9cd9f4121d1a880b169370efc0554dd31a64802a452"
   license "BSD-2-Clause"
+  revision 1
 
   livecheck do
     url :stable
@@ -24,6 +25,16 @@ class G2o < Formula
 
   depends_on "cmake" => :build
   depends_on "eigen"
+
+  # Backport support for eigen 5.0.0
+  patch do
+    url "https://github.com/RainerKuemmerle/g2o/commit/5ad2b3d8b550bad67242d90115f28c5b725da2a1.patch?full_index=1"
+    sha256 "f2c0139a045b0ef7380d56d368d1ee0cbd11feeff2dede9858d6a8532a7103bb"
+  end
+  patch do
+    url "https://github.com/RainerKuemmerle/g2o/commit/ef80e643adeb700536dd282dd4316c90cfc05fe8.patch?full_index=1"
+    sha256 "ac9abf38a4425fd95ceb4a295160bec5a2f2bbd2bb2f8695951ba9e0c101edc4"
+  end
 
   def install
     cmake_args = std_cmake_args + %w[-DG2O_BUILD_EXAMPLES=OFF]

--- a/Formula/g/g2o.rb
+++ b/Formula/g/g2o.rb
@@ -13,14 +13,14 @@ class G2o < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "8c43b5abf0708ddb98c08d56aad335d7a44789627413358ea7cd40d4a664bd12"
-    sha256 cellar: :any,                 arm64_sequoia: "14a9b3fa5a5807affa0289809e379b64edf01d701f3b5a654f2ca42b8325c41a"
-    sha256 cellar: :any,                 arm64_sonoma:  "9cad139379e98c63deaf37bed5ad74793ccb2730804f498e647faf996e8cc418"
-    sha256 cellar: :any,                 arm64_ventura: "ee55fcb396513cf2bdd28f279f6616c2e47cb5d86d19a7b2a4b5a0b30323952f"
-    sha256 cellar: :any,                 sonoma:        "b5dd18e068c2dd0e29b798854806ed1a441beca2b6d1c9b763b9891c7b6e4514"
-    sha256 cellar: :any,                 ventura:       "70d60d6efa8c3216129d34777c0715f7cfa5fa0c3a23f86335b0609ffb989dea"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "d017827ecc09b2036bee06e95bd388c87b95f57dc5f3b6a2c2790580a8676bb4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "432f0cc70da40868d5e102a30d2d4d0ce26c70b2431e5fa5fc4922de981b7046"
+    sha256 cellar: :any,                 arm64_tahoe:   "5ad0c65eda4765cf3816241e2d0604e2c2853783f6d9e8349843a97524f5fb43"
+    sha256 cellar: :any,                 arm64_sequoia: "e153559ae44f9a8f966ce19056422e03d812cca7c17e3787a9998ef2b03d12c5"
+    sha256 cellar: :any,                 arm64_sonoma:  "0effe3348f065a1ed358fd4555b51b5c28f02e846c21613452291db66690eea2"
+    sha256 cellar: :any,                 tahoe:         "e5b0c09abb8b30d083725953ccbff1f932572fb130a6b32fb406068e8d16bb40"
+    sha256 cellar: :any,                 sequoia:       "774980c34fa4a1e3bb4e7872f0fa5669786132ad28ed179d7377426d6bc9ed23"
+    sha256 cellar: :any,                 sonoma:        "bc60e66fe653f8541745eb9c767cef2b86b9710ea32d631020bdce5b03c7f8ae"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "0248efaf0de4f324fcab96dcb21faf224f4064249405f85ef7715bd3a2304001"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a5ba022e961df0b0629d7b57185a7867ede5c71151bf55720f06cee79fe75f61"
   end
 
   depends_on "cmake" => :build

--- a/Formula/i/ifopt.rb
+++ b/Formula/i/ifopt.rb
@@ -7,14 +7,12 @@ class Ifopt < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "5bf0d19327f812c4fafdd5bf01874b2d4a3699dc194d9e1d57cfe7936b8b6020"
-    sha256 cellar: :any,                 arm64_sequoia: "7f3e04dba4e270d64095bf3835bde2cf2fcb709e86cfbdad8d156859ff14238f"
-    sha256 cellar: :any,                 arm64_sonoma:  "e43d5ec40d0a0c692f6ab0271f10df4e5ab6a3dd0cbdb83209c274cf5d816324"
-    sha256 cellar: :any,                 arm64_ventura: "f545c8e42c49be06e5c7f2cf820d20850199be87eea52016a63aef2ae350ca66"
-    sha256 cellar: :any,                 sonoma:        "4c05cd8ad919c075bdd3eeb378b5cf0094e95a1157ed89c6645887c4a3fd2290"
-    sha256 cellar: :any,                 ventura:       "c1e79916555fefb52c6175c441b0a26f402dc6b8895313ea5ae7963c66434e11"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "832619dd1e2b379e80f7ec2447aaf912310f8ba8dd46b835c3afe892ee91a03c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3ab1eef461f9e9d7b924d607a0831ac311656735942aeb701a09b6bd504123b6"
+    sha256 cellar: :any,                 arm64_tahoe:   "864f67e4c11108278a44b019f9a10520097c130d228a634a83e23875eb36ed73"
+    sha256 cellar: :any,                 arm64_sequoia: "4d908163e23317019cf4fc7d2a8ea8a1b35f5bdf7ef67d787c6dca0dc3464c71"
+    sha256 cellar: :any,                 arm64_sonoma:  "d590493307a718a9917354c099f0270568b2638c92e5171d39483aab9601d9c9"
+    sha256 cellar: :any,                 sonoma:        "3976d40d74d9048118daf380378bc640c6021de1937ea449d3734a05de924e0c"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "957a65e9e0bfa0b1cea42e6d6fa0be3d1f362bc8d3070f0a2cdfde313cbec2dd"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4fd84637f15ad2aa59f01b9c42186bf9bc76d5a3ffd2a8d1e95af3b4e70ed7f3"
   end
 
   depends_on "cmake" => :build

--- a/Formula/i/ifopt.rb
+++ b/Formula/i/ifopt.rb
@@ -4,6 +4,7 @@ class Ifopt < Formula
   url "https://github.com/ethz-adrl/ifopt/archive/refs/tags/2.1.4.tar.gz"
   sha256 "da38f91a282f3ed305db163954c37d999b6e95f5d2c913a63bae3fef9ffb3a37"
   license "BSD-3-Clause"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "5bf0d19327f812c4fafdd5bf01874b2d4a3699dc194d9e1d57cfe7936b8b6020"
@@ -21,6 +22,13 @@ class Ifopt < Formula
   depends_on "eigen"
   depends_on "ipopt"
 
+  # Apply open PR to support eigen 5.0.0
+  # PR ref: https://github.com/ethz-adrl/ifopt/pull/110
+  patch do
+    url "https://github.com/ethz-adrl/ifopt/commit/deb3209d5e34cdaa896c7432f6ee1138148ddfda.patch?full_index=1"
+    sha256 "95e1ee352d1842811b2e015a78be304bfce0af867f8233f7e5e7e94aa01aae2d"
+  end
+
   def install
     system "cmake", "-S", ".", "-B", "build", "-DCMAKE_POLICY_VERSION_MINIMUM=3.5", *std_cmake_args
     system "cmake", "--build", "build"
@@ -30,7 +38,7 @@ class Ifopt < Formula
 
   test do
     cp pkgshare/"test/ex_test_ipopt.cc", "test.cpp"
-    system ENV.cxx, "-std=c++11", "test.cpp", "-o", "test",
+    system ENV.cxx, "-std=c++14", "test.cpp", "-o", "test",
                     "-I#{Formula["eigen"].opt_include}/eigen3",
                     "-L#{lib}", "-lifopt_core", "-lifopt_ipopt"
     assert_match "Optimal Solution Found", shell_output("./test")

--- a/Formula/l/lbfgspp.rb
+++ b/Formula/l/lbfgspp.rb
@@ -10,7 +10,7 @@ class Lbfgspp < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "915d14792b76cd42afb89064bd50c8119dcf4ba0f500d3d06032c6126a349011"
+    sha256 cellar: :any_skip_relocation, all: "5a7448c359aea68fd3317768eb086befc6442be56cf0d1c864d59aea9150d9da"
   end
 
   depends_on "cmake" => :build

--- a/Formula/l/lbfgspp.rb
+++ b/Formula/l/lbfgspp.rb
@@ -4,6 +4,7 @@ class Lbfgspp < Formula
   url "https://github.com/yixuan/LBFGSpp/archive/refs/tags/v0.4.0.tar.gz"
   sha256 "39c4aaebd8b94ccdc98191d51913a31cddd618cc0869d99f07a4b6da83ca6254"
   license "MIT"
+  revision 1
   head "https://github.com/yixuan/LBFGSpp.git", branch: "master"
 
   no_autobump! because: :requires_manual_review
@@ -14,6 +15,13 @@ class Lbfgspp < Formula
 
   depends_on "cmake" => :build
   depends_on "eigen"
+
+  # Apply open PR to support eigen 5.0.0
+  # PR ref: https://github.com/yixuan/LBFGSpp/pull/48
+  patch do
+    url "https://github.com/yixuan/LBFGSpp/commit/b7c91e57a7e5319b4f168ab5e381e92e95236694.patch?full_index=1"
+    sha256 "fbd364dae7afe1ae36b344a82425e42d4702f60da7e17e6789d289c03e0bef5e"
+  end
 
   def install
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args
@@ -62,7 +70,7 @@ class Lbfgspp < Formula
           return 0;
       }
     CPP
-    system ENV.cxx, testpath/"test.cpp", "-std=c++11",
+    system ENV.cxx, testpath/"test.cpp", "-std=c++14",
            "-I#{include}", "-I#{Formula["eigen"].opt_include}/eigen3",
            "-o", "test"
     assert_equal "1 1 1 1 1 1 1 1 1 1", shell_output(testpath/"test").chomp

--- a/Formula/o/open-babel.rb
+++ b/Formula/o/open-babel.rb
@@ -2,7 +2,7 @@ class OpenBabel < Formula
   desc "Chemical toolbox"
   homepage "https://github.com/openbabel/openbabel"
   license "GPL-2.0-only"
-  revision 2
+  revision 3
   head "https://github.com/openbabel/openbabel.git", branch: "master"
 
   stable do
@@ -64,6 +64,13 @@ class OpenBabel < Formula
     args << "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
     inreplace "CMakeLists.txt", "cmake_policy(SET CMP0042 OLD)",
                                 "cmake_policy(SET CMP0042 NEW)"
+
+    # Workaround to build with eigen 5.0.0
+    # Issue ref: https://github.com/openbabel/openbabel/issues/2839
+    args += %W[-DEIGEN3_FOUND=ON -DEIGEN3_INCLUDE_DIR=#{Formula["eigen"].opt_include}/eigen3]
+    inreplace "CMakeLists.txt", "set (CMAKE_CXX_STANDARD 11)", "set (CMAKE_CXX_STANDARD 14)"
+    rm "cmake/modules/FindEigen3.cmake"
+
     system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"

--- a/Formula/o/open-babel.rb
+++ b/Formula/o/open-babel.rb
@@ -19,13 +19,12 @@ class OpenBabel < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    rebuild 5
-    sha256                               arm64_tahoe:   "8aa3929bd15d13c66d1b5443dbfd8fd98e02b9cce1d63032888c915b44485d46"
-    sha256                               arm64_sequoia: "65eafc217a10604751abd22e88287b1438b102ec350c5ad048d5bcdcfd2c7a7b"
-    sha256                               arm64_sonoma:  "714b33b9ca188ed6ccd80f1685bd3ec3cf1d2a3943de60e406e1f796ceb93407"
-    sha256                               sonoma:        "ed785e17d0df66435ca7f7e717e1c9b15bba10963fd6ba7b23d8c016e796c8d0"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "2322af7a05a516be0a2249ab927ccdefe9017d68bd8792de30720067e9a832ae"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "ab9fd08d3145a9a52d22f61e352fcc4a32fd09ec94760c44202b5e5ffda86a15"
+    sha256                               arm64_tahoe:   "c47e9e8ea40a2696cec7bd243305ae343b0155fb83ea762de2fd19206d1d0fdd"
+    sha256                               arm64_sequoia: "b27a40c13f6483684ad331885588426d47769ae3e908eddfa85fc9b9fcb5d534"
+    sha256                               arm64_sonoma:  "aea63f9ac32d735934c888291feeaed2e0df311d9d9ca245c2a3badae11785bf"
+    sha256                               sonoma:        "17283bbbb30e3510464a2317b3de1103b5d7a40a362317cc5ec073ece0991a97"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "17fdce92285bb7c5701d4c10c24fff72e53a790537a3951ef78776c9a9e85b66"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d46e406f2ac959683c827270395e4dea9f2601f00cd7c657e549cdfcd01844b2"
   end
 
   depends_on "cmake" => :build

--- a/Formula/o/opencv.rb
+++ b/Formula/o/opencv.rb
@@ -2,7 +2,7 @@ class Opencv < Formula
   desc "Open source computer vision library"
   homepage "https://opencv.org/"
   license "Apache-2.0"
-  revision 13
+  revision 14
 
   stable do
     url "https://github.com/opencv/opencv/archive/refs/tags/4.12.0.tar.gz"
@@ -21,6 +21,12 @@ class Opencv < Formula
     patch do
       url "https://github.com/opencv/opencv/commit/90c444abd387ffa70b2e72a34922903a2f0f4f5a.patch?full_index=1"
       sha256 "5b662eea7b5de1dac3e06895c711955c9d1515d1202191b68594f4f9cfa23242"
+    end
+
+    # Backport support for eigen 5.0.0
+    patch do
+      url "https://github.com/opencv/opencv/commit/468de9b36740b3355f0d5cd8be2ce28b340df120.patch?full_index=1"
+      sha256 "b86ca3cf644a49ab7219348db2bc78497235df75ceef714d46fc80e9e80f2a06"
     end
   end
 

--- a/Formula/o/opencv.rb
+++ b/Formula/o/opencv.rb
@@ -38,12 +38,12 @@ class Opencv < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 arm64_tahoe:   "69878e1c23e30f06c6144ad65e7d069a96f958858bd23e9cd75db0c2a30e203e"
-    sha256 arm64_sequoia: "be1a00992a5ecafb7cc0757a88501a7bc7c372e9f94719ff66418e71b67121ca"
-    sha256 arm64_sonoma:  "43de3d8788aa3d328019bf148328fa7255016fd0ed2896b6bb2c9412bcb420f8"
-    sha256 sonoma:        "fd55a0d753703064d3cfff30c35d0793e903fa080daba5e8c5ad504ea6979d8d"
-    sha256 arm64_linux:   "92608887fab48ee5dbe5e0ed2ea3064bef29fc27b72b2fd0b92bad5c107849b5"
-    sha256 x86_64_linux:  "577df23fd07c1cec9a1582a2342c3e67d4f7d8a08a741b8790f1117ecbb388b9"
+    sha256 arm64_tahoe:   "4e73ba74aacb6c6904a67c4374fe3f321ab83c8850c69c1ec84c31625c782dff"
+    sha256 arm64_sequoia: "b4ca0e76f80388b82b6815f226a2478f1d6ebbaf004d0bc86f85f24c89234c26"
+    sha256 arm64_sonoma:  "1314a31b08110b7a02e8b045a4a3a7c3f63f4ba99091d7a2fbc9860fbe68b232"
+    sha256 sonoma:        "eef9799d1c8c66174010c4ae3fcfc5da425c242c766be3a8d3c41d618f239658"
+    sha256 arm64_linux:   "b6ff9c31554869d2f2599a2089826fb53ab47a3dec8b0bdd252aecd77dcc348e"
+    sha256 x86_64_linux:  "b8687c6d87099cb5e1c959ac0390365ac0ca082d793c3dc78c9320c80031f7c2"
   end
 
   head do

--- a/Formula/o/orocos-kdl.rb
+++ b/Formula/o/orocos-kdl.rb
@@ -7,12 +7,14 @@ class OrocosKdl < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "63bd25562899d50286d71174337878609041305d72923eee5eee59110ed8a688"
-    sha256 cellar: :any,                 arm64_sequoia: "481e5428dee3a6c21cd778be800155f2769d068be19d320d725dcebff21de6b8"
-    sha256 cellar: :any,                 arm64_sonoma:  "a1eaebcc52b6ac3618084d0da355f989d3c11cd4d9bb9ff5dd4f09decd2536aa"
-    sha256 cellar: :any,                 sonoma:        "24a8d96dfaa3d6b7e2721b8d8fa5c5f2727e0a2c49d45fcf5ee22f6ba6a20b11"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "6939db142728ba767a4fa239a9289740380386aa7ebe03cccfaa177e73a579a8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "09b0ae0640e6e94d36f6d1e87c612cf5a06a56b9f401b3756df6f1e7a3d40941"
+    sha256 cellar: :any,                 arm64_tahoe:   "f426120fbf55e9662b30801031021f06f97de8dceb6fa2b191767868e858f411"
+    sha256 cellar: :any,                 arm64_sequoia: "731dac44439182078ff405304de91785dd85c8c63ccdb9ace10b6c6892755b9a"
+    sha256 cellar: :any,                 arm64_sonoma:  "1e89c7a3075cb09bc42a48dac3e0615c3fb247610e47a1fed9b4ba16452523a7"
+    sha256 cellar: :any,                 tahoe:         "b3452bee349dfa41da18a7c9f3df3343561702441e13befe4f879bc4359c679e"
+    sha256 cellar: :any,                 sequoia:       "7c12c1c4509464c389d04d0a273e40d09e44da3df366ba5e889dc0051fa9823f"
+    sha256 cellar: :any,                 sonoma:        "c422791098d548a20a16a386b03514b3efddd1e4646804932559a98023ffd9f5"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "e0d188d3d5f65a19ecdd37d5a39d194177d341b70f755d7b8fb1459a59723fcd"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0b9fe98f805b5c9c3944a6288a5a3abdc262ee58755d259fbeb11f04571e30dc"
   end
 
   depends_on "cmake" => :build

--- a/Formula/o/orocos-kdl.rb
+++ b/Formula/o/orocos-kdl.rb
@@ -4,6 +4,7 @@ class OrocosKdl < Formula
   url "https://github.com/orocos/orocos_kinematics_dynamics/archive/refs/tags/1.5.3.tar.gz"
   sha256 "3895eed1b51a6803c79e7ac4acd6a2243d621b887ac26a1a6b82a86a1131c3b6"
   license "LGPL-2.1-or-later"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "63bd25562899d50286d71174337878609041305d72923eee5eee59110ed8a688"
@@ -18,8 +19,8 @@ class OrocosKdl < Formula
   depends_on "eigen"
 
   def install
-    ENV.cxx11
     system "cmake", "-S", "orocos_kdl", "-B", "build",
+                    "-DCMAKE_CXX_STANDARD=14",
                     "-DEIGEN3_INCLUDE_DIR=#{Formula["eigen"].opt_include}/eigen3",
                     *std_cmake_args
     system "cmake", "--build", "build"
@@ -39,7 +40,7 @@ class OrocosKdl < Formula
       }
     CPP
 
-    system ENV.cxx, "test.cpp", "-std=c++11", "-I#{include}", "-L#{lib}", "-lorocos-kdl",
+    system ENV.cxx, "test.cpp", "-std=c++14", "-I#{include}", "-L#{lib}", "-lorocos-kdl",
                     "-o", "test"
     system "./test"
   end

--- a/Formula/p/pagmo.rb
+++ b/Formula/p/pagmo.rb
@@ -7,14 +7,12 @@ class Pagmo < Formula
   revision 6
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "970141f824a1df8a43acb58e2d7f833d07b6fc783805fbeb691dafc8611c2f4d"
-    sha256 cellar: :any,                 arm64_sequoia: "d990228017c8de47ef6a251f01d9d3f1256692df3516459b13bbe9b409e45400"
-    sha256 cellar: :any,                 arm64_sonoma:  "a6f6f191b85a838faf5d10addc32f9f8e6565c4317caf8867bc80ce17d2ead44"
-    sha256 cellar: :any,                 arm64_ventura: "436417c8ba3422bd8fe6f3a5e8c5a20cd3256baae1137f3a928343303891414d"
-    sha256 cellar: :any,                 sonoma:        "669f2fed9d5aac73db355fa9ca25c2f16f9dbf32eaa9aae56ab9b2dc707e089c"
-    sha256 cellar: :any,                 ventura:       "3327fd6748b1d7cb0fffe50f567e9baea9c088e6c9c2e069aa1073ecd16fb2f3"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "44c6934ddde022ea5fbdeb64b5a8dfa0f0b3ad01407b051023a3ad274552fbd2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "ee1febbdbb2ebf081daef299a4cfbaea9b3f3182bd3efa0583fd2dee8bf1322b"
+    sha256 cellar: :any,                 arm64_tahoe:   "967ca7afd0f94fe22053b2cf187c97a14c853e160668700db06e8a64f76a704e"
+    sha256 cellar: :any,                 arm64_sequoia: "9d5ab6ee707031ed11dd9291c579b778e03ed5357a159fa2fa5c9b572c8fe49f"
+    sha256 cellar: :any,                 arm64_sonoma:  "4ec05c1307d3e5375802ddf095106412287eea4024037c4179960564284104f4"
+    sha256 cellar: :any,                 sonoma:        "9c6488dd49f684f62e4035943dc9a370a08eed979d71a5139061700570135ff3"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "fe0c1de3105984b315801418a3f104de528645485da9ca587777efe7b6da1820"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0bf66c10d87861392ebe1158c0f58ed438190310415b2f2093f53571c00eeaa7"
   end
 
   depends_on "cmake" => :build

--- a/Formula/p/pagmo.rb
+++ b/Formula/p/pagmo.rb
@@ -4,7 +4,7 @@ class Pagmo < Formula
   url "https://github.com/esa/pagmo2/archive/refs/tags/v2.19.1.tar.gz"
   sha256 "ecc180e669fa6bbece959429ac7d92439e89e1fd1c523aa72b11b6c82e414a1d"
   license any_of: ["LGPL-3.0-or-later", "GPL-3.0-or-later"]
-  revision 5
+  revision 6
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "970141f824a1df8a43acb58e2d7f833d07b6fc783805fbeb691dafc8611c2f4d"
@@ -22,6 +22,16 @@ class Pagmo < Formula
   depends_on "eigen"
   depends_on "nlopt"
   depends_on "tbb"
+
+  # Backport support for eigen 5.0.0
+  patch do
+    url "https://github.com/esa/pagmo2/commit/bdd8559d7663536c3a5f56b013f07da11a35c9b8.patch?full_index=1"
+    sha256 "f8679d6ca0d4bd5d9b44382da35ddc6f80404d389813ce05f050d00f5ce3706c"
+  end
+  patch do
+    url "https://github.com/esa/pagmo2/commit/d0e70403179769c326f2694673473e1d3ef0bec7.patch?full_index=1"
+    sha256 "6dcf5ac2cbd8e9b0de20845a51ef5d8eeb0ffd0472f32bcc833ce3f314718f0b"
+  end
 
   def install
     args = %w[

--- a/Formula/p/pcl.rb
+++ b/Formula/p/pcl.rb
@@ -17,13 +17,12 @@ class Pcl < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_tahoe:   "c06cc9485a67cba638ab78dbd215b4c8839f420e26fffed015bd0f95c7c07a70"
-    sha256 cellar: :any,                 arm64_sequoia: "982b8332e9e6de238fbf34c31057dc15767166f63f7b2b9c3f57f55d682e9b01"
-    sha256 cellar: :any,                 arm64_sonoma:  "122837c0587bd4e41ec76a36c5840d657e64e0d8465b53fa87f64637fbd66c1f"
-    sha256 cellar: :any,                 sonoma:        "d65d4d87b0f7e60a4be06db963bdaff7dca9c2bfaf837a2a79998838c8e6fc10"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "d545ba9d0477fb775588af1f44165524b90236acee0f715e8e3513fd1b42a7c6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0870d2eb742f352c2ca71955d0cd4711345bfec5beac6b8e903540a775d2cd64"
+    sha256 cellar: :any,                 arm64_tahoe:   "bffd9015641e8e0f41a330b289769f391526de7fce302c55b47a1810855c7714"
+    sha256 cellar: :any,                 arm64_sequoia: "05c3ab811e06258620ba9e48aed56ebd7554212475bf2edb28b02d733caf70d3"
+    sha256 cellar: :any,                 arm64_sonoma:  "ee46a4518eb4226857b485d46713fe174bc1ce94c50b00babb74e7490f88f838"
+    sha256 cellar: :any,                 sonoma:        "7c576693ae1468c7a962f072e67a453caf33f33fe9d8aabcd9cdf5606dbc2c49"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "c88cb862a00392e09048310d551d33f367d691af7320c9c261960bb7a3f7a6a8"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a5db03271116649a3db04c7895d4f37cc0c9b8297bd748418e10310570f2736e"
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/p/pcl.rb
+++ b/Formula/p/pcl.rb
@@ -1,11 +1,20 @@
 class Pcl < Formula
   desc "Library for 2D/3D image and point cloud processing"
   homepage "https://pointclouds.org/"
-  url "https://github.com/PointCloudLibrary/pcl/archive/refs/tags/pcl-1.15.1.tar.gz"
-  sha256 "e1d862c7b6bd27a45884a825a2e509bfcbd4561307d5bfe17ce5c8a3d94a6c29"
   license "BSD-3-Clause"
-  revision 1
+  revision 2
   head "https://github.com/PointCloudLibrary/pcl.git", branch: "master"
+
+  stable do
+    url "https://github.com/PointCloudLibrary/pcl/archive/refs/tags/pcl-1.15.1.tar.gz"
+    sha256 "e1d862c7b6bd27a45884a825a2e509bfcbd4561307d5bfe17ce5c8a3d94a6c29"
+
+    # Backport support for eigen 5.0.0
+    patch do
+      url "https://github.com/PointCloudLibrary/pcl/commit/2d6929bdcd98beaa28fa8ee3a105beb566f16347.patch?full_index=1"
+      sha256 "66e6b47a2373224f6a64a87124c94fbe79d3624b4cb0d71603c4805323343b62"
+    end
+  end
 
   bottle do
     rebuild 1

--- a/Formula/q/quantum++.rb
+++ b/Formula/q/quantum++.rb
@@ -4,6 +4,7 @@ class Quantumxx < Formula
   url "https://github.com/softwareQinc/qpp/archive/refs/tags/v6.0.tar.gz"
   sha256 "cdd6acf287b2f2dd124120ef2aba85660eee9482f5484dbd229c93b53a7d8a54"
   license "MIT"
+  revision 1
   head "https://github.com/softwareQinc/qpp.git", branch: "main"
 
   bottle do
@@ -14,6 +15,13 @@ class Quantumxx < Formula
   depends_on "googletest" => :build
   depends_on "eigen"
   depends_on "pybind11"
+
+  # Apply open PR to support eigen 5.0.0
+  # PR ref: https://github.com/softwareQinc/qpp/pull/192
+  patch do
+    url "https://github.com/softwareQinc/qpp/commit/dfe131d87ee304f7ceff5f346825874db3a7b7ed.patch?full_index=1"
+    sha256 "6cda6778e4799e9135b20330a506315de2e41dc6fe2775d07f00606750310a4c"
+  end
 
   def install
     args = %w[

--- a/Formula/q/quantum++.rb
+++ b/Formula/q/quantum++.rb
@@ -8,7 +8,7 @@ class Quantumxx < Formula
   head "https://github.com/softwareQinc/qpp.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "13832215cff599c6d60a58a3c40d0206d3f1082c0c42f1a8b9ee2a3c49087be8"
+    sha256 cellar: :any_skip_relocation, all: "99ebcbbe1c4f2197f74a726891f3dc35b93a34c1419d66bf568a4016c91ad9d3"
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/r/rtabmap.rb
+++ b/Formula/r/rtabmap.rb
@@ -17,13 +17,12 @@ class Rtabmap < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    rebuild 1
-    sha256                               arm64_tahoe:   "20a17805711d80ce4832d47579ed9364f7eab4efced20430b9f7ac71d0e86b6b"
-    sha256                               arm64_sequoia: "13d8848d802e0ce6afc36dc7b55c7fd758d841fde7865dd740c402af42b36818"
-    sha256                               arm64_sonoma:  "d8a8239c5d894d57f613789e70e27f9907dd05d0b2fe04d69407c714568cec78"
-    sha256                               sonoma:        "f765722a4937ee9af13ce4f84bc6a0d5152059eb88a66062d2b89318ad2ef6ff"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "fc9a8078f57e7cb5ab7a44a23a1ab03a0aaa93eaf6d575ebda6168795ebed23f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8db1652a2e0c0d1c6006fee21f2d2ea89e10a57996957c86838f3ade9cb09e95"
+    sha256                               arm64_tahoe:   "5ab791a5f38d7ad76eaba90c0abc16d8fc50d95618c4f3fa485c70f99d5094ca"
+    sha256                               arm64_sequoia: "f8fb6e3aa1a67d7cef01dda6f785f6dd15af1a9f54a967dcc9b49e8af4bdbe7c"
+    sha256                               arm64_sonoma:  "906cd0c764ddce8ad29e910dd28c10a1d1d7521e8a94d91f84b40835de10eb67"
+    sha256                               sonoma:        "354e88753335c1ec096ca6a6c10c9e915885ee559a1afa55b7ec6aad798017e4"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "28b477d18a34e7df7f12fa3f01d1bcd93e7a50b798464b3101bcd4d536bd9c00"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "9aa54a4462c4b890af182cef4321af20d943ccf35b835b272df6d8554b787c47"
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/r/rtabmap.rb
+++ b/Formula/r/rtabmap.rb
@@ -4,7 +4,7 @@ class Rtabmap < Formula
   url "https://github.com/introlab/rtabmap/archive/refs/tags/0.22.1.tar.gz"
   sha256 "3988ad84c409e39048a6b23317076d4ee1a0123e94a5ad6574db93647d7a80c0"
   license "BSD-3-Clause"
-  revision 4
+  revision 5
   head "https://github.com/introlab/rtabmap.git", branch: "master"
 
   # Upstream doesn't create releases for all tagged versions, so we use the
@@ -53,6 +53,9 @@ class Rtabmap < Formula
   end
 
   def install
+    # Use eigen's cmake configuration to support eigen 5.0.0
+    rm "cmake_modules/FindEigen3.cmake"
+
     system "cmake", "-S", ".", "-B", "build", "-DCMAKE_INSTALL_RPATH=#{rpath}", *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"

--- a/Formula/s/sophus.rb
+++ b/Formula/s/sophus.rb
@@ -4,6 +4,7 @@ class Sophus < Formula
   url "https://github.com/strasdat/Sophus/archive/refs/tags/1.24.6.tar.gz"
   sha256 "3f3098bdac2c74d42a921dbfb0e5e4b23601739e35a1c1236c2807c399da960c"
   license "MIT"
+  revision 1
   version_scheme 1
   head "https://github.com/strasdat/Sophus.git", branch: "main"
 
@@ -16,6 +17,13 @@ class Sophus < Formula
   depends_on "ceres-solver"
   depends_on "eigen"
   depends_on "fmt"
+
+  # Apply open PR to support eigen 5.0.0
+  # PR ref: https://github.com/strasdat/Sophus/pull/558
+  patch do
+    url "https://github.com/strasdat/Sophus/commit/fd3fcfa116f078d731d062d1d74f2b31aaf8854f.patch?full_index=1"
+    sha256 "0f91d6051c9b66051916a1c52fb223b63575a43ec941f5091a68848195aa2429"
+  end
 
   def install
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args,

--- a/Formula/s/sophus.rb
+++ b/Formula/s/sophus.rb
@@ -9,8 +9,7 @@ class Sophus < Formula
   head "https://github.com/strasdat/Sophus.git", branch: "main"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, all: "04f59dd02e4845866fc1513e4292e87432b29310adc0ebbc3c39f5ba4a1588ea"
+    sha256 cellar: :any_skip_relocation, all: "61f605f047032f7eadba09b95b8b76005c827b15fff2f484db5dd5322cc4499a"
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/s/spectra.rb
+++ b/Formula/s/spectra.rb
@@ -7,7 +7,8 @@ class Spectra < Formula
   head "https://github.com/yixuan/spectra.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "377f0b18a9ecae4ecf76abd9d031c9000f35176e4252331a6930927a2a7ea8ec"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "edd1c8fc5c4b6ea0ba64a9b48a0b86f986b0b24c4f6b624b45908b84ea3963f1"
   end
 
   depends_on "cmake" => :build

--- a/Formula/s/spectra.rb
+++ b/Formula/s/spectra.rb
@@ -22,25 +22,25 @@ class Spectra < Formula
   end
 
   test do
-    system ENV.cxx, pkgshare/"test.cpp", "-std=c++11",
+    system ENV.cxx, pkgshare/"test.cpp", "-std=c++14",
            "-I#{Formula["eigen"].opt_include/"eigen3"}", "-I#{include}", "-o", "test"
 
     macos_expected = <<~EOS
       5 Eigenvalues found:
-      1000.01
-      999.017
-      997.962
-      996.978
-      996.017
+      999.971
+       999.04
+      997.993
+      997.009
+      996.023
     EOS
 
     linux_expected = <<~EOS
       5 Eigenvalues found:
-      999.969
-      998.965
-      997.995
-      996.999
-      995.962
+      999.996
+      998.952
+       997.96
+      996.972
+      995.967
     EOS
 
     if OS.mac?

--- a/Formula/v/visp.rb
+++ b/Formula/v/visp.rb
@@ -14,12 +14,12 @@ class Visp < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "160b262691f59623a618257d39903b5e323dab097769a6e0d04e02bd0fbf2e9d"
-    sha256 cellar: :any,                 arm64_sequoia: "47def7ce212d709fda8fdc3f4b41c4c88161c8d56506d882f436649cf1fe2f11"
-    sha256 cellar: :any,                 arm64_sonoma:  "9b1be885e5d4154c5fc0d20936385f19ff33018940d61fc5fd3d263a23bc5651"
-    sha256 cellar: :any,                 sonoma:        "9c9807e08cf9160e0be9fe9fbf195a57d546aa52c90a1334993d60834a582179"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "d663bcaa78d922f702cd0b6c005642b975e3fb3caf6e556ac3ba39f9d14a63b2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "505be427ad6e27b0ff85408fa2db304883c48c4a43f76757a20dd927e8e767d6"
+    sha256 cellar: :any,                 arm64_tahoe:   "7efeb3c73ba6c90938f8df5cc15ad7e996cdaace2c7694056989536607b89e65"
+    sha256 cellar: :any,                 arm64_sequoia: "def3fe5709f81618936e77b2323f0accb57724ce33346dfefff79356ca663973"
+    sha256 cellar: :any,                 arm64_sonoma:  "a428e82264b87d1065860037c8e0d3a91b60c0d023314e8f3518bef3f2f39a27"
+    sha256 cellar: :any,                 sonoma:        "5b28a9211a9171ae48bb9e4ed235ca0e84e046ead0b5519fa9c64b34b4192ed7"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "b00e634ae5fa2b84cc6300c3bc89d6602e2dfa8cddcd7fc79158d4d86402ab36"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "227d11044d1fd82fddc407d2c63c8f4a121c33cbe81609442ab50ab2f6b2c7ae"
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/v/visp.rb
+++ b/Formula/v/visp.rb
@@ -4,7 +4,7 @@ class Visp < Formula
   url "https://visp-doc.inria.fr/download/releases/visp-3.6.0.tar.gz"
   sha256 "eec93f56b89fd7c0d472b019e01c3fe03a09eda47f3903c38dc53a27cbfae532"
   license "GPL-2.0-or-later"
-  revision 18
+  revision 19
 
   livecheck do
     url "https://visp.inria.fr/download/"
@@ -107,6 +107,7 @@ class Visp < Formula
                          "-DDC1394_LIBRARY=#{Formula["libdc1394"].opt_lib/shared_library("libdc1394")}",
                          "-DUSE_EIGEN3=ON",
                          "-DEigen3_DIR=#{Formula["eigen"].opt_share}/eigen3/cmake",
+                         "-DEIGEN3_INCLUDE_DIR=#{Formula["eigen"].opt_include}/eigen3",
                          "-DUSE_GSL=ON",
                          "-DGSL_INCLUDE_DIR=#{Formula["gsl"].opt_include}",
                          "-DGSL_cblas_LIBRARY=#{Formula["gsl"].opt_lib/shared_library("libgslcblas")}",

--- a/Formula/v/votca.rb
+++ b/Formula/v/votca.rb
@@ -4,6 +4,7 @@ class Votca < Formula
   url "https://github.com/votca/votca/archive/refs/tags/v2025.1.tar.gz"
   sha256 "85b487d2b2a31f26869be422c98f816b95c88a4ab112ea4650cccd4c2706bdbf"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     rebuild 1
@@ -33,6 +34,13 @@ class Votca < Formula
     depends_on "libomp"
   end
 
+  # Apply open PR to support eigen 5.0.0
+  # PR ref: https://github.com/votca/votca/pull/1189
+  patch do
+    url "https://github.com/votca/votca/commit/cc581d91196c3505c649e35ba69bcc8ec33fa14b.patch?full_index=1"
+    sha256 "08da2d4fd694eb1b3909fe4ef452b042a0b0733ca5d8b68e0e655b09842cb069"
+  end
+
   def install
     args = [
       "-DINSTALL_RC_FILES=OFF",
@@ -42,7 +50,7 @@ class Votca < Formula
       "-DENABLE_RPATH_INJECT=ON",
       "-DPYrdkit_FOUND=OFF",
     ]
-    system "cmake", "-S", ".", "-B", "build", *std_cmake_args, *args
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
   end

--- a/Formula/v/votca.rb
+++ b/Formula/v/votca.rb
@@ -7,13 +7,12 @@ class Votca < Formula
   revision 1
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_tahoe:   "72a7e979c09e507ffd4e176f4804b8edd351d7f3530747e0acf2b5c4fe3fd71f"
-    sha256 cellar: :any,                 arm64_sequoia: "b7d2c9c5455447bbe46b1f76c6d6aa0f45fec3fea090271eb4f9ca92679a9d6b"
-    sha256 cellar: :any,                 arm64_sonoma:  "8d05fa695814e71319f9078d4ad488e7f7e77768fc231be3c711104fec726313"
-    sha256 cellar: :any,                 sonoma:        "cf6fbd2feda356e3d7ff6e54759e23bd0316bd5dd1f01f4eabfe06cc9cb80154"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "1bfd361e34b774e8075310e994bbdac0c21baf1a8881df5bb1d071de9636ac84"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "08e9ae1f533a07865cc299655e7ea5442b7553f0d97dc9b8fab961fffa47cfe0"
+    sha256 cellar: :any,                 arm64_tahoe:   "fded17617f5140a20b04b5cfc9281e6429380d175d4e055a3d6b4dcc52a85b57"
+    sha256 cellar: :any,                 arm64_sequoia: "1cf98138786201b215734a1211d11cf41966ff3dce3d488b048628576236d4db"
+    sha256 cellar: :any,                 arm64_sonoma:  "4b16956c81ad38c7f4a48867d10f1e08e7b1c18018b47440d7b040a5fc48397b"
+    sha256 cellar: :any,                 sonoma:        "ae0f8523a835692c893098181ad612b727c3f0ada15d6d7d29f5cf0227f854c9"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "6599a17075e452492e0f9266812795c28c724103e97c58563058d8d2b436217d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "ab37fef79c54edc8f175901834c1d6a6017029943f52c33d308e34fda97d67a3"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
* Added livecheck as upstream uses future release date (pre-release) and repeatedly retag until official release.
* Replaced homepage as I think tuxfamily is gone now.
* Disable BLAS libraries (previously disabled by default). Installing them will make break all bottle and not sure how useful it is

---

Draft while doing a build-from-source dependents run since main part of Eigen is header-only so hard to detect breakages without rebuild. Especially after major release with 4 years of changes.

There is also a 3.4.1 if any dependents have issues.

---

Build failures to follow up on:
- [ ] `brew install --build-from-source dartsim`
- [x] `pinocchio` - #252411
- [x] `itk` - #252408

Upstream PRs
- [ ] `fcl` - https://github.com/flexible-collision-library/fcl/pull/649
- [ ] `lbfgspp` - https://github.com/yixuan/LBFGSpp/pull/48
- [ ] `sophus` - https://github.com/strasdat/Sophus/pull/558
- [ ] `vowpal-wabbit` - https://github.com/VowpalWabbit/vowpal_wabbit/pull/4720; #246900
- [x] `ifopt` - https://github.com/ethz-adrl/ifopt/pull/110
- [x] `alpscore` - https://github.com/ALPSCore/ALPSCore/pull/651
- [x] `quantum++` - https://github.com/softwareQinc/qpp/issues/191; https://github.com/softwareQinc/qpp/pull/192
- [x] `votca` - https://github.com/votca/votca/pull/1189

Backported commits
- [x] `eigenpy` - https://github.com/stack-of-tasks/eigenpy/commit/3bd6b04229035c55fe92bba42acb88ef2588850f
- [x] `g2o` - https://github.com/RainerKuemmerle/g2o/commit/ef80e643adeb700536dd282dd4316c90cfc05fe8
- [x] `opencv` - https://github.com/opencv/opencv/commit/468de9b36740b3355f0d5cd8be2ce28b340df120
- [x] `pagmo` - https://github.com/esa/pagmo2/commit/d0e70403179769c326f2694673473e1d3ef0bec7
- [x] `pcl` - https://github.com/PointCloudLibrary/pcl/commit/2d6929bdcd98beaa28fa8ee3a105beb566f16347

Other changes
- [x] `orocos-kdl` - update to c++14
- [x] `rtabmap` - avoid FindEigen3 module
- [x] `spectra` - update to c++14 and change test eigenvalues
- [x] `visp` - workaround for Eigen3 CMake changes
- [x] `open-babel` - workaround to find Eigen3

Eigen@3
- [x] `autodiff` - uses some private APIs that changed in 5.0.0
- [x] `dynet` - uses EIGEN_EMPTY_STRUCT_CTOR which isn't available in 5.0.0 - #252342