### PR TITLE
ts_query_ls 3.12.0 (new formula)

### DIFF
--- a/Formula/t/ts_query_ls.rb
+++ b/Formula/t/ts_query_ls.rb
@@ -5,6 +5,15 @@ class TsQueryLs < Formula
   sha256 "65ec3634b29102cddef7f53615c266bae2c2f18690b08aac814e7f317fc1167e"
   license "MIT"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "c019af3cde68b1981083d51dad506f861cf9a32fbe1c4f011f061b67f1a55021"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "578fc2884b6cea31ba9a3ac075ce443880a2920d263445c5481d54e200d02b2d"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "43dfd90a0fe6bc8e06bd536af594db98cc6eac0818cd266f9387e448a9361b91"
+    sha256 cellar: :any_skip_relocation, sonoma:        "48a4973f6b6e121e6662def9b6a5cdb58bf58ba9b4b3dfb276d6cecd9e2100b0"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "27ca5fcdf30f5445bfccedce9f16b3b88f3bd10164342c6b47edc7f554340156"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e898bc331803688882722d11407c233ecbed7dfb814a1a3c983155e7e24d30d8"
+  end
+
   depends_on "cmake" => :build
   depends_on "rust" => :build
 

--- a/Formula/t/ts_query_ls.rb
+++ b/Formula/t/ts_query_ls.rb
@@ -1,0 +1,32 @@
+class TsQueryLs < Formula
+  desc "LSP implementation for Tree-sitter's query files"
+  homepage "https://github.com/ribru17/ts_query_ls"
+  url "https://github.com/ribru17/ts_query_ls/archive/refs/tags/v3.12.0.tar.gz"
+  sha256 "65ec3634b29102cddef7f53615c266bae2c2f18690b08aac814e7f317fc1167e"
+  license "MIT"
+
+  depends_on "cmake" => :build
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    input = <<~JSON
+      {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+          "rootUri": null,
+          "capabilities": {}
+        }
+      }
+    JSON
+
+    output = /Content-Length: \d+\r\n\r\n/
+
+    assert_match output, pipe_output(bin/"ts_query_ls", input, 0)
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Let's try that again, shall we? Since #197587, this project has matured and become the de-facto static analyzer tool for tree-sitter queries used throughout the ecosystem ([nvim-treesitter projects](https://github.com/nvim-treesitter/nvim-treesitter/blob/main/Makefile), [tree-sitter-grammars](https://github.com/tree-sitter-grammars/tree-sitter-query) and [upstream tree-sitter parsers](https://github.com/tree-sitter/tree-sitter-julia), [neovim (soon™️)](https://github.com/neovim/neovim/pull/32890), ...) as part of CI. Having this in homebrew will make it easier for contributors to test their changes locally (besides being generally useful as an LSP).

This formula should be safe to the autobump list.