### PR TITLE
libunicode: add `gcc` dependency on Linux

### DIFF
--- a/audit_exceptions/linux_only_gcc_dependency_allowlist.json
+++ b/audit_exceptions/linux_only_gcc_dependency_allowlist.json
@@ -1,1 +1,3 @@
-[]
+[
+  "libunicode"
+]


### PR DESCRIPTION
Was thinking we can just provide exception for `libunicode` as a leaf formula.

It will be 1 of 2 formulae that require a newer libstdc++. The other one is `msc-generator` which does not need an audit exception as macOS uses GCC too.

There is also a fixed timeframe we need this for our CI runners, i.e. about 1 year until we decide to move to Ubuntu 24.04.

---

Other changes are due to `brew` now handling `llvm_clang` in std env and automatically prioritizing LLVM on macOS.