### PR TITLE
animdl: migrate to python@3.14

### DIFF
--- a/Formula/a/animdl.rb
+++ b/Formula/a/animdl.rb
@@ -7,7 +7,7 @@ class Animdl < Formula
   url "https://files.pythonhosted.org/packages/5b/79/4be6ac2caca32dea6fe500e5f5df9d74a3a5ce1d500175c3a7b69500bb3f/animdl-1.7.27.tar.gz"
   sha256 "fd97b278da4c82da88759993eaf6d8ad6fc3660d0f03de5b2151279c4ebd8370"
   license "GPL-3.0-only"
-  revision 1
+  revision 2
   head "https://github.com/justfoolingaround/animdl.git", branch: "master"
 
   bottle do
@@ -24,7 +24,7 @@ class Animdl < Formula
 
   depends_on "certifi"
   depends_on "libyaml"
-  depends_on "python@3.13"
+  depends_on "python@3.14"
 
   uses_from_macos "libxml2", since: :ventura
   uses_from_macos "libxslt"


### PR DESCRIPTION
animdl: migrate to python@3.14

following #245931
