### PR TITLE
fpc: use `MacOS.sdk_for_formula`

### DIFF
--- a/Formula/f/fpc.rb
+++ b/Formula/f/fpc.rb
@@ -87,7 +87,7 @@ class Fpc < Formula
     end
 
     # Help fpc find the startup files (crt1.o and friends)
-    args = if OS.mac? && (sdk = MacOS.sdk_path_if_needed)
+    args = if OS.mac? && (sdk = MacOS.sdk_for_formula(self).path)
       %W[OPT="-XR#{sdk}"]
     else
       []


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

A bit more accurate to use `sdk_for_formula` within build and `sdk_path_if_needed` may be deprecated given it is now just an alias for `sdk_path`