### PR TITLE
nanobind: fix formula deps

### DIFF
--- a/Formula/n/nanobind.rb
+++ b/Formula/n/nanobind.rb
@@ -13,7 +13,7 @@ class Nanobind < Formula
 
   depends_on "cmake" => [:build, :test]
   depends_on "python@3.14" => [:build, :test]
-  depends_on "robin-map" => [:build, :test]
+  depends_on "robin-map"
 
   def install
     system "cmake", "-S", ".", "-B", "build",


### PR DESCRIPTION
robin-map is required when using nanobind
This change mimics apt, pacman and pip that installs robin-map alongside nanobind

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
