### PR TITLE
bandcamp-dl beancount: remove unused dependencies after `lxml` removal

### DIFF
--- a/Formula/b/bandcamp-dl.rb
+++ b/Formula/b/bandcamp-dl.rb
@@ -17,9 +17,6 @@ class BandcampDl < Formula
   depends_on "certifi"
   depends_on "python@3.14"
 
-  uses_from_macos "libxml2", since: :ventura
-  uses_from_macos "libxslt"
-
   pypi_packages exclude_packages: "certifi"
 
   resource "beautifulsoup4" do

--- a/Formula/b/beancount.rb
+++ b/Formula/b/beancount.rb
@@ -25,8 +25,6 @@ class Beancount < Formula
   depends_on "python@3.14"
 
   uses_from_macos "flex" => :build
-  uses_from_macos "libxml2", since: :ventura
-  uses_from_macos "libxslt"
 
   on_linux do
     depends_on "patchelf" => :build


### PR DESCRIPTION
- `bandcamp-dl` - Follow up to 8447fcad7190b0d47d5293d0c8b518d16de5f02c
- `beancount` - Follow up to 86f0e66377134a633ac9ff926c87f5370093c023