### PR TITLE
triage: self-hosted for `qtwebengine`, long test for `qtbase`

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -372,7 +372,7 @@ jobs:
                 shared-mime-info|\
                 sqlite|\
                 suite-sparse|\
-                qtwebengine|\
+                qtbase|\
                 readline|\
                 unbound|\
                 xz|\
@@ -409,7 +409,8 @@ jobs:
               path: "Formula/.+/(\
                 dart-sdk|\
                 envoy|\
-                qt(@5)?|\
+                qt@5|\
+                qtwebengine|\
                 teleport|\
                 texlive\
                 ).rb"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Some changes from my last PR:
- Long dependent tests should have been for `qtbase` as that is common dependency.
- Forgot self-hosted. Still needed on `qtwebengine` - #246790 (https://github.com/Homebrew/homebrew-core/actions/runs/18232098228/job/51917917099)