### PR TITLE
libwebsockets: remove `zlib` dependency

### DIFF
--- a/Formula/lib/libwebsockets.rb
+++ b/Formula/lib/libwebsockets.rb
@@ -25,8 +25,6 @@ class Libwebsockets < Formula
   depends_on "libuv"
   depends_on "openssl@3"
 
-  uses_from_macos "zlib"
-
   def install
     system "cmake", "-S", ".", "-B", "build",
                     "-DLWS_IPV6=ON",


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
This had no linkage on Linux on the last update, so let's see if we can just remove it.