### PR TITLE
workflows: make resource updates required for automerge

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -68,7 +68,8 @@ jobs:
             if [[ "$label" = "CI-published-bottle-commits" ]] ||
                [[ "$label" = "automerge-skip" ]] ||
                [[ "$label" = "maintainer feedback" ]] ||
-               [[ "$label" = "pre-release" ]]
+               [[ "$label" = "pre-release" ]] ||
+               [[ "$label" = "resource updates needed" ]]
             then
               publishable=false
               break

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -444,6 +444,9 @@ jobs:
             - label: pip-audit
               pr_body_content: Created by `brew-pip-audit`
 
+            - label: resource updates needed
+              pr_body_content: \[ \] `resource` blocks have been checked for updates
+
             - label: alias
               path: Aliases/.+
               allow_any_match: true


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Want to experiment with detection of autobump checkbox as a requirement for merge. Mainly since it is easy to miss check box and we've often had to fix resources after user reports an issue.

Some inconvenience as clicking check box won't retrigger triage.yml so would need to manually do both (checkbox and remove label). Was also looking at draft PRs but didn't see an easy way to do this yet (may be easier to do in Homebrew/brew at PR creation rather than trying to get workflow to modify existing PR)

Not too sure on regex pattern for escaped brackets as can't tell how many backslashes are passed through.
