### PR TITLE
ansible-builder: migrate to python@3.14

### DIFF
--- a/Formula/a/ansible-builder.rb
+++ b/Formula/a/ansible-builder.rb
@@ -6,6 +6,7 @@ class AnsibleBuilder < Formula
   url "https://files.pythonhosted.org/packages/3c/d5/c94e86098107209a82de9401ec31413fabd4236af0be9427c57a5bdbf855/ansible_builder-3.1.0.tar.gz"
   sha256 "d2dc573e26a7bd5095e98aeb37ee9b00bc9f5005abea7147d74229c0f3426fcb"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "793f4a9b69d5f87bb30882a498d0200260bcaec7b425022d98074d8051b736ef"
@@ -20,7 +21,7 @@ class AnsibleBuilder < Formula
 
   depends_on "rust" => :build
   depends_on "libyaml"
-  depends_on "python@3.13"
+  depends_on "python@3.14"
 
   resource "attrs" do
     url "https://files.pythonhosted.org/packages/fc/0f/aafca9af9315aee06a89ffde799a10a582fe8de76c563ee80bbcdc08b3fb/attrs-24.2.0.tar.gz"


### PR DESCRIPTION
ansible-builder: migrate to python@3.14

following #245931
