### PR TITLE
vdirsyncer,virt-manager,vunnel: migrate to `pypi_packages` DSL

### DIFF
--- a/Formula/v/vdirsyncer.rb
+++ b/Formula/v/vdirsyncer.rb
@@ -23,6 +23,9 @@ class Vdirsyncer < Formula
   depends_on "certifi"
   depends_on "python@3.14"
 
+  pypi_packages package_name:     "vdirsyncer[google]",
+                exclude_packages: "certifi"
+
   resource "aiohappyeyeballs" do
     url "https://files.pythonhosted.org/packages/26/30/f84a107a9c4331c14b2b586036f40965c128aa4fee4dda5d3d51cb14ad54/aiohappyeyeballs-2.6.1.tar.gz"
     sha256 "c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558"

--- a/Formula/v/virt-manager.rb
+++ b/Formula/v/virt-manager.rb
@@ -36,6 +36,10 @@ class VirtManager < Formula
   depends_on "spice-gtk"
   depends_on "vte3"
 
+  pypi_packages package_name:     "",
+                exclude_packages: "certifi",
+                extra_packages:   "requests"
+
   resource "charset-normalizer" do
     url "https://files.pythonhosted.org/packages/83/2d/5fd176ceb9b2fc619e63405525573493ca23441330fcdaee6bef9460e924/charset_normalizer-3.4.3.tar.gz"
     sha256 "6fce4b8500244f6fcb71465d4a4930d132ba9ab8e71a7859e6a5d59851068d14"

--- a/Formula/v/vunnel.rb
+++ b/Formula/v/vunnel.rb
@@ -27,6 +27,8 @@ class Vunnel < Formula
   uses_from_macos "libxml2", since: :ventura
   uses_from_macos "libxslt"
 
+  pypi_packages exclude_packages: ["certifi", "rpds-py"]
+
   resource "attrs" do
     url "https://files.pythonhosted.org/packages/6b/5c/685e6633917e101e5dcb62b9dd76946cbb57c26e133bae9e0cd36033c0a9/attrs-25.4.0.tar.gz"
     sha256 "16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11"

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -1008,9 +1008,6 @@
     "exclude_packages": ["certifi"]
   },
   "uvicorn": "uvicorn[standard]",
-  "vunnel": {
-    "exclude_packages": ["certifi", "rpds-py"]
-  },
   "watson": {
     "exclude_packages": ["certifi"]
   },

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -1008,10 +1008,6 @@
     "exclude_packages": ["certifi"]
   },
   "uvicorn": "uvicorn[standard]",
-  "vdirsyncer": {
-    "package_name": "vdirsyncer[google]",
-    "exclude_packages": ["certifi"]
-  },
   "virt-manager": {
     "package_name": "",
     "exclude_packages": ["certifi"],

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -1008,11 +1008,6 @@
     "exclude_packages": ["certifi"]
   },
   "uvicorn": "uvicorn[standard]",
-  "virt-manager": {
-    "package_name": "",
-    "exclude_packages": ["certifi"],
-    "extra_packages": ["requests"]
-  },
   "vunnel": {
     "exclude_packages": ["certifi", "rpds-py"]
   },


### PR DESCRIPTION
vdirsyncer,virt-manager,vunnel: migrate to `pypi_packages` DSL

- https://github.com/Homebrew/brew/pull/20864