### PR TITLE
formulae: remove livecheck

### DIFF
--- a/Formula/a/ansible@10.rb
+++ b/Formula/a/ansible@10.rb
@@ -8,14 +8,6 @@ class AnsibleAT10 < Formula
   license "GPL-3.0-or-later"
   revision 6
 
-  livecheck do
-    url "https://pypi.org/rss/project/ansible/releases.xml"
-    regex(/^v?(10(?:\.\d+)+)$/i)
-    strategy :xml do |xml, regex|
-      xml.get_elements("//item/title").map { |item| item.text[regex, 1] }
-    end
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "f9d73aae386e968bb5bc720aabf62f83fcee6ee1e1b460fd2c95ef8b6c467190"
     sha256 cellar: :any,                 arm64_sequoia: "f8e04a12807cbf214cfe13cd8a8cb5654951a6936d4cfd6b7423b2dd79c240bc"

--- a/Formula/c/conan@1.rb
+++ b/Formula/c/conan@1.rb
@@ -8,11 +8,6 @@ class ConanAT1 < Formula
   license "MIT"
   revision 3
 
-  livecheck do
-    url "https://github.com/conan-io/conan.git"
-    regex(/^v?(1(?:\.\d+)+)$/i)
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "347415104db865374e09109080fa117d919130b502de713bc9062501e4ff8564"
     sha256 cellar: :any,                 arm64_sequoia: "7dcfb73f071f82c9a5a5a2c081b54030c8c7aa87f11293897d499400972a9b78"

--- a/Formula/e/erlang@25.rb
+++ b/Formula/e/erlang@25.rb
@@ -7,11 +7,6 @@ class ErlangAT25 < Formula
   license "Apache-2.0"
   revision 1
 
-  livecheck do
-    url :stable
-    regex(/^OTP[._-]v?(25(?:\.\d+)+)$/i)
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "33f70df37d2196f26aeac6cfbb090d8d9aee8007ab809e72aad4d41755ce5474"
     sha256 cellar: :any,                 arm64_sonoma:  "586d85e4927c178beecf49b78dcd9f27ab1624a0d7220195df1c0eaba6ca84ee"

--- a/Formula/g/gradle@7.rb
+++ b/Formula/g/gradle@7.rb
@@ -5,11 +5,6 @@ class GradleAT7 < Formula
   sha256 "6ed4d467349e2d3f555a578829c4aeadd67d73e2ec5d213c2a62f8f2829d9fa9"
   license "Apache-2.0"
 
-  livecheck do
-    url "https://gradle.org/releases/"
-    regex(/href=.*?gradle[._-]v?(7(?:\.\d+)+)-all\.(?:zip|t)/i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, all: "d65eb2a55c0be7b144b661bea1d9f3df08d67eb0aa7a033c3088a58272b7b2db"
   end
@@ -19,6 +14,7 @@ class GradleAT7 < Formula
   # EOL with Gradle 9 release on 2025-07-31.
   # https://docs.gradle.org/current/userguide/feature_lifecycle.html#eol_support
   deprecate! date: "2025-07-31", because: :unmaintained
+  disable! date: "2026-07-31", because: :unmaintained
 
   # TODO: Check if support for running on Java 20 is backported to Gradle 7.x.
   depends_on "openjdk@17"

--- a/Formula/m/mariadb@10.5.rb
+++ b/Formula/m/mariadb@10.5.rb
@@ -6,18 +6,6 @@ class MariadbAT105 < Formula
   license "GPL-2.0-only"
   revision 1
 
-  livecheck do
-    url "https://downloads.mariadb.org/rest-api/mariadb/all-releases/?olderReleases=false"
-    strategy :json do |json|
-      json["releases"]&.map do |release|
-        next unless release["release_number"]&.start_with?(version.major_minor)
-        next if release["status"] != "stable"
-
-        release["release_number"]
-      end
-    end
-  end
-
   bottle do
     sha256 arm64_tahoe:   "bc104c240968345cb39f6f28716a9606704026b37e81f4d92a54d7f69b693f36"
     sha256 arm64_sequoia: "a8c6bb26de1fa94be3319d9e32b63205f9078434ec2145badb5cdc6451f58f27"
@@ -32,6 +20,7 @@ class MariadbAT105 < Formula
   # See: https://mariadb.com/kb/en/changes-improvements-in-mariadb-105/
   # End-of-life on 2025-06-24: https://mariadb.org/about/#maintenance-policy
   deprecate! date: "2025-06-24", because: :unsupported
+  disable! date: "2026-06-24", because: :unsupported
 
   depends_on "bison" => :build
   depends_on "cmake" => :build

--- a/Formula/p/python-tk@3.9.rb
+++ b/Formula/p/python-tk@3.9.rb
@@ -5,10 +5,6 @@ class PythonTkAT39 < Formula
   sha256 "00e07d7c0f2f0cc002432d1ee84d2a40dae404a99303e3f97701c10966c91834"
   license "Python-2.0"
 
-  livecheck do
-    formula "python@3.9"
-  end
-
   no_autobump! because: :requires_manual_review
 
   bottle do

--- a/Formula/p/python@3.9.rb
+++ b/Formula/p/python@3.9.rb
@@ -5,11 +5,6 @@ class PythonAT39 < Formula
   sha256 "00e07d7c0f2f0cc002432d1ee84d2a40dae404a99303e3f97701c10966c91834"
   license "Python-2.0"
 
-  livecheck do
-    url "https://www.python.org/ftp/python/"
-    regex(%r{href=.*?v?(3\.9(?:\.\d+)*)/?["' >]}i)
-  end
-
   bottle do
     sha256 arm64_tahoe:   "aa558024f07820222f9eb9536205a2f25728c1702cf76b1a16ee52db7536ec6a"
     sha256 arm64_sequoia: "4c31fe761ed46dafc847808255c353ae4b730c49c8fc7a9bb1dc3803ee088f4f"


### PR DESCRIPTION
All of these are EOL. 

Marking these correctly can allow us to enable autobump of "deprecated" formulae which are actually still getting security releases.
