### PR TITLE
osrm-backend: remove dependencies

### DIFF
--- a/Formula/o/osrm-backend.rb
+++ b/Formula/o/osrm-backend.rb
@@ -28,9 +28,6 @@ class OsrmBackend < Formula
   depends_on "pkgconf" => :build
 
   depends_on "boost"
-  depends_on "libstxxl"
-  depends_on "libxml2"
-  depends_on "libzip"
   depends_on "lua"
   depends_on "tbb"
 


### PR DESCRIPTION
```console
$ brew linkage osrm-backend
System libraries:
  /lib/aarch64-linux-gnu/ld-linux-aarch64.so.1
  /lib/aarch64-linux-gnu/libc.so.6
  /lib/aarch64-linux-gnu/libgcc_s.so.1
  /lib/aarch64-linux-gnu/libm.so.6
  /lib/aarch64-linux-gnu/libstdc++.so.6
Homebrew libraries:
  /home/linuxbrew/.linuxbrew/opt/boost/lib/libboost_iostreams.so.1.89.0 (boost)
  /home/linuxbrew/.linuxbrew/opt/boost/lib/libboost_program_options.so.1.89.0 (boost)
  /home/linuxbrew/.linuxbrew/opt/boost/lib/libboost_thread.so.1.89.0 (boost)
  /home/linuxbrew/.linuxbrew/opt/bzip2/lib/libbz2.so.1.0 (bzip2)
  /home/linuxbrew/.linuxbrew/opt/expat/lib/libexpat.so.1 (expat)
  /home/linuxbrew/.linuxbrew/opt/lua/lib/liblua.so.5.4 (lua)
  /home/linuxbrew/.linuxbrew/opt/tbb/lib/libtbb.so.12 (tbb)
  /home/linuxbrew/.linuxbrew/opt/zlib/lib/libz.so.1 (zlib)
```