### PR TITLE
cython: migrate to python@3.14

### DIFF
--- a/Formula/c/cython.rb
+++ b/Formula/c/cython.rb
@@ -4,6 +4,7 @@ class Cython < Formula
   url "https://files.pythonhosted.org/packages/a7/f6/d762df1f436a0618455d37f4e4c4872a7cd0dcfc8dec3022ee99e4389c69/cython-3.1.4.tar.gz"
   sha256 "9aefefe831331e2d66ab31799814eae4d0f8a2d246cbaaaa14d1be29ef777683"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "9bad722f83c356020e597fc17d523292b041238c2f6594e67e28adf8276dddf8"
@@ -20,10 +21,10 @@ class Cython < Formula
   EOS
 
   depends_on "python-setuptools" => [:build, :test]
-  depends_on "python@3.13"
+  depends_on "python@3.14"
 
   def python3
-    "python3.13"
+    "python3.14"
   end
 
   def install


### PR DESCRIPTION
cython: migrate to python@3.14

following #245931
