### PR TITLE
misc: add issue link for hatch workaround

### DIFF
--- a/Formula/b/bbot.rb
+++ b/Formula/b/bbot.rb
@@ -324,7 +324,8 @@ class Bbot < Formula
   end
 
   def install
-    # The source doesn't have a valid SOURCE_DATE_EPOCH, so here we set default.
+    # hatch does not support a SOURCE_DATE_EPOCH before 1980.
+    # Remove after https://github.com/pypa/hatch/pull/1999 is released.
     ENV["SOURCE_DATE_EPOCH"] = "1451574000"
 
     virtualenv_install_with_resources

--- a/Formula/c/codelimit.rb
+++ b/Formula/c/codelimit.rb
@@ -141,7 +141,8 @@ class Codelimit < Formula
   end
 
   def install
-    # The source doesn't have a valid SOURCE_DATE_EPOCH, so here we set default.
+    # hatch does not support a SOURCE_DATE_EPOCH before 1980.
+    # Remove after https://github.com/pypa/hatch/pull/1999 is released.
     ENV["SOURCE_DATE_EPOCH"] = "1451574000"
 
     virtualenv_install_with_resources

--- a/Formula/c/commitizen.rb
+++ b/Formula/c/commitizen.rb
@@ -97,7 +97,8 @@ class Commitizen < Formula
   end
 
   def install
-    # The source doesn't have a valid SOURCE_DATE_EPOCH, so here we set default.
+    # hatch does not support a SOURCE_DATE_EPOCH before 1980.
+    # Remove after https://github.com/pypa/hatch/pull/1999 is released.
     ENV["SOURCE_DATE_EPOCH"] = "1451574000"
 
     virtualenv_install_with_resources

--- a/Formula/c/copier.rb
+++ b/Formula/c/copier.rb
@@ -121,7 +121,8 @@ class Copier < Formula
   end
 
   def install
-    # The source doesn't have a valid SOURCE_DATE_EPOCH, so here we set default.
+    # hatch does not support a SOURCE_DATE_EPOCH before 1980.
+    # Remove after https://github.com/pypa/hatch/pull/1999 is released.
     ENV["SOURCE_DATE_EPOCH"] = "1451574000"
 
     virtualenv_install_with_resources

--- a/Formula/c/cyclonedx-python.rb
+++ b/Formula/c/cyclonedx-python.rb
@@ -174,7 +174,8 @@ class CyclonedxPython < Formula
   end
 
   def install
-    # The source doesn't have a valid SOURCE_DATE_EPOCH, so here we set default.
+    # hatch does not support a SOURCE_DATE_EPOCH before 1980.
+    # Remove after https://github.com/pypa/hatch/pull/1999 is released.
     ENV["SOURCE_DATE_EPOCH"] = "1451574000"
 
     virtualenv_install_with_resources

--- a/Formula/d/dolphie.rb
+++ b/Formula/d/dolphie.rb
@@ -226,7 +226,8 @@ class Dolphie < Formula
   end
 
   def install
-    # The source doesn't have a valid SOURCE_DATE_EPOCH, so here we set default.
+    # hatch does not support a SOURCE_DATE_EPOCH before 1980.
+    # Remove after https://github.com/pypa/hatch/pull/1999 is released.
     ENV["SOURCE_DATE_EPOCH"] = "1451574000"
 
     virtualenv_install_with_resources

--- a/Formula/d/dooit.rb
+++ b/Formula/d/dooit.rb
@@ -108,7 +108,8 @@ class Dooit < Formula
   end
 
   def install
-    # The source doesn't have a valid SOURCE_DATE_EPOCH, so here we set default.
+    # hatch does not support a SOURCE_DATE_EPOCH before 1980.
+    # Remove after https://github.com/pypa/hatch/pull/1999 is released.
     ENV["SOURCE_DATE_EPOCH"] = "1451574000"
 
     virtualenv_install_with_resources

--- a/Formula/g/gptme.rb
+++ b/Formula/g/gptme.rb
@@ -355,7 +355,8 @@ class Gptme < Formula
   end
 
   def install
-    # The source doesn't have a valid SOURCE_DATE_EPOCH, so here we set default.
+    # hatch does not support a SOURCE_DATE_EPOCH before 1980.
+    # Remove after https://github.com/pypa/hatch/pull/1999 is released.
     ENV["SOURCE_DATE_EPOCH"] = "1451574000"
 
     virtualenv_install_with_resources

--- a/Formula/j/jiratui.rb
+++ b/Formula/j/jiratui.rb
@@ -287,7 +287,8 @@ class Jiratui < Formula
     # Issue ref: https://github.com/whyisdifficult/jiratui/issues/110
     inreplace "pyproject.toml", 'requires-python = ">=3.10,<3.14"', 'requires-python = ">=3.10"'
 
-    # The source doesn't have a valid SOURCE_DATE_EPOCH, so here we set default.
+    # hatch does not support a SOURCE_DATE_EPOCH before 1980.
+    # Remove after https://github.com/pypa/hatch/pull/1999 is released.
     ENV["SOURCE_DATE_EPOCH"] = "1451574000"
 
     virtualenv_install_with_resources

--- a/Formula/j/jrnl.rb
+++ b/Formula/j/jrnl.rb
@@ -112,7 +112,8 @@ class Jrnl < Formula
     # PR ref: https://github.com/jrnl-org/jrnl/pull/2015
     inreplace "pyproject.toml", 'python = ">=3.10.0, <3.14"', 'python = ">=3.10.0"'
 
-    # The source doesn't have a valid SOURCE_DATE_EPOCH, so here we set default.
+    # hatch does not support a SOURCE_DATE_EPOCH before 1980.
+    # Remove after https://github.com/pypa/hatch/pull/1999 is released.
     ENV["SOURCE_DATE_EPOCH"] = "1451574000"
 
     virtualenv_install_with_resources

--- a/Formula/k/kaskade.rb
+++ b/Formula/k/kaskade.rb
@@ -201,7 +201,8 @@ class Kaskade < Formula
     # Issue ref: https://github.com/sauljabin/kaskade/issues/65
     inreplace "pyproject.toml", 'requires-python = ">=3.10,<3.14"', 'requires-python = ">=3.10"'
 
-    # The source doesn't have a valid SOURCE_DATE_EPOCH, so here we set default.
+    # hatch does not support a SOURCE_DATE_EPOCH before 1980.
+    # Remove after https://github.com/pypa/hatch/pull/1999 is released.
     ENV["SOURCE_DATE_EPOCH"] = "1451574000"
     virtualenv_install_with_resources
   end

--- a/Formula/l/literate-git.rb
+++ b/Formula/l/literate-git.rb
@@ -50,7 +50,8 @@ class LiterateGit < Formula
   end
 
   def install
-    # The source doesn't have a valid SOURCE_DATE_EPOCH, so here we set default.
+    # hatch does not support a SOURCE_DATE_EPOCH before 1980.
+    # Remove after https://github.com/pypa/hatch/pull/1999 is released.
     ENV["SOURCE_DATE_EPOCH"] = "1451574000"
 
     virtualenv_install_with_resources

--- a/Formula/m/mac-cleanup-py.rb
+++ b/Formula/m/mac-cleanup-py.rb
@@ -97,7 +97,8 @@ class MacCleanupPy < Formula
   end
 
   def install
-    # The source doesn't have a valid SOURCE_DATE_EPOCH, so here we set default.
+    # hatch does not support a SOURCE_DATE_EPOCH before 1980.
+    # Remove after https://github.com/pypa/hatch/pull/1999 is released.
     ENV["SOURCE_DATE_EPOCH"] = "1451574000"
 
     # Allow 3.14: https://github.com/mac-cleanup/mac-cleanup-py/pull/277

--- a/Formula/m/manim.rb
+++ b/Formula/m/manim.rb
@@ -206,7 +206,8 @@ class Manim < Formula
   end
 
   def install
-    # The source doesn't have a valid SOURCE_DATE_EPOCH, so here we set default.
+    # hatch does not support a SOURCE_DATE_EPOCH before 1980.
+    # Remove after https://github.com/pypa/hatch/pull/1999 is released.
     ENV["SOURCE_DATE_EPOCH"] = "1451574000"
 
     if OS.mac?

--- a/Formula/o/otterdog.rb
+++ b/Formula/o/otterdog.rb
@@ -251,7 +251,8 @@ class Otterdog < Formula
   end
 
   def install
-    # The source doesn't have a valid SOURCE_DATE_EPOCH, so here we set default.
+    # hatch does not support a SOURCE_DATE_EPOCH before 1980.
+    # Remove after https://github.com/pypa/hatch/pull/1999 is released.
     ENV["SOURCE_DATE_EPOCH"] = "1451574000"
     ENV["SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PLAYWRIGHT"] = resource("playwright").version
     virtualenv_install_with_resources

--- a/Formula/p/podcast-archiver.rb
+++ b/Formula/p/podcast-archiver.rb
@@ -137,7 +137,8 @@ class PodcastArchiver < Formula
   end
 
   def install
-    # The source doesn't have a valid SOURCE_DATE_EPOCH, so here we set default.
+    # hatch does not support a SOURCE_DATE_EPOCH before 1980.
+    # Remove after https://github.com/pypa/hatch/pull/1999 is released.
     ENV["SOURCE_DATE_EPOCH"] = "1451574000"
 
     virtualenv_install_with_resources

--- a/Formula/p/poetry.rb
+++ b/Formula/p/poetry.rb
@@ -238,7 +238,8 @@ class Poetry < Formula
   end
 
   def install
-    # The source doesn't have a valid SOURCE_DATE_EPOCH, so here we set default.
+    # hatch does not support a SOURCE_DATE_EPOCH before 1980.
+    # Remove after https://github.com/pypa/hatch/pull/1999 is released.
     ENV["SOURCE_DATE_EPOCH"] = "1451574000"
 
     venv = virtualenv_install_with_resources without: "zstandard"

--- a/Formula/p/prowler.rb
+++ b/Formula/p/prowler.rb
@@ -827,7 +827,8 @@ class Prowler < Formula
   end
 
   def install
-    # The source doesn't have a valid SOURCE_DATE_EPOCH, so here we set default.
+    # hatch does not support a SOURCE_DATE_EPOCH before 1980.
+    # Remove after https://github.com/pypa/hatch/pull/1999 is released.
     ENV["SOURCE_DATE_EPOCH"] = "1451574000"
 
     virtualenv_install_with_resources

--- a/Formula/r/remarshal.rb
+++ b/Formula/r/remarshal.rb
@@ -75,7 +75,8 @@ class Remarshal < Formula
   end
 
   def install
-    # The source doesn't have a valid SOURCE_DATE_EPOCH, so here we set default.
+    # hatch does not support a SOURCE_DATE_EPOCH before 1980.
+    # Remove after https://github.com/pypa/hatch/pull/1999 is released.
     ENV["SOURCE_DATE_EPOCH"] = "1451574000"
 
     virtualenv_install_with_resources

--- a/Formula/r/rich-cli.rb
+++ b/Formula/r/rich-cli.rb
@@ -71,7 +71,8 @@ class RichCli < Formula
   end
 
   def install
-    # The source doesn't have a valid SOURCE_DATE_EPOCH, so here we set default.
+    # hatch does not support a SOURCE_DATE_EPOCH before 1980.
+    # Remove after https://github.com/pypa/hatch/pull/1999 is released.
     ENV["SOURCE_DATE_EPOCH"] = "1451574000"
 
     virtualenv_install_with_resources

--- a/Formula/s/sarif-tools.rb
+++ b/Formula/s/sarif-tools.rb
@@ -128,7 +128,8 @@ class SarifTools < Formula
   end
 
   def install
-    # The source doesn't have a valid SOURCE_DATE_EPOCH, so here we set default.
+    # hatch does not support a SOURCE_DATE_EPOCH before 1980.
+    # Remove after https://github.com/pypa/hatch/pull/1999 is released.
     ENV["SOURCE_DATE_EPOCH"] = "1451574000"
 
     virtualenv_install_with_resources

--- a/Formula/s/sceptre.rb
+++ b/Formula/s/sceptre.rb
@@ -158,7 +158,8 @@ class Sceptre < Formula
   end
 
   def install
-    # The source doesn't have a valid SOURCE_DATE_EPOCH, so here we set default.
+    # hatch does not support a SOURCE_DATE_EPOCH before 1980.
+    # Remove after https://github.com/pypa/hatch/pull/1999 is released.
     ENV["SOURCE_DATE_EPOCH"] = "1451574000"
 
     # Avoid issue if `numpy` is installed, https://github.com/Sceptre/sceptre/issues/1541

--- a/Formula/s/sherlock.rb
+++ b/Formula/s/sherlock.rb
@@ -103,7 +103,8 @@ class Sherlock < Formula
   end
 
   def install
-    # The source doesn't have a valid SOURCE_DATE_EPOCH, so here we set default.
+    # hatch does not support a SOURCE_DATE_EPOCH before 1980.
+    # Remove after https://github.com/pypa/hatch/pull/1999 is released.
     ENV["SOURCE_DATE_EPOCH"] = "1451574000"
 
     virtualenv_install_with_resources

--- a/Formula/s/sigma-cli.rb
+++ b/Formula/s/sigma-cli.rb
@@ -107,7 +107,8 @@ class SigmaCli < Formula
   end
 
   def install
-    # The source doesn't have a valid SOURCE_DATE_EPOCH, so here we set default.
+    # hatch does not support a SOURCE_DATE_EPOCH before 1980.
+    # Remove after https://github.com/pypa/hatch/pull/1999 is released.
     ENV["SOURCE_DATE_EPOCH"] = "1451574000"
 
     virtualenv_install_with_resources

--- a/Formula/s/snakefmt.rb
+++ b/Formula/s/snakefmt.rb
@@ -46,7 +46,8 @@ class Snakefmt < Formula
   end
 
   def install
-    # The source doesn't have a valid SOURCE_DATE_EPOCH, so here we set default.
+    # hatch does not support a SOURCE_DATE_EPOCH before 1980.
+    # Remove after https://github.com/pypa/hatch/pull/1999 is released.
     ENV["SOURCE_DATE_EPOCH"] = "1451574000"
 
     virtualenv_install_with_resources

--- a/Formula/s/streamrip.rb
+++ b/Formula/s/streamrip.rb
@@ -194,7 +194,8 @@ class Streamrip < Formula
   end
 
   def install
-    # The source doesn't have a valid SOURCE_DATE_EPOCH, so here we set default.
+    # hatch does not support a SOURCE_DATE_EPOCH before 1980.
+    # Remove after https://github.com/pypa/hatch/pull/1999 is released.
     ENV["SOURCE_DATE_EPOCH"] = "1451574000"
 
     virtualenv_install_with_resources

--- a/Formula/t/terraform-iam-policy-validator.rb
+++ b/Formula/t/terraform-iam-policy-validator.rb
@@ -62,7 +62,8 @@ class TerraformIamPolicyValidator < Formula
   end
 
   def install
-    # The source doesn't have a valid SOURCE_DATE_EPOCH, so here we set default.
+    # hatch does not support a SOURCE_DATE_EPOCH before 1980.
+    # Remove after https://github.com/pypa/hatch/pull/1999 is released.
     ENV["SOURCE_DATE_EPOCH"] = "1451574000"
 
     virtualenv_install_with_resources

--- a/Formula/v/vunnel.rb
+++ b/Formula/v/vunnel.rb
@@ -254,7 +254,8 @@ class Vunnel < Formula
     # Issue ref: https://github.com/anchore/vunnel/issues/904
     inreplace "pyproject.toml", 'requires-python = "<3.14,>=3.11"', 'requires-python = ">=3.11"'
 
-    # The source doesn't have a valid SOURCE_DATE_EPOCH, so here we set default.
+    # hatch does not support a SOURCE_DATE_EPOCH before 1980.
+    # Remove after https://github.com/pypa/hatch/pull/1999 is released.
     ENV["SOURCE_DATE_EPOCH"] = "1451574000"
 
     # Fix compilation of ijson native extensions, note:


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Hatch currently does not correctly handle a `SOURCE_DATE_EPOCH` before 1980 like other build backends. This will be fixed when https://github.com/pypa/hatch/pull/1999 is released, so let's clarify these misleading comments
