### PR TITLE
slicot 5.9.1 (new formula), dynare: use `slicot`, drop unused deps

### DIFF
--- a/Formula/d/dynare.rb
+++ b/Formula/d/dynare.rb
@@ -12,12 +12,13 @@ class Dynare < Formula
   end
 
   bottle do
-    sha256 cellar: :any, arm64_tahoe:   "18c5adf1dd2b462bf76c91cd0689ecb68b39139d7ffb9617a742fe05184db807"
-    sha256 cellar: :any, arm64_sequoia: "c2be8ed76b794b70e41e823f14a19cf216f70c43294e86270ae7b5363b54fcf9"
-    sha256 cellar: :any, arm64_sonoma:  "794f3c8a3172acba252bda3ad0a2aea5f4efecb4e4b73ac2b10a2b7c4d7a25f4"
-    sha256 cellar: :any, sonoma:        "ca1b81a8004d608901b9340aad1ac774d3bd4ddde4df31f04153664fa45984ee"
-    sha256               arm64_linux:   "7572998a297a61c8e5bfa26a4d83edc22a547765431f73643d4759abb678ce45"
-    sha256               x86_64_linux:  "37c914973788438a0eb6ecb15b4c5e6668a017b6b5457061d37618ff4168384c"
+    rebuild 1
+    sha256 cellar: :any, arm64_tahoe:   "5a66deb7887ad8c8d7d6fbb9a31f00de647eaa7988d5553599d60007ccf6b748"
+    sha256 cellar: :any, arm64_sequoia: "d4cb3df682a5246291b44896984983bacf416f5f48f2414538b3cf99447b5cef"
+    sha256 cellar: :any, arm64_sonoma:  "1815fcb8d7bd00d26287027f80c4ee8b05c85e65297670d7daccad3e59985029"
+    sha256 cellar: :any, sonoma:        "af541cbb7df48ac4cd82ea524d2044c34efa6f4f96672e915ba188827483a304"
+    sha256               arm64_linux:   "5a4a6414768cb0bacf17892f693f8645e589b58996a582d4bd0530909207913f"
+    sha256               x86_64_linux:  "500a3346e13e46eb9ec0e7c20ca8d035bef694ae026f4e1b6c4c2848b7549668"
   end
 
   depends_on "bison" => :build

--- a/Formula/s/slicot.rb
+++ b/Formula/s/slicot.rb
@@ -1,0 +1,29 @@
+class Slicot < Formula
+  desc "Fortran subroutines library for systems and control"
+  homepage "https://www.slicot.org/"
+  url "https://github.com/SLICOT/SLICOT-Reference/releases/download/v5.9.1/slicot-5.9.1.tar.gz"
+  sha256 "0f812933a07577db8c80dc53fc3663844114d43880f4c2fb383622891e931504"
+  license "BSD-3-Clause"
+
+  depends_on "cmake" => :build
+  depends_on "gcc" # for gfortran
+  depends_on "openblas"
+
+  def install
+    system "cmake", "-S", ".", "-B", "build",
+                    "-DBUILD_SHARED_LIBS=ON",
+                    "-DSLICOT_TESTING=OFF",
+                    *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+
+    # Using a test without 0.0000 which can fail from sign swapping to -0.0000
+    pkgshare.install "examples/TAB05RD.f", "examples/data/AB05RD.dat", "examples/results/AB05RD.res"
+  end
+
+  test do
+    system "gfortran", "-o", "test", pkgshare/"TAB05RD.f",
+                       "-L#{lib}", "-lslicot", "-L#{Formula["openblas"].opt_lib}", "-lopenblas"
+    assert_equal (pkgshare/"AB05RD.res").read, pipe_output("./test", (pkgshare/"AB05RD.dat").read, 0)
+  end
+end

--- a/Formula/s/slicot.rb
+++ b/Formula/s/slicot.rb
@@ -5,6 +5,15 @@ class Slicot < Formula
   sha256 "0f812933a07577db8c80dc53fc3663844114d43880f4c2fb383622891e931504"
   license "BSD-3-Clause"
 
+  bottle do
+    sha256 cellar: :any,                 arm64_tahoe:   "fe100cde167f2c093216156513328bb28f2a4c7ea5258c266cfc10d467bf59a2"
+    sha256 cellar: :any,                 arm64_sequoia: "f6871a8005e9bf5d72a32d14443624a914027946644bcd945f3e0cc4f3f573a9"
+    sha256 cellar: :any,                 arm64_sonoma:  "66ed2195520bfa80e07b7956f0b3d8e698b62702deba9960876f6a28c1de44b5"
+    sha256 cellar: :any,                 sonoma:        "e1686e0f706660d9fed58f3e75a2c89d8ef729f0b6a0c32ba6c27df8371bf743"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "9d5b8da792e3ef6cc877f3378cf09363e506a8f0343e2979d3119fb753859e04"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3ea5b7ec7913b21537a1372ee5644e9eb7fd2f70466c8b8a914a1cf82b589b41"
+  end
+
   depends_on "cmake" => :build
   depends_on "gcc" # for gfortran
   depends_on "openblas"


### PR DESCRIPTION
Formula refs:
- https://repology.org/project/slicot/versions
- https://packages.debian.org/sid/source/slicot
- https://www.slicot.org/2-uncategorised/128-github-download

---

The PR splits out the `slicot` resource from `dynare` and updates it to latest version.

Although it doesn't meet notability, the GitHub repo was only used for version 5.7+ while the source code was hosted elsewhere for most of its life. We were actually using old 5.0 copy from Debian. Seems to have undergone some license changes and 5.7 was first BSD licensed release.

We did use to have this formula but then it got tap migrated to `homebrew-science` in https://github.com/Homebrew/homebrew-core/commit/d423ce5f9604949db3a0c1c832cd95d69c45bb56. Since we don't maintain that anymore, can bring formula back.

---

For now, only building the minimum needed libraries, i.e. LP64 (integer4) shared library.

In Dynare, we used to build LP64 (integer4) and IPL64 (integer8) static libraries, but Octave-build only uses LP64 variant. And static library was used as more convenient when building as resource.
