### PR TITLE
xdot,xml2rfc,xonsh: migrate to `pypi_packages` DSL

### DIFF
--- a/Formula/x/xdot.rb
+++ b/Formula/x/xdot.rb
@@ -23,6 +23,9 @@ class Xdot < Formula
   depends_on "pygobject3"
   depends_on "python@3.14"
 
+  pypi_packages exclude_packages: ["numpy", "pygobject"],
+                extra_packages:   "graphviz"
+
   resource "graphviz" do
     url "https://files.pythonhosted.org/packages/fa/83/5a40d19b8347f017e417710907f824915fba411a9befd092e52746b63e9f/graphviz-0.20.3.zip"
     sha256 "09d6bc81e6a9fa392e7ba52135a9d49f1ed62526f96499325930e87ca1b5925d"

--- a/Formula/x/xml2rfc.rb
+++ b/Formula/x/xml2rfc.rb
@@ -28,6 +28,8 @@ class Xml2rfc < Formula
     depends_on "libxslt"
   end
 
+  pypi_packages exclude_packages: "certifi"
+
   # Keep none-any.whl for `google-i18n-address`,
   # if not then there will be an ModuleNotFoundError: No module named 'i18naddress'
 

--- a/Formula/x/xonsh.rb
+++ b/Formula/x/xonsh.rb
@@ -20,6 +20,8 @@ class Xonsh < Formula
 
   depends_on "python@3.14"
 
+  pypi_packages package_name: "xonsh[ptk,pygments,proctitle]"
+
   resource "prompt-toolkit" do
     url "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz"
     sha256 "28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855"

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -1044,10 +1044,6 @@
   "wxpython": {
     "exclude_packages": ["numpy", "pillow"]
   },
-  "xdot": {
-    "exclude_packages": ["numpy", "pygobject"],
-    "extra_packages": ["graphviz"]
-  },
   "xml2rfc": {
     "exclude_packages": ["certifi"]
   },

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -1044,7 +1044,6 @@
   "wxpython": {
     "exclude_packages": ["numpy", "pillow"]
   },
-  "xonsh": "xonsh[ptk,pygments,proctitle]",
   "yamlfix": {
     "exclude_packages": ["pydantic-core"]
   },

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -1044,9 +1044,6 @@
   "wxpython": {
     "exclude_packages": ["numpy", "pillow"]
   },
-  "xml2rfc": {
-    "exclude_packages": ["certifi"]
-  },
   "xonsh": "xonsh[ptk,pygments,proctitle]",
   "yamlfix": {
     "exclude_packages": ["pydantic-core"]


### PR DESCRIPTION
xdot,xml2rfc,xonsh: migrate to `pypi_packages` DSL

---

- https://github.com/Homebrew/brew/pull/20864