### PR TITLE
json2hcl: deprecate by repo archived

### DIFF
--- a/Formula/j/json2hcl.rb
+++ b/Formula/j/json2hcl.rb
@@ -17,6 +17,8 @@ class Json2hcl < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "2948c8a75a038d66472436983a09b1e32cab8b7dc9a5d3d3b8dfec86a75a2eaa"
   end
 
+  deprecate! date: "2025-10-26", because: :repo_archived
+
   depends_on "go" => :build
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Repo archived