### PR TITLE
redis@8.2 8.2.3 (new formula)

### DIFF
--- a/Formula/r/redis@8.2.rb
+++ b/Formula/r/redis@8.2.rb
@@ -16,6 +16,15 @@ class RedisAT82 < Formula
     regex(/href=.*?redis[._-]v?(8\.2(?:\.\d+)*)\.t/i)
   end
 
+  bottle do
+    sha256 cellar: :any,                 arm64_tahoe:   "7464135edd58367935f8d7b686d9fb010b3029f81fab35cba3158cac6bd11b4c"
+    sha256 cellar: :any,                 arm64_sequoia: "3a06ee53e02ebc4337c91d7b01d56b78b1620749a5ae94e377c92725572c2abb"
+    sha256 cellar: :any,                 arm64_sonoma:  "4d3f1eef9be56cc5a513c59a06106f80e4b83f780516fc73af3cffd03683e30e"
+    sha256 cellar: :any,                 sonoma:        "9b7db68f2122d3d1aeef9345dd70990df55fbd25eb2cb0902f8deca2aebb7944"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "ecbbcd33b86aceda55d3f3268c4faf0e4279cec8baad978b9605e2ce961c7eaa"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2c44ea9d0b00581d0d82fa8b2a138f8dead742fa456fc27a3724ccff427fc45e"
+  end
+
   keg_only :versioned_formula
 
   depends_on "openssl@3"

--- a/Formula/r/redis@8.2.rb
+++ b/Formula/r/redis@8.2.rb
@@ -1,0 +1,51 @@
+class RedisAT82 < Formula
+  desc "Persistent key-value database, with built-in net interface"
+  homepage "https://redis.io/"
+  url "https://download.redis.io/releases/redis-8.2.3.tar.gz"
+  sha256 "d88f2361fdf3a3a8668fe5753e29915566109dca07b4cb036427ea6dc7783671"
+  license all_of: [
+    "AGPL-3.0-only",
+    "BSD-2-Clause", # deps/jemalloc, deps/linenoise, src/lzf*
+    "BSL-1.0", # deps/fpconv
+    "MIT", # deps/lua
+    any_of: ["CC0-1.0", "BSD-2-Clause"], # deps/hdr_histogram
+  ]
+
+  livecheck do
+    url "https://download.redis.io/releases/"
+    regex(/href=.*?redis[._-]v?(8\.2(?:\.\d+)*)\.t/i)
+  end
+
+  keg_only :versioned_formula
+
+  depends_on "openssl@3"
+
+  def install
+    system "make", "install", "PREFIX=#{prefix}", "CC=#{ENV.cc}", "BUILD_TLS=yes"
+
+    %w[run db/redis log].each { |p| (var/p).mkpath }
+
+    # Fix up default conf file to match our paths
+    inreplace "redis.conf" do |s|
+      s.gsub! "/var/run/redis_6379.pid", var/"run/redis.pid"
+      s.gsub! "dir ./", "dir #{var}/db/redis/"
+      s.sub!(/^bind .*$/, "bind 127.0.0.1 ::1")
+    end
+
+    etc.install "redis.conf"
+    etc.install "sentinel.conf" => "redis-sentinel.conf"
+  end
+
+  service do
+    run [opt_bin/"redis-server", etc/"redis.conf"]
+    keep_alive true
+    error_log_path var/"log/redis.log"
+    log_path var/"log/redis.log"
+    working_dir var
+  end
+
+  test do
+    system bin/"redis-server", "--test-memory", "2"
+    %w[run db/redis log].each { |p| assert_path_exists var/p, "#{var/p} doesn't exist!" }
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I was hoping to get a `redis@8.2` formula released, since redis just recently released 8.4.0 and the homebrew `redis` package jumped up to that version. It would be nice not to always be on the bleeding edge, and this would be a great addition for those of us that use redis, similar to how the mysql package has mysql@8.0 for the same reasons. 

[The Redis maintenance policy](https://redis.io/legal/software-support-policy/) explicitly says Major releases are supported for 18 months after the a new Major release is made, and explicitly counts 8.* releases as Major releases. For quicker verification, also see https://endoflife.date/redis

NOTE: i read you guys prefer best try PR as opposed to a an issue... so this is that. Never worked with homebrew formulae so not sure I've done everything necessary, but i looked at the redis@6.2 and mysql@8.0 formulas for inspiration. This probably needs someone who knows what they are doing to double check it. 
