### PR TITLE
granted: fix missing assume binary

### DIFF
--- a/Formula/g/granted.rb
+++ b/Formula/g/granted.rb
@@ -7,12 +7,13 @@ class Granted < Formula
   head "https://github.com/fwdcloudsec/granted.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "905d6f692d85563eca73585449c2936f5086ce5cc1cc1e101a3bcd71ecf1e8f0"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "826f554acd21683c694d7b3ab363aee7a5339b9f488c8672b723494557dda323"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "4d6a65dc8bcb372ebbbdaee1ce5d47f14adec08b67b2ff8d6a6c28da6d29e8ad"
-    sha256 cellar: :any_skip_relocation, sonoma:        "2082c978cba759a2f55bcaa9e1afe102dc6bd03687deba376b075b043158358a"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "9ecdd52db4973da236d1317fbcd89309dd0ec5e36da27515463e29383ac423fa"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "bf9dfb7396fd9de587fabb3b7fa0246efdf9155a5c2ed32cf5ec2fab0d27848c"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "b2ae7e586190f7c5092da72f5e510a4c280b55c114975e39a9b5ca500ef5f601"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "fc90ac61d24f078333207f04e4750cbb0be674734ad42ee2f1c3d449069f7d95"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "f72bc786bb6f5e3bd0d23150d07c1f9a889d06b42a728589114ebb418b3bd505"
+    sha256 cellar: :any_skip_relocation, sonoma:        "ad6688f253dd0a2440dd3e3a4201bdfd729e77ef33b62e33668961c63bbe7386"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "eaf45439a1a8f236a254b8db441fada6c8813b314ed479aa65f201be47b031dc"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "534d96a5ee4e3075598d6be97a10c2df041a4fcf6f95f3498299fd9a777a0130"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
Granted requires both `granted` and `assume` to function. This PR fixes the missing `assume` command.

## What this PR does

- Adds `assumego` symlink pointing to the `granted` binary
- Installs `assume` shell script from source (`scripts/assume`)
- Installs `assume.fish` shell script from source (`scripts/assume.fish`)

## Why this is needed

Granted runs as two components:
1. `granted` - the Go binary (built from source)
2. `assume` - a shell script wrapper that calls `assumego` and exports AWS credentials to the parent shell

Without `assume`, users get "command not found: assume" making the tool non-functional.

## Testing

```bash
brew uninstall granted --force
HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source granted
```

**Verified all binaries installed:**
```
$ which granted && which assume && which assumego
/opt/homebrew/bin/granted
/opt/homebrew/bin/assume
/opt/homebrew/bin/assumego

$ granted --version
Granted version: 0.38.0
```

**Assume command works:**
```
$ assume poc
[✔] [poc](us-west-2) session credentials will expire in 12 hours
```

**Tests pass:**
```
$ brew test granted
==> Testing granted
==> /opt/homebrew/Cellar/granted/0.38.0/bin/granted --version
==> /opt/homebrew/Cellar/granted/0.38.0/bin/granted auth configure 2>&1
```

**Style check:**
```
$ brew style granted.rb
1 file inspected, no offenses detected
```

Closes #249904