### PR TITLE
python@*: fix altinstall for API source builds

### DIFF
--- a/Formula/p/python@3.12.rb
+++ b/Formula/p/python@3.12.rb
@@ -86,7 +86,7 @@ class PythonAT312 < Formula
   # The HOMEBREW_PREFIX location of site-packages.
   def site_packages = HOMEBREW_PREFIX/"lib/python#{version.major_minor}/site-packages"
 
-  def altinstall? = self != Formula["python3"]
+  def altinstall? = name != Formula["python3"].name
 
   def python3 = bin/"python#{version.major_minor}"
 

--- a/Formula/p/python@3.12.rb
+++ b/Formula/p/python@3.12.rb
@@ -11,15 +11,15 @@ class PythonAT312 < Formula
   end
 
   bottle do
-    rebuild 2
-    sha256 arm64_tahoe:   "e2f5b656048d4c8f5804251b4614ef0ca2a774c263857b5fa0250dd5954a8856"
-    sha256 arm64_sequoia: "85e70217ddc0c35f8c230a648672bd6a8295cac435b30a57d8b5348d707b1553"
-    sha256 arm64_sonoma:  "a6b1f0abe258baa09ea5f5b6cb74e6cb0e0cdfadb8aa8d22f15c7fe6da1279f2"
-    sha256 tahoe:         "0e0a3a29115ad0a6dd449917ffac06199401204f57aff1f639f057b1cf781238"
-    sha256 sequoia:       "4537baa7df94de0c1968c7f570d951ca68d017696b8be4c5a31aaab33974874e"
-    sha256 sonoma:        "d762f28338f4b79f1660170a533d451484fcb60dd9a3d7ab2f5c09d4e5a9c729"
-    sha256 arm64_linux:   "c1d35f3ed7a8a22b9ecd081ca53353cc7b9ba671f8f899a62f630d1ff2e0c011"
-    sha256 x86_64_linux:  "e3ca53f890dec487c628a6df56d49d491c23767ebfee7aed2ef4b6a88970f2d3"
+    rebuild 3
+    sha256 arm64_tahoe:   "d6f4a115a2acdea5d9bf0f968637af9e8d4a68d30254e37bcd72d39c0a51873d"
+    sha256 arm64_sequoia: "8574096eedc2dd46fc02afad5b60a8fd07cac566537e1533b9fc89145c4f2447"
+    sha256 arm64_sonoma:  "e189a66703407e19a2d7142e58e8d804190824563e65b8251a7a21d51cf2956e"
+    sha256 tahoe:         "75ec4ec2442cd0927e83e888f87a9347aa0773170c5d8af0192e10d46df6d72b"
+    sha256 sequoia:       "9071895c31ab3e093ec44b204a09d74e5307d3020b0845f005ac232c9426bcb6"
+    sha256 sonoma:        "230e687bd23cde9586ea6ab1dc49a5de85335d498d1a9b377d6b893e51144526"
+    sha256 arm64_linux:   "775d68fdcfd87f49ec5c6c222b12ffd408ceaff35a52d7ec4640356bd4d18134"
+    sha256 x86_64_linux:  "10e1295a1e4f42e7f7387c49ee733285b755bedd73ba14e2367728f96a4fb734"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/p/python@3.13.rb
+++ b/Formula/p/python@3.13.rb
@@ -82,7 +82,7 @@ class PythonAT313 < Formula
   # The HOMEBREW_PREFIX location of site-packages.
   def site_packages = HOMEBREW_PREFIX/"lib/python#{version.major_minor}/site-packages"
 
-  def altinstall? = self != Formula["python3"]
+  def altinstall? = name != Formula["python3"].name
 
   def python3 = bin/"python#{version.major_minor}"
 

--- a/Formula/p/python@3.13.rb
+++ b/Formula/p/python@3.13.rb
@@ -11,14 +11,15 @@ class PythonAT313 < Formula
   end
 
   bottle do
-    sha256 arm64_tahoe:   "c8b54ab4e20ee5f4b43b1cec2d4299997e310b839df16e9948f6a7f0123cef8a"
-    sha256 arm64_sequoia: "a322cf89659a0152e524435eaf0dcfe9692da889595028da40d0f1609224e648"
-    sha256 arm64_sonoma:  "f1472e8e354592aa785c65573f980fcf061dbc70e1682112c777d7d3ababfd15"
-    sha256 tahoe:         "8dadbb32681ebc3d00f9e5b09ea2e389fe9a0409219e6818bc4d4d1059d70141"
-    sha256 sequoia:       "f46f3eb3beb77ca48eb1abc00366877fa8a7443bb0ce7e95f3b325a8278f23dd"
-    sha256 sonoma:        "b3713ee4dfe45f2a8ed894f72d4d05bfa1365c2e737f4a5e23ccba3ff406ba61"
-    sha256 arm64_linux:   "f4ee9a5fdceb97d5cd112de344af83d2c7eb37a763a928e38e6588a76157a9af"
-    sha256 x86_64_linux:  "8c0ce49f7f3b8c6d70516eb44581b48f169326836b0c12be2bb400d31265b84d"
+    rebuild 1
+    sha256 arm64_tahoe:   "6a8cccd8ff09fd1e5e9f8e3491db8ea9cb93fd90bc06fd4cdbfa0fd437184fbf"
+    sha256 arm64_sequoia: "e3597fc0c7e3613477c8cc3b8399577add9ffd9ef5e36810f11785335dca9e57"
+    sha256 arm64_sonoma:  "857ecdba4e7b67dab93eda7113e85162637bfb1e712fbb02770ef49a006e9529"
+    sha256 tahoe:         "08de93aae754f7442742ba5ebd16e91ca415307ea86d5d473f28afc5c7508fff"
+    sha256 sequoia:       "4726a58b6430de1b58ef337309e913315be4caedc1dbceb5b2c0eed12e0c6e9a"
+    sha256 sonoma:        "044a0bae24e93058a292e10eec67c52bc5f408eb376194cd2d3a9c6c1cf5b786"
+    sha256 arm64_linux:   "ca5662926336672af94417027b0a779c278eb136ee6df05305b8b346174a87dc"
+    sha256 x86_64_linux:  "2ca5b858217abb665e40c501e84f052fe88b2e6283e0c8ca755a0ba8f8e82b30"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/p/python@3.14.rb
+++ b/Formula/p/python@3.14.rb
@@ -11,14 +11,15 @@ class PythonAT314 < Formula
   end
 
   bottle do
-    sha256 arm64_tahoe:   "4e7ee268e8f53127b99b0eaad544d25e1b2d8ce382996989c2fb1fcd49cac2a3"
-    sha256 arm64_sequoia: "4dce49c7fe46c415d2fd4daac0fe655ef8601ede59b9ab54b9d8cd43e90bb8a1"
-    sha256 arm64_sonoma:  "de13acb09424fd86894e72b1358f6fc04a6920a7c656a9b8c0833a9bc54227e8"
-    sha256 tahoe:         "4c54876bfd8fee699a74786ebd714104c835bee1332e34a2f86a23c37cbf5123"
-    sha256 sequoia:       "fdcd5b7701c8528cc72958e9c9f6a95f45e7704cd9be56efd473b59d722424a4"
-    sha256 sonoma:        "d5b0d55774003aa95fac167df9b140cb8ec88d9d35c20c63d6f98d26148d6bc5"
-    sha256 arm64_linux:   "89421722bbdc251eac8d39eba34d28430be765e09de4c2db2146a80c04fae60e"
-    sha256 x86_64_linux:  "d9648925b1a96afb3a0e70f50d174cc9486b79f59fce879c91267ec8923a0a87"
+    rebuild 1
+    sha256 arm64_tahoe:   "dd33d75c8933865d6e139ba2f356336d451ce2a059091ffedea203673ee6be32"
+    sha256 arm64_sequoia: "ab3c31672d8783cf59ace7dcd40727c6a51a445a7a5a10b01ec51d505f1274b3"
+    sha256 arm64_sonoma:  "7edaf92eefd507ee8e8a8bc34c97e1bbc3a1ff7af39429ce80b39a86abb7bfef"
+    sha256 tahoe:         "960914ebc70473c211faffdf279cf885b58ee72802b2b1f5ca59a10722f32570"
+    sha256 sequoia:       "07cf53b5761512ceb559761f16e57ba0d2defdba3e1dd32b14c04a493a29197d"
+    sha256 sonoma:        "1d0c8dd6dcd3835244ae016654c5257bbb8943df766c801755ee3f911f88333e"
+    sha256 arm64_linux:   "4484f23889804026d999ed92e58db34bb76fa2821926b754b9a02da604f1cecc"
+    sha256 x86_64_linux:  "0553ae247aa4909c616a27e587546bcd24b1e540f4ff9ccfcbec8d2806fbf770"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/p/python@3.14.rb
+++ b/Formula/p/python@3.14.rb
@@ -97,7 +97,7 @@ class PythonAT314 < Formula
   # The HOMEBREW_PREFIX location of site-packages.
   def site_packages = HOMEBREW_PREFIX/"lib/python#{version.major_minor}/site-packages"
 
-  def altinstall? = self != Formula["python3"]
+  def altinstall? = name != Formula["python3"].name
 
   def python3 = bin/"python#{version.major_minor}"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Fixes https://github.com/Homebrew/homebrew-core/pull/245931#issuecomment-3393125289

This inequality check works as expected for `HOMEBREW_NO_INSTALL_FROM_API=1`, but otherwise always returns true when building from source via the API. So those users don't end up with a `python3` in PATH. I haven't had time to track down this behavior difference in brew but simple enough to fix here
