### PR TITLE
catimg: cmake workaround to patch

### DIFF
--- a/Formula/c/catimg.rb
+++ b/Formula/c/catimg.rb
@@ -1,12 +1,20 @@
 class Catimg < Formula
   desc "Insanely fast image printing in your terminal"
   homepage "https://github.com/posva/catimg"
-  url "https://github.com/posva/catimg/archive/refs/tags/2.7.0.tar.gz"
-  sha256 "3a6450316ff62fb07c3facb47ea208bf98f62abd02783e88c56f2a6508035139"
   license "MIT"
   head "https://github.com/posva/catimg.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
+  stable do
+    url "https://github.com/posva/catimg/archive/refs/tags/2.7.0.tar.gz"
+    sha256 "3a6450316ff62fb07c3facb47ea208bf98f62abd02783e88c56f2a6508035139"
+
+    # CMake 4 build patch, remove in the next release
+    # PR ref: https://github.com/posva/catimg/pull/73
+    patch do
+      url "https://github.com/posva/catimg/commit/155786229230e2ddc2dd97e4e0219d1e2aa66099.patch?full_index=1"
+      sha256 "a06dddb1d563ee546bf1060fe2157436cc19d3adde9461cc0ddf5a3df787a0e5"
+    end
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "d92945a35325613398793b13459b570974bde19f5b0ad2fede646b1a44345dac"
@@ -27,11 +35,7 @@ class Catimg < Formula
   depends_on "cmake" => :build
 
   def install
-    args = %W[
-      -DMAN_OUTPUT_PATH=#{man1}
-    ]
-    # Workaround to build with CMake 4
-    args << "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+    args = %W[-DMAN_OUTPUT_PATH=#{man1}]
     system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
