### PR TITLE
diceware: migrate to python@3.14

### DIFF
--- a/Formula/d/diceware.rb
+++ b/Formula/d/diceware.rb
@@ -6,13 +6,14 @@ class Diceware < Formula
   url "https://files.pythonhosted.org/packages/8b/ba/db6c087f044f6a753a85c0d8b25848122018ced2130061298c0c08940a54/diceware-1.0.1.tar.gz"
   sha256 "54b690809f0c56ab3085a18e15a0c3804d4a0d127f38aef0b5cf5f859d0f6639"
   license "GPL-3.0-or-later"
+  revision 1
 
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "20c89c8bf827292f4377b46c7b0b7c9b33f60b877a563ff91821c425e958bdca"
   end
 
-  depends_on "python@3.13"
+  depends_on "python@3.14"
 
   def install
     virtualenv_install_with_resources


### PR DESCRIPTION
diceware: migrate to python@3.14

following #245931
