### PR TITLE
chttp 1.0.1 (new formula)

### DIFF
--- a/Formula/c/chttp.rb
+++ b/Formula/c/chttp.rb
@@ -1,0 +1,39 @@
+class Chttp < Formula
+  desc "Open-source C library for HTTP requests"
+  homepage "https://github.com/json031/chttp"
+  url "https://github.com/json031/chttp/archive/refs/tags/v1.0.1.tar.gz"
+  sha256 "6fd22b6cfad7078180b3fd76f4a2c1970672015786701c90595d91037320e1ba"
+  license "MIT"
+
+  depends_on "pkg-config" => :build
+  depends_on "cjson"
+  depends_on "curl"
+
+  def install
+    ENV.append "CFLAGS", "-I#{Formula["cjson"].opt_include}"
+    ENV.append "LDFLAGS", "-L#{Formula["cjson"].opt_lib}"
+
+    system "make"
+    system "make", "install", "PREFIX=#{prefix}"
+  end
+
+  test do
+
+  (testpath/"test.c").write <<~EOS
+    #include <chttp.h>
+    int main() { return 0; }
+  EOS
+
+  system ENV.cc,
+         "test.c",
+         "-I#{include}",                              # chttp include
+         "-I#{Formula["cjson"].opt_include}",         # cjson include
+         "-L#{lib}",                                  # chttp lib
+         "-L#{Formula["cjson"].opt_lib}",             # cjson lib
+         "-lcjson", "-lchttp", "-lcurl",
+         "-o", "test_chttp"
+
+  system "./test_chttp"
+
+  end
+end

--- a/Formula/c/chttp.rb
+++ b/Formula/c/chttp.rb
@@ -5,7 +5,7 @@ class Chttp < Formula
   sha256 "6fd22b6cfad7078180b3fd76f4a2c1970672015786701c90595d91037320e1ba"
   license "MIT"
 
-  depends_on "pkg-config" => :build
+  depends_on "pkgconf" => :build
   depends_on "cjson"
   depends_on "curl"
 

--- a/Formula/c/chttp.rb
+++ b/Formula/c/chttp.rb
@@ -18,13 +18,12 @@ class Chttp < Formula
   end
 
   test do
+    (testpath/"test.c").write <<~EOS
+      #include <chttp.h>
+      int main() { return 0; }
+    EOS
 
-  (testpath/"test.c").write <<~EOS
-    #include <chttp.h>
-    int main() { return 0; }
-  EOS
-
-  system ENV.cc,
+    system ENV.cc,
          "test.c",
          "-I#{include}",                              # chttp include
          "-I#{Formula["cjson"].opt_include}",         # cjson include
@@ -33,7 +32,6 @@ class Chttp < Formula
          "-lcjson", "-lchttp", "-lcurl",
          "-o", "test_chttp"
 
-  system "./test_chttp"
-
+    system "./test_chttp"
   end
 end


### PR DESCRIPTION
chttp is an open-source C library for making HTTP requests.

It provides a simple interface for:
- Sending GET and POST requests (`http_get_req`, `http_post_req`)
- Uploading files via POST (`http_post_upload_file_req`)
- Parsing JSON responses using cJSON (`cJSON *` return type)

Dependencies:
- curl: for HTTP networking
- cjson: for JSON parsing

This formula builds chttp from source and installs the library headers and compiled library, allowing other C projects to link against it.

The included `test do` block verifies that the library can be compiled and linked correctly in a minimal C program.

Source code is available at: https://github.com/json031/chttp, release v1.0.1.