### PR TITLE
catb.org formulae: update livecheck

### DIFF
--- a/Formula/a/ascii.rb
+++ b/Formula/a/ascii.rb
@@ -5,9 +5,14 @@ class Ascii < Formula
   sha256 "ed2fdc973e1b87da2af83050e560e731b0f3bf5f6b4fd9babc9f60bb2b992443"
   license "BSD-2-Clause"
 
+  # The homepage links to the `stable` tarball but it can take longer than the
+  # ten second livecheck timeout, so we check the Git tags as a workaround.
   livecheck do
-    url :homepage
-    regex(/ascii[._-]v?(\d+(?:\.\d+)+)/i)
+    url :head
+    regex(/^v?(\d+(?:[.-]\d+)+)$/i)
+    strategy :git do |tags, regex|
+      tags.filter_map { |tag| tag[regex, 1]&.tr("-", ".") }
+    end
   end
 
   bottle do

--- a/Formula/c/cvs-fast-export.rb
+++ b/Formula/c/cvs-fast-export.rb
@@ -5,9 +5,11 @@ class CvsFastExport < Formula
   sha256 "841c60d9af70ca260fec572f2ef08ed523314f6cacfda40bb44dacb9dbcda841"
   license "GPL-2.0-or-later"
 
+  # The homepage links to the `stable` tarball but it can take longer than the
+  # ten second livecheck timeout, so we check the Git tags as a workaround.
   livecheck do
-    url :homepage
-    regex(/href=.*?cvs-fast-export[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url :head
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do

--- a/Formula/d/deheader.rb
+++ b/Formula/d/deheader.rb
@@ -7,9 +7,11 @@ class Deheader < Formula
   sha256 "553fd064a0e46ff5a88efd121e68d7613c5ffa405d1e7f775ce03111eae30882"
   license "BSD-2-Clause"
 
+  # The homepage links to the `stable` tarball but it can take longer than the
+  # ten second livecheck timeout, so we check the Git tags as a workaround.
   livecheck do
-    url :homepage
-    regex(/href=.*?deheader[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url :head
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   no_autobump! because: :requires_manual_review

--- a/Formula/o/open-adventure.rb
+++ b/Formula/o/open-adventure.rb
@@ -8,9 +8,11 @@ class OpenAdventure < Formula
   license "BSD-2-Clause"
   head "https://gitlab.com/esr/open-adventure.git", branch: "master"
 
+  # The homepage links to the `stable` tarball but it can take longer than the
+  # ten second livecheck timeout, so we check the Git tags as a workaround.
   livecheck do
-    url :homepage
-    regex(/href=.*?advent[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url :head
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do

--- a/Formula/s/showkey.rb
+++ b/Formula/s/showkey.rb
@@ -6,9 +6,14 @@ class Showkey < Formula
   license "MIT"
   head "https://gitlab.com/esr/showkey.git", branch: "master"
 
+  # The homepage links to the `stable` tarball but it can take longer than the
+  # ten second livecheck timeout, so we check the Git tags as a workaround.
   livecheck do
-    url :homepage
-    regex(/showkey[._-]v?(\d+(?:\.\d+)+)/i)
+    url :head
+    regex(/^v?(\d+(?:[.-]\d+)+)$/i)
+    strategy :git do |tags, regex|
+      tags.filter_map { |tag| tag[regex, 1]&.tr("-", ".") }
+    end
   end
 
   bottle do

--- a/Formula/s/ski.rb
+++ b/Formula/s/ski.rb
@@ -7,6 +7,16 @@ class Ski < Formula
   sha256 "aaff38e0f6a2c789f2c1281871ecc4d3f4e9b14f938a6d3bf914b4285bbdb748"
   license "BSD-2-Clause"
 
+  # The homepage links to the `stable` tarball but it can take longer than the
+  # ten second livecheck timeout, so we check the Git tags as a workaround.
+  livecheck do
+    url :head
+    regex(/^v?(\d+(?:[.-]\d+)+)$/i)
+    strategy :git do |tags, regex|
+      tags.filter_map { |tag| tag[regex, 1]&.tr("-", ".") }
+    end
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "14141d2ba391efd4932d5c119c2429abb66f8ef243bc0b22fcf9b71f717be9aa"
   end

--- a/Formula/s/src.rb
+++ b/Formula/s/src.rb
@@ -5,9 +5,11 @@ class Src < Formula
   sha256 "5dc9302b161582149dbc191a0eeee43142b96386a542c870d56ac9fddb995d25"
   license "BSD-2-Clause"
 
+  # The homepage links to the `stable` tarball but it can take longer than the
+  # ten second livecheck timeout, so we check the Git tags as a workaround.
   livecheck do
-    url :homepage
-    regex(/href=.*?src[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url :head
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do

--- a/Formula/w/wumpus.rb
+++ b/Formula/w/wumpus.rb
@@ -5,9 +5,11 @@ class Wumpus < Formula
   sha256 "aa059e163b4f516580b83931ae29fbd5796302e854da283b85cc7fc887677d7c"
   license "BSD-2-Clause"
 
+  # The homepage links to the `stable` tarball but it can take longer than the
+  # ten second livecheck timeout, so we check the Git tags as a workaround.
   livecheck do
-    url :homepage
-    regex(/href=.*?wumpus[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url :head
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do
@@ -19,6 +21,11 @@ class Wumpus < Formula
     sha256 cellar: :any_skip_relocation, ventura:        "6e1866abf23ccf0920311248107cfacd4da35d2081903ade4bde1c7879c4f711"
     sha256 cellar: :any_skip_relocation, monterey:       "1ceb6248fd61580bb9c99ab1833503cad88c84daf4816771cfdc96f087755fa0"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "63f9a87dd8a82fc0bf2969cedfca5dd336e0e3575d6792bf3d8e19e6f3506332"
+  end
+
+  head do
+    url "https://gitlab.com/esr/wumpus.git", branch: "master"
+    depends_on "asciidoctor" => :build
   end
 
   # checksum got changed and no response from upstream, https://gitlab.com/esr/wumpus/-/issues/2


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` blocks for formulae with a catb.org homepage only work intermittently because the upstream server can take longer than the ten-second livecheck timeout. This updates these `livecheck` blocks to check the Git tags from the `head` repository as a workaround. Ideally we would continue to check the homepages (as they link to the `stable` tarball) but it's too slow and flaky right now and I've been seeing related livecheck errors in the autobump log.

For what it's worth, this omits `intercal`, as it's already checking the `head` repository tags.