### PR TITLE
csha 1.1.9 (new formula)

### DIFF
--- a/Formula/c/csha.rb
+++ b/Formula/c/csha.rb
@@ -1,0 +1,29 @@
+class Csha < Formula
+  desc "Cryptographic Steganography and Hashing Library"
+  homepage "https://gitlab.com/Malcolmston/project-final"
+  url "https://gitlab.com/Malcolmston/project-final/-/archive/v1.1.9/project-final-v1.1.9.tar.gz"
+  sha256 "21b70547c5283354e098292bb8166e93c1753f62dc8584c9ec59016ab64c894f"
+  license "MPL-2.0"
+
+  depends_on "pkgconf" => :build
+  depends_on "opencv"
+  depends_on "openssl@3"
+  depends_on "libzip"
+
+  def install
+    # Set OpenSSL path for macOS
+    ENV["OPENSSL_INC"] = Formula["openssl@3"].opt_include
+    ENV["OPENSSL_LIB"] = Formula["openssl@3"].opt_lib
+
+    # Build the project
+    system "make", "all"
+
+    # Install the binary
+    bin.install "csha"
+  end
+
+  test do
+    # Test that the binary runs and shows help
+    assert_match "Cryptographic Steganography and Hashing Library", shell_output("#{bin}/csha --help")
+  end
+end

--- a/Formula/c/csha.rb
+++ b/Formula/c/csha.rb
@@ -1,14 +1,14 @@
 class Csha < Formula
-  desc "Cryptographic Steganography and Hashing Library"
+  desc "Cryptographic steganography and hashing tool using Minecraft maps"
   homepage "https://gitlab.com/Malcolmston/project-final"
   url "https://gitlab.com/Malcolmston/project-final/-/archive/v1.1.9/project-final-v1.1.9.tar.gz"
   sha256 "21b70547c5283354e098292bb8166e93c1753f62dc8584c9ec59016ab64c894f"
   license "MPL-2.0"
 
   depends_on "pkgconf" => :build
+  depends_on "libzip"
   depends_on "opencv"
   depends_on "openssl@3"
-  depends_on "libzip"
 
   def install
     # Set OpenSSL path for macOS


### PR DESCRIPTION
Add csha, a cryptographic steganography and hashing tool that uses Minecraft maps.

## What does it do?
csha is a command-line tool that implements steganographic encryption using Minecraft world map generation. It can encode data into Minecraft map images using AES encryption (CBC/CTR/GCM modes) and various key derivation methods (PBKDF2/DIRECT/FIXED).

## Checklist
- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked that there aren't other open Pull Requests for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`?
- [x] Is your formula stable (not a development version)?
- [x] Does your formula build and run on a clean macOS installation?
- [x] Does `brew audit --strict --online <formula>` pass?

## Additional context
- Homepage: https://gitlab.com/Malcolmston/project-final
- License: MPL-2.0
- Version: 1.1.9