### PR TITLE
itstool: revision bump (libxml2 2.15.1)

### DIFF
--- a/Formula/i/itstool.rb
+++ b/Formula/i/itstool.rb
@@ -4,7 +4,7 @@ class Itstool < Formula
   url "https://files.itstool.org/itstool/itstool-2.0.7.tar.bz2"
   sha256 "6b9a7cd29a12bb95598f5750e8763cee78836a1a207f85b74d8b3275b27e87ca"
   license "GPL-3.0-or-later"
-  revision 1
+  revision 2
 
   livecheck do
     url "https://itstool.org/download.html"
@@ -15,7 +15,12 @@ class Itstool < Formula
 
   bottle do
     rebuild 6
-    sha256 cellar: :any_skip_relocation, all: "6a85d08730bddc99c0d9b2aef09627193c8b7fcc432a5bdc64fd04da448ee2ad"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "6a85d08730bddc99c0d9b2aef09627193c8b7fcc432a5bdc64fd04da448ee2ad"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "6a85d08730bddc99c0d9b2aef09627193c8b7fcc432a5bdc64fd04da448ee2ad"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "6a85d08730bddc99c0d9b2aef09627193c8b7fcc432a5bdc64fd04da448ee2ad"
+    sha256 cellar: :any_skip_relocation, sonoma:        "6a85d08730bddc99c0d9b2aef09627193c8b7fcc432a5bdc64fd04da448ee2ad"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "6a85d08730bddc99c0d9b2aef09627193c8b7fcc432a5bdc64fd04da448ee2ad"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "6a85d08730bddc99c0d9b2aef09627193c8b7fcc432a5bdc64fd04da448ee2ad"
   end
 
   head do
@@ -25,15 +30,48 @@ class Itstool < Formula
     depends_on "automake" => :build
   end
 
+  depends_on "doxygen" => :build # for libxml2 python bindings
+  depends_on "pkgconf" => :build # for libxml2 python bindings
+  depends_on "python-setuptools" => :build # for libxml2 python bindings
   depends_on "libxml2"
   depends_on "python@3.14"
+
+  # Need deprecated libxml2 python bindings. May switch to lxml in future:
+  # Ref: https://github.com/itstool/itstool/pull/57
+  resource "libxml2" do
+    url "https://download.gnome.org/sources/libxml2/2.15/libxml2-2.15.1.tar.xz"
+    sha256 "c008bac08fd5c7b4a87f7b8a71f283fa581d80d80ff8d2efd3b26224c39bc54c"
+  end
 
   def python3
     "python3.14"
   end
 
   def install
-    ENV.append_path "PYTHONPATH", Formula["libxml2"].opt_prefix/Language::Python.site_packages(python3)
+    resource("libxml2").stage do
+      # We need to insert our include dir first
+      includes = [Formula["libxml2"].opt_include]
+      includes << (OS.mac? ? "#{MacOS.sdk_path_if_needed}/usr/include" : HOMEBREW_PREFIX/"include")
+      inreplace "python/setup.py.in", "includes_dir = [",
+                                      "includes_dir = [#{includes.map { |inc| "'#{inc}'," }.join(" ")}"
+
+      # Run configure to generate setup.py and Doxygen XML
+      system "./configure", "--disable-silent-rules",
+                            "--with-history",
+                            "--with-http",
+                            "--with-icu",
+                            "--with-legacy", # https://gitlab.gnome.org/GNOME/libxml2/-/issues/751#note_2157870
+                            "--with-python",
+                            *std_configure_args(prefix: libexec)
+      system "make", "-C", "doc", "html.stamp"
+
+      # Needed for Python 3.12+.
+      # https://github.com/Homebrew/homebrew-core/pull/154551#issuecomment-1820102786
+      with_env(PYTHONPATH: Pathname.pwd/"python") do
+        system python3, "-m", "pip", "install", *std_pip_args(prefix: libexec), "./python"
+      end
+      ENV.append_path "PYTHONPATH", libexec/Language::Python.site_packages(python3)
+    end
 
     configure = build.head? ? "./autogen.sh" : "./configure"
     system configure, "--prefix=#{libexec}", "PYTHON=#{which(python3)}"

--- a/Formula/i/itstool.rb
+++ b/Formula/i/itstool.rb
@@ -14,13 +14,12 @@ class Itstool < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    rebuild 6
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "6a85d08730bddc99c0d9b2aef09627193c8b7fcc432a5bdc64fd04da448ee2ad"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "6a85d08730bddc99c0d9b2aef09627193c8b7fcc432a5bdc64fd04da448ee2ad"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "6a85d08730bddc99c0d9b2aef09627193c8b7fcc432a5bdc64fd04da448ee2ad"
-    sha256 cellar: :any_skip_relocation, sonoma:        "6a85d08730bddc99c0d9b2aef09627193c8b7fcc432a5bdc64fd04da448ee2ad"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "6a85d08730bddc99c0d9b2aef09627193c8b7fcc432a5bdc64fd04da448ee2ad"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "6a85d08730bddc99c0d9b2aef09627193c8b7fcc432a5bdc64fd04da448ee2ad"
+    sha256 cellar: :any,                 arm64_tahoe:   "716cb0efd44428ef62000438ff166627c117befbdd87b6d9c5580afac54c9dc2"
+    sha256 cellar: :any,                 arm64_sequoia: "8659b398ae66d88d974879a6a4e4372f21b81f7d018b13d9dd10b459e84ddd95"
+    sha256 cellar: :any,                 arm64_sonoma:  "d632addd4bb1f3f422347e9f78d49d5e50d15b7a2479ff197b228082b08c32f2"
+    sha256 cellar: :any,                 sonoma:        "9304cac2b3d4b0ce0cc09134157dcd281536f5ece469dda5f2bff14fbb16c126"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "d6482a8c862c867c1c53bd78c2128c9997d67a0905c700ba05eebbc0417742d6"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8847008ec88f06667281b8517d4a934cf68757cb3b835d2c00a0fe356190f02a"
   end
 
   head do

--- a/Formula/y/yelp-tools.rb
+++ b/Formula/y/yelp-tools.rb
@@ -7,6 +7,7 @@ class YelpTools < Formula
   url "https://download.gnome.org/sources/yelp-tools/42/yelp-tools-42.1.tar.xz"
   sha256 "3e496a4020d4145b99fd508a25fa09336a503a4e8900028421e72c6a4b11f905"
   license "GPL-2.0-or-later"
+  revision 1
 
   no_autobump! because: :requires_manual_review
 

--- a/Formula/y/yelp-tools.rb
+++ b/Formula/y/yelp-tools.rb
@@ -12,13 +12,12 @@ class YelpTools < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    rebuild 6
-    sha256 cellar: :any,                 arm64_tahoe:   "7cc5521c969220f384b20411deb90d5e05f1d178d8203a52303ce5a89d38ab82"
-    sha256 cellar: :any,                 arm64_sequoia: "772ad45116fc15ae25475b985b6248b4c3c18c78116f012864c62aec91fca64f"
-    sha256 cellar: :any,                 arm64_sonoma:  "5a3a6c2a52bbae96adc5eaebe69181fd4b4451d2626deca6008dd012b1e54ca8"
-    sha256 cellar: :any,                 sonoma:        "2afea63853c934f240b83e6a48e83a107259c812a13e2725b033cc98ae0618f7"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "8186b8958c98951dade64261639e1964cd136c2e806bd9eebce23fd6d0bef8a0"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c9d7a219224a7171620bf7f88e571a7c2af1bf887601012691817c420f2f7361"
+    sha256 cellar: :any,                 arm64_tahoe:   "aadb2689c5b993d7f4905f462f40ef9f83c2460e35122d580da4e7fd5303b3db"
+    sha256 cellar: :any,                 arm64_sequoia: "194d205a98e507aa391c1ee0df60a573a1f208cf18c44a8818de61fbe2cfea0c"
+    sha256 cellar: :any,                 arm64_sonoma:  "f9ae800d882b00715a2dc569a206ae2023db271190f6e638e674e90e1fe0e5ac"
+    sha256 cellar: :any,                 sonoma:        "80c6a766ea856ce7c3bc6350687e7d2462ad9ee068bde3aa7cb9c7595c77f3b8"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "5c81f1d642b3dcb2ba87061c787c8bc93836b1b82d572b5cc188283c2912db85"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "116324ef6b430649dec205fb66c33adc09ba9f719cadf7f33cf9d32e54c48de1"
   end
 
   depends_on "gettext" => :build


### PR DESCRIPTION
We plan to drop these in the next `libxml2` version bump. Need to break up all bottle due to platform-specific module

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
