### PR TITLE
CODEOWNERS: use lead-maintainers instead of tsc.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,18 +8,18 @@
 #
 # Note: @Homebrew/plc does not have write-access to this repository, and therefore cannot be listed in this file.
 
-CODEOWNERS                        @Homebrew/tsc @MikeMcQuaid
-CONTRIBUTING.md                   @Homebrew/tsc @MikeMcQuaid
-tap_migrations.json               @Homebrew/tsc @MikeMcQuaid
-.github/ISSUE_TEMPLATE/           @Homebrew/tsc @MikeMcQuaid
-.github/PULL_REQUEST_TEMPLATE.md  @Homebrew/tsc @MikeMcQuaid
-LICENSE.txt                       @Homebrew/tsc @MikeMcQuaid
+CODEOWNERS                        @Homebrew/lead-maintainers @MikeMcQuaid
+CONTRIBUTING.md                   @Homebrew/lead-maintainers @MikeMcQuaid
+tap_migrations.json               @Homebrew/lead-maintainers @MikeMcQuaid
+.github/ISSUE_TEMPLATE/           @Homebrew/lead-maintainers @MikeMcQuaid
+.github/PULL_REQUEST_TEMPLATE.md  @Homebrew/lead-maintainers @MikeMcQuaid
+LICENSE.txt                       @Homebrew/lead-maintainers @MikeMcQuaid
 .github/workflows/                @Homebrew/core @MikeMcQuaid
-.github/workflows/triage.yml      @Homebrew/tsc
+.github/workflows/triage.yml      @Homebrew/lead-maintainers
 
-audit_exceptions/linux_only_gcc_dependency_allowlist.json               @Homebrew/tsc
-audit_exceptions/permitted_formula_license_mismatches.json              @Homebrew/tsc @MikeMcQuaid
-audit_exceptions/provided_by_macos_depends_on_allowlist.json            @Homebrew/tsc @MikeMcQuaid
-audit_exceptions/relicensed_formulae_versions.json                      @Homebrew/tsc @MikeMcQuaid
-audit_exceptions/universal_binary_allowlist.json                        @Homebrew/tsc @carlocab
-audit_exceptions/versioned_formula_dependent_conflicts_allowlist.json   @Homebrew/tsc @MikeMcQuaid
+audit_exceptions/linux_only_gcc_dependency_allowlist.json               @Homebrew/lead-maintainers
+audit_exceptions/permitted_formula_license_mismatches.json              @Homebrew/lead-maintainers @MikeMcQuaid
+audit_exceptions/provided_by_macos_depends_on_allowlist.json            @Homebrew/lead-maintainers @MikeMcQuaid
+audit_exceptions/relicensed_formulae_versions.json                      @Homebrew/lead-maintainers @MikeMcQuaid
+audit_exceptions/universal_binary_allowlist.json                        @Homebrew/lead-maintainers @carlocab
+audit_exceptions/versioned_formula_dependent_conflicts_allowlist.json   @Homebrew/lead-maintainers @MikeMcQuaid


### PR DESCRIPTION
As per https://github.com/Homebrew/brew/pull/21156, the TSC no longer exists.