### PR TITLE
git-cola: Depend on qtwayland on Linux

### DIFF
--- a/Formula/g/git-cola.rb
+++ b/Formula/g/git-cola.rb
@@ -16,6 +16,10 @@ class GitCola < Formula
   depends_on "pyqt"
   depends_on "python@3.14"
 
+  on_linux do
+    depends_on "qtwayland" => :no_linkage
+  end
+
   resource "packaging" do
     url "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz"
     sha256 "d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"

--- a/Formula/g/git-cola.rb
+++ b/Formula/g/git-cola.rb
@@ -9,7 +9,8 @@ class GitCola < Formula
   head "https://github.com/git-cola/git-cola.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "5698d5131f01f052703da181ca11986b25dbf19846dfb6a71b42b06f79ed5d4e"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "4ddf9297d3761462640203f03f2e0e54b2690386f4da74fcd1c54066b523d2e2"
   end
 
   depends_on "git-gui"


### PR DESCRIPTION
This enables `git-cola`to start for me on Bluefin gts-41.20251019.

Fixes #231275

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

~~WIP: I made this edit in GitHub and expect CI to yell at me.~~ It got past the lints I thought would fail, so I'll take it out of draft.