### PR TITLE
mill 1.0.6

### DIFF
--- a/Formula/m/mill.rb
+++ b/Formula/m/mill.rb
@@ -11,7 +11,7 @@ class Mill < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "56fc5b0defb92df981fa9e406356ed7138bb458cdfb00308c277f8d815c1219f"
+    sha256 cellar: :any_skip_relocation, all: "dae7e2a795434699b9f3a1f4349c83da49a34afbef678b79af64ca6e44d587e0"
   end
 
   depends_on "openjdk"

--- a/Formula/m/mill.rb
+++ b/Formula/m/mill.rb
@@ -1,11 +1,9 @@
 class Mill < Formula
   desc "Fast, scalable JVM build tool"
   homepage "https://mill-build.org/"
-  # TODO: Check if we can use `openjdk` 25+ when bumping the version.
-  url "https://search.maven.org/remotecontent?filepath=com/lihaoyi/mill-dist/0.12.11/mill-dist-0.12.11.jar"
+  url "https://search.maven.org/remotecontent?filepath=com/lihaoyi/mill-dist/1.0.6/mill-dist-1.0.6.exe"
   sha256 "567a44bee9006ac943f8cbec18c38637c544144726cdc699aa4f3584ed52ae93"
   license "MIT"
-  revision 1
 
   livecheck do
     url "https://search.maven.org/remotecontent?filepath=com/lihaoyi/mill-dist/maven-metadata.xml"
@@ -16,12 +14,12 @@ class Mill < Formula
     sha256 cellar: :any_skip_relocation, all: "56fc5b0defb92df981fa9e406356ed7138bb458cdfb00308c277f8d815c1219f"
   end
 
-  depends_on "openjdk@21"
+  depends_on "openjdk"
 
   def install
     libexec.install Dir["*"].shift => "mill"
     chmod 0555, libexec/"mill"
-    (bin/"mill").write_env_script libexec/"mill", Language::Java.overridable_java_home_env("21")
+    (bin/"mill").write_env_script libexec/"mill", Language::Java.overridable_java_home_env
   end
 
   test do


### PR DESCRIPTION
Upstream changed extension to `.exe` to work around Sonatype - https://github.com/com-lihaoyi/mill/commit/06c62c33bff767cae0cf6cbddd6ebda9698829dd

These are still a shell script + JAR (zip) file (https://mill-build.org/blog/5-executable-jars.html)

```console
❯ curl -L -o mill.exe "https://search.maven.org/remotecontent?filepath=com/lihaoyi/mill-dist/1.0.6/mill-dist-1.0.6.exe"

❯ binwalk mill.exe

                                       /private/tmp/mill.exe
---------------------------------------------------------------------------------------------------
DECIMAL                            HEXADECIMAL                        DESCRIPTION
---------------------------------------------------------------------------------------------------
537                                0x219                              ZIP archive, file count:
                                                                      14835, total size: 36611240
                                                                      bytes
---------------------------------------------------------------------------------------------------

❯ unzip -l mill.exe | head -20
warning [mill.exe]:  537 extra bytes at beginning or within zipfile
  (attempting to process anyway)
Archive:  mill.exe
  Length      Date    Time    Name
---------  ---------- -----   ----
        0  10-01-2025 13:22   META-INF/
      131  10-01-2025 13:22   META-INF/MANIFEST.MF
        0  10-01-2025 13:22   scala/
        0  10-01-2025 13:22   scala/quoted/
     4580  10-01-2025 13:22   scala/quoted/ToExpr$ArrayOfCharToExpr$.class
        0  10-01-2025 13:22   coursier/
        0  10-01-2025 13:22   coursier/core/
        0  10-01-2025 13:22   coursier/core/shaded/
        0  10-01-2025 13:22   coursier/core/shaded/fastparse/
        0  10-01-2025 13:22   coursier/core/shaded/fastparse/internal/
     5714  10-01-2025 13:22   coursier/core/shaded/fastparse/internal/MacroImpls$$anonfun$$nestedInanonfun$parseCharCls$1$2.class
        0  10-01-2025 13:22   scala/jdk/
     2012  10-01-2025 13:22   scala/jdk/FunctionWrappers$RichDoubleBinaryOperatorAsFunction2.class
        0  10-01-2025 13:22   com/
        0  10-01-2025 13:22   com/sun/
        0  10-01-2025 13:22   com/sun/jna/
        0  10-01-2025 13:22   com/sun/jna/ptr/

❯ head -10 mill.exe
@ 2>/dev/null # 2>nul & echo off & goto BOF
:
if [ -z "$JAVA_HOME" ] ; then
  JAVACMD="java"
else
  JAVACMD="$JAVA_HOME/bin/java"
fi

exec "$JAVACMD" -Xmx128m -Djna.nosys=true $JAVA_OPTS -cp "$0" mill.launcher.MillLauncherMain "$@"
```