### PR TITLE
libedit: add `readline` compat symlinks in libexec

### DIFF
--- a/Formula/a/aamath.rb
+++ b/Formula/a/aamath.rb
@@ -30,10 +30,7 @@ class Aamath < Formula
 
   uses_from_macos "bison" => :build # for yacc
   uses_from_macos "flex" => :build
-
-  on_linux do
-    depends_on "readline"
-  end
+  uses_from_macos "libedit" # readline's license is incompatible with GPL-2.0-only
 
   # Fix build on clang; patch by Homebrew team
   # https://github.com/Homebrew/homebrew/issues/23872
@@ -43,6 +40,13 @@ class Aamath < Formula
   end
 
   def install
+    unless OS.mac?
+      inreplace "Makefile" do |s|
+        s.change_make_var! "CFLAGS", "#{s.get_make_var("CFLAGS")} -I#{Formula["libedit"].opt_libexec}/include"
+        s.change_make_var! "LFLAGS", "#{s.get_make_var("LFLAGS")} -L#{Formula["libedit"].opt_libexec}/lib"
+      end
+    end
+
     ENV.deparallelize
     system "make"
 

--- a/Formula/a/aamath.rb
+++ b/Formula/a/aamath.rb
@@ -13,19 +13,13 @@ class Aamath < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:    "e545971fc077cd2ef34f4a2d6c9ecbd3677eaad3c84695c27d7660f27c11e3f5"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "c62dab89088d46d52193768e3dd863939963ca8fbcf2eb67ecfd52c928117dfd"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "38e8b1fcd51f2be7c3b27818ffddf2b4fbf3de14da75b884e57bdbc8b4a3819b"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "0fdc50f0e8165ff7de731e092ddfa57149185bd1c1e1cf463e819645364d25ee"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "e823e4d89ae67660af61746c7472d80f0eb2ea70503471ac1190f9c0c691faf0"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "eec6c9dd0ae3b32b3d2b22ac4cf926c6b3084a41623361762a4c0a297dc05286"
-    sha256 cellar: :any_skip_relocation, sonoma:         "35be127036f118e9d0842c7cf9cf93bb306a51b9ce06a87e586805b7fa2b714c"
-    sha256 cellar: :any_skip_relocation, ventura:        "1edd59508421089d629ab153c03d9db3c5e0e3cad0a75d3baea36b533a5b1d0a"
-    sha256 cellar: :any_skip_relocation, monterey:       "58065a231153b1971495d1d07c7d68740a1e7ca51ff95d8c8684ab511aaa4ab7"
-    sha256 cellar: :any_skip_relocation, big_sur:        "588a5ccb517b6d41a4f323f7a376cd9a34e4d0d447baf15179c05fbbf2c0e588"
-    sha256 cellar: :any_skip_relocation, catalina:       "1ac1413ef0322b280ae5bd5663373ed959ee54d28dbdd3261fc4da6e57abf44c"
-    sha256 cellar: :any_skip_relocation, arm64_linux:    "720220ff8348613058bb9d4ef1cf87bea850c513e721906a37a406136e6d2327"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f803d33b088e251eba9820706307616a771dea7d2994818a8fc36aca85af0541"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "587054f7e1107e61554956c8ba147c9560af1e7138547651ba82d32464c0862c"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "7fb04795cf214c974e4e45cb8c369dad3232624dd070641a4f408808fbd98d3b"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "04bc9d4ebf6c7eb4e4634f79fdd297aa57c87d570f0e3f6937c9bf104d0c0f2a"
+    sha256 cellar: :any_skip_relocation, sonoma:        "56c65eaae7db0c86ca690b79cde6894c281877f00c18965975b4e4fd91b4fe71"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "912312e5d565a7255691d9cff437f1e66419054dc75365cda3af747ef5bf5c6f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "79b5ff4704b7f8393182ee3b68f5343a745e5e62ad4b2db90b3b4f28c186ae52"
   end
 
   uses_from_macos "bison" => :build # for yacc

--- a/Formula/lib/libedit.rb
+++ b/Formula/lib/libedit.rb
@@ -5,6 +5,7 @@ class Libedit < Formula
   version "20251016-3.1"
   sha256 "21362b00653bbfc1c71f71a7578da66b5b5203559d43134d2dd7719e313ce041"
   license "BSD-3-Clause"
+  revision 1
 
   livecheck do
     url :homepage
@@ -25,10 +26,17 @@ class Libedit < Formula
   uses_from_macos "ncurses"
 
   def install
-    system "./configure", "--disable-dependency-tracking",
-                          "--disable-silent-rules",
-                          "--prefix=#{prefix}"
+    system "./configure", "--disable-silent-rules", *std_configure_args
     system "make", "install"
+
+    # Create readline compatibility symlinks for use by license incompatible
+    # software. We put these in libexec to avoid conflict with readline.
+    # Similar to https://packages.debian.org/sid/libeditreadline-dev
+    %w[history readline].each do |libname|
+      (libexec/"include/readline").install_symlink include/"editline/readline.h" => "#{libname}.h"
+      (libexec/"lib").install_symlink lib/shared_library("libedit") => shared_library("lib#{libname}")
+      (libexec/"lib").install_symlink lib/"libedit.a" => "lib#{libname}.a"
+    end
   end
 
   test do

--- a/Formula/lib/libedit.rb
+++ b/Formula/lib/libedit.rb
@@ -13,12 +13,12 @@ class Libedit < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "b7908d3b0cb2d06c816ad380e8b968d9a733d8d2715d3efee37d30c84859b97f"
-    sha256 cellar: :any,                 arm64_sequoia: "130c26a65749e81d3dc981db8886115e7203062b0fc4c44d23916c318294c67e"
-    sha256 cellar: :any,                 arm64_sonoma:  "601a2ed57d0c8465f70e33c7b70f5955e836fe7f6beac6472fe74375b1a1c092"
-    sha256 cellar: :any,                 sonoma:        "a974fd48c78b24aff3b5e1dd4abc5edc7976dbb7e8f8ad155c5ab396f0603e4c"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "ea2ad9305e5d9c9e0c78631c9673aa7f027afeee465e149ef988e9f750ede779"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "72a509c156cd1752a7b4e5bfee1c1d63e491c166f8871879f93958df06ce3ae6"
+    sha256 cellar: :any,                 arm64_tahoe:   "2957d416dfdc8c58a1dd666669d3c7d1330ba15ededc2438a4de3059ca8ec20b"
+    sha256 cellar: :any,                 arm64_sequoia: "510068e4f21502b89b2c659b098f0f1a3adfa6e30e7cd77ec5389e78038026d9"
+    sha256 cellar: :any,                 arm64_sonoma:  "ff578f10a3f9bd4c183f97578b0e92893d27a1fdcdd3093ddb7bff44d4e61416"
+    sha256 cellar: :any,                 sonoma:        "a875f674adab029105a001dda7a43dbe44544887d73caad16a48cf7c51cacc4e"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "e61d1403b27ad966a5aafaafafd2db88aace8c717d57aa561df5f7b6d1f1fc69"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a0e22aa9e7d09e78d35b2a97e87747271a8651f7eabe4d0e424756939718dfe2"
   end
 
   keg_only :provided_by_macos

--- a/Formula/r/rolldice.rb
+++ b/Formula/r/rolldice.rb
@@ -23,9 +23,7 @@ class Rolldice < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "c528a9c75ae75ef5bf9c28db1b40cd8e30fee54029580bbd05c7b5cbc8449936"
   end
 
-  on_linux do
-    depends_on "readline"
-  end
+  uses_from_macos "libedit" # readline's license is incompatible with GPL-2.0-only
 
   # Submitted upstream at https://github.com/sstrickl/rolldice/pull/25
   # Remove if merged and included in a tagged release
@@ -35,6 +33,11 @@ class Rolldice < Formula
   end
 
   def install
+    unless OS.mac?
+      ENV.append_to_cflags "-I#{Formula["libedit"].opt_libexec}/include"
+      ENV.append "LDFLAGS", "-L#{Formula["libedit"].opt_libexec}/lib"
+    end
+
     system "make", "CC=#{ENV.cc}"
     bin.install "rolldice"
     man6.install Utils::Gzip.compress("rolldice.6")

--- a/Formula/r/rolldice.rb
+++ b/Formula/r/rolldice.rb
@@ -8,19 +8,13 @@ class Rolldice < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:    "5f9da4c5edfa67e45b7e2b77f52e20ce2cb11e66abe7edaebff7bb43ec20711f"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "f0b8ac560f934b0d4559fc18471a9fabba189ee9d41e050c03b88c6e56490054"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "4d805d84d6f2e3083c040c4e3c650009d34516e949c351e1d85a5906faa2c017"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "adeb468985368ac97a5e5e16a8276ca39a7c87f9615dbab892298e74d3d0f018"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "2fa79795244358b512e08fddb6cc86a27029ce8f14038130ab7fc33b84724f43"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "1feb7522fecad653acb8a6d91152475486f1fa0f19107df1086c7674074a6870"
-    sha256 cellar: :any_skip_relocation, sonoma:         "b241b74db5c976f271a7e32ce87054d1c74ac488e258bd0b152ccd173e544412"
-    sha256 cellar: :any_skip_relocation, ventura:        "3f3fa0150cb26cb71c0df08c79226e1258e738eb6c3f965a491d3e649dbf2b4f"
-    sha256 cellar: :any_skip_relocation, monterey:       "66ee3760def3920ddbeb564ed32f772fe12538c5db6124c7ebd56ef1a82eed97"
-    sha256 cellar: :any_skip_relocation, big_sur:        "65289049d189acb12af84edb62fb1fb5b0e8faa55931176aa4430d4442e28cdb"
-    sha256 cellar: :any_skip_relocation, catalina:       "a3fec25c1ccaf264a80a81f276aabf54cea670f3e88a48a40c7ffa9c7942bad4"
-    sha256 cellar: :any_skip_relocation, arm64_linux:    "f9367e489792cd6941e69ab7633fc40c8b6c5c964dd02b0e6f90d592eef26656"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c528a9c75ae75ef5bf9c28db1b40cd8e30fee54029580bbd05c7b5cbc8449936"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "09a28787c7477eadf288aa7a5ae71453ad26dd4625bb10f16fc018268a30d3ab"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "031af343a052cfcf699f759e5437a87deb519e69a4a5e6eefb321b9e2e1076bf"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "1d08c666a00ef58322bc11b9082b063330b818186a6f6fb06ef65e92b599ed96"
+    sha256 cellar: :any_skip_relocation, sonoma:        "9d31227c05f614fa803c1de1beba50ad7eafa06ac6f32afd8cf84af2798e778c"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "ebac82e928ab9231e039a3081c30662038cb584b9f3fb8bbca4c6eaa380440c5"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "92a41852d00239f7c3874e32f8cf7da6f8053a9ae0ddd906dd6e1f2c5da4176f"
   end
 
   uses_from_macos "libedit" # readline's license is incompatible with GPL-2.0-only


### PR DESCRIPTION
Same reason as Debian's compat package https://packages.debian.org/sid/libeditreadline-dev
> GNU readline changed its license from GPL-2 to GPL-3 with version 6, which excludes GPL-2-only programs from using current readline versions

However, I only added files to libexec rather than creating a new formula as it avoids unwanted mixing when both `readline` and compat formula is in dependency tree. Compat symlinks should be opt-in and should not be prioritized over `readline` dependency.

---

Note that this is not as compatible as Xcode's libedit. Apple seems to have modified functions to match `readline` which provides better drop-in support.