### PR TITLE
pypy3.10: update livecheck

### DIFF
--- a/Formula/p/pypy3.10.rb
+++ b/Formula/p/pypy3.10.rb
@@ -9,7 +9,7 @@ class Pypy310 < Formula
 
   livecheck do
     url "https://downloads.python.org/pypy/"
-    regex(/href=.*?pypy3(?:\.\d+)*[._-]v?(\d+(?:\.\d+)+)-src\.t/i)
+    regex(/href=.*?pypy3\.10[._-]v?(\d+(?:\.\d+)+)-src\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `pypy3.10` only restricts matching to 3.x Python versions but this formula is specifically intended for 3.10. This worked fine for a period of time but now livecheck is returning 7.3.20 as newest and there aren't assets for Python 3.10 (only 3.11), so this isn't an appropriate version for this formula. This updates the `livecheck` block regex to only match versions from tarballs for Python 3.10, so it correctly returns 7.3.19 as the latest version.