### PR TITLE
blastem: migrate to python@3.14

### DIFF
--- a/Formula/b/blastem.rb
+++ b/Formula/b/blastem.rb
@@ -2,7 +2,7 @@ class Blastem < Formula
   desc "Fast and accurate Genesis emulator"
   homepage "https://www.retrodev.com/blastem/"
   license "GPL-3.0-or-later"
-  revision 2
+  revision 3
   head "https://www.retrodev.com/repos/blastem", using: :hg
 
   stable do
@@ -51,7 +51,7 @@ class Blastem < Formula
   depends_on "imagemagick" => :build
   depends_on "pillow" => :build
   depends_on "pkgconf" => :build
-  depends_on "python@3.13" => :build
+  depends_on "python@3.14" => :build
   depends_on "glew"
   depends_on "sdl2"
 


### PR DESCRIPTION
blastem: migrate to python@3.14

following #245931
