### PR TITLE
Update Dnote port in ldflags and license

### DIFF
--- a/Formula/d/dnote.rb
+++ b/Formula/d/dnote.rb
@@ -3,7 +3,7 @@ class Dnote < Formula
   homepage "https://www.getdnote.com"
   url "https://github.com/dnote/dnote/archive/refs/tags/cli-v0.15.5.tar.gz"
   sha256 "923e959d32885f01e426e37e7240bf9a66addbdfd95620846fa535e4b7f7d2e4"
-  license "GPL-3.0-only"
+  license "Apache-2.0"
   head "https://github.com/dnote/dnote.git", branch: "master"
 
   livecheck do
@@ -25,7 +25,7 @@ class Dnote < Formula
   def install
     ENV["CGO_ENABLED"] = "1" if OS.linux? && Hardware::CPU.arm?
 
-    ldflags = "-s -w -X main.versionTag=#{version} -X main.apiEndpoint=http://localhost:3000/api"
+    ldflags = "-s -w -X main.versionTag=#{version} -X main.apiEndpoint=http://localhost:3001/api"
     system "go", "build", *std_go_args(ldflags:, tags: "fts5"), "./pkg/cli"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

* https://github.com/dnote/dnote/pull/687 changes the default port to 3001. For the convenience of users, update the build flags in the brew formula.
* https://github.com/dnote/dnote/pull/708 changes the license to Apache 2.0. Change the license in the formula.