### PR TITLE
pwsafe: replace Utils.popen usage

### DIFF
--- a/Formula/p/pwsafe.rb
+++ b/Formula/p/pwsafe.rb
@@ -63,13 +63,8 @@ class Pwsafe < Formula
     test_account_name = "testing"
     test_account_pass = "sg1rIWHL?WTOV=d#q~DmxiQq%_j-$f__U7EU"
 
-    resource("test-pwsafe-db").stage do
-      Utils.popen(
-        "#{bin}/pwsafe -f test.dat -p #{test_account_name}", "r+"
-      ) do |pipe|
-        pipe.puts test_db_passphrase
-        assert_match(/^#{Regexp.escape(test_account_pass)}$/, pipe.read)
-      end
-    end
+    resource("test-pwsafe-db").stage(testpath)
+    output = pipe_output("#{bin}/pwsafe -f test.dat -p #{test_account_name}", test_db_passphrase, 0)
+    assert_match(/^#{Regexp.escape(test_account_pass)}$/, output)
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Only usage of `Utils.popen` so can remove and make part of internal/private API so we only use `(safe_)popen_read`/`(safe_)popen_write` publicly. 
