### PR TITLE
clarinet: migrate to stacks labs

### DIFF
--- a/Formula/c/clarinet.rb
+++ b/Formula/c/clarinet.rb
@@ -1,10 +1,10 @@
 class Clarinet < Formula
   desc "Command-line tool and runtime for the Clarity smart contract language"
-  homepage "https://www.hiro.so/clarinet"
-  url "https://github.com/hirosystems/clarinet/archive/refs/tags/v3.9.1.tar.gz"
+  homepage "https://stackslabs.com/"
+  url "https://github.com/stx-labs/clarinet/archive/refs/tags/v3.9.1.tar.gz"
   sha256 "935ad4c43d35c796fb6f546b54b1d85e35423ccdb687279445200959768996be"
   license "GPL-3.0-only"
-  head "https://github.com/hirosystems/clarinet.git", branch: "main"
+  head "https://github.com/stx-labs/clarinet.git", branch: "main"
 
   livecheck do
     url :stable


### PR DESCRIPTION
Clarinet was recently transferred from Hirosystems to Stack Labs.

See the repository redirection:
https://github.com/hirosystems/clarinet

Homebrew was able to nicely handle the github redirection and release 3.9.0 and .1 from the new repository.
This PR updates the homepage and directly points to the new repository.

Thank you

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
