### PR TITLE
certifi: symlink files in case user has non-cleanable files

### DIFF
--- a/Formula/c/certifi.rb
+++ b/Formula/c/certifi.rb
@@ -28,16 +28,14 @@ class Certifi < Formula
     rm site_packages/"certifi/cacert.pem"
     (site_packages/"certifi").install_symlink Formula["ca-certificates"].pkgetc/"cert.pem" => "cacert.pem"
 
-    link_dirs = site_packages.children - [site_packages/"certifi"]
     python.versioned_formulae.each do |extra_python|
       next if extra_python.version < oldest_python.version
 
       # Cannot use Python.site_packages as that requires formula to be installed
       extra_site_packages = lib/"python#{extra_python.version.major_minor}/site-packages"
-      extra_site_packages.install_symlink link_dirs
-
-      # Symlink grandchildren so cache ends up in correct directory
-      (extra_site_packages/"certifi").install_symlink site_packages.glob("certifi/*")
+      site_packages.find do |path|
+        (extra_site_packages/path.relative_path_from(site_packages)).dirname.install_symlink path if path.file?
+      end
     end
   end
 

--- a/Formula/c/certifi.rb
+++ b/Formula/c/certifi.rb
@@ -7,7 +7,8 @@ class Certifi < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "d1eb3e86754cc51d5fb9513b6067c75fd90005cea0fab11134f6a7b482989015"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "33b92b7c105cc455a61116ec9277b93c3480ad07542a11633615f8ea2945c022"
   end
 
   depends_on "python@3.14" => [:build, :test]


### PR DESCRIPTION
Update to #247811

In theory, brew should be able to wipe old directory and install the symlink during upgrade 

However, if there are any extra non-Homebrew maintained files for some reason, then brew will fail to do this. So, symlinking files rather than directories is a bit safer here.

New layout:
```console
❯ tree -a /opt/homebrew/Cellar/certifi/2025.10.5_1
/opt/homebrew/Cellar/certifi/2025.10.5_1
├── .brew
│   └── certifi.rb
├── INSTALL_RECEIPT.json
├── lib
│   ├── python3.12
│   │   └── site-packages
│   │       ├── certifi
│   │       │   ├── __init__.py -> ../../../python3.14/site-packages/certifi/__init__.py
│   │       │   ├── __main__.py -> ../../../python3.14/site-packages/certifi/__main__.py
│   │       │   ├── cacert.pem -> ../../../python3.14/site-packages/certifi/cacert.pem
│   │       │   ├── core.py -> ../../../python3.14/site-packages/certifi/core.py
│   │       │   └── py.typed -> ../../../python3.14/site-packages/certifi/py.typed
│   │       └── certifi-2025.10.5.dist-info
│   │           ├── INSTALLER -> ../../../python3.14/site-packages/certifi-2025.10.5.dist-info/INSTALLER
│   │           ├── licenses
│   │           │   └── LICENSE -> ../../../../python3.14/site-packages/certifi-2025.10.5.dist-info/licenses/LICENSE
│   │           ├── METADATA -> ../../../python3.14/site-packages/certifi-2025.10.5.dist-info/METADATA
│   │           ├── REQUESTED -> ../../../python3.14/site-packages/certifi-2025.10.5.dist-info/REQUESTED
│   │           ├── top_level.txt -> ../../../python3.14/site-packages/certifi-2025.10.5.dist-info/top_level.txt
│   │           └── WHEEL -> ../../../python3.14/site-packages/certifi-2025.10.5.dist-info/WHEEL
│   ├── python3.13
│   │   └── site-packages
│   │       ├── certifi
│   │       │   ├── __init__.py -> ../../../python3.14/site-packages/certifi/__init__.py
│   │       │   ├── __main__.py -> ../../../python3.14/site-packages/certifi/__main__.py
│   │       │   ├── cacert.pem -> ../../../python3.14/site-packages/certifi/cacert.pem
│   │       │   ├── core.py -> ../../../python3.14/site-packages/certifi/core.py
│   │       │   └── py.typed -> ../../../python3.14/site-packages/certifi/py.typed
│   │       └── certifi-2025.10.5.dist-info
│   │           ├── INSTALLER -> ../../../python3.14/site-packages/certifi-2025.10.5.dist-info/INSTALLER
│   │           ├── licenses
│   │           │   └── LICENSE -> ../../../../python3.14/site-packages/certifi-2025.10.5.dist-info/licenses/LICENSE
│   │           ├── METADATA -> ../../../python3.14/site-packages/certifi-2025.10.5.dist-info/METADATA
│   │           ├── REQUESTED -> ../../../python3.14/site-packages/certifi-2025.10.5.dist-info/REQUESTED
│   │           ├── top_level.txt -> ../../../python3.14/site-packages/certifi-2025.10.5.dist-info/top_level.txt
│   │           └── WHEEL -> ../../../python3.14/site-packages/certifi-2025.10.5.dist-info/WHEEL
│   └── python3.14
│       └── site-packages
│           ├── certifi
│           │   ├── __init__.py
│           │   ├── __main__.py
│           │   ├── cacert.pem -> ../../../../../../../etc/ca-certificates/cert.pem
│           │   ├── core.py
│           │   └── py.typed
│           └── certifi-2025.10.5.dist-info
│               ├── INSTALLER
│               ├── licenses
│               │   └── LICENSE
│               ├── METADATA
│               ├── REQUESTED
│               ├── top_level.txt
│               └── WHEEL
├── LICENSE
├── README.rst
└── sbom.spdx.json
```