### PR TITLE
wifi-loc-control 1.0.5 (new formula)

### DIFF
--- a/Formula/w/wifi-loc-control.rb
+++ b/Formula/w/wifi-loc-control.rb
@@ -1,0 +1,35 @@
+class WifiLocControl < Formula
+  desc "Change macOS network location based on the Wi-Fi network name (SSID)"
+  homepage "https://github.com/vborodulin/wifi-loc-control"
+  url "https://github.com/vborodulin/wifi-loc-control/archive/refs/tags/1.0.5.tar.gz"
+  sha256 "13ef3b7611d519a1c5772432b64355c35d45df03af43e9afd260430d309664b6"
+  license "MIT"
+
+  depends_on :macos
+
+  def install
+    bin.install "wifi-loc-control.sh" => "wifi-loc-control"
+
+    # Modify the Program Path to brew installed one
+    inreplace "WifiLocControl.plist", "/usr/local/bin/wifi-loc-control.sh", bin/"wifi-loc-control"
+
+    # Install the plist file
+    prefix.install "WifiLocControl.plist" => "application.com.wifi-loc-control.plist"
+  end
+
+  service do
+    name macos: "application.com.wifi-loc-control"
+  end
+
+  def caveats
+    <<~EOS
+      To start wifi-loc-control now and restart at login:
+        brew services start wifi-loc-control
+    EOS
+  end
+
+  test do
+    assert_predicate bin/"wifi-loc-control", :executable?
+    assert_path_exists prefix/"application.com.wifi-loc-control.plist"
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
A tool for managing network location based on SSID on macOS.
Would love to see it being included in the homebrew-core for easy installation.