### PR TITLE
fontconfig: remove `util-linux` dependency

### DIFF
--- a/Formula/f/fontconfig.rb
+++ b/Formula/f/fontconfig.rb
@@ -37,10 +37,6 @@ class Fontconfig < Formula
     depends_on "gettext"
   end
 
-  on_linux do
-    depends_on "util-linux"
-  end
-
   def install
     font_dirs = %w[
       /System/Library/Fonts


### PR DESCRIPTION
I don't think it is needed based on local build and prior runs like https://github.com/Homebrew/homebrew-core/actions/runs/17515953778/job/49781351772#step:5:173
```
==> brew linkage --cached fontconfig
System libraries:
  /lib/aarch64-linux-gnu/ld-linux-aarch64.so.1
  /lib/aarch64-linux-gnu/libc.so.6
Homebrew libraries:
  /home/linuxbrew/.linuxbrew/opt/expat/lib/libexpat.so.1 (expat)
  /home/linuxbrew/.linuxbrew/Cellar/fontconfig/2.17.1/lib/libfontconfig.so.1 (fontconfig)
  /home/linuxbrew/.linuxbrew/lib/libfreetype.so.6 (freetype)
```

