### PR TITLE
asyncapi: bump version_scheme

### DIFF
--- a/Formula/a/asyncapi.rb
+++ b/Formula/a/asyncapi.rb
@@ -4,6 +4,7 @@ class Asyncapi < Formula
   url "https://registry.npmjs.org/@asyncapi/cli/-/cli-4.1.1.tgz"
   sha256 "2f4d12597d6fc30615b6dd27fdac2c63222726005d50f62300d1f6a257f6cf61"
   license "Apache-2.0"
+  version_scheme 1
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "3ebd61013a46b45e87e720f6a29a01b21f30284eb2cc189b64192b4ada07bf39"

--- a/Formula/a/asyncapi.rb
+++ b/Formula/a/asyncapi.rb
@@ -7,12 +7,13 @@ class Asyncapi < Formula
   version_scheme 1
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "3ebd61013a46b45e87e720f6a29a01b21f30284eb2cc189b64192b4ada07bf39"
-    sha256 cellar: :any,                 arm64_sequoia: "7aef6cc320594a4a347ed4cb8d2b233aa62fa6bf6d58e485eacf7f95a558cab2"
-    sha256 cellar: :any,                 arm64_sonoma:  "7aef6cc320594a4a347ed4cb8d2b233aa62fa6bf6d58e485eacf7f95a558cab2"
-    sha256 cellar: :any,                 sonoma:        "256cfaa02cb30e5633444226e24db3820b4008faf720552b28b162bff96f04d9"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "c7db0c88cd1cdec73bff3052af77a3ced1082ca4d5b8b76d77b038910bea805e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "7b598c9f62a1fc12200cb19235a92224b7cbb94eb3b890fc1d0f317449d97de7"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "e2727dfcfcf5cbf72a8d4042b91ff91d48141dc5129a78872361b1c3883caa2e"
+    sha256 cellar: :any,                 arm64_sequoia: "33c0d8ad34cce095409e61751a59f1752b3aa3eefb5f87e700b81aa353b84b64"
+    sha256 cellar: :any,                 arm64_sonoma:  "33c0d8ad34cce095409e61751a59f1752b3aa3eefb5f87e700b81aa353b84b64"
+    sha256 cellar: :any,                 sonoma:        "588f576b6911b914ab77aa9dffb16ca16094896159d0ac682f47f7602b706ed5"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "7a498282a790afaf15d4f21b16738d0d9de4e3324641d798075dca97c1a72208"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "6cba57e348287507ec7aab8824ce25e79de1828ca504d22de3d80fd4ef1b1114"
   end
 
   depends_on "node"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We recently downgraded `asyncapi` from 4.1.3 to 4.1.1 (https://github.com/Homebrew/homebrew-core/pull/255761), as 4.1.3 was yanked (presumably due to Shai Hulud 2.0). This ensured that new installations and upgrades afterward would install 4.1.1 but existing users who had upgraded to 4.1.3 would not be automatically downgraded. This bumps the `version_scheme` for the formula to ensure that users on 4.1.3 will be automatically downgraded.