### PR TITLE
mecab zig zig@0.14: use `binary_linked_to_library?`

### DIFF
--- a/Formula/m/mecab.rb
+++ b/Formula/m/mecab.rb
@@ -50,6 +50,8 @@ class Mecab < Formula
     assert_equal "#{HOMEBREW_PREFIX}/lib/mecab/dic", shell_output("#{bin}/mecab-config --dicdir").chomp
     return if OS.linux?
 
-    assert_includes (bin/"mecab").dynamically_linked_libraries, "/usr/lib/libiconv.2.dylib"
+    require "utils/linkage"
+    library = "/usr/lib/libiconv.2.dylib"
+    assert Utils.binary_linked_to_library?(bin/"mecab", library), "No linkage with #{library}!"
   end
 end

--- a/Formula/z/zig.rb
+++ b/Formula/z/zig.rb
@@ -121,7 +121,9 @@ class Zig < Formula
     return unless OS.mac?
 
     # See https://github.com/Homebrew/homebrew-core/pull/211129
-    assert_includes (bin/"zig").dynamically_linked_libraries, "/usr/lib/libc++.1.dylib"
+    require "utils/linkage"
+    library = "/usr/lib/libc++.1.dylib"
+    assert Utils.binary_linked_to_library?(bin/"zig", library), "No linkage with #{library}!"
   end
 end
 

--- a/Formula/z/zig@0.14.rb
+++ b/Formula/z/zig@0.14.rb
@@ -116,7 +116,9 @@ class ZigAT014 < Formula
     return unless OS.mac?
 
     # See https://github.com/Homebrew/homebrew-core/pull/211129
-    assert_includes (bin/"zig").dynamically_linked_libraries, "/usr/lib/libc++.1.dylib"
+    require "utils/linkage"
+    library = "/usr/lib/libc++.1.dylib"
+    assert Utils.binary_linked_to_library?(bin/"zig", library), "No linkage with #{library}!"
   end
 end
 


### PR DESCRIPTION
This avoids directly using monkey-patched `dynamically_linked_libraries` so that we don't experience any breakage if it gets removed.

Will need 
- https://github.com/Homebrew/brew/pull/21115
