### PR TITLE
cfripper: migrate to python@3.14

### DIFF
--- a/Formula/c/cfripper.rb
+++ b/Formula/c/cfripper.rb
@@ -6,6 +6,7 @@ class Cfripper < Formula
   url "https://files.pythonhosted.org/packages/fd/1e/a27bad490eff8d1d32db795ee1dbd664e33b727f7e45b5bd44a2bfdc978a/cfripper-1.18.0.tar.gz"
   sha256 "755bcbaf4ab8d923ffe8b02c36a3b6b74770c6c4a16b0c0917bb104e49e05656"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "3e5a912c63d33bb691fe20d7a8b3109c20fe2aa33df71ae7060cafe3f8548929"
@@ -20,7 +21,7 @@ class Cfripper < Formula
 
   depends_on "rust" => :build # for pydantic_core
   depends_on "libyaml"
-  depends_on "python@3.13"
+  depends_on "python@3.14"
 
   resource "annotated-types" do
     url "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz"


### PR DESCRIPTION
cfripper: migrate to python@3.14

following #245931
