### PR TITLE
nu: deprecate

### DIFF
--- a/Formula/n/nu.rb
+++ b/Formula/n/nu.rb
@@ -19,6 +19,10 @@ class Nu < Formula
     sha256               x86_64_linux:  "e574e9a1043c30df8da1995fb0d344271e4d2f3cd92815a57a3ddbf420a8f794"
   end
 
+  # Last release on 2019-07-29. Needs multiple workarounds/hacks and uses EOL `pcre`
+  deprecate! date: "2025-10-29", because: :unmaintained
+  disable! date: "2026-10-29", because: :unmaintained
+
   depends_on "pcre"
 
   uses_from_macos "llvm" => :build
@@ -27,6 +31,7 @@ class Nu < Formula
 
   on_linux do
     depends_on "gnustep-make" => :build
+    depends_on arch: :x86_64 # fails to build on arm64 linux
     depends_on "gnustep-base"
     depends_on "libobjc2"
     depends_on "readline"


### PR DESCRIPTION
Deprecating due to large list of workarounds/patches/hacks that were reported upstream:
- https://github.com/programming-nu/nu/issues/99
- https://github.com/programming-nu/nu/issues/97
- https://github.com/programming-nu/nu/issues/102
- https://github.com/programming-nu/nu/pull/103

Also part of work item to deprecate/remove `pcre` (already done by Debian, in progress at Arch Linux and other distros).

Making x86_64-only on Linux to hide from tracker as code doesn't build on arm64 without more patches.

---

Only distributed by us and MacPorts (https://repology.org/project/nu-lang/versions)