### PR TITLE
adaptivecpp: revision bump for llvm, shamrock: migrate to `python@3.14`

### DIFF
--- a/Formula/a/adaptivecpp.rb
+++ b/Formula/a/adaptivecpp.rb
@@ -4,7 +4,7 @@ class Adaptivecpp < Formula
   url "https://github.com/AdaptiveCpp/AdaptiveCpp/archive/refs/tags/v25.02.0.tar.gz"
   sha256 "8cc8a3be7bb38f88d7fd51597e0ec924b124d4233f64da62a31b9945b55612ca"
   license "BSD-2-Clause"
-  revision 1
+  revision 2
   head "https://github.com/AdaptiveCpp/AdaptiveCpp.git", branch: "develop"
 
   bottle do

--- a/Formula/a/adaptivecpp.rb
+++ b/Formula/a/adaptivecpp.rb
@@ -8,13 +8,12 @@ class Adaptivecpp < Formula
   head "https://github.com/AdaptiveCpp/AdaptiveCpp.git", branch: "develop"
 
   bottle do
-    rebuild 1
-    sha256 arm64_tahoe:   "37dd9cca4796ceef606befa403a354a6a19c4a87bbd7e3a2d0ce767539fc26bf"
-    sha256 arm64_sequoia: "b15d036cae2e39d5c4dabd86d8606d85aba8b777c93849ed01c7b69d95909777"
-    sha256 arm64_sonoma:  "17557ca2e27aacabcf97669602904b6e13ad9d19b715c9463e5d8216608279d0"
-    sha256 sonoma:        "bd71eb34aea708ced4cc1dd577ab816dbe00f2c6341022f369169e62074c71e7"
-    sha256 arm64_linux:   "68e47436f48595911a2fa1c08ca162c83f42ca60b69e64d5cd64d2d08e24d214"
-    sha256 x86_64_linux:  "5792881d3fa418198526fbbb381cead68d0eb343ce17095d5a90661e2e231123"
+    sha256 arm64_tahoe:   "b64dea8eba9f43b61be66118c129a95282af9774ff01ccb26462ca27c02ee2b4"
+    sha256 arm64_sequoia: "f8d303163cea44ae411f9e87ab47ee27d55c606947d53400ddb98bc0a5ded3d5"
+    sha256 arm64_sonoma:  "b3b96b81ff893ff2c13ee51aaae39b641578fb7396de843c45800eb06524de89"
+    sha256 sonoma:        "37f755b817e733580418205802ca9ee25b29714b02cd166cc6ac73360752ebbc"
+    sha256 arm64_linux:   "67ead23c19a08e8e48ab36fe97a5e602eb2508998bc4c93d098a3f369161a93a"
+    sha256 x86_64_linux:  "0007c52823b9d6ad8e2c13fe8a3d47f8d89b2230b4b6d626ab2c3718af24db64"
   end
 
   depends_on "cmake" => :build

--- a/Formula/s/shamrock.rb
+++ b/Formula/s/shamrock.rb
@@ -27,14 +27,14 @@ class Shamrock < Formula
   depends_on "adaptivecpp"
   depends_on "boost"
   depends_on "open-mpi"
-  depends_on "python@3.13"
+  depends_on "python@3.14"
 
   on_macos do
     depends_on "libomp"
   end
 
   def python
-    which("python3.13")
+    which("python3.14")
   end
 
   def site_packages(python)
@@ -83,6 +83,6 @@ class Shamrock < Formula
       shamrock.sys.init('0:0')
       shamrock.sys.close()
     PY
-    system "python3.13", testpath/"test.py"
+    system python, testpath/"test.py"
   end
 end

--- a/Formula/s/shamrock.rb
+++ b/Formula/s/shamrock.rb
@@ -10,14 +10,13 @@ class Shamrock < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 arm64_tahoe:   "aa610358c555b050b5b2f8e63ff9ffa3490f097950e98c0fd2a4fdee6170e5d2"
-    sha256 arm64_sequoia: "6687c40ab0b0822a689878016759da749b74b509f6cc87e97bf439f593e9bc21"
-    sha256 arm64_sonoma:  "c306d2283e47c569a2e43eda7bada1a251e96e6d11192d4f38f7aed36559d5b5"
-    sha256 arm64_ventura: "e27c1fde9845da8763005ce9b3fa6cc579f23ca1c73eaee98abfbe63d1908107"
-    sha256 sonoma:        "7655ea9e18cf8cc48d4ee516b51b42596bd78e144e09287972352f03cc64f29c"
-    sha256 ventura:       "66121774886d48bb65f150e6f3ec146b602ca1841603a943581f807381bf6483"
-    sha256 arm64_linux:   "d922ccf350167168fc47e70a741bb6c3d53e100e4294af21b08dbb978cf5632e"
-    sha256 x86_64_linux:  "babc28ee1a72de1e6d5b2418304e42d63c0009b7d5bea791bdaa7258a9524c9e"
+    rebuild 1
+    sha256 arm64_tahoe:   "6323f8da9268aff5d7ced2543cf89ebde8dc4cbc3dc50756fbebb71fa7945c1b"
+    sha256 arm64_sequoia: "cf3a4a0ebb0bad131f091c5f8c458affe09b3643b7683aa67b705a97d34f83d7"
+    sha256 arm64_sonoma:  "f891dda301e1f6f23a83c3decabd61df6ce73faae6e63552e4d058d26a212ba7"
+    sha256 sonoma:        "0c497859d5a8ff3387f7b46fad164c270728e8d1a74d39592edb39edaeddb9db"
+    sha256 arm64_linux:   "cc61abd988c7308020dc2ee2b60519a565267c9e93887ab414de98594e586618"
+    sha256 x86_64_linux:  "0bcb52e22880d47fafddc933f6e279a2c016f0c907afe39d40b60b77d8cb9abb"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
