### PR TITLE
rustup: add cargo completions; expand rustup completion shell support

### DIFF
--- a/Formula/r/rustup.rb
+++ b/Formula/r/rustup.rb
@@ -36,7 +36,13 @@ class Rustup < Formula
        rust-gdb rust-gdbgui rust-lldb rustc rustdoc rustfmt rustup].each do |name|
       bin.install_symlink bin/"rustup-init" => name
     end
-    generate_completions_from_executable(bin/"rustup", "completions")
+    # Generate rustup completions
+    generate_completions_from_executable(bin/"rustup", "completions", shells: [:bash, :zsh, :fish, :pwsh])
+    (share/"elvish/lib/rustup.elv").write Utils.safe_popen_read(bin/"rustup", "completions", "elvish")
+    # Generate cargo completions
+    (bash_completion/"cargo").write Utils.safe_popen_read(bin/"rustup", "completions", "bash", "cargo")
+    (zsh_completion/"_cargo").write Utils.safe_popen_read(bin/"rustup", "completions", "zsh", "cargo")
+    end
   end
 
   def post_install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- add rustup completion support for powershell and elvish
- add cargo completions to (upstream supported shells, namely,) bash and zsh