### PR TITLE
scip: update livecheck

### DIFF
--- a/Formula/s/scip.rb
+++ b/Formula/s/scip.rb
@@ -6,8 +6,8 @@ class Scip < Formula
   license "Apache-2.0"
 
   livecheck do
-    url "https://scipopt.org/scipdata.js"
-    regex(/["']name["']:\s*?["']scip[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url "https://github.com/scipopt/scip"
+    strategy :github_latest
   end
 
   bottle do


### PR DESCRIPTION
Closes #254033

Livecheck currently shows a beta release.

Easiest option seems to be using GitHub repo with `:github_latest` since tag version format is missing dots.
```
❯ brew lc scip --autobump --debug

Formula:          scip
livecheck block?: Yes

URL:              https://github.com/scipopt/scip
Strategy:         GithubLatest
URL (strategy):   https://api.github.com/repos/scipopt/scip/releases/latest
Regex (strategy): /v?(\d+(?:\.\d+)+)/i

Matched Versions:
9.2.4

scip: 9.2.4 ==> 9.2.4
```

If it ever fails, we can consider a more complicated match on https://scipopt.org/scipdata.js like
```rb
regex(/^v?(\d+(?:\.\d+)+)$/i)
strategy :page_match do |page, regex|
  next if (source = page[/source\s*=\s*(\[[^\]]*\]);/i, 1]).blank?

  JSON.parse(source).filter_map do |release|
    next if release["type"] != "scip"

    release["version"]&.[](regex, 1)
  end
end
```

The above seemed more fragile as it tries to get a particular variable in JavaScript file assuming it can be parsed as JSON with assumptions on the keys to access. 