### PR TITLE
sequoia-sq: add livecheck

### DIFF
--- a/Formula/s/sequoia-sq.rb
+++ b/Formula/s/sequoia-sq.rb
@@ -6,6 +6,11 @@ class SequoiaSq < Formula
   license "LGPL-2.0-or-later"
   head "https://gitlab.com/sequoia-pgp/sequoia-sq.git", branch: "main"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "af93f1cb2fa3295751c7789f2e19cb799036aa31f6574399cd4335452b92e8a0"
     sha256 cellar: :any,                 arm64_sequoia: "748da0543b832cadfa5607c47bd93938bb09a31447ba6470bed0eecd9eed5abe"


### PR DESCRIPTION
Closes #254321

```
❯ brew lc sequoia-sq --autobump
sequoia-sq: 1.3.1 ==> 1.3.1
```

Trying easier option first of just regex match on git tags. Hopefully upstream doesn't do prereleases on these tags.

If needed, we can switch to tracking Crates.io, but this will need brew changes to support `:crate` strategy outside of just `static.crates.io` URLs. We could switch to downloading crate but often less ideal as unpacking these is fragile due to rely on implementation details (i.e. assumed to be compressed tar but this is not standardized).