### PR TITLE
certifi: build once and symlink

### DIFF
--- a/Formula/c/certifi.rb
+++ b/Formula/c/certifi.rb
@@ -4,28 +4,40 @@ class Certifi < Formula
   url "https://files.pythonhosted.org/packages/4c/5b/b6ce21586237c77ce67d01dc5507039d444b630dd76611bbca2d8e5dcd91/certifi-2025.10.5.tar.gz"
   sha256 "47c09d31ccf2acf0be3f701ea53595ee7e0b8fa08801c6624be771df09ae7b43"
   license "MPL-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "de6342b72b69a473c6420dc822d0e103989bb68d8d06bc28fce4d82ec2da376f"
   end
 
-  depends_on "python@3.12" => [:build, :test]
-  depends_on "python@3.13" => [:build, :test]
+  depends_on "python@3.14" => [:build, :test]
+  depends_on "python@3.12" => :test # keep on oldest python to support (externally managed and not EOL)
   depends_on "ca-certificates"
 
   def pythons
-    deps.map(&:to_formula).sort_by(&:version).filter { |f| f.name.start_with?("python@") }
+    deps.filter_map { |dep| dep.to_formula if dep.name.start_with?("python@") }
   end
 
   def install
-    pythons.each do |python|
-      python_exe = python.opt_libexec/"bin/python"
-      system python_exe, "-m", "pip", "install", *std_pip_args(build_isolation: true), "."
+    oldest_python, python = pythons.sort_by(&:version)
+    python_exe = python.opt_libexec/"bin/python"
+    system python_exe, "-m", "pip", "install", *std_pip_args(build_isolation: true), "."
 
-      # Use brewed ca-certificates PEM file instead of the bundled copy
-      site_packages = Language::Python.site_packages("python#{python.version.major_minor}")
-      rm prefix/site_packages/"certifi/cacert.pem"
-      (prefix/site_packages/"certifi").install_symlink Formula["ca-certificates"].pkgetc/"cert.pem" => "cacert.pem"
+    # Use brewed ca-certificates PEM file instead of the bundled copy
+    site_packages = prefix/Language::Python.site_packages(python_exe)
+    rm site_packages/"certifi/cacert.pem"
+    (site_packages/"certifi").install_symlink Formula["ca-certificates"].pkgetc/"cert.pem" => "cacert.pem"
+
+    link_dirs = site_packages.children - [site_packages/"certifi"]
+    python.versioned_formulae.each do |extra_python|
+      next if extra_python.version < oldest_python.version
+
+      # Cannot use Python.site_packages as that requires formula to be installed
+      extra_site_packages = lib/"python#{extra_python.version.major_minor}/site-packages"
+      extra_site_packages.install_symlink link_dirs
+
+      # Symlink grandchildren so cache ends up in correct directory
+      (extra_site_packages/"certifi").install_symlink site_packages.glob("certifi/*")
     end
   end
 

--- a/Formula/c/certifi.rb
+++ b/Formula/c/certifi.rb
@@ -7,7 +7,7 @@ class Certifi < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "de6342b72b69a473c6420dc822d0e103989bb68d8d06bc28fce4d82ec2da376f"
+    sha256 cellar: :any_skip_relocation, all: "d1eb3e86754cc51d5fb9513b6067c75fd90005cea0fab11134f6a7b482989015"
   end
 
   depends_on "python@3.14" => [:build, :test]


### PR DESCRIPTION

Trying this again 
- #193919

Installation in keg:
```console
❯ tree -a /opt/homebrew/opt/certifi/
/opt/homebrew/opt/certifi/
├── .brew
│   └── certifi.rb
├── INSTALL_RECEIPT.json
├── lib
│   ├── python3.12
│   │   └── site-packages
│   │       ├── certifi
│   │       │   ├── __init__.py -> ../../../python3.14/site-packages/certifi/__init__.py
│   │       │   ├── __main__.py -> ../../../python3.14/site-packages/certifi/__main__.py
│   │       │   ├── cacert.pem -> ../../../python3.14/site-packages/certifi/cacert.pem
│   │       │   ├── core.py -> ../../../python3.14/site-packages/certifi/core.py
│   │       │   └── py.typed -> ../../../python3.14/site-packages/certifi/py.typed
│   │       └── certifi-2025.10.5.dist-info -> ../../python3.14/site-packages/certifi-2025.10.5.dist-info
│   ├── python3.13
│   │   └── site-packages
│   │       ├── certifi
│   │       │   ├── __init__.py -> ../../../python3.14/site-packages/certifi/__init__.py
│   │       │   ├── __main__.py -> ../../../python3.14/site-packages/certifi/__main__.py
│   │       │   ├── cacert.pem -> ../../../python3.14/site-packages/certifi/cacert.pem
│   │       │   ├── core.py -> ../../../python3.14/site-packages/certifi/core.py
│   │       │   └── py.typed -> ../../../python3.14/site-packages/certifi/py.typed
│   │       └── certifi-2025.10.5.dist-info -> ../../python3.14/site-packages/certifi-2025.10.5.dist-info
│   └── python3.14
│       └── site-packages
│           ├── certifi
│           │   ├── __init__.py
│           │   ├── __main__.py
│           │   ├── cacert.pem -> ../../../../../../../etc/ca-certificates/cert.pem
│           │   ├── core.py
│           │   └── py.typed
│           └── certifi-2025.10.5.dist-info
│               ├── INSTALLER
│               ├── licenses
│               │   └── LICENSE
│               ├── METADATA
│               ├── REQUESTED
│               ├── top_level.txt
│               └── WHEEL
├── LICENSE
├── README.rst
└── sbom.spdx.json

16 directories, 26 files
```

Cache files:
```console
❯ python3.12 -c "import certifi"

❯ tree -a /opt/homebrew/lib/python3.12/site-packages/certifi
/opt/homebrew/lib/python3.12/site-packages/certifi
├── __init__.py -> ../../../../Cellar/certifi/2025.10.5/lib/python3.12/site-packages/certifi/__init__.py
├── __main__.py -> ../../../../Cellar/certifi/2025.10.5/lib/python3.12/site-packages/certifi/__main__.py
├── __pycache__
│   ├── __init__.cpython-312.pyc
│   └── core.cpython-312.pyc
├── cacert.pem -> ../../../../Cellar/certifi/2025.10.5/lib/python3.12/site-packages/certifi/cacert.pem
├── core.py -> ../../../../Cellar/certifi/2025.10.5/lib/python3.12/site-packages/certifi/core.py
└── py.typed -> ../../../../Cellar/certifi/2025.10.5/lib/python3.12/site-packages/certifi/py.typed

2 directories, 7 files
```