### PR TITLE
censys: migrate to python@3.14

### DIFF
--- a/Formula/c/censys.rb
+++ b/Formula/c/censys.rb
@@ -6,6 +6,7 @@ class Censys < Formula
   url "https://files.pythonhosted.org/packages/ba/ef/c858baa23fa4edb496ba58ec329f9fa5df67b91ca755afa4219962231675/censys-2.2.18.tar.gz"
   sha256 "9410596197dc21d26dd5dfc83c0d58fde3768409d0f0ab0bc77570ec93473649"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     rebuild 1
@@ -13,7 +14,7 @@ class Censys < Formula
   end
 
   depends_on "certifi"
-  depends_on "python@3.13"
+  depends_on "python@3.14"
 
   resource "argcomplete" do
     url "https://files.pythonhosted.org/packages/16/0f/861e168fc813c56a78b35f3c30d91c6757d1fd185af1110f1aec784b35d0/argcomplete-3.6.2.tar.gz"


### PR DESCRIPTION
censys: migrate to python@3.14

following #245931
