### PR TITLE
eigen 3.4.1

### DIFF
--- a/Formula/c/ceres-solver.rb
+++ b/Formula/c/ceres-solver.rb
@@ -15,16 +15,12 @@ class CeresSolver < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:    "92f275053ffb7eb14a72172c0d98a3dc0c684bed6493a3091fd8458ad5440c05"
-    sha256 cellar: :any,                 arm64_sequoia:  "988b6c630059fd2c89f693ae791b329123e8edf5e1135f57b3a23434ef4fd6e2"
-    sha256 cellar: :any,                 arm64_sonoma:   "82321500433aa189b94707782c92b280d9f370c2da70d81f337c33e7d3ce0924"
-    sha256 cellar: :any,                 arm64_ventura:  "7b298b5e784c97df200a87e5ecb612c6a8a3feaff2b7906a47254822c697ddfa"
-    sha256 cellar: :any,                 arm64_monterey: "3de5b3e4c7e884954abc07b9456ec86e08cc98dc172194b2ab7781d354ccc412"
-    sha256 cellar: :any,                 sonoma:         "f949ae21f99855aa96d25e8cb2a30cf7d001b8af8193a9b0ab4032969c5ab6a9"
-    sha256 cellar: :any,                 ventura:        "0fb671f15c3b25e771ebeacb0bd8cfe5f3b47535c766091e24adc6f50e7e4e23"
-    sha256 cellar: :any,                 monterey:       "c3dce08c0c5c4c239c60fad44ebe52333428f4925fd3f69faa30d1ad34d11f65"
-    sha256 cellar: :any_skip_relocation, arm64_linux:    "a81bb14618a9bb0c8e3bace126d01e4d0e1c643aa10bc3bd6ce00f93a03ae3b4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "68107edf1952d270ebdad753857acf97e253956b48cd115047d89b6364c3f903"
+    sha256 cellar: :any,                 arm64_tahoe:   "313ed5690a361970bdea14a72c09a8303dc2172b84fc1d8204dbb79b913d00e7"
+    sha256 cellar: :any,                 arm64_sequoia: "4e5508fed469c7de173c44f6875a93e27758aa61a1f3ee0daa1bea279b5703b5"
+    sha256 cellar: :any,                 arm64_sonoma:  "4dc3d66678294486b58e513950109a4d593286eeb02d21b076de35d1aae0d126"
+    sha256 cellar: :any,                 sonoma:        "c17ec0c69c71db298cc62c1447e9c108cbbd8711e676051d7768049ec6614caa"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "ceceda8cfbf36c576474fef71487f756ee03183c20453e1fe25ba304972ee994"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3bf8a2f59441ee79ae0d2fab7a7cfabf6f3aec910c1c2695a215fe673bf7a0c5"
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/c/ceres-solver.rb
+++ b/Formula/c/ceres-solver.rb
@@ -4,7 +4,7 @@ class CeresSolver < Formula
   url "http://ceres-solver.org/ceres-solver-2.2.0.tar.gz"
   sha256 "48b2302a7986ece172898477c3bcd6deb8fb5cf19b3327bc49969aad4cede82d"
   license "BSD-3-Clause"
-  revision 1
+  revision 2
   head "https://ceres-solver.googlesource.com/ceres-solver.git", branch: "master"
 
   livecheck do

--- a/Formula/e/eigen.rb
+++ b/Formula/e/eigen.rb
@@ -1,18 +1,25 @@
 class Eigen < Formula
   desc "C++ template library for linear algebra"
-  homepage "https://eigen.tuxfamily.org/"
-  url "https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz"
-  sha256 "8586084f71f9bde545ee7fa6d00288b264a2b7ac3607b974e54d13e7162c1c72"
-  license "MPL-2.0"
-  revision 1
+  homepage "https://gitlab.com/libeigen/eigen"
+  # TODO: remove LGPL from licenses in 5.0.0
+  url "https://gitlab.com/libeigen/eigen/-/archive/3.4.1/eigen-3.4.1.tar.gz"
+  sha256 "b93c667d1b69265cdb4d9f30ec21f8facbbe8b307cf34c0b9942834c6d4fdbe2"
+  license all_of: [
+    "MPL-2.0",
+    "Apache-2.0",   # BFloat16.h
+    "BSD-3-Clause", # bindings to BLAS, LAPACKe and MKL
+    "Minpack",      # LevenbergMarquardt
+    "LGPL-2.1-only", # IterativeSolvers, removed in 5.0.0
+  ]
   head "https://gitlab.com/libeigen/eigen.git", branch: "master"
 
   livecheck do
-    url :stable
+    url "https://gitlab.com/api/v4/projects/libeigen%2Feigen/releases"
     regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :json do |json, regex|
+      json.filter_map { |item| item["tag_name"]&.[](regex, 1) unless item["upcoming_release"] }
+    end
   end
-
-  no_autobump! because: :requires_manual_review
 
   bottle do
     rebuild 3
@@ -22,8 +29,13 @@ class Eigen < Formula
   depends_on "cmake" => :build
 
   def install
-    system "cmake", "-S", ".", "-B", "eigen-build", "-Dpkg_config_libdir=#{lib}", *std_cmake_args
-    system "cmake", "--install", "eigen-build"
+    args = %w[
+      -DEIGEN_BUILD_BLAS=OFF
+      -DEIGEN_BUILD_LAPACK=OFF
+    ]
+
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
+    system "cmake", "--install", "build"
   end
 
   test do

--- a/Formula/e/eigen.rb
+++ b/Formula/e/eigen.rb
@@ -22,8 +22,7 @@ class Eigen < Formula
   end
 
   bottle do
-    rebuild 3
-    sha256 cellar: :any_skip_relocation, all: "06503290dc3c07a67b8f582046b0a7f0bd68c2cb2da1e5bc071710de5ba7f5ec"
+    sha256 cellar: :any_skip_relocation, all: "64ee1c43cc38e7ceb2efcfacd905212dcb4ffb1434d3833c006cbffdd3a7608c"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
* Update homepage as tuxfamily is no longer available
* Update license for all installed files
* Update livecheck as upstream uses pre-releases that get retagged
* Allow autobumps
* Disable BLAS, which was default for 3.4.0 and older. Enabling this will build shared libraries that impact the all bottle.

---

5.0.0 has lots of dependent failures from new version scheme so let's move to 3.4.1 first
- #246477

Building from source again to make sure no breakages.
