### PR TITLE
doc8: migrate to python@3.14

### DIFF
--- a/Formula/d/doc8.rb
+++ b/Formula/d/doc8.rb
@@ -7,13 +7,14 @@ class Doc8 < Formula
   sha256 "1267ad32758971fbcf991442417a3935c7bc9e52550e73622e0e56ba55ea1d40"
   license "Apache-2.0"
   head "https://github.com/PyCQA/doc8.git", branch: "main"
+  revision 1
 
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "fc572afecb02dbdabef0f28dcdfee67d507561751e4e8a1f0bd5dac689e773d4"
   end
 
-  depends_on "python@3.13"
+  depends_on "python@3.14"
 
   resource "docutils" do
     url "https://files.pythonhosted.org/packages/ae/ed/aefcc8cd0ba62a0560c3c18c33925362d46c6075480bfa4df87b28e169a9/docutils-0.21.2.tar.gz"


### PR DESCRIPTION
doc8: migrate to python@3.14

following #245931
