### PR TITLE
python@3.14: allow JIT to be enabled at runtime

### DIFF
--- a/Formula/p/python@3.14.rb
+++ b/Formula/p/python@3.14.rb
@@ -154,6 +154,8 @@ class PythonAT314 < Formula
       args << "--enable-framework=#{frameworks}"
       args << "--with-dtrace"
       args << "--with-dbmliborder=ndbm"
+      # requires an external (older) Python to build, which macOS already has
+      args << "--enable-experimental-jit=yes-off"
 
       # Avoid linking to libgcc https://mail.python.org/pipermail/python-dev/2012-February/116205.html
       args << "MACOSX_DEPLOYMENT_TARGET=#{MacOS.version}"

--- a/Formula/p/python@3.14.rb
+++ b/Formula/p/python@3.14.rb
@@ -23,6 +23,7 @@ class PythonAT314 < Formula
     sha256 x86_64_linux:  "d8de299d64613daedb3c80622a9eaf280a5fabcd5590defd64ec2c85f2130409"
   end
 
+  depends_on "python@3.13" => :build
   depends_on "pkgconf" => :build
   depends_on "mpdecimal"
   depends_on "openssl@3"


### PR DESCRIPTION
Python 3.14 started including built-in JIT (disabled by default) in the official builds, and packagers are supposed to enable it as well (https://docs.python.org/3/whatsnew/3.14.html#binary-releases-for-the-experimental-just-in-time-compiler).

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

A prebuilt (older is fine) Python is required to build the JIT. Not an issue on macOS, but we don't have an older Python laying around on the linux build.
