### PR TITLE
mcp-proxy: migrate to `python@3.14`

### DIFF
--- a/Formula/m/mcp-proxy.rb
+++ b/Formula/m/mcp-proxy.rb
@@ -19,7 +19,7 @@ class McpProxy < Formula
   depends_on "pkgconf" => :build
   depends_on "rust" => :build # for pydantic_core
   depends_on "certifi"
-  depends_on "python@3.13"
+  depends_on "python@3.14"
 
   resource "annotated-types" do
     url "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz"
@@ -27,8 +27,8 @@ class McpProxy < Formula
   end
 
   resource "anyio" do
-    url "https://files.pythonhosted.org/packages/f1/b4/636b3b65173d3ce9a38ef5f0522789614e590dab6a8d505340a4efe4c567/anyio-4.10.0.tar.gz"
-    sha256 "3f3fae35c96039744587aa5b8371e7e8e603c0702999535961dd336026973ba6"
+    url "https://files.pythonhosted.org/packages/c6/78/7d432127c41b50bccba979505f272c16cbcadcc33645d5fa3a738110ae75/anyio-4.11.0.tar.gz"
+    sha256 "82a8d0b81e318cc5ce71a5f1f8b5c4e63619620b63141ef8c995fa0db95a57c4"
   end
 
   resource "click" do
@@ -52,13 +52,13 @@ class McpProxy < Formula
   end
 
   resource "httpx-sse" do
-    url "https://files.pythonhosted.org/packages/6e/fa/66bd985dd0b7c109a3bcb89272ee0bfb7e2b4d06309ad7b38ff866734b2a/httpx_sse-0.4.1.tar.gz"
-    sha256 "8f44d34414bc7b21bf3602713005c5df4917884f76072479b21f68befa4ea26e"
+    url "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz"
+    sha256 "9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d"
   end
 
   resource "idna" do
-    url "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz"
-    sha256 "12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"
+    url "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz"
+    sha256 "795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902"
   end
 
   resource "mcp" do
@@ -67,18 +67,18 @@ class McpProxy < Formula
   end
 
   resource "pydantic" do
-    url "https://files.pythonhosted.org/packages/ff/5d/09a551ba512d7ca404d785072700d3f6727a02f6f3c24ecfd081c7cf0aa8/pydantic-2.11.9.tar.gz"
-    sha256 "6b8ffda597a14812a7975c90b82a8a2e777d9257aba3453f973acd3c032a18e2"
+    url "https://files.pythonhosted.org/packages/f3/1e/4f0a3233767010308f2fd6bd0814597e3f63f1dc98304a9112b8759df4ff/pydantic-2.12.3.tar.gz"
+    sha256 "1da1c82b0fc140bb0103bc1441ffe062154c8d38491189751ee00fd8ca65ce74"
   end
 
   resource "pydantic-core" do
-    url "https://files.pythonhosted.org/packages/ad/88/5f2260bdfae97aabf98f1778d43f69574390ad787afb646292a638c923d4/pydantic_core-2.33.2.tar.gz"
-    sha256 "7cb8bc3605c29176e1b105350d2e6474142d7c1bd1d9327c4a9bdb46bf827acc"
+    url "https://files.pythonhosted.org/packages/df/18/d0944e8eaaa3efd0a91b0f1fc537d3be55ad35091b6a87638211ba691964/pydantic_core-2.41.4.tar.gz"
+    sha256 "70e47929a9d4a1905a67e4b687d5946026390568a8e952b92824118063cee4d5"
   end
 
   resource "pydantic-settings" do
-    url "https://files.pythonhosted.org/packages/68/85/1ea668bbab3c50071ca613c6ab30047fb36ab0da1b92fa8f17bbc38fd36c/pydantic_settings-2.10.1.tar.gz"
-    sha256 "06f0062169818d0f5524420a360d632d5857b83cffd4d42fe29597807a1614ee"
+    url "https://files.pythonhosted.org/packages/20/c5/dbbc27b814c71676593d1c3f718e6cd7d4f00652cefa24b75f7aa3efb25e/pydantic_settings-2.11.0.tar.gz"
+    sha256 "d0e87a1c7d33593beb7194adb8470fc426e95ba02af83a0f23474a04c9a08180"
   end
 
   resource "python-dotenv" do
@@ -112,13 +112,13 @@ class McpProxy < Formula
   end
 
   resource "typing-inspection" do
-    url "https://files.pythonhosted.org/packages/f8/b1/0c11f5058406b3af7609f121aaa6b609744687f1d158b3c3a5bf4cc94238/typing_inspection-0.4.1.tar.gz"
-    sha256 "6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28"
+    url "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz"
+    sha256 "ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464"
   end
 
   resource "uvicorn" do
-    url "https://files.pythonhosted.org/packages/ef/5e/f0cd46063a02fd8515f0e880c37d2657845b7306c16ce6c4ffc44afd9036/uvicorn-0.36.0.tar.gz"
-    sha256 "527dc68d77819919d90a6b267be55f0e76704dca829d34aea9480be831a9b9d9"
+    url "https://files.pythonhosted.org/packages/71/57/1616c8274c3442d802621abf5deb230771c7a0fec9414cb6763900eb3868/uvicorn-0.37.0.tar.gz"
+    sha256 "4115c8add6d3fd536c8ee77f0e14a7fd2ebba939fed9b02583a97f80648f9e13"
   end
 
   def install

--- a/Formula/m/mcp-proxy.rb
+++ b/Formula/m/mcp-proxy.rb
@@ -8,12 +8,13 @@ class McpProxy < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "0b87e6a81b5046d5c89c6513e5aaa14bbbbcea6822ac650b8130ec28f7000b6d"
-    sha256 cellar: :any,                 arm64_sequoia: "e69beb4180d1462f16ea894c112b710a57a727d9295944ab2d6593465a840ee4"
-    sha256 cellar: :any,                 arm64_sonoma:  "174daddfdebe094574d3028b4e3a73255c2df970e83ae45d9d5881d19a366084"
-    sha256 cellar: :any,                 sonoma:        "b4165a7f9472f8031c3c0f29bc8b7291c202bb0edfee8cbce9602c6a7e593765"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "b15466c349243803049921f15aabab07221655e61cfc30d55f2ba3c9384d6fc0"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "6895dce0299a3e1a1dd2135a679cb31ddfa4e89422714dbfb5da5469ed5b59df"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "282021630aa5a6c860f0e7755782a609f4bcc67a3c5000665cca55205a6247fb"
+    sha256 cellar: :any,                 arm64_sequoia: "053c526cfbedf6c5fa9d323cce04c03d008e6df2a682a7f9d9248f717ca819d5"
+    sha256 cellar: :any,                 arm64_sonoma:  "571f60a9e0b99eff8af902379c044cf5cb71f4755d8c32305b2dcb04e3e19618"
+    sha256 cellar: :any,                 sonoma:        "c45aa9d5be3d97a17e8d5fd33821126bc2a8e407ef3c2a886356222d2d39f25b"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "ca521df585dd566741bfec5c27578f72f074827f0f809d912fe35fd24a5911b4"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5d514dc2adc8a9c8c88c784da1322276bc973fabdd52e0711fdf8f932e547247"
   end
 
   depends_on "pkgconf" => :build


### PR DESCRIPTION
mcp-proxy: migrate to `python@3.14`