### PR TITLE
workflows/triage: long/self-hosted tests for `python@3.14`

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -365,7 +365,7 @@ jobs:
                 p11-kit|\
                 pango|\
                 pcre2|\
-                python@3.13|\
+                python@3.14|\
                 rav1e|\
                 rust|\
                 sdl2|\
@@ -425,7 +425,7 @@ jobs:
                 libva|\
                 libxml2|\
                 openssl@3|\
-                python@3.13|\
+                python@3.14|\
                 wayland-protocols|\
                 zlib|\
                 ).rb"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

We've now mostly migrated to 3.14 (~[51 formulae](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-core+%2Fdepends_on+%22python%403.13%22%2F&type=code) still use 3.13) so just updating the long test labels
