### PR TITLE
asciidoc: migrate to python@3.14

### DIFF
--- a/Formula/a/asciidoc.rb
+++ b/Formula/a/asciidoc.rb
@@ -10,8 +10,7 @@ class Asciidoc < Formula
   head "https://github.com/asciidoc-py/asciidoc-py.git", branch: "main"
 
   bottle do
-    rebuild 2
-    sha256 cellar: :any_skip_relocation, all: "55973a31af5c129fa29e8d6bfb33c76ecd5eb7e60983f58db57872d8c5a4c3c7"
+    sha256 cellar: :any_skip_relocation, all: "1bc7364d821058b91231a5ccf9481b508bd85713522c2d2702c51807feecef78"
   end
 
   depends_on "docbook"

--- a/Formula/a/asciidoc.rb
+++ b/Formula/a/asciidoc.rb
@@ -6,6 +6,7 @@ class Asciidoc < Formula
   url "https://files.pythonhosted.org/packages/1d/e7/315a82f2d256e9270977aa3c15e8fe281fd7c40b8e2a0b97e0cb61ca8fa0/asciidoc-10.2.1.tar.gz"
   sha256 "d9f13c285981b3c7eb660d02ca0a2779981e88d48105de81bb40445e60dddb83"
   license "GPL-2.0-or-later"
+  revision 1
   head "https://github.com/asciidoc-py/asciidoc-py.git", branch: "main"
 
   bottle do
@@ -14,7 +15,7 @@ class Asciidoc < Formula
   end
 
   depends_on "docbook"
-  depends_on "python@3.13"
+  depends_on "python@3.14"
   depends_on "source-highlight"
 
   uses_from_macos "libxml2"


### PR DESCRIPTION
asciidoc: migrate to python@3.14

following #245931
