### PR TITLE
qwen-code: depend on ripgrep instead of vendored binary

### DIFF
--- a/Formula/q/qwen-code.rb
+++ b/Formula/q/qwen-code.rb
@@ -15,6 +15,7 @@ class QwenCode < Formula
   end
 
   depends_on "node"
+  depends_on "ripgrep"
 
   def install
     system "npm", "install", *std_npm_args

--- a/Formula/q/qwen-code.rb
+++ b/Formula/q/qwen-code.rb
@@ -6,12 +6,13 @@ class QwenCode < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256                               arm64_tahoe:   "64e1887456dfe8ff4513fda3edec0ccd2b4c6de47a53f0c3cb51adea6a9fd6c6"
-    sha256                               arm64_sequoia: "d19206917860df2729ad8038e8d146da6962f71b05a2d9a31870851bf754358f"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "abe809cb8691816e2470915976185e5787d876feaa06c25ee016fc6c45332de9"
-    sha256 cellar: :any_skip_relocation, sonoma:        "ffd433d5a2fa7e17b56dacb1007d89ab112fa585fd1133526424ea40e46170dc"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "a763cd48b323bedcc4b578425b66199036504ed28f918caf6f9ba284e965f7a5"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "cb8fd9543e987e43dd49977b0faf3605b82d377646efb5a2248c92fb28fd1967"
+    rebuild 1
+    sha256                               arm64_tahoe:   "60b15d952e516f832aba3284261dfc74fb54a89e0a34ea4eb1466e7419e82dc3"
+    sha256                               arm64_sequoia: "3883e09999a486d976cc0ce2f35f4f83982302702b5df40a250c8d49757d9259"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "72276d2e6e6001d68cf69faa88c2a47b4a18dfea5c7722257bfb654167ff3517"
+    sha256 cellar: :any_skip_relocation, sonoma:        "8ea5dfc3c9d1b2e5bdbba948e07eab1a142d5cb2fa018b209394ba78b43df213"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "3f62fadb434fc8477f4d114b37afe01b4ed24e8bd39da41b469fc96d12eb6ba9"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4510ab5d2b1d0f808aece5f3fc61639e2996b7b89e55cf79f3b379c1c105ecf1"
   end
 
   depends_on "node"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

### 🛠️ Summary

This PR updates the `qwen-code` formula to correctly depend on Homebrew's `ripgrep` package, instead of using the vendored binary bundled within the npm package.

### 🔍 Background

The original formula includes:

```ruby
# Remove incompatible pre-built binaries
rm_r(libexec/"lib/node_modules/@qwen-code/qwen-code/vendor/ripgrep")
```

This removes the pre-built binary shipped under `vendor/ripgrep` in compliance with Homebrew’s policy against vendored binaries.

However, `qwen-code` relies on `ripgrep` for search and introspection features. Removing the vendor binary without providing a system-level replacement results in search functionality being silently broken in Homebrew installations.

### 👇 Fix

This patch introduces:

```ruby
depends_on "ripgrep"
```

This ensures that when the vendored binary is removed, Homebrew supplies a compatible version of `ripgrep` via its own build pipeline.

No other logic was modified — this change lets `qwen-code` resolve `rg` through `PATH` correctly post-install.

### 📚 Reference

Upstream issue tracking the problem: [https://github.com/QwenLM/qwen-code/issues/1055](https://github.com/QwenLM/qwen-code/issues/1055)
