### PR TITLE
nss: use optimized ARM64 crypto on Mac

### DIFF
--- a/Formula/n/nss.rb
+++ b/Formula/n/nss.rb
@@ -39,7 +39,7 @@ class Nss < Formula
     cd "nss"
     # Set architecture flags for ARM-based Macs correctly.
     inreplace "coreconf/Darwin.mk", "# Nothing set for arm currently.",
-      "CC += -arch aarch64\nCCC += -arch aarch64\noverride CPU_ARCH	= aarch64"
+      "CC += -arch aarch64\nCCC += -arch aarch64\noverride CPU_ARCH = aarch64"
 
     args = %W[
       BUILD_OPT=1

--- a/Formula/n/nss.rb
+++ b/Formula/n/nss.rb
@@ -4,6 +4,7 @@ class Nss < Formula
   url "https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_117_RTM/src/nss-3.117.tar.gz"
   sha256 "5786b523a2f2e9295ed10d711960d2e33cd620bb80d6288443eda43553a51996"
   license "MPL-2.0"
+  revision 1
 
   livecheck do
     url "https://ftp.mozilla.org/pub/security/nss/releases/"
@@ -33,11 +34,12 @@ class Nss < Formula
   conflicts_with "resty", because: "both install `pp` binaries"
 
   def install
-    # Fails on arm64 macOS for some reason with:
-    #   aes-armv8.c:14:2: error: "Compiler option is invalid"
-    ENV.runtime_cpu_detection if OS.linux? || Hardware::CPU.intel?
+    ENV.runtime_cpu_detection
     ENV.deparallelize
     cd "nss"
+    # Set architecture flags for ARM-based Macs correctly.
+    inreplace "coreconf/Darwin.mk", "# Nothing set for arm currently.",
+      "CC += -arch aarch64\nCCC += -arch aarch64\noverride CPU_ARCH	= aarch64"
 
     args = %W[
       BUILD_OPT=1


### PR DESCRIPTION
By providing the correct flag overrides. Should speed up some crypto operations considerably.

CC @dennisjackson @martinthomson

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
