### PR TITLE
libdecor: add livecheck

### DIFF
--- a/Formula/lib/libdecor.rb
+++ b/Formula/lib/libdecor.rb
@@ -5,6 +5,14 @@ class Libdecor < Formula
   sha256 "b17cf420e8dcb526bf82da5d36f8443a91fad0777083fa4ec5c1df8ee877416f"
   license "MIT"
 
+  livecheck do
+    url "https://gitlab.freedesktop.org/api/v4/projects/18349/releases"
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :json do |json, regex|
+      json.filter_map { |item| item["tag_name"]&.[](regex, 1) }
+    end
+  end
+
   bottle do
     sha256 arm64_linux:  "0ce1db47f5f6e33e2eb9e56441bfd76e0743d3d73fe36ec03fc70706546e1c0b"
     sha256 x86_64_linux: "01ed6ba19998c4ec2aa7093b943d75a8c491616c0a3638779c7297e4da276ea1"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck is unable to check `libdecor` and gives an "Unable to get versions" error. The homepage is simply the upstream repository and the `stable` URL is a GitLab release, so this adds a `livecheck` block that checks the related API for release tags.