### PR TITLE
dtrx: migrate to python@3.14

### DIFF
--- a/Formula/d/dtrx.rb
+++ b/Formula/d/dtrx.rb
@@ -6,6 +6,7 @@ class Dtrx < Formula
   url "https://files.pythonhosted.org/packages/b7/e6/204294b57be7bb5072c217a1c3ddd5acf9b60b006c215e13e11121c04108/dtrx-8.5.3.tar.gz"
   sha256 "eec67869b85068fac8406f5018d781aee5b55422f3b7698bfea43468b2cec67c"
   license "GPL-3.0-or-later"
+  revision 1
 
   bottle do
     rebuild 1
@@ -14,7 +15,7 @@ class Dtrx < Formula
 
   # Include a few common decompression handlers in addition to the python dep
   depends_on "p7zip"
-  depends_on "python@3.13"
+  depends_on "python@3.14"
   depends_on "xz"
 
   uses_from_macos "zip" => :test


### PR DESCRIPTION
dtrx: migrate to python@3.14

following #245931
