### PR TITLE
qt-unixodbc: build with Ninja to match other Qt formulae

### DIFF
--- a/Formula/q/qt-unixodbc.rb
+++ b/Formula/q/qt-unixodbc.rb
@@ -21,16 +21,15 @@ class QtUnixodbc < Formula
   end
 
   depends_on "cmake" => [:build, :test]
+  depends_on "ninja" => :build
 
   depends_on "qtbase"
   depends_on "unixodbc"
 
-  conflicts_with "qt-libiodbc",
-    because: "qt-unixodbc and qt-libiodbc install the same binaries"
+  conflicts_with "qt-libiodbc", because: "both install the same binaries"
 
   def install
-    args = %W[
-      -DCMAKE_STAGING_PREFIX=#{prefix}
+    args = %w[
       -DFEATURE_sql_ibase=OFF
       -DFEATURE_sql_mysql=OFF
       -DFEATURE_sql_oci=OFF
@@ -41,22 +40,18 @@ class QtUnixodbc < Formula
     ]
     args << "-DQT_NO_APPLE_SDK_AND_XCODE_CHECK=ON" if OS.mac?
 
-    system "cmake", "-S", "src/plugins/sqldrivers", "-B", "build", *args, *std_cmake_args
+    system "cmake", "-S", "src/plugins/sqldrivers", "-B", "build", "-G", "Ninja", *args, *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
   end
 
   test do
     (testpath/"CMakeLists.txt").write <<~CMAKE
-      cmake_minimum_required(VERSION #{Formula["cmake"].version})
+      cmake_minimum_required(VERSION 4.0)
       project(test VERSION 1.0.0 LANGUAGES CXX)
-      set(CMAKE_CXX_STANDARD 17)
-      set(CMAKE_CXX_STANDARD_REQUIRED ON)
-      set(CMAKE_AUTOMOC ON)
-      set(CMAKE_AUTORCC ON)
-      set(CMAKE_AUTOUIC ON)
       find_package(Qt6 COMPONENTS Core Sql REQUIRED)
-      add_executable(test main.cpp)
+      qt_standard_project_setup()
+      qt_add_executable(test main.cpp)
       target_link_libraries(test PRIVATE Qt6::Core Qt6::Sql)
     CMAKE
 
@@ -76,7 +71,6 @@ class QtUnixodbc < Formula
       #include <cassert>
       int main(int argc, char *argv[])
       {
-        QCoreApplication::addLibraryPath("#{share}/qt/plugins");
         QCoreApplication a(argc, argv);
         QSqlDatabase db = QSqlDatabase::addDatabase("QODBC");
         assert(db.isValid());
@@ -85,7 +79,7 @@ class QtUnixodbc < Formula
     CPP
 
     ENV["LC_ALL"] = "en_US.UTF-8"
-    system "cmake", "-S", ".", "-B", "build", "-DCMAKE_BUILD_TYPE=Debug"
+    system "cmake", "-S", ".", "-B", "build"
     system "cmake", "--build", "build"
     system "./build/test"
 

--- a/Formula/q/qt-unixodbc.rb
+++ b/Formula/q/qt-unixodbc.rb
@@ -12,12 +12,13 @@ class QtUnixodbc < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "1589d4a98b18cf52d15a61dace7830fcd03d6211f69b64e1b0c4863768e6d8c5"
-    sha256 cellar: :any,                 arm64_sequoia: "1b5461acec7bba9750afa1b51ef716925c4ff20d09964752492adbce9f500682"
-    sha256 cellar: :any,                 arm64_sonoma:  "5fabce420fa3ed6a8d5021867eaaeb9b3f9e34d0dff991ced59092dd0bed52c0"
-    sha256 cellar: :any,                 sonoma:        "1d1036ee7ba9efad7060650522a428d46245b69adeaab8458ca81620ae72e736"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "de6b1187ab26141901825b1c538d2f3347c09cb3083e21afc98e26029172dbf1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5e86a8aaf55ee4bce3c938528d25666bc1fb980cca69953d714d18dd4c2ebfa5"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "759c552b47b2079674aa8e32dfe68fe07d105617836d0d592ea2c739d1214a5a"
+    sha256 cellar: :any,                 arm64_sequoia: "28723ba39c3a5f96660da5b402a1e963cd5415973f37c21e1d64c4ed93a9676e"
+    sha256 cellar: :any,                 arm64_sonoma:  "73d6f8b034d1782597c3f59f67aa431c1d66738b2f53113630ad7780fc026ca4"
+    sha256 cellar: :any,                 sonoma:        "544c549fcb7475de2c28c0c9d753b99cc3293f0459ce1d94af1ebb2091d35d29"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "36153e0040372b78e175dc304af0cc100431d868e6f436e5bbb8065421533fee"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5c45588734da878f2733abf7b7e1c3b6644cc7b1baf99eba9317c56ddd97d358"
   end
 
   depends_on "cmake" => [:build, :test]


### PR DESCRIPTION
Also:
* Use same message format as other conflicts_with usage
* Build without `CMAKE_STAGING_PREFIX` as install prefix is set
* Remove `addLibraryPath` from test to make sure Qt can find the plugin by just installing the formula without any workarounds.
* Simplify CMake test script with Qt's helpers. Also use a fixed CMake version to avoid unexpected dependent test breakage on new CMake

