### PR TITLE
ng-log 0.8.2 (new formula), glog: make keg-only

### DIFF
--- a/Formula/g/glog.rb
+++ b/Formula/g/glog.rb
@@ -4,7 +4,7 @@ class Glog < Formula
   url "https://github.com/google/glog/archive/refs/tags/v0.6.0.tar.gz"
   sha256 "8a83bf982f37bb70825df71a9709fa90ea9f4447fb3c099e1d720a439d88bad6"
   license "BSD-3-Clause"
-  revision 1
+  revision 2
   head "https://github.com/google/glog.git", branch: "master"
 
   no_autobump! because: :requires_manual_review
@@ -17,6 +17,8 @@ class Glog < Formula
     sha256 cellar: :any_skip_relocation, arm64_linux:   "148610f0d05d41387d7dd402fec0b7cafbe2603a7a5745734ecd6db50f279425"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "0624b3d83129dd0efe76d79ae8c8f5a406e98b0b6a49b7ad5d6915ed669f4e4c"
   end
+
+  keg_only "it conflicts with maintained, API-compatible `ng-log`"
 
   # deprecate! date: "2025-12-10", because: :repo_archived, replacement_formula: "abseil"
 

--- a/Formula/n/ng-log.rb
+++ b/Formula/n/ng-log.rb
@@ -1,0 +1,47 @@
+class NgLog < Formula
+  desc "C++ library for application-level logging"
+  homepage "https://ng-log.github.io/ng-log/"
+  url "https://github.com/ng-log/ng-log/archive/refs/tags/v0.8.2.tar.gz"
+  sha256 "4d7467025b800828d3b2eb87eb506b310d090171788857601a708a46825953a8"
+  license "BSD-3-Clause"
+  head "https://github.com/ng-log/ng-log.git", branch: "master"
+
+  depends_on "cmake" => [:build, :test]
+  depends_on "gflags"
+
+  # ng-log provides compatibility libraries for glog
+  link_overwrite "include/glog", "lib/cmake/glog", "lib/libglog.dylib", "lib/libglog.so"
+
+  def install
+    system "cmake", "-S", ".", "-B", "build", "-DCMAKE_INSTALL_RPATH=#{rpath}", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~CPP
+      #include <ng-log/logging.h>
+
+      int main(int argc, char* argv[]) {
+        nglog::InitializeLogging(argv[0]);
+        LOG(INFO) << "test";
+      }
+    CPP
+
+    (testpath/"CMakeLists.txt").write <<~CMAKE
+      cmake_minimum_required(VERSION 4.0)
+      project(test VERSION 1.0)
+      find_package(ng-log CONFIG REQUIRED)
+      add_executable(test test.cpp)
+      target_link_libraries(test ng-log::ng-log)
+    CMAKE
+
+    ENV["TMPDIR"] = testpath
+    system "cmake", "-S", ".", "-B", "build"
+    system "cmake", "--build", "build"
+    system "./build/test"
+
+    assert_path_exists testpath/"test.INFO"
+    assert_match "test.cpp:5] test", File.read("test.INFO")
+  end
+end


### PR DESCRIPTION
`ng-log` is API-compatible to `glog` as mentioned by `glog` README: https://github.com/google/glog?tab=readme-ov-file#google-logging-library

Seems to be maintained by some of `glog` maintainers but just without Google affiliation.

Making `glog` keg-only as it is still needed by various dependents (e.g. Facebook formulae).

---

Note that dependents should only switch to `ng-log` if entire deps tree can be migrated together. This won't be verified by audit so need to be careful here.

Partially switching this can lead to loading duplicate copies of libraries/symbols which can lead to crashes and other problems.