### PR TITLE
python-markdown: migrate to `python@3.14`

### DIFF
--- a/Formula/p/python-markdown.rb
+++ b/Formula/p/python-markdown.rb
@@ -12,7 +12,7 @@ class PythonMarkdown < Formula
     sha256 cellar: :any_skip_relocation, all: "3fb23d502577f2c1219bc47cf1c9a9f2ca21b3c3e689062722ce2cc4f861f504"
   end
 
-  depends_on "python@3.13"
+  depends_on "python@3.14"
 
   def install
     virtualenv_install_with_resources

--- a/Formula/p/python-markdown.rb
+++ b/Formula/p/python-markdown.rb
@@ -9,7 +9,8 @@ class PythonMarkdown < Formula
   head "https://github.com/Python-Markdown/markdown.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "3fb23d502577f2c1219bc47cf1c9a9f2ca21b3c3e689062722ce2cc4f861f504"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "43daa06408e2aad27172be846736935c73710e453ddcc781d29b68fc0b235d9a"
   end
 
   depends_on "python@3.14"


### PR DESCRIPTION
python-markdown: migrate to `python@3.14`