### PR TITLE
mm-common: migrate to `python@3.14`

### DIFF
--- a/Formula/m/mm-common.rb
+++ b/Formula/m/mm-common.rb
@@ -13,7 +13,7 @@ class MmCommon < Formula
 
   depends_on "meson" => :build
   depends_on "ninja" => :build
-  depends_on "python@3.13"
+  depends_on "python@3.14"
 
   def install
     system "meson", "setup", "build", *std_meson_args

--- a/Formula/m/mm-common.rb
+++ b/Formula/m/mm-common.rb
@@ -8,7 +8,8 @@ class MmCommon < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "9b105ad896eeb16cfc9f158c87db7c4a63b03b3d58ae50fae9984b00feb02c24"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "6555a3ef530a9a88869752d8ed91867b30242d26d66b397906e46cda0e1eb8ef"
   end
 
   depends_on "meson" => :build


### PR DESCRIPTION
Migrate mm-common to Python 3.14