### PR TITLE
httping: enable TUI with FFT support

### DIFF
--- a/Formula/h/httping.rb
+++ b/Formula/h/httping.rb
@@ -4,6 +4,8 @@ class Httping < Formula
   url "https://github.com/folkertvanheusden/HTTPing/archive/refs/tags/v4.4.0.tar.gz"
   sha256 "87fa2da5ac83c4a0edf4086161815a632df38e1cc230e1e8a24a8114c09da8fd"
   license "AGPL-3.0-only"
+  revision 1
+  head "https://github.com/folkertvanheusden/HTTPing.git", branch: "master"
 
   # There can be a notable gap between when a version is tagged and a
   # corresponding release is created, so we check the "latest" release instead
@@ -26,6 +28,8 @@ class Httping < Formula
 
   depends_on "cmake" => :build
   depends_on "gettext" => :build # for msgfmt
+  depends_on "pkgconf" => :build
+  depends_on "fftw"
   depends_on "openssl@3"
 
   uses_from_macos "ncurses"
@@ -41,12 +45,21 @@ class Httping < Formula
   end
 
   def install
-    system "cmake", "-S", ".", "-B", "build", "-DUSE_SSL=ON", "-DUSE_GETTEXT=ON", *std_cmake_args
+    system "cmake", "-S", ".", "-B", "build",
+                    "-DCMAKE_BUILD_TYPE=Release",
+                    "-DUSE_SSL=ON",
+                    "-DUSE_GETTEXT=ON",
+                    "-DUSE_TUI=ON",
+                    "-DUSE_FFTW3=ON",
+                    *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
   end
 
   test do
+    expected = /HTTPing v#{Regexp.escape(version.to_s)}.*SSL support included.*ncurses interface with FFT included/m
+    assert_match expected, shell_output("#{bin}/httping --version 2>&1")
+
     system bin/"httping", "-c", "2", "-g", "https://brew.sh/"
   end
 end

--- a/Formula/h/httping.rb
+++ b/Formula/h/httping.rb
@@ -16,14 +16,12 @@ class Httping < Formula
   end
 
   bottle do
-    sha256 arm64_tahoe:   "5895bed583e9faad9d7be382a6890f92ca1cd229729977729246a0b3b8603597"
-    sha256 arm64_sequoia: "2edf3ec3576fcb84bcd40124d94c84e80fedba5975fa7c22aa30375e40ab48c6"
-    sha256 arm64_sonoma:  "f51c8f88fcfdf499b9402d73c8e694395f1ee09af0a1d988774f02cdd7ae9fed"
-    sha256 arm64_ventura: "cd0bd242c917ce8ce4699733fb6bd36cfccefd36bd8b0b7fba4822842601a351"
-    sha256 sonoma:        "5c887df378bbfbe24b8049e579a6325bbd7d8cba076eebe392ae3dab8dd6f832"
-    sha256 ventura:       "12e2cbfeb500c53bd2cde0ec98d9426a9736d4a40cce70035869b5220108ff6f"
-    sha256 arm64_linux:   "21a1a7426bddeb581154982e0752a0a745069893d7fb04872e2700bccb8a26db"
-    sha256 x86_64_linux:  "d216d2e231fe96782beab3f205156d657da0c91f6c6c98e2a2ab1218a1db0f33"
+    sha256 arm64_tahoe:   "071348d10108c95a9cd23e105942b81e63fbd1caea8f2367427a554f406b68e4"
+    sha256 arm64_sequoia: "b6188bb2590af36f19f4f7d2fdee0004bc740cca357770f823eace71fd576195"
+    sha256 arm64_sonoma:  "194a46abe5b4fd668eac0dbdc42d94e72b84dc7abb6fb75b180cec07f03dfda7"
+    sha256 sonoma:        "aab01cd51be36a661adb1fab505740b3cdf0b156e13d96ba6886e1389761bf1a"
+    sha256 arm64_linux:   "3dfe264e40fbf0b9759dbb72b968bc9b3a87fe01f8acb603dfab8d285880f509"
+    sha256 x86_64_linux:  "51e8dc57762f328e29329501734ca6e2b9437a69613abcc68830cc4fcf13bbd7"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

upstream ref:
* https://github.com/folkertvanheusden/HTTPing/pull/69