### PR TITLE
findutils: move post-installed var subdirs to bottle

### DIFF
--- a/Formula/f/findutils.rb
+++ b/Formula/f/findutils.rb
@@ -22,17 +22,14 @@ class Findutils < Formula
 
   def install
     args = %W[
-      --prefix=#{prefix}
-      --localstatedir=#{var}/locate
-      --disable-dependency-tracking
-      --disable-debug
       --disable-nls
+      --localstatedir=#{var}/locate
       --with-packager=Homebrew
       --with-packager-bug-reports=#{tap.issues_url}
     ]
-
     args << "--program-prefix=g" if OS.mac?
-    system "./configure", *args
+
+    system "./configure", *args, *std_configure_args
     system "make", "install"
 
     if OS.mac?
@@ -46,9 +43,6 @@ class Findutils < Formula
     end
 
     (libexec/"gnubin").install_symlink "../gnuman" => "man"
-  end
-
-  def post_install
     (var/"locate").mkpath
   end
 

--- a/Formula/f/findutils.rb
+++ b/Formula/f/findutils.rb
@@ -7,17 +7,13 @@ class Findutils < Formula
   license "GPL-3.0-or-later"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:    "2714b06fa5b249234308f3339d22a2b6570872364a190f81fb87508c65f79c62"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "c09536c5626e7159ccbee77d9a8c771397305bdaecd8a9a67c495482c8dba0f7"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "1c9fb06c4b3b4bdd0cf9dd38b18168a2ec9bfd689af59ef95808246c4b7c3c91"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "0f8cb6a602454e6739de9b20f925692c192d33d9d3b725447be3e9eee9ebd13f"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "a95af4320383b2e5b00f76fa5b17dc904cc5f1599536fc316f79000c6d85483d"
-    sha256 cellar: :any_skip_relocation, sonoma:         "6f6c220a82a470cd41bd33c330d6bb752df6da9df4aa2ead4e011fff80abad0c"
-    sha256 cellar: :any_skip_relocation, ventura:        "90ec3d5bf4c1f5c58bad4e40a28f00f856e5f15f995a2e724b89a882112e4db2"
-    sha256 cellar: :any_skip_relocation, monterey:       "642fe05dc9e71c9941570328bf7f8ab9d5c61e5517211ab8f62a08f9d3936ac5"
-    sha256 cellar: :any_skip_relocation, arm64_linux:    "18a1a2feb194d1e22a457160a5bc7ab8aa0a82888d5117c89981193e42075640"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "0e2d353feb5ebd258d6a53a4ca3c5904dec97797c56bbd13ae5ff75cdebc0492"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "bbf1fa06d2c0dd2b170e83266bfb76f9b59e6bd8a44423009aebdd23c99b5138"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "c0ba2122a404aa878c9dc830fa726bd16b15c6c01a00b14837064b788c1deba4"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "5f132d0f2ed5d4805e0c1b6266b7899298d79eb2e79231b3c023e9eba2a4f46e"
+    sha256 cellar: :any_skip_relocation, sonoma:        "ee53e5aa5b42856fe2feb224eb8348714e47bfdadb7084f903750ec0d6a9b0f4"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "efc2f7cef22fbf5d5926c972fc0340c3c5a2063b744dd86e34df16192e4adcfb"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c6eca32ebb39b10a1e1f6f78fb60ff1ad2c5b0f9e87c8dcb90ff9a113776fab1"
   end
 
   def install


### PR DESCRIPTION
Also use std_configure_args

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
