### PR TITLE
libxml2: drop `--with-http` and `--with-icu`, qt@5 5.15.18

### DIFF
--- a/Formula/lib/libspatialite.rb
+++ b/Formula/lib/libspatialite.rb
@@ -2,7 +2,7 @@ class Libspatialite < Formula
   desc "Adds spatial SQL capabilities to SQLite"
   homepage "https://www.gaia-gis.it/fossil/libspatialite/index"
   license any_of: ["MPL-1.1", "GPL-2.0-or-later", "LGPL-2.1-or-later"]
-  revision 2
+  revision 3
 
   stable do
     url "https://www.gaia-gis.it/gaia-sins/libspatialite-sources/libspatialite-5.1.0.tar.gz"
@@ -49,6 +49,14 @@ class Libspatialite < Formula
   depends_on "proj"
   depends_on "sqlite"
   uses_from_macos "zlib"
+
+  # Apply Debian patch to allow disabling the usage of removed libxml2 HTTP API.
+  # Ref: https://groups.google.com/g/spatialite-users/c/nyT4iAJbttY
+  # Ref: https://www.gaia-gis.it/fossil/libspatialite/tktview/ac85f0fca35de00b9aaadb5078061791fc799d9c
+  patch do
+    url "https://salsa.debian.org/debian-gis-team/spatialite/-/raw/38481157178415322d78a3a45dab18f0c1d45daa/debian/patches/libxml2-nanohttp.patch"
+    sha256 "477188c95b635e0abb97bc659ce9ba8883814f9c7d2466352491eabbe7f6a3f9"
+  end
 
   def install
     system "autoreconf", "--force", "--install", "--verbose" if build.head?

--- a/Formula/lib/libspatialite.rb
+++ b/Formula/lib/libspatialite.rb
@@ -25,12 +25,12 @@ class Libspatialite < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "d2449d25a5846ffdad3cb2a6a40f9185e1b9f36dbffc4a13e98e3bfe9fcf9de0"
-    sha256 cellar: :any,                 arm64_sequoia: "ba5cba2cdd2fc0767f89788c3f05b8609b9cac6861256050ec920dd8e94e0a01"
-    sha256 cellar: :any,                 arm64_sonoma:  "e08b2a520b656ba2b4f60606034e5844012e1816af1a9fdac162acd8c591fc0b"
-    sha256 cellar: :any,                 sonoma:        "76d89daed0f282ee4479694783d828765047fa1c722d1cf2e67943fc5d2f787e"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "a1687abac4fba6dd0be2972527cbda92aca130d517617c46856e6722844cf4dc"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "dc4f78d60c5db59102f81e68b1dbb54fbb87687554a2afb5db0a3eac0f782f6f"
+    sha256 cellar: :any,                 arm64_tahoe:   "ec71d022fb73c458f7cffae0653b47966afedfd983505dc3f258de7cee10ae69"
+    sha256 cellar: :any,                 arm64_sequoia: "f8fce6ef602c6ba94ba50021c98ef28d4f229e2a1b68c67af847c72cc3f86340"
+    sha256 cellar: :any,                 arm64_sonoma:  "e6cdb74bf39ad03b1cbee89f33d2e0c1995e996c54b15ba616cf45035ee0a38e"
+    sha256 cellar: :any,                 sonoma:        "1ba1a71a2e5f482de9dea30d398ef7848313d2012dce11233c6d66b20bd9df40"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "0a76a81771f5568851ce32fbf406a060b4d7f9946f7c8e11ce99c52439bc076b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c3a454cd563efc53e1636abd085bea6cbba2b5dd7c95727cb496ea8881966deb"
   end
 
   head do

--- a/Formula/lib/libxml2.rb
+++ b/Formula/lib/libxml2.rb
@@ -14,12 +14,13 @@ class Libxml2 < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "e76405cf2d17023bd38266cc74f7ad310e29fd39828dcc2786752cb598e84d74"
-    sha256 cellar: :any,                 arm64_sequoia: "b5c41a7a40c8e68e45b551d0b520adc23a9ebd4a0f3a40662e08e45dfdea0b68"
-    sha256 cellar: :any,                 arm64_sonoma:  "4aa659b9756ace59200bd7ffa3f53fde9b7317ed276d5e1d63386fb12c133b4e"
-    sha256 cellar: :any,                 sonoma:        "cd4e6a57e38d34a95165af7124fce4a677afe534487174e62d8a721495047415"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "0568bf7925c997532e450bc025663be693de3dda965b2f2a5aed1b067c6d18c9"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d3d6e52d3b7b6343c519784cb4509b5082403e0d81e6e4648bcf99a47b0c75ff"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "9e3cde9378a4638dc046655cc428e2fbf4cd2ec2991337fae3e57a9f065ef0e6"
+    sha256 cellar: :any,                 arm64_sequoia: "d0656869714b8c590f9c980b08860c7245834a2679310ac7d411b1b9366593b1"
+    sha256 cellar: :any,                 arm64_sonoma:  "ce27f215780fe6f227d0e24571d84d781c6ad52d8537d2ad6a1b5d404753c09a"
+    sha256 cellar: :any,                 sonoma:        "833e98eaf14e628e1b3d3a7389be56eed7c476c807a60d43ff3fda3f972ebe18"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "23f7f1f4c905b53efa09671d5a784742909ed0d108ccc8573ba32397cbec461b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3845c8e494648b4acecd10d54117f661a22fc637ac2b1c5e106d67caaa0939ba"
   end
 
   head do

--- a/Formula/lib/libxml2.rb
+++ b/Formula/lib/libxml2.rb
@@ -33,38 +33,20 @@ class Libxml2 < Formula
   keg_only :provided_by_macos
 
   depends_on "pkgconf" => [:build, :test]
-  depends_on "icu4c@78"
   depends_on "readline"
 
   uses_from_macos "zlib"
-
-  def icu4c
-    deps.find { |dep| dep.name.match?(/^icu4c(@\d+)?$/) }
-        .to_formula
-  end
 
   def install
     system "autoreconf", "--force", "--install", "--verbose" if build.head?
     system "./configure", "--disable-silent-rules",
                           "--sysconfdir=#{etc}",
                           "--with-history",
-                          "--with-http",
-                          "--with-icu",
                           "--with-legacy", # https://gitlab.gnome.org/GNOME/libxml2/-/issues/751#note_2157870
                           *std_configure_args
     system "make", "install"
 
-    inreplace [bin/"xml2-config", lib/"pkgconfig/libxml-2.0.pc"] do |s|
-      s.gsub! prefix, opt_prefix
-      s.gsub! icu4c.prefix.realpath, icu4c.opt_prefix, audit_result: false
-    end
-
-    # `icu4c` is keg-only on macOS and can be during migration on Linux,
-    # so we need to tell `pkg-config` where to find its modules.
-    icu_uc_pc = icu4c.opt_lib/"pkgconfig/icu-uc.pc"
-    inreplace lib/"pkgconfig/libxml-2.0.pc",
-              /^Requires\.private:(.*)\bicu-uc\b(.*)$/,
-              "Requires.private:\\1#{icu_uc_pc}\\2"
+    inreplace [bin/"xml2-config", lib/"pkgconfig/libxml-2.0.pc"], prefix, opt_prefix
   end
 
   test do

--- a/Formula/m/morpheus.rb
+++ b/Formula/m/morpheus.rb
@@ -4,7 +4,7 @@ class Morpheus < Formula
   url "https://gitlab.com/morpheus.lab/morpheus/-/archive/v2.3.9/morpheus-v2.3.9.tar.gz"
   sha256 "d27b7c2b5ecf503fd11777b3a75d4658a6926bfd9ae78ef97abf5e9540a6fb29"
   license "BSD-3-Clause"
-  revision 2
+  revision 3
 
   livecheck do
     url :stable
@@ -32,6 +32,7 @@ class Morpheus < Formula
   depends_on "libtiff"
   depends_on "qt@5"
 
+  uses_from_macos "libxslt" => :build
   uses_from_macos "bzip2"
   uses_from_macos "libxml2"
   uses_from_macos "zlib"

--- a/Formula/m/morpheus.rb
+++ b/Formula/m/morpheus.rb
@@ -12,12 +12,12 @@ class Morpheus < Formula
   end
 
   bottle do
-    sha256                               arm64_tahoe:   "121da65691eee624e3929e5a3f6550c0295b16996180d4a045cfaaacecfac2df"
-    sha256                               arm64_sequoia: "d4560f21a97fae5914b76b37f034ce3380cc1fe7a21220bb243bc00056926863"
-    sha256                               arm64_sonoma:  "5970ad56a9271c47f9600c29a15b07913f75b8e1c2cec68fbfbfdabfda6f1ada"
-    sha256 cellar: :any,                 sonoma:        "db8e0bfc85fd552320a35413ec5179c8a7525fcc58ffc127bfe232eceb8f2d29"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "730115a2edf27e7b25cb85715206a29d8f5a286d2d07d6e36b9e9f374757f31a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3e11b0f061d009c76ad0d1d420a34c0479d37a18d8ef3211af9e1c15f7c4ab38"
+    sha256                               arm64_tahoe:   "52e6c2dc8cd3261d122cb100833b7639b74e826bb62c3e65ae83c7028ddd6033"
+    sha256                               arm64_sequoia: "86df5016fe99402f8a02f6a21a99519622c57ac3ae150645f2ea701f5e43dc03"
+    sha256                               arm64_sonoma:  "e3848e01955a771f9414faa7852bc0162bdb20b2144c21061d890c34b47a4bea"
+    sha256 cellar: :any,                 sonoma:        "d7be53ebc4fd1230ebd6b2e5facaf100ce47ef547b5b502728a38e52e3c2171e"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "aad6af47b8833dbb44fa5f69cce496236ce5eb70cd65b9efe73d55c2bfbf9b47"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "6fc10f654b9f073a70c202d30192407ce4f1d10c12bdebe9314be6677971e644"
   end
 
   # Can undeprecate if new release with Qt 6 support is available.

--- a/Formula/p/pyqt@5.rb
+++ b/Formula/p/pyqt@5.rb
@@ -7,12 +7,12 @@ class PyqtAT5 < Formula
   revision 2
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "7c644cc70170c656e7c4f6604b663a5af0f8bc1d09b095711cab7a920a397386"
-    sha256 cellar: :any,                 arm64_sequoia: "7db6700257362834be48fdb3f21216c623062568dbee04ee726eaf1b38b98365"
-    sha256 cellar: :any,                 arm64_sonoma:  "9b4dd05af3998cc273b6ad22754cdbca605889c291992bfea744d190e09d4d38"
-    sha256 cellar: :any,                 sonoma:        "091e15df83f1e875c8994b8ba89393a30ab2ddc891f39c6c102475d0022164f2"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "c9febdc10fe92c98c76bd1cb3d58acdde779a65d6fbebc21c5bc0effed143b24"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "97e6286b2b996eac230230c2d886f3f901ff77288881e488fada2124d13f6c6d"
+    sha256 cellar: :any,                 arm64_tahoe:   "d3944d21d80b85aadc871416d4072fad865a21b7d19c213bcced248534c1c1c2"
+    sha256 cellar: :any,                 arm64_sequoia: "b92c0343b0fe78cd9d028e0b8c8d3ba566b044482415cef4f359df8b6c2b3ae2"
+    sha256 cellar: :any,                 arm64_sonoma:  "b04e80d2ce51fbd1700e73cb12b733554a994cf297718b2b985f205de92aa377"
+    sha256 cellar: :any,                 sonoma:        "9071ce79a740aaf8fad54d9f28796bc76a1a81342a377df0c143647155f09eb5"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "92f0b1de8c364103ad2bdca8a22f6b786960d0f3df2ca86ec981ad8908bc0f5b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "cba9e3e411e7161d02642f0bf4cd4254d03b180a5c108f184d45e346b9c7c123"
   end
 
   deprecate! date: "2026-05-19", because: "is for end-of-life Qt 5"

--- a/Formula/p/pyqt@5.rb
+++ b/Formula/p/pyqt@5.rb
@@ -4,7 +4,7 @@ class PyqtAT5 < Formula
   url "https://files.pythonhosted.org/packages/0e/07/c9ed0bd428df6f87183fca565a79fee19fa7c88c7f00a7f011ab4379e77a/PyQt5-5.15.11.tar.gz"
   sha256 "fda45743ebb4a27b4b1a51c6d8ef455c4c1b5d610c90d2934c7802b5c1557c52"
   license "GPL-3.0-only"
-  revision 1
+  revision 2
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "7c644cc70170c656e7c4f6604b663a5af0f8bc1d09b095711cab7a920a397386"
@@ -23,9 +23,9 @@ class PyqtAT5 < Formula
 
   pypi_packages exclude_packages: %w[pyqt5-qt5 pyqt3d-qt5 pyqtchart-qt5
                                      pyqtdatavisualization-qt5 pyqtnetworkauth-qt5
-                                     pyqtpurchasing-qt5 pyqtwebengine-qt5],
+                                     pyqtpurchasing-qt5],
                 extra_packages:   %w[pyqt3d pyqtchart pyqtdatavisualization
-                                     pyqtnetworkauth pyqtpurchasing pyqtwebengine]
+                                     pyqtnetworkauth pyqtpurchasing]
 
   # extra components
   resource "pyqt3d" do
@@ -56,11 +56,6 @@ class PyqtAT5 < Formula
   resource "pyqtpurchasing" do
     url "https://files.pythonhosted.org/packages/68/cf/005c9e79536473c8354c1c2b59a2adcae8aa5b7269b42c06514490aa47fb/PyQtPurchasing-5.15.6.tar.gz"
     sha256 "304b1ea3bfb6555202751220700d9a98d1de9eab464515dfccca96f306ddf00e"
-  end
-
-  resource "pyqtwebengine" do
-    url "https://files.pythonhosted.org/packages/18/e8/19a00646866e950307f8cd73841575cdb92800ae14837d5821bcbb91392c/PyQtWebEngine-5.15.7.tar.gz"
-    sha256 "f121ac6e4a2f96ac289619bcfc37f64e68362f24a346553f5d6c42efa4228a4d"
   end
 
   def python3
@@ -107,7 +102,6 @@ class PyqtAT5 < Formula
       Network
       Quick
       Svg
-      WebEngineWidgets
       Widgets
       Xml
     ]

--- a/Formula/q/qt@5.rb
+++ b/Formula/q/qt@5.rb
@@ -1,17 +1,12 @@
-# Patches for Qt must be at the very least submitted to Qt's Gerrit codereview
-# rather than their bug-report Jira. The latter is rarely reviewed by Qt.
 class QtAT5 < Formula
-  include Language::Python::Virtualenv
-
   desc "Cross-platform application and UI framework"
   homepage "https://www.qt.io/"
   # NOTE: Use *.diff for GitLab/KDE patches to avoid their checksums changing.
-  url "https://download.qt.io/archive/qt/5.15/5.15.17/single/qt-everywhere-opensource-src-5.15.17.tar.xz"
-  mirror "https://mirrors.dotsrc.org/qtproject/archive/qt/5.15/5.15.17/single/qt-everywhere-opensource-src-5.15.17.tar.xz"
-  mirror "https://mirrors.ocf.berkeley.edu/qt/archive/qt/5.15/5.15.17/single/qt-everywhere-opensource-src-5.15.17.tar.xz"
-  sha256 "85eb566333d6ba59be3a97c9445a6e52f2af1b52fc3c54b8a2e7f9ea040a7de4"
+  url "https://download.qt.io/archive/qt/5.15/5.15.18/single/qt-everywhere-opensource-src-5.15.18.tar.xz"
+  mirror "https://mirrors.dotsrc.org/qtproject/archive/qt/5.15/5.15.18/single/qt-everywhere-opensource-src-5.15.18.tar.xz"
+  mirror "https://mirrors.ocf.berkeley.edu/qt/archive/qt/5.15/5.15.18/single/qt-everywhere-opensource-src-5.15.18.tar.xz"
+  sha256 "cea1fbabf02455f3f0e8eaa839f5d6f45cdb56b62c8a83af5c1d00ac05f912ea"
   license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-2.1-only", "LGPL-3.0-only"]
-  revision 1
 
   livecheck do
     url "https://download.qt.io/archive/qt/5.15/"
@@ -45,10 +40,7 @@ class QtAT5 < Formula
   # [^5]: https://discourse.ubuntu.com/t/removing-qt-5-from-ubuntu-before-the-release-of-26-04-lts/49296
   deprecate! date: "2026-05-19", because: :unsupported
 
-  depends_on "ninja" => :build
-  depends_on "node" => :build
   depends_on "pkgconf" => :build
-  depends_on "python@3.13" => :build
   depends_on xcode: :build
   depends_on "freetype"
   depends_on "glib"
@@ -61,9 +53,7 @@ class QtAT5 < Formula
   depends_on "webp"
   depends_on "zstd"
 
-  uses_from_macos "bison" => :build
-  uses_from_macos "flex" => :build
-  uses_from_macos "gperf" => :build
+  uses_from_macos "python" => :build
   uses_from_macos "krb5"
   uses_from_macos "zlib"
 
@@ -72,107 +62,30 @@ class QtAT5 < Formula
   end
 
   on_linux do
+    depends_on "at-spi2-core" => :build
+    depends_on "libxext" => :build
     depends_on "alsa-lib"
-    depends_on "at-spi2-core"
-    depends_on "dbus"
+    depends_on "dbus" => :no_linkage
     depends_on "double-conversion"
-    depends_on "expat"
     depends_on "fontconfig"
     depends_on "harfbuzz"
-    depends_on "icu4c@77"
+    depends_on "icu4c@78"
     depends_on "libdrm"
-    depends_on "libevent"
     depends_on "libice"
     depends_on "libsm"
-    depends_on "libvpx"
     depends_on "libx11"
     depends_on "libxcb"
     depends_on "libxcomposite"
-    depends_on "libxdamage"
-    depends_on "libxext"
-    depends_on "libxfixes"
     depends_on "libxkbcommon"
-    depends_on "libxkbfile"
-    depends_on "libxml2"
-    depends_on "libxrandr"
-    depends_on "libxslt"
-    depends_on "libxtst"
-    depends_on "llvm"
     depends_on "mesa"
-    depends_on "minizip"
-    depends_on "nspr"
-    depends_on "nss"
-    depends_on "opus"
     depends_on "pulseaudio"
     depends_on "sdl2"
-    depends_on "snappy"
     depends_on "systemd"
     depends_on "wayland"
     depends_on "xcb-util-image"
     depends_on "xcb-util-keysyms"
     depends_on "xcb-util-renderutil"
     depends_on "xcb-util-wm"
-  end
-
-  resource "qtwebengine" do
-    url "https://code.qt.io/qt/qtwebengine.git",
-        tag:      "v5.15.19-lts",
-        revision: "a5d11cd6f8c487443c15c7e3a6cd8090b65cb313"
-
-    # Apply FreeBSD patches for newer LLVM/Clang
-    # Ref: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=281431
-    on_sequoia :or_newer do
-      patch :p0 do
-        url "https://raw.githubusercontent.com/freebsd/freebsd-ports/0ddd6468fb3cb9ba390973520517cb1ca2cd690d/www/qt5-webengine/files/patch-libc%2B%2B19"
-        sha256 "45455e5b5cbeb2abf74733e550ed1c4fdc85a43de9f209dcbbe04ba6c93e1775"
-      end
-      patch :p0 do
-        url "https://raw.githubusercontent.com/freebsd/freebsd-ports/0ddd6468fb3cb9ba390973520517cb1ca2cd690d/www/qt5-webengine/files/patch-src_3rdparty_chromium_third__party_blink_renderer_platform_wtf_hash__table.h"
-        sha256 "d1738d95f24fe38b5b5bc86110f9dff9c2df98f229401e162e8f8fdfa8e9ac6e"
-      end
-      patch :p0 do
-        url "https://raw.githubusercontent.com/freebsd/freebsd-ports/0ddd6468fb3cb9ba390973520517cb1ca2cd690d/www/qt5-webengine/files/patch-src_3rdparty_chromium_third__party_perfetto_include_perfetto_tracing_internal_track__event__data__source.h"
-        sha256 "b75ffdf65ba35c63f208b34c908a5f0554683c7b9034f924cb2dc9b2d4f3f215"
-      end
-    end
-
-    # Use Debian patches for ICU 75+, brew Ninja and Python 3.13
-    patch do
-      url "https://deb.debian.org/debian/pool/main/q/qtwebengine-opensource-src/qtwebengine-opensource-src_5.15.19+dfsg2-1.debian.tar.xz"
-      sha256 "ef152684cfaf20640cf80466c3fec9a3c9595e5f1b09995847e6d231dc10d11e"
-      apply "patches/build-with-c++17.patch",
-            "patches/ninja-1.12.patch",
-            "patches/python3.13-pipes.patch"
-    end
-
-    # Backport fix for bundled libpng used on macOS
-    patch do
-      url "https://github.com/qt/qtwebengine-chromium/commit/eb486f33ed1109a78f2794c98aad624023ea26ea.patch?full_index=1"
-      sha256 "7377fd75bd63f789563aa229ff861a1b934fe9b6052ce86d5d01f1f3fff94d89"
-      directory "src/3rdparty"
-    end
-
-    # Backport fix for https://bugreports.qt.io/browse/QTBUG-138486
-    patch do
-      url "https://github.com/qt/qtwebengine-chromium/commit/1d29d95bf4732a2d6f46547aa2773c9e742ad52e.patch?full_index=1"
-      sha256 "0bc0855a104d695acc8e9dabd5aa122b292fbd123058c0b52e7c733bcbe2d801"
-      directory "src/3rdparty"
-    end
-  end
-
-  resource "html5lib" do
-    url "https://files.pythonhosted.org/packages/ac/b6/b55c3f49042f1df3dcd422b7f224f939892ee94f22abcf503a9b7339eaf2/html5lib-1.1.tar.gz"
-    sha256 "b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f"
-  end
-
-  resource "six" do
-    url "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz"
-    sha256 "ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"
-  end
-
-  resource "webencodings" do
-    url "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz"
-    sha256 "b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"
   end
 
   # Fix build with ICU 75
@@ -209,14 +122,6 @@ class QtAT5 < Formula
   # Below are CVE patches from https://download.qt.io/archive/qt/5.15/
   # detailed at https://wiki.qt.io/List_of_known_vulnerabilities_in_Qt_products
 
-  # CVE-2024-39936
-  # Remove with Qt 5.15.18
-  patch do
-    url "https://download.qt.io/archive/qt/5.15/CVE-2024-39936-qtbase-5.15.patch"
-    sha256 "2cc23afba9d7e48f8faf8664b4c0324a9ac31a4191da3f18bd0accac5c7704de"
-    directory "qtbase"
-  end
-
   # CVE-2025-23050
   # Remove with Qt 5.15.19
   patch do
@@ -250,17 +155,12 @@ class QtAT5 < Formula
   end
 
   def install
-    # Install python dependencies for QtWebEngine
-    venv = virtualenv_create(buildpath/"venv", "python3.13")
-    venv.pip_install resources.reject { |r| r.name == "qtwebengine" }
-    ENV.prepend_path "PATH", venv.root/"bin"
-
-    rm_r(buildpath/"qtwebengine")
-    (buildpath/"qtwebengine").install resource("qtwebengine")
-
-    # FIXME: GN requires clang in clangBasePath/bin
-    inreplace "qtwebengine/src/3rdparty/chromium/build/toolchain/mac/BUILD.gn",
-              'rebase_path("$clang_base_path/bin/", root_build_dir)', '""'
+    # Remove QtWebEngine. It has a copy of Chromium with unfixed vulnerabilities,
+    # requires dozens of patches to build and is becoming more unmaintainable.
+    # This is the same decision made by Arch Linux[^1].
+    #
+    # [^1]: https://lists.archlinux.org/archives/list/arch-dev-public@lists.archlinux.org/thread/U45C4RAW4IXVLO376XGFNLEGGFFXCULV/
+    rm_r("qtwebengine")
 
     args = %W[
       -verbose
@@ -271,7 +171,6 @@ class QtAT5 < Formula
       -nomake tests
       -pkg-config
       -dbus-runtime
-      -proprietary-codecs
       -system-freetype
       -system-libjpeg
       -system-libmd4c
@@ -279,7 +178,7 @@ class QtAT5 < Formula
       -system-pcre
       -system-sqlite
       -system-zlib
-      -webengine-python-version python3
+      -skip qtwebengine
     ]
 
     if OS.mac?
@@ -301,48 +200,19 @@ class QtAT5 < Formula
       args << "-no-avx512"
       args << "-no-sql-mysql"
 
+      # Avoid linkage to LLVM for same reason as Qt6
+      args << "-no-feature-qdoc"
+
       # Use additional system libraries on Linux.
-      # Currently we have to use vendored ffmpeg because the chromium copy adds a symbol not
-      # provided by the brewed version.
-      # See here for an explanation of why upstream ffmpeg does not want to add this:
-      # https://www.mail-archive.com/ffmpeg-devel@ffmpeg.org/msg124998.html
-      # On macOS chromium will always use bundled copies and the webengine_*
-      # arguments are ignored.
       args += %w[
         -system-doubleconversion
         -system-harfbuzz
-        -webengine-alsa
-        -webengine-icu
-        -webengine-kerberos
-        -webengine-opus
-        -webengine-pulseaudio
-        -webengine-webp
       ]
-
-      # Chromium in QtWebEngine needs hardware CRC32 support via `-march=armv8-a+crc`
-      ENV.runtime_cpu_detection if Hardware::CPU.arm?
-
-      # Homebrew-specific workaround to ignore spurious linker warnings on Linux.
-      inreplace "qtwebengine/src/3rdparty/chromium/build/config/compiler/BUILD.gn",
-                "fatal_linker_warnings = true",
-                "fatal_linker_warnings = false"
     end
 
     # Work around Clang failure in bundled Boost and V8:
     # error: integer value -1 is outside the valid range of values [0, 3] for this enumeration type
-    if DevelopmentTools.clang_build_version >= 1500
-      args << "QMAKE_CXXFLAGS+=-Wno-enum-constexpr-conversion"
-      inreplace "qtwebengine/src/3rdparty/chromium/build/config/compiler/BUILD.gn",
-                /^\s*"-Wno-thread-safety-attributes",$/,
-                "\\0 \"-Wno-enum-constexpr-conversion\","
-    end
-
-    # Work around Clang failure in bundled freetype: error: unknown type name 'Byte'
-    # https://gitlab.freedesktop.org/freetype/freetype/-/commit/a25e85ed95dc855e42e6bb55138e27d362c5ea1e
-    if DevelopmentTools.clang_build_version >= 1600
-      inreplace "qtwebengine/src/3rdparty/chromium/third_party/freetype/src/src/gzip/ftzconf.h",
-                "#if !defined(MACOS) && !defined(TARGET_OS_MAC)", "#if !defined(__MACTYPES__)"
-    end
+    args << "QMAKE_CXXFLAGS+=-Wno-enum-constexpr-conversion" if DevelopmentTools.clang_build_version >= 1500
 
     system "./configure", *args
     system "make"
@@ -353,10 +223,6 @@ class QtAT5 < Formula
     inreplace prefix/"mkspecs/qmodule.pri",
               /^PKG_CONFIG_EXECUTABLE = .*$/,
               "PKG_CONFIG_EXECUTABLE = #{Formula["pkgconf"].opt_bin}/pkg-config"
-
-    # Fix find_package call using QtWebEngine version to find other Qt5 modules.
-    inreplace lib.glob("cmake/Qt5WebEngine*/*Config.cmake"),
-              " #{resource("qtwebengine").version} ", " #{version} "
 
     # Install a qtversion.xml to ease integration with QtCreator
     # As far as we can tell, there is no ability to make the Qt buildsystem
@@ -417,11 +283,13 @@ class QtAT5 < Formula
         Preferences > Qt Versions > Link with Qt...
       pressing "Choose..." and selecting as the Qt installation path:
         #{opt_prefix}
+
+      QtWebEngine is no longer included as its Chromium has unfixed vulnerabilities.
     EOS
   end
 
   test do
-    (testpath/"hello.pro").write <<~EOS
+    (testpath/"hello.pro").write <<~QMAKE
       QT       += core
       QT       -= gui
       TARGET    = hello
@@ -429,7 +297,7 @@ class QtAT5 < Formula
       CONFIG   -= app_bundle
       TEMPLATE  = app
       SOURCES  += main.cpp
-    EOS
+    QMAKE
 
     (testpath/"main.cpp").write <<~CPP
       #include <QCoreApplication>

--- a/Formula/q/qt@5.rb
+++ b/Formula/q/qt@5.rb
@@ -16,12 +16,12 @@ class QtAT5 < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "ccffe1390fd587e2e6b094e278b2fd765746eccd30f9e59c8ff17abe5a3348da"
-    sha256 cellar: :any,                 arm64_sequoia: "2c95f726f4ec9546aab4355a0cab1e3a68afdbd43c4200d40f730214d97db754"
-    sha256 cellar: :any,                 arm64_sonoma:  "8ae245b551b5e82988ad8188961fe75dc942e7a192a32f5917eb39f295a974b9"
-    sha256 cellar: :any,                 sonoma:        "0a5f4640f5b93ebb10661262899af5cf226c821f489f8a06bdc9425932b1f1ef"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "c3ec83bcc8404ba35d4a38c3aed8bb1f3235a3d9062d2945b613295d9208fa61"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "02bcdc299c2b64c2a097cf52396e92310a2f99c48ebb01233b8d24b6a8cd567e"
+    sha256 cellar: :any,                 arm64_tahoe:   "cd8c7ae611392bd37adbb4627da29590a449364bf791eadbc844ab43af09a793"
+    sha256 cellar: :any,                 arm64_sequoia: "bf59af2d056ff752867e4a7644c5345294db703dd530b27a12696252a3d049cf"
+    sha256 cellar: :any,                 arm64_sonoma:  "ef8f1cad7f33032b321ef7ce0c615d6cc088858dd83348051d029b46cd2b1226"
+    sha256 cellar: :any,                 sonoma:        "2f51c28d5df0a599c59f83dba9b622bea6956711bc1faabd7d4aa1701000501b"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "1d60e61eff3d32923ef688aaf8424b6db13ba03b3bb67027cc0bdceeabf8c8bc"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a2a8a128dbd22813720394f555be69b3bde75e530e1b5d8257787caf77cba012"
   end
 
   keg_only :versioned_formula

--- a/style_exceptions/runtime_cpu_detection_allowlist.json
+++ b/style_exceptions/runtime_cpu_detection_allowlist.json
@@ -42,7 +42,6 @@
   "postgresql@18",
   "pytorch",
   "qt",
-  "qt@5",
   "qtbase",
   "qtwebengine",
   "spades",


### PR DESCRIPTION
Experimenting for now if these are still needed:
* `--with-http` just provides "ABI compatibility for removed HTTP support" in 2.15+. Trying to check if any dependents fail without this.
* `--with-icu` was added for Qt5 (#103721) but upstream recommends against it (https://gitlab.gnome.org/GNOME/libxml2#dependencies).
  * This might require bundling `libxml2` in Qt5 which I may end up doing as it is entering EOL.
  * At least Fedora has been shipping `libxml2` without ICU support. They do use it in Qt6 but the bundled copy for Qt5.

---

For Qt5, decided to drop support for QtWebEngine due to unmaintained, insecure Chromium. The risk in this component is worse than other parts of Qt5 due to how quickly the CVE list grows for old copies of Chromium.