### PR TITLE
mandoc: install the libmandoc library

### DIFF
--- a/Formula/m/mandoc.rb
+++ b/Formula/m/mandoc.rb
@@ -90,6 +90,7 @@ class Mandoc < Formula
     ENV.deparallelize do
       system "make"
       system "make", "install"
+      system "make", "lib-install"
     end
   end
 


### PR DESCRIPTION
This commit adds the libmandoc library as an installation target to the mandoc formula.  It has to be manually installed via the `lib-install` target, because `install` only installs the binaries.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
