### PR TITLE
cert_error_allowlist: remove formulae

### DIFF
--- a/audit_exceptions/cert_error_allowlist.json
+++ b/audit_exceptions/cert_error_allowlist.json
@@ -1,13 +1,1 @@
-{
-  "cryptopp": "https://cryptopp.com/",
-  "fibjs": "https://fibjs.org/",
-  "gnuradio": "https://gnuradio.org/",
-  "hashcat": "https://hashcat.net/hashcat/",
-  "libbladerf": "https://nuand.com/",
-  "libogg": "https://www.xiph.org/ogg/",
-  "micropython": "https://www.micropython.org/",
-  "minio": "https://min.io",
-  "monero": "https://www.getmonero.org/",
-  "opusfile": "https://www.opus-codec.org/",
-  "volk": "https://www.libvolk.org/"
-}
+{}


### PR DESCRIPTION
Testing if audit exceptions are still needed. Will remove revision bumps once testing is done.