### PR TITLE
dotnet: WIP PR for trying to fix AOT codegen

### DIFF
--- a/Formula/d/dotnet.rb
+++ b/Formula/d/dotnet.rb
@@ -83,7 +83,13 @@ class Dotnet < Formula
                 '"true"'
     end
 
-    args = ["--clean-while-building", "--source-build", "--with-system-libs", "brotli+libunwind+rapidjson+zlib"]
+    args = %w[
+      --clean-while-building
+      --source-build
+      --with-system-libs
+      brotli+libunwind+rapidjson+zlib
+      /p:BundleNativeAotCompiler=false
+    ]
     if build.stable?
       args += ["--release-manifest", "release.json"]
       odie "Update release.json resource!" if resource("release.json").version != version
@@ -170,5 +176,9 @@ class Dotnet < Formula
     resource("docfx").stage do
       system bin/"dotnet", "restore", "src/docfx", "--disable-build-servers", "--no-cache"
     end
+
+    # Confirm that building/publishing with native AOT works
+    system bin/"dotnet", "new", "console", "-o", "TestConsoleAOT", "--aot"
+    system bin/"dotnet", "publish", "TestConsoleAOT"
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] Confirm that current build process results in build/publish failure by adding steps in test (control case) - https://github.com/Homebrew/homebrew-core/actions/runs/18620780185.
- [x] Try setting `/p:PortableBuild=true` as a fix. If build and modified test succeeds, download the resulting bottles and see how linkage differs.
- [ ] Try setting `/p:BundleNativeAotCompiler=false` as a fix. If build and modified test succeeds, confirm no change in linkage and that the test is indeed pulling AOT compiler from NuGet.

-----

Current linkage (macOS):
```
System libraries:
  /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
  /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices
  /System/Library/Frameworks/CryptoKit.framework/Versions/A/CryptoKit
  /System/Library/Frameworks/Foundation.framework/Versions/C/Foundation
  /System/Library/Frameworks/GSS.framework/Versions/A/GSS
  /System/Library/Frameworks/Security.framework/Versions/A/Security
  /usr/lib/libSystem.B.dylib
  /usr/lib/libc++.1.dylib
  /usr/lib/libicucore.A.dylib
  /usr/lib/libobjc.A.dylib
  /usr/lib/libz.1.dylib
  /usr/lib/swift/libswiftCore.dylib
  /usr/lib/swift/libswiftFoundation.dylib
Homebrew libraries:
  /opt/homebrew/opt/brotli/lib/libbrotlidec.1.dylib (brotli)
  /opt/homebrew/opt/brotli/lib/libbrotlienc.1.dylib (brotli)
  /opt/homebrew/Cellar/dotnet/9.0.8/libexec/shared/Microsoft.NETCore.App/9.0.8/libmscordaccore.dylib (dotnet)
```