### PR TITLE
vtk: make `pyqt` a test dependency

### DIFF
--- a/Formula/v/vtk.rb
+++ b/Formula/v/vtk.rb
@@ -16,6 +16,7 @@ class Vtk < Formula
   end
 
   depends_on "cmake" => [:build, :test]
+  depends_on "pyqt" => :test
   depends_on "boost"
   depends_on "cgns"
   depends_on "double-conversion"
@@ -34,7 +35,6 @@ class Vtk < Formula
   depends_on "nlohmann-json"
   depends_on "proj"
   depends_on "pugixml"
-  depends_on "pyqt"
   depends_on "python@3.14"
   depends_on "qtbase"
   depends_on "qtdeclarative"
@@ -153,5 +153,6 @@ class Vtk < Formula
     PYTHON
 
     system bin/"vtkpython", "Distance2BetweenPoints.py"
+    system bin/"vtkpython", "-c", "from vtkmodules.qt.QVTKRenderWindowInteractor import QVTKRenderWindowInteractor"
   end
 end


### PR DESCRIPTION
The installed Python code will check for PySide6 and then PyQt6 at runtime so user can just install whichever they want.

Removing hard `pyqt` dependency avoids pulling in a large number of dependencies that are not needed for main functionality.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The dependency is also not used when `pyside` is installed as that has priority - https://github.com/Kitware/VTK/blob/master/Wrapping/Python/vtkmodules/qt/QVTKRenderWindowInteractor.py#L79-L85

