### PR TITLE
vapor 20.0.0

### DIFF
--- a/Formula/v/vapor.rb
+++ b/Formula/v/vapor.rb
@@ -7,14 +7,10 @@ class Vapor < Formula
   head "https://github.com/vapor/toolbox.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "b6716440de079f3dfbeb56279efdfa6cdcee4e14c23dff68238146868e3b7c85"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "0f2c6943fa3c7ce08edf4fe755bc457fd5182b5cbefbb8d72c529c9c725b7a29"
-    sha256 cellar: :any,                 arm64_sonoma:  "e4eb5458e494f81f695d6be97343d49befba175e46d1408f2d97d39ad60a9e3e"
-    sha256 cellar: :any,                 arm64_ventura: "485828ab22141232f3b316fe8bb6d71140de71ef521de4854a1500b922ba093b"
-    sha256 cellar: :any,                 sonoma:        "286cab5c6174a01ace08ae6c190aff18d484b7466ea718164bea75ced45540db"
-    sha256 cellar: :any,                 ventura:       "140bed5e1eb6392a50317549580f1ed06031cc684c32337cc28e668e92d71e89"
-    sha256                               arm64_linux:   "3c7444e3bc22eda208626e10ebf482b669a7fe043cd83912ed9227e4e8b5a681"
-    sha256                               x86_64_linux:  "68d00588ea3a03d785c0e2fd0745d3310136cd5f366de20a9b2db8142d0be06b"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "ad33e861b01620717b6a38a87ff83fe4b79e3447067be1eede4db6d2fa544bc0"
+    sha256 cellar: :any,                 arm64_sequoia: "9db6e2d0f5e2c9d5dea8f930db379e2f8a899d5af09f402d29521074cb05afdd"
+    sha256                               arm64_linux:   "b91ac9e335b8342682cf2032ea9a91336c870f01ebad067ce2bb1523ada305aa"
+    sha256                               x86_64_linux:  "7d4caa94d7be2095ee335b2c954bea42d308e4f79aa641bf4d345671bb8445f1"
   end
 
   depends_on macos: :sequoia

--- a/Formula/v/vapor.rb
+++ b/Formula/v/vapor.rb
@@ -1,8 +1,8 @@
 class Vapor < Formula
   desc "Command-line tool for Vapor (Server-side Swift web framework)"
   homepage "https://vapor.codes"
-  url "https://github.com/vapor/toolbox/archive/refs/tags/19.2.0.tar.gz"
-  sha256 "c2970459166469afe8614ecdca33dae556a5e2fb386b92eeba2498af9014fc60"
+  url "https://github.com/vapor/toolbox/archive/refs/tags/20.0.0.tar.gz"
+  sha256 "b3b215a69ae8b5235d4f37229313ee1947de5c5b9ad2142a76b17c105dd758cf"
   license "MIT"
   head "https://github.com/vapor/toolbox.git", branch: "main"
 
@@ -17,7 +17,9 @@ class Vapor < Formula
     sha256                               x86_64_linux:  "68d00588ea3a03d785c0e2fd0745d3310136cd5f366de20a9b2db8142d0be06b"
   end
 
-  uses_from_macos "swift", since: :sequoia # Swift 6.0
+  depends_on macos: :sequoia
+
+  uses_from_macos "swift", since: :tahoe # Swift 6.1
 
   def install
     args = if OS.mac?


### PR DESCRIPTION
Updated the Vapor formula to use Swift 6.1 and removed macOS 13 and 14 as they are no longer supported.

This PR should fix the CI failures in https://github.com/Homebrew/homebrew-core/pull/255442

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
