### PR TITLE
launch_socket_server: fix service socket.

### DIFF
--- a/Formula/l/launch_socket_server.rb
+++ b/Formula/l/launch_socket_server.rb
@@ -34,7 +34,7 @@ class LaunchSocketServer < Formula
     require_root true
     error_log_path var/"log/launch_socket_server.log"
     log_path var/"log/launch_socket_server.log"
-    sockets "tcp://127.0.0.1:80"
+    sockets Socket: "tcp://127.0.0.1:80"
   end
 
   test do

--- a/Formula/l/launch_socket_server.rb
+++ b/Formula/l/launch_socket_server.rb
@@ -9,13 +9,11 @@ class LaunchSocketServer < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "24960fd5bd4f03830d135a4cc6150ec49b516ce8c3bdaf16b240669310565536"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "6974a57e3a6bd5f01dc3b62d4a4592afb791af68f230b7ea5e60a46cffc0d395"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "92a59f265b9a67885cd73be07b4fa591b0ff76e382ac7c2db5099e02d2212bfe"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "7d09862a50bec1441d8d5cf4eabb2318942fab969ebddb67b9f3739e784e5a13"
-    sha256 cellar: :any_skip_relocation, sonoma:        "570f75f0fa24b34b03a278f1dc9f46f554c651b966204943fb3b5f25f412ee81"
-    sha256 cellar: :any_skip_relocation, ventura:       "38b8161c24c87504fe237154e1b287d1493f9a16f41bced1f942ebb5ce9b6d06"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "cd7f62d360a2d0e3ccbc0d127e6c93cf7b04341547a0cc47712e9cc30bfada44"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "7f9379e42b9f24b9f1d7c8e4f899901ad90999fe69c526c081c883e813cd36ea"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "b39407abb6a275dc2f8d7cee19b56126213e46ed61e6ef0d9e0eff631112c3e9"
+    sha256 cellar: :any_skip_relocation, sonoma:        "bffce7fd244160abb5333fed263f40e868bd09c2da174a51d7be6b255101992f"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The macOS [launch_activate_socket](https://developer.apple.com/documentation/xpc/launch_activate_socket) function requires the `name` parameter to be "The name of the socket entry in the service’s Sockets dictionary." Since 103d1e7ed0cb33cefa4ac04c9aa8cd835cfdc227 switched the Formula to use the service block instead of a custom defined plist, the Homebrew-generated plist has used the default [`listeners`](https://docs.brew.sh/Formula-Cookbook#sockets-format) name.

launch_socket_server has the ability to specify the socket name via an env var, but if it's unset it defaults to `Socket`:
[launch_socket_server.go](https://github.com/mistydemeo/launch_socket_server/blob/0fd9c1c09c602bbda7ae92a1fe5e670d58d9e647/src/launch_socket_server.go#L28-L32)
```golang
	daemonSocketName = os.Getenv("LAUNCH_DAEMON_SOCKET_NAME")
	if daemonSocketName == "" {
		daemonSocketName = "Socket"
		os.Setenv("LAUNCH_DAEMON_SOCKET_NAME", daemonSocketName)
	}
```

This PR changes the `service` stanza to specify the socket name, and restores the LaunchAgent to a working state.