### PR TITLE
go@1.24 1.24.8

### DIFF
--- a/Formula/g/go@1.24.rb
+++ b/Formula/g/go@1.24.rb
@@ -1,9 +1,9 @@
 class GoAT124 < Formula
   desc "Open source programming language to build simple/reliable/efficient software"
   homepage "https://go.dev/"
-  url "https://go.dev/dl/go1.24.7.src.tar.gz"
-  mirror "https://fossies.org/linux/misc/go1.24.7.src.tar.gz"
-  sha256 "2a8f50db0f88803607c50d7ea8834dcb7bd483c6b428a91e360fdf8624b46464"
+  url "https://go.dev/dl/go1.24.8.src.tar.gz"
+  mirror "https://fossies.org/linux/misc/go1.24.8.src.tar.gz"
+  sha256 "b1ff32c5c4a50ddfa1a1cb78b60dd5a362aeb2184bb78f008b425b62095755fb"
   license "BSD-3-Clause"
 
   livecheck do

--- a/Formula/g/go@1.24.rb
+++ b/Formula/g/go@1.24.rb
@@ -20,14 +20,12 @@ class GoAT124 < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "99d7885acd026bc8bac68ae38bef84c3346d029b0fd267547fdcc5bfcd1b8d6b"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "99d7885acd026bc8bac68ae38bef84c3346d029b0fd267547fdcc5bfcd1b8d6b"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "99d7885acd026bc8bac68ae38bef84c3346d029b0fd267547fdcc5bfcd1b8d6b"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "99d7885acd026bc8bac68ae38bef84c3346d029b0fd267547fdcc5bfcd1b8d6b"
-    sha256 cellar: :any_skip_relocation, sonoma:        "8f9bb55fd2e9f0d4ad327a9417029d29375fe0e2abe2aeb2c347c24d0f5380ce"
-    sha256 cellar: :any_skip_relocation, ventura:       "8f9bb55fd2e9f0d4ad327a9417029d29375fe0e2abe2aeb2c347c24d0f5380ce"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "aeaaf56c0642e4389c212c27675eefa5143320ea0632346fb51bf46079c435ec"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "987f45c63d25f0c8978e957176e3452762b7e68e7519101ebba009ef80d806c5"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "46aab06912425dc499f9b4376d7c464dfd1bfaa65cd05ac77e2bb0d780abea76"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "46aab06912425dc499f9b4376d7c464dfd1bfaa65cd05ac77e2bb0d780abea76"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "46aab06912425dc499f9b4376d7c464dfd1bfaa65cd05ac77e2bb0d780abea76"
+    sha256 cellar: :any_skip_relocation, sonoma:        "1bfd0ccba107c7a48546058aaa6c9f78fe5d85e23f53c91faf78314744e7a966"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "288648becf05c70f322d1780de2c96c48c507626f9b9827c49d42205ea4f491a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2236048913f56eceaefcff1cb2675b316008d5ff1036a95c7cea19d25e851499"
   end
 
   keg_only :versioned_formula


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Pre-announcement: https://groups.google.com/g/golang-announce/c/ask65OnfzGU
Announcement: https://groups.google.com/g/golang-announce/c/4Emdl2iQ_bI
Download: https://go.dev/dl/
Issues: https://github.com/golang/go/issues?q=milestone%3AGo1.24.8
Release notes: https://go.dev/doc/devel/release#go1.24.8
>go1.24.8 (released 2025-10-07) includes security fixes to the archive/tar, crypto/tls, crypto/x509, encoding/asn1, encoding/pem, net/http, net/mail, net/textproto, and net/url packages, as well as bug fixes to the compiler, the linker, and the debug/pe, net/http, os, and sync/atomic packages. See the [Go 1.24.8 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.24.8+label%3ACherryPickApproved) on our issue tracker for details.
