### PR TITLE
aws-shell: migrate to python@3.14

### DIFF
--- a/Formula/a/aws-shell.rb
+++ b/Formula/a/aws-shell.rb
@@ -6,7 +6,7 @@ class AwsShell < Formula
   url "https://files.pythonhosted.org/packages/01/31/ee166a91c865a855af4f15e393974eadf57762629fc2a163a3eb3f470ac5/aws-shell-0.2.2.tar.gz"
   sha256 "fd1699ea5f201e7cbaacaeb34bf1eb88c8fe6dc6b248bce1b3d22b3e099a41e5"
   license "Apache-2.0"
-  revision 7
+  revision 8
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "dc721d3dd2315f261dc9e68cb218af83b0dc72fa16d2cbeb05a278e62faaaeb3"
@@ -20,7 +20,7 @@ class AwsShell < Formula
   end
 
   depends_on "libyaml"
-  depends_on "python@3.13"
+  depends_on "python@3.14"
 
   resource "awscli" do
     url "https://files.pythonhosted.org/packages/be/b9/a4be1043737628a311884d559b8072a5a25876d86bc00fd62bfea6cf652b/awscli-1.40.38.tar.gz"


### PR DESCRIPTION
aws-shell: migrate to python@3.14

following #245931
