### PR TITLE
granted: install shell wrappers and assumego symlink

### DIFF
--- a/Formula/g/granted.rb
+++ b/Formula/g/granted.rb
@@ -20,6 +20,13 @@ class Granted < Formula
   def install
     ldflags = "-s -w -X github.com/common-fate/granted/internal/build.Version=#{version}"
     system "go", "build", *std_go_args(ldflags:), "./cmd/granted"
+
+    # Install shell wrapper scripts
+    bin.install "scripts/assume"
+    bin.install "scripts/assume.fish"
+
+    # Create assumego symlink
+    bin.install_symlink "granted" => "assumego"
   end
 
   test do


### PR DESCRIPTION
The formula was only installing the granted binary. This left the package non-functional because the assume workflow requires three additional components that weren't being installed.

The assume script is a POSIX shell wrapper that calls assumego and exports AWS credentials into the current shell environment. The assume.fish script does the same for fish shell. The assumego binary is accessed via symlink to the granted binary - the code checks argv[0] to determine behavior.

Without these components, users couldn't actually assume AWS roles because the credentials wouldn't propagate to their shell session.

This adds installation of scripts/assume and scripts/assume.fish from the source tree, and creates the assumego -> granted symlink during the install phase.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
