### PR TITLE
aws-sam-cli cfn-lint moto: use `python@3.13`

### DIFF
--- a/Formula/a/aws-sam-cli.rb
+++ b/Formula/a/aws-sam-cli.rb
@@ -21,7 +21,7 @@ class AwsSamCli < Formula
   depends_on "cryptography" => :no_linkage
   depends_on "libyaml"
   depends_on "pydantic" => :no_linkage
-  depends_on "python@3.14"
+  depends_on "python@3.13" # Pydantic v1 is incompatible with Python 3.14, issue ref: https://github.com/aws/serverless-application-model/issues/3831
   depends_on "rpds-py" => :no_linkage
 
   uses_from_macos "libffi"

--- a/Formula/a/aws-sam-cli.rb
+++ b/Formula/a/aws-sam-cli.rb
@@ -8,12 +8,13 @@ class AwsSamCli < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "46fd44bf5ce85f3fb7165e6acbd205b4c82774d5378f95646c287390f3bf0e4e"
-    sha256 cellar: :any,                 arm64_sequoia: "9f0eb4c73b1e3f52d4399a6a66463b250f9625d7edbddbdaf126a78bbf03d4d4"
-    sha256 cellar: :any,                 arm64_sonoma:  "383e1317ddada4af0fbe6f6b14293bff5e1fe87a7a29a92eeffc26f415f8bfbb"
-    sha256 cellar: :any,                 sonoma:        "575c09a648b392e0252bab05b20ab2cd6e6f98bca69c59983edd5c93f98bdca0"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "06d7ffef44adb1935120865db2fa9e00984cedba48945ca6d75a37510664a5ac"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4d08bda3efb6a4ba445a129b8103cacd9a5bdca3bdaadb3c7ca931107757b2a1"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "c82495eaa9ee591ea788826048fdb9137b5d72816263240f6cd52b32ab23edd5"
+    sha256 cellar: :any,                 arm64_sequoia: "cfb938b28ea1dd4a024ac08d5c647da28c8eb3bfe2e50d538aa115567b78635f"
+    sha256 cellar: :any,                 arm64_sonoma:  "5c9330c16ba4fc8f590b789ab8e2158d2dd1c0ce0d77e4783a792e4b10878e17"
+    sha256 cellar: :any,                 sonoma:        "36bff61b94e45270ba83b14cc473067e1fda1e0ad81ba1b9c7f213db06d642cd"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "d535984df909383724f89d1e98c89bcc1a44bc9b3f1cdd573ae1a3bd028c058d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0bb6d8cc34a6ebf992e0f873aa6b86fb45cbf3994bee69e39675bacf3820da99"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/c/cfn-lint.rb
+++ b/Formula/c/cfn-lint.rb
@@ -8,12 +8,13 @@ class CfnLint < Formula
   license "MIT-0"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "e60e80e52a4326e7d5d26214c679bf17c5284a703a74c58e425c4a1339032a75"
-    sha256 cellar: :any,                 arm64_sequoia: "7f190bfb519d3cd684ba68f7bf0b865381dbee72e2672b7d33e162e8d3c3f903"
-    sha256 cellar: :any,                 arm64_sonoma:  "9f7645eb651453fa81f83e12ac5b23fa6ffb93bdfd54699fc74710196aa138df"
-    sha256 cellar: :any,                 sonoma:        "ae652f271b71041f5695a9099b190c5a719ae71ebc9a01f3f28e10877b828c4a"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "882cb8a1737301b1a007fe6d38c160dbfa1121f634dbd514c7f6a030c02837cb"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "877231c424a47fb7fe170fce516c92f52a2d6fc520f1b3a5df7a16fc44e87cb6"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "a68a9da99e5267f215ce877db9a7ea08501f2b5df53f7c72ae9c207e95609cfa"
+    sha256 cellar: :any,                 arm64_sequoia: "0037b779ac780d30f0a8dc43708683e3c3f6876ac27e53012d667356088b6b0a"
+    sha256 cellar: :any,                 arm64_sonoma:  "d12867a40797c794c21b823a3fc0910273d812a8581a43985ab06efbbe2614e5"
+    sha256 cellar: :any,                 sonoma:        "e1e07a57f3ebd4c850cd9101ee60823e22a10747c10c6950bbda5f4af861e5fe"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "511e361712a67f5e3ac8913569c014d947326e75efac5b12dc1c89314c3317d8"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "ea4fc907574490734f82c9e78b199b98d29395a7782229e56b8694023d577610"
   end
 
   depends_on "libyaml"

--- a/Formula/c/cfn-lint.rb
+++ b/Formula/c/cfn-lint.rb
@@ -18,7 +18,7 @@ class CfnLint < Formula
 
   depends_on "libyaml"
   depends_on "pydantic" => :no_linkage
-  depends_on "python@3.14"
+  depends_on "python@3.13" # Pydantic v1 is incompatible with Python 3.14, issue ref: https://github.com/aws/serverless-application-model/issues/3831
   depends_on "rpds-py" => :no_linkage
 
   pypi_packages exclude_packages: ["pydantic", "rpds-py"]

--- a/Formula/m/moto.rb
+++ b/Formula/m/moto.rb
@@ -20,7 +20,7 @@ class Moto < Formula
   depends_on "cryptography" => :no_linkage
   depends_on "libyaml"
   depends_on "pydantic" => :no_linkage
-  depends_on "python@3.14"
+  depends_on "python@3.13" # Pydantic v1 is incompatible with Python 3.14, issue ref: https://github.com/aws/serverless-application-model/issues/3831
   depends_on "rpds-py" => :no_linkage
 
   pypi_packages package_name:     "moto[all,server]",
@@ -282,7 +282,7 @@ class Moto < Formula
   end
 
   def python3
-    which("python3.14")
+    which("python3.13")
   end
 
   def install

--- a/Formula/m/moto.rb
+++ b/Formula/m/moto.rb
@@ -8,12 +8,13 @@ class Moto < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "3fca729465854a5a0ee7eec948d169d141f154f3fc0ebf7f01b334e6387a3d5c"
-    sha256 cellar: :any,                 arm64_sequoia: "32bfe6df444aaaf5fd3dae170b721bd409e38666744c987bb874bb525453efcc"
-    sha256 cellar: :any,                 arm64_sonoma:  "e9214c619f4e119cabafb2071a9cccfc39197dcd96b2bcece434b728f405e70b"
-    sha256 cellar: :any,                 sonoma:        "d32366eb473a02679f1aa4a9f8b66c3bb8a0e87ffebd86faa63c6a595c1827d2"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "3952612feddcc7d71d0b09611e1302e581d2b7c32c632fde11f1e446fd0a3f6c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e1c155da4ff35761076efc100764a5c49ff106dc32a3480ccbf7a629b212819b"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "38c84483a645d5748e9accdb80e05ab4a3e81c2d7fe3dcd6dccd1e562e936640"
+    sha256 cellar: :any,                 arm64_sequoia: "02345137fd460a70ed62ffc6f1a9f411adc4035a8e671a30ec15457b72e85c85"
+    sha256 cellar: :any,                 arm64_sonoma:  "7c985d134b999b028f9c2566fbcf626ece5d5d7e86a2fcb99a409eb29fc7d0fc"
+    sha256 cellar: :any,                 sonoma:        "aad3d67029f1ffb8c07d77f4aabd33ba380caff53dce2f8314300ec78d36df08"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "d175df0f29ed134d741dfd3f25eeb19cb9e64cab336dfd1b5ab4b0e604dbf55b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3881630ae0ef92aa8fa50e97365104f60d56986f8640cd0ee9e56c228c143312"
   end
 
   depends_on "certifi" => :no_linkage


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`aws-sam-translator` resource is not compatible with `python@3.14` yet, and so dependents print warning that is annoying users. Let's revert python version.

EDIT: Fixes #255029