### PR TITLE
qtbase: apply upstreamed patch to fix pkg-config Cflags

### DIFF
--- a/Formula/a/audacious.rb
+++ b/Formula/a/audacious.rb
@@ -44,6 +44,7 @@ class Audacious < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkgconf" => :build
+  depends_on "qttools" => :build
   depends_on "faad2"
   depends_on "ffmpeg"
   depends_on "flac"
@@ -65,7 +66,10 @@ class Audacious < Formula
   depends_on "mpg123"
   depends_on "neon"
   depends_on "opusfile"
-  depends_on "qt"
+  depends_on "qtbase"
+  depends_on "qtimageformats" => :no_linkage # for webp album covers
+  depends_on "qtmultimedia"
+  depends_on "qtsvg" => :no_linkage # for svg icons
   depends_on "sdl2"
   depends_on "wavpack"
 
@@ -74,7 +78,6 @@ class Audacious < Formula
 
   on_macos do
     depends_on "gettext"
-    depends_on "opus"
   end
 
   on_linux do

--- a/Formula/a/audacious.rb
+++ b/Formula/a/audacious.rb
@@ -23,13 +23,12 @@ class Audacious < Formula
   end
 
   bottle do
-    sha256 arm64_tahoe:   "dd28e858bc3a5e82fb73be784b5a2ceec204418dd915406f14b16925dd29fc32"
-    sha256 arm64_sequoia: "da5a135943193ca45ebc751814045797ced67045e1329b61f3c8d786a58d150e"
-    sha256 arm64_sonoma:  "ec5a613c9c634e0e53fa1a39e52fbdd4d1cd48dcbf9d009ed547cd34b5e26a52"
-    sha256 arm64_ventura: "0fc42570974a4671bce5381306c275810c1e032e3eb449a23e36b6d6d67dbc2b"
-    sha256 sonoma:        "2f37ac529fefa8d6e1165942699c2371bff51984df7b49daef35aa25cec68172"
-    sha256 ventura:       "b06c1d390c4123eb885f785f776dcf1148fb299be937a478a97b9c3d62cb1eb7"
-    sha256 x86_64_linux:  "bad3cbe9fb783f5c087d26d1ff4425dc0b72f44f1b5327883e935add9161827c"
+    rebuild 1
+    sha256 arm64_tahoe:   "3b829640b0cc7b22b0f282e8ab130fd6bbc5848f5d0eb2bd55c33b6274560000"
+    sha256 arm64_sequoia: "af302255ecb85db566402b0df1eb92965dfbb6464899cd0bac235dae93f8db95"
+    sha256 arm64_sonoma:  "777753090239d0c200cf857435d144df7575fa8988a6784f10c3693fade8a9ab"
+    sha256 sonoma:        "b62ee7187df43d86850bd74b6a6a2b8491250c998c27e9ba59d86178b26242e4"
+    sha256 x86_64_linux:  "56afb109a127599f5a9e6a2bcbbb1717f1796ccf3ab83a1dfba66aa4e1de3c54"
   end
 
   head do

--- a/Formula/g/gnuplot.rb
+++ b/Formula/g/gnuplot.rb
@@ -11,14 +11,12 @@ class Gnuplot < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 arm64_tahoe:   "7d09003be2d42dabc884f5d593bf3b0d16681b854371ab78280f900c07b06d5d"
-    sha256 arm64_sequoia: "133bc5f100993ca1ad181a3ca097851c626076a619e9c4941e8c62352ad20b8d"
-    sha256 arm64_sonoma:  "4f2052aecbd2f736e1b2318acce36c0cb233af6be0935deddcf998bd822b1013"
-    sha256 arm64_ventura: "644cb48402329094a8de79741d5798c3720682f22c11330621d348e69bbb968b"
-    sha256 sonoma:        "e347e5938f393d37b8d2f5e3b0bca7954d6829174af3c7768c13ac0c49874bf4"
-    sha256 ventura:       "f8827be16a188c2388f7ad2ff9ccf5eda60152fc98a8fd64df6bbec7227c7011"
-    sha256 x86_64_linux:  "ab0c9ee561bf5ad5c80c772b0210dc905319ac694e6867cef09dbce7d4c63508"
+    rebuild 2
+    sha256 arm64_tahoe:   "955fa674228be8dfeaeaaff768395a020923d859dc68a3f310488247e3ce4415"
+    sha256 arm64_sequoia: "09d2a9f66dfc73e37386e1223398a68d5ce218be88c1071aa718163d9ed61048"
+    sha256 arm64_sonoma:  "48dd121ea7f5d69f691e0388bf2c2b6361c3bb70183157198ae96ac40838c7d1"
+    sha256 sonoma:        "3bdf53b8e9713d484b746bd7b9abe32f8d636fbbaa658edddcbe2d1e15b3d965"
+    sha256 x86_64_linux:  "d72dfd859cb4e2332bde4404b84e8158b8395a0a887b0a0f9f24a98d5125baa6"
   end
 
   head do

--- a/Formula/g/gnuplot.rb
+++ b/Formula/g/gnuplot.rb
@@ -29,8 +29,8 @@ class Gnuplot < Formula
     depends_on "libtool" => :build
   end
 
-  depends_on "gnu-sed" => :build # https://sourceforge.net/p/gnuplot/bugs/2676/
   depends_on "pkgconf" => :build
+  depends_on "qttools" => :build
 
   depends_on "cairo"
   depends_on "gd"
@@ -38,7 +38,9 @@ class Gnuplot < Formula
   depends_on "libcerf"
   depends_on "lua"
   depends_on "pango"
-  depends_on "qt"
+  depends_on "qt5compat"
+  depends_on "qtbase"
+  depends_on "qtsvg"
   depends_on "readline"
   depends_on "webp"
 
@@ -55,32 +57,7 @@ class Gnuplot < Formula
       --with-qt
       --without-x
       --without-latex
-      LRELEASE=#{Formula["qt"].bin}/lrelease
-      MOC=#{Formula["qt"].pkgshare}/libexec/moc
-      RCC=#{Formula["qt"].pkgshare}/libexec/rcc
-      UIC=#{Formula["qt"].pkgshare}/libexec/uic
     ]
-
-    # https://sourceforge.net/p/gnuplot/bugs/2676/
-    ENV.prepend_path "PATH", Formula["gnu-sed"].opt_libexec/"gnubin"
-
-    if OS.mac?
-      # pkg-config files are not shipped on macOS, making our job harder
-      # https://bugreports.qt.io/browse/QTBUG-86080
-      # Hopefully in the future gnuplot can autodetect this information
-      # https://sourceforge.net/p/gnuplot/feature-requests/560/
-      qtcflags = []
-      qtlibs = %W[-F#{Formula["qt"].opt_prefix}/Frameworks]
-      %w[Core Gui Network Svg PrintSupport Widgets Core5Compat].each do |m|
-        qtcflags << "-I#{Formula["qt"].opt_include}/Qt#{m}"
-        qtlibs << "-framework Qt#{m}"
-      end
-
-      args += %W[
-        QT_CFLAGS=#{qtcflags.join(" ")}
-        QT_LIBS=#{qtlibs.join(" ")}
-      ]
-    end
 
     ENV.append "CXXFLAGS", "-std=c++17" # needed for Qt 6
     system "./prepare" if build.head?

--- a/Formula/q/qalculate-qt.rb
+++ b/Formula/q/qalculate-qt.rb
@@ -17,9 +17,10 @@ class QalculateQt < Formula
   end
 
   depends_on "pkgconf" => :build
+  depends_on "qttools" => :build
 
   depends_on "libqalculate"
-  depends_on "qt"
+  depends_on "qtbase"
 
   on_macos do
     depends_on "gmp"
@@ -27,7 +28,7 @@ class QalculateQt < Formula
   end
 
   def install
-    system Formula["qt"].bin/"qmake", "qalculate-qt.pro"
+    system Formula["qtbase"].bin/"qmake", "qalculate-qt.pro"
     system "make"
     if OS.mac?
       prefix.install "qalculate-qt.app"

--- a/Formula/q/qalculate-qt.rb
+++ b/Formula/q/qalculate-qt.rb
@@ -7,13 +7,12 @@ class QalculateQt < Formula
   head "https://github.com/Qalculate/qalculate-qt.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "e0dd06ab870288d7ad9b5a99bc8cfb6ad7a8f338181668680931be564bdd24aa"
-    sha256 cellar: :any,                 arm64_sequoia: "d5ca870a7b73a435e81f15cc3b5c73c8d12e68e70696fa597574fec00106999f"
-    sha256 cellar: :any,                 arm64_sonoma:  "ecbc0902df9615ab02cc14c7821b763df4cd91815c320790e2d37227dea33ab6"
-    sha256 cellar: :any,                 arm64_ventura: "f2cad1739fd3afa7ccd0d56ba2309f528505de2bdc97120dbe11870d82fe9b78"
-    sha256 cellar: :any,                 sonoma:        "6f457c9182a94f0b80ec5b59f735c88e9e7f58de4af63d52a6ea535be56dbcff"
-    sha256 cellar: :any,                 ventura:       "9c10be6c17d81fd8f881e87e0b4119f115895c310cfeb26fd0e4e99314312fba"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "63e9383503ff926b1bb7c0646624d8589eab2530eb83e52f5a496d5ad52305d2"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "26b8843f8e3bc933466a7ca78ca60beeb498452e736fbd09b6ed27f65c5ad94a"
+    sha256 cellar: :any,                 arm64_sequoia: "3a5903ad430375c98dd363bd2eae18a1faf0ecdd491c3171a9be258de61d10b1"
+    sha256 cellar: :any,                 arm64_sonoma:  "47e659391bea63d7646e9e3a2fb03f41f4fedcbfdbeb484e6a99c8adbfefd9ac"
+    sha256 cellar: :any,                 sonoma:        "13f441fb6a0373fd027167ce0e30b9f860a8bf9755c8a37f057119ea33842d75"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "09f64db8f68961a6a9dcbd460484d7458e1b6f3bc109bc797000a0a3deaaf1bf"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/q/qtbase.rb
+++ b/Formula/q/qtbase.rb
@@ -21,12 +21,13 @@ class Qtbase < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "031dc8feea7e91068bad640f2384309b5d73983f5e13b63fd41019a492365d6a"
-    sha256 cellar: :any,                 arm64_sequoia: "f81cd92620f9a76049a118e983b68141d469825828fbc317e04c4449c3e7066d"
-    sha256 cellar: :any,                 arm64_sonoma:  "73404da080f30f866f0edd489527ed879a06a2a956f59c6ed52d47c7e32668f5"
-    sha256 cellar: :any,                 sonoma:        "6a51ae0cf024a196bba21a5ba75bf7d4c35aedcdae23476ff2f948cecb3602a9"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "e4852adbad72798a532d616ebbda7fb3576ae2293ca31252dace8a4415848975"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "28447cd1dc3f8930358e067866bc3b68c24f26ab5a19ba7bd7d22e8978924a42"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "b71662b2a584d66df3cb7693453c0c685aeaac59bdbebf09c6525a95336c92d8"
+    sha256 cellar: :any,                 arm64_sequoia: "e01b6da67665aacb7251e9402f9ff61cdf15eefbe18d3bd162a4f031e24b0375"
+    sha256 cellar: :any,                 arm64_sonoma:  "e5e9230b6d4d803f2c82d317832ef225debd4218b0289ea58e1e2abffbb4f62a"
+    sha256 cellar: :any,                 sonoma:        "ea8dd5c6dd29e5d2c8477024026cb841d0982f01b3d698bd2751bff1875b3656"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "b0790ab124d71c60905dcc5d6a9023b9aebe0392c9e374422341eb3a2e068b95"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d65327cb727685833b1706b1f431d61bc80e4172526fb8a61c27870979d1bbee"
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/q/qtbase.rb
+++ b/Formula/q/qtbase.rb
@@ -79,6 +79,13 @@ class Qtbase < Formula
     depends_on "xcb-util-wm"
   end
 
+  # Add framework directory to Cflags on macOS
+  # Ref: https://codereview.qt-project.org/c/qt/qtbase/+/682915
+  patch do
+    url "https://codereview.qt-project.org/changes/qt%2Fqtbase~682915/revisions/1/patch?zip"
+    sha256 "41fc97843c891cc8c5fe513acfc5779bb42a2ac417e6c931efee08ed5eb62201"
+  end
+
   def install
     # Allow -march options to be passed through, as Qt builds
     # arch-specific code with runtime detection of capabilities:


### PR DESCRIPTION
Example diff of pkg-config file:
```diff
@@ -9,5 +9,5 @@ Name: Qt6 Core
 Description: Qt Core module
 Version: 6.9.3
 Libs: -F${libdir} -framework QtCore
-Cflags: -I${libdir}/QtCore.framework/Headers -I${libdir}/QtCore.framework -DQT_CORE_LIB
+Cflags: -F${libdir} -I${libdir}/QtCore.framework/Headers -I${libdir}/QtCore.framework -DQT_CORE_LIB
 Requires: Qt6Platform
```

Should allow building Meson projects (audacious) and some Autotools projects (gnuplot).

Octave will need some upstream help to get this into QT_CPPFLAGS.

Not related to this, but still need to figure out PySide6.