### PR TITLE
mavsdk: migrate to `python@3.14`

### DIFF
--- a/Formula/m/mavsdk.rb
+++ b/Formula/m/mavsdk.rb
@@ -22,7 +22,8 @@ class Mavsdk < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "python@3.13" => :build
+  depends_on "python@3.14" => :build
+  depends_on "rust" => :build
   depends_on "abseil"
   depends_on "c-ares"
   depends_on "curl"


### PR DESCRIPTION
mavsdk: migrate to `python@3.14`