### PR TITLE
testkube 2.4.0

### DIFF
--- a/Formula/t/testkube.rb
+++ b/Formula/t/testkube.rb
@@ -12,12 +12,12 @@ class Testkube < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "6b3c1dfb3c4cd6d6528ffdf474fd2c1d832aadc9e037be0e8ee65bf021e9fb4d"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "6b3c1dfb3c4cd6d6528ffdf474fd2c1d832aadc9e037be0e8ee65bf021e9fb4d"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "6b3c1dfb3c4cd6d6528ffdf474fd2c1d832aadc9e037be0e8ee65bf021e9fb4d"
-    sha256 cellar: :any_skip_relocation, sonoma:        "01e0c5489fdea3cf4b51f71564d61564868f89bc46a257354d15829f1b7f8601"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "d02d9f1ad169aea94805023ad9131f6feb0b04298495f1ff62c150f10471f1cd"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e6e9540598fed819983a2196a3d0f7648a073d961162466aa410380a63f8a35b"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "fe42514d58c866c7129237d0c701a222a40073b0d9b1f845a4419a5975dabacb"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "810863fbe8dc1b06280df208045c18681b41808d0102f9697db39126e7744f1d"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "64b01198f3049632289e1b956fbf99a3e99226d470039f4fbdbc56aa504d861e"
+    sha256 cellar: :any_skip_relocation, sonoma:        "711465ffaa278fbe1b3f7598a5ebcfbe3d840b1bdefda1189df9ff33d190dca5"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "278131aa64098950e166608da28feaba3398e7b24c1bf974bce5bfdfec80a057"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c37aa1a042b556772db7b783f494d52a6c2193e81bb614f7075fbf0cb9b675a3"
   end
 
   depends_on "go" => :build

--- a/Formula/t/testkube.rb
+++ b/Formula/t/testkube.rb
@@ -1,8 +1,8 @@
 class Testkube < Formula
   desc "Kubernetes-native framework for test definition and execution"
   homepage "https://testkube.io"
-  url "https://github.com/kubeshop/testkube/archive/refs/tags/v2.3.0.tar.gz"
-  sha256 "cf8d2519691e7d3c05be796ef6404c3d711c544a803180842a2563cb998ceb75"
+  url "https://github.com/kubeshop/testkube/archive/refs/tags/2.4.0.tar.gz"
+  sha256 "9071609e51bebd3cb028e89bffcfbc7a90aef4541030163b413f57f92e49ae1c"
   license "MIT"
   head "https://github.com/kubeshop/testkube.git", branch: "main"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`testkube` is autobumped but the workflow failed to update to version 2.4.0 because the tag format for this release is `2.4.0` instead of `v2.4.0`. This manually updates the formula `url` accordingly.