### PR TITLE
fabric-ai: add shell completions

### DIFF
--- a/Formula/f/fabric-ai.rb
+++ b/Formula/f/fabric-ai.rb
@@ -7,11 +7,12 @@ class FabricAi < Formula
   head "https://github.com/danielmiessler/fabric.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "e6631f44ec4f5dd42127eedb5b503f6f2acbe0aee823d5ce65b005228d2a4ba3"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e6631f44ec4f5dd42127eedb5b503f6f2acbe0aee823d5ce65b005228d2a4ba3"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "e6631f44ec4f5dd42127eedb5b503f6f2acbe0aee823d5ce65b005228d2a4ba3"
-    sha256 cellar: :any_skip_relocation, sonoma:        "83352d1d066d5a3432c95bdb5621a0572defadc5be17c0b981f4bf38ff6d4c1e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a550fa188baaa3bb9bfd2663b2600994f50a8e668314757a82dd4ec25c98f661"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "165f3c14db3f93edd1b9ec627438b907c38f8d08381be09ed17bdc0448f220cb"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "165f3c14db3f93edd1b9ec627438b907c38f8d08381be09ed17bdc0448f220cb"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "165f3c14db3f93edd1b9ec627438b907c38f8d08381be09ed17bdc0448f220cb"
+    sha256 cellar: :any_skip_relocation, sonoma:        "7294c2ed6ccde95d950cae40f58bd9696f7d1e0a1053a296974650fcc7a47d5d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "975cf82b4e998c3e070612495728b95003daff53b0464d996d6d7c8b02610416"
   end
 
   depends_on "go" => :build

--- a/Formula/f/fabric-ai.rb
+++ b/Formula/f/fabric-ai.rb
@@ -18,6 +18,10 @@ class FabricAi < Formula
 
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w"), "./cmd/fabric"
+    # Install completions
+    bash_completion.install "completions/fabric.bash" => "fabric-ai"
+    fish_completion.install "completions/fabric.fish" => "fabric-ai.fish"
+    zsh_completion.install "completions/_fabric" => "_fabric-ai"
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Adds shell completion support for Bash, Fish, and Zsh to the fabric-ai Homebrew
formula to automate the process instead of doing it manually as described in the
repos README[^1].

The completion names were chosen to be called 'fabric-ai' instead of 'fabric',
this was implemented with commit b36e5d3`[^2]. Tested it locally with zsh.

Ping @ksylvan to notify them of this addition to the brew installation process.

[^1]: https://github.com/danielmiessler/Fabric/blob/main/README.md#shell-completions
[^2]: https://github.com/danielmiessler/Fabric/commit/b36e5d3
