### PR TITLE
lastpass-cli : add workaround for openssl 3.5 API change

### DIFF
--- a/Formula/l/lastpass-cli.rb
+++ b/Formula/l/lastpass-cli.rb
@@ -34,6 +34,13 @@ class LastpassCli < Formula
     sha256 "a4c2a16fd47942a511c0ebbce08bee5ffdb0d6141f6c9b60ce397db9e207d8be"
   end
 
+  # Workaround for for API change in OpenSSL 3.5
+  # PR ref: https://github.com/lastpass/lastpass-cli/pull/716
+  patch do
+    url "https://github.com/lastpass/lastpass-cli/commit/95fff9accc5832264e31af3f54f49af461339693.patc>
+    sha256 "5d7559511b1814c6f9d8cccc02b7c5dbf8a4e6d2927a94cf76d090cc45a47dd2"
+  end
+
   def install
     ENV["XML_CATALOG_FILES"] = etc/"xml/catalog"
 


### PR DESCRIPTION
This pulls in a PR from the lastpass-cli repository that primarily fixes the ability to write notes.

Without it, the cli tool breaks frequently with an error about being unable to base64 decode the response - this is because lastpass-cli without the change blindly passes all input from the attachment_key field to OpenSSL.

Older versions of OpenSSL silently dealt with this, newer ones don't so the patch referenced is a 1 line change to make sure that if the string that would be passed to OpenSSL is "skipped", the string is not passed to OpenSSL so the same code path is followed under all versions.

I am not the author of the patch - I'm a user of the CLI tool, and have been using a source version of the tool with the patch for around 3 months on both Sequoia and Tahoe with no issues.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
