### PR TITLE
gdk-pixbuf: fix libdeflate detection in pkg-config

### DIFF
--- a/Formula/g/gdk-pixbuf.rb
+++ b/Formula/g/gdk-pixbuf.rb
@@ -51,6 +51,7 @@ class GdkPixbuf < Formula
               "-DGDK_PIXBUF_LIBDIR=\"@0@\"'.format('#{HOMEBREW_PREFIX}/lib')"
 
     ENV["DESTDIR"] = "/"
+    ENV.prepend_path "PKG_CONFIG_PATH", Formula["libdeflate"].opt_lib/"pkgconfig"
     system "meson", "setup", "build", "-Drelocatable=false",
                                       "-Dnative_windows_loaders=false",
                                       "-Dtests=false",


### PR DESCRIPTION
Add libdeflate to PKG_CONFIG_PATH to resolve build failures where libtiff-4.pc requires libdeflate but pkg-config cannot locate libdeflate.pc during the meson build process.

Fixes: Package libdeflate was not found in the pkg-config search path
Closes: #XXXXX

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
