### PR TITLE
libdecor 0.2.4 (new formula)

### DIFF
--- a/Formula/lib/libdecor.rb
+++ b/Formula/lib/libdecor.rb
@@ -5,6 +5,11 @@ class Libdecor < Formula
   sha256 "b17cf420e8dcb526bf82da5d36f8443a91fad0777083fa4ec5c1df8ee877416f"
   license "MIT"
 
+  bottle do
+    sha256 arm64_linux:  "0ce1db47f5f6e33e2eb9e56441bfd76e0743d3d73fe36ec03fc70706546e1c0b"
+    sha256 x86_64_linux: "01ed6ba19998c4ec2aa7093b943d75a8c491616c0a3638779c7297e4da276ea1"
+  end
+
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkgconf" => :build

--- a/Formula/lib/libdecor.rb
+++ b/Formula/lib/libdecor.rb
@@ -1,0 +1,38 @@
+class Libdecor < Formula
+  desc "Client-side decorations library for Wayland client"
+  homepage "https://gitlab.freedesktop.org/libdecor/libdecor"
+  url "https://gitlab.freedesktop.org/libdecor/libdecor/-/releases/0.2.4/downloads/libdecor-0.2.4.tar.xz"
+  sha256 "b17cf420e8dcb526bf82da5d36f8443a91fad0777083fa4ec5c1df8ee877416f"
+  license "MIT"
+
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+  depends_on "pkgconf" => :build
+  depends_on "cairo"
+  depends_on "dbus"
+  depends_on "glib"
+  depends_on "gtk+3"
+  depends_on :linux
+  depends_on "pango"
+  depends_on "wayland"
+  depends_on "wayland-protocols"
+
+  def install
+    system "meson", "setup", "build", "-Ddemo=false", *std_meson_args
+    system "meson", "compile", "-C", "build", "--verbose"
+    system "meson", "install", "-C", "build"
+  end
+
+  test do
+    (testpath/"test.c").write <<~C
+      #include <libdecor.h>
+
+      int main() {
+        struct libdecor *context;
+        return 0;
+      }
+    C
+    system ENV.cc, "test.c", "-o", "test", "-I#{include}/libdecor-0"
+    system "./test"
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Adds [libdecor](https://gitlab.freedesktop.org/libdecor/libdecor), a library for Wayland on Linux that helps applications running on GNOME draw window decorations.

This is beneficial on Fedora Silverblue and derivatives for providing pkg-config files for libdecor. Fedora Silverblue already ships with the library, but it doesn't have the development packages by default, and since it is an immutable OS, it is preferential to acquire them through brew, much like the Wayland formulae.

This formula is Linux only. It depends on the wayland formula, which is likewise Linux only. I'm not sure exactly what exception qualified Wayland to be included, but I would presume it could apply here.

I should disclaim, that while I am on a Fedora Silverblue derivative (Bazzite), it did not build for me _on_ Fedora Silverblue. **However**, I ran a podman container with regular Fedora, and it did build there. There error related to GCC not being able to find the include directories for dbus, pango, and gtk. I'm inclined to attribute this to the `/home` directory being a symlink to `/var/home` on Silverblue. I didn't bother trying to build it on my mac, since it's a support library for GNOME and Wayland, which would be unlikely to ever work on macOS; and since it has a hard dependency on wayland which already has a hard dependency on `:linux`, I presumed it would not build.