### PR TITLE
config-file-validator 1.8.1 (new formula)

### DIFF
--- a/Formula/c/config-file-validator.rb
+++ b/Formula/c/config-file-validator.rb
@@ -6,6 +6,14 @@ class ConfigFileValidator < Formula
   license "Apache-2.0"
   head "https://github.com/Boeing/config-file-validator.git", branch: "main"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "00d8fa20356bcbc53c4ef85a293cb05510901e713d8f33d3f4c5f260afc8551e"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "00d8fa20356bcbc53c4ef85a293cb05510901e713d8f33d3f4c5f260afc8551e"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "00d8fa20356bcbc53c4ef85a293cb05510901e713d8f33d3f4c5f260afc8551e"
+    sha256 cellar: :any_skip_relocation, sonoma:        "84aaa61b1cc799fe5cee90dab4f458f5630912e27e5d1209f7232f49d9082afb"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d0bcb1d4be243ae3e6606946650aec179de717df9e26654867e850993f66fbc2"
+  end
+
   depends_on "go" => :build
 
   def install

--- a/Formula/c/config-file-validator.rb
+++ b/Formula/c/config-file-validator.rb
@@ -1,0 +1,25 @@
+class ConfigFileValidator < Formula
+  desc "CLI tool to validate different configuration file types"
+  homepage "https://boeing.github.io/config-file-validator/"
+  url "https://github.com/Boeing/config-file-validator/archive/refs/tags/v1.8.1.tar.gz"
+  sha256 "e7c50fded0e036ef56d2479a2fee1eba35ea7fd232a4ba7c98ab087e4ae521ed"
+  license "Apache-2.0"
+  head "https://github.com/Boeing/config-file-validator.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    ENV["CGO_ENABLED"] = "0" if OS.linux? && Hardware::CPU.arm?
+
+    ldflags = "-s -w -X github.com/Boeing/config-file-validator.version=#{version}"
+    system "go", "build", *std_go_args(ldflags:, output: bin/"validator"), "./cmd/validator"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/validator -version")
+
+    test_file = testpath/"test.json"
+    test_file.write('{"valid": "json"}')
+    assert_match "✓ #{test_file}", shell_output("#{bin}/validator #{test_file}")
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
