### PR TITLE
zssh: disable `readline` due to incompatible license

### DIFF
--- a/Formula/z/zssh.rb
+++ b/Formula/z/zssh.rb
@@ -33,18 +33,18 @@ class Zssh < Formula
   depends_on "libtool"  => :build
   depends_on "lrzsz"
 
-  on_linux do
-    depends_on "readline"
-  end
-
   def install
     # Workaround for Xcode 15
     ENV.append_to_cflags "-Wno-incompatible-function-pointer-types" if DevelopmentTools.clang_build_version >= 1500
 
     rm_r "lrzsz-0.12.20"
 
+    # NOTE: readline must be disabled as the license is incompatible with GPL-2.0-only,
+    # https://www.gnu.org/licenses/gpl-faq.html#AllCompatibility
+    args = ["--disable-readline"] if OS.linux?
+
     system "autoreconf", "--force", "--install", "--verbose"
-    system "./configure", *std_configure_args
+    system "./configure", *args, *std_configure_args
     system "make"
 
     bin.install "zssh", "ztelnet"

--- a/Formula/z/zssh.rb
+++ b/Formula/z/zssh.rb
@@ -13,19 +13,13 @@ class Zssh < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:    "c1ebd8cd9ef8b9656a8ceb87c3ed618fa97d853e355c3f0d9fe706499053e759"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "ef79ef8cbe611003a77f4b5e4728dbce1e2916ea6aa1d34054d495d6b35d043c"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "b16fd704253185960f793a025ef7fe510186de420f653602946319d94893b302"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "c89cb5197c40525efecccb42fb351668392d9c425742450896e4ecdc46b59587"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "4450134a2610b41d037efaf910d6ccdf2cc6d836887b877337f91bf73d49f44c"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "9b567d08589f3ba595994ca4906bfde9fe2651ef246bbd872f332e9cc8993a60"
-    sha256 cellar: :any_skip_relocation, sonoma:         "03cb8f6eea5ed39cc82de6d173e5eff34986fa1821a28e52db61d0c70abb1df1"
-    sha256 cellar: :any_skip_relocation, ventura:        "3168f9fb757fefc2c5ab7a5382a6fac4e489963324f9d57da667596769882713"
-    sha256 cellar: :any_skip_relocation, monterey:       "9387acd7dec913faa9917b3d27baaff250a412ecd509eba625543d188c6922a9"
-    sha256 cellar: :any_skip_relocation, big_sur:        "54bb3ff51405eda0900361c829fad63f988c21e685645fe5c8076c456567bd0b"
-    sha256 cellar: :any_skip_relocation, catalina:       "6b9bce24c13dd2e979cdae57892e1b595bfcbd1d342bb81419dda378b8439495"
-    sha256 cellar: :any_skip_relocation, arm64_linux:    "4cd6fe33f62e215d3a06ad134b2081f627d4be3ff13bb734484019fb948f59da"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "fb3265fd04dd6210c8706f04435d145e0941a50793aaccf7e1660b2956c1872c"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "bf52245597c50c4d6d826e9be5a239ba19ac959c304ef69d75f9240092453128"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "7f263234cd88fe188d247aaaf24e7d64e8cf990bbf671c0e98b96801710a3c2c"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "762936295a2235c95c7a274daaf3e8b86c6154a2c17f272d852c3a951557f4de"
+    sha256 cellar: :any_skip_relocation, sonoma:        "0e88312f111f00dc479f90c1a317f7ceaa0aff00a6d6b7b24114a1952ceca529"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "da32e62bd2610001f40c5e4e4ea30571f772a5198abebb78df5adbb8378218bd"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d0550b13ce3b5a29c94c0124f03ac8dffbe76455395172d9b35b00f4c8328068"
   end
 
   depends_on "autoconf" => :build


### PR DESCRIPTION
Can keep on macOS as system `libedit` has modifications that improve compatibility with `readline`. On Linux with brew `libedit`, it fails
```
completion.c:56:40: error: ‘CPPFunction’ undeclared (first use in this function)
```

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
