### PR TITLE
workflows/triage: CI-skip-recursive-dependents for `harfbuzz`

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -397,6 +397,7 @@ jobs:
                 curl|\
                 gettext|\
                 glib|\
+                harfbuzz|\
                 openssl@3|\
                 wayland-protocols|\
                 sqlite|\


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

According to https://github.com/harfbuzz/harfbuzz/?tab=readme-ov-file#download HarfBuzz is API/ABI stable across all version bumps:

> The API and ABI are stable even across major version number jumps. In fact, current HarfBuzz is API/ABI compatible all the way back to the 0.9.x series. If one day we need to break the API/ABI, that would be called a new a library.
> 
> As such, we bump the major version number only when we add major new features, the minor version when there is new API, and the micro version when there are bug fixes.

