### PR TITLE
git-extras: add fish shell completions

### DIFF
--- a/Formula/g/git-extras.rb
+++ b/Formula/g/git-extras.rb
@@ -7,7 +7,8 @@ class GitExtras < Formula
   head "https://github.com/tj/git-extras.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "ab7f49444bdd81c79d987f8e86668b225d6cc74f01b09ac91f7b35cde0a9bb98"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "68e0ef44b443f683c0f8d21f1a72162ff1063377582b60855a7fbace9ad3a5ab"
   end
 
   on_linux do

--- a/Formula/g/git-extras.rb
+++ b/Formula/g/git-extras.rb
@@ -22,6 +22,7 @@ class GitExtras < Formula
 
   def install
     system "make", "PREFIX=#{prefix}", "COMPL_DIR=#{bash_completion}", "INSTALL_VIA=brew", "install"
+    fish_completion.install "etc/git-extras.fish"
     pkgshare.install "etc/git-extras-completion.zsh"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The git-extras repository has included fish shell completions (`etc/git-extras.fish`) since July 2020 (tj/git-extras@4a7fcb7), but they have never been installed by the Homebrew formula. This adds fish completions to match the existing bash and zsh completions support.