### PR TITLE
autodiff: migrate to python@3.14

### DIFF
--- a/Formula/a/autodiff.rb
+++ b/Formula/a/autodiff.rb
@@ -5,6 +5,7 @@ class Autodiff < Formula
   sha256 "86f68aabdae1eed214bfbf0ddaa182c78ea1bb99e4df404efb7b94d30e06b744"
   license "MIT"
   head "https://github.com/autodiff/autodiff.git", branch: "main"
+  revision 1
 
   bottle do
     rebuild 1
@@ -20,12 +21,12 @@ class Autodiff < Formula
 
   depends_on "cmake" => :build
   depends_on "python-setuptools" => :build
-  depends_on "python@3.13" => [:build, :test]
+  depends_on "python@3.14" => [:build, :test]
   depends_on "eigen"
   depends_on "pybind11"
 
   def python3
-    "python3.13"
+    "python3.14"
   end
 
   def install


### PR DESCRIPTION
autodiff: migrate to python@3.14

following #245931
