### PR TITLE
aws-google-auth: migrate to python@3.14

### DIFF
--- a/Formula/a/aws-google-auth.rb
+++ b/Formula/a/aws-google-auth.rb
@@ -6,7 +6,7 @@ class AwsGoogleAuth < Formula
   url "https://files.pythonhosted.org/packages/32/4c/3a1dd1781c9d3bb4a85921b3d3e6e32fc0f0bad61ace6a8e1bd1a59c5ba0/aws-google-auth-0.0.38.tar.gz"
   sha256 "7a044636df2f0ce6ceb01f8f57aba0b6a79ae58a91bef788b0ccc6474914e8ee"
   license "MIT"
-  revision 13
+  revision 14
   head "https://github.com/cevoaustralia/aws-google-auth.git", branch: "master"
 
   bottle do
@@ -22,7 +22,7 @@ class AwsGoogleAuth < Formula
 
   depends_on "certifi"
   depends_on "pillow"
-  depends_on "python@3.13"
+  depends_on "python@3.14"
 
   uses_from_macos "libxml2", since: :ventura
   uses_from_macos "libxslt"


### PR DESCRIPTION
aws-google-auth: migrate to python@3.14

following #245931
