### PR TITLE
rumdl 0.0.164 (new formula)

### DIFF
--- a/Formula/r/rumdl.rb
+++ b/Formula/r/rumdl.rb
@@ -1,0 +1,47 @@
+class Rumdl < Formula
+  desc "Fast Markdown linter and formatter"
+  homepage "https://github.com/rvben/rumdl"
+  url "https://github.com/rvben/rumdl/archive/refs/tags/v0.0.164.tar.gz"
+  sha256 "045c05237203301dcdf0c3e7b565346fbddd6c888e7f04f8de5f424d9fe0c905"
+  license "MIT"
+  head "https://github.com/rvben/rumdl.git", branch: "main"
+
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    # Test version output
+    assert_match "rumdl #{version}", shell_output("#{bin}/rumdl --version")
+
+    # Test that rumdl successfully checks valid markdown (exit code 0)
+    (testpath/"valid.md").write <<~EOS
+      # Valid Heading
+
+      This is valid markdown with proper spacing.
+
+      - List item 1
+      - List item 2
+    EOS
+
+    output = shell_output("#{bin}/rumdl check #{testpath}/valid.md")
+    assert_match "No issues found", output
+
+    # Test that rumdl detects issues in invalid markdown (exit code 1)
+    (testpath/"invalid.md").write <<~EOS
+      # Bad Heading
+      Missing blank line below heading
+    EOS
+
+    output = shell_output("#{bin}/rumdl check #{testpath}/invalid.md 2>&1", 1)
+    assert_match "MD022", output
+    assert_match "Expected 1 blank line below heading", output
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine with `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict --online <formula>`?

rumdl is a fast Markdown linter and formatter written in Rust. It provides comprehensive Markdown linting with auto-fix capabilities, similar to markdownlint but with significantly better performance.

**Project Info:**
- Homepage: https://github.com/rvben/rumdl
- License: MIT
- Stars: 249
- Language: Rust
- Version: 0.0.164

**Testing (macOS Sequoia, Apple Silicon):**
- ✅ `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source rumdl` (builds in ~1.5 minutes)
- ✅ `brew test rumdl`
- ✅ `brew audit --new rumdl`
- ✅ `brew audit --strict --online rumdl`
- ✅ `brew style rumdl`

The formula includes comprehensive tests that verify both successful linting (exit 0) and issue detection (exit 1).