### PR TITLE
crosstool-ng: migrate to python@3.14

### DIFF
--- a/Formula/c/crosstool-ng.rb
+++ b/Formula/c/crosstool-ng.rb
@@ -5,6 +5,7 @@ class CrosstoolNg < Formula
   sha256 "5750e29a2bda5cd8d67900592576b1670a1987a4dcd5e4f6beae09138a1f5699"
   license "GPL-2.0-only"
   head "https://github.com/crosstool-ng/crosstool-ng.git", branch: "master"
+  revision 1
 
   livecheck do
     url "https://crosstool-ng.github.io/download/"
@@ -32,7 +33,7 @@ class CrosstoolNg < Formula
   depends_on "lzip"
   depends_on "m4"
   depends_on "ncurses"
-  depends_on "python@3.13"
+  depends_on "python@3.14"
   depends_on "xz"
 
   uses_from_macos "flex" => :build
@@ -58,7 +59,7 @@ class CrosstoolNg < Formula
 
     ENV["BISON"] = Formula["bison"].opt_bin/"bison"
     ENV["M4"] = Formula["m4"].opt_bin/"m4"
-    ENV["PYTHON"] = Formula["python@3.13"].opt_bin/"python3.13"
+    ENV["PYTHON"] = Formula["python@3.14"].opt_bin/"python3.14"
 
     if OS.mac?
       ENV["MAKE"] = Formula["make"].opt_bin/"gmake"


### PR DESCRIPTION
crosstool-ng: migrate to python@3.14

following #245931
