### PR TITLE
pytorch, torchvision, etc: migrate to `python@3.14`

### DIFF
--- a/Formula/a/archgw.rb
+++ b/Formula/a/archgw.rb
@@ -9,13 +9,12 @@ class Archgw < Formula
   revision 1
 
   bottle do
-    rebuild 2
-    sha256 cellar: :any,                 arm64_tahoe:   "e5c84edea9bf01e6b3940eb1dc7e35a023e408f0f97632ba405d415198f0182f"
-    sha256 cellar: :any,                 arm64_sequoia: "bc16076639115dd44dab5600acb31d5c215abe8d1d7a7bc110c8f8029d1b3275"
-    sha256 cellar: :any,                 arm64_sonoma:  "8cb76c7b2b50d8925888cb8ca4474910058609c48ef683cb9cd8b583bde77fd6"
-    sha256 cellar: :any,                 sonoma:        "11a828235b4a0a957d336820aec5964e56ba6d1a8537f4704a02b1eeb5134bb2"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "e2e1739f657f400affcc71695b885b6a282efecf1227cfd96a6fd25cc844072a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b2ebe5a0a8f32d3446f407506fad2b56cb1985b7dd1670992a91e545e76bb06d"
+    sha256 cellar: :any,                 arm64_tahoe:   "7e26f99b1d0af187f843bf7b7ad8a742ccec41bcb3ea4ae199dff773f241eb22"
+    sha256 cellar: :any,                 arm64_sequoia: "ad6cc3ebc095532c7deb0756d063bfba56f76e40bdade5ce2df7310643e35de2"
+    sha256 cellar: :any,                 arm64_sonoma:  "395b43bf0cce0537fb5b836307db5cdcd5f2d777db10ce427e2f0b4a7c90ac67"
+    sha256 cellar: :any,                 sonoma:        "cb0362495fa14147b4cf36561ce3d48c2df5c8a3162a757ecee6567b8b0d34fd"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "6009409acef8156df5ed2a5682ccae1a582e1a02b71c076373964722cfeb0320"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "cdc37119620b24af89df157d9cbd0d273a933cafbb978074932ef208565539b5"
   end
 
   depends_on "rust" => :build # for hf-xet, jitter and safetensors

--- a/Formula/a/archgw.rb
+++ b/Formula/a/archgw.rb
@@ -6,6 +6,7 @@ class Archgw < Formula
   url "https://files.pythonhosted.org/packages/99/97/24c0999cc5aa5e5cd9f1a50d7f7d86ba129a69c3e5258d536f0f5a34453f/archgw-0.3.17.tar.gz"
   sha256 "dee2439288f47981f6411127a2cc4ca0ad17e92d68c41fe95299c5399fa1ecbb"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     rebuild 2
@@ -22,7 +23,7 @@ class Archgw < Formula
   depends_on "libyaml"
   depends_on "numpy"
   depends_on "pydantic-core" => :no_linkage
-  depends_on "python@3.13"
+  depends_on "python@3.14"
   depends_on "pytorch"
   depends_on "rpds-py" => :no_linkage
 

--- a/Formula/b/backgroundremover.rb
+++ b/Formula/b/backgroundremover.rb
@@ -9,13 +9,12 @@ class Backgroundremover < Formula
   revision 2
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_tahoe:   "d2b21276350dba7e2699108574cd3608c25c5e22d72c9434fe352c165d12ad98"
-    sha256 cellar: :any,                 arm64_sequoia: "e083a60c6869c60574e1968a635b7d8f1654cfb0dfae5a0da4a29c58066667ed"
-    sha256 cellar: :any,                 arm64_sonoma:  "a8718a44aa6a253f9b9af1fca66e406eb1cb96bb28f8f1ff4de50579e1173558"
-    sha256 cellar: :any,                 sonoma:        "c2981ba9aa8107bcd22fa3f542b50ef164a0d967c5f2bf723b7d658e4eba2326"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "b0f7510adcb19eff67fef89eda903390de96d266747fc21b8757fa1cef652fd5"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "21cb19aaaf5b99436075ad9d0d9eb7d3aef96eb4357d6b20c25b6ac2c3b04294"
+    sha256 cellar: :any,                 arm64_tahoe:   "47670e19d3401ac962ad008a87e145636fc0700592fbe82e216577aa859de77d"
+    sha256 cellar: :any,                 arm64_sequoia: "48877e3f30160439254633c0333b86890b571fa8cc9d70594f5bcdb5873d0f91"
+    sha256 cellar: :any,                 arm64_sonoma:  "ad99ed4e1052a9967395eac4bcc83b98a05c2222d8a2148f8bd33f150c696e60"
+    sha256 cellar: :any,                 sonoma:        "5257f4d79d258ec2474e6f40f3e576450adb2a4b37144b8a9479c7c5063d07ef"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "93db10c23a7ce007d554c0b8e2ee57246f53e9cb8fc76fde6ed2ff5e5a08d8f0"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "bdf05188369165206939c0b9b271b36b0afd1a05e91ef64ad7fa437d9e12b660"
   end
 
   depends_on "cmake" => :build

--- a/Formula/b/backgroundremover.rb
+++ b/Formula/b/backgroundremover.rb
@@ -6,7 +6,7 @@ class Backgroundremover < Formula
   url "https://files.pythonhosted.org/packages/81/c9/5c7d668bea7bb5ae6e069afe33c19e55ae95975a87a7e3a5bbd3d6199f74/backgroundremover-0.3.4.tar.gz"
   sha256 "c4ce35da0194138c115017dba9f5dae38b7e2bfcf15a413ef04d8ce01e66e214"
   license "MIT"
-  revision 1
+  revision 2
 
   bottle do
     rebuild 1
@@ -24,7 +24,7 @@ class Backgroundremover < Formula
   depends_on "llvm@20"
   depends_on "numpy"
   depends_on "pillow"
-  depends_on "python@3.13"
+  depends_on "python@3.14"
   depends_on "scikit-image"
   depends_on "scipy"
   depends_on "torchvision"
@@ -37,8 +37,8 @@ class Backgroundremover < Formula
                 extra_packages:   "imageio"
 
   resource "charset-normalizer" do
-    url "https://files.pythonhosted.org/packages/83/2d/5fd176ceb9b2fc619e63405525573493ca23441330fcdaee6bef9460e924/charset_normalizer-3.4.3.tar.gz"
-    sha256 "6fce4b8500244f6fcb71465d4a4930d132ba9ab8e71a7859e6a5d59851068d14"
+    url "https://files.pythonhosted.org/packages/13/69/33ddede1939fdd074bce5434295f38fae7136463422fe4fd3e0e89b98062/charset_normalizer-3.4.4.tar.gz"
+    sha256 "94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a"
   end
 
   resource "commandlines" do
@@ -72,8 +72,8 @@ class Backgroundremover < Formula
   end
 
   resource "idna" do
-    url "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz"
-    sha256 "12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"
+    url "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz"
+    sha256 "795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902"
   end
 
   resource "imageio-ffmpeg" do
@@ -82,8 +82,8 @@ class Backgroundremover < Formula
   end
 
   resource "llvmlite" do
-    url "https://files.pythonhosted.org/packages/9d/73/4b29b502618766276816f2f2a7cf9017bd3889bc38a49319bee9ad492b75/llvmlite-0.45.0.tar.gz"
-    sha256 "ceb0bcd20da949178bd7ab78af8de73e9f3c483ac46b5bef39f06a4862aa8336"
+    url "https://files.pythonhosted.org/packages/c1/39/be3a8255c8c40fcab6d54d147ae5bda00104e861b108c541f2b2ecb30c44/llvmlite-0.46.0b1.tar.gz"
+    sha256 "ea7208f342cc157e600093862ff87ab5d296680d7dfff0a01dc13668ecbc60d0"
   end
 
   resource "more-itertools" do
@@ -97,8 +97,8 @@ class Backgroundremover < Formula
   end
 
   resource "numba" do
-    url "https://files.pythonhosted.org/packages/e5/96/66dae7911cb331e99bf9afe35703317d8da0fad81ff49fed77f4855e4b60/numba-0.62.0.tar.gz"
-    sha256 "2afcc7899dc93fefecbb274a19c592170bc2dbfae02b00f83e305332a9857a5a"
+    url "https://files.pythonhosted.org/packages/8b/ce/efb2667849b0abac22d1499bc855f67b97c3d23bb4f43c1d854ec2a0c716/numba-0.63.0b1.tar.gz"
+    sha256 "66b7a0052e2cfe8befa273e5af3eae75e102ac9c3da7d2ca361b7b72cf5051c8"
   end
 
   resource "proglog" do
@@ -117,8 +117,8 @@ class Backgroundremover < Formula
   end
 
   resource "python-dotenv" do
-    url "https://files.pythonhosted.org/packages/f6/b0/4bc07ccd3572a2f9df7e6782f52b0c6c90dcbb803ac4a167702d7d0dfe1e/python_dotenv-1.1.1.tar.gz"
-    sha256 "a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab"
+    url "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz"
+    sha256 "42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6"
   end
 
   resource "requests" do

--- a/Formula/o/openai-whisper.rb
+++ b/Formula/o/openai-whisper.rb
@@ -6,6 +6,7 @@ class OpenaiWhisper < Formula
   url "https://files.pythonhosted.org/packages/35/8e/d36f8880bcf18ec026a55807d02fe4c7357da9f25aebd92f85178000c0dc/openai_whisper-20250625.tar.gz"
   sha256 "37a91a3921809d9f44748ffc73c0a55c9f366c85a3ef5c2ae0cc09540432eb96"
   license "MIT"
+  revision 1
   head "https://github.com/openai/whisper.git", branch: "main"
 
   no_autobump! because: "`update-python-resources` cannot update resource blocks"
@@ -27,24 +28,24 @@ class OpenaiWhisper < Formula
   depends_on "ffmpeg"
   depends_on "llvm@20"
   depends_on "numpy"
-  depends_on "python@3.13"
+  depends_on "python@3.14"
   depends_on "pytorch"
 
   pypi_packages exclude_packages: %w[certifi numpy torch]
 
   resource "charset-normalizer" do
-    url "https://files.pythonhosted.org/packages/83/2d/5fd176ceb9b2fc619e63405525573493ca23441330fcdaee6bef9460e924/charset_normalizer-3.4.3.tar.gz"
-    sha256 "6fce4b8500244f6fcb71465d4a4930d132ba9ab8e71a7859e6a5d59851068d14"
+    url "https://files.pythonhosted.org/packages/13/69/33ddede1939fdd074bce5434295f38fae7136463422fe4fd3e0e89b98062/charset_normalizer-3.4.4.tar.gz"
+    sha256 "94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a"
   end
 
   resource "idna" do
-    url "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz"
-    sha256 "12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"
+    url "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz"
+    sha256 "795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902"
   end
 
   resource "llvmlite" do
-    url "https://files.pythonhosted.org/packages/9d/73/4b29b502618766276816f2f2a7cf9017bd3889bc38a49319bee9ad492b75/llvmlite-0.45.0.tar.gz"
-    sha256 "ceb0bcd20da949178bd7ab78af8de73e9f3c483ac46b5bef39f06a4862aa8336"
+    url "https://files.pythonhosted.org/packages/c1/39/be3a8255c8c40fcab6d54d147ae5bda00104e861b108c541f2b2ecb30c44/llvmlite-0.46.0b1.tar.gz"
+    sha256 "ea7208f342cc157e600093862ff87ab5d296680d7dfff0a01dc13668ecbc60d0"
   end
 
   resource "more-itertools" do
@@ -53,13 +54,13 @@ class OpenaiWhisper < Formula
   end
 
   resource "numba" do
-    url "https://files.pythonhosted.org/packages/e5/96/66dae7911cb331e99bf9afe35703317d8da0fad81ff49fed77f4855e4b60/numba-0.62.0.tar.gz"
-    sha256 "2afcc7899dc93fefecbb274a19c592170bc2dbfae02b00f83e305332a9857a5a"
+    url "https://files.pythonhosted.org/packages/8b/ce/efb2667849b0abac22d1499bc855f67b97c3d23bb4f43c1d854ec2a0c716/numba-0.63.0b1.tar.gz"
+    sha256 "66b7a0052e2cfe8befa273e5af3eae75e102ac9c3da7d2ca361b7b72cf5051c8"
   end
 
   resource "regex" do
-    url "https://files.pythonhosted.org/packages/b2/5a/4c63457fbcaf19d138d72b2e9b39405954f98c0349b31c601bfcb151582c/regex-2025.9.1.tar.gz"
-    sha256 "88ac07b38d20b54d79e704e38aa3bd2c0f8027432164226bdee201a1c0c9c9ff"
+    url "https://files.pythonhosted.org/packages/f8/c8/1d2160d36b11fbe0a61acb7c3c81ab032d9ec8ad888ac9e0a61b85ab99dd/regex-2025.10.23.tar.gz"
+    sha256 "8cbaf8ceb88f96ae2356d01b9adf5e6306fa42fa6f7eab6b97794e37c959ac26"
   end
 
   resource "requests" do
@@ -68,8 +69,8 @@ class OpenaiWhisper < Formula
   end
 
   resource "tiktoken" do
-    url "https://files.pythonhosted.org/packages/a7/86/ad0155a37c4f310935d5ac0b1ccf9bdb635dcb906e0a9a26b616dd55825a/tiktoken-0.11.0.tar.gz"
-    sha256 "3c518641aee1c52247c2b97e74d8d07d780092af79d5911a6ab5e79359d9b06a"
+    url "https://files.pythonhosted.org/packages/7d/ab/4d017d0f76ec3171d469d80fc03dfbb4e48a4bcaddaa831b31d526f05edc/tiktoken-0.12.0.tar.gz"
+    sha256 "b18ba7ee2b093863978fcb14f74b3707cdc8d4d4d3836853ce7ec60772139931"
   end
 
   resource "tqdm" do

--- a/Formula/o/openai-whisper.rb
+++ b/Formula/o/openai-whisper.rb
@@ -12,13 +12,12 @@ class OpenaiWhisper < Formula
   no_autobump! because: "`update-python-resources` cannot update resource blocks"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_tahoe:   "1cd169f2942f8942a368479d83f5ae0fd8a68104de51a0ffb40b205d1eecfc36"
-    sha256 cellar: :any,                 arm64_sequoia: "cb61f56b09b4b160a563824e41d1d2443954f9d9da1b374056570cb93822c5a4"
-    sha256 cellar: :any,                 arm64_sonoma:  "eb058d8c012fdaa90ceb76c1912e86c1e6a8eddfce9068d21d27e8f23ce59f13"
-    sha256 cellar: :any,                 sonoma:        "1e391ad933a20ce38fadcd5168e35041c127754838479fdade17e616c901d82f"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "3050f76ba7941f34b96e87013818d8a22c6348ce42edc40a862f4c9e708147cb"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4cec7e344024f3e6f68098b51679ae034f81eaa596920d37acbb48a5f4703251"
+    sha256 cellar: :any,                 arm64_tahoe:   "7f2aca24bef213888b85b6a6836ccd0741b654f02a1033f724bcdca45b93ffc2"
+    sha256 cellar: :any,                 arm64_sequoia: "65535d05c8598cbd0ee9781228d27abac5f412b41eb47740303dda0cc23406b6"
+    sha256 cellar: :any,                 arm64_sonoma:  "9eefa0114835eb0beb294045f72a9dcde73589bc9f232a26d79f15cacb2ed009"
+    sha256 cellar: :any,                 sonoma:        "a022fc299bf43a63cd011699f68fb6739904f7c3f43e3ef05802a394669f85d9"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "ce2a701ecdbbd852ae2537ad1a72ebd74789e2b08436eb389b963f0b8d3000d9"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2c7784c62adef0cd329ae435f3d5ad7d680b3d652037fcd3e376b3dd9f6fc579"
   end
 
   depends_on "cmake" => :build

--- a/Formula/p/pytorch.rb
+++ b/Formula/p/pytorch.rb
@@ -16,12 +16,12 @@ class Pytorch < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any, arm64_tahoe:   "7e058e9afa62a272e04e7fd848dd76579d677aa49d41a9b8117fa2610d8b37db"
-    sha256 cellar: :any, arm64_sequoia: "9f54190831f06186cce645472349edd64379c390ed603c5adb186be3d8a43322"
-    sha256 cellar: :any, arm64_sonoma:  "5d015c3abd6e77293ca963793b72feaabacc3f1762ccf97be8a9d33c4e7fdd01"
-    sha256 cellar: :any, sonoma:        "3b61917a41a63bc9fc66fe75938e88ba43b9dbfd89782d8657118ca330c12959"
-    sha256               arm64_linux:   "adb009a7d3de3fb96a0518bf0ca77483e0c4a9f521669e35e825ed520e47828e"
-    sha256               x86_64_linux:  "3c4581e40297185c27467e538e07c26c25bf9ef06d8151028367967c54a94f01"
+    sha256 cellar: :any, arm64_tahoe:   "580a5a2b22ed3dbf1ca9486ac54d1e43ac628543226008dc426168d61fff19a7"
+    sha256 cellar: :any, arm64_sequoia: "8bdc7bed1b02b6e5d60858753f457a17a1ccab17aa80d0013071ae138168af69"
+    sha256 cellar: :any, arm64_sonoma:  "0f37e0a2aabe74bb50775785054749a8f4b7beec4e66f2b905721df194881e34"
+    sha256 cellar: :any, sonoma:        "f40de3d44de7b223dc446f8872557f1ffd08e9884ea48dd04b6575e29ca77c52"
+    sha256               arm64_linux:   "4a3d153f17734a30a3527a374095895bfd5ea05d20e16ffe7434ec49c68a63ed"
+    sha256               x86_64_linux:  "d2fdb7433b5238280ce2003ef71c2148a172921dbd0509c5b324e4033a23cf62"
   end
 
   depends_on "cmake" => :build

--- a/Formula/p/pytorch.rb
+++ b/Formula/p/pytorch.rb
@@ -6,6 +6,7 @@ class Pytorch < Formula
   url "https://github.com/pytorch/pytorch/releases/download/v2.9.0/pytorch-v2.9.0.tar.gz"
   sha256 "c6980af3c0ea311f49f90987982be715e4d702539fea41e52f55ad7f0b105dc3"
   license "BSD-3-Clause"
+  revision 1
 
   livecheck do
     url :stable
@@ -25,7 +26,7 @@ class Pytorch < Formula
 
   depends_on "cmake" => :build
   depends_on "ninja" => :build
-  depends_on "python@3.13" => [:build, :test]
+  depends_on "python@3.14" => [:build, :test]
   depends_on xcode: :build
   depends_on "abseil"
   depends_on "eigen"
@@ -102,7 +103,7 @@ class Pytorch < Formula
   end
 
   def install
-    python3 = "python3.13"
+    python3 = "python3.14"
 
     # Avoid building AVX512 code
     inreplace "cmake/Modules/FindAVX.cmake", /^CHECK_SSE\(CXX "AVX512"/, "#\\0"

--- a/Formula/s/scikit-image.rb
+++ b/Formula/s/scikit-image.rb
@@ -6,6 +6,7 @@ class ScikitImage < Formula
   url "https://files.pythonhosted.org/packages/c7/a8/3c0f256012b93dd2cb6fda9245e9f4bff7dc0486880b248005f15ea2255e/scikit_image-0.25.2.tar.gz"
   sha256 "e5a37e6cd4d0c018a7a55b9d601357e3382826d3888c10d0213fc63bff977dde"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/scikit-image/scikit-image.git", branch: "main"
 
   bottle do
@@ -24,7 +25,7 @@ class ScikitImage < Formula
   depends_on "pkgconf" => :build
   depends_on "numpy"
   depends_on "pillow"
-  depends_on "python@3.13"
+  depends_on "python@3.14"
   depends_on "scipy"
 
   on_linux do
@@ -44,18 +45,18 @@ class ScikitImage < Formula
   end
 
   resource "networkx" do
-    url "https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz"
-    sha256 "307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1"
+    url "https://files.pythonhosted.org/packages/6c/4f/ccdb8ad3a38e583f214547fd2f7ff1fc160c43a75af88e6aec213404b96a/networkx-3.5.tar.gz"
+    sha256 "d4c6f9cf81f52d69230866796b82afbccdec3db7ae4fbd1b65ea750feed50037"
   end
 
   resource "packaging" do
-    url "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz"
-    sha256 "c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"
+    url "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz"
+    sha256 "d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"
   end
 
   resource "tifffile" do
-    url "https://files.pythonhosted.org/packages/d5/fc/697d8dac6936a81eda88e7d4653d567fcb0d504efad3fd28f5272f96fcf9/tifffile-2025.1.10.tar.gz"
-    sha256 "baaf0a3b87bf7ec375fa1537503353f70497eabe1bdde590f2e41cc0346e612f"
+    url "https://files.pythonhosted.org/packages/2d/b5/0d8f3d395f07d25ec4cafcdfc8cab234b2cc6bf2465e9d7660633983fe8f/tifffile-2025.10.16.tar.gz"
+    sha256 "425179ec7837ac0e07bc95d2ea5bea9b179ce854967c12ba07fc3f093e58efc1"
   end
 
   def install

--- a/Formula/s/scikit-image.rb
+++ b/Formula/s/scikit-image.rb
@@ -10,14 +10,12 @@ class ScikitImage < Formula
   head "https://github.com/scikit-image/scikit-image.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "a8cac211787f4ee9e93494a7a4dc40ab36f57744988df294b62372a1bdcb629a"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "7f92c634789c248e5faa16af8c885c76a797561f9caa90ad3ba6771ee8adc65a"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "dfcc775c8fdda7398e80b2684303c3c68310221e1fb0e83bcd69df31f4d25971"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "5aabdc0e3471dda66884980b61a1c2f6f762a26016e724bcbde3f7659c2d1412"
-    sha256 cellar: :any_skip_relocation, sonoma:        "dad009c5f2e033d67da433674f7e4900f84a47ae676050d58adf14808fc2c565"
-    sha256 cellar: :any_skip_relocation, ventura:       "06de5f36d41949dd79b01e05bd6e10f27f8a1d808b7cb096b607484eb6af6632"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "f3e3dc643fb1f17f0632ee7db9208753ced229c1fb14bf1412508f06813fde4f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0426a7009a7096077fc58841681b3606ce906feb7abb54d15dcea8fa6cdaeb1c"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "f27da6cc33d77c6a785a9c8ea4df0d2f7edfa03dc24085a1608edcef43b13044"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "ddce8132980d3b4e3f94babf269f076f136b309401de1877c3b3689a1b016557"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "f357f344cc9bcf5d1a75190aca51d004e003a2a70f320cdb4d7f1147db7201f6"
+    sha256 cellar: :any_skip_relocation, sonoma:        "654d5b525c02f6b0f6bcfa442b3f58125e2cac12875a9335aee531b6e108a710"
+    sha256                               arm64_linux:   "0b04fcd70cba257b24cbf944e8e95013c5744e4367547e8eac93e040b18484ae"
+    sha256                               x86_64_linux:  "24372313c3590ffa120fa37bbc6b8f9da8cec269511c25f57fdf99635988f2b4"
   end
 
   depends_on "meson" => :build

--- a/Formula/t/torchvision.rb
+++ b/Formula/t/torchvision.rb
@@ -16,12 +16,12 @@ class Torchvision < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "e4b6d2af2da3ce2dfd09941abb65598f174cacafdbadc230bcbff275f31ea49c"
-    sha256 cellar: :any,                 arm64_sequoia: "60e4d085fcabb9a91ac23e8d5a1a9c42ad8802e4e766cb19fcd0800fe12247e7"
-    sha256 cellar: :any,                 arm64_sonoma:  "fcfa90f312c4aa99846af5e5f8dff42607ce9fc5fcd4dc6b6d8c4e74aff015c1"
-    sha256 cellar: :any,                 sonoma:        "89a099bb4303411baa2ecd592dc04d51ba2cacee8d1df4b9353a69a4632a4c5c"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "68d1d99e4f42b119ca5bd4c568a9208d0d9868255445b442c17e4ce59d639369"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "359a8bcf0b1ce4cef8c291af048f4506a9e0f703ea1207f2ea36dc738e22a81a"
+    sha256 cellar: :any,                 arm64_tahoe:   "900f3b8a00d3dc5544803d42890d1744f47a621c2fbee0f55b67b3a0af848fee"
+    sha256 cellar: :any,                 arm64_sequoia: "6da1e31b6e478bba712f3e93f19ca15bb4e27ce16d674219c80d2dd06e6faa73"
+    sha256 cellar: :any,                 arm64_sonoma:  "82cf2692496050e4cb06fe77a0f9003238cbbfe07d8351f158e07490fec11415"
+    sha256 cellar: :any,                 sonoma:        "051d2fd6ab5276fbe72f26fff49d598b2b7b10eab4cedb6369856bc299f20df0"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "28f574c23e35e7a347ae81dfffaaabaecdbe16be30fc7b8c5e48620152b675da"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "37b65a878423eb3d380e60ae22ac96598af0fb79757d2401bf868d99104639db"
   end
 
   depends_on "cmake" => :build

--- a/Formula/t/torchvision.rb
+++ b/Formula/t/torchvision.rb
@@ -6,6 +6,7 @@ class Torchvision < Formula
   url "https://github.com/pytorch/vision/archive/refs/tags/v0.24.0.tar.gz"
   sha256 "f799cdd1d67a3edbcdc6af8fb416fe1b019b512fb426c0314302cd81518a0095"
   license "BSD-3-Clause"
+  revision 1
 
   livecheck do
     url :stable
@@ -25,7 +26,7 @@ class Torchvision < Formula
 
   depends_on "cmake" => :build
   depends_on "ninja" => :build
-  depends_on "python@3.13" => [:build, :test]
+  depends_on "python@3.14" => [:build, :test]
   depends_on "jpeg-turbo"
   depends_on "libpng"
   depends_on "numpy"
@@ -48,14 +49,14 @@ class Torchvision < Formula
       'jpeg_found, jpeg_include_dir, jpeg_library_dir = find_library(header="jpeglib.h")',
       "jpeg_found, jpeg_include_dir, jpeg_library_dir = True, '#{jpeg.include}', '#{jpeg.lib}'"
 
-    python3 = "python3.13"
+    python3 = "python3.14"
     venv = virtualenv_create(libexec, python3)
     venv.pip_install resources
 
     # We depend on pytorch, but that's a separate formula, so install a `.pth` file to link them.
     # This needs to happen _before_ we try to install torchvision.
     # NOTE: This is an exception to our usual policy as building `pytorch` is complicated
-    site_packages = Language::Python.site_packages(python3)
+    site_packages = Language::Python.site_packages(venv.root/"bin/python3")
     pth_contents = "import site; site.addsitedir('#{Formula["pytorch"].opt_libexec/site_packages}')\n"
     (venv.site_packages/"homebrew-pytorch.pth").write pth_contents
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Latest pytorch release has 3.14 wheels, so let's try this out

```console
$ curl -s https://pypi.org/pypi/torch/json | jq '.releases."2.9.0"' | grep cp314-macos
    "filename": "torch-2.9.0-cp314-cp314-macosx_11_0_arm64.whl",
    "url": "https://files.pythonhosted.org/packages/5c/73/9f70af34b334a7e0ef496ceec96b7ec767bd778ea35385ce6f77557534d1/torch-2.9.0-cp314-cp314-macosx_11_0_arm64.whl",
```
