### PR TITLE
opencascade: remove `freeimage` support

### DIFF
--- a/Formula/o/opencascade.rb
+++ b/Formula/o/opencascade.rb
@@ -1,9 +1,8 @@
 class Opencascade < Formula
   desc "3D modeling and numerical simulation software for CAD/CAM/CAE"
   homepage "https://dev.opencascade.org/"
-  url "https://git.dev.opencascade.org/gitweb/?p=occt.git;a=snapshot;h=refs/tags/V7_9_2;sf=tgz"
-  version "7.9.2"
-  sha256 "e9f69bde521e718f10f1896e5bea070fbd5dfb205d8da422f5be2d521db666c5"
+  url "https://github.com/Open-Cascade-SAS/OCCT/archive/refs/tags/V7_9_2.tar.gz"
+  sha256 "3cd080d3fc33ba0c6c157e110afe3e015859524c4694dbb09812ec9d61595639"
   license "LGPL-2.1-only"
 
   # The first-party download page (https://dev.opencascade.org/release)
@@ -33,7 +32,6 @@ class Opencascade < Formula
   depends_on "doxygen" => :build
   depends_on "rapidjson" => :build
   depends_on "fontconfig"
-  depends_on "freeimage"
   depends_on "freetype"
   depends_on "tbb"
   depends_on "tcl-tk@8" # TCL 9 issue: https://tracker.dev.opencascade.org/view.php?id=33725
@@ -44,20 +42,20 @@ class Opencascade < Formula
   end
 
   def install
-    # Fix incorrect version
-    inreplace "adm/cmake/version.cmake", "set (OCC_VERSION_MAINTENANCE 1 )", "set (OCC_VERSION_MAINTENANCE 2 )"
+    # FreeImage has multiple CVEs and has been dropped by distros like Arch Linux
+    # Ref: https://archlinux.org/todo/drop-freeimage/
+    odie "FreeImage should not be a dependency!" if deps.map(&:name).include?("freeimage")
 
     tcltk = Formula["tcl-tk@8"]
     libtcl = tcltk.opt_lib/shared_library("libtcl#{tcltk.version.major_minor}")
     libtk = tcltk.opt_lib/shared_library("libtk#{tcltk.version.major_minor}")
 
     system "cmake", "-S", ".", "-B", "build",
-                    "-DUSE_FREEIMAGE=ON",
+                    "-DUSE_FREEIMAGE=OFF",
                     "-DUSE_RAPIDJSON=ON",
                     "-DUSE_TBB=ON",
                     "-DINSTALL_DOC_Overview=ON",
                     "-DBUILD_RELEASE_DISABLE_EXCEPTIONS=OFF",
-                    "-D3RDPARTY_FREEIMAGE_DIR=#{Formula["freeimage"].opt_prefix}",
                     "-D3RDPARTY_FREETYPE_DIR=#{Formula["freetype"].opt_prefix}",
                     "-D3RDPARTY_RAPIDJSON_DIR=#{Formula["rapidjson"].opt_prefix}",
                     "-D3RDPARTY_RAPIDJSON_INCLUDE_DIR=#{Formula["rapidjson"].opt_include}",

--- a/Formula/o/opencascade.rb
+++ b/Formula/o/opencascade.rb
@@ -21,11 +21,12 @@ class Opencascade < Formula
   no_autobump! because: :incompatible_version_format
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "4660451ad938efaa9866c11e26feaf6477e9ffc2ed465ec0e9c9ee3e883aa1c7"
-    sha256 cellar: :any,                 arm64_sequoia: "909aa33f35f20ba42068fcc35030389f878f6fa71dafa481148bcc40a1224922"
-    sha256 cellar: :any,                 arm64_sonoma:  "192f5b9934455b54a1e4d90b7bfa4b0f983aea39ceae5f75ff49e09d519ccb01"
-    sha256 cellar: :any,                 sonoma:        "94081fbc6d9504ef3fd83ca3d76cdd86ca3808d009b68c6e33a6920bb724c314"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3878643a038002cd189e57aff2dd2424159cc46b8126ae16b08c2d40df707926"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "05c90efe2139c4c46c4f53536e554d356765281b824301ca21f62d5264fa1473"
+    sha256 cellar: :any,                 arm64_sequoia: "450ba8e8785c1348a3a7254d20847de69a237b39c1dc6bdb50218e1c3e306380"
+    sha256 cellar: :any,                 arm64_sonoma:  "39160ae92917d9be76d9c79056a8bfdc41b3d129eada5474be5538d98c9db912"
+    sha256 cellar: :any,                 sonoma:        "90aab756f98430cf0d80a62e9ef3725117900a4784080039c821166d2f621e0f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d0a579da97350eb4843ed2a1d77c106ea74329a2b8d4e9e74bbbd150896d2e32"
   end
 
   depends_on "cmake" => [:build, :test]


### PR DESCRIPTION
See reasoning in #251833 for `freeimage`

---

Checksum changed as upstream decided to force update tag - https://github.com/Open-Cascade-SAS/OCCT/discussions/751#discussioncomment-14719286

Since https://dev.opencascade.org/release shows GitHub tarballs, switched to those:
> Download Open CASCADE Technology source package, archives:
>
> - [opencascade-7.9.2.tar.gz](https://github.com/Open-Cascade-SAS/OCCT/archive/refs/tags/V7_9_2.tar.gz)
> - [opencascade-7.9.2.zip](https://github.com/Open-Cascade-SAS/OCCT/archive/refs/tags/V7_9_2.zip)