### PR TITLE
bbftp-client: fix livecheck

### DIFF
--- a/Formula/b/bbftp-client.rb
+++ b/Formula/b/bbftp-client.rb
@@ -2,14 +2,17 @@ class BbftpClient < Formula
   desc "Secure file transfer software, optimized for large files"
   homepage "https://gitlab.in2p3.fr/cc-in2p3-hpss-service/bbftp"
   url "https://pkg.freebsd.org/ports-distfiles/bbftp-client-3.2.1.tar.gz"
-  mirror "http://software.in2p3.fr/bbftp/dist/bbftp-client-3.2.1.tar.gz"
   sha256 "4000009804d90926ad3c0e770099874084fb49013e8b0770b82678462304456d"
   license "GPL-2.0-or-later"
   revision 3
+  head "https://gitlab.in2p3.fr/cc-in2p3-hpss-service/bbftp.git", branch: "master"
 
   livecheck do
-    url "http://software.in2p3.fr/bbftp/download.html"
-    regex(/href=.*?bbftp-client[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url :head
+    regex(/^(?:BBFTP|Version)[._-]v?(\d+(?:[._-]\d+)+[a-z]?)$/i)
+    strategy :git do |tags, regex|
+      tags.filter_map { |tag| tag[regex, 1]&.tr("_-", ".") }
+    end
   end
 
   no_autobump! because: :requires_manual_review


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- Old mirror and livecheck source is gone, replace it with new GitLab instance owned by upstream.
- Add a `head` url while we're at it (livecheck depends on it anyways)