### PR TITLE
libxmlsec1 1.3.8

### DIFF
--- a/Formula/lib/libxmlsec1.rb
+++ b/Formula/lib/libxmlsec1.rb
@@ -1,14 +1,16 @@
 class Libxmlsec1 < Formula
   desc "XML security library"
   homepage "https://www.aleksey.com/xmlsec/"
-  url "https://www.aleksey.com/xmlsec/download/xmlsec1-1.3.7.tar.gz"
-  mirror "https://github.com/lsh123/xmlsec/releases/download/1.3.7/xmlsec1-1.3.7.tar.gz"
-  sha256 "d82e93b69b8aa205a616b62917a269322bf63a3eaafb3775014e61752b2013ea"
+  url "https://www.aleksey.com/xmlsec/download/xmlsec1-1.3.8.tar.gz"
+  mirror "https://github.com/lsh123/xmlsec/releases/download/1.3.8/xmlsec1-1.3.8.tar.gz"
+  sha256 "d0180916ae71be28415a6fa919a0684433ec9ec3ba1cc0866910b02e5e13f5bd"
   license "MIT"
 
+  # Checking the first-party download page persistently fails in the autobump
+  # environment, so we check GitHub releases as a workaround.
   livecheck do
-    url "https://www.aleksey.com/xmlsec/download/"
-    regex(/href=.*?xmlsec1[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url "https://github.com/lsh123/xmlsec"
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/lib/libxmlsec1.rb
+++ b/Formula/lib/libxmlsec1.rb
@@ -14,14 +14,12 @@ class Libxmlsec1 < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "f26847eb1c512aa63d535a25508ad6305a84aec698cc47d9293d9e525753b397"
-    sha256 cellar: :any,                 arm64_sequoia: "dd0bd557a369d063dd16612dde3a3a673aea225376db8ee674cdb97867bff28c"
-    sha256 cellar: :any,                 arm64_sonoma:  "e1b1f314c2c9d2aa76755bfa33a8f4018455cb697110e8718d5044e3452b0183"
-    sha256 cellar: :any,                 arm64_ventura: "d4b92a70262c9ba01a7ec1956bee5c677de07ccae16b86f1f9e4d5cadb94b0f2"
-    sha256 cellar: :any,                 sonoma:        "ab66efc3b6fb18b9f00d8fbacebba05c6299a0af4ffd6bbfd0bc2c1ac0617b19"
-    sha256 cellar: :any,                 ventura:       "8a5ac37287e46fb1b50a11b99a802b095feb1664bf86e92fae1757a809f985ee"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "251a6cf05aa3f3dcf207029f3ce9b17a93f02d201701dba8c9724696f4e5eb73"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "091ee1ac09d65ac2cfab2f1695366534a65e6c8f304782136de299001b6291a5"
+    sha256 cellar: :any,                 arm64_tahoe:   "fc7d7f2bdede18efca4297314a9ce6ed38cc9e0d1bbd5646d8cfa3e99847b1ed"
+    sha256 cellar: :any,                 arm64_sequoia: "c815906d815893e06f8e3e2c4b99a46d4bbd12f01d62191a0bbef2ca9cf3568b"
+    sha256 cellar: :any,                 arm64_sonoma:  "d7440efc573def202b718f37cc69338e747b8914bed4638214771791460b294c"
+    sha256 cellar: :any,                 sonoma:        "4b63d45886511b343d73532455211bbf49455afa4c0dae05d528ae07f3c19122"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "bfeb5578368bd4658c125d80191f9beac3f8c490c037b4467b924d9189cbe099"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d0b86a2aecd40e0bf2758a9e714aac9278195796425644a5e08e508a263c472a"
   end
 
   depends_on "pkgconf" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`libxmlsec1` is autobumped but the workflow failed to update to version 1.3.8 because livecheck gave an "Unable to get versions" error in the autobump run. This manually updates the version.

The livecheck error appears to be a persistent failure in the autobump environment, so this also updates the `livecheck` block to check GitHub releases as a workaround.