### PR TITLE
pango: apply patch to fix crash with emoji on macOS

### DIFF
--- a/Formula/p/pango.rb
+++ b/Formula/p/pango.rb
@@ -16,14 +16,12 @@ class Pango < Formula
   end
 
   bottle do
-    sha256 cellar: :any, arm64_tahoe:   "cc25f12c05e5a49b2d73b0c4161554f72dce3b813ad9790ed94f146564e4a79f"
-    sha256 cellar: :any, arm64_sequoia: "af46edb4113ff0190d78175fb4e82296467cef2ed216267bcc3b26f151b2fe0a"
-    sha256 cellar: :any, arm64_sonoma:  "5574b80791985eddd56246754eae3b4d35404fef8618d217595dbcd115e87cf9"
-    sha256 cellar: :any, arm64_ventura: "a540a741aa1f48d1aa12a4da48c14ed0684f7622e5f5c00acbec5fbf8cdbad08"
-    sha256 cellar: :any, sonoma:        "2e14b5c3420123b2d1fee02cbf9e9bffebfbe680ba116353bd44faa598ec9d14"
-    sha256 cellar: :any, ventura:       "901790521cdaa6ed8a4ca3161a7afdb954d2d8e3d65460f47d7393a3c9ca7fe4"
-    sha256               arm64_linux:   "0fe86be52c9a3244e9badf8116eaf985003ca39aff68957a3e4082a1bc5bfac0"
-    sha256               x86_64_linux:  "e4e73119da00a975bb646eed9d6fadea31032286ac43ef8ff57bf7dc2edc0b20"
+    sha256 cellar: :any, arm64_tahoe:   "dd27a8a5aa57deade2909c9f8054000cf8f289e4c416b3448c4c71159941e941"
+    sha256 cellar: :any, arm64_sequoia: "b81624cd5d7a41cfa1242840ca5d8deb0e03e9fa1951841690fa1a94291293ef"
+    sha256 cellar: :any, arm64_sonoma:  "6edeafd5ccd0552dfa16d7790ab1e07a736076bfead4998d4e8222ae430e7ddc"
+    sha256 cellar: :any, sonoma:        "ae4ef39435487540dff3163e170936841edd376cd6ca56d5f4ba9765ce8f144e"
+    sha256               arm64_linux:   "20e27986a4cb125faff80a45c80e3bf052f0f47deedb1f845f85010185d43ffa"
+    sha256               x86_64_linux:  "0d6b77557f01f42a3143618f129f096403ac2fb84475017057b7d9fd09f00261"
   end
 
   depends_on "gobject-introspection" => :build

--- a/Formula/p/pango.rb
+++ b/Formula/p/pango.rb
@@ -4,6 +4,7 @@ class Pango < Formula
   url "https://download.gnome.org/sources/pango/1.57/pango-1.57.0.tar.xz"
   sha256 "890640c841dae77d3ae3d8fe8953784b930fa241b17423e6120c7bfdf8b891e7"
   license "LGPL-2.0-or-later"
+  revision 1
   head "https://gitlab.gnome.org/GNOME/pango.git", branch: "main"
 
   # Pango doesn't follow GNOME's "even-numbered minor is stable" version
@@ -35,6 +36,12 @@ class Pango < Formula
   depends_on "fribidi"
   depends_on "glib"
   depends_on "harfbuzz"
+
+  # PR ref: https://gitlab.gnome.org/GNOME/pango/-/merge_requests/891
+  patch do
+    url "https://gitlab.gnome.org/GNOME/pango/-/commit/4403954455f2b4a815b32e11c44f79b2e665e94c.diff"
+    sha256 "f674089884839f64b5c04032325c2230f19049759a94dcb1daf82f832ff70e33"
+  end
 
   def install
     args = %w[


### PR DESCRIPTION
**Context**: With version 1.57.0, pango crashes on MacOS when trying to render any Emoji. [Pango Bug #871](https://gitlab.gnome.org/GNOME/pango/-/issues/871) contains [a patch](https://gitlab.gnome.org/GNOME/pango/-/issues/871#note_2576793), but no ETA yet for a merge or a new version. In the meantime, any application using it trying to render an Emoji and using the default backend will crash (example: [graphviz #2741](https://gitlab.com/graphviz/graphviz/-/issues/2741))

**Solution**: until a new release of Pango fixes the issue, I propose to downgrade it to avoid having many apps to crash

Patch proposal ref: https://gitlab.gnome.org/GNOME/pango/-/issues/871#note_2576793

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
