### PR TITLE
ansible-lint: migrate to python@3.14

### DIFF
--- a/Formula/a/ansible-lint.rb
+++ b/Formula/a/ansible-lint.rb
@@ -6,6 +6,7 @@ class AnsibleLint < Formula
   url "https://files.pythonhosted.org/packages/17/dd/6c1dd87464488a8d848d3e9dc5b833f0328ce9b4b7fcb6511a702d4cf0cd/ansible_lint-25.9.2.tar.gz"
   sha256 "0eea8a5d17dd328bef12e7c9b6eb8714ba03fb1af62d9c700bf46e4858d1a6a4"
   license all_of: ["MIT", "GPL-3.0-or-later"]
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "f20be1e71dc856ad2b191e7e7536415950b265e0b75dd9de483e12444156fc5c"
@@ -21,7 +22,7 @@ class AnsibleLint < Formula
   depends_on "ansible" => :test
   depends_on "cryptography"
   depends_on "libyaml"
-  depends_on "python@3.13"
+  depends_on "python@3.14"
 
   resource "ansible-compat" do
     url "https://files.pythonhosted.org/packages/e3/06/5e66f1f0d482b21b0dc03c9b9e47cab58dd4efc770f41029bb244e86b608/ansible_compat-25.8.2.tar.gz"


### PR DESCRIPTION
ansible-lint: migrate to python@3.14

following #245931
