### PR TITLE
libptytty: add livecheck

### DIFF
--- a/Formula/lib/libptytty.rb
+++ b/Formula/lib/libptytty.rb
@@ -5,6 +5,11 @@ class Libptytty < Formula
   sha256 "8033ed3aadf28759660d4f11f2d7b030acf2a6890cb0f7926fb0cfa6739d31f7"
   license "GPL-2.0-or-later"
 
+  livecheck do
+    url "https://dist.schmorp.de/libptytty/"
+    regex(/href=.*?libptytty[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "5a8043eb470230c18db586ab547552e89aa343c13f3d101df7a8ddfb8ef2cd2f"
     sha256 cellar: :any,                 arm64_sequoia: "e04e49991b1e9e2df45463c865a99ba056d15bb854b30342955741b4be83bfae"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck is unable to check `libptytty` and returns an `Unable to get versions` error. This adds a `livecheck` block that checks the directory listing page where the `stable` tarball is found, as the homepage links to this as the source for release files.