### PR TITLE
workflows/triage: add `keep_if_no_match` for `CI-no-bottles`

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -436,6 +436,7 @@ jobs:
               path: Formula/p/portable-.+
               except:
                 - Formula/p/portable-ruby.rb
+              keep_if_no_match: true
 
             - label: bump-formula-pr
               pr_body_content: Created with `brew bump-formula-pr`


### PR DESCRIPTION
Omitting this will make the triage workflow remove the https://github.com/Homebrew/homebrew-core/labels/CI-no-bottles
label for PRs that do not touch the `portable-*` formulae. I don't think
we want that.
