### PR TITLE
prestodb 0.294

### DIFF
--- a/Formula/p/prestodb.rb
+++ b/Formula/p/prestodb.rb
@@ -16,7 +16,7 @@ class Prestodb < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "45cd80935b6db206ab8616a14ba44a12a958e3db3e0c23d85903fdef027b393b"
+    sha256 cellar: :any_skip_relocation, all: "2b29226f67e82e5257ab5bf154521da407a8df43bfaed129122ef5b328096a26"
   end
 
   depends_on "openjdk@17"

--- a/Formula/p/prestodb.rb
+++ b/Formula/p/prestodb.rb
@@ -3,8 +3,8 @@ class Prestodb < Formula
 
   desc "Distributed SQL query engine for big data"
   homepage "https://prestodb.io"
-  url "https://search.maven.org/remotecontent?filepath=com/facebook/presto/presto-server/0.293/presto-server-0.293.tar.gz", using: :nounzip
-  sha256 "dd0e8bb1919da27973961a35483f2fb795795c63d5a3684c50fc029c242d4840"
+  url "https://search.maven.org/remotecontent?filepath=com/facebook/presto/presto-server/0.294/presto-server-0.294.tar.gz"
+  sha256 "30364cf54ea068f9a0f9c140d857f07379124251a1a7fe17935ead4e9ec6c3d1"
   license "Apache-2.0"
 
   # Upstream has said that we should check Maven for Presto version information
@@ -23,8 +23,8 @@ class Prestodb < Formula
   depends_on "python@3.13"
 
   resource "presto-cli" do
-    url "https://search.maven.org/remotecontent?filepath=com/facebook/presto/presto-cli/0.293/presto-cli-0.293-executable.jar"
-    sha256 "e64bdfdaaae45031fc3f88d235215896c1fddbf0a0485d3d3ece94864b510972"
+    url "https://github.com/prestodb/presto/releases/download/0.294/presto-cli-0.294-executable.jar"
+    sha256 "26ad727b02d58b45916a1a690fdfa1ae01d133568df7058205b1f00169852c50"
 
     livecheck do
       formula :parent
@@ -35,14 +35,12 @@ class Prestodb < Formula
     java_version = "17"
     odie "presto-cli resource needs to be updated" if version != resource("presto-cli").version
 
-    # Manually extract tarball to avoid multiple copies/moves of over 2GB of files
-    libexec.mkpath
-    system "tar", "-C", libexec.to_s, "--strip-components", "1", "-xzf", "presto-server-#{version}.tar.gz"
+    libexec.install Dir["*"]
 
     (libexec/"etc/node.properties").write <<~EOS
       node.environment=production
       node.id=ffffffff-ffff-ffff-ffff-ffffffffffff
-      node.data-dir=#{var}/presto/data
+      node.data-dir=#{var}/prestodb/data
     EOS
 
     (libexec/"etc/jvm.config").write <<~EOS


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Hardlinks have reduced tarball size and probably okay to just move files now.

CLI was moved according to release notes https://prestodb.io/docs/current/release/release-0.294.html
> From release 0.294, due to Maven Central publishing limitations, executable jar files including presto-cli, presto-benchmark-driver, and presto-test-server-launcher are no longer published on Maven Central repository. These jars can now be found on the [Presto Github release page](https://github.com/prestodb/presto/releases/tag/0.294).