### PR TITLE
scip 10.0.0

### DIFF
--- a/Formula/o/or-tools.rb
+++ b/Formula/o/or-tools.rb
@@ -27,12 +27,12 @@ class OrTools < Formula
   end
 
   bottle do
-    sha256 cellar: :any, arm64_tahoe:   "a4ac96bc43c89b21f73cd7d3d612e7c9dfbb51691187327b751eaaa1e02da162"
-    sha256 cellar: :any, arm64_sequoia: "87b7e1a6df98f9e467fb7836256544d88c011b621fda9fb48435fbb34a48cd99"
-    sha256 cellar: :any, arm64_sonoma:  "8b22e6ff9efcb5232b80c30c98ebf65fa00316ba1950d8c12268efb60dcb8d5d"
-    sha256 cellar: :any, sonoma:        "2a5e6d88f593c0f4e7de562888988a37fb43ef9e262b0716d43df93c7cbbb42c"
-    sha256               arm64_linux:   "018636956133a206930362a92426326a6bac922e0da679d0697175d355a280b2"
-    sha256               x86_64_linux:  "75f68270d6ffb6363f34dd283bd0b52f34d81fae8bd23029d210dcb9394b30dc"
+    sha256 cellar: :any, arm64_tahoe:   "77367f0a8d406375be72d7d6c96e26b5c1891f994a85ab7bf01d5e9305cfe2e9"
+    sha256 cellar: :any, arm64_sequoia: "582e9f727a2f706eb561e7e05e36289337dff6c5584702f6934295f8e8d08d76"
+    sha256 cellar: :any, arm64_sonoma:  "c25fe2a1d9d167d6d4d04c53c60e595e0890a91db91ba9a9ffd19767b04146c1"
+    sha256 cellar: :any, sonoma:        "d2f676b856070f592d82ffab5d4a5f2d7455e511b31f9829ca749ab62efcfb19"
+    sha256               arm64_linux:   "10a9f21a0b1b6fdd2ed56edb3bc3a3366ee81f6f49783ba345a06e0b764c516b"
+    sha256               x86_64_linux:  "eb3091e6c99c57c686715ed4760054e8dfb6c2162b067f610626a0918e7f2764"
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/s/scip.rb
+++ b/Formula/s/scip.rb
@@ -1,8 +1,8 @@
 class Scip < Formula
   desc "Solver for mixed integer programming and mixed integer nonlinear programming"
   homepage "https://scipopt.org"
-  url "https://scipopt.org/download/release/scip-9.2.4.tgz"
-  sha256 "d88217393a6f86c18f2957c6d36d90d28287a01473fb7378417ab49ad72a50ea"
+  url "https://scipopt.org/download/release/scip-10.0.0.tgz"
+  sha256 "b91d2ed32c422a13c502c37cf296eb9550e55d6bd311e61bfa6dfb9811b03d87"
   license "Apache-2.0"
 
   livecheck do
@@ -20,10 +20,11 @@ class Scip < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "boost"
-  depends_on "cppad"
+  depends_on "boost" => :no_linkage
+  depends_on "cppad" => :no_linkage
   depends_on "gmp"
   depends_on "ipopt"
+  depends_on "mpfr" => :no_linkage
   depends_on "openblas"
   depends_on "papilo"
   depends_on "readline"
@@ -43,10 +44,15 @@ class Scip < Formula
 
     pkgshare.install "check/instances/MIP/enigma.mps"
     pkgshare.install "check/instances/MINLP/gastrans.nl"
+    pkgshare.install "check/instances/MIPEX/flugpl_rational.mps"
   end
 
   test do
-    assert_match "problem is solved [optimal solution found]", shell_output("#{bin}/scip -f #{pkgshare}/enigma.mps")
-    assert_match "problem is solved [optimal solution found]", shell_output("#{bin}/scip -f #{pkgshare}/gastrans.nl")
+    expected = "problem is solved [optimal solution found]"
+    assert_match expected, shell_output("#{bin}/scip -f #{pkgshare}/enigma.mps")
+    assert_match expected, shell_output("#{bin}/scip -f #{pkgshare}/gastrans.nl")
+
+    command = "set exact enable TRUE read #{pkgshare}/flugpl_rational.mps optimize quit"
+    assert_match expected, shell_output("#{bin}/scip -c \"#{command}\"")
   end
 end

--- a/Formula/s/scip.rb
+++ b/Formula/s/scip.rb
@@ -11,12 +11,12 @@ class Scip < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "8e345527c5788204b410c15d3f9ad6ef3a30d626641c49c80429b96f93d8a28a"
-    sha256 cellar: :any,                 arm64_sequoia: "8cfd22fa1f1a525de6a8fe28acf3b5c8ed7e3aaf0fff4bed1f323a56b29c6e00"
-    sha256 cellar: :any,                 arm64_sonoma:  "a6d778cea731f914cb00cd4a8a8cc9465c4dfc28793c51025e078d087e27c011"
-    sha256 cellar: :any,                 sonoma:        "fc8a392321d3640bd79af687a026e83ec83090ae1a78453474f1f1432a481803"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "87ead7c33e3744da5cc7d6a79955e7fcfc013338a8f49024eee7f82647ee46ee"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "beee5ba170ef0b8e55436ca899e694759c286d005c94277203a36b7cf6d74a45"
+    sha256 cellar: :any,                 arm64_tahoe:   "d34ce00329bf1ee4b0eb0e173c8a32559d3e5ed807a58ce7c38d64b2a5a8b515"
+    sha256 cellar: :any,                 arm64_sequoia: "53cc523a67b262b84cfcd148cc45e341b0e78af1a09726f05cd3806ca96a816a"
+    sha256 cellar: :any,                 arm64_sonoma:  "14e01b3befd24f3a7c7a6f4fcc5ac8040207d6c6b558e88b55de1571d05c6420"
+    sha256 cellar: :any,                 sonoma:        "169ba2332962c0dd133d2d818132af9dec46687cb34cb2b464350a2a7b847cbf"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "e261bc85758fd9965ef7173d4b7eb14d4cbf09228a1835df0ec34043bc92fc52"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2159678993d921f14507fa26cc06e12d51e383df2079b8bbe5f03321c2aaac4c"
   end
 
   depends_on "cmake" => :build

--- a/Patches/or-tools/abseil-bump.diff
+++ b/Patches/or-tools/abseil-bump.diff
@@ -1,0 +1,158 @@
+diff --git a/ortools/math_opt/cpp/model.cc b/ortools/math_opt/cpp/model.cc
+index 12ea552d78..9d19f5af72 100644
+--- a/ortools/math_opt/cpp/model.cc
++++ b/ortools/math_opt/cpp/model.cc
+@@ -55,7 +55,7 @@ constexpr double kInf = std::numeric_limits<double>::infinity();
+ 
+ absl::StatusOr<std::unique_ptr<Model>> Model::FromModelProto(
+     const ModelProto& model_proto) {
+-  ASSIGN_OR_RETURN(absl::Nonnull<std::unique_ptr<ModelStorage>> storage,
++  ASSIGN_OR_RETURN(absl_nonnull std::unique_ptr<ModelStorage> storage,
+                    ModelStorage::FromModelProto(model_proto));
+   return std::make_unique<Model>(std::move(storage));
+ }
+@@ -63,10 +63,10 @@ absl::StatusOr<std::unique_ptr<Model>> Model::FromModelProto(
+ Model::Model(const absl::string_view name)
+     : storage_(std::make_shared<ModelStorage>(name)) {}
+ 
+-Model::Model(absl::Nonnull<std::unique_ptr<ModelStorage>> storage)
++Model::Model(absl_nonnull std::unique_ptr<ModelStorage> storage)
+     : storage_(ABSL_DIE_IF_NULL(std::move(storage))) {}
+ 
+-absl::Nonnull<std::unique_ptr<Model>> Model::Clone(
++absl_nonnull std::unique_ptr<Model> Model::Clone(
+     const std::optional<absl::string_view> new_name) const {
+   return std::make_unique<Model>(storage_->Clone(new_name));
+ }
+diff --git a/ortools/math_opt/cpp/model.h b/ortools/math_opt/cpp/model.h
+index bb9939f098..6cb65ed256 100644
+--- a/ortools/math_opt/cpp/model.h
++++ b/ortools/math_opt/cpp/model.h
+@@ -137,7 +137,7 @@ class Model {
+   // This constructor is used when loading a model, for example from a
+   // ModelProto or an MPS file. Note that in those cases the FromModelProto()
+   // should be used.
+-  explicit Model(absl::Nonnull<std::unique_ptr<ModelStorage>> storage);
++  explicit Model(absl_nonnull std::unique_ptr<ModelStorage> storage);
+ 
+   Model(const Model&) = delete;
+   Model& operator=(const Model&) = delete;
+@@ -159,7 +159,7 @@ class Model {
+   //   * in an arbitrary order using Variables() and LinearConstraints().
+   //
+   // Note that the returned model does not have any update tracker.
+-  absl::Nonnull<std::unique_ptr<Model>> Clone(
++  absl_nonnull std::unique_ptr<Model> Clone(
+       std::optional<absl::string_view> new_name = std::nullopt) const;
+ 
+   inline absl::string_view name() const;
+@@ -925,7 +925,7 @@ class Model {
+   // We use a shared_ptr here so that the UpdateTracker class can have a
+   // weak_ptr on the ModelStorage. This let it have a destructor that don't
+   // crash when called after the destruction of the associated Model.
+-  const absl::Nonnull<std::shared_ptr<ModelStorage>> storage_;
++  const absl_nonnull std::shared_ptr<ModelStorage> storage_;
+ };
+ 
+ ////////////////////////////////////////////////////////////////////////////////
+diff --git a/ortools/math_opt/storage/model_storage.cc b/ortools/math_opt/storage/model_storage.cc
+index 3c5139d07e..9c24890944 100644
+--- a/ortools/math_opt/storage/model_storage.cc
++++ b/ortools/math_opt/storage/model_storage.cc
+@@ -46,7 +46,7 @@
+ namespace operations_research {
+ namespace math_opt {
+ 
+-absl::StatusOr<absl::Nonnull<std::unique_ptr<ModelStorage>>>
++absl::StatusOr<absl_nonnull std::unique_ptr<ModelStorage>>
+ ModelStorage::FromModelProto(const ModelProto& model_proto) {
+   // We don't check names since ModelStorage does not do so before exporting
+   // models. Thus a model built by ModelStorage can contain duplicated
+@@ -144,7 +144,7 @@ void ModelStorage::UpdateLinearConstraintCoefficients(
+   }
+ }
+ 
+-absl::Nonnull<std::unique_ptr<ModelStorage>> ModelStorage::Clone(
++absl_nonnull std::unique_ptr<ModelStorage> ModelStorage::Clone(
+     const std::optional<absl::string_view> new_name) const {
+   // We leverage the private copy constructor that copies copyable_data_ but not
+   // update_trackers_ here.
+diff --git a/ortools/math_opt/storage/model_storage.h b/ortools/math_opt/storage/model_storage.h
+index 2334290cdc..127dbce14c 100644
+--- a/ortools/math_opt/storage/model_storage.h
++++ b/ortools/math_opt/storage/model_storage.h
+@@ -177,7 +177,7 @@ class ModelStorage {
+   // considered invalid when solving.
+   //
+   // See ApplyUpdateProto() for dealing with subsequent updates.
+-  static absl::StatusOr<absl::Nonnull<std::unique_ptr<ModelStorage> > >
++  static absl::StatusOr<absl_nonnull std::unique_ptr<ModelStorage>>
+   FromModelProto(const ModelProto& model_proto);
+ 
+   // Creates an empty minimization problem.
+@@ -192,7 +192,7 @@ class ModelStorage {
+   // reused any id of variable/constraint that was deleted in the original.
+   //
+   // Note that the returned model does not have any update tracker.
+-  absl::Nonnull<std::unique_ptr<ModelStorage> > Clone(
++  absl_nonnull std::unique_ptr<ModelStorage> Clone(
+       std::optional<absl::string_view> new_name = std::nullopt) const;
+ 
+   inline const std::string& name() const { return copyable_data_.name; }
+@@ -1311,10 +1311,10 @@ namespace operations_research::math_opt {
+ 
+ // Aliases for non-nullable and nullable pointers to a `ModelStorage`.
+ // We should mostly be using the former, but in some cases we need the latter.
+-using ModelStoragePtr = absl::Nonnull<ModelStorage*>;
+-using NullableModelStoragePtr = absl::Nullable<ModelStorage*>;
+-using ModelStorageCPtr = absl::Nonnull<const ModelStorage*>;
+-using NullableModelStorageCPtr = absl::Nullable<const ModelStorage*>;
++using ModelStoragePtr = ModelStorage* absl_nonnull;
++using NullableModelStoragePtr = ModelStorage* absl_nullable;
++using ModelStorageCPtr = const ModelStorage* absl_nonnull;
++using NullableModelStorageCPtr = const ModelStorage* absl_nullable;
+ 
+ }  // namespace operations_research::math_opt
+ 
+diff --git a/ortools/math_opt/storage/model_storage_v2.cc b/ortools/math_opt/storage/model_storage_v2.cc
+index e911eaecc4..60b0ec952d 100644
+--- a/ortools/math_opt/storage/model_storage_v2.cc
++++ b/ortools/math_opt/storage/model_storage_v2.cc
+@@ -76,13 +76,13 @@ void ModelStorageV2::DeleteLinearConstraint(LinearConstraintId id) {
+       << ", it is not in the model";
+ }
+ 
+-absl::StatusOr<absl::Nonnull<std::unique_ptr<ModelStorageV2>>>
++absl::StatusOr<absl_nonnull std::unique_ptr<ModelStorageV2>>
+ ModelStorageV2::FromModelProto(const ModelProto& model_proto) {
+   ASSIGN_OR_RETURN(Elemental e, Elemental::FromModelProto(model_proto));
+   return absl::WrapUnique(new ModelStorageV2(std::move(e)));
+ }
+ 
+-absl::Nonnull<std::unique_ptr<ModelStorageV2>> ModelStorageV2::Clone(
++absl_nonnull std::unique_ptr<ModelStorageV2> ModelStorageV2::Clone(
+     const std::optional<absl::string_view> new_name) const {
+   return absl::WrapUnique(new ModelStorageV2(elemental_.Clone(new_name)));
+ }
+diff --git a/ortools/math_opt/storage/model_storage_v2.h b/ortools/math_opt/storage/model_storage_v2.h
+index 45078bedad..c8c13b7232 100644
+--- a/ortools/math_opt/storage/model_storage_v2.h
++++ b/ortools/math_opt/storage/model_storage_v2.h
+@@ -90,7 +90,7 @@ class ModelStorageV2 {
+   // considered invalid when solving.
+   //
+   // See ApplyUpdateProto() for dealing with subsequent updates.
+-  static absl::StatusOr<absl::Nonnull<std::unique_ptr<ModelStorageV2>>>
++  static absl::StatusOr<absl_nonnull std::unique_ptr<ModelStorageV2>>
+   FromModelProto(const ModelProto& model_proto);
+ 
+   // Creates an empty minimization problem.
+@@ -106,7 +106,7 @@ class ModelStorageV2 {
+   // reused any id of variable/constraint that was deleted in the original.
+   //
+   // Note that the returned model does not have any update tracker.
+-  absl::Nonnull<std::unique_ptr<ModelStorageV2>> Clone(
++  absl_nonnull std::unique_ptr<ModelStorageV2> Clone(
+       std::optional<absl::string_view> new_name = std::nullopt) const;
+ 
+   inline const std::string& name() const { return elemental_.model_name(); }


### PR DESCRIPTION
Motivation: The current formula for the SCIP MIP solver does not build with MPFR and hence lacks its new numerically exact solving mode over rational numbers. This PR

- requires MPFR as dependency in SCIP formula
- adds a test for exact solving in SCIP formula
- removes unnecessary openblas and tbb dependency in SCIP formula

There is a closed PR for the SCIP 10.0.0 update here: https://github.com/Homebrew/homebrew-core/pull/254033

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

@DominikKamp has tested and can probably check the remaining boxes.

