### PR TITLE
clingo: migrate to python@3.14

### DIFF
--- a/Formula/c/clingo.rb
+++ b/Formula/c/clingo.rb
@@ -4,6 +4,7 @@ class Clingo < Formula
   url "https://github.com/potassco/clingo/archive/refs/tags/v5.8.0.tar.gz"
   sha256 "4ddd5975e79d7a0f8d126039f1b923a371b1a43e0e0687e1537a37d6d6d5cc7c"
   license "MIT"
+  revision 1
 
   livecheck do
     url :stable
@@ -31,7 +32,7 @@ class Clingo < Formula
   depends_on "doxygen" => :build
   depends_on "cffi"
   depends_on "lua"
-  depends_on "python@3.13"
+  depends_on "python@3.14"
 
   # This formula replaced the clasp & gringo formulae.
   # https://github.com/Homebrew/homebrew-core/pull/20281
@@ -42,7 +43,7 @@ class Clingo < Formula
   link_overwrite "bin/reify"
 
   def python3
-    which("python3.13")
+    which("python3.14")
   end
 
   def install


### PR DESCRIPTION
clingo: migrate to python@3.14

following #245931
