### PR TITLE
audiowaveform: update homepage and source location 

### DIFF
--- a/Formula/a/audiowaveform.rb
+++ b/Formula/a/audiowaveform.rb
@@ -6,14 +6,13 @@ class Audiowaveform < Formula
   license "GPL-3.0-only"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "a0883230a730a658b0037ad1d4fd80a0843bfcbd6a1820bc463648429df5f216"
-    sha256 cellar: :any,                 arm64_sequoia: "1e9fefd035443e96fc39605c249e618408b8d79852d8b635e4c73fa72633fd80"
-    sha256 cellar: :any,                 arm64_sonoma:  "889c6dfe09ecd0e73ae9aa5640a09ea428b30f50f95a6e8c236d5bd810db65c4"
-    sha256 cellar: :any,                 arm64_ventura: "d18a60880174cfcab31fffaccd30fd4d9599016abc57bea6876482300082cc18"
-    sha256 cellar: :any,                 sonoma:        "4b0a4c44b31fb0d5d4053cdafc13b2f61a7b51511d7c76c5b853745a4ad73544"
-    sha256 cellar: :any,                 ventura:       "03b9eb62b31e53d0aed8a618a3e73c402c816e936763a57d243fe536dcd74852"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "1ae6cd104cd3c23dccc7a19265ef3a44168abf208c45064a1788155564ad9394"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "513241538f7c5d46a3f0b2830649ce4aab77aee49aa08966bf82d9039f829ae0"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "40d9bf787e5f7813ed51079d59716a7f88c6cd2c0076dc04b5838bf0d769536d"
+    sha256 cellar: :any,                 arm64_sequoia: "0847aa9b5ae424d084e9ca3b8d00e703d1935237fe107ac87495ddf3301e360c"
+    sha256 cellar: :any,                 arm64_sonoma:  "0edef92eb11576b39b7b4684c5c853a6e3e42b3784870d1e57406256c8baa110"
+    sha256 cellar: :any,                 sonoma:        "93f324ec4b218cda6afb1459b53efe02d5a1887a1494831b89bcb753749ed752"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "5832d40c71610ac220ad80dc716d252108916ad7f2b421f147d185c94ff7e7e8"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5be140b85eb627cbb179bfc6252d6af35f80dd9972b67426687af659e88a8996"
   end
 
   depends_on "cmake" => :build

--- a/Formula/a/audiowaveform.rb
+++ b/Formula/a/audiowaveform.rb
@@ -1,8 +1,8 @@
 class Audiowaveform < Formula
   desc "Generate waveform data and render waveform images from audio files"
-  homepage "https://waveform.prototyping.bbc.co.uk"
-  url "https://github.com/bbc/audiowaveform/archive/refs/tags/1.10.3.tar.gz"
-  sha256 "191b7d46964de9080b6321411d79c6a2746c6da40bda283bb0d46cc7e718c90b"
+  homepage "https://codeberg.org/chrisn/audiowaveform"
+  url "https://codeberg.org/chrisn/audiowaveform/archive/1.10.3.tar.gz"
+  sha256 "f33680a4c74a718648ee0567511537ad80e015fb3bf5c8440a8176414afb415a"
   license "GPL-3.0-only"
 
   bottle do


### PR DESCRIPTION
The previous homepage URL goes to a site which has an SSL issue, and
if bypassed ends with a 503 error about no server existing.
Additionally, active development has moved to Codeberg.

- update the homepage to the Codeberg repository page
- update the source URL to the Codeberg release archive
- update the sha256 for the tarball

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
