### PR TITLE
misc: remove `python@3.12`

### DIFF
--- a/Formula/c/cffi.rb
+++ b/Formula/c/cffi.rb
@@ -17,7 +17,6 @@ class Cffi < Formula
     sha256                               x86_64_linux:  "bad3335bd82f947b8283832392a0c37035e500e5732dd63b0f9878dcaf05d639"
   end
 
-  depends_on "python@3.12" => [:build, :test]
   depends_on "python@3.13" => [:build, :test]
   depends_on "python@3.14" => [:build, :test]
   depends_on "pycparser"

--- a/Formula/c/cryptography.rb
+++ b/Formula/c/cryptography.rb
@@ -18,7 +18,6 @@ class Cryptography < Formula
   depends_on "maturin" => :build
   depends_on "pkgconf" => :build
   depends_on "python-setuptools" => :build
-  depends_on "python@3.12" => [:build, :test]
   depends_on "python@3.13" => [:build, :test]
   depends_on "python@3.14" => [:build, :test]
   depends_on "rust" => :build

--- a/Formula/n/numpy.rb
+++ b/Formula/n/numpy.rb
@@ -18,7 +18,6 @@ class Numpy < Formula
   depends_on "gcc" => :build # for gfortran
   depends_on "meson" => :build
   depends_on "ninja" => :build
-  depends_on "python@3.12" => [:build, :test]
   depends_on "python@3.13" => [:build, :test]
   depends_on "python@3.14" => [:build, :test]
   depends_on "openblas"

--- a/Formula/p/pycparser.rb
+++ b/Formula/p/pycparser.rb
@@ -10,7 +10,6 @@ class Pycparser < Formula
     sha256 cellar: :any_skip_relocation, all: "9e1c78dae771f3b5f7e085ec7600b1317c259e5b493d81cb66334a919b1a81c6"
   end
 
-  depends_on "python@3.12" => [:build, :test]
   depends_on "python@3.13" => [:build, :test]
   depends_on "python@3.14" => [:build, :test]
 

--- a/Formula/p/pygit2.rb
+++ b/Formula/p/pygit2.rb
@@ -15,7 +15,6 @@ class Pygit2 < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "119c10991289e7b902f9540d8624b2d04d5d79b97c130386848016461effc2fb"
   end
 
-  depends_on "python@3.12" => [:build, :test]
   depends_on "python@3.13" => [:build, :test]
   depends_on "python@3.14" => [:build, :test]
   depends_on "cffi"


### PR DESCRIPTION

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

These don't appear to be used anymore. This leaves

```console
$ rg -l 'depends_on "python@3.12"' | xargs rg -l 'depends_on "python@3.13"'
Formula/p/protobuf@21.rb
Formula/p/python-setuptools.rb
Formula/p/pillow.rb
Formula/s/six.rb
```

Besides deprecated/disabled, `pillow` is still used by `aider` and `python-setuptools` by `llvm@14` + `sapling`
