### PR TITLE
synergy-core: drop caveat after license update

### DIFF
--- a/Formula/s/synergy-core.rb
+++ b/Formula/s/synergy-core.rb
@@ -99,17 +99,11 @@ class SynergyCore < Formula
   end
 
   def caveats
-    # Because we used `license :cannot_represent` above, tell the user how to
-    # read the license.
-    s = <<~EOS
-      Read the synergy-core license here:
-        #{opt_prefix}/LICENSE
-    EOS
     # The binaries built by brew are not signed by a trusted certificate, so the
     # user may need to revoke all permissions for 'Accessibility' and re-grant
     # them when upgrading synergy-core.
     on_macos do
-      s += "\n" + <<~EOS
+      s = <<~EOS
         Synergy requires the 'Accessibility' permission.
         You can grant this permission by navigating to:
           System Preferences -> Security & Privacy -> Privacy -> Accessibility
@@ -137,8 +131,8 @@ class SynergyCore < Formula
             (2) #{opt_bin}/synergy
         EOS
       end
+      s
     end
-    s
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
