### PR TITLE
.github/workflows/tests.yml: add `CI-no-fail-fast-syntax` handling

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
         stable: [false, true]
     name: tap_syntax${{ matrix.stable && ' (stable)' || '' }}
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.stable || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'CI-no-fail-fast-syntax')) }}
+    continue-on-error: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'CI-no-fail-fast-syntax') }}
     container:
       image: ghcr.io/homebrew/ubuntu22.04:${{ matrix.stable && 'latest' || 'main'}}
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
         stable: [false, true]
     name: tap_syntax${{ matrix.stable && ' (stable)' || '' }}
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.stable }}
+    continue-on-error: ${{ matrix.stable || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'CI-no-fail-fast-syntax')) }}
     container:
       image: ghcr.io/homebrew/ubuntu22.04:${{ matrix.stable && 'latest' || 'main'}}
     env:


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR adds handling of a new PR label `CI-no-fail-fast-syntax`.
There are rare occasions, as seen in https://github.com/Homebrew/homebrew-core/pull/243473 where the `tap_syntax` job may fail for a valid reason[^1], which prevents the tests from being run.

The handling of the label allows the tests to be run on the PR, but will prevent the PR from being successful as the `tap_syntax` job will remain with a failed state.

[^1]: In this instance there is an existing cask with the same token as the proposed formula that would be migrated when the PR is ready. While the development is taking place we cannot test on CI without this label.
