### PR TITLE
workflows: check nodejs before early exit

### DIFF
--- a/.github/workflows/scripts/check-labels.js
+++ b/.github/workflows/scripts/check-labels.js
@@ -19,6 +19,8 @@ module.exports = async ({github, context, core}, formulae_detect, dependent_test
       console.log('No CI-syntax-only label found. Running tests job.')
     }
 
+    core.setOutput('nodejs', !syntax_only && label_names.includes('nodejs'))
+
     core.setOutput('syntax-only', syntax_only)
     if (syntax_only) {
       return
@@ -146,6 +148,4 @@ module.exports = async ({github, context, core}, formulae_detect, dependent_test
 
     core.setOutput('test-bot-formulae-args', test_bot_formulae_args.join(" "))
     core.setOutput('test-bot-dependents-args', test_bot_dependents_args.join(" "))
-
-    core.setOutput('nodejs', label_names.includes('nodejs'))
 }


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

To avoid https://github.com/Homebrew/homebrew-core/actions/runs/19673544557/job/56348472947. Doesn't impact publish bottle merge but will for `CI-syntax-only` PRs