### PR TITLE
macvim: sign and use correct runtime entitlements

### DIFF
--- a/Formula/m/macvim.rb
+++ b/Formula/m/macvim.rb
@@ -25,10 +25,11 @@ class Macvim < Formula
   no_autobump! because: :incompatible_version_format
 
   bottle do
-    sha256 cellar: :any, arm64_tahoe:   "080aafdee7b089bdb764625f0ac7a19c69c17263b15c579298ed349425069952"
-    sha256 cellar: :any, arm64_sequoia: "7411602e3e72396de784580bd449c590df25137ec2071c412eb03dc29a85cfe2"
-    sha256 cellar: :any, arm64_sonoma:  "c7550a62ad426be5c7fbb149d848dd139227ea0b3cb51174bbe7219cddb6736f"
-    sha256 cellar: :any, sonoma:        "c8adcf1e753a966f80166c98c684a45518c10e7315e95195b6da26b544f46542"
+    rebuild 1
+    sha256 cellar: :any, arm64_tahoe:   "eae0d53565e43eeeb5995fd9dcd15dba9dd7b7126abfeca9223d5d527c73a552"
+    sha256 cellar: :any, arm64_sequoia: "88149d3fd08c35a282e1e402bcf7f04b4937ed0b9aba409695381ab1dd9d7185"
+    sha256 cellar: :any, arm64_sonoma:  "13baf6a9fcfae5fc9bece16bbc64088c27c83cd0f5dc97c1a65b2f9f28e59304"
+    sha256 cellar: :any, sonoma:        "6298c5dcc4a8d214897c44d192d1f802f88bb3fc05d7d85ebf0bd9fb83a457d1"
   end
 
   depends_on "gettext" => :build

--- a/Formula/m/macvim.rb
+++ b/Formula/m/macvim.rb
@@ -76,6 +76,9 @@ class Macvim < Formula
                           "--with-macarchs=#{Hardware::CPU.arch}"
     system "make"
 
+    # Sign with the correct runtime entitlements
+    system "make", "-C", "src", "macvim-signed-adhoc"
+
     prefix.install "src/MacVim/build/Release/MacVim.app"
     %w[gvimtutor mvim vimtutor xxd].each { |e| bin.install_symlink prefix/"MacVim.app/Contents/bin/#{e}" }
 


### PR DESCRIPTION
By default, Homebrew was building MacVim with a default ad-hoc signature with get-task-allow enabled. This could have security implications as it allows other apps to hook into the app and inspect/interfere with its operation. MacVim has added a new Makefile target specifically for signing the app with the correct runtime hardening and entitlements with an ad-hoc signature. Use it here so Homebrew's version of MacVim has the correct runtime entitlements.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Just for reference, the `macvim-signed-adhoc` target can be found at https://github.com/macvim-dev/macvim/blob/e14eb0c41078d41754d0487d32b126daf3d45914/src/Makefile#L3789. It calls a script called [sign-developer-id](https://github.com/macvim-dev/macvim/blob/master/src/MacVim/scripts/sign-developer-id) to sign the app. I added this target to MacVim for the explicit purpose of allowing package managers like Homebrew to have the same entitlement configuration as the normal binary releases.