### PR TITLE
perl: update livecheck

### DIFF
--- a/Formula/p/perl.rb
+++ b/Formula/p/perl.rb
@@ -7,7 +7,7 @@ class Perl < Formula
   head "https://github.com/perl/perl5.git", branch: "blead"
 
   livecheck do
-    url "https://www.cpan.org/src/"
+    url "https://www.cpan.org/src/#{version.major}.0/"
     regex(/href=.*?perl[._-]v?(\d+\.\d*[02468](?:\.\d+)*)\.t/i)
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `perl` checks the upstream Perl Source page and this previously linked to the newest tarballs but now it doesn't link to any tarballs at all. This addresses the issue by updating the `livecheck` block URL to check the directory listing page for the version directory where the `stable` tarball is found. This approach will fail to surface new major versions (i.e., it will continue to return the newest 5.x version), so we will have to manually identify new major versions (which should be very rare).