### PR TITLE
gradle: depend on gradle-completion

### DIFF
--- a/Formula/g/gradle.rb
+++ b/Formula/g/gradle.rb
@@ -14,6 +14,7 @@ class Gradle < Formula
     sha256 cellar: :any_skip_relocation, all: "41a3dfeca469b7c6f97f749f189d4aec7e9bba58a3c1cd8c1ca57c81cc8ce0c9"
   end
 
+  depends_on "gradle-completion"
   # https://github.com/gradle/gradle/blob/master/platforms/documentation/docs/src/docs/userguide/releases/compatibility.adoc
   depends_on "openjdk"
 


### PR DESCRIPTION
This PR makes the [`gradle`](https://formulae.brew.sh/formula/gradle) formula depend on the [`gradle-completion`](https://formulae.brew.sh/formula/gradle-completion) formula.

Discussed here:
https://github.com/orgs/Homebrew/discussions/6533

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
