### PR TITLE
granted: deprecate formula

### DIFF
--- a/Formula/g/granted.rb
+++ b/Formula/g/granted.rb
@@ -15,6 +15,12 @@ class Granted < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "bf9dfb7396fd9de587fabb3b7fa0246efdf9155a5c2ed32cf5ec2fab0d27848c"
   end
 
+  # Formula does not function properly without additional shell wrapper scripts
+  # that must be sourced into the user's shell environment. The upstream project
+  # maintains a third-party tap with the complete installation:
+  # https://github.com/common-fate/homebrew-granted/issues/2
+  deprecate! date: "2025-10-15", because: "requires shell wrapper scripts not suitable for homebrew-core"
+
   depends_on "go" => :build
 
   def install


### PR DESCRIPTION
The formula does not function properly without additional shell wrapper scripts (assume and assume.fish) that must be sourced into the user's shell environment to export AWS credentials. These scripts require being in the user's PATH for first-run setup but must also be sourced rather than executed, which doesn't align well with homebrew-core's bin directory conventions.

The upstream project maintains a third-party tap at common-fate/homebrew-granted with the complete installation including these wrapper scripts. Users should migrate to that tap for a working installation.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
