### PR TITLE
credstash: migrate to python@3.14

### DIFF
--- a/Formula/c/credstash.rb
+++ b/Formula/c/credstash.rb
@@ -6,7 +6,7 @@ class Credstash < Formula
   url "https://files.pythonhosted.org/packages/b4/89/f929fda5fec87046873be2420a4c0cb40a82ab5e30c6d9cb22ddec41450b/credstash-1.17.1.tar.gz"
   sha256 "6c04e8734ef556ab459018da142dd0b244093ef176b3be5583e582e9a797a120"
   license "Apache-2.0"
-  revision 12
+  revision 13
   head "https://github.com/fugue/credstash.git", branch: "master"
 
   bottle do
@@ -14,7 +14,7 @@ class Credstash < Formula
   end
 
   depends_on "cryptography"
-  depends_on "python@3.13"
+  depends_on "python@3.14"
 
   resource "boto3" do
     url "https://files.pythonhosted.org/packages/70/b0/a35b320e5084821de69a66962513dcc8aa37b7a5bc80e761685533e97be9/boto3-1.38.39.tar.gz"


### PR DESCRIPTION
credstash: migrate to python@3.14

following #245931
