### PR TITLE
blis: enable openmp

### DIFF
--- a/Formula/b/blis.rb
+++ b/Formula/b/blis.rb
@@ -7,14 +7,13 @@ class Blis < Formula
   head "https://github.com/flame/blis.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "5bb226f60a5cffc5e2e7a79daa6daefbe33dcc46c0aef737e0cf71398ce49407"
-    sha256 cellar: :any,                 arm64_sequoia: "eaa5b7da801e3b1915288ce0938b19d5add45ba87ce3dab1277e2beb78d77654"
-    sha256 cellar: :any,                 arm64_sonoma:  "ffd36f20fb15992d43255e6cd4ef2180d7415d54504d4793f9355e365e9bbc28"
-    sha256 cellar: :any,                 arm64_ventura: "90e2dad3813b09a2782a32a20555d5e2a9f046040bbcbda52f53ce6962a9b25d"
-    sha256 cellar: :any,                 sonoma:        "2164b835421ca2348ea9345fb673e48f97590f763fba9067ce10a181d42e661a"
-    sha256 cellar: :any,                 ventura:       "d8f4e5be9a956ac208b0aa9abde47dabac3968e194b008b1b5816cca934c538a"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "e26aed017b11935a26a0390a2ce77619d9886ff9c760db40509f3ae106390dea"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "dca702952b8f726f414761a5714ba34a5ba69df4e4f1e5e94a45a2d55aaa023a"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "ae5b40dcc1bb83dcc0742f24a1bfe0991bc3a349d34aa329a0b12f88b2b880fe"
+    sha256 cellar: :any,                 arm64_sequoia: "461fd80b3bd293dffab9b1a1ed90a35ef4c9b2f6f3546bc44fa06411681871dd"
+    sha256 cellar: :any,                 arm64_sonoma:  "91e2bd552c5f1df187fdee979635b0c87ce5ea700127ec2110ef16da2ea005dd"
+    sha256 cellar: :any,                 sonoma:        "a6f83d702d2ca94890919df8c80e998a874846677d9c6131358e10f5c03bdb35"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "3c654866bff3d54735f76b81eb0318d3d85727b3224c84c95f7e4a3db851593b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f201ae6efcebd05d84ae5360d95bffa2871344f6384a92be7019948429704776"
   end
 
   uses_from_macos "python" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Enable OpenMP variant to align with other BLAS formulae.

This provides the configure time requirement for multithreading but users will still need to enable at runtime too 
- https://github.com/flame/blis/blob/master/docs/Multithreading.md#specifying-multithreading 

There is also pthread option but upstream recommends OpenMP 
- https://github.com/flame/blis/blob/master/docs/Multithreading.md#choosing-openmp-vs-pthreads

For macOS, although it is possible to link to `libomp` via CFLAGS/LDFLAGS, the common.mk is installed so patching that to make sure anything that uses it works correctly. Not as inreplace since there are sections for GCC and other compilers.