### PR TITLE
synergy-core: use specific Qt dependencies

### DIFF
--- a/Formula/s/synergy-core.rb
+++ b/Formula/s/synergy-core.rb
@@ -3,21 +3,7 @@ class SynergyCore < Formula
   homepage "https://symless.com/synergy"
   url "https://github.com/symless/synergy/archive/refs/tags/v1.19.0.tar.gz"
   sha256 "c18750b6d6b217f8439199ac90bb4633ef0611d4a962a383c6b424a984f388fa"
-
-  # The synergy-core/LICENSE file contains the following preamble:
-  #   This program is released under the GPL with the additional exemption
-  #   that compiling, linking, and/or using OpenSSL is allowed.
-  # This preamble is followed by the text of the GPL-2.0.
-  #
-  # The synergy-core license is a free software license but it cannot be
-  # represented with the brew `license` statement.
-  #
-  # The GitHub Licenses API incorrectly says that this project is licensed
-  # strictly under GPLv2 (rather than GPLv2 plus a special exception).
-  # This requires synergy-core to appear as an exception in:
-  #   audit_exceptions/permitted_formula_license_mismatches.json
-  # That exception can be removed if the nonfree GitHub Licenses API is fixed.
-  license :cannot_represent
+  license "GPL-2.0-only" => { with: "openvpn-openssl-exception" }
   head "https://github.com/symless/synergy-core.git", branch: "master"
 
   # This repository contains old 2.0.0 tags, one of which uses a stable tag
@@ -40,8 +26,7 @@ class SynergyCore < Formula
 
   depends_on "cmake" => :build
   depends_on "openssl@3"
-  depends_on "pugixml"
-  depends_on "qt"
+  depends_on "qtbase"
 
   on_macos do
     depends_on "llvm" => :build if DevelopmentTools.clang_build_version <= 1402
@@ -77,6 +62,9 @@ class SynergyCore < Formula
   end
 
   def install
+    # Avoid statically linking OpenSSL on macOS
+    inreplace "cmake/Libraries.cmake", "set(OPENSSL_USE_STATIC_LIBS TRUE)", ""
+
     mkdir_p buildpath/"ext/synergy-extra"
     (buildpath/"ext/synergy-extra").install resource("synergy-extra")
 
@@ -90,8 +78,6 @@ class SynergyCore < Formula
 
     args = %w[
       -DBUILD_TESTS:BOOL=OFF
-      -DCMAKE_INSTALL_DO_STRIP=1
-      -DSYSTEM_PUGIXML:BOOL=ON
       -DSYNERGY_VERSION_RELEASE=ON
     ]
     system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args

--- a/Formula/s/synergy-core.rb
+++ b/Formula/s/synergy-core.rb
@@ -17,11 +17,12 @@ class SynergyCore < Formula
   end
 
   bottle do
-    sha256                               arm64_tahoe:   "25913ff6edf63076ea08d23df11d8a3bdd6127cdba722efddb0935f579afa48e"
-    sha256                               arm64_sequoia: "650387faa695e66321282436bd4c5ad056ef3fa228faf568c894667f950c2dd0"
-    sha256                               arm64_sonoma:  "bcebaedefbe2244aa1b13b18d89cb2d3c10e196d0122b898d563c20660865adc"
-    sha256                               sonoma:        "2a1acad3e5d1114fe68664e6b634d81f9263b60a889ebc8b1877640e15244943"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "cc936636d4ad598d9c0209aa12ee9d002ddd3c533e984466601fd24745169496"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "84cbe86fc9c9078649380899f5efe79f500b8816ad5d0f0f6a78526328959092"
+    sha256 cellar: :any,                 arm64_sequoia: "08d10a75a4b369dd67bd04159a660d6d8ebed3a3934ecd062fae29d3afd42b51"
+    sha256 cellar: :any,                 arm64_sonoma:  "76bc87f5bedbb52183aca4f452a49a184a217a53a4f713dc1279c48882a1073c"
+    sha256 cellar: :any,                 sonoma:        "6ba729c50b1ce75370f5340183f96167daff313757d879983a4d718456717a7c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "aec5aca73d1ddde4e6b4c708d0a9038d2b189b078699aa946279f6a41cd1de94"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

New bottles for OpenSSL linkage.

License exception - https://github.com/symless/synergy/commit/b7d8007223205f5cc532003a13376c61b11a53c2
