### PR TITLE
lastpass-cli : add workaround for openssl 3.5 API change

### DIFF
--- a/Formula/l/lastpass-cli.rb
+++ b/Formula/l/lastpass-cli.rb
@@ -8,12 +8,12 @@ class LastpassCli < Formula
   head "https://github.com/lastpass/lastpass-cli.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "93b96dc3bb80345c74934995e2e4899bad889abf98fefec321707ef216d787cd"
-    sha256 cellar: :any,                 arm64_sequoia: "840a351d5bd7022e7c60f2cc9c47b65bacd9b1cfb4314d604b7a5b9ee119c273"
-    sha256 cellar: :any,                 arm64_sonoma:  "76fcf9be8c41da58c8f15255048f4a755579655d8eaeccc84b5ac05a96c9d9e0"
-    sha256 cellar: :any,                 sonoma:        "09a1378f0bc30b4718a8a2752c75be049cf6ca5cdf105fd6a0307e26656fe149"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "9ab592522ad509c596a81bc676aaaf6e19bfed68672037d42637f293d69c9918"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "604fa7938c619c42ddb92b76c410f1d9fd2d16b156befc61cc36ad1121fe243f"
+    sha256 cellar: :any,                 arm64_tahoe:   "c2a5f02a4ca98532c55385ebacc3539000fa5c6b5a4682f3e5cd5124ff1d6cff"
+    sha256 cellar: :any,                 arm64_sequoia: "569c58eb35aeb7992dc6fe294bc12ffb9080a583bc84d135ddd93bab2d3995ec"
+    sha256 cellar: :any,                 arm64_sonoma:  "e13a16eda126d0829f53904319b45663deb23d226af8ec7906e82a66bfc7d5ca"
+    sha256 cellar: :any,                 sonoma:        "e23cb4d80dee3fa976237e1df4305538652531ab1a9d1b13d22d583c330b7898"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "ce94668af616a6b2f3ef80f465e1da9e4537998e2ff886e1a0f1b4b06dd6502d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "7e72da4920d9db53e2c8cc5b4fd99c2ba72c55dce8721e90fac8657c777ebb58"
   end
 
   depends_on "asciidoc" => :build

--- a/Formula/l/lastpass-cli.rb
+++ b/Formula/l/lastpass-cli.rb
@@ -4,7 +4,7 @@ class LastpassCli < Formula
   url "https://github.com/lastpass/lastpass-cli/releases/download/v1.6.1/lastpass-cli-1.6.1.tar.gz"
   sha256 "5e4ff5c9fef8aa924547c565c44e5b4aa31e63d642873847b8e40ce34558a5e1"
   license "GPL-2.0-or-later" => { with: "openvpn-openssl-exception" }
-  revision 1
+  revision 2
   head "https://github.com/lastpass/lastpass-cli.git", branch: "master"
 
   bottle do
@@ -32,6 +32,13 @@ class LastpassCli < Formula
   patch do
     url "https://github.com/lastpass/lastpass-cli/commit/31a4ad5f735933ff8e96403103d5b4f61faee945.patch?full_index=1"
     sha256 "a4c2a16fd47942a511c0ebbce08bee5ffdb0d6141f6c9b60ce397db9e207d8be"
+  end
+
+  # Workaround for for API change in OpenSSL 3.5
+  # PR ref: https://github.com/lastpass/lastpass-cli/pull/718
+  patch do
+    url "https://github.com/lastpass/lastpass-cli/commit/95fff9accc5832264e31af3f54f49af461339693.patch?full_index=1"
+    sha256 "5d7559511b1814c6f9d8cccc02b7c5dbf8a4e6d2927a94cf76d090cc45a47dd2"
   end
 
   def install


### PR DESCRIPTION
This pulls in a PR from the lastpass-cli repository that primarily fixes the ability to write notes.

Without it, the cli tool breaks frequently with an error about being unable to base64 decode the response - this is because lastpass-cli without the change blindly passes all input from the attachment_key field to OpenSSL.

Older versions of OpenSSL silently dealt with this, newer ones don't so the patch referenced is a 1 line change to make sure that if the string that would be passed to OpenSSL is "skipped", the string is not passed to OpenSSL so the same code path is followed under all versions.

I am not the author of the patch - I'm a user of the CLI tool, and have been using a source version of the tool with the patch for around 3 months on both Sequoia and Tahoe with no issues.

This is a re-submit of #254800 as I'm not able to re-open it with the truncated line fixed.
I've bumped the revision as suggested and used the re-formatted title, however I'm not sure what is meant by 'please make sure you are a human'.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----