### PR TITLE
Revise the brew install command for wireshark-app

### DIFF
--- a/Formula/w/wireshark.rb
+++ b/Formula/w/wireshark.rb
@@ -76,7 +76,7 @@ class Wireshark < Formula
       This formula only installs the command-line utilities by default.
 
       Install Wireshark.app with Homebrew Cask:
-        brew install wireshark-app
+        brew install --cask wireshark-app
 
       If your list of available capture interfaces is empty
       (default macOS behavior), install ChmodBPF:


### PR DESCRIPTION
Ref - https://formulae.brew.sh/cask/wireshark-app#default

The command present is 
brew install wireshark-app

The command after revision is 
brew install --cask wireshark-app

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
