### PR TITLE
mlx-lm: require arm64 and bump minimum macOS

### DIFF
--- a/Formula/m/mlx-lm.rb
+++ b/Formula/m/mlx-lm.rb
@@ -12,15 +12,15 @@ class MlxLm < Formula
     rebuild 1
     sha256 cellar: :any, arm64_tahoe:   "7a36e27a8350113180be35f99194240bf58bf845d050e09792ed572bad431e59"
     sha256 cellar: :any, arm64_sequoia: "5a029f3083a8bf6675c2b7ed0f60845ff67459398353c748efda798aab064fcf"
-    sha256 cellar: :any, arm64_sonoma:  "76c124083ab2d8c933f1ff347b161d9ef7cdbe10ac7f2c43d90ea2d544e570cc"
   end
 
   depends_on "pkgconf" => :build
   depends_on "rust" => :build
+  depends_on arch: :arm64
   depends_on "certifi" => :no_linkage
   depends_on "libyaml"
   depends_on :macos
-  depends_on macos: :ventura
+  depends_on macos: :sequoia
   depends_on "mlx"
   depends_on "numpy"
   depends_on "protobuf"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
This only works on devices with Apple silicon. Upstream's README also calls out macOS 15 as a requirement for working with large models.