### PR TITLE
CONTRIBUTING: update Docker image address

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ If you're still stuck: don't fret. Leave a comment on your PR describing what yo
 Linux CI runs on a Docker container running Ubuntu 22.04. If you have Docker installed, you can use our container with:
 
 ```
-docker run --interactive --tty --rm --pull always homebrew/ubuntu22.04:latest /bin/bash
+docker run --interactive --tty --rm --pull always ghcr.io/homebrew/ubuntu22.04:latest /bin/bash
 ```
 
 If you don't have Docker installed:


### PR DESCRIPTION
We're no longer updating Docker Hub. See Homebrew/brew#20938.
