### PR TITLE
keepkey-agent: migrate to `python@3.14`

### DIFF
--- a/Formula/k/keepkey-agent.rb
+++ b/Formula/k/keepkey-agent.rb
@@ -25,7 +25,7 @@ class KeepkeyAgent < Formula
   depends_on "hidapi"
   depends_on "libsodium" # for pynacl
   depends_on "libusb" # for libusb1
-  depends_on "python@3.13"
+  depends_on "python@3.14"
 
   uses_from_macos "libffi"
 
@@ -45,8 +45,8 @@ class KeepkeyAgent < Formula
   end
 
   resource "docutils" do
-    url "https://files.pythonhosted.org/packages/ae/ed/aefcc8cd0ba62a0560c3c18c33925362d46c6075480bfa4df87b28e169a9/docutils-0.21.2.tar.gz"
-    sha256 "3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f"
+    url "https://files.pythonhosted.org/packages/4a/c0/89fe6215b443b919cb98a5002e107cb5026854ed1ccb6b5833e0768419d1/docutils-0.22.2.tar.gz"
+    sha256 "9fdb771707c8784c8f2728b67cb2c691305933d68137ef95a75db5f4dfbc213d"
   end
 
   resource "ecdsa" do
@@ -90,13 +90,13 @@ class KeepkeyAgent < Formula
   end
 
   resource "pymsgbox" do
-    url "https://files.pythonhosted.org/packages/7d/ff/4c6f31a4f08979f12a663f2aeb6c8b765d3bd592e66eaaac445f547bb875/PyMsgBox-1.0.9.tar.gz"
-    sha256 "2194227de8bff7a3d6da541848705a155dcbb2a06ee120d9f280a1d7f51263ff"
+    url "https://files.pythonhosted.org/packages/ae/6a/e80da7594ee598a776972d09e2813df2b06b3bc29218f440631dfa7c78a8/pymsgbox-2.0.1.tar.gz"
+    sha256 "98d055c49a511dcc10fa08c3043e7102d468f5e4b3a83c6d3c61df722c7d798d"
   end
 
   resource "pynacl" do
-    url "https://files.pythonhosted.org/packages/a7/22/27582568be639dfe22ddb3902225f91f2f17ceff88ce80e4db396c8986da/PyNaCl-1.5.0.tar.gz"
-    sha256 "8ac7448f09ab85811607bdd21ec2464495ac8b7c66d146bf545b0f08fb9220ba"
+    url "https://files.pythonhosted.org/packages/06/c6/a3124dee667a423f2c637cfd262a54d67d8ccf3e160f3c50f622a85b7723/pynacl-1.6.0.tar.gz"
+    sha256 "cb36deafe6e2bce3b286e5d1f3e1c246e0ccdb8808ddb4550bb2792f2df298f2"
   end
 
   resource "python-daemon" do

--- a/Formula/k/keepkey-agent.rb
+++ b/Formula/k/keepkey-agent.rb
@@ -9,15 +9,13 @@ class KeepkeyAgent < Formula
   revision 10
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_tahoe:   "ecf478d2618fa269b67bf48de04df51692c72b6c6906f2f9214b8ebc5c3197ec"
-    sha256 cellar: :any,                 arm64_sequoia: "4ef9604e5cdd45c1cd054e8e9d3be0cc25b7473a784a276129d621d7dd316114"
-    sha256 cellar: :any,                 arm64_sonoma:  "d5204bced64588374c8271149e09a929ac222cb83a39ce82992f18600afc36a8"
-    sha256 cellar: :any,                 arm64_ventura: "13776ec6e720d1df734940c512c73ebaa4c2990080c0e8d6414f40e806a1f78d"
-    sha256 cellar: :any,                 sonoma:        "71cd7cb34c99602040d7f5055f76a6e69a8dceaa01120677c03c546bca3b3f78"
-    sha256 cellar: :any,                 ventura:       "f004387f6363861d62f69eb4773835f28176dad695ef6d95f15d1899616406e4"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "45959a29c69d70cbd6ba9e6d375368d1cc858236b1b3445d838a79c22bcffde9"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8ff47e5fe6dec3c9699dac2ade4f5682ade18531e1d2371eb9e1379ef1a3f2c4"
+    rebuild 2
+    sha256 cellar: :any,                 arm64_tahoe:   "40acf7033656bb375b6ceac017ca2cdd56c68fef74a8cfedb259992a132ca0ac"
+    sha256 cellar: :any,                 arm64_sequoia: "f5e695f3523f6e80f9e440279f48e6e3d54b1b685c0ba6dc437d1ec281ae1b49"
+    sha256 cellar: :any,                 arm64_sonoma:  "aa277831739bfb00672b2f995b2ee19e7d5bb7afc307b501651e85685b8fe91f"
+    sha256 cellar: :any,                 sonoma:        "22a2da737679ca48d801860a712d088bbf0231688475b2dda4c590b08adf73f6"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "640dc5b61a554fe2d0fbd869d20e4e053554b71d14afba0ac19cfe1b759a25db"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c3b4aa1d98ae8a92be3dc01d612c979d0dee3ba49b65403deae62df0b5c6e37b"
   end
 
   depends_on "pkgconf" => :build # for hidapi resource


### PR DESCRIPTION
Migrate keepkey-agent to Python 3.14