### PR TITLE
dotdrop: migrate to python@3.14

### DIFF
--- a/Formula/d/dotdrop.rb
+++ b/Formula/d/dotdrop.rb
@@ -6,7 +6,7 @@ class Dotdrop < Formula
   url "https://files.pythonhosted.org/packages/66/a7/8c8f1d7268bcb0ae3f7e43d8b0da03ad0c1336baabbd4b9ce88a4b1d7b36/dotdrop-1.15.0.tar.gz"
   sha256 "7e7b5558a66ac514c3861e0bb31262d5972bc15fc97c1402aef8cccffd0bde61"
   license "GPL-3.0-or-later"
-  revision 4
+  revision 5
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "e5b02bc65bf607b1b5c939364d53f75ce807bcec59d961ddf3c3a93ba9428291"
@@ -21,7 +21,7 @@ class Dotdrop < Formula
 
   depends_on "certifi"
   depends_on "libmagic"
-  depends_on "python@3.13"
+  depends_on "python@3.14"
 
   resource "charset-normalizer" do
     url "https://files.pythonhosted.org/packages/e4/33/89c2ced2b67d1c2a61c19c6751aa8902d46ce3dacb23600a283619f5a12d/charset_normalizer-3.4.2.tar.gz"


### PR DESCRIPTION
dotdrop: migrate to python@3.14

following #245931
