### PR TITLE
spatialite-gui: revision bump (libxml2 2.15.1)

### DIFF
--- a/Formula/s/spatialite-gui.rb
+++ b/Formula/s/spatialite-gui.rb
@@ -4,7 +4,7 @@ class SpatialiteGui < Formula
   url "https://www.gaia-gis.it/gaia-sins/spatialite-gui-sources/spatialite_gui-2.1.0-beta1.tar.gz"
   sha256 "ba48d96df18cebc3ff23f69797207ae1582cce62f4596b69bae300ca3c23db33"
   license "GPL-3.0-or-later"
-  revision 12
+  revision 13
 
   livecheck do
     url "https://www.gaia-gis.it/gaia-sins/spatialite-gui-sources/"

--- a/Formula/s/spatialite-gui.rb
+++ b/Formula/s/spatialite-gui.rb
@@ -14,14 +14,12 @@ class SpatialiteGui < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "6905028f8a5725ce128325dbe01e1d2b2a0e46de526a1d3409e5162e95a09133"
-    sha256 cellar: :any,                 arm64_sequoia: "0729ab0ef78b34d21105dfa31efdb84466c3f1299a11cea3c039ff91725fa941"
-    sha256 cellar: :any,                 arm64_sonoma:  "024efe736240e668fb049f06eb744ed03223ca08edbb59e00e67dc67d9db1a1e"
-    sha256 cellar: :any,                 arm64_ventura: "9e2d9c4d64a8e60daa2420254efbf2495442d957ca58231ae474b4f927e396f0"
-    sha256 cellar: :any,                 sonoma:        "fe1ceda3cf1e7cde15a38279c2c78c73366bcf44f7f764aaa16d4ddece1c90fa"
-    sha256 cellar: :any,                 ventura:       "a384ed8c6464d25bdc0e308dec8e3fcafbe3a0ab3d2e051a393f827470a74452"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "5a6e1e70058432026f675c50dbdba7a5237357de31655d9fb0ba71d4cb86051e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2470cea3a02d2b41424b39e453d047412ecffda08a2aa73d8d10c68ccd9ff90f"
+    sha256 cellar: :any,                 arm64_tahoe:   "a4b7fbc50b115548016a5cd4437a86b97620f0b5bb778e697c8f4aff7ef91a06"
+    sha256 cellar: :any,                 arm64_sequoia: "0478a3a71b216e6f74a596beb56d3fb3a0460daadafc3090a0779f38522f28ab"
+    sha256 cellar: :any,                 arm64_sonoma:  "fbd21ec2235d230c3dd6feaa32ffa0fec4f75eac486bf1e9b7afbaf6402c20aa"
+    sha256 cellar: :any,                 sonoma:        "8fba83b40f1e121779745c21d151e8f4a88e9e45244856c4cdfee3bf1a173918"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "86a09cf730602dc22b2ae197c1c9a4f651643c663163e468785876cd2ef8173c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "87acde87d2c6e11a658f8bc7c210eadeb28ce2aa885364c1f39cd37b473235b3"
   end
 
   depends_on "pkgconf" => :build


### PR DESCRIPTION
spatialite-gui: revision bump (libxml2 2.15.1)

---

found in https://github.com/Homebrew/homebrew-core/actions/runs/19124423671/job/54652304206?pr=253163#step:3:532

- https://github.com/Homebrew/homebrew-core/pull/252666