### PR TITLE
mas: increase xcode dependency to 16.0 because of Swift 6.0.

### DIFF
--- a/Formula/m/mas.rb
+++ b/Formula/m/mas.rb
@@ -21,7 +21,7 @@ class Mas < Formula
     sha256 cellar: :any_skip_relocation, sonoma:        "b9005575e04c459782434b97e9183b090cbf0da2a494d5a5d2a6704b0c3493d1"
   end
 
-  depends_on xcode: ["15.0", :build]
+  depends_on xcode: ["16.0", :build]
   depends_on :macos
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

mas 3.0.0+ is written in Swift 6.0, which requires Xcode 16+.

I didn't make this a new revision of the formula because all the bottles built fine beforehand, so Homebrew obviously used some Xcode 16+. There's no need for a new revision or new bottles.