### PR TITLE
httptap tremor-runtime: remove default base_name

### DIFF
--- a/Formula/h/httptap.rb
+++ b/Formula/h/httptap.rb
@@ -116,7 +116,6 @@ class Httptap < Formula
 
     generate_completions_from_executable(
       libexec/"bin/register-python-argcomplete", "httptap",
-      base_name:              "httptap",
       shell_parameter_format: :arg
     )
 

--- a/Formula/t/tremor-runtime.rb
+++ b/Formula/t/tremor-runtime.rb
@@ -64,7 +64,7 @@ class TremorRuntime < Formula
 
     system "cargo", "install", *std_cargo_args(path: "tremor-cli")
 
-    generate_completions_from_executable(bin/"tremor", "completions", base_name: "tremor")
+    generate_completions_from_executable(bin/"tremor", "completions")
 
     # main binary
     bin.install "target/release/tremor"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

For `httptap`, the executable is not in the path `bin` and `sbin`, then the base_name will be formula name by default. So we can remove.

For `tremor-runtime`, the executable is in the base `bin` and so the base_name will be same as the executable name and no need to set the value here too.