### PR TITLE
apache-spark: switch to `openjdk@21`

### DIFF
--- a/Formula/a/apache-spark.rb
+++ b/Formula/a/apache-spark.rb
@@ -6,6 +6,7 @@ class ApacheSpark < Formula
   version "4.0.1"
   sha256 "bd5315fa89db737f005971835b94e093c3d2b8581d2411737d281627d6803cc3"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/apache/spark.git", branch: "master"
 
   # The download page creates file links using JavaScript, so we identify
@@ -19,7 +20,7 @@ class ApacheSpark < Formula
     sha256 cellar: :any_skip_relocation, all: "9a976508713bf1895b09cd55d0ac0f573f033a701e0f719302535cb5f36c96a1"
   end
 
-  depends_on "openjdk@17"
+  depends_on "openjdk@21"
 
   def install
     # Rename beeline to distinguish it from hive's beeline
@@ -28,16 +29,22 @@ class ApacheSpark < Formula
     rm(Dir["bin/*.cmd"])
     libexec.install Dir["*"]
     bin.install Dir[libexec/"bin/*"]
-    bin.env_script_all_files(libexec/"bin", JAVA_HOME: Language::Java.overridable_java_home_env("17")[:JAVA_HOME])
+    bin.env_script_all_files(libexec/"bin", JAVA_HOME: Language::Java.overridable_java_home_env("21")[:JAVA_HOME])
   end
 
   test do
     require "pty"
 
+    (testpath/"data.txt").write <<~EOS
+      Homebrew test
+      Homebrew Spark test
+      Spark test Homebrew
+    EOS
+
     output = ""
     PTY.spawn(bin/"spark-shell") do |r, w, pid|
       w.puts "sc.parallelize(1 to 1000).count()"
-      w.puts "jdk.incubator.foreign.FunctionDescriptor.TRIVIAL_ATTRIBUTE_NAME"
+      w.puts 'sc.textFile("data.txt").filter(line => line.contains("Spark")).first()'
       w.puts ":quit"
       begin
         r.each_line { |line| output += line }
@@ -55,6 +62,6 @@ class ApacheSpark < Formula
     end
 
     assert_match "Long = 1000", output
-    assert_match "String = abi/trivial", output
+    assert_match "String = Homebrew Spark test", output
   end
 end

--- a/Formula/a/apache-spark.rb
+++ b/Formula/a/apache-spark.rb
@@ -17,7 +17,7 @@ class ApacheSpark < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "9a976508713bf1895b09cd55d0ac0f573f033a701e0f719302535cb5f36c96a1"
+    sha256 cellar: :any_skip_relocation, all: "6567eb49d5d7f9e6e63d272d674e3d2e96a9eac837a8fee7d11f8c824f443177"
   end
 
   depends_on "openjdk@21"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Apache Spark supports Java 21 (but not Java 25 yet) [^1].

Also, remove a test depending on an incubating feature (`jdk.incubator.foreign`) [^2] that was removed in Java 21.

[^1]: https://spark.apache.org/docs/latest/#downloading
[^2]: https://docs.oracle.com/en/java/javase/17/docs/api/jdk.incubator.foreign/module-summary.html
