### PR TITLE
yasm: fix livecheck

### DIFF
--- a/Formula/y/yasm.rb
+++ b/Formula/y/yasm.rb
@@ -15,8 +15,8 @@ class Yasm < Formula
   revision 2
 
   livecheck do
-    url "https://yasm.tortall.net/Download.html"
-    regex(/href=.*?yasm[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url "https://www.tortall.net/projects/yasm/releases/"
+    regex(/href=["']?yasm[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   no_autobump! because: :requires_manual_review


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- Check the directory which contains the `url`, rather than the previous homepage (which is now dead)
- Match closely against hrefs of which start with `yasm` immediately after the quote, as there are other links too which contain `yasm` in the name (e.g. `vsyasm`)
  - These other links currently are zips rather than tarballs so we would miss them anyways, but in the case that they are released as tarballs in the future, that could break things.