### PR TITLE
stlink: fix libusb detection for unstable builds

### DIFF
--- a/Formula/s/stlink.rb
+++ b/Formula/s/stlink.rb
@@ -1,10 +1,18 @@
 class Stlink < Formula
   desc "STM32 discovery line Linux programmer"
   homepage "https://github.com/stlink-org/stlink"
-  url "https://github.com/stlink-org/stlink/archive/refs/tags/v1.8.0.tar.gz"
-  sha256 "cff760b5c212c2cc480f705b9ca7f3828d6b9c267950c6a547002cd0a1f5f6ac"
   license "BSD-3-Clause"
-  head "https://github.com/stlink-org/stlink.git", branch: "develop"
+
+  stable do
+    url "https://github.com/stlink-org/stlink/archive/refs/tags/v1.8.0.tar.gz"
+    sha256 "cff760b5c212c2cc480f705b9ca7f3828d6b9c267950c6a547002cd0a1f5f6ac"
+
+    # upstream PR ref, https://github.com/stlink-org/stlink/pull/1373
+    patch do
+      url "https://github.com/stlink-org/stlink/commit/4eafbb29d106b32221c8d3b375b31d78f07de182.patch?full_index=1"
+      sha256 "a745b3f10eb9c831838afc53e94038f61b29cdbe70970d3417d15f0db5301791"
+    end
+  end
 
   no_autobump! because: :requires_manual_review
 
@@ -21,15 +29,20 @@ class Stlink < Formula
     sha256 x86_64_linux:   "7872c14d351e27c5953bc0565d4eb64312d3e54abc898b05197af8a631abab2c"
   end
 
+  head do
+    url "https://github.com/stlink-org/stlink.git", branch: "develop"
+
+    # same libusb-related patch as stable, should be removed on next release, since they will sync again
+    patch do
+      url "https://github.com/stlink-org/stlink/commit/45f1c2ca0032afdbb6b71e1e93527310ae429b0e.patch?full_index=1"
+      sha256 "810d99f9411837754d9ec9f76ba576e1404b65d94fa98f7a24b09e5f5a914907"
+    end
+  end
+
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
   depends_on "libusb"
 
-  # upstream PR ref, https://github.com/stlink-org/stlink/pull/1373
-  patch do
-    url "https://github.com/stlink-org/stlink/commit/4eafbb29d106b32221c8d3b375b31d78f07de182.patch?full_index=1"
-    sha256 "a745b3f10eb9c831838afc53e94038f61b29cdbe70970d3417d15f0db5301791"
-  end
   patch do
     url "https://github.com/stlink-org/stlink/commit/d742e752d896c0f8d4a61b282457401f7a681b16.patch?full_index=1"
     sha256 "1f86ccdcb6bbf2d8cf53d6c96e76c1f11aef83c9de0e8dbe9b8d5cafab02c28d"

--- a/Formula/s/stlink.rb
+++ b/Formula/s/stlink.rb
@@ -17,16 +17,13 @@ class Stlink < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 arm64_tahoe:    "7cc317395306550102803a7cd3ee1416ab2d7bcc0993d8641a5d1a879df58cce"
-    sha256 arm64_sequoia:  "234d04d230556d8342bc80d9d8564e7c643f86ebd39c8e3d9cd10667076c4459"
-    sha256 arm64_sonoma:   "182146c51940a4851235c5a1e66e0a1455d5833a112537c366b68314f4280d62"
-    sha256 arm64_ventura:  "11f6ede1d7a55e0ceb814ea59df7e88560f317fd9ed9d1bf47c9905bb1b28b68"
-    sha256 arm64_monterey: "5aec98fdb4a07aa5abfd1292ec15bf9c385869845fc107c905f35baf2c21bb75"
-    sha256 sonoma:         "123d84cd6f2bdeeabce247febb96aed963876789e3e23bec7312098b2590483c"
-    sha256 ventura:        "96b6ee1f313c0b377a3882eb33191164b751f171dd1ba2c6c9e8ef525b663798"
-    sha256 monterey:       "5c33e3d172d272295fa0d27e08d80fd86e0429156e44b72b934898c11d08ab11"
-    sha256 arm64_linux:    "4b0deecf90ccc793307fb68a4b72e13a7cd8eebf05012ad6d26fd4f2adfa80e7"
-    sha256 x86_64_linux:   "7872c14d351e27c5953bc0565d4eb64312d3e54abc898b05197af8a631abab2c"
+    rebuild 1
+    sha256 arm64_tahoe:   "a1318d007d2ebd3a5efac196e4c2be465b0bb7a4f6b7b937211d17ad447d983e"
+    sha256 arm64_sequoia: "74429f7151b0a5f5ec7e8f150dadcaad6fc89c8c100edbada6360195e257322c"
+    sha256 arm64_sonoma:  "f446d762cfa087474e6c4110af9cfd1764501715b1f6e6c67e73f66950a4ab08"
+    sha256 sonoma:        "535d44df1d077f72e893542b763d70fd8cb527dd23801e9bea188146f2f4b7e8"
+    sha256 arm64_linux:   "3acecdba1528f1b3be80a7323eee6810539ef12e53943db52ee2806354e9d4a8"
+    sha256 x86_64_linux:  "08e0054f6e1ecf8c7298ca5938e79b3d9533d2ddbcc90585adf1303bf2ef0423"
   end
 
   head do


### PR DESCRIPTION
There is a patch that changes a C header that checks for minimal libusb versions. This header was changed in git develop branch, and the patch that applies to 1.8.0 does not applies to develop branch anymore. This commit adds a new patch, that is used only for unstable builds.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
