### PR TITLE
feat(formula): add Labctl CLI tool integration for Homebrew

### DIFF
--- a/Formula/l/labctl.rb
+++ b/Formula/l/labctl.rb
@@ -1,0 +1,36 @@
+class Labctl < Formula
+    desc "CLI tool for interacting with iximiuz labs and playgrounds"
+    homepage "https://github.com/iximiuz/labctl"
+    license "MIT"
+  
+    version "0.1.50"
+  
+    on_macos do
+      if Hardware::CPU.arm?
+        url "https://github.com/iximiuz/labctl/releases/download/v#{version}/labctl_darwin_arm64.tar.gz"
+        sha256 "6d4209f50f7cc1ae33bc2d492ffb5d2dd9083475dfc7d787c45e08acc2ca5ad1"
+      else
+        url "https://github.com/iximiuz/labctl/releases/download/v#{version}/labctl_darwin_amd64.tar.gz"
+        sha256 "274ea09f6d93a5d0bf35b7767b842d6bbc9c5199ef9fd1dd324ba3c7fa0e1601"
+      end
+    end
+  
+    on_linux do
+      if Hardware::CPU.arm?
+        url "https://github.com/iximiuz/labctl/releases/download/v#{version}/labctl_linux_arm64.tar.gz"
+        sha256 "df136bb19c164e6828fce045114708ee5170e053c756b5a410e1c6c6deeb74da"
+      else
+        url "https://github.com/iximiuz/labctl/releases/download/v#{version}/labctl_linux_amd64.tar.gz"
+        sha256 "34f4f9c3643e37f2fabf26b01620d7f0b7bed34481ad9e1869a017478b356f4b"
+      end
+    end
+  
+    def install
+      bin.install "labctl"
+    end
+  
+    test do
+      output = shell_output("#{bin}/labctl --help")
+      assert_match "labctl", output
+    end
+  end  

--- a/Formula/l/labctl.rb
+++ b/Formula/l/labctl.rb
@@ -1,36 +1,35 @@
 class Labctl < Formula
-    desc "CLI tool for interacting with iximiuz labs and playgrounds"
-    homepage "https://github.com/iximiuz/labctl"
-    license "MIT"
-  
-    version "0.1.50"
-  
-    on_macos do
-      if Hardware::CPU.arm?
-        url "https://github.com/iximiuz/labctl/releases/download/v#{version}/labctl_darwin_arm64.tar.gz"
-        sha256 "6d4209f50f7cc1ae33bc2d492ffb5d2dd9083475dfc7d787c45e08acc2ca5ad1"
-      else
-        url "https://github.com/iximiuz/labctl/releases/download/v#{version}/labctl_darwin_amd64.tar.gz"
-        sha256 "274ea09f6d93a5d0bf35b7767b842d6bbc9c5199ef9fd1dd324ba3c7fa0e1601"
-      end
+  desc "CLI tool for interacting with iximiuz labs and playgrounds"
+  homepage "https://github.com/iximiuz/labctl"
+  license "MIT"
+
+  version "0.1.50"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/iximiuz/labctl/releases/download/v0.1.50/labctl_darwin_arm64.tar.gz"
+      sha256 "6d4209f50f7cc1ae33bc2d492ffb5d2dd9083475dfc7d787c45e08acc2ca5ad1"
+    else
+      url "https://github.com/iximiuz/labctl/releases/download/v0.1.50/labctl_darwin_amd64.tar.gz"
+      sha256 "274ea09f6d93a5d0bf35b7767b842d6bbc9c5199ef9fd1dd324ba3c7fa0e1601"
     end
-  
-    on_linux do
-      if Hardware::CPU.arm?
-        url "https://github.com/iximiuz/labctl/releases/download/v#{version}/labctl_linux_arm64.tar.gz"
-        sha256 "df136bb19c164e6828fce045114708ee5170e053c756b5a410e1c6c6deeb74da"
-      else
-        url "https://github.com/iximiuz/labctl/releases/download/v#{version}/labctl_linux_amd64.tar.gz"
-        sha256 "34f4f9c3643e37f2fabf26b01620d7f0b7bed34481ad9e1869a017478b356f4b"
-      end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm?
+      url "https://github.com/iximiuz/labctl/releases/download/v0.1.50/labctl_linux_arm64.tar.gz"
+      sha256 "df136bb19c164e6828fce045114708ee5170e053c756b5a410e1c6c6deeb74da"
+    else
+      url "https://github.com/iximiuz/labctl/releases/download/v0.1.50/labctl_linux_amd64.tar.gz"
+      sha256 "34f4f9c3643e37f2fabf26b01620d7f0b7bed34481ad9e1869a017478b356f4b"
     end
-  
-    def install
-      bin.install "labctl"
-    end
-  
-    test do
-      output = shell_output("#{bin}/labctl --help")
-      assert_match "labctl", output
-    end
-  end  
+  end
+
+  def install
+    bin.install "labctl"
+  end
+
+  test do
+    assert_match "labctl", shell_output("#{bin}/labctl --help")
+  end
+end


### PR DESCRIPTION
- Introduced Labctl as a new formula for Homebrew.
- Added support for macOS and Linux architectures (arm64 and amd64).
- Included installation and testing methods for the Labctl executable.
- Documented the tool with a description and homepage link.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
