### PR TITLE
gpgmepy: remove no-op `--use-pep517`

### DIFF
--- a/Formula/g/gpgmepy.rb
+++ b/Formula/g/gpgmepy.rb
@@ -37,7 +37,7 @@ class Gpgmepy < Formula
     # https://dev.gnupg.org/T6784
     inreplace "Makefile.in",
               /^\s*\$\$PYTHON setup\.py\s*\\/,
-              "$$PYTHON -m pip install --use-pep517 #{std_pip_args.join(" ")} . && : \\"
+              "$$PYTHON -m pip install #{std_pip_args.join(" ")} . && : \\"
 
     system "./configure", *std_configure_args
     system "make", "COPY_FILES="


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

With [pip 25.3](https://github.com/pypa/pip/commit/2a2960de8fdcc42c38d1c44868f62d320af594a1), this is now the default
