### PR TITLE
lizard-analyzer: migrate to `python@3.14`

### DIFF
--- a/Formula/l/lizard-analyzer.rb
+++ b/Formula/l/lizard-analyzer.rb
@@ -8,7 +8,8 @@ class LizardAnalyzer < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "fae29ca25d368f861992d85a8ded8abb7afc64e4b9f6fdcb883e40d12149d587"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "4c5b0ef8cf12e3d69918fc9c9ff74d64af5c7aaad659dd000707bdca0e43e069"
   end
 
   depends_on "python@3.14"

--- a/Formula/l/lizard-analyzer.rb
+++ b/Formula/l/lizard-analyzer.rb
@@ -11,7 +11,7 @@ class LizardAnalyzer < Formula
     sha256 cellar: :any_skip_relocation, all: "fae29ca25d368f861992d85a8ded8abb7afc64e4b9f6fdcb883e40d12149d587"
   end
 
-  depends_on "python@3.13"
+  depends_on "python@3.14"
 
   conflicts_with "lizard", because: "both install `lizard` binaries"
 


### PR DESCRIPTION
lizard-analyzer: migrate to `python@3.14`