### PR TITLE
gtkwave 3.4.0 (new formula)

### DIFF
--- a/Formula/g/gtkwave.rb
+++ b/Formula/g/gtkwave.rb
@@ -1,0 +1,29 @@
+class Gtkwave < Formula
+  desc "GTK-based wave viewer for viewing VCD, GHW, FST, and other waveform files"
+  homepage "https://gtkwave.github.io/gtkwave/"
+  url "https://github.com/gtkwave/gtkwave/archive/refs/tags/v3.4.0.tar.gz"
+  sha256 "d5558cd419c8d46bdc958064cb97f963d1ea793866414c025906ec15033512ed"
+  license "GPL-2.0-or-later"
+  head "https://github.com/gtkwave/gtkwave.git", branch: "master"
+
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+  depends_on "pkg-config" => :build
+  depends_on "glib"
+  depends_on "gtk+3"
+  depends_on "gtk4"
+
+  on_macos do
+    depends_on "gtk-mac-integration"
+  end
+
+  def install
+    system "meson", "setup", "build", *std_meson_args
+    system "meson", "compile", "-C", "build", "--verbose"
+    system "meson", "install", "-C", "build"
+  end
+
+  test do
+    system bin/"gtkwave", "--version"
+  end
+end

--- a/Formula/g/gtkwave.rb
+++ b/Formula/g/gtkwave.rb
@@ -6,24 +6,50 @@ class Gtkwave < Formula
   license "GPL-2.0-or-later"
   head "https://github.com/gtkwave/gtkwave.git", branch: "master"
 
+  depends_on "flex" => :build
+  depends_on "gperf" => :build
   depends_on "meson" => :build
   depends_on "ninja" => :build
-  depends_on "pkg-config" => :build
+  depends_on "pkgconf" => :build
   depends_on "glib"
+  # GTKWave requires both GTK3 and GTK4 - the upstream meson.build unconditionally
+  # requires both: gtk+-3.0 for the main application and gtk4 for libgtkwave library.
+  # See: https://github.com/gtkwave/gtkwave/blob/v3.4.0/meson.build
   depends_on "gtk+3"
   depends_on "gtk4"
+
+  uses_from_macos "bzip2"
+  uses_from_macos "zlib"
 
   on_macos do
     depends_on "gtk-mac-integration"
   end
 
   def install
-    system "meson", "setup", "build", *std_meson_args
+    system "meson", "setup", "build", *std_meson_args, "-Dupdate_mime_database=false"
     system "meson", "compile", "-C", "build", "--verbose"
     system "meson", "install", "-C", "build"
   end
 
   test do
-    system bin/"gtkwave", "--version"
+    # Create a minimal VCD file
+    (testpath/"test.vcd").write <<~VCD
+      $timescale 1ns $end
+      $var wire 1 ! clk $end
+      $enddefinitions $end
+      #0
+      0!
+      #10
+      1!
+      #20
+      0!
+    VCD
+
+    # Convert VCD to FST format and verify the output file exists
+    system bin/"vcd2fst", "test.vcd", "test.fst"
+    assert_path_exists testpath/"test.fst"
+
+    # Verify version output
+    assert_match version.to_s, shell_output("#{bin}/gtkwave --version")
   end
 end


### PR DESCRIPTION
## Description
This adds a new formula for **GTKWave**, a GTK-based wave viewer for VCD, GHW, FST, and other waveform files. It is commonly used for viewing simulation outputs from GHDL, Icarus Verilog, Verilator, and other HDL simulators.

## Motivation
The existing Homebrew **cask** (`gtkwave`) has been [deprecated](https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/g/gtkwave.rb) because it only provided x86_64 pre-built binaries. This **formula** builds from source, providing:
- ✅ Native **Apple Silicon (arm64)** support
- ✅ Native **Intel (x86_64)** support  
- ✅ Up-to-date version (3.4.0 vs deprecated cask's 3.3.107)

## Formula Details
- **Build system**: meson + ninja
- **Dependencies**: glib, gtk+3, gtk4, gtk-mac-integration (macOS)
- **License**: GPL-2.0-or-later

## Testing
- Built and tested on macOS Sequoia (Apple Silicon)
- `brew audit --strict` passes
- `gtkwave --version` works correctly

## Checklist
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`?
- [x] Does your build pass `brew audit --strict <formula>`?