### PR TITLE
glyr, abcde: deprecate

### DIFF
--- a/Formula/a/abcde.rb
+++ b/Formula/a/abcde.rb
@@ -12,8 +12,6 @@ class Abcde < Formula
     regex(/href=.*?abcde[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "580cb0f7c45b342dbdfac94e4fe3a2dc6db572409e212d963b22fba20a002423"
     sha256 cellar: :any,                 arm64_sequoia:  "48c8a99c5cf28e44096fe46c62f5dc826a90282769b895fb50807cca0f5383b0"
@@ -29,6 +27,11 @@ class Abcde < Formula
     sha256 cellar: :any_skip_relocation, arm64_linux:    "16b246ffcc1d24acb0aba75e1ba6995535470fc90b0992746bd38e3f2aa10243"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "93e3d734fe73f1ca3edeab8e4f25794a28acbdde6df9f3ffd7d01b2e16ce31a2"
   end
+
+  # use deprecated glyr,
+  # no new commits over the last four years and no new commits over the past six years
+  deprecate! date: "2025-12-08", because: :unmaintained
+  disable! date: "2026-12-08", because: :unmaintained
 
   depends_on "pkgconf" => :build
 

--- a/Formula/g/glyr.rb
+++ b/Formula/g/glyr.rb
@@ -6,8 +6,6 @@ class Glyr < Formula
   license "LGPL-3.0-or-later"
   revision 3
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "b4f97cce0791e26fdb4ada285bc982bb96548886442bde705a9c5d9656bbc8e5"
     sha256 cellar: :any,                 arm64_sequoia: "9ff02541efeba578a7e20d6d3ba1cd80c71d4f80e37306a35cb9b13e1e9ef4e8"
@@ -18,6 +16,10 @@ class Glyr < Formula
     sha256 cellar: :any_skip_relocation, arm64_linux:   "92a13d57476ddb835effaba42d9c57f0070e4378b8b258711e9748cbfe603e4a"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "299191466994be32c6b0fd7ffe958623ddbffb940428b95c25eba2fa6b5bff21"
   end
+
+  # Various lyrics providers broken, https://github.com/sahib/glyr/issues/102
+  deprecate! date: "2025-12-08", because: :unmaintained
+  disable! date: "2026-12-08", because: :unmaintained
 
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build


### PR DESCRIPTION
glyr: deprecate

---

relates to 
- #257745
- https://github.com/sahib/glyr/issues/102

seeing  https://github.com/Homebrew/homebrew-core/actions/runs/20036294008/job/57461688501?pr=257745#step:3:1361

```
  ==> Testing glyr (again)
  ==> /opt/homebrew/Cellar/glyr/1.0.10_3/bin/glyrc lyrics --no-download --artist Beatles --title 'Eight Days A Week' -w stdout
  - Artist   : beatles
  - Title    : eight days a week
  - Language : en
  - Type     : lyrics
  
  ---- Triggering: musictree 
  ---- Triggering: local 
  ---- Triggering: lyricswiki 
  ---- Triggering: vagalume 
  ---- Triggering: lipwalk 
  ---- Triggering: lyrdb 
  ---- Triggering: elyrics 
  ---- Triggering: lyricstime 
  ---- Triggering: chartlyrics 
  ---- Triggering: lyrix 
  ---- Triggering: lyricsvip 
  ---- Triggering: magistrix 
  ---- Triggering: metallum 
  ---- Triggering: lyricsreg 
  
  Error: glyr: failed
  An exception occurred within a child process:
    Minitest::Assertion: Expected: 0
    Actual: 1
```