### PR TITLE
topgrade: add no_autobump

### DIFF
--- a/Formula/t/topgrade.rb
+++ b/Formula/t/topgrade.rb
@@ -11,6 +11,8 @@ class Topgrade < Formula
     strategy :github_latest
   end
 
+  no_autobump! because: :bumped_by_upstream
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "96dd09d80604a4052f1df24d239d9c3a884900106dfe05d0463b535c71d286f8"
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "df0032bdc7a994892625b2bc08a29c618d88d5f7d21055ee903478042f16a45d"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Hi, maintainer of [topgrade](https://github.com/topgrade-rs/topgrade) here. I'm trying to replace the 3-hourly automatic PR by one opened by the release workflow at our side, using https://github.com/dawidd6/action-homebrew-bump-formula, as suggested in https://github.com/Homebrew/actions/issues/757. I am getting this error:
```
Error: Whoops, the topgrade formula has its version update
pull requests automatically opened by BrewTestBot every ~3 hours!
We'd still love your contributions, though, so try another one
that is excluded from autobump list (i.e. it has 'no_autobump!'
method or 'livecheck' block with 'skip'.)
```
I'm adding
```rb
no_autobump! because: :bumped_by_upstream
```
in this PR to fix that.