### PR TITLE
xcresultparser: remove `uses_from_macos "swift"`

### DIFF
--- a/Formula/x/xcresultparser.rb
+++ b/Formula/x/xcresultparser.rb
@@ -15,7 +15,6 @@ class Xcresultparser < Formula
 
   depends_on xcode: ["15.0", :build]
   depends_on :macos
-  uses_from_macos "swift"
 
   def install
     system "swift", "build", "--disable-sandbox", "--configuration", "release"


### PR DESCRIPTION
xcresultparser: remove `uses_from_macos "swift"`

----

it should be covered by xcode requirement