### PR TITLE
liquibase: use github artifact as `liquibase-4.33.0.tar.gz` no longer exists in `package.liquibase.com`

### DIFF
--- a/Formula/l/liquibase.rb
+++ b/Formula/l/liquibase.rb
@@ -2,7 +2,7 @@ class Liquibase < Formula
   desc "Library for database change tracking"
   homepage "https://www.liquibase.org/"
   # NOTE: Do not bump to v5.0.0+ as license changed to FSL-1.1-ALv2
-  url "https://package.liquibase.com/downloads/liquibase/homebrew/liquibase-4.33.0.tar.gz"
+  url "https://github.com/liquibase/liquibase/releases/download/v4.33.0/liquibase-4.33.0.tar.gz"
   sha256 "689acfcdc97bad0d4c150d1efab9c851e251b398cb3d6326f75e8aafe40ed578"
   license "Apache-2.0"
   revision 1


### PR DESCRIPTION
liquibase: use github artifact as `liquibase-4.33.0.tar.gz` no longer exists in `package.liquibase.com`

---

see in https://github.com/Homebrew/homebrew-core/actions/runs/18736860606/job/53618942029?pr=250760#step:3:7017

- https://github.com/Homebrew/homebrew-core/pull/250760