### PR TITLE
awsume: migrate to python@3.14

### DIFF
--- a/Formula/a/awsume.rb
+++ b/Formula/a/awsume.rb
@@ -6,7 +6,7 @@ class Awsume < Formula
   url "https://files.pythonhosted.org/packages/d7/08/264d5c0b1a2618c95f3a391e038830c18bcccce5f202b293acdb14b7ac63/awsume-4.5.4.tar.gz"
   sha256 "4c1f6336e1f9e36b2144761345967f50f43128363892cc62325577201e133b1b"
   license "MIT"
-  revision 2
+  revision 3
   head "https://github.com/trek10inc/awsume.git", branch: "master"
 
   bottle do
@@ -21,7 +21,7 @@ class Awsume < Formula
   end
 
   depends_on "libyaml"
-  depends_on "python@3.13"
+  depends_on "python@3.14"
 
   uses_from_macos "sqlite"
 


### PR DESCRIPTION
awsume: migrate to python@3.14

following #245931
