### PR TITLE
python-setuptools: build once and symlink

### DIFF
--- a/Formula/p/python-setuptools.rb
+++ b/Formula/p/python-setuptools.rb
@@ -7,7 +7,8 @@ class PythonSetuptools < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "90d1373d4b921632e3da896be98326b463867c0a4f9e742c6a98c09caae96fd7"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "3f1216774825c551075a7a28ca8c7412e56ddb635f495275e5c231801d3a5abd"
   end
 
   depends_on "python@3.14" => [:build, :test]

--- a/Formula/p/python-setuptools.rb
+++ b/Formula/p/python-setuptools.rb
@@ -10,38 +10,47 @@ class PythonSetuptools < Formula
     sha256 cellar: :any_skip_relocation, all: "90d1373d4b921632e3da896be98326b463867c0a4f9e742c6a98c09caae96fd7"
   end
 
-  depends_on "python@3.12" => [:build, :test]
-  depends_on "python@3.13" => [:build, :test]
   depends_on "python@3.14" => [:build, :test]
+  depends_on "python@3.12" => :test # keep on oldest python to support (externally managed and not EOL)
 
   def pythons
-    deps.map(&:to_formula)
-        .select { |f| f.name.match?(/^python@\d\.\d+$/) }
-        .map { |f| f.opt_libexec/"bin/python" }
+    deps.filter_map { |dep| dep.to_formula if dep.name.start_with?("python@") }
   end
 
   def install
-    inreplace_paths = %w[
-      _distutils/compilers/C/unix.py
-      _vendor/platformdirs/unix.py
-    ]
+    odie "Need exactly 2 python dependencies!" if pythons.count != 2
+    oldest_python, python = pythons.sort_by(&:version)
+    python_exe = python.opt_libexec/"bin/python"
+    system python_exe, "-m", "pip", "install", *std_pip_args, "."
 
-    pythons.each do |python|
-      system python, "-m", "pip", "install", *std_pip_args, "."
+    # Pure python setuptools installation can be used on different Python versions
+    site_packages = prefix/Language::Python.site_packages(python_exe)
+    python.versioned_formulae.each do |extra_python|
+      next if extra_python.version < oldest_python.version
 
-      # Ensure uniform bottles
-      setuptools_site_packages = prefix/Language::Python.site_packages(python)/"setuptools"
-      inreplace setuptools_site_packages/"_vendor/platformdirs/macos.py", "/opt/homebrew", HOMEBREW_PREFIX
+      # Cannot use Python.site_packages as that requires formula to be installed
+      extra_site_packages = lib/"python#{extra_python.version.major_minor}/site-packages"
+      site_packages.find do |path|
+        next unless path.file?
 
-      inreplace_files = inreplace_paths.map { |file| setuptools_site_packages/file }
-      inreplace_files += setuptools_site_packages.glob("_vendor/platformdirs-*dist-info/METADATA")
-      inreplace inreplace_files, "/usr/local", HOMEBREW_PREFIX
+        target = extra_site_packages/path.relative_path_from(site_packages)
+        target.dirname.install_symlink path
+      end
     end
+
+    # Ensure uniform bottles
+    setuptools_site_packages = site_packages/"setuptools"
+    inreplace_files = %W[
+      #{setuptools_site_packages}/_distutils/compilers/C/unix.py
+      #{setuptools_site_packages}/_vendor/platformdirs/unix.py
+    ] + setuptools_site_packages.glob("_vendor/platformdirs-*dist-info/METADATA")
+    inreplace inreplace_files, "/usr/local", HOMEBREW_PREFIX
+    inreplace setuptools_site_packages/"_vendor/platformdirs/macos.py", "/opt/homebrew", HOMEBREW_PREFIX
   end
 
   test do
     pythons.each do |python|
-      system python, "-c", "import setuptools"
+      system python.opt_libexec/"bin/python", "-c", "import setuptools"
     end
   end
 end


### PR DESCRIPTION
Setuptools is pure python and an any wheel (https://pypi.org/project/setuptools/#setuptools-80.9.0-py3-none-any.whl) so it isn't Python version-specific.

Can also see from existing bottle, the contents of subdirectories are the same, e.g.
```console
❯ diff --recursive $(brew --prefix python-setuptools)/lib/python3.12/ $(brew --prefix python-setuptools)/lib/python3.13/

❯ echo $?
0
```

---

For now, can keep all versions as we use Setuptools in some formulae we are unable to rebuild, e.g. versioned LLVM. Can re-consider in future.

Minor reduction in size from symlinks, though not that significant as only 4.3MB with 1 Python and 12.0MB with 3 Pythons.