### PR TITLE
formulae: use `binary_linked_to_library?`

### DIFF
--- a/Formula/c/cocogitto.rb
+++ b/Formula/c/cocogitto.rb
@@ -40,12 +40,9 @@ class Cocogitto < Formula
     system "git", "commit", "-m", "chore: initial commit"
     assert_equal "No errored commits", shell_output("#{bin}/cog check 2>&1").strip
 
-    linkage_with_libgit2 = (bin/"cog").dynamically_linked_libraries.any? do |dll|
-      next false unless dll.start_with?(HOMEBREW_PREFIX.to_s)
-
-      File.realpath(dll) == (Formula["libgit2"].opt_lib/shared_library("libgit2")).realpath.to_s
-    end
-
-    assert linkage_with_libgit2, "No linkage with libgit2! Cargo is likely using a vendored version."
+    require "utils/linkage"
+    library = Formula["libgit2"].opt_lib/shared_library("libgit2")
+    assert Utils.binary_linked_to_library?(bin/"cog", library),
+           "No linkage with #{library.basename}! Cargo is likely using a vendored version."
   end
 end

--- a/Formula/c/convco.rb
+++ b/Formula/c/convco.rb
@@ -38,11 +38,9 @@ class Convco < Formula
       shell_output("#{bin}/convco check", 1).lines.first)
 
     # Verify that we are using the libgit2 library
-    linkage_with_libgit2 = (bin/"convco").dynamically_linked_libraries.any? do |dll|
-      next false unless dll.start_with?(HOMEBREW_PREFIX.to_s)
-
-      File.realpath(dll) == (Formula["libgit2"].opt_lib/shared_library("libgit2")).realpath.to_s
-    end
-    assert linkage_with_libgit2, "No linkage with libgit2! Cargo is likely using a vendored version."
+    require "utils/linkage"
+    library = Formula["libgit2"].opt_lib/shared_library("libgit2")
+    assert Utils.binary_linked_to_library?(bin/"convco", library),
+           "No linkage with #{library.basename}! Cargo is likely using a vendored version."
   end
 end

--- a/Formula/c/corsixth.rb
+++ b/Formula/c/corsixth.rb
@@ -98,10 +98,10 @@ class Corsixth < Formula
 
   test do
     if OS.mac?
+      require "utils/linkage"
       lua = Formula["lua"]
-
       app = prefix/"CorsixTH.app/Contents/MacOS/CorsixTH"
-      assert_includes app.dynamically_linked_libraries, "#{lua.opt_lib}/liblua.dylib"
+      assert Utils.binary_linked_to_library?(app, lua.opt_lib/"liblua.dylib"), "No linkage with lua!"
     end
 
     PTY.spawn(bin/"CorsixTH") do |r, _w, pid|

--- a/Formula/e/eza.rb
+++ b/Formula/e/eza.rb
@@ -58,12 +58,9 @@ class Eza < Formula
     system "git", "commit", "-m", "Initial commit"
     assert_equal "--", eza_output.call
 
-    linkage_with_libgit2 = (bin/"eza").dynamically_linked_libraries.any? do |dll|
-      next false unless dll.start_with?(HOMEBREW_PREFIX.to_s)
-
-      File.realpath(dll) == (Formula["libgit2"].opt_lib/shared_library("libgit2")).realpath.to_s
-    end
-
-    assert linkage_with_libgit2, "No linkage with libgit2! Cargo is likely using a vendored version."
+    require "utils/linkage"
+    library = Formula["libgit2"].opt_lib/shared_library("libgit2")
+    assert Utils.binary_linked_to_library?(bin/"eza", library),
+           "No linkage with #{library.basename}! Cargo is likely using a vendored version."
   end
 end

--- a/Formula/g/gfold.rb
+++ b/Formula/g/gfold.rb
@@ -48,17 +48,13 @@ class Gfold < Formula
     end
 
     assert_match "\e[0m\e[32mclean\e[0m (master)", shell_output("#{bin}/gfold #{testpath} 2>&1")
+    assert_match "gfold #{version}", shell_output("#{bin}/gfold --version")
 
     # libgit2 linkage test to avoid using vendored one
     # https://github.com/Homebrew/homebrew-core/pull/125393#issuecomment-1465250076
-    linkage_with_libgit2 = (bin/"gfold").dynamically_linked_libraries.any? do |dll|
-      next false unless dll.start_with?(HOMEBREW_PREFIX.to_s)
-
-      File.realpath(dll) == (Formula["libgit2"].opt_lib/shared_library("libgit2")).realpath.to_s
-    end
-
-    assert linkage_with_libgit2, "No linkage with libgit2! Cargo is likely using a vendored version."
-
-    assert_match "gfold #{version}", shell_output("#{bin}/gfold --version")
+    require "utils/linkage"
+    library = Formula["libgit2"].opt_lib/shared_library("libgit2")
+    assert Utils.binary_linked_to_library?(bin/"gfold", library),
+           "No linkage with #{library.basename}! Cargo is likely using a vendored version."
   end
 end

--- a/Formula/g/git-absorb.rb
+++ b/Formula/g/git-absorb.rb
@@ -50,12 +50,9 @@ class GitAbsorb < Formula
     system "git", "add", "test"
     system "git", "absorb"
 
-    linkage_with_libgit2 = (bin/"git-absorb").dynamically_linked_libraries.any? do |dll|
-      next false unless dll.start_with?(HOMEBREW_PREFIX.to_s)
-
-      File.realpath(dll) == (Formula["libgit2"].opt_lib/shared_library("libgit2")).realpath.to_s
-    end
-
-    assert linkage_with_libgit2, "No linkage with libgit2! Cargo is likely using a vendored version."
+    require "utils/linkage"
+    library = Formula["libgit2"].opt_lib/shared_library("libgit2")
+    assert Utils.binary_linked_to_library?(bin/"git-absorb", library),
+           "No linkage with #{library.basename}! Cargo is likely using a vendored version."
   end
 end

--- a/Formula/g/git-branchless.rb
+++ b/Formula/g/git-branchless.rb
@@ -59,12 +59,9 @@ class GitBranchless < Formula
     system "git", "branchless", "init"
     assert_match "Initial Commit", shell_output("git sl").strip
 
-    linkage_with_libgit2 = (bin/"git-branchless").dynamically_linked_libraries.any? do |dll|
-      next false unless dll.start_with?(HOMEBREW_PREFIX.to_s)
-
-      File.realpath(dll) == (Formula["libgit2"].opt_lib/shared_library("libgit2")).realpath.to_s
-    end
-
-    assert linkage_with_libgit2, "No linkage with libgit2! Cargo is likely using a vendored version."
+    require "utils/linkage"
+    library = Formula["libgit2"].opt_lib/shared_library("libgit2")
+    assert Utils.binary_linked_to_library?(bin/"git-branchless", library),
+           "No linkage with #{library.basename}! Cargo is likely using a vendored version."
   end
 end

--- a/Formula/g/git-cliff.rb
+++ b/Formula/g/git-cliff.rb
@@ -56,12 +56,9 @@ class GitCliff < Formula
       - Initial commit
     EOS
 
-    linkage_with_libgit2 = (bin/"git-cliff").dynamically_linked_libraries.any? do |dll|
-      next false unless dll.start_with?(HOMEBREW_PREFIX.to_s)
-
-      File.realpath(dll) == (Formula["libgit2"].opt_lib/shared_library("libgit2")).realpath.to_s
-    end
-
-    assert linkage_with_libgit2, "No linkage with libgit2! Cargo is likely using a vendored version."
+    require "utils/linkage"
+    library = Formula["libgit2"].opt_lib/shared_library("libgit2")
+    assert Utils.binary_linked_to_library?(bin/"git-cliff", library),
+           "No linkage with #{library.basename}! Cargo is likely using a vendored version."
   end
 end


### PR DESCRIPTION
brew changes planned to remove some Pathname monkey-patching so trying to switch to `binary_linked_to_library?` check instead.