### PR TITLE
various: standardize Git commit ldflags

### DIFF
--- a/Formula/a/apko.rb
+++ b/Formula/a/apko.rb
@@ -29,7 +29,7 @@ class Apko < Formula
     ldflags = %W[
       -s -w
       -X sigs.k8s.io/release-utils/version.gitVersion=#{version}
-      -X sigs.k8s.io/release-utils/version.gitCommit=brew
+      -X sigs.k8s.io/release-utils/version.gitCommit=#{tap.user}
       -X sigs.k8s.io/release-utils/version.gitTreeState=clean
       -X sigs.k8s.io/release-utils/version.buildDate=#{time.iso8601}
     ]
@@ -60,6 +60,6 @@ class Apko < Formula
     system bin/"apko", "build", testpath/"test.yml", "apko-alpine:test", "apko-alpine.tar"
     assert_path_exists testpath/"apko-alpine.tar"
 
-    assert_match version.to_s, shell_output("#{bin}/apko version 2>&1")
+    assert_match version.to_s, shell_output("#{bin}/apko version")
   end
 end

--- a/Formula/a/atlantis.rb
+++ b/Formula/a/atlantis.rb
@@ -24,6 +24,7 @@ class Atlantis < Formula
   depends_on "opentofu" => :test
 
   def install
+    # The commit variable only displays 7 characters, so we can't use #{tap.user} or "Homebrew".
     ldflags = %W[
       -s -w
       -X main.version=#{version}

--- a/Formula/c/ctrld.rb
+++ b/Formula/c/ctrld.rb
@@ -20,7 +20,7 @@ class Ctrld < Formula
     ldflags = %W[
       -s -w
       -X github.com/Control-D-Inc/ctrld/cmd/cli.version=#{version}
-      -X github.com/Control-D-Inc/ctrld/cmd/cli.commit=homebrew
+      -X github.com/Control-D-Inc/ctrld/cmd/cli.commit=#{tap.user}
     ]
     system "go", "build", *std_go_args(ldflags:), "./cmd/ctrld"
   end

--- a/Formula/d/dumpling.rb
+++ b/Formula/d/dumpling.rb
@@ -30,7 +30,7 @@ class Dumpling < Formula
       -s -w
       -X #{project}/cli.ReleaseVersion=#{version}
       -X #{project}/cli.BuildTimestamp=#{time.iso8601}
-      -X #{project}/cli.GitHash=brew
+      -X #{project}/cli.GitHash=#{tap.user}
       -X #{project}/cli.GitBranch=#{version}
       -X #{project}/cli.GoVersion=go#{Formula["go"].version}
     ]
@@ -42,6 +42,6 @@ class Dumpling < Formula
     output = shell_output("#{bin}/dumpling --database db 2>&1", 1)
     assert_match "create dumper failed", output
 
-    assert_match "Release version: #{version}", shell_output("#{bin}/dumpling --version 2>&1")
+    assert_match version.to_s, shell_output("#{bin}/dumpling --version 2>&1")
   end
 end

--- a/Formula/f/fzf.rb
+++ b/Formula/f/fzf.rb
@@ -24,7 +24,7 @@ class Fzf < Formula
     ldflags = %W[
       -s -w
       -X main.version=#{version}
-      -X main.revision=brew
+      -X main.revision=#{tap.user}
     ]
 
     system "go", "build", *std_go_args(ldflags:)
@@ -52,6 +52,8 @@ class Fzf < Formula
   end
 
   test do
+    assert_match version.to_s, shell_output("#{bin}/fzf --version")
+
     (testpath/"list").write %w[hello world].join($INPUT_RECORD_SEPARATOR)
     assert_equal "world", pipe_output("#{bin}/fzf -f wld", (testpath/"list").read).chomp
   end

--- a/Formula/g/gibo.rb
+++ b/Formula/g/gibo.rb
@@ -25,8 +25,6 @@ class Gibo < Formula
     ldflags = %W[
       -s -w
       -X github.com/simonwhitaker/gibo/cmd.version=#{version}
-      -X github.com/simonwhitaker/gibo/cmd.commit=brew
-      -X github.com/simonwhitaker/gibo/cmd.date=#{time.iso8601}
     ]
     system "go", "build", *std_go_args(ldflags:)
     generate_completions_from_executable(bin/"gibo", "completion")

--- a/Formula/h/hugo.rb
+++ b/Formula/h/hugo.rb
@@ -30,7 +30,7 @@ class Hugo < Formula
       -s -w
       -X github.com/gohugoio/hugo/common/hugo.commitHash=#{tap.user}
       -X github.com/gohugoio/hugo/common/hugo.buildDate=#{time.iso8601}
-      -X github.com/gohugoio/hugo/common/hugo.vendorInfo=brew
+      -X github.com/gohugoio/hugo/common/hugo.vendorInfo=#{tap.user}
     ]
     tags = %w[extended withdeploy]
     system "go", "build", *std_go_args(ldflags:, tags:)

--- a/Formula/k/kubevpn.rb
+++ b/Formula/k/kubevpn.rb
@@ -25,7 +25,7 @@ class Kubevpn < Formula
       -s -w
       -X #{project}/pkg/config.Image=ghcr.io/kubenetworks/kubevpn:v#{version}
       -X #{project}/pkg/config.Version=v#{version}
-      -X #{project}/pkg/config.GitCommit=brew
+      -X #{project}/pkg/config.GitCommit=#{tap.user}
       -X #{project}/cmd/kubevpn/cmds.BuildTime=#{time.iso8601}
       -X #{project}/cmd/kubevpn/cmds.Branch=master
       -X #{project}/cmd/kubevpn/cmds.OsArch=#{goos}/#{goarch}
@@ -36,7 +36,7 @@ class Kubevpn < Formula
   end
 
   test do
-    assert_match "Version: v#{version}", shell_output("#{bin}/kubevpn version")
+    assert_match version.to_s, shell_output("#{bin}/kubevpn version")
     assert_path_exists testpath/".kubevpn/config.yaml"
     assert_path_exists testpath/".kubevpn/daemon"
   end

--- a/Formula/l/lazyssh.rb
+++ b/Formula/l/lazyssh.rb
@@ -18,8 +18,12 @@ class Lazyssh < Formula
   depends_on "go" => :build
 
   def install
-    # has to be `brew` for `gitCommit` due to length constraint
-    ldflags = "-s -w -X main.version=#{version} -X main.gitCommit=brew"
+    # The commit variable only displays 7 characters, so we can't use #{tap.user} or "Homebrew".
+    ldflags = %W[
+      -s -w
+      -X main.version=#{version}
+      -X main.gitCommit=brew
+    ]
     system "go", "build", *std_go_args(ldflags:), "./cmd"
   end
 

--- a/Formula/m/melange.rb
+++ b/Formula/m/melange.rb
@@ -26,7 +26,7 @@ class Melange < Formula
     ldflags = %W[
       -s -w
       -X sigs.k8s.io/release-utils/version.gitVersion=#{version}
-      -X sigs.k8s.io/release-utils/version.gitCommit=brew
+      -X sigs.k8s.io/release-utils/version.gitCommit=#{tap.user}
       -X sigs.k8s.io/release-utils/version.gitTreeState=clean
       -X sigs.k8s.io/release-utils/version.buildDate=#{time.iso8601}
     ]

--- a/Formula/n/nerdlog.rb
+++ b/Formula/n/nerdlog.rb
@@ -27,9 +27,9 @@ class Nerdlog < Formula
     ldflags = %W[
       -s -w
       -X github.com/dimonomid/nerdlog/version.version=#{version}
-      -X github.com/dimonomid/nerdlog/version.commit=Homebrew
+      -X github.com/dimonomid/nerdlog/version.commit=#{tap.user}
       -X github.com/dimonomid/nerdlog/version.date=#{time.iso8601}
-      -X github.com/dimonomid/nerdlog/version.builtBy=Homebrew
+      -X github.com/dimonomid/nerdlog/version.builtBy=#{tap.user}
     ]
     system "go", "build", *std_go_args(ldflags:), "./cmd/nerdlog"
   end

--- a/Formula/n/nexttrace.rb
+++ b/Formula/n/nexttrace.rb
@@ -30,7 +30,7 @@ class Nexttrace < Formula
     ldflags = %W[
       -s -w
       -X github.com/nxtrace/NTrace-core/config.Version=#{version}
-      -X github.com/nxtrace/NTrace-core/config.CommitID=brew
+      -X github.com/nxtrace/NTrace-core/config.CommitID=#{tap.user}
       -X github.com/nxtrace/NTrace-core/config.BuildDate=#{time.iso8601}
       -checklinkname=0
     ]
@@ -50,6 +50,7 @@ class Nexttrace < Formula
     return_status = OS.mac? ? 0 : 1
     output = shell_output("#{bin}/nexttrace --language en 1.1.1.1 2>&1", return_status)
     assert_match "[NextTrace API]", output
+
     assert_match version.to_s, shell_output("#{bin}/nexttrace --version")
   end
 end

--- a/Formula/o/openfga.rb
+++ b/Formula/o/openfga.rb
@@ -21,7 +21,7 @@ class Openfga < Formula
     ldflags = %W[
       -s -w
       -X github.com/openfga/openfga/internal/build.Version=#{version}
-      -X github.com/openfga/openfga/internal/build.Commit=brew
+      -X github.com/openfga/openfga/internal/build.Commit=#{tap.user}
       -X github.com/openfga/openfga/internal/build.Date=#{time.iso8601}
     ]
     system "go", "build", *std_go_args(ldflags:), "./cmd/openfga"
@@ -30,6 +30,8 @@ class Openfga < Formula
   end
 
   test do
+    assert_match version.to_s, shell_output("#{bin}/openfga version 2>&1")
+
     port = free_port
     pid = fork do
       exec bin/"openfga", "run", "--playground-port", port.to_s

--- a/Formula/p/phoneinfoga.rb
+++ b/Formula/p/phoneinfoga.rb
@@ -37,13 +37,14 @@ class Phoneinfoga < Formula
     ldflags = %W[
       -s -w
       -X github.com/sundowndev/phoneinfoga/v2/build.Version=v#{version}
-      -X github.com/sundowndev/phoneinfoga/v2/build.Commit=brew
+      -X github.com/sundowndev/phoneinfoga/v2/build.Commit=#{tap.user}
     ]
     system "go", "build", *std_go_args(ldflags:)
   end
 
   test do
-    assert_match "PhoneInfoga v#{version}-brew", shell_output("#{bin}/phoneinfoga version")
+    assert_match version.to_s, shell_output("#{bin}/phoneinfoga version")
+
     system bin/"phoneinfoga", "scanners"
     assert_match "given phone number is not valid", shell_output("#{bin}/phoneinfoga scan -n foobar 2>&1", 1)
   end

--- a/Formula/s/slsa-verifier.rb
+++ b/Formula/s/slsa-verifier.rb
@@ -31,7 +31,7 @@ class SlsaVerifier < Formula
     ldflags = %W[
       -s -w
       -X sigs.k8s.io/release-utils/version.gitVersion=#{version}
-      -X sigs.k8s.io/release-utils/version.gitCommit=brew
+      -X sigs.k8s.io/release-utils/version.gitCommit=#{tap.user}
       -X sigs.k8s.io/release-utils/version.gitTreeState=clean
       -X sigs.k8s.io/release-utils/version.buildDate=#{time.iso8601}
     ]
@@ -47,6 +47,6 @@ class SlsaVerifier < Formula
     expected_output = "FAILED: SLSA verification failed: the image is mutable: 'docker://alpine'"
     assert_match expected_output, output
 
-    assert_match version.to_s, shell_output("#{bin}/slsa-verifier version 2>&1")
+    assert_match version.to_s, shell_output("#{bin}/slsa-verifier version")
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Standardizes some discrepancies between Go formulae. All tested fine locally.