### PR TITLE
portable-ruby: revision bump.

### DIFF
--- a/Formula/p/portable-ruby.rb
+++ b/Formula/p/portable-ruby.rb
@@ -6,6 +6,7 @@ class PortableRuby < PortableFormula
   url "https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.7.tar.gz"
   sha256 "23815a6d095696f7919090fdc3e2f9459b2c83d57224b2e446ce1f5f7333ef36"
   license "Ruby"
+  revision 1
 
   # This regex restricts matching to versions other than X.Y.0.
   livecheck do


### PR DESCRIPTION
Testing a revision bump here for `brew test-bot` changes in https://github.com/Homebrew/brew/pull/20874