### PR TITLE
ruby@3.1: update openssl gem for OpenSSL 3.6+

### DIFF
--- a/Formula/r/ruby@3.1.rb
+++ b/Formula/r/ruby@3.1.rb
@@ -7,15 +7,12 @@ class RubyAT31 < Formula
   revision 1
 
   bottle do
-    rebuild 1
-    sha256 arm64_tahoe:   "dc72852c7a776cf641d2e16f772472598d8a0f35b5ebc3858efb335fb286fd55"
-    sha256 arm64_sequoia: "0b2c994b56cc016e46c5897105ec0c68ce7a84dc755e2ffab9fbcbca55997998"
-    sha256 arm64_sonoma:  "3198d30fb1e0727f1a68f20378d7a91be4de039fb2f0ef6fe818e0be1122e36f"
-    sha256 arm64_ventura: "ccb66ea8882437d80774ca761207d8207d061958615fc5869f8a4e717950d45a"
-    sha256 sonoma:        "6fbb3535f124ecccb1a8d717d724c64d623e8622aac47c19861db79cee5119f6"
-    sha256 ventura:       "4eae88a8a7d9606e90a79a05e9dd26f95f0f3e66741361b43c6f5b09ebe87345"
-    sha256 arm64_linux:   "3ea209c0300bd00dd41982809bcdfae936e4b0dea615be35fbfbadebdeb1fa64"
-    sha256 x86_64_linux:  "09a389c668f653f5d2fbc5de2c94e5bb13591a3161731828561033c8b994db4f"
+    sha256 arm64_tahoe:   "2cc59176253bc1c01a3edd0b95755b5c3b3ae4aabe429c73f4a0258133b180e7"
+    sha256 arm64_sequoia: "92903704cc5d9d37f66230174ff388340eafc43f7066383d900699df9e5fffcc"
+    sha256 arm64_sonoma:  "510daa18857bbdfca6cd36aa19adca0ef969f422e0447be9747a38120f27aeec"
+    sha256 sonoma:        "1e58691327c76cb8e297e80738ebfac66888b4b1bfacbcf670fa7ba964d74650"
+    sha256 arm64_linux:   "ee69b92c9720d2f814ef0482746e7879ee8299d3717b8756113c2a5b4ffa68ff"
+    sha256 x86_64_linux:  "1254c0da70acc105ffc4e77233428ac5018495a4a7b03e87c62f2d326e565e9a"
   end
 
   keg_only :versioned_formula

--- a/Formula/r/ruby@3.1.rb
+++ b/Formula/r/ruby@3.1.rb
@@ -4,6 +4,7 @@ class RubyAT31 < Formula
   url "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.7.tar.gz"
   sha256 "0556acd69f141ddace03fa5dd8d76e7ea0d8f5232edf012429579bcdaab30e7b"
   license "Ruby"
+  revision 1
 
   bottle do
     rebuild 1
@@ -39,6 +40,13 @@ class RubyAT31 < Formula
     sha256 "4521b52f843620a9fc5ca7414526b7463b0989564c3ae80b26b68fbd1304c818"
   end
 
+  # Update the bundled openssl gem for compatibility with OpenSSL 3.6+
+  # Using 3.1.x series to minimize chances of breakage from upgrading bundled 3.0.x
+  resource "openssl" do
+    url "https://github.com/ruby/openssl/archive/refs/tags/v3.1.2.tar.gz"
+    sha256 "0abb96cdeaef1c0a2bfc8e0a4557467d7f2e93cabdd00d0d387afb1d0e1569a9"
+  end
+
   def api_version
     "3.1.0"
   end
@@ -48,6 +56,13 @@ class RubyAT31 < Formula
   end
 
   def install
+    rm_r(%w[ext/openssl test/openssl])
+    resource("openssl").stage do
+      (buildpath/"ext").install "ext/openssl"
+      (buildpath/"ext/openssl").install "lib", "History.md", "openssl.gemspec"
+      (buildpath/"test").install "test/openssl"
+    end
+
     # otherwise `gem` command breaks
     ENV.delete("SDKROOT")
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Deprecated but we officially try to fix these so may as well handle OpenSSL 3.6