### PR TITLE
solr@8.11: deprecate

### DIFF
--- a/Formula/s/solr@8.11.rb
+++ b/Formula/s/solr@8.11.rb
@@ -6,16 +6,15 @@ class SolrAT811 < Formula
   sha256 "163fbdf246bbd78910bc36c3257ad50cdf31ccc3329a5ef885c23c9ef69e0ebe"
   license "Apache-2.0"
 
-  livecheck do
-    url "https://solr.apache.org/downloads.html"
-    regex(/href=.*?solr[._-]v?(8\.11(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, all: "65d79494d324de0e00931020fc1e1624c7929566a4d66cee0b33052111f6e523"
   end
 
   keg_only :versioned_formula
+
+  # Solr 8 reached end of life (EOL) on 2024-10-25:
+  # https://solr.apache.org/news.html#solr-8-reaches-end-of-life
+  deprecate! date: "2025-11-07", because: :unsupported
 
   depends_on "openjdk"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Solr 8 reached end of life (EOL) on 2024-10-25 and the [downloads page](https://solr.apache.org/downloads.html) no longer links to any 8.x versions. This removes the [broken] `livecheck` block and deprecates the formula accordingly.