### PR TITLE
wasi-libc: build `:all` bottle

### DIFF
--- a/Formula/w/wasi-libc.rb
+++ b/Formula/w/wasi-libc.rb
@@ -42,12 +42,10 @@ class WasiLibc < Formula
     ENV.remove_cc_etc
     ENV.remove "PATH", Superenv.shims_path
 
-    # Flags taken from Arch:
-    # https://gitlab.archlinux.org/archlinux/packaging/packages/wasi-libc/-/blob/main/PKGBUILD
     make_args = [
-      "WASM_CC=#{Formula["llvm"].opt_bin}/clang",
-      "WASM_AR=#{Formula["llvm"].opt_bin}/llvm-ar",
-      "WASM_NM=#{Formula["llvm"].opt_bin}/llvm-nm",
+      "CC=#{Formula["llvm"].opt_bin}/clang",
+      "AR=#{Formula["llvm"].opt_bin}/llvm-ar --format=gnu",
+      "NM=#{Formula["llvm"].opt_bin}/llvm-nm",
       "INSTALL_DIR=#{share}/wasi-sysroot",
     ]
 

--- a/Formula/w/wasi-libc.rb
+++ b/Formula/w/wasi-libc.rb
@@ -20,12 +20,8 @@ class WasiLibc < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "17e4a77b687c84974474f58bb51730e05edd490297bf524da80b1c84430d2ae4"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "17e4a77b687c84974474f58bb51730e05edd490297bf524da80b1c84430d2ae4"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "17e4a77b687c84974474f58bb51730e05edd490297bf524da80b1c84430d2ae4"
-    sha256 cellar: :any_skip_relocation, sonoma:        "17e4a77b687c84974474f58bb51730e05edd490297bf524da80b1c84430d2ae4"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "df3c7604191a99d4e45b25af688dfa8264a4bd8e5d18a81d1ce8154fa67a9c8b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "df3c7604191a99d4e45b25af688dfa8264a4bd8e5d18a81d1ce8154fa67a9c8b"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "a529c0735dbb8a0650b31e03540ce34aa2821efba92b1b032e15e47a662fe5d9"
   end
 
   depends_on "llvm" => [:build, :test]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We need to pass `--format=gnu` to `llvm-ar` because it defaults to
`--format=darwin` on macOS, which results in differences in the stub
archives.

Also, remove the `WASM_` prefixes. Upstream stopped using these in
WebAssembly/wasi-libc@9eb4a995ea2b8ed6ed362efbc31b1ba7f9afec47.
