### PR TITLE
clippy 1.5.1 (new formula)

### DIFF
--- a/Formula/c/clippy.rb
+++ b/Formula/c/clippy.rb
@@ -1,0 +1,29 @@
+class Clippy < Formula
+  desc "Copy files from your terminal that actually paste into GUI apps"
+  homepage "https://github.com/neilberkman/clippy"
+  url "https://github.com/neilberkman/clippy/archive/refs/tags/v1.5.1.tar.gz"
+  sha256 "e1775535ee7b00ba1344696d0d60ae8067b445fa0e3b9ffb5fdfb56a0a10a0be"
+  license "MIT"
+
+  depends_on "go" => :build
+  depends_on :macos
+
+  def install
+    ldflags = %W[
+      -s -w
+      -X github.com/neilberkman/clippy/cmd/internal/common.Version=#{version}
+      -X github.com/neilberkman/clippy/cmd/internal/common.Commit=#{tap.user}
+      -X github.com/neilberkman/clippy/cmd/internal/common.Date=#{time.iso8601}
+    ]
+    system "go", "build", *std_go_args(ldflags:), "./cmd/clippy"
+    system "go", "build", *std_go_args(ldflags:, output: bin/"pasty"), "./cmd/pasty"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/clippy --version")
+    assert_match version.to_s, shell_output("#{bin}/pasty --version")
+
+    (testpath/"test.txt").write("test content")
+    system bin/"clippy", "-t", testpath/"test.txt"
+  end
+end

--- a/Formula/c/clippy.rb
+++ b/Formula/c/clippy.rb
@@ -5,6 +5,13 @@ class Clippy < Formula
   sha256 "e1775535ee7b00ba1344696d0d60ae8067b445fa0e3b9ffb5fdfb56a0a10a0be"
   license "MIT"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "85a30b02ea2324f7a0926268ded16b7a7c83422cc48f9b1cfeac1fc1e93a56c5"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "9082c3d04f630353c7e24f177059ff054ac3863b2fb8243c00c923dba4acaee1"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "0b35fa12fb7ee1fa69cc18c96dd4595d202180d15c7c8cc0724bd757851ef5bb"
+    sha256 cellar: :any_skip_relocation, sonoma:        "f6e7c9b9c650e237f1175a092e93a57974444836f8352a20305a8b6665b873f5"
+  end
+
   depends_on "go" => :build
   depends_on :macos
 


### PR DESCRIPTION
Unified clipboard tool for macOS that bridges terminal and GUI clipboard workflows.

**What it solves:** macOS's pbcopy/pbpaste work with file contents, not file references. This breaks workflows where you need to paste actual files into GUI apps (Slack, email, browsers). Clippy fixes this fundamental gap.

**Commands:**
- clippy: Copy files/text to clipboard (GUI-pasteable)
- pasty: Paste clipboard contents to filesystem

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/brew/blob/HEAD/docs/How-To-Open-a-Homebrew-Pull-Request.md#contributing-to-homebrew)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open pull requests for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>`?