### PR TITLE
php@8.4: complete license

### DIFF
--- a/Formula/p/php@8.4.rb
+++ b/Formula/p/php@8.4.rb
@@ -5,7 +5,30 @@ class PhpAT84 < Formula
   url "https://www.php.net/distributions/php-8.4.15.tar.xz"
   mirror "https://fossies.org/linux/www/php-8.4.15.tar.xz"
   sha256 "a060684f614b8344f9b34c334b6ba8db1177555997edb5b1aceab0a4b807da7e"
-  license "PHP-3.01"
+  license all_of: [
+    "PHP-3.01",
+
+    # Extra licenses not documented in README.REDIST.BINS
+    "Zend-2.0", # Zend/LICENSE
+    "BSL-1.0",  # Zend/asm/LICENSE
+    "MIT",      # ext/date/lib/LICENSE.rst
+
+    # Extra licenses documented in README.REDIST.BINS ignoring unbundled pcre2lib (3) and gd (13)
+    # ref: https://github.com/php/php-src/blob/PHP-8.4/README.REDIST.BINS
+    "Apache-1.0",            # 10
+    "Apache-2.0",            # 20
+    "bcrypt-Solar-Designer", # 5
+    "BSD-2-Clause-Darwin",   # 1
+    "BSD-2-Clause",          # 14, 18, 19, 21; also TSRM/LICENSE
+    "BSD-3-Clause",          # 4, 6, 11, 12, 15
+    "BSD-4-Clause-UC",       # 9
+    "ISC",                   # 10
+    "LGPL-2.1-only",         # 2
+    "LGPL-2.1-or-later",     # 16
+    "OLDAP-2.8",             # 17
+    "TCL",                   # 7
+    "Zlib",                  # 8
+  ]
 
   livecheck do
     url "https://www.php.net/downloads?source=Y"


### PR DESCRIPTION
Similar to
- #255320

With 1 extra license (Apache-2.0) due to lexbor - https://github.com/php/php-src/blob/PHP-8.4/ext/dom/lexbor/LICENSE