### PR TITLE
save3ds_fuse 1.4, custom-install 2.1 (new formula)

### DIFF
--- a/Formula/c/custom-install.rb
+++ b/Formula/c/custom-install.rb
@@ -1,0 +1,49 @@
+class CustomInstall < Formula
+  include Language::Python::Virtualenv
+
+  desc "Install CIA files directly to Nintendo 3DS SD card"
+  homepage "https://github.com/ihaveamac/custom-install"
+  url "https://github.com/ihaveamac/custom-install/archive/refs/tags/v2.1.tar.gz"
+  sha256 "35477355c8981d7aa55ace60fc3e43e1f96f762d141cf8773eb22df1ce4c50f8"
+  license "MIT"
+
+  depends_on "python@3.14"
+  depends_on "save3ds_fuse"
+
+  resource "events" do
+    url "https://files.pythonhosted.org/packages/f6/2b/b92ae30db60cb3c2043da3b72abf30158c92cc77922280b45e9edf36bbf8/Events-0.4.tar.gz"
+    sha256 "01d9dd2a061f908d74a89fa5c8f07baa694f02a2a5974983663faaf7a97180f5"
+  end
+
+  resource "pycryptodomex" do
+    url "https://files.pythonhosted.org/packages/c9/85/e24bf90972a30b0fcd16c73009add1d7d7cd9140c2498a68252028899e41/pycryptodomex-3.23.0.tar.gz"
+    sha256 "71909758f010c82bc99b0abf4ea12012c98962fbf0583c2164f8b84533c2e4da"
+  end
+
+  resource "pyctr" do
+    url "https://files.pythonhosted.org/packages/f5/8e/e586fff15921fbc0f7f35750bfcc621c88f02790006fe29cb7b5155414e3/pyctr-0.6.0.tar.gz"
+    sha256 "d3994c72c21e2481c8dcbc074138ebe0cf9b9f5146f8642c72e1aadf85f18caf"
+  end
+
+  def install
+    venv = virtualenv_create(libexec, "python3.14")
+    venv.pip_install resources
+
+    inreplace "custominstall.py",
+              "save3ds_fuse_path = join(script_dir, 'bin', platform, 'save3ds_fuse')",
+              "save3ds_fuse_path = '#{Formula["save3ds_fuse"].opt_bin}/save3ds_fuse'"
+    libexec.install "custominstall.py"
+    (bin/"custom-install").write <<~BASH
+      #!/bin/bash
+      exec "#{libexec}/bin/python3" "#{libexec}/custominstall.py" "$@"
+    BASH
+  end
+
+  test do
+    assert_match "the following arguments are required:", shell_output("#{bin}/custom-install 2>&1", 2)
+
+    touch testpath/"boot9.bin"
+    output = shell_output("#{bin}/custom-install -b boot9.bin -m s1.sed --sd #{testpath}/tmp f1.cia f2.cia 2>&1", 1)
+    assert_match "BootromNotFoundError", output
+  end
+end

--- a/Formula/c/custom-install.rb
+++ b/Formula/c/custom-install.rb
@@ -7,6 +7,15 @@ class CustomInstall < Formula
   sha256 "35477355c8981d7aa55ace60fc3e43e1f96f762d141cf8773eb22df1ce4c50f8"
   license "MIT"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "61a022ea5b0f415929d32b8cb527f0772b065da9084df4feb3ea606bee39db83"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "1dcfb60764dc38a009ee05ea94148df24426e920a89a432d96c3da69bfeb1b3a"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "52459657c539c5094957b985437531219f6e19282ed8c4c693040609a7bc4a5f"
+    sha256 cellar: :any_skip_relocation, sonoma:        "74ce576ef08e7769e5f95e2062b928ecdc07b87550426eeb50645738d091105b"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "0877be59f541572b6a19f107bbbbf8490cff0ce865e54715cbe22c782ddc1e1d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a37d6e1c136e15b4627953afc2c8baa93736bb7f170df4a6ba56255e9b9f8eeb"
+  end
+
   depends_on "python@3.14"
   depends_on "save3ds_fuse"
 

--- a/Formula/s/save3ds_fuse.rb
+++ b/Formula/s/save3ds_fuse.rb
@@ -1,0 +1,22 @@
+class Save3dsFuse < Formula
+  desc "Extract/Import/FUSE for 3DS save/extdata/database"
+  homepage "https://github.com/wwylele/save3ds"
+  url "https://github.com/wwylele/save3ds/archive/refs/tags/v1.4.0.tar.gz"
+  sha256 "3bf47e34db1f3e5162df5b8e67a5673b473b37bf0eaa729be28e5e7a62212858"
+  license "Apache-2.0"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", "--no-default-features", *std_cargo_args(path: "save3ds_fuse")
+  end
+
+  test do
+    # `save3ds_fuse` requires a mount path to operate correctly
+    assert_match "Please specify one mount path", shell_output(bin/"save3ds_fuse")
+
+    (testpath/"testfile").write "test"
+    output = shell_output("#{bin}/save3ds_fuse --bare testfile #{testpath}/tmp 2>&1", 1)
+    assert_match "Out-of-bound access, caused by corrupted data", output
+  end
+end

--- a/Formula/s/save3ds_fuse.rb
+++ b/Formula/s/save3ds_fuse.rb
@@ -5,6 +5,15 @@ class Save3dsFuse < Formula
   sha256 "3bf47e34db1f3e5162df5b8e67a5673b473b37bf0eaa729be28e5e7a62212858"
   license "Apache-2.0"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "e7066052c1d3ab588faf21f2dea3dfb908f4837fa7f361ad0c5af12ea2566fe0"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "1a602758550d203e0a7583b046eedabcefe521271bc833bb7031145b914a40bf"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "0e3183ee54ff79857302e409ffb95af7bde9e10c34c600139c2238b4179653bc"
+    sha256 cellar: :any_skip_relocation, sonoma:        "d5877b7d8b6bf492e485d88513f330e032f64904e5259e1c31918d708da9de22"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "e1a18296ce539d04b8806a1743abf9c31713246a76bd987cf51a8e9b9b2c197e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4e9272100fe4d01b7fd078b9aec2e8ccdec2fe009f6b9f8959fbe69570c38650"
+  end
+
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
  Tool to install CIA files directly to Nintendo 3DS SD cards.
  Primary coomunity tool for 3DS homebrew with ~1000 GitHub stars.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
