### PR TITLE
otterdog: fix missing typing-extensions

### DIFF
--- a/Formula/o/otterdog.rb
+++ b/Formula/o/otterdog.rb
@@ -6,6 +6,7 @@ class Otterdog < Formula
   url "https://files.pythonhosted.org/packages/68/d8/4c1827aa29bc22f4a8f4cb4a755f4505c7e84fc54a6a67e3a5bbd4dc0389/otterdog-1.1.0.tar.gz"
   sha256 "b1dc49d7cd0b4f077aa84d924299412539960cb848efbfbe69d9689adebc4832"
   license "EPL-2.0"
+  revision 1
   head "https://github.com/eclipse-csi/otterdog.git", branch: "main"
 
   # https://github.com/microsoft/playwright-python/issues/2579
@@ -48,13 +49,13 @@ class Otterdog < Formula
   end
 
   resource "aiohttp" do
-    url "https://files.pythonhosted.org/packages/ba/fa/3ae643cd525cf6844d3dc810481e5748107368eb49563c15a5fb9f680750/aiohttp-3.13.1.tar.gz"
-    sha256 "4b7ee9c355015813a6aa085170b96ec22315dabc3d866fd77d147927000e9464"
+    url "https://files.pythonhosted.org/packages/1c/ce/3b83ebba6b3207a7135e5fcaba49706f8a4b6008153b4e30540c982fae26/aiohttp-3.13.2.tar.gz"
+    sha256 "40176a52c186aefef6eb3cad2cdd30cd06e3afbe88fe8ab2af9c0b90f228daca"
   end
 
   resource "aiohttp-client-cache" do
-    url "https://files.pythonhosted.org/packages/7f/5d/f57bab0b5e4854f8cbd323f4b09c84cd1767ed00836af6d62d0445e32242/aiohttp_client_cache-0.14.1.tar.gz"
-    sha256 "af5556f719814aca02db6384271069cec6a67be31a6b7d9437e0a6a9980a494f"
+    url "https://files.pythonhosted.org/packages/29/af/b8e2f6ce10f0f71d675386a785966532a3e72db6d67558bab533f9cdb94a/aiohttp_client_cache-0.14.2.tar.gz"
+    sha256 "d3f4b81204de9dce59894d9ecb9c77a8dfd633d73c920bbcf8a7370650656585"
   end
 
   resource "aiohttp-retry" do
@@ -63,8 +64,8 @@ class Otterdog < Formula
   end
 
   resource "aioshutil" do
-    url "https://files.pythonhosted.org/packages/75/e4/ef86f1777a9bc0c51d50487b471644ae20941afe503591d3a4c86e456dac/aioshutil-1.5.tar.gz"
-    sha256 "2756d6cd3bb03405dc7348ac11a0b60eb949ebd63cdd15f56e922410231c1201"
+    url "https://files.pythonhosted.org/packages/d3/bd/dcea5abb1792269e70cc75d5f9ae9adbdfba0f0d08a207eb788ec3b469b6/aioshutil-1.6.tar.gz"
+    sha256 "9eae342b9a4cacc2c2c5877877a2d2f7a2b66c62aa1ab57d7e95c8cfd4ede507"
   end
 
   resource "aiosignal" do
@@ -235,6 +236,11 @@ class Otterdog < Formula
   resource "sniffio" do
     url "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz"
     sha256 "f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"
+  end
+
+  resource "typing-extensions" do
+    url "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz"
+    sha256 "0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"
   end
 
   resource "url-normalize" do

--- a/Formula/o/otterdog.rb
+++ b/Formula/o/otterdog.rb
@@ -13,13 +13,12 @@ class Otterdog < Formula
   no_autobump! because: "'playwright' resource lacks PyPI sdist"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_tahoe:   "99257156b6700723367104827453d2e0a2d5462b282f60347aeb89bae0197b4d"
-    sha256 cellar: :any,                 arm64_sequoia: "5f20c8552aaa1072a66810ae512dbd92092aab3c0f1e4df8d948e0fe4d0c98f2"
-    sha256 cellar: :any,                 arm64_sonoma:  "6de91da57b2653adf2ca824839cb9a5d4cf5b685707af6366dbc5f97cb74cf27"
-    sha256 cellar: :any,                 sonoma:        "ecf9448d0afa3f620adf426933e9590dfce2d3fcb5504b4dc8ba856df5881f3e"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "0f4f6de5036111648e2da764c6f8ac7272c4e82d25ead2b5849dc16b94991850"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "ec43bd12f2a973a9448ac8ea8e635cdd32d8a62103f1684cba6cf26c9d86e283"
+    sha256 cellar: :any,                 arm64_tahoe:   "d61eef326e9a480c756c5b88765d359ff5c9e921640199b59b09016996102da4"
+    sha256 cellar: :any,                 arm64_sequoia: "0117b7f162a0825f16f64f03a67144f26f9f541cfa47d7bbd1485f2589e36b08"
+    sha256 cellar: :any,                 arm64_sonoma:  "3d3cfd2483d64e7ac99829078e7a765804b77c74ecca0481c89f9aa7fa78db64"
+    sha256 cellar: :any,                 sonoma:        "03cbe996382869410de116740323dd5ad4c8834ffc4bc2babc5bc50526067177"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "7779baa5c53834ac8ba765a52bd4ac32e433066bc53595b8ec1bad69c49b5beb"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d3b1ffc1b3f9103231e45fda37b3cce4fc41c0e48b030977779e5bdcab3ba862"
   end
 
   depends_on "rust" => :build # for rjsonnet


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Fixes #252164

Looks like this was accidentally omitted when manually excluding `playwright` (which is necessary since there is no sdist)

Plan on reviving https://github.com/Homebrew/brew/pull/17886 to catch these issues
