### PR TITLE
somo: add shell completions

### DIFF
--- a/Formula/s/somo.rb
+++ b/Formula/s/somo.rb
@@ -6,12 +6,13 @@ class Somo < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "8f7e71eb3e92c9f824271445b6bc9acedef1fab585256bfb96166685cf02326f"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "08a35a350cbb0b833e804dc0512eca3a5b730f3c982795a008300bed6f903ac2"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "fd1de69079b2dc705459349aeb10e7b1f9185e93871cd562058a1471a7bb5fbd"
-    sha256 cellar: :any_skip_relocation, sonoma:        "67c190daa017dca0b5eeb53f23df6efb607995a8e0df7223a99d55b7db1471ac"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "01a2fda10ce89efe876b1dfdb63a5e4891670b66ed3f9f815ec14de591f60b16"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3d9467ef9bb64060bcf096643b2affbd0b234ed23f9558e6190010b794e65f73"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "d1e4a32220ea96d4283cffda348749c885d43f2b3834f9e306691e5fc6ac763c"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "ecb8e0c668adb150edd002fa4bc9b224f86cd141ee9421e00a107f00b2629eda"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "87af655d47845d6eacc5d7a217a0efc09a4088d7bdfdbe1ef9af898411010595"
+    sha256 cellar: :any_skip_relocation, sonoma:        "eb59ce4399c33c94add85e8b5861196cfea87fc045dd2ef4b69bfcb71722df96"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "e43ff516d2765ad335067b0545c272fd1a329b60d0b21ccb505f729687379d3b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e59b3ca9e13adf08d2d0ea12ca81311e61ed092a2e059239abd9db73b2a79fce"
   end
 
   depends_on "rust" => :build

--- a/Formula/s/somo.rb
+++ b/Formula/s/somo.rb
@@ -18,6 +18,7 @@ class Somo < Formula
 
   def install
     system "cargo", "install", *std_cargo_args
+    generate_completions_from_executable(bin/"somo", "generate-completions")
   end
 
   test do


### PR DESCRIPTION
somo supports 'somo generate-completions', so call it at install using generate_completions_from_executable.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`somo` has a `generate-completions` option—perhaps this was added recently? In any event, this PR adds a call to it at install time, using `generate_completions_from_executable`.

Side note: there's no mention of `generate_completions_from_executable` anywhere on docs.brew.sh that I could find, but it seems to be used fairly widely in formulae, so hopefully it isn't the "don't use this" kind of undocumented.