### PR TITLE
rolesanywhere-credential-helper 1.7.1 (new formula)

### DIFF
--- a/Formula/r/rolesanywhere-credential-helper.rb
+++ b/Formula/r/rolesanywhere-credential-helper.rb
@@ -1,0 +1,58 @@
+class RolesanywhereCredentialHelper < Formula
+  desc "Manages getting temporary security credentials from IAM Roles Anywhere"
+  homepage "https://github.com/aws/rolesanywhere-credential-helper"
+  url "https://github.com/aws/rolesanywhere-credential-helper/archive/refs/tags/v1.7.1.tar.gz"
+  sha256 "80baa67fd94c347779419b2adb72aabcd5af8952267b5c63a3a97b1718f45f75"
+  license "Apache-2.0"
+  head "https://github.com/aws/rolesanywhere-credential-helper.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = "-s -w -X github.com/aws/rolesanywhere-credential-helper/cmd.Version=#{version}"
+    system "go", "build", *std_go_args(ldflags:, output: bin/"aws_signing_helper")
+
+    generate_completions_from_executable(bin/"aws_signing_helper", "completion")
+  end
+
+  test do
+    # Testing real functionality requires a complete setup of AWS account and much
+    # more configuration.
+    (testpath/"cert.pem").write <<~CERT
+      -----BEGIN CERTIFICATE-----
+      MIIE/zCCAuegAwIBAgIUWnMzjNagfF7z9opuIl6h4wCv4GIwDQYJKoZIhvcNAQEL
+      BQAwDzENMAsGA1UEAwwEVEVTVDAeFw0yNTEwMDcxNTM2MzJaFw0zNTEwMDUxNTM2
+      MzJaMA8xDTALBgNVBAMMBFRFU1QwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIK
+      AoICAQCtaWxvgFyT0SfhEAy6K/yJOSitfGci89XphbuTFnCIoqRo/qD8K+ZbaFM6
+      zRL7zCL0UMlJingi7MVERox/yufTH0najVhKBM30736N6wzWzUuA4vQmaExOwbLe
+      ExgOeoSufS+h5WeUZAm03z3RRzmQwIpaxx7aZwkP40o5v+I795RaQle145jNdzAD
+      pzFwn1iBCemVOMfBqRn73mH77n/ujQghol03Hroy3Va4P6qoV35+hUr89zUMyBYS
+      r4Hrpp0YHVh3cJ+uUrCoTrpNYZ5ykCdPLw8LT1ZF5eruhIVDnlRM4n+zdR11+qb8
+      1o7aUr0UIiKe9O6FULnN6GBcWwp8JrCQtllw8tiG2XFfNTkU8ASg2jL0Laauu/Vq
+      lsHuTIKwGI4mVbFYW7REWdB7aoVLhn1nT66hko6YV02XugW3KCRomDaqtZXIDTPA
+      cFShtRNpjxmDrSuysm3U8jtrIGJoWc1jl93mawAoZaIn+c12+nuXvPyuI4CEP5mp
+      Xuj5WhAtkX7GqqKaBmJKsgbAeicRB5MHyMHlS3AVAUYzClxFzlvmk6pdhDlb8eQw
+      Ul++rCFliCtzAPJfarZ9iqhjXMVIqIukMQmBpvSpk0IUOswkhyWS7gFQOzSDDDfc
+      1KmNrpOhyhYfFM+mVqv4GOpNw0epctuN2XleIFbuHdocKenwLwIDAQABo1MwUTAd
+      BgNVHQ4EFgQUP/1BBPiRUBA2gTbKqqm8sMVAR2EwHwYDVR0jBBgwFoAUP/1BBPiR
+      UBA2gTbKqqm8sMVAR2EwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOC
+      AgEASQf6WaIGnR+Tlx4Vq7woxGUS5oZggqeRait8R9bk5Y6zR6WeuuVV7Wa8DiaN
+      ix+wSZbSYj78oFmJIIFq08syWGorWrffMQ/KegRFaYIjY6v0DZk4eJS9Eyy32m2o
+      Gh8LhfICXDV3JbP+6UcjNiROrfvAfirT3s57TVDiK+zEItYA4WHITmezUy5l4RMB
+      WMCYp3ie4FjSCgVk1Q0yqIS6dCHR1bj1WnMuSv+V6rRA6chcavxar7jEcnBy6uu5
+      NJRWjS/FOZdbyxfNWKMauctUBg2E3z0oDPcJBMDl0il54J6E1rU0pnKDAqcs6BxJ
+      qMDFLYsexcglk9ISmEzf3YHaV39ukb+eX0LogTYXi9Mh/FUj30Pd4Z398Ihogm4t
+      FNR+ur24BoT5wl79Js3oN8fekT4ULwfGg+lcAOi1IiRH9yJqHlGOpgu+kBeg43qe
+      svK9bpMddqY6Q6ryHPQAc+P6bLKs5yfx3cItjqhHhVq8cVqEOoZhhtQ38anklLct
+      ePEWPXvZFeufOEoOkQwySYiUQhXlcCveJmNHBkvNIotYH5h6fuX2HvJfBfnvqkkM
+      dIpUtT+Di4Gjzk8GNAmISGmlayogyMyHOQR03xRPu2DU6gMpOiLo0isIQvpHdhdq
+      g0HKj0SpvXaT/uTqr+B4tG1KDO76d/okqxtYzPGvlUhEysA=
+      -----END CERTIFICATE-----
+    CERT
+
+    read_cert_output = shell_output("#{bin}/aws_signing_helper read-certificate-data --certificate cert.pem 2>&1")
+    assert_match '"serialNumber":"516378245723378548683302024520857503286885867618"', read_cert_output
+
+    assert_match version.to_s, shell_output("#{bin}/aws_signing_helper version 2>&1")
+  end
+end

--- a/Formula/r/rolesanywhere-credential-helper.rb
+++ b/Formula/r/rolesanywhere-credential-helper.rb
@@ -6,6 +6,14 @@ class RolesanywhereCredentialHelper < Formula
   license "Apache-2.0"
   head "https://github.com/aws/rolesanywhere-credential-helper.git", branch: "main"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "3c697318f62b446aaba0a20290ea036c71cef2ee5b424d20006dcb703458e5f6"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "5f2fe7c610c146037ec31114e3535cefb4efc67e25847e67339b79113c5bccad"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "7ba22e6393778c286860036cb314594f4932ec1ca3d8688fa71b9b42757cc2d6"
+    sha256 cellar: :any_skip_relocation, sonoma:        "c1d04d97222d42b71ba4d6f79aee94fa24531d6d1f65a54b01e6bff170ae6592"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d331365e22b91e363c2c2978de9484349aa61b466e5ef68e62ed3b65d918dc0d"
+  end
+
   depends_on "go" => :build
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
This adds a credential helper from AWS for use with the IAM Roles Anywhere product.
Documentation for reference: https://docs.aws.amazon.com/rolesanywhere/latest/userguide/credential-helper.html

I built this as a cask first and then realized that since it's available as source, it should be added as a formula.