### PR TITLE
mas 3.0.0

### DIFF
--- a/Formula/m/mas.rb
+++ b/Formula/m/mas.rb
@@ -2,8 +2,8 @@ class Mas < Formula
   desc "Mac App Store command-line interface"
   homepage "https://github.com/mas-cli/mas"
   url "https://github.com/mas-cli/mas.git",
-      tag:      "v2.3.0",
-      revision: "c93a4fca67cc56585bea1650ba268503ea1883a6"
+      tag:      "v3.0.0",
+      revision: "e8993b7de5256074f2fd069d80e60fbc9e4dfaad"
   license "MIT"
   head "https://github.com/mas-cli/mas.git", branch: "main"
 
@@ -28,9 +28,10 @@ class Mas < Formula
 
   def install
     ENV["MAS_DIRTY_INDICATOR"] = ""
-    system "Scripts/build", "homebrew/core/mas", "--disable-sandbox"
+    system "Scripts/build", "homebrew/core/mas", "--disable-sandbox", "-c", "release"
     bin.install ".build/release/mas"
-
+    system "swift", "package", "--disable-sandbox", "generate-manual"
+    man1.install ".build/plugins/GenerateManual/outputs/mas/mas.1"
     bash_completion.install "contrib/completion/mas-completion.bash" => "mas"
     fish_completion.install "contrib/completion/mas.fish"
   end

--- a/Formula/m/mas.rb
+++ b/Formula/m/mas.rb
@@ -15,12 +15,10 @@ class Mas < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "a1f595639e93d5ad5c1cdadfb39a1ce190393a5fdbdcf34dbabdaf6dbe58ade6"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "b1dbec5f7cc97c21b9c41aff384531d3bc065611d9e5f6377afbec4a59010ab5"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "bf056bf44898315518be7c9de6c53de45b3f8bcd83e2aa62ee1ce501239217c2"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "0777dcb10e7d45e2ce5299a58bcf41b99897eb18184f2af532911f2a5f0d0cc9"
-    sha256 cellar: :any_skip_relocation, sonoma:        "f36d6c89870328a360b3ea74dc65e3a659eb8fe0d40bf4c722189487e17f04a0"
-    sha256 cellar: :any_skip_relocation, ventura:       "ae1c6e102f61ef8704807180a323f50f7d1bf0f380ab36977e23d93394e39afb"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "1cd574ef2fa8fcbd57d51208b7b78c1dce49bee72d7a94c2b6c38eb8ee185301"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "81091c673925397daa82d39e78a7fecce014ce8942ece4a3804d0458f9a6dbc8"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "9968a96c48d37995da35a2e357563edb333b856774e0d1d69f3a9da30d0fac1f"
+    sha256 cellar: :any_skip_relocation, sonoma:        "b7edfb5bcdf496b08a8d3fe5e9443c51c43930e437292896e34f1050a9bb57ad"
   end
 
   depends_on xcode: ["15.0", :build]


### PR DESCRIPTION
mas 3.0.0.

Added 2 newly necessary build arguments.

Generate man page.

Note: This version (3.0.0) does not fix the [recent errors for `get`, `install`, `lucky`, `purchase`, `update` & `upgrade` caused by macOS 26.1, 15.7.2 & 14.8.2](https://github.com/mas-cli/mas/issues/1029). They will be fixed in the forthcoming mas 4.0.0.

mas 3.0.0 is being released with many other previously completed changes so that they can be used without the disruptive change to core mas functionality in mas 4.0.0.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
