### PR TITLE
cekit: migrate to python@3.14

### DIFF
--- a/Formula/c/cekit.rb
+++ b/Formula/c/cekit.rb
@@ -6,6 +6,7 @@ class Cekit < Formula
   url "https://files.pythonhosted.org/packages/19/bf/e6f731ca9eae441dbf08d4af91ed3fc76eb021f1e5870dff3692936bb50b/cekit-4.15.0.tar.gz"
   sha256 "3ced63835728e6fe43c63583ca0b1a45e65b573230ec9cb73dcd3aa9aa0a5aa9"
   license "MIT"
+  revision 1
 
   bottle do
     rebuild 1
@@ -20,7 +21,7 @@ class Cekit < Formula
   end
 
   depends_on "libyaml"
-  depends_on "python@3.13"
+  depends_on "python@3.14"
 
   resource "click" do
     url "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz"


### PR DESCRIPTION
cekit: migrate to python@3.14

following #245931
