### PR TITLE
adaptivecpp: avoid hard-coded refs to `llvm`'s cellar path

### DIFF
--- a/Formula/a/adaptivecpp.rb
+++ b/Formula/a/adaptivecpp.rb
@@ -4,7 +4,7 @@ class Adaptivecpp < Formula
   url "https://github.com/AdaptiveCpp/AdaptiveCpp/archive/refs/tags/v25.02.0.tar.gz"
   sha256 "8cc8a3be7bb38f88d7fd51597e0ec924b124d4233f64da62a31b9945b55612ca"
   license "BSD-2-Clause"
-  revision 2
+  revision 3
   head "https://github.com/AdaptiveCpp/AdaptiveCpp.git", branch: "develop"
 
   bottle do
@@ -40,7 +40,10 @@ class Adaptivecpp < Formula
       libomp_root = Formula["libomp"].opt_prefix
       ["-DOpenMP_ROOT=#{libomp_root}"]
     else
-      ["-DACPP_EXPERIMENTAL_LLVM=ON"]
+      %W[
+        -DACPP_EXPERIMENTAL_LLVM=ON
+        -DCLANG_EXECUTABLE_PATH=#{Formula["llvm"].opt_bin/"clang++"}
+      ]
     end
 
     system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
@@ -72,5 +75,11 @@ class Adaptivecpp < Formula
     C
     system bin/"acpp", "hellosycl.cpp", "-o", "hello"
     system "./hello"
+
+    unless OS.mac?
+      refute_match Formula["llvm"].prefix.realpath.to_s,
+                   (etc/"AdaptiveCpp/acpp-core.json").read,
+                   "`acpp-core.json` references `llvm`'s cellar path"
+    end
   end
 end

--- a/Formula/a/adaptivecpp.rb
+++ b/Formula/a/adaptivecpp.rb
@@ -8,12 +8,12 @@ class Adaptivecpp < Formula
   head "https://github.com/AdaptiveCpp/AdaptiveCpp.git", branch: "develop"
 
   bottle do
-    sha256 arm64_tahoe:   "b64dea8eba9f43b61be66118c129a95282af9774ff01ccb26462ca27c02ee2b4"
-    sha256 arm64_sequoia: "f8d303163cea44ae411f9e87ab47ee27d55c606947d53400ddb98bc0a5ded3d5"
-    sha256 arm64_sonoma:  "b3b96b81ff893ff2c13ee51aaae39b641578fb7396de843c45800eb06524de89"
-    sha256 sonoma:        "37f755b817e733580418205802ca9ee25b29714b02cd166cc6ac73360752ebbc"
-    sha256 arm64_linux:   "67ead23c19a08e8e48ab36fe97a5e602eb2508998bc4c93d098a3f369161a93a"
-    sha256 x86_64_linux:  "0007c52823b9d6ad8e2c13fe8a3d47f8d89b2230b4b6d626ab2c3718af24db64"
+    sha256 arm64_tahoe:   "c7d4959352b8ebddf43641929597f0ba52212c921c1f3933980f32fa06d925fe"
+    sha256 arm64_sequoia: "8d7276450c277fe9378aa8bb2c959adbec2ea0a4072ec9416cb3cb43263b6950"
+    sha256 arm64_sonoma:  "a7d8243f1f5151c7a3b2875f9fba1412755663d5b085c87e9ec3b6a005f9cb35"
+    sha256 sonoma:        "0e5825f933f4d87ec3d66a25c4d7a931cd5be6aaf7d0dd5e2d62cfdcca9e8396"
+    sha256 arm64_linux:   "1442b54a1ed1362ef94e93e073c8090df229b495195131e5e66467cc6b1be3eb"
+    sha256 x86_64_linux:  "ba6fea3e06fe2291cad07ec926c56cc1335b29401ca984a01be13484689def1e"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This helps to avoid rebuilds on `llvm` updates.
