### PR TITLE
go 1.25.2

### DIFF
--- a/Formula/g/garble.rb
+++ b/Formula/g/garble.rb
@@ -8,13 +8,11 @@ class Garble < Formula
   head "https://github.com/burrowers/garble.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "d2cea3e26879537701838d2a9dabce5cc793bc9ac4a6e793e27720612df3b304"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "d2cea3e26879537701838d2a9dabce5cc793bc9ac4a6e793e27720612df3b304"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "d2cea3e26879537701838d2a9dabce5cc793bc9ac4a6e793e27720612df3b304"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "d2cea3e26879537701838d2a9dabce5cc793bc9ac4a6e793e27720612df3b304"
-    sha256 cellar: :any_skip_relocation, sonoma:        "5c67079b98f17e7b0fba76ca1034d6937ef2053ed5a6a683a2eb09ecb62101db"
-    sha256 cellar: :any_skip_relocation, ventura:       "5c67079b98f17e7b0fba76ca1034d6937ef2053ed5a6a683a2eb09ecb62101db"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0f4f1598d9c2769351a128b107c22de29466aa968e841caa29320a807c425d03"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "dca149aa49d2190f405e83f6fb513646045c5d37013c15e856e38952adc04d8d"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "dca149aa49d2190f405e83f6fb513646045c5d37013c15e856e38952adc04d8d"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "dca149aa49d2190f405e83f6fb513646045c5d37013c15e856e38952adc04d8d"
+    sha256 cellar: :any_skip_relocation, sonoma:        "8fc0e7a8e7041ff0b4b654c5a05d9acdb0cbd1be73c01dfe9013997d6f22d640"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "fc806bf1e6ded5ecba0d4538285904c6e5fdaf94a892fe9d8df4592bcc23dacc"
   end
 
   depends_on "go" => [:build, :test]

--- a/Formula/g/garble.rb
+++ b/Formula/g/garble.rb
@@ -4,7 +4,7 @@ class Garble < Formula
   url "https://github.com/burrowers/garble/archive/refs/tags/v0.15.0.tar.gz"
   sha256 "b429b24dafa851a25bbeca635db33eb4162b8e3109fb234a2c8e7780a837b958"
   license "BSD-3-Clause"
-  revision 1
+  revision 2
   head "https://github.com/burrowers/garble.git", branch: "master"
 
   bottle do

--- a/Formula/g/go.rb
+++ b/Formula/g/go.rb
@@ -21,14 +21,12 @@ class Go < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "418083bbfb10fd9fbc095faaf2d930110fd7de28471329e047d2563de50ce953"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "418083bbfb10fd9fbc095faaf2d930110fd7de28471329e047d2563de50ce953"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "418083bbfb10fd9fbc095faaf2d930110fd7de28471329e047d2563de50ce953"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "418083bbfb10fd9fbc095faaf2d930110fd7de28471329e047d2563de50ce953"
-    sha256 cellar: :any_skip_relocation, sonoma:        "0561d9e89ed4b003a1a4febced502a6e9f6cb23ef334a8d9cfca7c9d8bacb146"
-    sha256 cellar: :any_skip_relocation, ventura:       "0561d9e89ed4b003a1a4febced502a6e9f6cb23ef334a8d9cfca7c9d8bacb146"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "6f5067fc7327f34cf29ce5fdf70323bb007722a541c6b9275a12e53c48e2536d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0da51192080d913b1809f7a79ae162cddc1820c1f41dd1c7ded53db92009831c"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "90051b9544c65fbfdb60c1db01a6ac841179b9fff7c349862921ee37db815a57"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "90051b9544c65fbfdb60c1db01a6ac841179b9fff7c349862921ee37db815a57"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "90051b9544c65fbfdb60c1db01a6ac841179b9fff7c349862921ee37db815a57"
+    sha256 cellar: :any_skip_relocation, sonoma:        "8cef63226eab81681d76d1c385ddc81be4b8727f88a07fcd798c4c5610ceffaf"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "6a89c0f5c75f47f6c238233d3e3ace3d0cad0e2abe4f28f8d4e38bc3958bc230"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "7938299072e9254d9578f166cf83fdae502f372c9b79168ff465c33238a25324"
   end
 
   depends_on macos: :monterey

--- a/Formula/g/go.rb
+++ b/Formula/g/go.rb
@@ -1,9 +1,9 @@
 class Go < Formula
   desc "Open source programming language to build simple/reliable/efficient software"
   homepage "https://go.dev/"
-  url "https://go.dev/dl/go1.25.1.src.tar.gz"
-  mirror "https://fossies.org/linux/misc/go1.25.1.src.tar.gz"
-  sha256 "d010c109cee94d80efe681eab46bdea491ac906bf46583c32e9f0dbb0bd1a594"
+  url "https://go.dev/dl/go1.25.2.src.tar.gz"
+  mirror "https://fossies.org/linux/misc/go1.25.2.src.tar.gz"
+  sha256 "3711140cfb87fce8f7a13f7cd860df041e6c12f7610f40cac6ec6fa2b65e96e4"
   license "BSD-3-Clause"
   head "https://go.googlesource.com/go.git", branch: "master"
 

--- a/Formula/s/staticcheck.rb
+++ b/Formula/s/staticcheck.rb
@@ -8,13 +8,11 @@ class Staticcheck < Formula
   head "https://github.com/dominikh/go-tools.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "dc76e2d678df0f309499650e7ba0d36d73e7241e9664fc19365ff718c882beb7"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "dc76e2d678df0f309499650e7ba0d36d73e7241e9664fc19365ff718c882beb7"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "dc76e2d678df0f309499650e7ba0d36d73e7241e9664fc19365ff718c882beb7"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "dc76e2d678df0f309499650e7ba0d36d73e7241e9664fc19365ff718c882beb7"
-    sha256 cellar: :any_skip_relocation, sonoma:        "6600fc1d98f050fe14cd7f05adf9cc80d6f0cd447c1c3d8857c97a3662d24498"
-    sha256 cellar: :any_skip_relocation, ventura:       "6600fc1d98f050fe14cd7f05adf9cc80d6f0cd447c1c3d8857c97a3662d24498"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "822ed472184f0e3f5b920184dd9829bc78c80dd3c9866ff7d4e5a4f0081e9e04"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "04be74b836b4249fb5000aaa75632821e5ef41b0db6f58af82edf9b115b01523"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "04be74b836b4249fb5000aaa75632821e5ef41b0db6f58af82edf9b115b01523"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "04be74b836b4249fb5000aaa75632821e5ef41b0db6f58af82edf9b115b01523"
+    sha256 cellar: :any_skip_relocation, sonoma:        "1e5afb2347109f0d52b4814edf5b3d4f2161650492886e8779eae33ad12bf3ba"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "deb3b563cc09846dcb13e44b0ad246d2294550e58e9116390f45003a28dd3965"
   end
 
   depends_on "go"

--- a/Formula/s/staticcheck.rb
+++ b/Formula/s/staticcheck.rb
@@ -4,7 +4,7 @@ class Staticcheck < Formula
   url "https://github.com/dominikh/go-tools/archive/refs/tags/2025.1.1.tar.gz"
   sha256 "259aaf528e4d98e7d3652e283e8551cfdb98cd033a7c01003cd377c2444dd6de"
   license "MIT"
-  revision 7
+  revision 8
   head "https://github.com/dominikh/go-tools.git", branch: "master"
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Pre-announcement: https://groups.google.com/g/golang-announce/c/ask65OnfzGU
Announcement: https://groups.google.com/g/golang-announce/c/4Emdl2iQ_bI
Download: https://go.dev/dl/
Issues: https://github.com/golang/go/issues?q=milestone%3AGo1.25.2
Release notes: https://go.dev/doc/devel/release#go1.25.2
>go1.25.2 (released 2025-10-07) includes security fixes to the archive/tar, crypto/tls, crypto/x509, encoding/asn1, encoding/pem, net/http, net/mail, net/textproto, and net/url packages, as well as bug fixes to the compiler, the runtime, and the context, debug/pe, net/http, os, and sync/atomic packages. See the [Go 1.25.2 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.25.2+label%3ACherryPickApproved) on our issue tracker for details.