### PR TITLE
djlint: migrate to python@3.14

### DIFF
--- a/Formula/d/djlint.rb
+++ b/Formula/d/djlint.rb
@@ -7,6 +7,7 @@ class Djlint < Formula
   sha256 "17254f218b46fe5a714b224c85074c099bcb74e3b2e1f15c2ddc2cf415a408a1"
   license "GPL-3.0-or-later"
   head "https://github.com/djlint/djLint.git", branch: "master"
+  revision 1
 
   bottle do
     rebuild 2
@@ -21,7 +22,7 @@ class Djlint < Formula
   end
 
   depends_on "libyaml"
-  depends_on "python@3.13"
+  depends_on "python@3.14"
 
   resource "click" do
     url "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz"


### PR DESCRIPTION
djlint: migrate to python@3.14

following #245931
