### PR TITLE
soplex 8.0.0

### DIFF
--- a/Formula/s/soplex.rb
+++ b/Formula/s/soplex.rb
@@ -11,12 +11,13 @@ class Soplex < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "cb16219c3ec40a99330682bfc6a1b8330965dcf1f38549d615c6c43f3f5a1253"
-    sha256 cellar: :any,                 arm64_sequoia: "0af4252d52360c93ec4c81340376a50cc1d6a0f5ca36c03713d237ba519d39f1"
-    sha256 cellar: :any,                 arm64_sonoma:  "2c08fc2ab9d1e6572bcd42bccb3abb311b67e6b4419f4f5dd4fcdf8cfdd318f8"
-    sha256 cellar: :any,                 sonoma:        "ca1cc65b9f5ccbc1f7c0337025bf98ee2dc509e564421aa7760c3119fce90ca8"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "63eba82c6bb4edcd6b50ce73bd744292ad5853964a43d8dd4170dd8efae6a468"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "66ee8e874f5050b40a6175b14d6ed3266fb89a4652c1dbf6b2db3debccb6b760"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "68059b60d46e80cf6c28d41c65190e6a0198421dcf3c2e7eeecf5c1890fc6e28"
+    sha256 cellar: :any,                 arm64_sequoia: "50ab905ad91e6ceff4c92fc4851705374cf20c928737ff83719681cd9cd1b1d2"
+    sha256 cellar: :any,                 arm64_sonoma:  "3238afa7cad64a68f290efaee60ccc9c2fd2f3ab60a3b1f258c24e091576c069"
+    sha256 cellar: :any,                 sonoma:        "78413d50a860c9da05d5b4504c57d7a8e1aeffba6c6109b3d5a1f37783eb8997"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "32d147f2be34f87c6654cebe431867e661840b5b45675b73ba1e8da41b2d6a9c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "dc647fe802d9c62b04aa8a7a5cc46f67b60b6291a4d511fc016919b3a5193336"
   end
 
   depends_on "cmake" => :build

--- a/Formula/s/soplex.rb
+++ b/Formula/s/soplex.rb
@@ -2,7 +2,7 @@ class Soplex < Formula
   desc "Optimization package for solving linear programming problems (LPs)"
   homepage "https://soplex.zib.de/"
   url "https://soplex.zib.de/download/release/soplex-8.0.0.tgz"
-  sha256 "6c3d0a3a2a0f6520a7334d10eaadb34a2f258035e8df40abc18ccf862a0b892a"
+  sha256 "7b69b4a3dad3c85bbffb30f1a7862e441b9c2984c063e60468d883df0ca0cf28"
   license "Apache-2.0"
 
   livecheck do
@@ -22,11 +22,11 @@ class Soplex < Formula
   depends_on "cmake" => :build
   depends_on "boost"
   depends_on "gmp"
-  depends_on "tbb"
+  depends_on "mpfr"
   uses_from_macos "zlib"
 
   def install
-    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    system "cmake", "-S", ".", "-B", "build", "-DPAPILO=OFF", *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
     pkgshare.install "src/example.cpp"
@@ -47,10 +47,14 @@ class Soplex < Formula
        x4
       End
     EOS
-    assert_match "problem is solved [optimal]", shell_output("#{bin}/soplex test.lp")
+    assert_match "problem is solved [optimal]",
+      shell_output("#{bin}/soplex test.lp")
+    assert_match "problem is solved [optimal]",
+      shell_output("#{bin}/soplex test.lp -f0 -o0 --readmode=1 --solvemode=2")
 
     system ENV.cxx, pkgshare/"example.cpp", "-std=c++14", "-L#{lib}", "-I#{include}",
-      "-L#{Formula["gmp"].opt_lib}", "-lsoplex", "-lz", "-lgmp", "-o", "test"
+      "-L#{Formula["gmp"].opt_lib}", "-L#{Formula["mpfr"].opt_lib}",
+      "-lsoplex", "-lz", "-lgmp", "-lmpfr", "-o", "test"
     system "./test"
   end
 end


### PR DESCRIPTION
Motivation: The current formula for the SoPlex LP solver does not build with MPFR and hence lacks in solving performance for its exact solving mode over rational numbers. This PR

- updates SoPlex formula to version 8.0.0
- removes unnecessary dependency on PaPILO and tbb
- adds dependency on MPFR for better support of numerically exact solving
- adds test for numerically exact solve

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

@DominikKamp has tested and can probably check the remaining boxes.