### PR TITLE
sgram-tui 0.1.1 (new formula)

### DIFF
--- a/Formula/s/scope-tui.rb
+++ b/Formula/s/scope-tui.rb
@@ -8,7 +8,7 @@ class ScopeTui < Formula
   depends_on "rust" => :build
 
   def install
-    system "cargo", "install", *std_cargo_args(path: "sgram-tui")
+    system "cargo", "install", *std_cargo_args
     bin.install_symlink bin/"sgram-tui" => "scope-tui"
   end
 

--- a/Formula/s/scope-tui.rb
+++ b/Formula/s/scope-tui.rb
@@ -1,0 +1,18 @@
+class ScopeTui < Formula
+  desc "Terminal spectrogram viewer (WAV/mic) with palettes and exports"
+  homepage "https://github.com/arian-shamaei/sgram-tui"
+  url "https://github.com/arian-shamaei/sgram-tui/archive/refs/tags/v0.1.0.tar.gz"
+  sha256 "3021eb08bfb114624a4d23164008cb52a7d5fec52e530949c0a089a579440b76"
+  license "MIT"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args(path: "sgram-tui")
+    bin.install_symlink bin/"sgram-tui" => "scope-tui"
+  end
+
+  test do
+    assert_match "Terminal spectrogram viewer", shell_output("#{bin}/scope-tui --help")
+  end
+end

--- a/Formula/s/sgram-tui.rb
+++ b/Formula/s/sgram-tui.rb
@@ -1,8 +1,8 @@
 class SgramTui < Formula
   desc "Terminal spectrogram viewer (WAV/mic) with palettes and exports"
   homepage "https://github.com/arian-shamaei/sgram-tui"
-  url "https://github.com/arian-shamaei/sgram-tui/archive/refs/tags/v0.1.0.tar.gz"
-  sha256 "3021eb08bfb114624a4d23164008cb52a7d5fec52e530949c0a089a579440b76"
+url "https://github.com/arian-shamaei/sgram-tui/archive/refs/tags/v0.1.1.tar.gz"
+sha256 "6bde58115351f2d328ec827352cef3faef610a8f94d671a52473565a41414f46"
   license "MIT"
 
   depends_on "rust" => :build

--- a/Formula/s/sgram-tui.rb
+++ b/Formula/s/sgram-tui.rb
@@ -1,4 +1,4 @@
-class ScopeTui < Formula
+class SgramTui < Formula
   desc "Terminal spectrogram viewer (WAV/mic) with palettes and exports"
   homepage "https://github.com/arian-shamaei/sgram-tui"
   url "https://github.com/arian-shamaei/sgram-tui/archive/refs/tags/v0.1.0.tar.gz"
@@ -9,10 +9,10 @@ class ScopeTui < Formula
 
   def install
     system "cargo", "install", *std_cargo_args
-    bin.install_symlink bin/"sgram-tui" => "scope-tui"
+    
   end
 
   test do
-    assert_match "Terminal spectrogram viewer", shell_output("#{bin}/scope-tui --help")
+    assert_match "Terminal spectrogram viewer", shell_output("#{bin}/sgram-tui --help")
   end
 end

--- a/Formula/s/sgram-tui.rb
+++ b/Formula/s/sgram-tui.rb
@@ -1,15 +1,14 @@
 class SgramTui < Formula
   desc "Terminal spectrogram viewer (WAV/mic) with palettes and exports"
   homepage "https://github.com/arian-shamaei/sgram-tui"
-url "https://github.com/arian-shamaei/sgram-tui/archive/refs/tags/v0.1.1.tar.gz"
-sha256 "6bde58115351f2d328ec827352cef3faef610a8f94d671a52473565a41414f46"
+  url "https://github.com/arian-shamaei/sgram-tui/archive/refs/tags/v0.1.1.tar.gz"
+  sha256 "6bde58115351f2d328ec827352cef3faef610a8f94d671a52473565a41414f46"
   license "MIT"
 
   depends_on "rust" => :build
 
   def install
     system "cargo", "install", *std_cargo_args
-    
   end
 
   test do

--- a/Formula/s/sgram-tui.rb
+++ b/Formula/s/sgram-tui.rb
@@ -5,6 +5,11 @@ class SgramTui < Formula
   sha256 "6bde58115351f2d328ec827352cef3faef610a8f94d671a52473565a41414f46"
   license "MIT"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   depends_on "rust" => :build
   on_linux do
     depends_on "alsa-lib"

--- a/Formula/s/sgram-tui.rb
+++ b/Formula/s/sgram-tui.rb
@@ -6,10 +6,12 @@ class SgramTui < Formula
   license "MIT"
 
   depends_on "rust" => :build
+  on_linux do
+    depends_on "alsa-lib"
+  end
 
   def install
-    # Build without optional microphone feature to keep Linux bottle deps minimal
-    system "cargo", "install", *std_cargo_args, "--no-default-features"
+    system "cargo", "install", *std_cargo_args, "--features=mic"
   end
 
   test do

--- a/Formula/s/sgram-tui.rb
+++ b/Formula/s/sgram-tui.rb
@@ -8,7 +8,8 @@ class SgramTui < Formula
   depends_on "rust" => :build
 
   def install
-    system "cargo", "install", *std_cargo_args
+    # Build without optional microphone feature to keep Linux bottle deps minimal
+    system "cargo", "install", *std_cargo_args, "--no-default-features"
   end
 
   test do


### PR DESCRIPTION
New formula: sgram-tui 0.1.1 (Rust terminal spectrogram viewer).\n\nHighlights\n- MIT licensed (LICENSE added)\n- Full functionality: live mic input enabled via Cargo feature\n- on_linux depends_on "alsa-lib" for mic support\n- Builds with cargo from repo root\n- Livecheck via GitHub latest releases\n\nRepo: https://github.com/arian-shamaei/sgram-tui\nTarball: https://github.com/arian-shamaei/sgram-tui/archive/refs/tags/v0.1.1.tar.gz\nSHA256: 6bde58115351f2d328ec827352cef3faef610a8f94d671a52473565a41414f46