### PR TITLE
codespell: migrate to python@3.14

### DIFF
--- a/Formula/c/codespell.rb
+++ b/Formula/c/codespell.rb
@@ -6,13 +6,14 @@ class Codespell < Formula
   url "https://files.pythonhosted.org/packages/15/e0/709453393c0ea77d007d907dd436b3ee262e28b30995ea1aa36c6ffbccaf/codespell-2.4.1.tar.gz"
   sha256 "299fcdcb09d23e81e35a671bbe746d5ad7e8385972e65dbb833a2eaac33c01e5"
   license "GPL-2.0-only"
+  revision 1
 
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "3ed767cf4f214f6a9da62406d751800e0c6f3574da059e80c8744574a3b6f1d1"
   end
 
-  depends_on "python@3.13"
+  depends_on "python@3.14"
 
   def install
     virtualenv_install_with_resources


### PR DESCRIPTION
codespell: migrate to python@3.14

following #245931
