### PR TITLE
archgw huggingface-cli: add workaround for arm64 linux

### DIFF
--- a/Formula/a/archgw.rb
+++ b/Formula/a/archgw.rb
@@ -332,7 +332,17 @@ class Archgw < Formula
     # Remove after https://github.com/pypa/hatch/pull/1999 is released.
     ENV["SOURCE_DATE_EPOCH"] = "1451574000"
 
-    venv = virtualenv_install_with_resources
+    venv = virtualenv_install_with_resources(without: "hf-xet")
+
+    resource("hf-xet").stage do
+      if ENV.effective_arch == :armv8
+        # Disable sha2-asm which requires a minimum of -march=armv8-a+crypto
+        inreplace "data/Cargo.toml",
+                  'sha2 = { workspace = true, features = ["asm"] }',
+                  "sha2 = { workspace = true }"
+      end
+      venv.pip_install Pathname.pwd
+    end
 
     # NOTE: This is an exception to our usual policy as building `pytorch` is complicated
     site_packages = Language::Python.site_packages(venv.root/"bin/python3")

--- a/Formula/a/archgw.rb
+++ b/Formula/a/archgw.rb
@@ -8,12 +8,12 @@ class Archgw < Formula
   license "Apache-2.0"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_tahoe:   "c10db98bb7361677d43a4502db9f2a23877a163e92697a526c18dc9a6b23833e"
-    sha256 cellar: :any,                 arm64_sequoia: "49ba8976c244113c500931442f9754c1e149d74f72121d7d13492f0770f66129"
-    sha256 cellar: :any,                 arm64_sonoma:  "245bde81d1dd6316fbe1b332c21e52de54d72504d45e3b7148abda2402694295"
-    sha256 cellar: :any,                 sonoma:        "d7ba09267c8c4291e3d06827101b06d5d2077b00c7d3c8dfa20c414c5a0daaa0"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a642bfb67f3d57a357bd037915d1ace73e08d6fd748f2483d1c7ecedaaf3e419"
+    rebuild 2
+    sha256 cellar: :any,                 arm64_tahoe:   "e5c84edea9bf01e6b3940eb1dc7e35a023e408f0f97632ba405d415198f0182f"
+    sha256 cellar: :any,                 arm64_sequoia: "bc16076639115dd44dab5600acb31d5c215abe8d1d7a7bc110c8f8029d1b3275"
+    sha256 cellar: :any,                 arm64_sonoma:  "8cb76c7b2b50d8925888cb8ca4474910058609c48ef683cb9cd8b583bde77fd6"
+    sha256 cellar: :any,                 sonoma:        "11a828235b4a0a957d336820aec5964e56ba6d1a8537f4704a02b1eeb5134bb2"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b2ebe5a0a8f32d3446f407506fad2b56cb1985b7dd1670992a91e545e76bb06d"
   end
 
   depends_on "rust" => :build # for hf-xet, jitter and safetensors

--- a/Formula/h/huggingface-cli.rb
+++ b/Formula/h/huggingface-cli.rb
@@ -9,11 +9,12 @@ class HuggingfaceCli < Formula
   head "https://github.com/huggingface/huggingface_hub.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "87e2cb3e0a978bfb715d9fab4e009fde35e0d7550bf056212694f2c04b51a67a"
-    sha256 cellar: :any,                 arm64_sequoia: "fe43d06f7030440cf4f9aa96e5e5d62cc1b64afea8eab667485be4f6acb80281"
-    sha256 cellar: :any,                 arm64_sonoma:  "a4d3a7db40661d241041ca55583218676d09a074e44ee74cd72b42713bb8e451"
-    sha256 cellar: :any,                 sonoma:        "1ac123a8df526e94943a92b1bee7a74e93d310043a88478c3c98fe104f4f7ae0"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1e4f4f96ad0979ca3749c98c63e900cb91745f52614a2871879761f3bbcfacb8"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "f589c998d8e6bf0ea92c36782ab6a606d0f9c26bcb70a27127e1968e759af210"
+    sha256 cellar: :any,                 arm64_sequoia: "37779da9ced13fe2b691961a72892e76905dd7adce25f9584ae716f1efbe63be"
+    sha256 cellar: :any,                 arm64_sonoma:  "4c3cec5c45de604797f558ce2fdff1863e48c0c30817a9225610d4baacc1385d"
+    sha256 cellar: :any,                 sonoma:        "548c795aed25a3a41122fb030ac707c1341e533194a8e13fa8616f1232dee20a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "cb75fca90b64eac0c0ff0bab6bfce3a3ebd02d263a6526ac8af20ced29865ac2"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/h/huggingface-cli.rb
+++ b/Formula/h/huggingface-cli.rb
@@ -112,7 +112,17 @@ class HuggingfaceCli < Formula
   end
 
   def install
-    virtualenv_install_with_resources
+    venv = virtualenv_install_with_resources(without: "hf-xet")
+
+    resource("hf-xet").stage do
+      if ENV.effective_arch == :armv8
+        # Disable sha2-asm which requires a minimum of -march=armv8-a+crypto
+        inreplace "data/Cargo.toml",
+                  'sha2 = { workspace = true, features = ["asm"] }',
+                  "sha2 = { workspace = true }"
+      end
+      venv.pip_install Pathname.pwd
+    end
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Checking if newer hf-xet works with arm64 linux without extra workaround.