### PR TITLE
lastpass-cli: remove `on_mojave` block.

### DIFF
--- a/Formula/l/lastpass-cli.rb
+++ b/Formula/l/lastpass-cli.rb
@@ -28,11 +28,6 @@ class LastpassCli < Formula
   uses_from_macos "libxml2"
   uses_from_macos "libxslt"
 
-  # Avoid crashes on Mojave's version of libcurl (https://github.com/lastpass/lastpass-cli/issues/427)
-  on_mojave :or_newer do
-    depends_on "curl"
-  end
-
   # Workaround for CMake 4 compatibility
   # PR ref: https://github.com/lastpass/lastpass-cli/pull/716
   patch do


### PR DESCRIPTION
Mojave support will be removed in 4.7.0.

I'm dubious about this still being required so let's just remove it.