### PR TITLE
dnote 0.15.2 (new formula)

### DIFF
--- a/Formula/d/dnote.rb
+++ b/Formula/d/dnote.rb
@@ -1,0 +1,32 @@
+class Dnote < Formula
+  desc "Simple command-line notebook"
+  homepage "https://www.getdnote.com"
+  url "https://github.com/dnote/dnote/archive/refs/tags/cli-v0.15.2.tar.gz"
+  sha256 "d68fd975a91b1872d15c2bfea12a1b43d8878c9811d1df4876c07f3d10f05e4e"
+  license "GPL-3.0-only"
+  head "https://github.com/dnote/dnote.git", branch: "master"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = %W[
+      -s -w
+      -X main.versionTag=#{version}
+      -X main.apiEndpoint=http://localhost:3000/api
+    ]
+    system "go", "build", *std_go_args(ldflags:), "-tags", "fts5", "./pkg/cli"
+  end
+
+  test do
+    ENV["XDG_CONFIG_HOME"] = testpath
+    ENV["XDG_DATA_HOME"] = testpath
+    ENV["XDG_CACHE_HOME"] = testpath
+
+    assert_match version.to_s, shell_output("#{bin}/dnote version")
+
+    desc = "Check disk usage with df -h"
+    system bin/"dnote", "add", "linux", "-c", desc
+    assert_match desc, shell_output("#{bin}/dnote view linux")
+    assert_match desc, shell_output("#{bin}/dnote find 'disk usage'")
+  end
+end

--- a/Formula/d/dnote.rb
+++ b/Formula/d/dnote.rb
@@ -6,6 +6,14 @@ class Dnote < Formula
   license "GPL-3.0-only"
   head "https://github.com/dnote/dnote.git", branch: "master"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "ca0d5c2c89e54661d1acef6bec74aa22397755e502d0d692c7e355d002493f69"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "7a1d3d6358a11edae43465a046927690efbd591b87b71a2cbbe78bde802c7c2a"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "a8a29c44a56d826dca695c3307f46ebd784ad44d7c93d48b5248b8d678976c8f"
+    sha256 cellar: :any_skip_relocation, sonoma:        "f49a252c80178c5dc230dc95cfa45b4a34e748cf91ced442c1c5e9aa0e50a1d5"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1874739a52c05c5c86480cce7c5a4e2e3ecf43f18858a5de403c74fe37264c93"
+  end
+
   depends_on "go" => :build
 
   def install


### PR DESCRIPTION
I'd like to add dnote, a command line notebook. It has been maintaining its own tap (https://github.com/dnote/homebrew-dnote/) since 2017 and users preferred the official tap.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)? - Commit message dnote 0.15.2 (new formula) matches required format
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change? - No existing commit.
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?

```
▶ HOMEBREW_NO_INSTALL_FROM_API=1 /home/linuxbrew/.linuxbrew/bin/brew install --build-from-source dnote
==> Fetching downloads for: dnote
==> Fetching dnote/dnote/dnote
==> Downloading https://github.com/dnote/dnote/archive/refs/tags/cli-v0.15.2.tar.gz
==> Downloading from https://codeload.github.com/dnote/dnote/tar.gz/refs/tags/cli-v0.15.2
        -=O=- #         #          #            #                                                                                                                                                                    
==> Installing dnote from dnote/dnote
==> go build -ldflags=-s -w -X main.apiEndpoint=http://localhost:3000/api -X main.versionTag=0.15.2 -tags fts5 ./pkg/cli
🍺  /home/linuxbrew/.linuxbrew/Cellar/dnote/0.15.2: 7 files, 8.9MB, built in 1 minute 3 seconds
==> Running `brew cleanup dnote`...
Disable this behaviour by setting `HOMEBREW_NO_INSTALL_CLEANUP=1`.
Hide these hints with `HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).
==> No outdated dependents to upgrade!
```

- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?

```
▶ /home/linuxbrew/.linuxbrew/bin/brew test dnote                                                      
Warning: test is a developer command, so Homebrew's
developer mode has been automatically turned on.
To turn developer mode off, run:
  brew developer off

==> Installing 'bundler' gem
Fetching bundler-2.6.8.gem
Fetching gem metadata from https://rubygems.org/.......
Fetching public_suffix 6.0.2
Fetching base64 0.3.0
Fetching bindata 2.5.1
Fetching concurrent-ruby 1.3.5
Installing base64 0.3.0
Fetching minitest 5.25.5
Installing public_suffix 6.0.2
Fetching plist 3.7.2
Installing bindata 2.5.1
Fetching ruby-macho 4.1.0
Installing concurrent-ruby 1.3.5
Fetching sorbet-runtime 0.6.12578
Installing minitest 5.25.5
Fetching warning 1.5.0
Installing plist 3.7.2
Fetching addressable 2.8.7
Installing ruby-macho 4.1.0
Fetching elftools 1.3.1
Installing sorbet-runtime 0.6.12578
Installing warning 1.5.0
Installing addressable 2.8.7
Installing elftools 1.3.1
Fetching patchelf 1.5.1
Installing patchelf 1.5.1
Bundle complete! 43 Gemfile dependencies, 13 gems now installed.
Bundled gems are installed into `../../../linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/bundle`
==> Testing dnote/dnote/dnote
==> /home/linuxbrew/.linuxbrew/Cellar/dnote/0.15.2/bin/dnote version
```

- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

Yes.

```
▶/home/linuxbrew/.linuxbrew/bin/brew audit --new dnote

▶ /home/linuxbrew/.linuxbrew/bin/brew audit --strict dnote                                            

```

-----
