### PR TITLE
cruft: migrate to python@3.14

### DIFF
--- a/Formula/c/cruft.rb
+++ b/Formula/c/cruft.rb
@@ -6,7 +6,7 @@ class Cruft < Formula
   url "https://files.pythonhosted.org/packages/d1/7e/0e20012f2aa156e5d6a70483a8d90accb7ed4966dddb0c58987d9f6eba12/cruft-2.16.0.tar.gz"
   sha256 "184662853fbc1c16c0137fe0e9444e0cbe95e40362f5ebb2d9fae33d9223e73f"
   license "MIT"
-  revision 3
+  revision 4
   head "https://github.com/cruft/cruft.git", branch: "master"
 
   bottle do
@@ -22,7 +22,7 @@ class Cruft < Formula
 
   depends_on "certifi"
   depends_on "libyaml"
-  depends_on "python@3.13"
+  depends_on "python@3.14"
 
   resource "arrow" do
     url "https://files.pythonhosted.org/packages/2e/00/0f6e8fcdb23ea632c866620cc872729ff43ed91d284c866b515c6342b173/arrow-1.3.0.tar.gz"


### PR DESCRIPTION
cruft: migrate to python@3.14

following #245931
