### PR TITLE
reorder-python-imports: migrate to `python@3.14`

### DIFF
--- a/Formula/r/reorder-python-imports.rb
+++ b/Formula/r/reorder-python-imports.rb
@@ -9,7 +9,8 @@ class ReorderPythonImports < Formula
   head "https://github.com/asottile/reorder-python-imports.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "75e5e7eb82f552991c8a90c57e5eb35676f41c586c8445605a6c5ff82fbf555a"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "b28e6bd4d9505b58ecfac7c217340dc308db444a53440e9453c52db9b018418f"
   end
 
   depends_on "python@3.14"

--- a/Formula/r/reorder-python-imports.rb
+++ b/Formula/r/reorder-python-imports.rb
@@ -12,7 +12,7 @@ class ReorderPythonImports < Formula
     sha256 cellar: :any_skip_relocation, all: "75e5e7eb82f552991c8a90c57e5eb35676f41c586c8445605a6c5ff82fbf555a"
   end
 
-  depends_on "python@3.13"
+  depends_on "python@3.14"
 
   resource "classify-imports" do
     url "https://files.pythonhosted.org/packages/7e/b6/6cdc486fced92110a8166aa190b7d60435165119990fc2e187a56d15144b/classify_imports-4.2.0.tar.gz"


### PR DESCRIPTION
reorder-python-imports: migrate to `python@3.14`