### PR TITLE
libgweather: migrate to `python@3.14` and backport build fix

### DIFF
--- a/Formula/lib/libgweather.rb
+++ b/Formula/lib/libgweather.rb
@@ -33,7 +33,7 @@ class Libgweather < Formula
   depends_on "ninja" => :build
   depends_on "pkgconf" => [:build, :test]
   depends_on "pygobject3" => :build
-  depends_on "python@3.13" => :build
+  depends_on "python@3.14" => :build
 
   depends_on "geocode-glib"
   depends_on "glib"
@@ -47,11 +47,14 @@ class Libgweather < Formula
     depends_on "gettext"
   end
 
+  # Backport fix for "error: call to undeclared library function 'alloca'"
+  patch do
+    url "https://gitlab.gnome.org/GNOME/libgweather/-/commit/12080775978b6d5140c741562894ea5d21601e15.diff"
+    sha256 "64f638c4ffe0936016117f7355a1bbbbf2fec41b1e67bb64eac1bdca760eba23"
+  end
+
   def install
     ENV["DESTDIR"] = "/"
-
-    # Fix compile with newer Clang
-    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     system "meson", "setup", "build", "-Dgtk_doc=false", "-Dtests=false", *std_meson_args
     system "meson", "compile", "-C", "build", "--verbose"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
