### PR TITLE
eye-d3: fix error with python 3.14

### DIFF
--- a/Formula/e/eye-d3.rb
+++ b/Formula/e/eye-d3.rb
@@ -9,8 +9,8 @@ class EyeD3 < Formula
   head "https://github.com/nicfit/eyeD3.git", branch: "0.9.x"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, all: "ae16b3eff6a5254049a8ba9cac20ae0109417ee0c1daaba5de6ada9a6a8119df"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, all: "b5e7af9000a35d628bc1c9410be411d08b693c5a72e000b7c60da35f9755e049"
   end
 
   depends_on "python@3.14"

--- a/Formula/e/eye-d3.rb
+++ b/Formula/e/eye-d3.rb
@@ -31,6 +31,10 @@ class EyeD3 < Formula
   end
 
   def install
+    # Fix to error: SystemError: buffer overflow
+    # Issue ref: https://github.com/nicfit/eyeD3/issues/680
+    inreplace "eyed3/utils/console.py", "'\\0'", "b'\\\\0'"
+
     virtualenv_install_with_resources
     doc.install Dir["docs/*"]
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Will fix https://github.com/Homebrew/homebrew-core/issues/248654#issuecomment-3412823816