### PR TITLE
spotify_player: fix Linux audio, add MPRIS support

### DIFF
--- a/Formula/s/spotify_player.rb
+++ b/Formula/s/spotify_player.rb
@@ -19,7 +19,7 @@ class SpotifyPlayer < Formula
   depends_on "rust" => :build
 
   on_linux do
-    depends_on "alsa-lib"
+    depends_on "pulseaudio"
     depends_on "dbus"
     depends_on "openssl@3"
   end
@@ -29,7 +29,11 @@ class SpotifyPlayer < Formula
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
     ENV["OPENSSL_NO_VENDOR"] = "1"
 
-    system "cargo", "install", "--features", "image,notify", *std_cargo_args(path: "spotify_player")
+    if OS.linux?
+      system "cargo", "install", "--no-default-features", "--features", "pulseaudio-backend,streaming,media-control,image,notify", *std_cargo_args(path: "spotify_player")
+    else
+      system "cargo", "install", "--features", "image,notify", *std_cargo_args(path: "spotify_player")
+    end
     bin.install "target/release/spotify_player"
   end
 


### PR DESCRIPTION
The default rodio backend uses alsa in a way that doesn't work with some modern Linux PipeWire+PulseAudio stacks.  Adding the media-control feature also enables MPRIS control of the player.  That feature doesn't work right on MacOS per the upstream github repo, but it does on Linux.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
