### PR TITLE
workflows/tests: check nodejs label via check-labels.js

### DIFF
--- a/.github/workflows/scripts/check-labels.js
+++ b/.github/workflows/scripts/check-labels.js
@@ -73,11 +73,11 @@ module.exports = async ({github, context, core}, formulae_detect, dependent_test
     const test_bot_dependents_args = ["--only-formulae-dependents", "--junit"]
 
     if (label_names.includes(`CI-test-bot-no-concurrent-downloads`)) {
-      console.log(`CI-test-bot-no-concurrent-downloads label found. Not passing --concurrent-downloads to brew test-bot.`)
+      console.log(`CI-test-bot-no-concurrent-downloads label found. Running with HOMEBREW_DOWNLOAD_CONCURRENCY=1`)
+      core.setOutput('download-concurrency', '1')
     } else {
-      console.log(`No CI-test-bot-no-concurrent-downloads label found. Passing --concurrent-downloads to brew test-bot.`)
-      test_bot_formulae_args.push('--concurrent-downloads')
-      test_bot_dependents_args.push('--concurrent-downloads')
+      console.log(`No CI-test-bot-no-concurrent-downloads label found. Running with HOMEBREW_DOWNLOAD_CONCURRENCY=auto`)
+      core.setOutput('download-concurrency', 'auto')
     }
 
     if (label_names.includes(`CI-test-bot-fail-fast${deps_suffix}`)) {
@@ -146,4 +146,6 @@ module.exports = async ({github, context, core}, formulae_detect, dependent_test
 
     core.setOutput('test-bot-formulae-args', test_bot_formulae_args.join(" "))
     core.setOutput('test-bot-dependents-args', test_bot_dependents_args.join(" "))
+
+    core.setOutput('nodejs', label_names.includes('nodejs'))
 }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -143,14 +143,11 @@ jobs:
       long-timeout: ${{ steps.check-labels.outputs.long-timeout }}
       test-bot-formulae-args: ${{ steps.check-labels.outputs.test-bot-formulae-args }}
       test-bot-dependents-args: ${{ steps.check-labels.outputs.test-bot-dependents-args }}
+      download-concurrency: ${{ steps.check-labels.outputs.download-concurrency }}
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           persist-credentials: false
-
-      - name: Check if nodejs formula
-        if: contains(github.event.pull_request.labels.*.name, 'nodejs')
-        run: exit 1
 
       - name: Check for CI labels
         id: check-labels
@@ -177,6 +174,10 @@ jobs:
             } catch (error) {
               console.error(error);
             }
+
+      - name: Check if nodejs formula
+        if: fromJson(steps.check-labels.outputs.nodejs)
+        run: exit 1
 
   setup_runners:
     needs: [formulae_detect, setup_tests]
@@ -244,6 +245,7 @@ jobs:
             --deleted-formulae="$DELETED_FORMULAE" \
             <<<"$TEST_BOT_FORMULAE_ARGS"
         env:
+          HOMEBREW_DOWNLOAD_CONCURRENCY: ${{ needs.setup_tests.outputs.download-concurrency }}
           TEST_BOT_FORMULAE_ARGS: ${{ needs.setup_tests.outputs.test-bot-formulae-args }}
           TESTING_FORMULAE: ${{ needs.formulae_detect.outputs.testing_formulae }}
           ADDED_FORMULAE: ${{ needs.formulae_detect.outputs.added_formulae }}
@@ -273,6 +275,7 @@ jobs:
       long-timeout: ${{ steps.check-labels.outputs.long-timeout }}
       test-bot-formulae-args: ${{ steps.check-labels.outputs.test-bot-formulae-args }}
       test-bot-dependents-args: ${{ steps.check-labels.outputs.test-bot-dependents-args }}
+      download-concurrency: ${{ steps.check-labels.outputs.download-concurrency }}
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
@@ -376,6 +379,7 @@ jobs:
             --tested-formulae="$TESTED_FORMULAE" \
             <<<"$TEST_BOT_DEPENDENTS_ARGS"
         env:
+          HOMEBREW_DOWNLOAD_CONCURRENCY: ${{ needs.setup_dep_tests.outputs.download-concurrency }}
           TEST_BOT_DEPENDENTS_ARGS: ${{ needs.setup_dep_tests.outputs.test-bot-dependents-args }}
           TESTED_FORMULAE: ${{ needs.formulae_detect.outputs.testing_formulae }}
         working-directory: ${{ env.BOTTLES_DIR }}


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Otherwise it uses labels prior to triage.yml run. Though should hopefully be removed soon once we have sufficient confidence in state of npm.

Also adjust `CI-test-bot-no-concurrent-downloads` as `--concurrent-downloads` doesn't do anything. Still needed to debug some new CI issues like hitting disk space limit on Linux runners.

---

For latter, I was trying to see if https://github.com/Homebrew/homebrew-core/pull/254950 running out of space was due to concurrent downloads. I have a feeling it is given recent uptick in needing to run on self-hosted runner.

This should also be temporary until we iron out all the issues happening on CI.