### PR TITLE
extra-cmake-modules: update homepage and livecheck

### DIFF
--- a/Formula/e/extra-cmake-modules.rb
+++ b/Formula/e/extra-cmake-modules.rb
@@ -1,13 +1,13 @@
 class ExtraCmakeModules < Formula
   desc "Extra modules and scripts for CMake"
-  homepage "https://api.kde.org/frameworks/extra-cmake-modules/html/index.html"
+  homepage "https://api.kde.org/ecm/"
   url "https://download.kde.org/stable/frameworks/6.19/extra-cmake-modules-6.19.0.tar.xz"
   sha256 "a4f0c1d8181f43e9af4b9b44696c77760b5bc9dae5bdb921f090bce664e9ca84"
   license all_of: ["BSD-2-Clause", "BSD-3-Clause", "MIT"]
   head "https://invent.kde.org/frameworks/extra-cmake-modules.git", branch: "master"
 
   livecheck do
-    url "https://download.kde.org/stable/frameworks/"
+    url "https://kde.org/announcements/frameworks/#{version.major}/"
     regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 


### PR DESCRIPTION
Seeing if this will help with autobump. Not updating version to check result in next CI run.
```console
❯ brew lc extra-cmake-modules --autobump
extra-cmake-modules: 6.19.0 ==> 6.20.0
```

---

The previous livecheck was only getting major.minor version which won't be able to bump version.

There is a git repository, but the tag occurs too early as all parts of framework is released together. Using git tags would cause autobump failures for a couple days.

---

If this doesn't work, we could run 2nd HTTP request to find the missing patch part.