### PR TITLE
gnupg@2.5 2.5.14 (new formula)

### DIFF
--- a/Formula/g/gnupg@2.5.rb
+++ b/Formula/g/gnupg@2.5.rb
@@ -1,0 +1,83 @@
+class GnupgAT25 < Formula
+  desc "GNU Privacy Guard (OpenPGP) - production-ready pre 2.6-stable release"
+  homepage "https://lists.gnupg.org/pipermail/gnupg-announce/2025q4/000499.html"
+  url "https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.5.14.tar.bz2"
+  version "2.5.14-devel"
+  sha256 "25a622e625a1cc9078b5e3f7adf2bd02b86759170e2fbb8542bca8e907214610"
+  license "GPL-3.0-or-later"
+
+  keg_only :versioned_formula
+
+  depends_on "pkgconf" => :build      # enables: Keyboxd, TOFU support
+  depends_on "gnutls"                 # enables: Dirmngr, LDAP support, TLS support, Tor support (complete)
+  depends_on "libassuan"              # required
+  depends_on "libgcrypt"              # required
+  depends_on "libgpg-error"           # required
+  depends_on "libksba"                # required
+  depends_on "libusb"                 # enables: Smartcard (complete)
+  depends_on "npth"                   # required
+  depends_on "pinentry"               # ensures key passphrase entry
+  depends_on "readline"               # enables: Readline support
+
+  def install
+    mkdir "build" do
+      system "../configure",
+        "--disable-silent-rules",
+        "--enable-all-tests",
+        "--sysconfdir=#{etc}",
+        "--with-pinentry-pgm=#{Formula["pinentry"].opt_bin}/pinentry",
+        "--with-readline=#{Formula["readline"].opt_prefix}",
+        *std_configure_args
+
+      system "make"
+      # system "make", "check"        # inactive to satisfy "$ brew audit --strict"
+      system "make", "install"
+    end
+  end
+
+  def post_install
+    (var/"run").mkpath
+
+    # restart daemons after upgrades
+    quiet_system "gpgconf", "--kill", "all"
+  end
+
+  test do
+    (testpath/"batch.gpg").write <<-GPG
+      Key-Type: EDDSA
+      Key-Curve: ed25519
+      Key-Usage: cert,sign
+      Subkey-Type: ECDH
+      Subkey-Curve: cv25519
+      Subkey-Usage: encrypt
+      Name-Real: test
+      Name-Email: test@test
+      Expire-Date: 1d
+      %no-protection
+      %commit
+    GPG
+
+    begin
+      # pinentry is executable, which provides key passphrase entry:
+      #   gpg --quick-generate-key --batch --pinentry ask pinentry@test
+      system "test", "-x", "#{Formula["pinentry"].opt_bin}/pinentry"
+
+      # readline lib exists
+      libreadline_ext = OS.mac? ? "dylib" : "so"
+      system "test", "-f", "#{Formula["readline"].opt_lib}/libreadline.#{libreadline_ext}"
+
+      # keys are created
+      system bin/"gpg", "--batch", "--gen-key", "batch.gpg"
+
+      # file is encrypted and signed
+      file = "test.txt"
+      (testpath/file).write "test content"
+      system bin/"gpg", "--encrypt", "--sign", "--recipient", "test@test", file
+
+      # file is decrypted
+      system bin/"gpg", "--decrypt", "#{file}.gpg"
+    ensure
+      system bin/"gpgconf", "--kill", "all"
+    end
+  end
+end


### PR DESCRIPTION
Adds a new keg-only versioned formula for GNU Privacy Guard `gnupg v2.5.14` ([release notes](https://lists.gnupg.org/pipermail/gnupg-announce/2025q4/000499.html)).

Should this package be considered cryptography and exempt from the error below? GNU Privacy Guard generates cryptographic encryption/signing/auth keys (via `libcrypt`). I commented out `system "make", "check"` to satisfy `brew audit --strict --new gnupg@2.5`.

```
Formulae in homebrew/core (except e.g. cryptography, libraries) should not run build-time checks
```

Feature parity is maintained with the Homebrew's curent release.

```txt
gnupg@2.5 (this)                          gnupg
——————————————————————————————————————    ——————————————————————————————————————
                                          
GnuPG v2.5.14 has been                    GnuPG v2.4.8 has been
  configured as follows:                    configured as follows:
                                          
Revision:  4d993c37d  (19865)             Revision:  6f39568ae  (28473)
Platform:  Darwin                         Platform:  Darwin
                                          
OpenPGP:   yes                            OpenPGP:   yes
S/MIME:    yes                            S/MIME:    yes
Agent:     yes                            Agent:     yes
Smartcard: yes                            Smartcard: yes 
TPM:       no                             TPM:       no 
G13:       no                             G13:       no
Dirmngr:   yes                            Dirmngr:   yes
Keyboxd:   yes                            Keyboxd:   yes
Gpgtar:    yes                            Gpgtar:    yes
WKS tools: yes                            WKS tools: yes
                                          
Protect tool:       (default)             Protect tool:       (default)
LDAP wrapper:       (default)             LDAP wrapper:       (default)
Default agent:      (default)             Default agent:      (default)
Default pinentry:                         Default pinentry:
  /usr/local/opt/pinentry/bin/pinentry      /usr/local/opt/pinentry/bin/pinentry
Default scdaemon:   (default)             Default scdaemon:   (default)
Default keyboxd:    (default)             Default keyboxd:    (default)
Default tpm2daemon: (default)             Default tpm2daemon: (default)
Default dirmngr:    (default)             Default dirmngr:    (default)
                                          
Dirmngr auto start:  yes                  Dirmngr auto start:  yes
Readline support:    yes                  Readline support:    yes
LDAP support:        yes                  LDAP support:        yes
TLS support:         gnutls               TLS support:         gnutls
TOFU support:        yes                  TOFU support:        yes
Tor support:         yes                  Tor support:         yes
```

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
