### PR TITLE
pivy: migrate to `python@3.14`

### DIFF
--- a/Formula/p/pivy.rb
+++ b/Formula/p/pivy.rb
@@ -19,11 +19,11 @@ class Pivy < Formula
   depends_on "swig" => :build
   depends_on "coin3d"
   depends_on "pyside"
-  depends_on "python@3.13"
+  depends_on "python@3.14"
   depends_on "qtbase"
 
   def python3
-    "python3.13"
+    "python3.14"
   end
 
   def install


### PR DESCRIPTION
Migrate pivy to Python 3.14