### PR TITLE
antigen: deprecate

### DIFF
--- a/Formula/a/antigen.rb
+++ b/Formula/a/antigen.rb
@@ -7,8 +7,8 @@ class Antigen < Formula
   head "https://github.com/zsh-users/antigen.git", branch: "develop"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, all: "c5b90cbbac10593d4cdc737303340894b65b0598a564cc9eafe1466f33936503"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, all: "3256f387fafd0971b040e466f519ba6be88de0a5d98aec8310b173b8ebfed7a8"
   end
 
   # project has no commits and release since 2019

--- a/Formula/a/antigen.rb
+++ b/Formula/a/antigen.rb
@@ -1,17 +1,21 @@
 class Antigen < Formula
   desc "Plugin manager for zsh, inspired by oh-my-zsh and vundle"
-  homepage "https://antigen.sharats.me/"
+  homepage "https://github.com/zsh-users/antigen"
   url "https://github.com/zsh-users/antigen/releases/download/v2.2.3/v2.2.3.tar.gz"
   sha256 "bd3f1077050d52f459bc30fa3f025c44c528d625b4924a2f487fd2bacb89d61e"
   license "MIT"
   head "https://github.com/zsh-users/antigen.git", branch: "develop"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "c5b90cbbac10593d4cdc737303340894b65b0598a564cc9eafe1466f33936503"
   end
+
+  # project has no commits and release since 2019
+  # and some crash reports, https://github.com/zsh-users/antigen/issues/712
+  # https://github.com/zsh-users/antigen/issues/753
+  deprecate! date: "2025-11-22", because: :unmaintained
+  disable! date: "2026-11-22", because: :unmaintained
 
   uses_from_macos "zsh"
 


### PR DESCRIPTION
project has no commits and release since 2019
and some crash reports, https://github.com/zsh-users/antigen/issues/712
https://github.com/zsh-users/antigen/issues/753

<img width="741" height="707" alt="image" src="https://github.com/user-attachments/assets/ddc64d79-cdc1-4ab7-8e67-718b5c4cda3a" />
