### PR TITLE
corepack 0.34.2 (new formula)

### DIFF
--- a/Formula/c/corepack.rb
+++ b/Formula/c/corepack.rb
@@ -1,0 +1,31 @@
+class Corepack < Formula
+  desc "Package acting as bridge between Node projects and their package managers"
+  homepage "https://github.com/nodejs/corepack"
+  url "https://registry.npmjs.org/corepack/-/corepack-0.34.2.tgz"
+  sha256 "a462abcfecd6e272fe0cd62cee62d05af6fbac88c560b1f38b40bfcdf86168be"
+  license "MIT"
+
+  livecheck do
+    url "https://registry.npmjs.org/corepack/latest"
+    regex(/["']version["']:\s*?["']([^"']+)["']/i)
+  end
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    system bin/"corepack"
+
+    (testpath/"package.json").write('{"name": "test"}')
+    system bin/"yarn", "add", "jquery"
+    system bin/"yarn", "add", "fsevents", "--build-from-source=true" if OS.mac?
+
+    (testpath/"package.json").delete
+    system bin/"pnpm", "init"
+    assert_path_exists testpath/"package.json", "package.json must exist"
+  end
+end

--- a/Formula/c/corepack.rb
+++ b/Formula/c/corepack.rb
@@ -10,6 +10,10 @@ class Corepack < Formula
     regex(/["']version["']:\s*?["']([^"']+)["']/i)
   end
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, all: "8a7abdcbc25cfe2764ca51bf69ddbc16539481643bfd9fce7dde924339f9b9e6"
+  end
+
   depends_on "node"
 
   def install

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -24,7 +24,6 @@
   "cloudflare-wrangler2": "cloudflare-wrangler",
   "commonmark": "cmark",
   "coq": "rocq",
-  "corepack": "node",
   "cppformat": "fmt",
   "crystal-lang": "crystal",
   "cutter": "cutter-cli",


### PR DESCRIPTION
corepack was shipped by node at one point.
We removed the corepack formula to be consistent with that: https://github.com/Homebrew/homebrew-core/pull/195770

Since node 25, corepack is not shipped anymore by node. See https://github.com/Homebrew/homebrew-core/issues/252875

Thus, add the formula back ...

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

relates to

- https://github.com/Homebrew/homebrew-core/pull/249782
- https://github.com/nodejs/TSC/pull/1697#issuecomment-2737093616