### PR TITLE
workflow/remove-unused-patches: prefix increment to avoid error code

### DIFF
--- a/.github/workflows/remove-unused-patches.yml
+++ b/.github/workflows/remove-unused-patches.yml
@@ -93,7 +93,7 @@ jobs:
           while IFS= read -r patch_file; do
             if ! grep -Fxq "$patch_file" "$referenced_patches"; then
               echo "$patch_file" >> "$unused_patches"
-              ((unused_count++))
+              ((++unused_count))
             fi
           done < "$all_patches"
           


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

A bit of a workaround so that first returned value isn't 0 which bash will handle as error code:
```console
❯ /bin/bash -c 'x=0; ((x++)); echo $?'
1

❯ /bin/bash -c 'x=0; ((++x)); echo $?'
0
```