### PR TITLE
dotnet rdkit: add `no_autobump!`

### DIFF
--- a/Formula/d/dotnet.rb
+++ b/Formula/d/dotnet.rb
@@ -27,6 +27,8 @@ class Dotnet < Formula
     regex(/^v?(\d+\.\d+\.\d{1,2})$/i)
   end
 
+  no_autobump! because: :incompatible_version_format
+
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "343566caa1011741a13303014ceee74a91d807de9cd77f0438324939f9ff65bb"
     sha256 cellar: :any,                 arm64_sequoia: "0f23879804542b8e66c8521b87af973069165fc9379749083a25537aae9f94b1"

--- a/Formula/r/rdkit.rb
+++ b/Formula/r/rdkit.rb
@@ -16,6 +16,8 @@ class Rdkit < Formula
     end
   end
 
+  no_autobump! because: :incompatible_version_format
+
   bottle do
     sha256                               arm64_tahoe:   "4cc1e1aa5a8ca900685a73d18a3acd594bde744ace6da9c4ceb769d2ceb798b2"
     sha256                               arm64_sequoia: "9474376a2348d49158d03e76f32f11912a37d0deee81cbf6d71cee9838eb1d18"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
