### PR TITLE
openstackclient: add gnureadline dependency

### DIFF
--- a/Formula/o/openstackclient.rb
+++ b/Formula/o/openstackclient.rb
@@ -416,6 +416,11 @@ class Openstackclient < Formula
     sha256 "f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0"
   end
 
+  resource "gnureadline" do
+    url "https://files.pythonhosted.org/packages/cb/92/20723aa239b9a8024e6f8358c789df8859ab1085a1ae106e5071727ad20f/gnureadline-8.2.13.tar.gz"
+    sha256 "c9b9e1e7ba99a80bb50c12027d6ce692574f77a65bf57bc97041cf81c0f49bd1"
+  end
+
   def install
     virtualenv_install_with_resources
   end

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -681,7 +681,7 @@
   },
   "openstackclient": {
     "extra_packages": [
-      "keystoneauth-websso", "osc-placement", "python-barbicanclient",
+      "gnureadline", "keystoneauth-websso", "osc-placement", "python-barbicanclient",
       "python-cloudkittyclient", "python-designateclient",
       "python-glanceclient", "python-heatclient", "python-ironicclient",
       "python-magnumclient", "python-manilaclient", "python-mistralclient",


### PR DESCRIPTION
Fixes #132854

Adds gnureadline to extra_packages to resolve readline warning on macOS/Linux.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
