### PR TITLE
abcde: depend on `cd-discid`

### DIFF
--- a/Formula/a/abcde.rb
+++ b/Formula/a/abcde.rb
@@ -32,6 +32,7 @@ class Abcde < Formula
 
   depends_on "pkgconf" => :build
 
+  depends_on "cd-discid"
   depends_on "cdrtools"
   depends_on "eye-d3"
   depends_on "flac"


### PR DESCRIPTION
Make formula `abcde` depend on `cd-discid`, since `abcde` does not work without.

Depends on #253371.

-----

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
