### PR TITLE
libgcrypt: remove outdated codesign

### DIFF
--- a/Formula/lib/libgcrypt.rb
+++ b/Formula/lib/libgcrypt.rb
@@ -24,19 +24,17 @@ class Libgcrypt < Formula
   depends_on "libgpg-error"
 
   def install
-    system "./configure", *std_configure_args,
+    system "./configure", "--disable-asm",
                           "--disable-silent-rules",
                           "--enable-static",
-                          "--disable-asm",
-                          "--with-libgpg-error-prefix=#{Formula["libgpg-error"].opt_prefix}"
+                          "--with-libgpg-error-prefix=#{Formula["libgpg-error"].opt_prefix}",
+                          *std_configure_args
 
     # The jitter entropy collector must be built without optimisations
     ENV.O0 { system "make", "-C", "random", "rndjent.o", "rndjent.lo" }
 
     # Parallel builds work, but only when run as separate steps
     system "make"
-    MachO.codesign!("#{buildpath}/tests/.libs/random") if OS.mac? && Hardware::CPU.arm?
-
     system "make", "check"
     system "make", "install"
 


### PR DESCRIPTION
Should have been removed in 6e9b10d75ee0daff082e95ec1373309b9f6c9594

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
