### PR TITLE
netsurf formulae: fix head and ensure livecheck

### DIFF
--- a/Formula/lib/libcss.rb
+++ b/Formula/lib/libcss.rb
@@ -4,7 +4,7 @@ class Libcss < Formula
   url "https://download.netsurf-browser.org/libs/releases/libcss-0.9.2-src.tar.gz"
   sha256 "2df215bbec34d51d60c1a04b01b2df4d5d18f510f1f3a7af4b80cddb5671154e"
   license "MIT"
-  head "https://git.netsurf-browser.org/libcss.git", branch: "master"
+  head "git://git.netsurf-browser.org/libcss.git", branch: "master"
 
   livecheck do
     url :homepage

--- a/Formula/lib/libhubbub.rb
+++ b/Formula/lib/libhubbub.rb
@@ -4,7 +4,7 @@ class Libhubbub < Formula
   url "https://download.netsurf-browser.org/libs/releases/libhubbub-0.3.8-src.tar.gz"
   sha256 "8ac1e6f5f3d48c05141d59391719534290c59cd029efc249eb4fdbac102cd5a5"
   license "MIT"
-  head "https://git.netsurf-browser.org/libhubbub.git", branch: "master"
+  head "git://git.netsurf-browser.org/libhubbub.git", branch: "master"
 
   livecheck do
     url :homepage

--- a/Formula/lib/libnsgif.rb
+++ b/Formula/lib/libnsgif.rb
@@ -4,14 +4,12 @@ class Libnsgif < Formula
   url "https://download.netsurf-browser.org/libs/releases/libnsgif-1.0.0-src.tar.gz"
   sha256 "6014c842f61454d2f5a0f8243d7a8d7bde9b7da3ccfdca2d346c7c0b2c4c061b"
   license "MIT"
-  head "https://git.netsurf-browser.org/libnsgif.git", branch: "master"
+  head "git://git.netsurf-browser.org/libnsgif.git", branch: "master"
 
   livecheck do
     url :homepage
     regex(/href=.*?libnsgif[._-]v?(\d+(?:\.\d+)+)[._-]src\.t/i)
   end
-
-  no_autobump! because: :requires_manual_review
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "24a59de1bad99d2d805e0054f54b09fdadd75c69f50aa3d105d34aaeee184d21"

--- a/Formula/lib/libparserutils.rb
+++ b/Formula/lib/libparserutils.rb
@@ -4,9 +4,12 @@ class Libparserutils < Formula
   url "https://download.netsurf-browser.org/libs/releases/libparserutils-0.2.5-src.tar.gz"
   sha256 "317ed5c718f17927b5721974bae5de32c3fd6d055db131ad31b4312a032ed139"
   license "MIT"
-  head "https://git.netsurf-browser.org/libparserutils.git", branch: "master"
+  head "git://git.netsurf-browser.org/libparserutils.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
+  livecheck do
+    url :homepage
+    regex(/href=.*?libparserutils[._-]v?(\d+(?:\.\d+)+)[._-]src\.t/i)
+  end
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "f611219c6ad2fa78766ef8c18c4518dedb5f4c271266107cdac37b35100e8a48"

--- a/Formula/n/netsurf-buildsystem.rb
+++ b/Formula/n/netsurf-buildsystem.rb
@@ -1,12 +1,15 @@
 class NetsurfBuildsystem < Formula
   desc "Makefiles shared by NetSurf projects"
-  homepage "https://source.netsurf-browser.org/buildsystem.git"
+  homepage "https://www.netsurf-browser.org/"
   url "https://download.netsurf-browser.org/libs/releases/buildsystem-1.10.tar.gz"
   sha256 "3d3e39d569e44677c4b179129bde614c65798e2b3e6253160239d1fd6eae4d79"
   license "MIT"
-  head "https://git.netsurf-browser.org/buildsystem.git", branch: "master"
+  head "git://git.netsurf-browser.org/buildsystem.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
+  livecheck do
+    url "https://download.netsurf-browser.org/libs/releases/"
+    regex(/href=.*?buildsystem[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     rebuild 1


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

It looks like NetSurf has disabled web access to their Git repositories.
- Adjust `head` of formulae which already have one defined, to use `git://` instead of `https://` (which is still provided)
- Add a `livecheck` where needed to ensure that formulae can be autobumped