### PR TITLE
boost-python3: migrate to python@3.14

### DIFF
--- a/Formula/b/boost-python3.rb
+++ b/Formula/b/boost-python3.rb
@@ -5,6 +5,7 @@ class BoostPython3 < Formula
   sha256 "875cc413afa6b86922b6df3b2ad23dec4511c8a741753e57c1129e7fa753d700"
   license "BSL-1.0"
   head "https://github.com/boostorg/boost.git", branch: "master"
+  revision 1
 
   livecheck do
     formula "boost"
@@ -25,10 +26,10 @@ class BoostPython3 < Formula
 
   depends_on "numpy" => :build
   depends_on "boost"
-  depends_on "python@3.13"
+  depends_on "python@3.14"
 
   def python3
-    "python3.13"
+    "python3.14"
   end
 
   def install


### PR DESCRIPTION
boost-python3: migrate to python@3.14

following #245931
