### PR TITLE
libxmlsec1: update auto-substituted placeholder in patch

### DIFF
--- a/Formula/lib/libxmlsec1.rb
+++ b/Formula/lib/libxmlsec1.rb
@@ -62,7 +62,7 @@ index 6e8a56a..0e7f06b 100644
      }
 
  #ifdef XMLSEC_DL_LIBLTDL
-+    lt_dlsetsearchpath("HOMEBREW_PREFIX/lib");
++    lt_dlsetsearchpath("@@HOMEBREW_PREFIX@@/lib");
      lib->handle = lt_dlopenext((char*)lib->filename);
      if(lib->handle == NULL) {
          xmlSecError(XMLSEC_ERRORS_HERE,


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Prefer `@@HOMEBREW_PREFIX@@` since https://github.com/Homebrew/brew/releases/tag/4.6.14 as less likely to correspond to actual code