### PR TITLE
workflows/actionlint: don't use `GH_TOKEN` with zizmor

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -47,8 +47,6 @@ jobs:
           persist-credentials: false
 
       - run: zizmor --format sarif . > results.sarif
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload SARIF file
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2


### PR DESCRIPTION
Temporarily removing this to reduce our API usage and prevent rate limiting.