### PR TITLE
wv2: remove `libxml2` dependency but keep workaround for indirect dep

### DIFF
--- a/Formula/w/wv2.rb
+++ b/Formula/w/wv2.rb
@@ -38,7 +38,6 @@ class Wv2 < Formula
   depends_on "glib"
   depends_on "libgsf"
 
-  uses_from_macos "libxml2"
   uses_from_macos "zlib"
 
   # Temporary test resource for bottles built before testole.doc was added.
@@ -54,7 +53,9 @@ class Wv2 < Formula
   def install
     ENV.append "LDFLAGS", "-lgobject-2.0" # work around broken detection
     ENV.append "LDFLAGS", "-liconv" if OS.mac?
+    # Help libgsf find its libxml2 dependency. It is not directly used by wv2
     ENV.append "CXXFLAGS", "-I#{Formula["libxml2"].include}/libxml2" unless OS.mac?
+
     # Workaround to build with CMake 4
     args = %w[-DCMAKE_POLICY_VERSION_MINIMUM=3.5]
     system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args


### PR DESCRIPTION
wv2's CMake file doesn't properly pass down the necessary cflags to use libgsf so we need to keep CXXFLAGS workaround.

However, there should be no direct dependency here.

---

Helps track dependents of `libxml2` better for upcoming bump