### PR TITLE
astrometry-net: migrate to python@3.14

### DIFF
--- a/Formula/a/astrometry-net.rb
+++ b/Formula/a/astrometry-net.rb
@@ -6,6 +6,7 @@ class AstrometryNet < Formula
   url "https://github.com/dstndstn/astrometry.net/releases/download/0.97/astrometry.net-0.97.tar.gz"
   sha256 "e4eef1b658ba5ad462282b661c0ca3a5c538ba1716e853f7970b7b9fa4a33459"
   license "BSD-3-Clause"
+  revision 1
 
   livecheck do
     url :stable
@@ -32,7 +33,7 @@ class AstrometryNet < Formula
   depends_on "libpng"
   depends_on "netpbm"
   depends_on "numpy"
-  depends_on "python@3.13"
+  depends_on "python@3.14"
   depends_on "wcslib"
 
   resource "fitsio" do
@@ -49,7 +50,7 @@ class AstrometryNet < Formula
     ENV["NETPBM_INC"] = "-I#{Formula["netpbm"].opt_include}/netpbm"
     ENV["NETPBM_LIB"] = "-L#{Formula["netpbm"].opt_lib} -lnetpbm"
     ENV["SYSTEM_GSL"] = "yes"
-    ENV["PYTHON"] = python3 = which("python3.13")
+    ENV["PYTHON"] = python3 = which("python3.14")
 
     venv = virtualenv_create(libexec, python3)
     venv.pip_install(resources, build_isolation: false)


### PR DESCRIPTION
astrometry-net: migrate to python@3.14

following #245931
