### PR TITLE
man-db: caveat: gapropos/gwhatis require gmandb

### DIFF
--- a/Formula/m/man-db.rb
+++ b/Formula/m/man-db.rb
@@ -84,6 +84,10 @@ class ManDb < Formula
       If you need to use these commands with their normal names, you
       can add a "bin" directory to your PATH from your bashrc like:
         PATH="#{opt_libexec}/bin:$PATH"
+
+      If you will use "gapropos" or "gwhatis" (which is especially likely
+      if you override PATH as described above), make sure to run "gmandb"
+      once as well as every time the set of available man pages has changed.
     EOS
   end
 


### PR DESCRIPTION
As reported in https://github.com/fish-shell/fish-shell/discussions/12062,

	$ brew install man-db
	$ echo >>~/.zprofile 'PATH="/opt/homebrew/opt/man-db/libexec/bin:$PATH"'

breaks commands like

	$ apropos zsh
	zsh: nothing appropriate

until the user runs "gmandb".

This has caused confusion because fish shell uses "apropos" to compute
completions for the "man" command.

Maybe we can find a reliable way to:
1. either run "gmandb" automatically as needed (maybe we should ask
   "man-db" upstream to make this the responsibility of "apropos"
   and "whatis").
2. or at least detect this case (user trying to use "gaprops" with empty
   "/opt/homebrew/var/cache/man/") and tell them to run "gmandb".

Until then, add a caveat telling the user to run "gmandb" (or "mandb"
I guess).

At the risk of being patronizing, emphasize that this is more likely
to be necessary if the user makes "apropos" run "gapropos" because
of cases like fish. Happy to remove this.
