### PR TITLE
archgw 0.3.16

### DIFF
--- a/Formula/a/archgw.rb
+++ b/Formula/a/archgw.rb
@@ -3,8 +3,8 @@ class Archgw < Formula
 
   desc "CLI for Arch Gateway"
   homepage "https://github.com/katanemo/archgw/tree/main/arch/tools"
-  url "https://files.pythonhosted.org/packages/75/22/1fcf44dc8393382fe62ef6c28a108498ed1ee1a964174e39191cb6f5c133/archgw-0.3.7.tar.gz"
-  sha256 "b8c69fcb3844beaaafcbc15b151e65d7acf49951402ecd5ec468cc0c509cb943"
+  url "https://files.pythonhosted.org/packages/26/e9/a05e4b61a71dc0f84f2d84e011f3bbfabfa4ca76887689f6dc8fca98b4e2/archgw-0.3.16.tar.gz"
+  sha256 "00eeffb5e6c2300621160a6bb9233a75dc0b9baebe5b1f24831869cc93a3b7ca"
   license "Apache-2.0"
 
   bottle do
@@ -24,8 +24,8 @@ class Archgw < Formula
   depends_on "pytorch"
 
   resource "accelerate" do
-    url "https://files.pythonhosted.org/packages/b1/72/ff3961c19ee395c3d30ac630ee77bfb0e1b46b87edc504d4f83bb4a89705/accelerate-1.10.1.tar.gz"
-    sha256 "3dea89e433420e4bfac0369cae7e36dcd6a56adfcfd38cdda145c6225eab5df8"
+    url "https://files.pythonhosted.org/packages/23/60/2757c4f03a8705dbf80b1268b03881927878dca5ed07d74f733fb6c219e0/accelerate-1.11.0.tar.gz"
+    sha256 "bb1caf2597b4cd632b917b5000c591d10730bb024a79746f1ee205bba80bd229"
   end
 
   resource "annotated-types" do
@@ -39,8 +39,8 @@ class Archgw < Formula
   end
 
   resource "archgw-modelserver" do
-    url "https://files.pythonhosted.org/packages/b8/2c/6da7d9a28d02218bdecd6ad70e6cd31dd4180ee6b285b96fa574c3fd12e9/archgw_modelserver-0.3.15.tar.gz"
-    sha256 "942792e8c776225227783ca9c91927abb74f795938f02f8b8662bfe655649674"
+    url "https://files.pythonhosted.org/packages/7e/de/f82a3125dc0280fbe1128d69cdc1d77c56999417ec765e718d387482f581/archgw_modelserver-0.3.16.tar.gz"
+    sha256 "6ceded5a305d3987212565fb943ae7a822aebdf622886bfdc9d18c3c8a400e38"
   end
 
   resource "asgiref" do
@@ -83,19 +83,14 @@ class Archgw < Formula
     sha256 "f93b4ca3529a8ebc6fc3fcf710e5efa8de3df9b41570958abf1d97d843138004"
   end
 
-  resource "filelock" do
-    url "https://files.pythonhosted.org/packages/58/46/0028a82567109b5ef6e4d2a1f04a583fb513e6cf9527fcdd09afd817deeb/filelock-3.20.0.tar.gz"
-    sha256 "711e943b4ec6be42e1d4e6690b48dc175c822967466bb31c0c293f34334c13f4"
-  end
-
   resource "googleapis-common-protos" do
-    url "https://files.pythonhosted.org/packages/39/24/33db22342cf4a2ea27c9955e6713140fedd51e8b141b5ce5260897020f1a/googleapis_common_protos-1.70.0.tar.gz"
-    sha256 "0e1b44e0ea153e6594f9f394fef15193a68aaaea2d843f83e2742717ca753257"
+    url "https://files.pythonhosted.org/packages/30/43/b25abe02db2911397819003029bef768f68a974f2ece483e6084d1a5f754/googleapis_common_protos-1.71.0.tar.gz"
+    sha256 "1aec01e574e29da63c80ba9f7bbf1ccfaacf1da877f23609fe236ca7c72a2e2e"
   end
 
   resource "grpcio" do
-    url "https://files.pythonhosted.org/packages/9d/f7/8963848164c7604efb3a3e6ee457fdb3a469653e19002bd24742473254f8/grpcio-1.75.1.tar.gz"
-    sha256 "3e81d89ece99b9ace23a6916880baca613c03a799925afb2857887efa8b1b3d2"
+    url "https://files.pythonhosted.org/packages/b6/e0/318c1ce3ae5a17894d5791e87aea147587c9e702f24122cc7a5c8bbaeeb1/grpcio-1.76.0.tar.gz"
+    sha256 "7be78388d6da1a25c0d5ec506523db58b18be22d9c37d8d3a32c08be4987bd73"
   end
 
   resource "h11" do
@@ -119,8 +114,8 @@ class Archgw < Formula
   end
 
   resource "huggingface-hub" do
-    url "https://files.pythonhosted.org/packages/10/7e/a0a97de7c73671863ca6b3f61fa12518caf35db37825e43d63a70956738c/huggingface_hub-0.35.3.tar.gz"
-    sha256 "350932eaa5cc6a4747efae85126ee220e4ef1b54e29d31c3b45c5612ddf0b32a"
+    url "https://files.pythonhosted.org/packages/98/63/4910c5fa9128fdadf6a9c5ac138e8b1b6cee4ca44bf7915bbfbce4e355ee/huggingface_hub-0.36.0.tar.gz"
+    sha256 "47b3f0e2539c39bf5cde015d63b72ec49baff67b6931c3d97f3f84532e2b8d25"
   end
 
   resource "idna" do
@@ -131,6 +126,11 @@ class Archgw < Formula
   resource "importlib-metadata" do
     url "https://files.pythonhosted.org/packages/cd/12/33e59336dca5be0c398a7482335911a33aa0e20776128f038019f1a95f1b/importlib_metadata-8.5.0.tar.gz"
     sha256 "71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7"
+  end
+
+  resource "iniconfig" do
+    url "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz"
+    sha256 "c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730"
   end
 
   resource "jiter" do
@@ -218,14 +218,24 @@ class Archgw < Formula
     sha256 "55158fa3d93b98cc75299b1e67078ad9003ca27945c76162c1c0766d6f91820a"
   end
 
+  resource "packaging" do
+    url "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz"
+    sha256 "d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"
+  end
+
+  resource "pluggy" do
+    url "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz"
+    sha256 "7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"
+  end
+
   resource "protobuf" do
     url "https://files.pythonhosted.org/packages/43/29/d09e70352e4e88c9c7a198d5645d7277811448d76c23b00345670f7c8a38/protobuf-5.29.5.tar.gz"
     sha256 "bc1463bafd4b0929216c35f437a8e28731a2b7fe3d98bb77a600efced5a15c84"
   end
 
   resource "psutil" do
-    url "https://files.pythonhosted.org/packages/b3/31/4723d756b59344b643542936e37a31d1d3204bcdc42a7daa8ee9eb06fb50/psutil-7.1.0.tar.gz"
-    sha256 "655708b3c069387c8b77b072fc429a57d0e214221d01c0a772df7dfedcb3bcd2"
+    url "https://files.pythonhosted.org/packages/89/fc/889242351a932d6183eec5df1fc6539b6f36b6a88444f1e63f18668253aa/psutil-7.1.1.tar.gz"
+    sha256 "092b6350145007389c1cfe5716050f02030a05219d90057ea867d18fe8d372fc"
   end
 
   resource "pydantic" do
@@ -236,6 +246,36 @@ class Archgw < Formula
   resource "pydantic-core" do
     url "https://files.pythonhosted.org/packages/df/18/d0944e8eaaa3efd0a91b0f1fc537d3be55ad35091b6a87638211ba691964/pydantic_core-2.41.4.tar.gz"
     sha256 "70e47929a9d4a1905a67e4b687d5946026390568a8e952b92824118063cee4d5"
+  end
+
+  resource "pygments" do
+    url "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz"
+    sha256 "636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"
+  end
+
+  resource "pytest" do
+    url "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz"
+    sha256 "86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"
+  end
+
+  resource "pytest-asyncio" do
+    url "https://files.pythonhosted.org/packages/42/86/9e3c5f48f7b7b638b216e4b9e645f54d199d7abbbab7a64a13b4e12ba10f/pytest_asyncio-1.2.0.tar.gz"
+    sha256 "c609a64a2a8768462d0c99811ddb8bd2583c33fd33cf7f21af1c142e824ffb57"
+  end
+
+  resource "pytest-httpserver" do
+    url "https://files.pythonhosted.org/packages/f1/d8/def15ba33bd696dd72dd4562a5287c0cba4d18a591eeb82e0b08ab385afc/pytest_httpserver-1.1.3.tar.gz"
+    sha256 "af819d6b533f84b4680b9416a5b3f67f1df3701f1da54924afd4d6e4ba5917ec"
+  end
+
+  resource "pytest-retry" do
+    url "https://files.pythonhosted.org/packages/c5/5b/607b017994cca28de3a1ad22a3eee8418e5d428dcd8ec25b26b18e995a73/pytest_retry-1.7.0.tar.gz"
+    sha256 "f8d52339f01e949df47c11ba9ee8d5b362f5824dff580d3870ec9ae0057df80f"
+  end
+
+  resource "python-dateutil" do
+    url "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz"
+    sha256 "37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"
   end
 
   resource "pytz" do
@@ -254,8 +294,8 @@ class Archgw < Formula
   end
 
   resource "regex" do
-    url "https://files.pythonhosted.org/packages/49/d3/eaa0d28aba6ad1827ad1e716d9a93e1ba963ada61887498297d3da715133/regex-2025.9.18.tar.gz"
-    sha256 "c5ba23274c61c6fef447ba6a39333297d0c247f53059dba0bca415cac511edc4"
+    url "https://files.pythonhosted.org/packages/f8/c8/1d2160d36b11fbe0a61acb7c3c81ab032d9ec8ad888ac9e0a61b85ab99dd/regex-2025.10.23.tar.gz"
+    sha256 "8cbaf8ceb88f96ae2356d01b9adf5e6306fa42fa6f7eab6b97794e37c959ac26"
   end
 
   resource "requests" do
@@ -264,13 +304,18 @@ class Archgw < Formula
   end
 
   resource "rpds-py" do
-    url "https://files.pythonhosted.org/packages/e9/dd/2c0cbe774744272b0ae725f44032c77bdcab6e8bcf544bffa3b6e70c8dba/rpds_py-0.27.1.tar.gz"
-    sha256 "26a1c73171d10b7acccbded82bf6a586ab8203601e565badc74bbbf8bc5a10f8"
+    url "https://files.pythonhosted.org/packages/48/dc/95f074d43452b3ef5d06276696ece4b3b5d696e7c9ad7173c54b1390cd70/rpds_py-0.28.0.tar.gz"
+    sha256 "abd4df20485a0983e2ca334a216249b6186d6e3c1627e106651943dbdb791aea"
   end
 
   resource "safetensors" do
     url "https://files.pythonhosted.org/packages/ac/cc/738f3011628920e027a11754d9cae9abec1aed00f7ae860abbf843755233/safetensors-0.6.2.tar.gz"
     sha256 "43ff2aa0e6fa2dc3ea5524ac7ad93a9839256b8703761e76e2d0b2a3fa4f15d9"
+  end
+
+  resource "six" do
+    url "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz"
+    sha256 "ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"
   end
 
   resource "sniffio" do
@@ -318,6 +363,11 @@ class Archgw < Formula
     sha256 "13bc21373d103859f68fe739608e2eb054a816dea79189bc3ca08ea89a275906"
   end
 
+  resource "werkzeug" do
+    url "https://files.pythonhosted.org/packages/9f/69/83029f1f6300c5fb2471d621ab06f6ec6b3324685a2ce0f9777fd4a8b71e/werkzeug-3.1.3.tar.gz"
+    sha256 "60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746"
+  end
+
   resource "wrapt" do
     url "https://files.pythonhosted.org/packages/95/8f/aeb76c5b46e273670962298c23e7ddde79916cb74db802131d49a85e4b7d/wrapt-1.17.3.tar.gz"
     sha256 "f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0"
@@ -329,7 +379,12 @@ class Archgw < Formula
   end
 
   def install
-    virtualenv_install_with_resources
+    venv = virtualenv_install_with_resources
+
+    # NOTE: This is an exception to our usual policy as building `pytorch` is complicated
+    site_packages = Language::Python.site_packages(venv.root/"bin/python3")
+    pth_contents = "import site; site.addsitedir('#{Formula["pytorch"].opt_libexec/site_packages}')\n"
+    (venv.site_packages/"homebrew-pytorch.pth").write pth_contents
   end
 
   test do

--- a/Formula/a/archgw.rb
+++ b/Formula/a/archgw.rb
@@ -8,12 +8,11 @@ class Archgw < Formula
   license "Apache-2.0"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_tahoe:   "41d988a69edc9fcd2bfb42826c250c63839c056852e7dc0014588bc817b37c9b"
-    sha256 cellar: :any,                 arm64_sequoia: "844d121813ff804d31b9c709ce0536ccda94ed5873ebb7dd8cbf8e1604c66fc9"
-    sha256 cellar: :any,                 arm64_sonoma:  "4e2f4b80e4bbe2b4d1cce5ecee94e7e1b2af9d28b0a9aaf180be0c2b4497421f"
-    sha256 cellar: :any,                 sonoma:        "4f7baf393084d2c19b89ec6cc22b20a27629e44700405829f74ef64649b754fd"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b1b767c73e3e74109c9306b63ada0b9ac4b64507f9b7128fc734fa4a37011bff"
+    sha256 cellar: :any,                 arm64_tahoe:   "268fe6e59d6dcd3141d817f98327cc638745cf6d054feb5ee05927640319dc06"
+    sha256 cellar: :any,                 arm64_sequoia: "58ed34f0fc315c71e0ae110e22e2fc3a759f5c7aa31efedc8f70155a1213e349"
+    sha256 cellar: :any,                 arm64_sonoma:  "833eafb593f7c831e5ff1bdc225c3589fa1a9dc7897e13ab3a05478549ad96d4"
+    sha256 cellar: :any,                 sonoma:        "56cea7a390a5d0fd1344a833fb4626b2ff503ae7011c3f908ae9449461ae305d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "fb58037040a41d683a74838298ee30f39d54e28ac60a88a767a80805a4799862"
   end
 
   depends_on "rust" => :build # for pydantic

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -67,11 +67,7 @@
     "extra_packages": ["gymnasium"]
   },
   "archgw": {
-    "exclude_packages": [
-      "certifi", "numpy", "torch", "pytest", "pytest-asyncio",
-      "pytest-httpserver", "pytest-retry", "python-dateutil"
-    ],
-    "extra_packages": ["filelock"]
+    "exclude_packages": ["certifi", "numpy", "torch"]
   },
   "arjun": {
     "exclude_packages": ["certifi"]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

https://github.com/katanemo/archgw/pull/602 will fix the manually exclude `pytest` deps. Removing since they break our dependency resolution (as we expect excluded deps to be provided by a formula instead). Also fix missing pytorch pth file

```console
$ pip3 --python $(brew --prefix archgw)/libexec check
archgw 0.3.16 requires jinja2, which is not installed.
archgw 0.3.16 requires setuptools, which is not installed.
pydantic 2.12.3 requires typing-extensions, which is not installed.
fastapi 0.115.0 requires typing-extensions, which is not installed.
opentelemetry-sdk 1.28.2 requires typing-extensions, which is not installed.
dateparser 1.2.2 requires python-dateutil, which is not installed.
openai 1.109.1 requires typing-extensions, which is not installed.
accelerate 1.11.0 requires packaging, which is not installed.
accelerate 1.11.0 requires torch, which is not installed.
opentelemetry-instrumentation 0.49b2 requires packaging, which is not installed.
transformers 4.57.1 requires filelock, which is not installed.
transformers 4.57.1 requires packaging, which is not installed.
grpcio 1.76.0 requires typing-extensions, which is not installed.
archgw-modelserver 0.3.16 requires pytest, which is not installed.
archgw-modelserver 0.3.16 requires pytest-asyncio, which is not installed.
archgw-modelserver 0.3.16 requires pytest-httpserver, which is not installed.
archgw-modelserver 0.3.16 requires pytest-retry, which is not installed.
archgw-modelserver 0.3.16 requires setuptools, which is not installed.
archgw-modelserver 0.3.16 requires torch, which is not installed.
pydantic-core 2.41.4 requires typing-extensions, which is not installed.
typing-inspection 0.4.2 requires typing-extensions, which is not installed.
huggingface-hub 0.36.0 requires filelock, which is not installed.
huggingface-hub 0.36.0 requires fsspec, which is not installed.
huggingface-hub 0.36.0 requires packaging, which is not installed.
huggingface-hub 0.36.0 requires typing-extensions, which is not installed.
```