### PR TITLE
zopfli: deprecate by repo archived; pigz: use vendored `zopfli`

### DIFF
--- a/Formula/p/pigz.rb
+++ b/Formula/p/pigz.rb
@@ -15,18 +15,12 @@ class Pigz < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:    "61447a94a14880951c88b71720cd1528a5763708b692ad2c7fe0cfbd42f94f75"
-    sha256 cellar: :any,                 arm64_sequoia:  "64097e66f14e0e16ab597007639492ac10e2d0f499968b757f91fa700f06f952"
-    sha256 cellar: :any,                 arm64_sonoma:   "97752b6fd2b65df80d73068299789a714fb01b6b904fd843c142677e4f2c3db7"
-    sha256 cellar: :any,                 arm64_ventura:  "ddd9fed16f07f42285d3a4a46b6d769f4ca2e902827dbd44a3f69597eca5cb77"
-    sha256 cellar: :any,                 arm64_monterey: "043af6f4e17cb7776003f982331552ed3b6ce10a46fdce4687952fa9443fbab8"
-    sha256 cellar: :any,                 arm64_big_sur:  "1f4b378d4427db80c89231ddf0ca710f11c6a300d36687b30025dcd263c9441e"
-    sha256 cellar: :any,                 sonoma:         "cd7b739570e228afbea2ad719c4789607d41a441d6c03dd4115a97e67cae729c"
-    sha256 cellar: :any,                 ventura:        "0d30f581ef66c28103ccec510b9df46f2cd761bc9f9ce76af0422b60256739f7"
-    sha256 cellar: :any,                 monterey:       "0ef362a072b9e707ee292162d44d46a23e9f04c1e239d05f462d20fad9c8c1b2"
-    sha256 cellar: :any,                 big_sur:        "cd36e7d4ec7c3f373a4e74f280ac1001aa834d035f20a3ec3a2e3140f75fd525"
-    sha256 cellar: :any_skip_relocation, arm64_linux:    "60978f631c2c096cd2ee62e2e3e8742ce16ef0ee7fb76d9258aec97915578d32"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ca1011cd83d5acec7b50fd581f4efa9d189c22058d652736f3dc565a0165c67b"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "826d8436f8f3d6f7ec60f78f728f966499f295539f132ae06a20532696742d99"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "2136c50e0f5f4e7078f8e323aa6bfd5dbd170da137e7930f9f4a28d32be4a4e1"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "7d530c3e0e7ace1ca42ba8b4f233b42294024ca5b1d896e59d794372a447b70b"
+    sha256 cellar: :any_skip_relocation, sonoma:        "ad8e22780abe73636213e792aa1d9f77593d392508b7ac45f0e0310c6f1c387b"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "5943909e6487fc62989be3ee2dc9788b28322f6f0025c52f59df30e3dd5e11e8"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d6f8eefa10c0d4704e5ab22e5211d683972f25e1573618191e6d29342a838c44"
   end
 
   uses_from_macos "zlib"

--- a/Formula/p/pigz.rb
+++ b/Formula/p/pigz.rb
@@ -4,7 +4,8 @@ class Pigz < Formula
   url "https://zlib.net/pigz/pigz-2.8.tar.gz"
   sha256 "eb872b4f0e1f0ebe59c9f7bd8c506c4204893ba6a8492de31df416f0d5170fd0"
   license "Zlib"
-  head "https://github.com/madler/pigz.git", branch: "develop"
+  revision 1
+  head "https://github.com/madler/pigz.git", branch: "master"
 
   livecheck do
     url :homepage
@@ -28,12 +29,10 @@ class Pigz < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "ca1011cd83d5acec7b50fd581f4efa9d189c22058d652736f3dc565a0165c67b"
   end
 
-  depends_on "zopfli"
   uses_from_macos "zlib"
 
   def install
-    libzopfli = Formula["zopfli"].opt_lib/shared_library("libzopfli")
-    system "make", "CC=#{ENV.cc}", "CFLAGS=#{ENV.cflags}", "ZOP=#{libzopfli}"
+    system "make", "CC=#{ENV.cc}", "CFLAGS=#{ENV.cflags}"
     bin.install "pigz", "unpigz"
     man1.install "pigz.1"
     man1.install_symlink "pigz.1" => "unpigz.1"

--- a/Formula/z/zopfli.rb
+++ b/Formula/z/zopfli.rb
@@ -10,19 +10,13 @@ class Zopfli < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:    "5b6adb20e537ce4f8fcb5d372c1dc80d42f99bd455ac4d5d9a872dfcfafc5a04"
-    sha256 cellar: :any,                 arm64_sequoia:  "87b9f0523e7d1233fcaec2d394122f9aab234bf00a026f4f9322b47b1ef8f8ae"
-    sha256 cellar: :any,                 arm64_sonoma:   "171ca3e9b77ac8ebac1b2c082c4938d845605d599e30c671003ca3b5f8f0f795"
-    sha256 cellar: :any,                 arm64_ventura:  "68ec999fc21b6ea2e0a44fe4a9cb23dc6fbfac6f51ee153b268fd33408f6d801"
-    sha256 cellar: :any,                 arm64_monterey: "31f0023436da6f38a1a1df31ca8b2fd82eaac4a7ce1bc2a2b7cf05a0c4ec2f05"
-    sha256 cellar: :any,                 arm64_big_sur:  "2f093e34188e4c0b3d7b2acdd913ecc302ba6dafe722f943e579bf70a09ef15a"
-    sha256 cellar: :any,                 sonoma:         "cee5a9b397978a707970ca5f9caaa4c5c461effcb3c4291ae74d2e40ac769dc2"
-    sha256 cellar: :any,                 ventura:        "ef2f18c71a1473972602aa28fc2e0c508c89336e42633423804877ab33dc6ccb"
-    sha256 cellar: :any,                 monterey:       "6f02f39b1b143725890fb1d1a33e6f587daf33ef473ff2991189e2fd1d1a5f85"
-    sha256 cellar: :any,                 big_sur:        "64f2102bff6163156d073e4554532c990c3a65669b7a52d2cec83a22d5b32d4c"
-    sha256 cellar: :any,                 catalina:       "288d48544556b28451e536b142dcc2235ea9dfe52dfe79d0b1d5f50db85c16dd"
-    sha256 cellar: :any_skip_relocation, arm64_linux:    "3424c6b2263832ea51f0b089bc7b8d1bbdfe041006847803ec32a7cc348c67c4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "6994139461f1d64975551091d1254a906a8957c3ce08c0c2b6d8d5c995b66f05"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "60d92c2dba51adbc2b158013f76e713caf79039176b8fce561d71e64eeb1ab1f"
+    sha256 cellar: :any,                 arm64_sequoia: "05a753407e078eb62cc7763b8aadc6b5c239b961aa5208fa100ffcfacde1074d"
+    sha256 cellar: :any,                 arm64_sonoma:  "abce2f037e1d3678b11116c779de02206b14d49da1388953414bd5f187ff1245"
+    sha256 cellar: :any,                 sonoma:        "0f106e6ca21e768d2cee053ab91204dd59bdf02c2acfe94780d4f344dd32da9c"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "73928042ea7ad2aeddbd734193759c045dd8320742be243256ccb12951daecdc"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "66ed41c03d5bf67bc664988336d1cde7e330f24cd4b376eeaf1361a330ec02dd"
   end
 
   deprecate! date: "2025-11-13", because: :repo_archived

--- a/Formula/z/zopfli.rb
+++ b/Formula/z/zopfli.rb
@@ -25,6 +25,8 @@ class Zopfli < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "6994139461f1d64975551091d1254a906a8957c3ce08c0c2b6d8d5c995b66f05"
   end
 
+  deprecate! date: "2025-11-13", because: :repo_archived
+
   depends_on "cmake" => :build
 
   # Backport fix for CMake 4 compatibility


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Repo archived and so deprecate it, change dependent to use their vendored `zopfli`. Welcome any feedback.