### PR TITLE
formulae(go): linux arm disable cgo

### DIFF
--- a/Formula/c/csprecon.rb
+++ b/Formula/c/csprecon.rb
@@ -17,6 +17,8 @@ class Csprecon < Formula
   depends_on "go" => :build
 
   def install
+    ENV["CGO_ENABLED"] = "0" if OS.linux? && Hardware::CPU.arm?
+
     system "go", "build", *std_go_args(ldflags: "-s -w"), "./cmd/csprecon"
   end
 

--- a/Formula/i/infisical.rb
+++ b/Formula/i/infisical.rb
@@ -17,6 +17,8 @@ class Infisical < Formula
   depends_on "go" => :build
 
   def install
+    ENV["CGO_ENABLED"] = "0" if OS.linux? && Hardware::CPU.arm?
+
     ldflags = %W[
       -s -w
       -X github.com/Infisical/infisical-merge/packages/util.CLI_VERSION=#{version}

--- a/Formula/m/multi-gitter.rb
+++ b/Formula/m/multi-gitter.rb
@@ -17,6 +17,8 @@ class MultiGitter < Formula
   depends_on "go" => :build
 
   def install
+    ENV["CGO_ENABLED"] = "0" if OS.linux? && Hardware::CPU.arm?
+
     ldflags = "-s -w -X main.version=#{version} -X main.commit=#{tap.user} -X main.date=#{time.iso8601}"
     system "go", "build", *std_go_args(ldflags:)
 

--- a/Formula/p/pulumi.rb
+++ b/Formula/p/pulumi.rb
@@ -20,9 +20,12 @@ class Pulumi < Formula
   depends_on "go" => :build
 
   def install
+    ENV["CGO_ENABLED"] = "0" if OS.linux? && Hardware::CPU.arm?
+
     cd "./sdk" do
       system "go", "mod", "download"
     end
+
     cd "./pkg" do
       system "go", "mod", "download"
     end

--- a/Formula/t/terragrunt.rb
+++ b/Formula/t/terragrunt.rb
@@ -27,6 +27,8 @@ class Terragrunt < Formula
   conflicts_with "tgenv", because: "tgenv symlinks terragrunt binaries"
 
   def install
+    ENV["CGO_ENABLED"] = "0" if OS.linux? && Hardware::CPU.arm?
+
     ldflags = %W[
       -s -w
       -X github.com/gruntwork-io/go-commons/version.Version=#{version}

--- a/Formula/y/yutu.rb
+++ b/Formula/y/yutu.rb
@@ -17,6 +17,8 @@ class Yutu < Formula
   depends_on "go" => :build
 
   def install
+    ENV["CGO_ENABLED"] = "0" if OS.linux? && Hardware::CPU.arm?
+
     mod = "github.com/eat-pray-ai/yutu/cmd"
     ldflags = %W[
       -s -w

--- a/Formula/z/zrok.rb
+++ b/Formula/z/zrok.rb
@@ -7,7 +7,7 @@ class Zrok < Formula
   license all_of: ["Apache-2.0", "BSD-3-Clause", "MIT"]
   head "https://github.com/openziti/zrok.git", branch: "main"
 
-  no_autobump! because: :requires_manual_review
+  no_autobump! because: :bumped_by_upstream
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "69512d5888b0ab4f9a81010b546c4d1e7b48b52be839c8ff1cdd904a9bb1d7c1"
@@ -27,6 +27,8 @@ class Zrok < Formula
         system "npm", "run", "build"
       end
     end
+
+    ENV["CGO_ENABLED"] = "0" if OS.linux? && Hardware::CPU.arm?
 
     ldflags = %W[
       -s -w


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
for #211761, see #239862