### PR TITLE
spidermonkey@128 (new formula)

### DIFF
--- a/Formula/s/spidermonkey@128.rb
+++ b/Formula/s/spidermonkey@128.rb
@@ -1,0 +1,106 @@
+class SpidermonkeyAT128 < Formula
+  desc "JavaScript-C Engine"
+  homepage "https://spidermonkey.dev"
+  url "https://archive.mozilla.org/pub/firefox/releases/128.14.0esr/source/firefox-128.14.0esr.source.tar.xz"
+  version "128.14.0"
+  sha256 "93b9ef6229f41cb22ff109b95bbf61a78395a0fe4b870192eeca22947cb09a53"
+  license "MPL-2.0"
+
+  # Spidermonkey versions use the same versions as Firefox, so we simply check
+  # Firefox ESR release versions.
+  livecheck do
+    url "https://www.mozilla.org/en-US/firefox/releases/"
+    regex(%r{href=.*?/v?(128(?:\.\d+)+)/releasenotes}i)
+  end
+
+  keg_only :versioned_formula
+
+  depends_on "cbindgen" => :build
+  depends_on "pkgconf" => :build
+  depends_on "python@3.13" => :build
+  depends_on "rust" => :build
+  depends_on "icu4c@77"
+  depends_on "nspr"
+  depends_on "readline"
+
+  uses_from_macos "llvm" => :build # for llvm-objdump
+  uses_from_macos "m4" => :build
+  uses_from_macos "zlib"
+
+  # From python/mozbuild/mozbuild/test/configure/test_toolchain_configure.py
+  fails_with :gcc do
+    version "7"
+    cause "Only GCC 8.1 or newer is supported"
+  end
+
+  # Apply patch used by `gjs` to bypass build error.
+  # ERROR: *** The pkg-config script could not be found. Make sure it is
+  # *** in your path, or set the PKG_CONFIG environment variable
+  # *** to the full path to pkg-config.
+  # Ref: https://bugzilla.mozilla.org/show_bug.cgi?id=1783570
+  # Ref: https://discourse.gnome.org/t/gnome-45-to-depend-on-spidermonkey-115/16653
+  patch do
+    on_macos do
+      url "https://github.com/ptomato/mozjs/commit/c82346c4e19a73ed4c7f65a6b274fc2138815ae9.patch?full_index=1"
+      sha256 "0f1cd5f80b4ae46e614efa74a409133e8a69fff38220314f881383ba0adb0f87"
+    end
+  end
+
+  def install
+    # Workaround for ICU 76+
+    # Issue ref: https://bugzilla.mozilla.org/show_bug.cgi?id=1927380
+    inreplace "js/moz.configure", '"icu-i18n >= 73.1"', '"icu-i18n >= 73.1 icu-uc"'
+
+    if OS.mac?
+      inreplace "build/moz.configure/toolchain.configure" do |s|
+        # Help the build script detect ld64 as it expects logs from LD_PRINT_OPTIONS=1 with -Wl,-version
+        # Issue ref: https://bugzilla.mozilla.org/show_bug.cgi?id=1844694
+        s.sub! '"-Wl,--version"', '"-Wl,-ld_classic,-v"' if DevelopmentTools.clang_build_version >= 1500
+        # Allow using brew libraries on macOS (not officially supported)
+        s.sub!(/^(\s*def no_system_lib_in_sysroot\(.*\n\s*if )bootstrapped and value:/, "\\1False:")
+        # Work around upstream only allowing build on limited macOS SDK (14.4 as of Spidermonkey 128)
+        s.sub!(/^(\s*def mac_sdk_min_version\(.*\n\s*return )"\d+(\.\d+)*"$/, "\\1\"#{MacOS.version}\"")
+      end
+    end
+
+    mkdir "brew-build" do
+      args = %W[
+        --prefix=#{prefix}
+        --enable-hardening
+        --enable-optimize
+        --enable-readline
+        --enable-release
+        --enable-rust-simd
+        --enable-shared-js
+        --disable-bootstrap
+        --disable-debug
+        --disable-jemalloc
+        --with-intl-api
+        --with-system-icu
+        --with-system-nspr
+        --with-system-zlib
+      ]
+
+      system "../js/src/configure", *args
+      ENV.deparallelize { system "make" }
+      system "make", "install"
+    end
+
+    rm(lib/"libjs_static.ajs")
+
+    # Add an unversioned `js` to be used by dependents like `jsawk` & `plowshare`
+    bin.install_symlink "js#{version.major}" => "js"
+
+    # Avoid writing nspr's versioned Cellar path in js*-config
+    inreplace bin/"js#{version.major}-config",
+              Formula["nspr"].prefix.realpath,
+              Formula["nspr"].opt_prefix
+  end
+
+  test do
+    path = testpath/"test.js"
+    path.write "print('hello');"
+    assert_equal "hello", shell_output("#{bin}/js#{version.major} #{path}").strip
+    assert_equal "hello", shell_output("#{bin}/js #{path}").strip
+  end
+end


### PR DESCRIPTION
Adding SpiderMonkey v128 as additional version

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
