### PR TITLE
aom: remove jpeg-xl & libvmaf dependencies

### DIFF
--- a/Formula/a/aom.rb
+++ b/Formula/a/aom.rb
@@ -20,8 +20,6 @@ class Aom < Formula
 
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
-  depends_on "jpeg-xl"
-  depends_on "libvmaf"
 
   on_intel do
     depends_on "yasm" => :build
@@ -38,7 +36,7 @@ class Aom < Formula
       "-DENABLE_TESTS=off",
       "-DENABLE_TOOLS=off",
       "-DBUILD_SHARED_LIBS=on",
-      "-DCONFIG_TUNE_VMAF=1",
+      "-DCONFIG_TUNE_VMAF=0",
     ]
 
     system "cmake", "-S", ".", "-B", "brewbuild", *args, *std_cmake_args


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Removes the `jpeg-xl` and `libvmaf` dependencies from libaom.

- `jpeg-xl` is currently unused; it was used for Butteraugli support, which is no longer included in the libjxl repo or meaningfully utilized within libaom.
- `libvmaf` provides support for libaom's previously experimental VMAF tune for video. This tune is functionally dead at this point, and is no longer under active development. The flagship tunes for video remain tune=ssim and tune=psnr.