### PR TITLE
mismatched_binary_allowlist: add ghidra exercise files

### DIFF
--- a/audit_exceptions/mismatched_binary_allowlist.json
+++ b/audit_exceptions/mismatched_binary_allowlist.json
@@ -4,6 +4,7 @@
   "balena-cli": "**/*",
   "elf2uf2-rs": "share/elf2uf2-rs/examples/*.elf",
   "faust": "share/faust/android/app/lib/libsndfile/lib/*/libsndfile.so",
+  "ghidra": "libexec/docs/GhidraClass/ExerciseFiles/Advanced/*",
   "i686-elf-grub": "lib/i686-elf/grub/i386-pc/*",
   "lima": "share/lima/lima-guestagent.Linux-*",
   "picotool": "share/picotool/*.elf",


### PR DESCRIPTION
Seem to be documented example ELF binaries for user to try Ghidra on.

Could alternatively remove them.