### PR TITLE
qtmultimedia: add xcode dependency for older macOS

### DIFF
--- a/Formula/q/qtmultimedia.rb
+++ b/Formula/q/qtmultimedia.rb
@@ -34,12 +34,17 @@ class Qtmultimedia < Formula
   depends_on "vulkan-headers" => :build
   depends_on "pkgconf" => :test
 
+  depends_on macos: :ventura
   depends_on "qtbase"
   depends_on "qtdeclarative"
   depends_on "qtquick3d"
 
   on_macos do
     depends_on "qtshadertools"
+  end
+
+  on_ventura do
+    depends_on xcode: ["15.0", :build] # for `@available(macOS 14)`
   end
 
   on_linux do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Qt Multimedia can be compiled with only CLT on newer macOS.

However, will need Sonoma SDK which means Ventura needs Xcode.app 15.0 - https://en.wikipedia.org/wiki/Xcode#Xcode_15.0_-_16.x_(since_visionOS_support)

Implicitly means Ventura is oldest macOS that can build formula.

---

I don't think this will conflict with other PR. Bottle cache is likely going to be invalidated by `at-spi2-core` and other formulae anyways so doesn't matter if we merge now.