### PR TITLE
pyparsing 3.2.5 (new formula)

### DIFF
--- a/Formula/p/pyparsing.rb
+++ b/Formula/p/pyparsing.rb
@@ -1,0 +1,25 @@
+class Pyparsing < Formula
+  include Language::Python::Virtualenv
+
+  desc "Classes and methods to define and execute parsing grammars"
+  homepage "https://github.com/pyparsing/pyparsing"
+  url "https://files.pythonhosted.org/packages/f2/a5/181488fc2b9d093e3972d2a472855aae8a03f000592dbfce716a512b3359/pyparsing-3.2.5.tar.gz"
+  sha256 "2df8d5b7b2802ef88e8d016a2eb9c7aeaa923529cd251ed0fe4608275d4105b6"
+  license "MIT"
+
+  depends_on "python@3.13"
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    (testpath/"test.py").write <<~PYTHON
+      from pyparsing import Word, alphas
+      greet = Word(alphas) + "," + Word(alphas) + "!"
+      hello = "Hello, World!"
+      print(hello, "->", greet.parse_string(hello))
+    PYTHON
+    assert_equal "Hello, World! -> ['Hello', ',', 'World', '!']", shell_output("#{libexec}/bin/python test.py").chomp
+  end
+end


### PR DESCRIPTION
Adds the pyparsing python library as a new formula.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

A question for reviewers: this library requires `python >= 3.9`, what should be the python `depends_on`?

Thank you,

tiferrei
