### PR TITLE
python@3.10, python-tk@3.10: deprecate

### DIFF
--- a/Formula/p/python-tk@3.10.rb
+++ b/Formula/p/python-tk@3.10.rb
@@ -20,6 +20,10 @@ class PythonTkAT310 < Formula
 
   keg_only :versioned_formula
 
+  # https://devguide.python.org/versions/#versions
+  deprecate! date: "2026-10-15", because: :deprecated_upstream
+  disable! date: "2027-10-15", because: :deprecated_upstream
+
   depends_on "python@3.10"
   depends_on "tcl-tk@8"
 

--- a/Formula/p/python@3.10.rb
+++ b/Formula/p/python@3.10.rb
@@ -24,6 +24,10 @@ class PythonAT310 < Formula
   # build packages later. Xcode-only systems need different flags.
   pour_bottle? only_if: :clt_installed
 
+  # https://devguide.python.org/versions/#versions
+  deprecate! date: "2026-10-15", because: :deprecated_upstream
+  disable! date: "2027-10-15", because: :deprecated_upstream
+
   depends_on "pkgconf" => :build
   depends_on "gdbm"
   depends_on "mpdecimal"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
`pyside@2` is the only formula still using `python@3.10`, and it's already been disabled.