### PR TITLE
asyncapi: downgrade to 4.1.1

### DIFF
--- a/Formula/a/asyncapi.rb
+++ b/Formula/a/asyncapi.rb
@@ -1,17 +1,17 @@
 class Asyncapi < Formula
   desc "All in one CLI for all AsyncAPI tools"
   homepage "https://github.com/asyncapi/cli"
-  url "https://registry.npmjs.org/@asyncapi/cli/-/cli-4.1.3.tgz"
-  sha256 "76678b918e11bb9250e693243943067a2e85ae42a53add1dfc09c7723a2c3a29"
+  url "https://registry.npmjs.org/@asyncapi/cli/-/cli-4.1.1.tgz"
+  sha256 "2f4d12597d6fc30615b6dd27fdac2c63222726005d50f62300d1f6a257f6cf61"
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "4b86665793599ac770687e80c078416589077512038e0aa5d23d66aa7836cbd6"
-    sha256 cellar: :any,                 arm64_sequoia: "6c50bf9e49c38a38b224e21273b20c0775caf4c1356bf3c8d3bb6cf3b22f31f4"
-    sha256 cellar: :any,                 arm64_sonoma:  "6c50bf9e49c38a38b224e21273b20c0775caf4c1356bf3c8d3bb6cf3b22f31f4"
-    sha256 cellar: :any,                 sonoma:        "c76afb91e4ef94750d18849e840c55965c3c8b0e0d4fbde0de32584953bfc630"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "0cfe4eb7538c4522554568088771c1fd4cbf68b4f8f3101731996972ee5550f7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0c7ee55be8ce0eec3d6e9c0bee4243ff42b5064441ac8c5f0e34bae669960a7e"
+    sha256 cellar: :any,                 arm64_tahoe:   "3ebd61013a46b45e87e720f6a29a01b21f30284eb2cc189b64192b4ada07bf39"
+    sha256 cellar: :any,                 arm64_sequoia: "7aef6cc320594a4a347ed4cb8d2b233aa62fa6bf6d58e485eacf7f95a558cab2"
+    sha256 cellar: :any,                 arm64_sonoma:  "7aef6cc320594a4a347ed4cb8d2b233aa62fa6bf6d58e485eacf7f95a558cab2"
+    sha256 cellar: :any,                 sonoma:        "256cfaa02cb30e5633444226e24db3820b4008faf720552b28b162bff96f04d9"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "c7db0c88cd1cdec73bff3052af77a3ced1082ca4d5b8b76d77b038910bea805e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "7b598c9f62a1fc12200cb19235a92224b7cbb94eb3b890fc1d0f317449d97de7"
   end
 
   depends_on "node"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Version 4.1.3 of `asyncapi` has been yanked upstream (likely related to Shai Hulud 2.0) and 4.1.1 is the latest version on npm, so this downgrades the formula accordingly.

To be clear, this won't automatically downgrade users with an existing installation and they will need to manually run `brew reinstall asyncapi` to downgrade to 4.1.1.