### PR TITLE
domaindetails 1.0.1 (new formula)

### DIFF
--- a/Formula/d/domaindetails.rb
+++ b/Formula/d/domaindetails.rb
@@ -1,0 +1,25 @@
+class Domaindetails < Formula
+  desc "Fast CLI tool for domain registration lookups via RDAP and WHOIS"
+  homepage "https://domaindetails.com"
+  url "https://github.com/simplebytes-com/domaindetails-cli/archive/refs/tags/v1.0.1.tar.gz"
+  sha256 "a7ac0c70b6f3c10a2ca4840431a0b0c46927658a3512fcca093545dd0022dae7"
+  license "MIT"
+  head "https://github.com/simplebytes-com/domaindetails-cli.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = %W[
+      -s -w
+      -X main.version=#{version}
+      -X main.commit=#{tap.user}
+      -X main.date=#{time.iso8601}
+    ]
+    system "go", "build", *std_go_args(ldflags:), "./cmd/domaindetails"
+  end
+
+  test do
+    assert_match "domaindetails", shell_output("#{bin}/domaindetails --help")
+    assert_match version.to_s, shell_output("#{bin}/domaindetails --version")
+  end
+end


### PR DESCRIPTION
## Description

A fast CLI tool for domain registration lookups via RDAP and WHOIS.

**domaindetails** performs RDAP lookups (preferred) with automatic WHOIS fallback for comprehensive domain registration information. It caches IANA bootstrap data locally for improved performance.

### Features
- RDAP lookups with IANA bootstrap caching
- Automatic WHOIS fallback for TLDs without RDAP
- JSON and raw output formats
- Cross-platform (macOS, Linux, Windows)

### Usage
```bash
domaindetails lookup example.com
domaindetails rdap google.com --json
domaindetails whois github.io --raw
```

## Note on Notability

This is a new project that doesn't yet meet the 75-star threshold. However, we believe it provides genuine value to the Homebrew community:

1. **Unique functionality**: First CLI tool to combine RDAP + WHOIS with smart fallback
2. **Privacy-focused**: No tracking, local caching, open source
3. **Active development**: Part of the DomainDetails.com ecosystem with ongoing support
4. **Real users**: Already distributed via our own tap with active installations

We understand if this needs to wait for more community traction, but wanted to submit early to get feedback on the formula itself.

## Checklist
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`?
- [x] Does your build pass `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>`? (except notability)