### PR TITLE
jello: migrate to `python@3.14`

### DIFF
--- a/Formula/j/jello.rb
+++ b/Formula/j/jello.rb
@@ -11,11 +11,11 @@ class Jello < Formula
     sha256 cellar: :any_skip_relocation, all: "6aee2f309a909d8f46313936879821ecd4dfbef13d3a1c75732fee794eb941b4"
   end
 
-  depends_on "python@3.13"
+  depends_on "python@3.14"
 
   resource "pygments" do
-    url "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz"
-    sha256 "61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f"
+    url "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz"
+    sha256 "636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"
   end
 
   def install

--- a/Formula/j/jello.rb
+++ b/Formula/j/jello.rb
@@ -8,7 +8,8 @@ class Jello < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "6aee2f309a909d8f46313936879821ecd4dfbef13d3a1c75732fee794eb941b4"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "851ca4782d37f715f8e522040d2aa8c9e7fbc948da3f42f43e653778432eb291"
   end
 
   depends_on "python@3.14"


### PR DESCRIPTION
Migrate jello to Python 3.14