### PR TITLE
tracy 0.12.2

### DIFF
--- a/Formula/t/tracy.rb
+++ b/Formula/t/tracy.rb
@@ -1,8 +1,8 @@
 class Tracy < Formula
   desc "Real-time, nanosecond resolution frame profiler"
   homepage "https://github.com/wolfpld/tracy"
-  url "https://github.com/wolfpld/tracy/archive/refs/tags/v0.11.1.tar.gz"
-  sha256 "2c11ca816f2b756be2730f86b0092920419f3dabc7a7173829ffd897d91888a1"
+  url "https://github.com/wolfpld/tracy/archive/refs/tags/v0.12.2.tar.gz"
+  sha256 "09617765ba5ff1aa6da128d9ba3c608166c5ef05ac28e2bb77f791269d444952"
   license "BSD-3-Clause"
 
   bottle do
@@ -22,6 +22,7 @@ class Tracy < Formula
   depends_on "pkgconf" => :build
   depends_on "capstone"
   depends_on "freetype"
+  depends_on "zstd"
 
   on_macos do
     depends_on "glfw"
@@ -37,7 +38,7 @@ class Tracy < Formula
   end
 
   def install
-    args = %w[CAPSTONE GLFW FREETYPE].map { |arg| "-DDOWNLOAD_#{arg}=OFF" }
+    args = %w[CAPSTONE GLFW FREETYPE ZSTD].map { |arg| "-DDOWNLOAD_#{arg}=OFF" }
 
     buildpath.each_child do |child|
       next unless child.directory?


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

> [!NOTE]
> This is my first time contributing to the formulae. Please let me know if I'm missing anything, as I'm still a beginner! :)

This is my attempt at updating [Tracy](https://github.com/wolfpld/tracy) from v0.11.1 to v0.12.2. I'm unable to successfully build it, however, since it appears to be missing the `zstd` dependency. I would appreciate any help in getting this building, as I'm unsure how to fix the error!

```
Last 15 lines from /Users/bd/Library/Logs/Homebrew/tracy/01.cmake.log:
-- CPM: Adding package zstd@1.5.7 (v1.5.7 to /private/tmp/tracy-20251020-34177-ifkdqm/tracy-0.12.2/capture/build/.cpm-cache/zstd/dfd2e0b6e613dcf44911302708e636a8aee527d2)
CMake Error at /opt/homebrew/Library/Homebrew/cmake/trap_fetchcontent_provider.cmake:12 (message):
  Refusing to populate dependency 'zstd' with FetchContent while building in
  Homebrew, please use a formula dependency or add a resource to the formula.
Call Stack (most recent call first):
  /opt/homebrew/opt/cmake/share/cmake/Modules/FetchContent.cmake:2468:EVAL:1 (trap_fetchcontent_provider)
  /opt/homebrew/opt/cmake/share/cmake/Modules/FetchContent.cmake:2468 (cmake_language)
  /opt/homebrew/opt/cmake/share/cmake/Modules/FetchContent.cmake:2314 (__FetchContent_MakeAvailable_eval_code)
  /private/tmp/tracy-20251020-34177-ifkdqm/tracy-0.12.2/cmake/CPM.cmake:1114 (FetchContent_MakeAvailable)
  /private/tmp/tracy-20251020-34177-ifkdqm/tracy-0.12.2/cmake/CPM.cmake:895 (cpm_fetch_package)
  /private/tmp/tracy-20251020-34177-ifkdqm/tracy-0.12.2/cmake/vendor.cmake:106 (CPMAddPackage)
  CMakeLists.txt:17 (include)


-- Configuring incomplete, errors occurred!
```