### PR TITLE
mecab-unidic: replace osdn.net source with `mirrors.dotsrc.org` same as `mecab-unidic-extended`

### DIFF
--- a/Formula/m/mecab-unidic.rb
+++ b/Formula/m/mecab-unidic.rb
@@ -1,8 +1,8 @@
 class MecabUnidic < Formula
   desc "Morphological analyzer for MeCab"
   homepage "https://clrd.ninjal.ac.jp/unidic/en/"
-  # Canonical: https://osdn.net/dl/unidic/unidic-mecab-2.1.2_src.zip
-  url "https://dotsrc.dl.osdn.net/osdn/unidic/58338/unidic-mecab-2.1.2_src.zip"
+  url "https://mirrors.dotsrc.org/osdn/unidic/58338/unidic-mecab-2.1.2_src.zip"
+  mirror "https://clrd.ninjal.ac.jp/unidic_archive/cwj/2.1.2/unidic-mecab-2.1.2_src.zip"
   sha256 "6cce98269214ce7de6159f61a25ffc5b436375c098cc86d6aa98c0605cbf90d4"
   license any_of: ["GPL-2.0-only", "LGPL-2.1-only", "BSD-3-Clause"]
 
@@ -10,8 +10,6 @@ class MecabUnidic < Formula
     url "https://clrd.ninjal.ac.jp/unidic/en/back_number_en.html"
     regex(/href=.*?unidic-mecab[._-]v?(\d+(?:\.\d+)+)[._-]src\.zip/i)
   end
-
-  no_autobump! because: :requires_manual_review
 
   bottle do
     rebuild 3
@@ -23,10 +21,7 @@ class MecabUnidic < Formula
   link_overwrite "lib/mecab/dic"
 
   def install
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
-                          "--prefix=#{prefix}",
-                          "--with-dicdir=#{lib}/mecab/dic/unidic"
+    system "./configure", "--with-dicdir=#{lib}/mecab/dic/unidic", *std_configure_args
     system "make", "install"
   end
 


### PR DESCRIPTION
the two artifacts carry two different sha

```
  url "https://mirrors.dotsrc.org/osdn/unidic/58338/unidic-mecab-2.1.2_src.zip" # e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
  mirror "https://clrd.ninjal.ac.jp/unidic_archive/cwj/2.1.2/unidic-mecab-2.1.2_src.zip" # e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
```
