### PR TITLE
deck erlang-language-platform: remove shell definition to use default

### DIFF
--- a/Formula/d/deck.rb
+++ b/Formula/d/deck.rb
@@ -20,7 +20,7 @@ class Deck < Formula
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w"), "./cmd/deck"
 
-    generate_completions_from_executable(bin/"deck", "completion", shells: [:zsh, :bash, :fish])
+    generate_completions_from_executable(bin/"deck", "completion")
   end
 
   test do

--- a/Formula/e/erlang-language-platform.rb
+++ b/Formula/e/erlang-language-platform.rb
@@ -37,7 +37,7 @@ class ErlangLanguagePlatform < Formula
     build_args = ["build", "--release"]
     system "cargo", *build_args, *std_cargo_args.reject { |arg| arg["--root"] || arg["--path"] }
     bin.install "target/release/elp"
-    generate_completions_from_executable(bin/"elp", "generate-completions", shells: [:bash, :fish, :zsh])
+    generate_completions_from_executable(bin/"elp", "generate-completions")
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

For the shell completion generation, we already use `bash`, `fish` and `zsh` for default values and so remove it.