### PR TITLE
datasette: migrate to python@3.14

### DIFF
--- a/Formula/d/datasette.rb
+++ b/Formula/d/datasette.rb
@@ -6,7 +6,7 @@ class Datasette < Formula
   url "https://files.pythonhosted.org/packages/db/94/e6408997861e9de3ec61fb8107efe9eaf70f765ad2cd4e20b552dd340899/datasette-0.65.1.tar.gz"
   sha256 "d8be37ae6dafbfd8e510d49c0dc0fc6696081614d048a507eed86dd2ae433223"
   license "Apache-2.0"
-  revision 3
+  revision 4
   head "https://github.com/simonw/datasette.git", branch: "main"
 
   bottle do
@@ -23,7 +23,7 @@ class Datasette < Formula
 
   depends_on "certifi"
   depends_on "libyaml"
-  depends_on "python@3.13"
+  depends_on "python@3.14"
 
   resource "aiofiles" do
     url "https://files.pythonhosted.org/packages/0b/03/a88171e277e8caa88a4c77808c20ebb04ba74cc4681bf1e9416c862de237/aiofiles-24.1.0.tar.gz"


### PR DESCRIPTION
datasette: migrate to python@3.14

following #245931
