### PR TITLE
ghidra: Update test to use non-deprecated binary

### DIFF
--- a/Formula/g/ghidra.rb
+++ b/Formula/g/ghidra.rb
@@ -41,8 +41,8 @@ class Ghidra < Formula
     (testpath/"analyzeHeadless").write_env_script libexec/"support/analyzeHeadless",
                                                   Language::Java.overridable_java_home_env("21")
     (testpath/"project").mkpath
-    system shellpath.to_s, testpath/"analyzeHeadless", testpath/"project",
-                           "HomebrewTest", "-import", shellpath.to_s, "-noanalysis"
+    system shellpath, testpath/"analyzeHeadless", testpath/"project",
+                           "HomebrewTest", "-import", shellpath, "-noanalysis"
     assert_path_exists testpath/"project/HomebrewTest.rep"
   end
 end

--- a/Formula/g/ghidra.rb
+++ b/Formula/g/ghidra.rb
@@ -37,11 +37,12 @@ class Ghidra < Formula
   end
 
   test do
+    shellpath = OS.mac? ? "/bin/zsh" : "/bin/bash"
     (testpath/"analyzeHeadless").write_env_script libexec/"support/analyzeHeadless",
                                                   Language::Java.overridable_java_home_env("21")
     (testpath/"project").mkpath
-    system "/bin/bash", testpath/"analyzeHeadless", testpath/"project",
-                        "HomebrewTest", "-import", "/bin/bash", "-noanalysis"
+    system shellpath.to_s, testpath/"analyzeHeadless", testpath/"project",
+                           "HomebrewTest", "-import", shellpath.to_s, "-noanalysis"
     assert_path_exists testpath/"project/HomebrewTest.rep"
   end
 end

--- a/Formula/g/ghidra.rb
+++ b/Formula/g/ghidra.rb
@@ -42,7 +42,7 @@ class Ghidra < Formula
                                                   Language::Java.overridable_java_home_env("21")
     (testpath/"project").mkpath
     system shellpath, testpath/"analyzeHeadless", testpath/"project",
-                           "HomebrewTest", "-import", shellpath, "-noanalysis"
+                      "HomebrewTest", "-import", shellpath, "-noanalysis"
     assert_path_exists testpath/"project/HomebrewTest.rep"
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`/bin/bash` is deprecated on macOS and could end up being removed at some point.  This switches to `/bin/zsh` on macOS for the test, while leaving it as `/bin/bash` on other OSes (Linux), which tend to use that as the default shell.