### PR TITLE
csha 1.1.9 (new formula)

### DIFF
--- a/Formula/c/csha.rb
+++ b/Formula/c/csha.rb
@@ -1,0 +1,29 @@
+class Csha < Formula
+  desc "Cryptographic Steganography and Hashing Library"
+  homepage "https://gitlab.com/Malcolmston/project-final"
+  url "https://gitlab.com/Malcolmston/project-final/-/archive/v1.1.9/project-final-v1.1.9.tar.gz"
+  sha256 "21b70547c5283354e098292bb8166e93c1753f62dc8584c9ec59016ab64c894f"
+  license "MPL-2.0"
+
+  depends_on "pkgconf" => :build
+  depends_on "opencv"
+  depends_on "openssl@3"
+  depends_on "libzip"
+
+  def install
+    # Set OpenSSL path for macOS
+    ENV["OPENSSL_INC"] = Formula["openssl@3"].opt_include
+    ENV["OPENSSL_LIB"] = Formula["openssl@3"].opt_lib
+
+    # Build the project
+    system "make", "all"
+
+    # Install the binary
+    bin.install "csha"
+  end
+
+  test do
+    # Test that the binary runs and shows help
+    assert_match "Cryptographic Steganography and Hashing Library", shell_output("#{bin}/csha --help")
+  end
+end


### PR DESCRIPTION
## Summary
- Add new formula for csha (Cryptographic Steganography and Hashing Library)
- Version 1.1.9
- MPL-2.0 licensed
- Provides cryptographic steganography capabilities with AES encryption and Minecraft map-based data hiding

## Details
- **Homepage**: https://gitlab.com/Malcolmston/project-final
- **License**: MPL-2.0 (Mozilla Public License 2.0)
- **Dependencies**: opencv, openssl@3, libzip, pkg-config (build)
- **Binary**: csha

## Features
- Multiple AES encryption modes (CBC, CTR, GCM)
- Multiple key derivation methods (PBKDF2, DIRECT, FIXED)
- Steganographic data embedding in Minecraft map images
- Support for encoding/decoding text, files, and zip archives

## Test Plan
- [x] Formula builds successfully from source
- [x] Binary installs to correct location
- [x] Help text displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)