### PR TITLE
mysql-search-replace: remove unused rewrite_shebang

### DIFF
--- a/Formula/m/mysql-search-replace.rb
+++ b/Formula/m/mysql-search-replace.rb
@@ -1,6 +1,4 @@
 class MysqlSearchReplace < Formula
-  include Language::PHP::Shebang
-
   desc "Database search and replace script in PHP"
   homepage "https://interconnectit.com/products/search-and-replace-for-wordpress-databases/"
   url "https://github.com/interconnectit/Search-Replace-DB/archive/refs/tags/4.1.4.tar.gz"
@@ -17,7 +15,6 @@ class MysqlSearchReplace < Formula
   def install
     libexec.install "srdb.class.php"
     libexec.install "srdb.cli.php" => "srdb"
-    rewrite_shebang detected_php_shebang, libexec/"srdb" if OS.linux?
     bin.write_exec_script libexec/"srdb"
   end
 


### PR DESCRIPTION
Draft to make sure, but I think it will work given we have an `:all` bottle which wouldn't be possible if only modifying file on Linux