### PR TITLE
cycode: migrate to python@3.14

### DIFF
--- a/Formula/c/cycode.rb
+++ b/Formula/c/cycode.rb
@@ -7,6 +7,7 @@ class Cycode < Formula
   sha256 "b2a8eb30eeee211526946bfe7d9bfbcff4a226875df514004974aa87745a4357"
   license "MIT"
   head "https://github.com/cycodehq/cycode-cli.git", branch: "main"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "3e1dd2c514e95b8069cb959c27babb0524645547f75dfcf013988d6e5164ec25"
@@ -21,7 +22,7 @@ class Cycode < Formula
   depends_on "rust" => :build # for mcp
   depends_on "certifi"
   depends_on "libyaml"
-  depends_on "python@3.13"
+  depends_on "python@3.14"
 
   resource "annotated-types" do
     url "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz"


### PR DESCRIPTION
cycode: migrate to python@3.14

following #245931
