### PR TITLE
libvirt: update dependencies

### DIFF
--- a/Formula/lib/libvirt.rb
+++ b/Formula/lib/libvirt.rb
@@ -30,16 +30,14 @@ class Libvirt < Formula
   depends_on "glib"
   depends_on "gnutls"
   depends_on "json-c"
-  depends_on "libgcrypt"
   depends_on "libiscsi"
   depends_on "libssh2"
   depends_on "readline" # Possible opportunistic linkage. TODO: Check if this can be removed.
-  depends_on "yajl"
 
+  uses_from_macos "libxslt" => :build
   uses_from_macos "perl" => :build
   uses_from_macos "curl"
   uses_from_macos "libxml2"
-  uses_from_macos "libxslt"
 
   on_macos do
     depends_on "gettext"
@@ -47,6 +45,7 @@ class Libvirt < Formula
 
   on_linux do
     depends_on "acl"
+    depends_on "cyrus-sasl"
     depends_on "libnl"
     depends_on "libtirpc"
     depends_on "util-linux"


### PR DESCRIPTION
- libgcrypt - https://gitlab.com/libvirt/libvirt/-/commit/279a27d4aaba9002c0342bf1ce251407713f105e
- yajl - https://gitlab.com/libvirt/libvirt/-/commit/d96e753d843921fde6575a691b166a54e3474e64
- cyrus-sasl - indirectly linked on Linux but not using macOS copy. Meson might not be able to detect macOS one since we don't provide a pkg-config file.
- libxslt - looks to be used at build time for xsltproc