### PR TITLE
libu2f-server: deprecate in favor of libfido2

### DIFF
--- a/Formula/lib/libu2f-server.rb
+++ b/Formula/lib/libu2f-server.rb
@@ -6,13 +6,6 @@ class Libu2fServer < Formula
   license "BSD-2-Clause"
   revision 3
 
-  livecheck do
-    url "https://developers.yubico.com/libu2f-server/Releases/"
-    regex(/href=.*?libu2f-server[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:    "bfeddb8ea5570906354b711dd21758baaa28c612ddde47ec17f22f30c2d8b9ac"
@@ -29,6 +22,10 @@ class Libu2fServer < Formula
     sha256 cellar: :any_skip_relocation, arm64_linux:    "380db415620d20a896929d242dfeceae1ee2588ad8fd18544fef87b3f10a2d0c"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "c7e4dfb9db89bfc5720aba123638286a77d5d76d9bb108a1bf7b2c1bf01ffa6e"
   end
+
+  # https://www.yubico.com/support/terms-conditions/yubico-end-of-life-policy/eol-products/
+  deprecate! date: "2025-11-22", because: :unmaintained, replacement_formula: "libfido2"
+  disable! date: "2026-11-22", because: :unmaintained, replacement_formula: "libfido2"
 
   depends_on "check" => :build
   depends_on "gengetopt" => :build


### PR DESCRIPTION
libu2f-server: deprecate in favor of libfido2

https://www.yubico.com/support/terms-conditions/yubico-end-of-life-policy/eol-products/

<img width="846" height="121" alt="image" src="https://github.com/user-attachments/assets/09f625b4-042c-4819-9274-4f4dd41cd1cd" />

<img width="699" height="556" alt="image" src="https://github.com/user-attachments/assets/ac4e1a06-a652-4d2e-8bc4-489142c3e9ed" />
