### PR TITLE
libxmlsec1 1.3.9

### DIFF
--- a/Formula/lib/libxmlsec1.rb
+++ b/Formula/lib/libxmlsec1.rb
@@ -1,16 +1,15 @@
 class Libxmlsec1 < Formula
   desc "XML security library"
   homepage "https://www.aleksey.com/xmlsec/"
-  url "https://www.aleksey.com/xmlsec/download/xmlsec1-1.3.8.tar.gz"
-  mirror "https://github.com/lsh123/xmlsec/releases/download/1.3.8/xmlsec1-1.3.8.tar.gz"
-  sha256 "d0180916ae71be28415a6fa919a0684433ec9ec3ba1cc0866910b02e5e13f5bd"
+  url "https://github.com/lsh123/xmlsec/releases/download/1.3.9/xmlsec1-1.3.9.tar.gz"
+  mirror "https://www.aleksey.com/xmlsec/download/xmlsec1-1.3.9.tar.gz"
+  sha256 "a631c8cd7a6b86e6adb9f5b935d45a9cf9768b3cb090d461e8eb9d043cf9b62f"
   license "MIT"
-  revision 1
 
   # Checking the first-party download page persistently fails in the autobump
   # environment, so we check GitHub releases as a workaround.
   livecheck do
-    url "https://github.com/lsh123/xmlsec"
+    url :stable
     strategy :github_latest
   end
 
@@ -25,7 +24,6 @@ class Libxmlsec1 < Formula
 
   depends_on "pkgconf" => :build
   depends_on "gnutls" # Yes, it wants both ssl/tls variations
-  depends_on "libgcrypt"
   depends_on "libxml2"
   depends_on "openssl@3"
   uses_from_macos "libxslt"
@@ -34,14 +32,14 @@ class Libxmlsec1 < Formula
   patch :DATA
 
   def install
-    args = [
-      "--disable-crypto-dl",
-      "--disable-apps-crypto-dl",
-      "--with-nss=no",
-      "--with-nspr=no",
-      "--enable-mscrypto=no",
-      "--enable-mscng=no",
-      "--with-openssl=#{Formula["openssl@3"].opt_prefix}",
+    args = %W[
+      --disable-apps-crypto-dl
+      --disable-crypto-dl
+      --disable-mscrypto
+      --disable-mscng
+      --without-nss
+      --without-nspr
+      --with-openssl=#{Formula["openssl@3"].opt_prefix}
     ]
 
     system "./configure", *args, *std_configure_args

--- a/Formula/lib/libxmlsec1.rb
+++ b/Formula/lib/libxmlsec1.rb
@@ -14,12 +14,12 @@ class Libxmlsec1 < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "1c48cfa8328041e1862476ec913a4bafa79fbc201f374483fdf2acd8b852cb77"
-    sha256 cellar: :any,                 arm64_sequoia: "19db0998f5f1a02813871d26801f7539edc3590e1b5e40ebbb9a4e90c3075486"
-    sha256 cellar: :any,                 arm64_sonoma:  "523eeb5a5a75353805ba933e81c8d559b7ef1daf963f04e94ee18a58c01a193a"
-    sha256 cellar: :any,                 sonoma:        "d88edf3d5ccbe612a2ef128a1bba206ede0e212f6d5a08cb800c5226fc97750e"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "ea9d560a48fb126589874b0ecee3b0a210ecb06ea0ef67574e8046a1af0ef307"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "60dc6a1a1254f6d42250214518232e46199c75223bb5b59e83c31e5db84c7997"
+    sha256 cellar: :any,                 arm64_tahoe:   "4a0347f04db0fafdd4c94056e921f5a28a934c718f254bc878dd93e91ce59fb3"
+    sha256 cellar: :any,                 arm64_sequoia: "bf8736ca35b30186ac8023ffdd6141104bda810502bf81da0a79a0e9b5e6ea05"
+    sha256 cellar: :any,                 arm64_sonoma:  "a46d51ed400865642998a65d2a3f3ea29a514a51e4a89e05028bcd2a605ec644"
+    sha256 cellar: :any,                 sonoma:        "c2a986b51f0d901b71400760b77711f34fcfcd3c3f991c5bda92389bdaad1c3e"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "116bd2f4c3f372406ae26b53f8e7dc6e6b286abbbd277cfdfb95c8a3db8cad4a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e94dcf7bb5692df44d334784fb03d2a032e52f71d50b951f1615b330fcccbbaf"
   end
 
   depends_on "pkgconf" => :build


### PR DESCRIPTION
Also use GitHub as main URL to allow autobump to work.

---

https://github.com/Homebrew/homebrew-core/actions/runs/19252779610/job/55040938949#step:6:10527
```
==> Downloading https://www.aleksey.com/xmlsec/download/xmlsec1-1.3.9.tar.gz
curl: (22) The requested URL returned error: 403
Error: Failed to download resource "libxmlsec1"
Download failed: https://www.aleksey.com/xmlsec/download/xmlsec1-1.3.9.tar.gz
```