### PR TITLE
gost 3.2.4

### DIFF
--- a/Formula/g/gost.rb
+++ b/Formula/g/gost.rb
@@ -12,13 +12,11 @@ class Gost < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "b074c277af3a33652020d02819a234f3a83154a8b3ac73ef5b99c89f5ed9958c"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "57e454b905ac17f21519f34ed868db709413efb45f53fe37edeb9bd0e9da0259"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "86b48c89f4ea3d4edaaa3cec855981de9ac0fc36cc82f50b166bf6bf688c8997"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "189a833087438d49b52688387ab96ff43aa9728337fc24c236e007691dae1eb4"
-    sha256 cellar: :any_skip_relocation, sonoma:        "e9f65b51d764ccac83750b55a03bb3895cd0c2e32a2e57697fa3323a12499c67"
-    sha256 cellar: :any_skip_relocation, ventura:       "4c956460f08c30254b98a089e1ee60a62ca5721f2525638ed16af81c46e28a8e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "de78cc69979d46baeb0727157ea88dc6b6f3c263258e2d99c32040c5a9abd28c"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "0e787f163b99a3d181c7d80c405d1b28b0e1e3c228008a17fdf1e76f518a787d"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "0e787f163b99a3d181c7d80c405d1b28b0e1e3c228008a17fdf1e76f518a787d"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "0e787f163b99a3d181c7d80c405d1b28b0e1e3c228008a17fdf1e76f518a787d"
+    sha256 cellar: :any_skip_relocation, sonoma:        "29fef5f7669f9e1177b8d7dc25d6b960cade021ede591454bd219b0441de54a0"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "551ebd4cffd93ed23342dfb4545112cc3c636579b4b7330f4b94a28071cceaf8"
   end
 
   depends_on "go" => :build

--- a/Formula/g/gost.rb
+++ b/Formula/g/gost.rb
@@ -1,12 +1,15 @@
 class Gost < Formula
   desc "GO Simple Tunnel - a simple tunnel written in golang"
-  homepage "https://github.com/ginuerzh/gost"
-  url "https://github.com/ginuerzh/gost/archive/refs/tags/v2.12.0.tar.gz"
-  sha256 "ed575807b0490411670556d4471338f418c326bb1ffe25f52977735012851765"
+  homepage "https://gost.run/"
+  url "https://github.com/go-gost/gost/archive/refs/tags/v3.2.4.tar.gz"
+  sha256 "893aedaaf9b701e6847d14e63a0e5609245dae099e3124f3f1095c44595f7b5e"
   license "MIT"
-  head "https://github.com/ginuerzh/gost.git", branch: "master"
+  head "https://github.com/go-gost/gost.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "b074c277af3a33652020d02819a234f3a83154a8b3ac73ef5b99c89f5ed9958c"
@@ -35,7 +38,6 @@ class Gost < Formula
     sleep 2
     output = shell_output("curl -I -x #{bind_address} https://github.com")
     assert_match %r{HTTP/\d+(?:\.\d+)? 200}, output
-    assert_match %r{Proxy-Agent: gost/#{version}}i, output
     assert_match(/Server: GitHub.com/i, output)
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`gost` v2 has been discontinued, and the v3 repository has moved from [ginuerzh/gost](https://github.com/ginuerzh/gost) to [go-gost/gost](https://github.com/go-gost/gost). However, there’s an issue — `gost` v3 is not 100% compatible with v2. Should we keep `gost` v2 and rename it to `gost@2`?