### PR TITLE
lua-language-server: fix version detection

### DIFF
--- a/Formula/l/lua-language-server.rb
+++ b/Formula/l/lua-language-server.rb
@@ -11,12 +11,13 @@ class LuaLanguageServer < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "3102c7b726af1b7f76113a05912a1037b42843c756261660986fcf835323661d"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "4019f44924838952372d203004c67fcf986b7fce830908ce4079bf91309e23af"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "84a7a14e2a40339cbd484b193d445f1f1a074d0d4e1ae4bf5ffb9343dd14bde2"
-    sha256 cellar: :any_skip_relocation, sonoma:        "2d27ad9d4dd9e02140bfc7517c8154f0d173a826f667951b22492b4f482a8c50"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "74b6da52eeb2560147f73497d598509521a66f8530d30aaf156f64ca7b0cfb25"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1ec93281d45c0ec2e94cfb3f49d9d73c2247eed70ba64d6a7bedde1aac6e20ac"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "ab48d1402bc65a475f90da76e03eaa4a93396d40eaffb9566c24a43745f27888"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "49d5a3c5ac7dd70da1cf14fbd44ff035cd7dadff077dfae65b9ce1fec7891635"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "3ffcb34b7af2bbe454c86eae301444826159e0d937e1d7590901b51467fd4465"
+    sha256 cellar: :any_skip_relocation, sonoma:        "4c460a8f92c363e9aab64eba2edc5a3a87cebe8dd6ecac2b9f24ce62e0b07049"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "1b98fbe3eafe3fc1b4a61c467ddd600322314697252e31ba50f0890b65b285ad"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "968ecabb1580b66366d71a8af6b86cb7731d48ee3817fa60d112853b4b436530"
   end
 
   depends_on "ninja" => :build

--- a/Formula/l/lua-language-server.rb
+++ b/Formula/l/lua-language-server.rb
@@ -49,7 +49,16 @@ class LuaLanguageServer < Formula
     BASH
   end
 
+  # `lua-language-server` uses `changelog.md` in `libexec`
+  # directory to determine its version. Installing the changelog
+  # in `def install` does not work because it cleanups metafiles
+  # from non-root directory
+  def post_install
+    libexec.install_symlink prefix/"changelog.md"
+  end
+
   test do
+    assert_match version.to_s, shell_output("#{bin}/lua-language-server --version")
     pid = spawn bin/"lua-language-server", "--logpath=."
     sleep 5
     assert_path_exists testpath/"service.log"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

In the previous installation, `lua-language-server` was unable to obtain its current version number. Both the `lua-language-server --version` command and the runtime logs only displayed `<Unknown>`.

The reason is that `lua-language-server` looks for the version number in the changelog.md file located in its installation directory (`libexec`). However, Homebrew does not install this file in that location.

In this commit, I attempted to add `libexec.install_symlink prefix/"changelog.md"` directly in the `install` method, but the installation process failed with the following error:

> ArgumentError: same file: /opt/homebrew/Cellar/lua-language-server/3.15.0/changelog.md and /opt/homebrew/Cellar/lua-language-server/3.15.0/changelog.md

I wasn’t able to resolve this issue, so I had no choice but to perform this action in the `post_install` method instead.
If there’s a proper way to achieve this within the `install` method, I’d greatly appreciate your guidance.