### PR TITLE
vis: tre support

### DIFF
--- a/Formula/v/vis.rb
+++ b/Formula/v/vis.rb
@@ -7,16 +7,13 @@ class Vis < Formula
   head "https://github.com/martanne/vis.git", branch: "master"
 
   bottle do
-    sha256 arm64_tahoe:    "4992b4301f1c6ce8f29ad461e9586a566e99fcfd98f1658a57de1397a7b6f3ca"
-    sha256 arm64_sequoia:  "6edc0624be797ed3bbee95686dd3af6f164c24e95d520b809004f12518d02553"
-    sha256 arm64_sonoma:   "04a4e8d45b5442ffb3397012eccde1c747b249ae42e8468b24d557dd15ea6081"
-    sha256 arm64_ventura:  "ce1c6d2521a9ab11b32316850690289887a739b2b88a9809b1678682b586fc26"
-    sha256 arm64_monterey: "aeb76e19c965bce4434207059279cae63e30be3e51e933bee8ff52f579b8035d"
-    sha256 sonoma:         "77bfde98fc76bf93d057923482bd1e9b3d538ef8c3875f4b9b579a63cbb75d22"
-    sha256 ventura:        "b27829afe0c6cbb2792f3340ac3605caa16c68677764a1c586879f5387064ca4"
-    sha256 monterey:       "30d9272d1e6e00b8b87c61157e157df124a32c265d4f8befc52df8ac8e2545fb"
-    sha256 arm64_linux:    "20a9cd517f37b2fb444de7e9b6df60a3b57e519a189d7c824501aae6b5251e78"
-    sha256 x86_64_linux:   "6f7e0f61479a8c931556361f8c0dd42a913211ddff0a8b8dfb6b2240f6fb2c6b"
+    rebuild 1
+    sha256 arm64_tahoe:   "9d3f2a7bde3bb933488eb286842e9eecfe7a65443189c12a3b1e351a3d2738e4"
+    sha256 arm64_sequoia: "f1c209db49526dc713fdf8663255d7aef96ce0faf1cca2b2d037fa88888f975b"
+    sha256 arm64_sonoma:  "4de1ac73095911d0aaebca111f7dd326b96c6eec57f5488e76be4ca56ab345e0"
+    sha256 sonoma:        "30727e3f7d1ef664832a4f26127fefc72378b27ea57099b9a10c299494c2e6c3"
+    sha256 arm64_linux:   "ca1b523f0ad09b716cee018694c0cea5a2fd54d2b5357e473fb4b94502eafa8e"
+    sha256 x86_64_linux:  "8c183d876deb3dc5fbcd043e61bb3292eadeb90650e08fbe820d0e40eeebc3bd"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/v/vis.rb
+++ b/Formula/v/vis.rb
@@ -23,6 +23,7 @@ class Vis < Formula
   depends_on "libtermkey"
   depends_on "lpeg"
   depends_on "lua"
+  depends_on "tre"
 
   uses_from_macos "unzip" => :build
   uses_from_macos "ncurses"


### PR DESCRIPTION
Some of the features of vis depend on TRE, such as word completion (see https://github.com/martanne/vis/issues/1269).

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
