### PR TITLE
cloudformation-cli: use brewed `pydantic-core`

### DIFF
--- a/Formula/c/cloudformation-cli.rb
+++ b/Formula/c/cloudformation-cli.rb
@@ -9,13 +9,13 @@ class CloudformationCli < Formula
   revision 3
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_tahoe:   "a72ab2ffe671cb4743d7945617cb2a00bf3adba93bdd3d321f8fdfa627d92ff2"
-    sha256 cellar: :any,                 arm64_sequoia: "1a7e580f9901efcee922d0fb95de231a24c1504db8f171ea5b7faf29fb1078b2"
-    sha256 cellar: :any,                 arm64_sonoma:  "fee5f8f28c999f3e79c4c3645f0fb024bb35515eef89d8f6b034eedeb77561d0"
-    sha256 cellar: :any,                 sonoma:        "33e9919c592c5e023a63b172de9b41d050e3a7089d67e2f9db936c1ad2780b71"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "6a05b76c1e4ba46322182325647659d4dd4455fb2c7696e429a3a74ce7caffad"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c30785238da87286c174afe43a8bb038a3c9d0dc5ce180a08317e99c2c4ae3f5"
+    rebuild 2
+    sha256 cellar: :any,                 arm64_tahoe:   "3239476c905659510cb4b67e5ea97306b3be8aeffbac70282da8e049d9374f70"
+    sha256 cellar: :any,                 arm64_sequoia: "61a3f9aebfb554021954b8d7edfb112f180e80e42a2f53666ab6309fbbde335e"
+    sha256 cellar: :any,                 arm64_sonoma:  "1a4ff6f73426611cbb960f356a993bcd946432b71864d89b7b0f0adaeb75eec4"
+    sha256 cellar: :any,                 sonoma:        "4e95865fb03ee41895af8ec1f636c89b8693570adc987685d592a03251ce3cbf"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "f2a2bf5c017a3c27af177e9816d096d22a13829ab57c1ee2ce4ff53307465b1b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d7a3b70c6851a3e92cc58ad453187675c19c5a520e04d774c885e0130a967023"
   end
 
   depends_on "go" => :test

--- a/Formula/c/cloudformation-cli.rb
+++ b/Formula/c/cloudformation-cli.rb
@@ -18,13 +18,13 @@ class CloudformationCli < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "c30785238da87286c174afe43a8bb038a3c9d0dc5ce180a08317e99c2c4ae3f5"
   end
 
-  depends_on "rust" => :build # for pydantic
   depends_on "go" => :test
-  depends_on "certifi"
+  depends_on "certifi" => :no_linkage
   depends_on "libyaml"
+  depends_on "pydantic-core" => :no_linkage
   depends_on "python@3.14"
 
-  pypi_packages exclude_packages: "certifi",
+  pypi_packages exclude_packages: ["certifi", "pydantic-core"],
                 extra_packages:   %w[cloudformation-cli-go-plugin cloudformation-cli-java-plugin
                                      cloudformation-cli-python-plugin setuptools]
 
@@ -44,13 +44,13 @@ class CloudformationCli < Formula
   end
 
   resource "boto3" do
-    url "https://files.pythonhosted.org/packages/50/d8/a279c054e0c9731172f05b3d118f3ffc9d74806657f84fc0c93c42d1bb5d/boto3-1.40.55.tar.gz"
-    sha256 "27e35b4fa9edd414ce06c1a748bf57cacd8203271847d93fc1053e4a4ec6e1a9"
+    url "https://files.pythonhosted.org/packages/08/d2/e508e5f42dc1c8a7412f5170751e626a18ed32c6e95c5df30bde6c5addf1/boto3-1.40.64.tar.gz"
+    sha256 "b92d6961c352f2bb8710c9892557d4b0e11258b70967d4e740e1c97375bcd779"
   end
 
   resource "botocore" do
-    url "https://files.pythonhosted.org/packages/a4/92/dce4842b2e215d213d34b064fcdd13c6a782c43344e77336bcde586e9229/botocore-1.40.55.tar.gz"
-    sha256 "79b6472e2de92b3519d44fc1eec8c5feced7f99a0d10fdea6dc93133426057c1"
+    url "https://files.pythonhosted.org/packages/c1/15/109cb31c156a64bfaf4c809d2638fd95d8ba39b6deb7f1d0526c05257fd7/botocore-1.40.64.tar.gz"
+    sha256 "a13af4009f6912eafe32108f6fa584fb26e24375149836c2bcaaaaec9a7a9e58"
   end
 
   resource "cfn-flip" do
@@ -59,8 +59,8 @@ class CloudformationCli < Formula
   end
 
   resource "cfn-lint" do
-    url "https://files.pythonhosted.org/packages/cd/3e/0e653b305bf8f77d377943e7294176bdc4b1db9d29c989c1cc6255f7ac40/cfn_lint-1.40.2.tar.gz"
-    sha256 "5822b2c90f7f2646823a47db9df7a60c23df46bbac34b2081d8a0b3b806c91eb"
+    url "https://files.pythonhosted.org/packages/68/d3/daf6b773ac204ac34e3a06b16dc6667ba4d1cd6cbd046b90ad28cc635936/cfn_lint-1.40.3.tar.gz"
+    sha256 "3f51f7fc66be9a31762d17f821839b32071a891e2d71ed6ab33dbc71a4dec938"
   end
 
   resource "charset-normalizer" do
@@ -99,8 +99,8 @@ class CloudformationCli < Formula
   end
 
   resource "hypothesis" do
-    url "https://files.pythonhosted.org/packages/de/13/a4f29624db4d88811d6c4b7708769180004b26f5a2ee6e8a2e8c605da5da/hypothesis-6.142.1.tar.gz"
-    sha256 "3179cb08756562c526aaf4a9871ebbff83d2d75c03896ed0bc9c1d14097a930c"
+    url "https://files.pythonhosted.org/packages/e5/31/24e8be99d813060a7ab522458fcd843c75a8c0654a8a8996554526af6480/hypothesis-6.142.5.tar.gz"
+    sha256 "7bb5ed8ec3b6ea0c5d2fe92316cc123d7cf9a5f472099a25dc25476e0d3a356c"
   end
 
   resource "idna" do
@@ -109,8 +109,8 @@ class CloudformationCli < Formula
   end
 
   resource "iniconfig" do
-    url "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz"
-    sha256 "3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7"
+    url "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz"
+    sha256 "c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730"
   end
 
   resource "jinja2" do
@@ -178,11 +178,6 @@ class CloudformationCli < Formula
     sha256 "1da1c82b0fc140bb0103bc1441ffe062154c8d38491189751ee00fd8ca65ce74"
   end
 
-  resource "pydantic-core" do
-    url "https://files.pythonhosted.org/packages/df/18/d0944e8eaaa3efd0a91b0f1fc537d3be55ad35091b6a87638211ba691964/pydantic_core-2.41.4.tar.gz"
-    sha256 "70e47929a9d4a1905a67e4b687d5946026390568a8e952b92824118063cee4d5"
-  end
-
   resource "pygments" do
     url "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz"
     sha256 "636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"
@@ -219,8 +214,8 @@ class CloudformationCli < Formula
   end
 
   resource "regex" do
-    url "https://files.pythonhosted.org/packages/49/d3/eaa0d28aba6ad1827ad1e716d9a93e1ba963ada61887498297d3da715133/regex-2025.9.18.tar.gz"
-    sha256 "c5ba23274c61c6fef447ba6a39333297d0c247f53059dba0bca415cac511edc4"
+    url "https://files.pythonhosted.org/packages/f8/c8/1d2160d36b11fbe0a61acb7c3c81ab032d9ec8ad888ac9e0a61b85ab99dd/regex-2025.10.23.tar.gz"
+    sha256 "8cbaf8ceb88f96ae2356d01b9adf5e6306fa42fa6f7eab6b97794e37c959ac26"
   end
 
   resource "requests" do
@@ -261,11 +256,6 @@ class CloudformationCli < Formula
   resource "types-dataclasses" do
     url "https://files.pythonhosted.org/packages/4b/6a/dec8fbc818b1e716cb2d9424f1ea0f6f3b1443460eb6a70d00d9d8527360/types-dataclasses-0.6.6.tar.gz"
     sha256 "4b5a2fcf8e568d5a1974cd69010e320e1af8251177ec968de7b9bb49aa49f7b9"
-  end
-
-  resource "typing-extensions" do
-    url "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz"
-    sha256 "0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"
   end
 
   resource "typing-inspection" do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

During test step, I found a warning

```
/opt/homebrew/Cellar/cloudformation-cli/0.2.39_3/libexec/lib/python3.14/site-packages/samtranslator/compat.py:2: UserWarning: Core Pydantic V1 functionality isn't compatible with Python 3.14 or greater.
  from pydantic import v1 as pydantic
```

where the warning from `aws-sam-translator` resource. It uses `pydantic` v1 api and it  may be fine for basic models but could fail silently with Python 3.14.

- https://github.com/aws/serverless-application-model/issues/3831
- https://github.com/pydantic/pydantic/issues/12363

Maybe we have to roll back but need feedback.
- `chatblade` is similar situation with outdated `openai` resource.
- `pieces-cli` too

