### PR TITLE
qtwebengine: reduce parallel jobs on arm64 Linux runner

### DIFF
--- a/Formula/q/qtwebengine.rb
+++ b/Formula/q/qtwebengine.rb
@@ -39,6 +39,7 @@ class Qtwebengine < Formula
     sha256 cellar: :any,                 arm64_sequoia: "9df4c8809d485020236fc790ae397b5b2220e6cd26432ea03ad3c1eea8ea393f"
     sha256 cellar: :any,                 arm64_sonoma:  "bcd697cc0be3dcaf4648854c6b954ca8f70994c62ba8cc9dca2b457d15d8eadf"
     sha256 cellar: :any,                 sonoma:        "8812fb7078e8756e40290f9cd5e8c1f7ce4438b93591c8bca36a16bc14e57361"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "d44bac3fb4e40746803fdba22decab93539a102434c31dfc6eab4b0ba48a48af"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "d44bac3fb4e40746803fdba22decab93539a102434c31dfc6eab4b0ba48a48af"
   end
 
@@ -146,6 +147,7 @@ class Qtwebengine < Formula
       -DCMAKE_STAGING_PREFIX=#{prefix}
       -DFEATURE_webengine_proprietary_codecs=ON
       -DFEATURE_webengine_kerberos=ON
+      -DNinja_EXECUTABLE=#{which("ninja")}
     ]
 
     # Chromium always uses bundled libraries on macOS


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Seeing if memory is our main limit or if we will hit disk space / timeout too.

Changing linker could help based on Chromium results at https://github.com/rui314/mold?tab=readme-ov-file#mold-a-modern-linker

However, Qt doesn't seem to provide an easy way to change linker in specific module. Qt saves linker in `qtbase` based on whether feature was enabled (e.g. `FEATURE_use_mold_linker` / `FEATURE_use_lld_linker`)