### PR TITLE
gnupg 2.5 is a production release now

### DIFF
--- a/Formula/g/gnupg.rb
+++ b/Formula/g/gnupg.rb
@@ -9,7 +9,7 @@ class Gnupg < Formula
   # (https://gnupg.org/download/#end-of-life).
   livecheck do
     url "https://gnupg.org/ftp/gcrypt/gnupg/"
-    regex(/href=.*?gnupg[._-]v?(\d+\.\d*[02468](?:\.\d+)*)\.t/i)
+    regex(/href=.*?gnupg[._-]v?(\d+\.\d*[024568](?:\.\d+)*)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
https://lists.gnupg.org/pipermail/gnupg-announce/2025q4/000499.html

https://www.gnupg.org says 

> We are pleased to announce the availability of a new GnuPG release: Version 2.5.14. This release adds new features and fixes a couple of bugs. New Debian packages are also also availabe; see repos.gnupg.org.
> 
> Note that this 2.5 series is fully supported and thus ready for production use. This means we won't break anything but may add some more features before 2.6."

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
