### PR TITLE
go 1.25.5

### DIFF
--- a/Formula/g/garble.rb
+++ b/Formula/g/garble.rb
@@ -4,7 +4,7 @@ class Garble < Formula
   url "https://github.com/burrowers/garble/archive/refs/tags/v0.15.0.tar.gz"
   sha256 "b429b24dafa851a25bbeca635db33eb4162b8e3109fb234a2c8e7780a837b958"
   license "BSD-3-Clause"
-  revision 4
+  revision 5
   head "https://github.com/burrowers/garble.git", branch: "master"
 
   bottle do

--- a/Formula/g/garble.rb
+++ b/Formula/g/garble.rb
@@ -8,12 +8,12 @@ class Garble < Formula
   head "https://github.com/burrowers/garble.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "b63963d1cf9d5d5c7a493fae78496623337df6378c0fec2776a85c5c8a3111da"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "b63963d1cf9d5d5c7a493fae78496623337df6378c0fec2776a85c5c8a3111da"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "b63963d1cf9d5d5c7a493fae78496623337df6378c0fec2776a85c5c8a3111da"
-    sha256 cellar: :any_skip_relocation, sonoma:        "cc68af1371aaf89e5f85ce2e5a9949629acbda6271cea3c38c31f6545d42fdd9"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "f81db4409934a5cc26ea1c9e3308f41ca1336d0455fb21ff36a96412492e7e0b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "56885a7d6b4597fcd29339cde7bebd7ea149de9a269338ff63a7033c379aca4e"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "9a723761caefd99a243ede0763f6e468988d17fae15a234591f4bc3d4951807e"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "9a723761caefd99a243ede0763f6e468988d17fae15a234591f4bc3d4951807e"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "9a723761caefd99a243ede0763f6e468988d17fae15a234591f4bc3d4951807e"
+    sha256 cellar: :any_skip_relocation, sonoma:        "6e1b7789a134b3eb6d5d32dcf0957223adc2e711ef6b8e34edd53badb67c33bd"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "dbe1171298ffe0a1a7a17e252c37268f302cdb7d9984e678fa9f13921847a4d0"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "89e70170430bc876393c37e7080381b4b384b1b8d6b1475baa4e11c362ee1067"
   end
 
   depends_on "go" => [:build, :test]

--- a/Formula/g/go.rb
+++ b/Formula/g/go.rb
@@ -1,9 +1,9 @@
 class Go < Formula
   desc "Open source programming language to build simple/reliable/efficient software"
   homepage "https://go.dev/"
-  url "https://go.dev/dl/go1.25.4.src.tar.gz"
-  mirror "https://fossies.org/linux/misc/go1.25.4.src.tar.gz"
-  sha256 "160043b7f17b6d60b50369436917fda8d5034640ba39ae2431c6b95a889cc98c"
+  url "https://go.dev/dl/go1.25.5.src.tar.gz"
+  mirror "https://fossies.org/linux/misc/go1.25.5.src.tar.gz"
+  sha256 "22a5fd0a91efcd28a1b0537106b9959b2804b61f59c3758b51e8e5429c1a954f"
   license "BSD-3-Clause"
   head "https://go.googlesource.com/go.git", branch: "master"
 
@@ -44,21 +44,21 @@ class Go < Formula
 
     on_arm do
       on_macos do
-        url "https://storage.googleapis.com/golang/go#{version}.darwin-arm64.tar.gz"
+        url "https://go.dev/dl/go#{version}.darwin-arm64.tar.gz"
         sha256 checksums["darwin-arm64"]
       end
       on_linux do
-        url "https://storage.googleapis.com/golang/go#{version}.linux-arm64.tar.gz"
+        url "https://go.dev/dl/go#{version}.linux-arm64.tar.gz"
         sha256 checksums["linux-arm64"]
       end
     end
     on_intel do
       on_macos do
-        url "https://storage.googleapis.com/golang/go#{version}.darwin-amd64.tar.gz"
+        url "https://go.dev/dl/go#{version}.darwin-amd64.tar.gz"
         sha256 checksums["darwin-amd64"]
       end
       on_linux do
-        url "https://storage.googleapis.com/golang/go#{version}.linux-amd64.tar.gz"
+        url "https://go.dev/dl/go#{version}.linux-amd64.tar.gz"
         sha256 checksums["linux-amd64"]
       end
     end

--- a/Formula/g/go.rb
+++ b/Formula/g/go.rb
@@ -21,12 +21,12 @@ class Go < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "44df21e7328ae7e73fa930d63808994fc172309e7b3bb24ce2f98201819902c4"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "44df21e7328ae7e73fa930d63808994fc172309e7b3bb24ce2f98201819902c4"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "44df21e7328ae7e73fa930d63808994fc172309e7b3bb24ce2f98201819902c4"
-    sha256 cellar: :any_skip_relocation, sonoma:        "ed43607b0e11521ca83ce45ff30de166e607ff7d918e425f7ec60664aab999dc"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "268b1ecf7519460b062d55a9698fcdaad166178e6489391cf4f92de90eaf28ec"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "fdf081ccfc1970fc81e7d13f22476497a26694c3d41e44e9de70c3e37866657a"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "a08dc2f6914ccf3edf0a4e0401595216fb890ffd253ee1147a7241e4f5dc8c15"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "a08dc2f6914ccf3edf0a4e0401595216fb890ffd253ee1147a7241e4f5dc8c15"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "a08dc2f6914ccf3edf0a4e0401595216fb890ffd253ee1147a7241e4f5dc8c15"
+    sha256 cellar: :any_skip_relocation, sonoma:        "b40bc5deb0d8f4a0ed30763b774c294e2033be3af9ae1febc428260bc9080739"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "986db3b38f0108765760294d979cbe758411f9668b099ab852ca1f463d9aa2ca"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c44f1e34c0b26a987008b483cf22f188a0c60533277ffcb9485bf66045c82094"
   end
 
   depends_on macos: :monterey

--- a/Formula/s/staticcheck.rb
+++ b/Formula/s/staticcheck.rb
@@ -8,12 +8,12 @@ class Staticcheck < Formula
   head "https://github.com/dominikh/go-tools.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "b585be62a7ff056e7f3a041679c50defe0cec2340d1245ee85689b553fc8207a"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "b585be62a7ff056e7f3a041679c50defe0cec2340d1245ee85689b553fc8207a"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "b585be62a7ff056e7f3a041679c50defe0cec2340d1245ee85689b553fc8207a"
-    sha256 cellar: :any_skip_relocation, sonoma:        "cd02e3b5a92803d1a8998da309dc79dc58904e2637eba895eb9352216782623a"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "686e0d540024ddf21813ce6fd216496ae4230e40c09c2f9a01dc04310681e3b3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4d3cdba3c8999cce182e57c1ac0bb33075d5fbd3cf96b3d7d385d0b801929737"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "51133b84e20aa3d2295fb85e04b8812fcb5bae200adda0c1abc9c48de2a32eb3"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "51133b84e20aa3d2295fb85e04b8812fcb5bae200adda0c1abc9c48de2a32eb3"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "51133b84e20aa3d2295fb85e04b8812fcb5bae200adda0c1abc9c48de2a32eb3"
+    sha256 cellar: :any_skip_relocation, sonoma:        "17dec85804bf3247643d6d8d45b9318497e8154414dfe81f5807d87ef2bc4941"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "0ffe4c7a9cd5ea6fadb127cde6b78a9554e7d641f346f7a5e0cd152b9f053265"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "307a08710779d94bdea89a81b4ebf6bf7b68d3a2c6394badd7380bfcc1f70ef6"
   end
 
   depends_on "go"

--- a/Formula/s/staticcheck.rb
+++ b/Formula/s/staticcheck.rb
@@ -4,7 +4,7 @@ class Staticcheck < Formula
   url "https://github.com/dominikh/go-tools/archive/refs/tags/2025.1.1.tar.gz"
   sha256 "259aaf528e4d98e7d3652e283e8551cfdb98cd033a7c01003cd377c2444dd6de"
   license "MIT"
-  revision 10
+  revision 11
   head "https://github.com/dominikh/go-tools.git", branch: "master"
 
   bottle do


### PR DESCRIPTION
Fixes CVE-2025-61729, CVE-2025-61727

https://groups.google.com/g/golang-announce/c/8FJoBkPddm4/m/kYpVlPw1CQAJ

https://go.dev/dl/#go1.25.5

---
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
