### PR TITLE
terminal-painter 0.1.0 (new formula)

### DIFF
--- a/Formula/t/terminal-painter.rb
+++ b/Formula/t/terminal-painter.rb
@@ -1,0 +1,24 @@
+class TerminalPainter < Formula
+  desc "MSPaint for the terminal using the Kitty Graphics Protocol"
+  homepage "https://github.com/anand-ts/terminal-painter"
+  url "https://github.com/anand-ts/terminal-painter/archive/refs/tags/v0.1.0.tar.gz"
+  sha256 "9c64bb80384cbe126740ae2c951e03ca2b21f4d448510bf99d6853276ae11144"
+  license "MIT"
+
+  depends_on "python@3.12"
+
+  def install
+    bin.install "kitty_painter.py" => "terminal-painter"
+  end
+
+  def caveats
+    <<~EOS
+      Requires a terminal that supports the Kitty Graphics Protocol (Kitty, recent WezTerm).
+      Run: terminal-painter
+    EOS
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/terminal-painter --version")
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

Summary
- New formula: terminal-painter 0.1.0 (Kitty Graphics Protocol painter; installs kitty_painter.py as `terminal-painter`)
- Depends on python@3.12
- Test: `--version`

Testing
- HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source ./Formula/t/terminal-painter.rb
- HOMEBREW_NO_INSTALL_FROM_API=1 brew test terminal-painter

Audit
- brew audit --new terminal-painter fails notability (“GitHub repository not notable enough (<30 forks/<30 watchers/<75 stars)”).
- The project does not meet the threshold, but I'd be happy for any justifications/exceptions if possible!
-----
