### PR TITLE
bento4: migrate to python@3.14

### DIFF
--- a/Formula/b/bento4.rb
+++ b/Formula/b/bento4.rb
@@ -5,6 +5,7 @@ class Bento4 < Formula
   version "1.6.0-641"
   sha256 "8258faf0de7253f2aac016018f33d4a04c16d9060735e14ec8711f84aaedf0c8"
   license "GPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url "https://www.bok.net/Bento4/source/"
@@ -26,7 +27,7 @@ class Bento4 < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "python@3.13"
+  depends_on "python@3.14"
 
   conflicts_with "mp4v2", because: "both install `mp4extract` and `mp4info` binaries"
 

--- a/Formula/b/bento4.rb
+++ b/Formula/b/bento4.rb
@@ -15,15 +15,12 @@ class Bento4 < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "08775d900541613de11edaa6fc724afd0773aa8aa500e5edd0dfb6add8193a9a"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "d7eb7ebefa4071ee7a67625f7fcbd85d47551ba51028f89ae1d97fbf59830d98"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "d60460f56f54ce560cc79cc02dcfefc11e7f8a16dace21b3816e3076206debc2"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "cc230cd8ae1f04cde434c3b74783a1d1ca7d9ec67c36bea84ff7429e7a3197ff"
-    sha256 cellar: :any_skip_relocation, sonoma:        "8d40c01a5f94bcc32d4a7476e7517ed85a19a95b8f51311246475c1fde2ad432"
-    sha256 cellar: :any_skip_relocation, ventura:       "b6cdf83e994059b63c281f1af930101efe7cf9a004d56b4b8964136dddd09679"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "a92753cbbc9cb5493602ec41aeeed8c2b9588921cf76465f1cb4a915492da680"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "bf92475fac85e78bbf5ead0e87492ee452bb21a70c0c2a270e332c61d12c5f51"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "5367dba6956a756d81d778166578f003e29d2509b16e84a8fb0118b8bc387560"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "3be0b7e4aa10081340266b8c4ecd5ff536ea75489fc739cfd3948195d94508af"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "7e46e918ac116bfab1bad50f448b816fe75aba44b9f1331dcd01e9f4f8c9d1c8"
+    sha256 cellar: :any_skip_relocation, sonoma:        "8c362b9bfd9caf4a3dfad70c80adb0d5166489c87021c17ee5ffc34ade8a34a9"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "e3cedc1416a3b31db7e328d170bbfd699b6d315ac1930aafbeb67bf283e0533b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "79f1631cc68c122870fefb5815f100643587326f7663bfc1ff0b91657c5dc11e"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
bento4: migrate to python@3.14

following #245931
