### PR TITLE
dr 0.0.3 (new formula)

### DIFF
--- a/Formula/d/dr.rb
+++ b/Formula/d/dr.rb
@@ -1,0 +1,18 @@
+class Dr < Formula
+  desc "DataRobot command-line interface"
+  homepage "https://github.com/datarobot-oss/cli"
+  url "https://github.com/datarobot-oss/cli/archive/refs/tags/v0.0.3.tar.gz"
+  sha256 "6df4a739dae533ddc30d099d9a34954dcb081aced6e831b01ac2976a96444d80"
+  license "Apache-2.0"
+  head "https://github.com/datarobot-oss/cli.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", "-o", bin/"dr"
+  end
+
+  test do
+    system bin/"dr", "version"
+  end
+end


### PR DESCRIPTION
This is a fresh pull request to add DataRobot's CLI to homebrew with updates based on reviewer comments on https://github.com/Homebrew/homebrew-core/pull/246209. 

We have updated the license to Apache-2.0, and updated our Go build command to simplify things. However, we have maintained the "version" test, as that is still the best test of a successful installation. We believe that notability will increase as this is the first release of this CLI which is linked to major products being announced by DataRobot in the near future.

cc @carsongee

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
