### PR TITLE
freediameter: use etc.install for default config file

### DIFF
--- a/Formula/f/freediameter.rb
+++ b/Formula/f/freediameter.rb
@@ -5,6 +5,7 @@ class Freediameter < Formula
   sha256 "0bb4ed33ada0b57ab681d86ae3fe0e3a9ce95892f492c401cbb68a87ec1d47bc"
   license "BSD-3-Clause"
   head "https://github.com/freeDiameter/freeDiameter.git", branch: "master"
+
   livecheck do
     url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
@@ -38,14 +39,10 @@ class Freediameter < Formula
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
 
+    cp "doc/freediameter.conf.sample", "freeDiameter.conf"
+    etc.install "freeDiameter.conf"
     doc.install Dir["doc/*"]
     pkgshare.install "contrib"
-  end
-
-  def post_install
-    return if File.exist?(etc/"freeDiameter.conf")
-
-    cp doc/"freediameter.conf.sample", etc/"freeDiameter.conf"
   end
 
   def caveats

--- a/Formula/f/freediameter.rb
+++ b/Formula/f/freediameter.rb
@@ -12,12 +12,13 @@ class Freediameter < Formula
   end
 
   bottle do
-    sha256                               arm64_tahoe:   "d88969b28d22359bcee5f87c000240bc2703bdbff5af20f8b47c3bfafaa8925b"
-    sha256                               arm64_sequoia: "0dcb6c8ca66c2195ef3a78ab62b0e32b6303c7ea4bb31c3b5244a2c22bc643a9"
-    sha256                               arm64_sonoma:  "f6407fa06f58db5b23da3d1a888a96bc68d2231cf35bd5dd8bf30129a6fcdd1e"
-    sha256                               sonoma:        "b9afd84d7c426896a62987a0ad22e6504f5b4fda0ab85b2555bdce78e7c0d314"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "2de09eb57cad6101295a235df9a462d905f2a95a820ea2e80d77b8f81ff6deb8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "9f337536d0f52776b2c4daa5968b309d169f572a8132b14cfe263cf10ed79c8e"
+    rebuild 1
+    sha256                               arm64_tahoe:   "79b0aab464344c4db67cf04e06843db87e219a7b05d852b927d6fcd24cf3f7af"
+    sha256                               arm64_sequoia: "b8c2fe00ccc13df0321b77ba8b9b8287c6de4639864b37fa1f4fc21fb4fe383b"
+    sha256                               arm64_sonoma:  "97fc7352a5df11e743dd713984e3c40d80a0fec9f0a1ac6f77932be2f4edb129"
+    sha256                               sonoma:        "339a7c3048eb764262f7cc21c6124b343073c1da9b8a17de666d538297679530"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "5dcd802cca540beb227ba97fe1f24e3e7bd2487613d2069090933c85da5b28b3"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b3514c432b5aa213070d850934ff359f3caca1e1e04862e3ab215f676356f139"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
Allows brew to handle installation without overwriting existing file

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
