### PR TITLE
libsoup: remove `libxml2` dependency

### DIFF
--- a/Formula/lib/libsoup.rb
+++ b/Formula/lib/libsoup.rb
@@ -23,7 +23,7 @@ class Libsoup < Formula
   depends_on "vala" => :build
 
   depends_on "glib"
-  depends_on "glib-networking"
+  depends_on "glib-networking" => :no_linkage
   depends_on "gnutls"
   depends_on "libnghttp2"
   depends_on "libpsl"
@@ -31,7 +31,6 @@ class Libsoup < Formula
 
   uses_from_macos "python" => :build
   uses_from_macos "krb5"
-  uses_from_macos "libxml2"
   uses_from_macos "zlib"
 
   on_macos do


### PR DESCRIPTION
https://gitlab.gnome.org/GNOME/libsoup/-/commit/2a28a4496829abf998f50c586aea91506ea71de3

and linkage:

```console
$ brew linkage libsoup
System libraries:
  /lib/aarch64-linux-gnu/ld-linux-aarch64.so.1
  /lib/aarch64-linux-gnu/libc.so.6
Homebrew libraries:
  /home/linuxbrew/.linuxbrew/opt/brotli/lib/libbrotlidec.so.1 (brotli)
  /home/linuxbrew/.linuxbrew/opt/glib/lib/libgio-2.0.so.0 (glib)
  /home/linuxbrew/.linuxbrew/opt/glib/lib/libglib-2.0.so.0 (glib)
  /home/linuxbrew/.linuxbrew/opt/glib/lib/libgmodule-2.0.so.0 (glib)
  /home/linuxbrew/.linuxbrew/opt/glib/lib/libgobject-2.0.so.0 (glib)
  /home/linuxbrew/.linuxbrew/opt/krb5/lib/libgssapi_krb5.so.2 (krb5)
  /home/linuxbrew/.linuxbrew/opt/libnghttp2/lib/libnghttp2.so.14 (libnghttp2)
  /home/linuxbrew/.linuxbrew/opt/libpsl/lib/libpsl.so.5 (libpsl)
  /home/linuxbrew/.linuxbrew/opt/sqlite/lib/libsqlite3.so (sqlite)
  /home/linuxbrew/.linuxbrew/lib/libz.so.1 (zlib)
Dependencies with no linkage:
  glib-networking
```

`glib-networking` + `gnutls` is used for TLS support.