### PR TITLE
ortp: switch to `openssl@3` to avoid not upstreamed patch

### DIFF
--- a/Formula/o/ortp.rb
+++ b/Formula/o/ortp.rb
@@ -1,9 +1,11 @@
 class Ortp < Formula
   desc "Real-time transport protocol (RTP, RFC3550) library"
   homepage "https://linphone.org/"
-  license "GPL-3.0-or-later"
+  license all_of: ["AGPL-3.0-or-later", "GPL-3.0-or-later"]
+  head "https://gitlab.linphone.org/BC/public/linphone-sdk.git", branch: "master"
 
   stable do
+    # TODO: Switch to monorepo in 5.5.x
     url "https://gitlab.linphone.org/BC/public/ortp/-/archive/5.4.65/ortp-5.4.65.tar.bz2"
     sha256 "4ecee5c64b60c8e0b34f6c44cbfd022705d5a06bddbb010e442c4c5503e7022b"
 
@@ -16,8 +18,6 @@ class Ortp < Formula
       livecheck do
         formula :parent
       end
-
-      patch :DATA
     end
   end
 
@@ -32,48 +32,40 @@ class Ortp < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "3c160aca28623991d9f61817b8621ba76458056136bc250da335d47ae9f7566b"
   end
 
-  head do
-    url "https://gitlab.linphone.org/BC/public/ortp.git", branch: "master"
-
-    resource "bctoolbox" do
-      url "https://gitlab.linphone.org/BC/public/bctoolbox.git", branch: "master"
-    end
-  end
-
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
-  depends_on "mbedtls@3"
+  depends_on "openssl@3"
 
   def install
-    odie "bctoolbox resource needs to be updated" if build.stable? && version != resource("bctoolbox").version
-
-    resource("bctoolbox").stage do
-      args = %w[
-        -DENABLE_TESTS_COMPONENT=OFF
-        -DBUILD_SHARED_LIBS=ON
-        -DENABLE_MBEDTLS=ON
-      ]
-
-      system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args(install_prefix: libexec)
-      system "cmake", "--build", "build"
-      system "cmake", "--install", "build"
+    if build.stable?
+      odie "bctoolbox resource needs to be updated" if version != resource("bctoolbox").version
+      (buildpath/"bctoolbox").install resource("bctoolbox")
+    else
+      rm_r("external")
     end
 
-    ENV.prepend_path "PKG_CONFIG_PATH", libexec/"lib/pkgconfig"
-    ENV.append "LDFLAGS", "-Wl,-rpath,#{libexec}/lib" if OS.linux?
-    ENV.append_to_cflags "-I#{libexec}/include"
-
-    args = %W[
-      -DCMAKE_PREFIX_PATH=#{libexec}
+    args = %w[
       -DBUILD_SHARED_LIBS=ON
-      -DENABLE_DOC=NO
-      -DENABLE_UNIT_TESTS=NO
+      -DENABLE_MBEDTLS=OFF
+      -DENABLE_OPENSSL=ON
+      -DENABLE_TESTS_COMPONENT=OFF
     ]
-    args << "-DCMAKE_INSTALL_RPATH=#{libexec}/Frameworks" if OS.mac?
 
-    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
-    system "cmake", "--build", "build"
-    system "cmake", "--install", "build"
+    system "cmake", "-S", "bctoolbox", "-B", "build_bctoolbox", *args, *std_cmake_args
+    system "cmake", "--build", "build_bctoolbox"
+    system "cmake", "--install", "build_bctoolbox"
+    prefix.install "bctoolbox/LICENSE.txt" => "LICENSE-bctoolbox.txt"
+
+    args = %w[
+      -DBUILD_SHARED_LIBS=ON
+      -DENABLE_DOC=OFF
+      -DENABLE_UNIT_TESTS=OFF
+    ]
+    args << "-DCMAKE_INSTALL_RPATH=#{frameworks}" if OS.mac?
+
+    system "cmake", "-S", (build.head? ? "ortp" : "."), "-B", "build_ortp", *args, *std_cmake_args
+    system "cmake", "--build", "build_ortp"
+    system "cmake", "--install", "build_ortp"
   end
 
   test do
@@ -88,30 +80,7 @@ class Ortp < Formula
       }
     C
     linker_flags = OS.mac? ? %W[-F#{frameworks} -framework ortp] : %W[-L#{lib} -lortp]
-    system ENV.cc, "test.c", "-o", "test", "-I#{include}", "-I#{libexec}/include", *linker_flags
+    system ENV.cc, "test.c", "-o", "test", "-I#{include}", *linker_flags
     system "./test"
   end
 end
-
-__END__
-diff --git a/src/crypto/mbedtls.cc b/src/crypto/mbedtls.cc
-index cf146fd..8886b2d 100644
---- a/src/crypto/mbedtls.cc
-+++ b/src/crypto/mbedtls.cc
-@@ -80,8 +80,6 @@ public:
- 
- 	std::unique_ptr<RNG> sRNG;
- 	mbedtlsStaticContexts() {
--		mbedtls_threading_set_alt(threading_mutex_init_cpp, threading_mutex_free_cpp, threading_mutex_lock_cpp,
--		                          threading_mutex_unlock_cpp);
- 		if (psa_crypto_init() != PSA_SUCCESS) {
- 			bctbx_error("MbedTLS PSA init fail");
- 		}
-@@ -92,7 +90,6 @@ public:
- 		// before destroying mbedtls internal context, destroy the static RNG
- 		sRNG = nullptr;
- 		mbedtls_psa_crypto_free();
--		mbedtls_threading_free_alt();
- 	}
- };
- static const auto mbedtlsStaticContextsInstance = std::make_unique<mbedtlsStaticContexts>();

--- a/Formula/o/ortp.rb
+++ b/Formula/o/ortp.rb
@@ -24,12 +24,13 @@ class Ortp < Formula
   no_autobump! because: "resources cannot be updated automatically"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "3f4036d6d1ecc587ac38b917c9ee7212ee3f873268530944514443de49dc4b98"
-    sha256 cellar: :any,                 arm64_sequoia: "c94660b5863e83e14d30b129570068bdb89ad7546e64f203829acd62aaec32ad"
-    sha256 cellar: :any,                 arm64_sonoma:  "95016dbdbd9baed93e2e51c8741d4d2c1b44d6b7bd540f0635d1646de3a18420"
-    sha256 cellar: :any,                 sonoma:        "b5e18148def0f1df105de7a3d158514df5186940e417e67726070dcb3bd4f2de"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "bf1c33177868c6be84da67fa32435220dce3321f52fcbbc0241c693dfd2a858b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3c160aca28623991d9f61817b8621ba76458056136bc250da335d47ae9f7566b"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "b34c76a2b6c6402c5451556d32593df1093820f0a31716738f93bb493008087d"
+    sha256 cellar: :any,                 arm64_sequoia: "0c29edd8a9da07e162e053064e543e768435055cc836854025417ca5e02b0610"
+    sha256 cellar: :any,                 arm64_sonoma:  "1095e20896fdf6f7b536105f4c7ac70cf396438ba46a9baa1b930de2b980069e"
+    sha256 cellar: :any,                 sonoma:        "cfae74b62d03aac89fa18c2f530b24317d814ce98d266f3d894bbc066ceeed89"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "4142d57d7aacf74603c979a427620c03d0e9cb5281521b2acdb3110c94777c49"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e033762038c4b25e371fbe23ff64be5d9bf08216809663182fe4b8f55156903a"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
Also update HEAD build to use monorepo as `ortp` and `bctoolbox` has been merged into `linphone-sdk` where 5.5.0 and later will be released. See https://gitlab.linphone.org/BC/public/ortp/-/blob/master/README.md

In addition, we can just install `bctoolbox` into prefix to simplify usage and avoid extra `libexec` paths. If there is a situation that another formula need `bctoolbox`, then it can be split to a separate formula. For now not doing this given monorepo changes.

---

I had added changes to switch to OpenSSL 3 in version 5.4 back in #192670 but looks like they got removed at some point.

We don't like non-upstreamed patches and generally prefer OpenSSL when multiple SSL/TLS options are available so can just use OpenSSL. Minimum requirement for MbedTLS would be upstream fix.

---

Need to check on Linux build as some CMake args may still be needed