### PR TITLE
mariadb: Use accurate end-of-life dates

### DIFF
--- a/Formula/m/mariadb@10.6.rb
+++ b/Formula/m/mariadb@10.6.rb
@@ -28,8 +28,8 @@ class MariadbAT106 < Formula
 
   keg_only :versioned_formula
 
-  # See: https://mariadb.com/kb/en/changes-improvements-in-mariadb-106/
-  deprecate! date: "2026-06-01", because: :unsupported
+  # See: https://mariadb.org/about/#maintenance-policy
+  deprecate! date: "2026-07-06", because: :unsupported
 
   depends_on "bison" => :build
   depends_on "cmake" => :build

--- a/Formula/m/mariadb@11.4.rb
+++ b/Formula/m/mariadb@11.4.rb
@@ -28,8 +28,9 @@ class MariadbAT114 < Formula
 
   keg_only :versioned_formula
 
-  # See: https://mariadb.com/kb/en/changes-improvements-in-mariadb-11-4/
-  # End-of-life on 2029-05-29: https://mariadb.org/about/#maintenance-policy
+  # From https://mariadb.org/about/#maintenance-policy:
+  # > For releases up to MariaDB 11.4, the binaries are released for 5 years
+  # > after the GA date (29 May 2024)
   deprecate! date: "2029-05-29", because: :unsupported
 
   depends_on "bison" => :build

--- a/Formula/m/mariadb@11.8.rb
+++ b/Formula/m/mariadb@11.8.rb
@@ -28,8 +28,11 @@ class MariadbAT118 < Formula
 
   keg_only :versioned_formula
 
-  # End-of-life on 2028-06-04: https://mariadb.org/about/#maintenance-policy
-  deprecate! date: "2028-06-04", because: :unsupported
+  # From https://mariadb.org/about/#maintenance-policy:
+  # > Critical security fixes will be provided as source code releases only and
+  # > on a best effort basis for 2 additional years beyond Community maintenance
+  # > LTS level
+  deprecate! date: "2030-06-04", because: :unsupported
 
   depends_on "bison" => :build
   depends_on "cmake" => :build


### PR DESCRIPTION
As MariaDB is built from sources on Homebrew, the actual end-of-life dates announced on Homebrew should reflect the date MariaDB is committed to publish updates as source code, which is further out than what they commit to regarding binaries.

With these updates all current LTS versions of MariaDB have correct EOL dates on Homebrew.

---
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?

This is the same change done in a uniform way to 3 formulaes. Technically this violates the rule of one PR per formulae, but it could also be justified that this update is "atomic" in a way as it is the same change. I can split this into 3 identical PRs if reviewers request it.