### PR TITLE
djl-serving: update livecheck

### DIFF
--- a/Formula/d/djl-serving.rb
+++ b/Formula/d/djl-serving.rb
@@ -8,8 +8,11 @@ class DjlServing < Formula
   # `djl-serving` versions aren't considered released until a corresponding
   # release is created in the main `deepjavalibrary/djl` repository.
   livecheck do
-    url "https://github.com/deepjavalibrary/djl"
-    strategy :github_latest
+    url "https://docs.djl.ai/versions.json"
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :json do |json, regex|
+      json.map { |item| item["version"]&.[](regex, 1) }
+    end
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Trying a different livecheck based on documentation page - https://docs.djl.ai/master/docs/serving/index.html
```
❯ brew lc djl-serving --debug --autobump

Formula:          djl-serving
livecheck block?: Yes

URL:              https://docs.djl.ai/versions.json
Strategy:         Json
Regex:            /^v?(\d+(?:\.\d+)+)$/i

Matched Versions:
0.35.0, 0.34.0, 0.33.0, 0.32.0

djl-serving: 0.35.0 ==> 0.35.0
```

If it doesn't work, can switch back or try a something like the version in Gradle file - https://github.com/deepjavalibrary/djl-serving/blob/master/gradle/libs.versions.toml (this will still have false livechecks during time interval when PR to update this gets merged and the new release is created).