### PR TITLE
cryfs: migrate to python@3.14

### DIFF
--- a/Formula/c/cryfs.rb
+++ b/Formula/c/cryfs.rb
@@ -6,7 +6,7 @@ class Cryfs < Formula
   url "https://github.com/cryfs/cryfs/releases/download/1.0.1/cryfs-1.0.1.tar.gz"
   sha256 "5383cd77c4ef606bb44568e9130c35a996f1075ee1bdfb68471ab8bc8229e711"
   license "LGPL-3.0-or-later"
-  revision 3
+  revision 4
   head "https://github.com/cryfs/cryfs.git", branch: "develop"
 
   bottle do
@@ -17,7 +17,7 @@ class Cryfs < Formula
   depends_on "cmake" => :build
   depends_on "curl" => :build
   depends_on "pkgconf" => :build
-  depends_on "python@3.13" => :build
+  depends_on "python@3.14" => :build
   depends_on "range-v3" => :build
   depends_on "boost"
   depends_on "fmt"


### PR DESCRIPTION
cryfs: migrate to python@3.14

following #245931
