### PR TITLE
otto-stack 1.1.0

### DIFF
--- a/Formula/o/otto-stack.rb
+++ b/Formula/o/otto-stack.rb
@@ -1,0 +1,29 @@
+class OttoStack < Formula
+  desc "Powerful development stack management tool for streamlined local development"
+  homepage "https://github.com/otto-nation/otto-stack"
+  url "https://github.com/otto-nation/otto-stack/archive/refs/tags/otto-stack-v1.1.0.tar.gz"
+  sha256 "833ca32760e38e351a6bb3f4e9cc6c3b9875041c0323590172155f79c16411e9"
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = %W[
+      -s -w
+      -X github.com/otto-nation/otto-stack/internal/pkg/cli/handlers/version.Version=#{version}
+      -X github.com/otto-nation/otto-stack/internal/pkg/cli/handlers/version.BuildDate=#{time.iso8601}
+      -X github.com/otto-nation/otto-stack/internal/pkg/cli/handlers/version.GitCommit=#{tap.user}
+    ]
+
+    system "go", "build", *std_go_args(ldflags:), "./cmd/otto-stack"
+
+    generate_completions_from_executable(bin/"otto-stack", "completion")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/otto-stack version")
+
+    # Test init command in a temporary directory
+    system bin/"otto-stack", "init", "--help"
+  end
+end


### PR DESCRIPTION
Update otto-stack to version 1.1.0
- Update version from previous to 1.1.0
- Update SHA256 hash to 833ca32760e38e351a6bb3f4e9cc6c3b9875041c0323590172155f79c16411e9

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
