### PR TITLE
apache-flink-cdc: move post-installed var subdirs to bottle

### DIFF
--- a/Formula/a/apache-flink-cdc.rb
+++ b/Formula/a/apache-flink-cdc.rb
@@ -11,48 +11,97 @@ class ApacheFlinkCdc < Formula
     sha256 cellar: :any_skip_relocation, all: "a2ef1ef002c24579098ea4ad0474551fa6899e052fc03397616fee4bd1ab92aa"
   end
 
-  depends_on "apache-flink@1" => :test
+  depends_on "apache-flink@1" => :test # Compatible version at https://flink.apache.org/downloads/#apache-flink-cdc
 
   # See: https://github.com/apache/flink-cdc/blob/master/docs/content/docs/connectors/pipeline-connectors/overview.md#supported-connectors
   resource "mysql-connector" do
     url "https://search.maven.org/remotecontent?filepath=org/apache/flink/flink-cdc-pipeline-connector-mysql/3.5.0/flink-cdc-pipeline-connector-mysql-3.5.0.jar"
     sha256 "60ace993199e26f3b06c45ff71732d974bbb4c8e35b960fd8d58ea6d37b21a0e"
+
+    livecheck do
+      formula :parent
+    end
   end
+
   resource "oceanbase-connector" do
     url "https://search.maven.org/remotecontent?filepath=org/apache/flink/flink-cdc-pipeline-connector-oceanbase/3.5.0/flink-cdc-pipeline-connector-oceanbase-3.5.0.jar"
     sha256 "60ace993199e26f3b06c45ff71732d974bbb4c8e35b960fd8d58ea6d37b21a0e"
+
+    livecheck do
+      formula :parent
+    end
   end
+
   resource "paimon-connector" do
     url "https://search.maven.org/remotecontent?filepath=org/apache/flink/flink-cdc-pipeline-connector-paimon/3.5.0/flink-cdc-pipeline-connector-paimon-3.5.0.jar"
     sha256 "0431fd6d42b9475506842b5409c37c35ac932e4a84d143d5c493c7d46fced74b"
+
+    livecheck do
+      formula :parent
+    end
   end
+
   resource "kafka-connector" do
     url "https://search.maven.org/remotecontent?filepath=org/apache/flink/flink-cdc-pipeline-connector-kafka/3.5.0/flink-cdc-pipeline-connector-kafka-3.5.0.jar"
     sha256 "8f9ac34b28b72797ec8af0f402f382c75299a78df863c1ddd1a683919c7eac28"
+
+    livecheck do
+      formula :parent
+    end
   end
+
   resource "maxcompute-connector" do
     url "https://search.maven.org/remotecontent?filepath=org/apache/flink/flink-cdc-pipeline-connector-maxcompute/3.5.0/flink-cdc-pipeline-connector-maxcompute-3.5.0.jar"
     sha256 "0b398c78f9431b44113ad32ed90616df49dcbf82b5d5703de2ed08c738dddb21"
+
+    livecheck do
+      formula :parent
+    end
   end
+
   resource "doris-connector" do
     url "https://search.maven.org/remotecontent?filepath=org/apache/flink/flink-cdc-pipeline-connector-doris/3.5.0/flink-cdc-pipeline-connector-doris-3.5.0.jar"
     sha256 "1cbbdd5a296420b78e2b748867bbbb12d44384d0d11d8654312beb53eb140899"
+
+    livecheck do
+      formula :parent
+    end
   end
+
   resource "elasticsearch-connector" do
     url "https://search.maven.org/remotecontent?filepath=org/apache/flink/flink-cdc-pipeline-connector-elasticsearch/3.5.0/flink-cdc-pipeline-connector-elasticsearch-3.5.0.jar"
     sha256 "d973b966bc5123cd378fb841f919312805e615cd6fd54dea3d2b4331ae081a30"
+
+    livecheck do
+      formula :parent
+    end
   end
+
   resource "starrocks-connector" do
     url "https://search.maven.org/remotecontent?filepath=org/apache/flink/flink-cdc-pipeline-connector-starrocks/3.5.0/flink-cdc-pipeline-connector-starrocks-3.5.0.jar"
     sha256 "0848c35d0068329f5d90c5729df2814692677946bd42f34b68decebc23cdb3cf"
+
+    livecheck do
+      formula :parent
+    end
   end
+
   resource "values-connector" do
     url "https://search.maven.org/remotecontent?filepath=org/apache/flink/flink-cdc-pipeline-connector-values/3.5.0/flink-cdc-pipeline-connector-values-3.5.0.jar"
     sha256 "075aa185925ac78b411ccad049ea3f5ecbb647d7054dbde653f4029a05ad7e16"
+
+    livecheck do
+      formula :parent
+    end
   end
+
   resource "iceberg-connector" do
     url "https://search.maven.org/remotecontent?filepath=org/apache/flink/flink-cdc-pipeline-connector-iceberg/3.5.0/flink-cdc-pipeline-connector-iceberg-3.5.0.jar"
     sha256 "e11a47e6da8c2879acf1694387599e477180126b212224ab46e5819333667988"
+
+    livecheck do
+      formula :parent
+    end
   end
 
   def install
@@ -72,9 +121,7 @@ class ApacheFlinkCdc < Formula
     # Store configs in etc, outside of keg
     pkgetc.install Dir["conf/*"]
     libexec.install_symlink pkgetc => "conf"
-  end
 
-  def post_install
     (var/"log/apache-flink-cdc").mkpath
     libexec.install_symlink var/"log/apache-flink-cdc" => "log"
   end

--- a/Formula/a/apache-flink-cdc.rb
+++ b/Formula/a/apache-flink-cdc.rb
@@ -8,7 +8,8 @@ class ApacheFlinkCdc < Formula
   head "https://github.com/apache/flink-cdc.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "a2ef1ef002c24579098ea4ad0474551fa6899e052fc03397616fee4bd1ab92aa"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "68fe50aa347d8bea103b9f25ac983ac7fd078c7b82eeedb9589c888b73e754eb"
   end
 
   depends_on "apache-flink@1" => :test # Compatible version at https://flink.apache.org/downloads/#apache-flink-cdc


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Contents of new bottle include:
```
...
apache-flink-cdc/3.5.0/.bottle/
apache-flink-cdc/3.5.0/.bottle/etc/
apache-flink-cdc/3.5.0/.bottle/var/
apache-flink-cdc/3.5.0/.bottle/var/log/
apache-flink-cdc/3.5.0/.bottle/var/log/apache-flink-cdc/
apache-flink-cdc/3.5.0/.bottle/etc/apache-flink-cdc/
apache-flink-cdc/3.5.0/.bottle/etc/apache-flink-cdc/log4j-cli.properties
apache-flink-cdc/3.5.0/.bottle/etc/apache-flink-cdc/flink-cdc.yaml
apache-flink-cdc/3.5.0/libexec/bin/
apache-flink-cdc/3.5.0/libexec/lib/
apache-flink-cdc/3.5.0/libexec/log
apache-flink-cdc/3.5.0/libexec/conf
...
```