### PR TITLE
lima: install libexec

### DIFF
--- a/Formula/l/lima.rb
+++ b/Formula/l/lima.rb
@@ -35,6 +35,7 @@ class Lima < Formula
     end
 
     bin.install Dir["_output/bin/*"]
+    libexec.install Dir["_output/libexec/*"]
     share.install Dir["_output/share/*"]
 
     # Install shell completions

--- a/Formula/l/lima.rb
+++ b/Formula/l/lima.rb
@@ -7,14 +7,13 @@ class Lima < Formula
   head "https://github.com/lima-vm/lima.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "f99ea39cfe538e790b9dd1877c58f1a779324be427e287f288a6909c4a7f0f04"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "d0f6fe33566069289518680dfe58a4488ad03bacb30edbeec3c75f9d62ecb707"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "577b9a4bdc83f4d52dc2f556daef6d2f8a4a38d8c168a8e61f07f1b6b14f4ac9"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "6e6c9ca5131d4961826100369abd78fd97c513cb5cda66e0f9b2801e248c4841"
-    sha256 cellar: :any_skip_relocation, sonoma:        "987df34a6ffc46d752c0c146f6a1130dd91d7299cb3ff175b8edfe3da8cc5c5d"
-    sha256 cellar: :any_skip_relocation, ventura:       "9b8c8d588c824b5b26e02a79dca5e64a1db3d428d003b830aaaaa1c3c22e68c9"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "5a48a6373589db1ff2f1ea139f853d7b5ece4dc7b8dc0d4741b4868d700d9a9f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b865114b961820b339f908eeb7cfcc9e48f03b9c4aba3e2169511cd5c7ca7155"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "2d9fe181a6dd1e019e24216aaaa15c88791598d7d23621f56a56345d425c5ad6"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "4214fdc16f886f7054c39ae85819ccde5080efba083006565503a4349f7c36e8"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "091c535e72c639e3a5acc9d0cc6520a3eb9b2edbe883e54d3fdee4a37df4706e"
+    sha256 cellar: :any_skip_relocation, sonoma:        "2e103dad6cb82d59d9f7b6f3c2d8219863c0e48e650da5acd71460e4a2ce3242"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "7594b0a496f9a1b0e994ffc414662c969d10cb6a6d565747ed3409644421ca75"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "627b3697f9c72c9261cff35b9fc5e01f32b630c5b2872ca5f19862e529901118"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
HEAD (v2.0.0-rc.N) now requires PREFIX/libexec/lima to be installed.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
