### PR TITLE
bitcoin: head requires capnp

### DIFF
--- a/Formula/b/bitcoin.rb
+++ b/Formula/b/bitcoin.rb
@@ -9,7 +9,6 @@ class Bitcoin < Formula
     "BSL-1.0", # src/tinyformat.h
     "Sleepycat", # resource("bdb")
   ]
-  head "https://github.com/bitcoin/bitcoin.git", branch: "master"
 
   livecheck do
     url "https://bitcoincore.org/en/download/"
@@ -23,6 +22,13 @@ class Bitcoin < Formula
     sha256 cellar: :any, sonoma:        "b62278e3ada8701c9a542bee64adeaf50a5c8b1aa5b7cf172f9a96ddf24aed3b"
     sha256               arm64_linux:   "d1ca6acf2612a816805f118f1625b04ba332b23f1a97d2c3febed168862207a7"
     sha256               x86_64_linux:  "b7290cd2f6e3e5b41170d1d3fd7c7460c4a715bdb97cd5205655a68c454383cc"
+  end
+
+  head do
+    url "https://github.com/bitcoin/bitcoin.git", branch: "master"
+
+    # Move to stable block when updated to v30.0
+    depends_on "capnp" => :build
   end
 
   depends_on "boost" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

A `brew install bitcoin --HEAD` currently fails with:
```bash
brew install bitcoin --HEAD
<snip>
==> make install_lib install_include
==> cmake -S . -B build -DWITH_BDB=ON -DBerkeleyDB_INCLUDE_DIR:PATH=/private/tmp/bitcoin-20251008-91832-hrvcgb/bdb/include -DWITH_ZMQ=ON
Last 15 lines from /Library/Logs/Homebrew/bitcoin/04.cmake.log:
-- Looking for F_FULLFSYNC
-- Looking for F_FULLFSYNC - found
-- Performing Test HAVE_CLMUL
-- Performing Test HAVE_CLMUL - Failed
CMake Error at src/ipc/libmultiprocess/CMakeLists.txt:18 (message):
  Cap'n Proto is required but was not found.

  To resolve, choose one of the following:

    - Install Cap'n Proto (version 1.0+ recommended)
    - For Bitcoin Core compilation build with -DENABLE_IPC=OFF to disable multiprocess support



-- Configuring incomplete, errors occurred!
```