### PR TITLE
deno 2.5.5

### DIFF
--- a/Formula/d/deno.rb
+++ b/Formula/d/deno.rb
@@ -1,8 +1,8 @@
 class Deno < Formula
   desc "Secure runtime for JavaScript and TypeScript"
   homepage "https://deno.com/"
-  url "https://github.com/denoland/deno/releases/download/v2.5.4/deno_src.tar.gz"
-  sha256 "d92d0c2b85f016769dcc2f0b86ae03861d2303bb165aac4c7911559c052301ca"
+  url "https://github.com/denoland/deno/releases/download/v2.5.5/deno_src.tar.gz"
+  sha256 "900be91d2a925a293915b454ec24e94188ce14c68fb04916d9a00e2e2f6d5a89"
   license "MIT"
   head "https://github.com/denoland/deno.git", branch: "main"
 


### PR DESCRIPTION
deno 2.5.5

---

- https://github.com/Homebrew/homebrew-core/actions/runs/18887303369/job/53905854587#step:6:4112

```
==> Downloading https://github.com/denoland/deno/releases/download/v2.5.5/deno_src.tar.gz
curl: (22) The requested URL returned error: 404
```