### PR TITLE
sprocket 0.18.0

### DIFF
--- a/Formula/s/sprocket.rb
+++ b/Formula/s/sprocket.rb
@@ -14,12 +14,12 @@ class Sprocket < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "900f29532e238df4be8d3b87b4c6be773df42df2027aaa38bc0bc685831442ce"
-    sha256 cellar: :any,                 arm64_sequoia: "5ee7d0e3d30fe78fd7a6cf97940710ab23e6d8e2cbb945fb70f01aef88ce9717"
-    sha256 cellar: :any,                 arm64_sonoma:  "4a2ec2fa95e2bd0196435e40541b4800bf8258dee998637929b621201d09f795"
-    sha256 cellar: :any,                 sonoma:        "fa4ce7cd37fac0a61e0fe2c45d506101e1681264b8b16eba30be67a187363f79"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "f7929b4f8f95be452937e95c2ac58774beebd06464cab42aad772360fdcbecd8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b60cea4c2d9916e741fdfd6b573edffe06721340f39485a242ffdbee42e3be1b"
+    sha256 cellar: :any,                 arm64_tahoe:   "a918c88d1763c710a25b4f8c5f1948d8e3ef2a691fc0648d34bdb2985aa62f6f"
+    sha256 cellar: :any,                 arm64_sequoia: "c5e4197d5538054f53c52d913b76279418b17f4fb9d21eaa3df0f2a5f2185208"
+    sha256 cellar: :any,                 arm64_sonoma:  "c54e8c7d944f5bdc3629e9570514683671f643e03c56c0278b1f9a091a4ff6d0"
+    sha256 cellar: :any,                 sonoma:        "716ad267bcb384d7426b5400da2aeff12248d2f14058a33acf607641104262da"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "5cd2e170f6047a11b389b3fad33d2678b35909e6bb9271221bb1440f5cc62d3b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e5f9aa2bb7563e48898cb0562e5b03909dceb53d0dbec30419af68ce81603cb4"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/s/sprocket.rb
+++ b/Formula/s/sprocket.rb
@@ -1,10 +1,17 @@
 class Sprocket < Formula
   desc "Bioinformatics workflow engine built on the Workflow Description Language (WDL)"
   homepage "https://sprocket.bio"
-  url "https://github.com/stjude-rust-labs/sprocket/archive/refs/tags/v0.17.1.tar.gz"
-  sha256 "cf72f8d4930ce16ae3adc73f82c9ed82aceb8f09330e5f78658a88e0b5d99986"
+  # pull from git tag to get submodules
+  url "https://github.com/stjude-rust-labs/sprocket.git",
+      tag:      "v0.18.0",
+      revision: "3f19960e232ac96af539ab8aeda7a8101832d213"
   license any_of: ["Apache-2.0", "MIT"]
   head "https://github.com/stjude-rust-labs/sprocket.git", branch: "main"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "900f29532e238df4be8d3b87b4c6be773df42df2027aaa38bc0bc685831442ce"
@@ -52,8 +59,8 @@ class Sprocket < Formula
 
     expected = <<~JSON.strip
       {
-        "say_hello.greeting": "String",
-        "say_hello.name": "String"
+        "say_hello.greeting": "String <REQUIRED>",
+        "say_hello.name": "String <REQUIRED>"
       }
     JSON
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`sprocket` is autobumped but the workflow failed to update to version 0.18.0 because livecheck is incorrectly returning 0.19.0 as newest (from a `wdl-v0.19.0` tag). This updates the version and adds a `livecheck` block that restricts matching to tags like `v0.18.0`.

Upstream uses a Git submodule for `crankshaft`, so this updates the formula to check out the Git tag. If there's a better way to handle this (e.g., adding `crankshaft` as a resource), do let me know. Besides that, the test output has slightly changed, so I updated the test string accordingly.