### PR TITLE
fatal fizz: use tag archive not release

### DIFF
--- a/Formula/f/fatal.rb
+++ b/Formula/f/fatal.rb
@@ -1,8 +1,8 @@
 class Fatal < Formula
   desc "Facebook Template Library"
   homepage "https://www.facebook.com/groups/libfatal/"
-  url "https://github.com/facebook/fatal/releases/download/v2025.11.24.00/fatal-v2025.11.24.00.tar.gz"
-  sha256 "8bbdca046f0d060787e485348ac750615ee6562ee486d486b6612c3a4552a4c1"
+  url "https://github.com/facebook/fatal/archive/refs/tags/v2025.11.24.00.tar.gz"
+  sha256 "9fa0394cd126e1024d077a30a529e84304a9bbebca7a70f1e46908b3a50f9711"
   license "BSD-3-Clause"
   head "https://github.com/facebook/fatal.git", branch: "main"
 

--- a/Formula/f/fizz.rb
+++ b/Formula/f/fizz.rb
@@ -1,8 +1,8 @@
 class Fizz < Formula
   desc "C++14 implementation of the TLS-1.3 standard"
   homepage "https://github.com/facebookincubator/fizz"
-  url "https://github.com/facebookincubator/fizz/releases/download/v2025.11.10.00/fizz-v2025.11.10.00.tar.gz"
-  sha256 "21ad7e064215f5f4e4ae9fbdf2cefe7cdde50db483eee996efd4efd00ccb0658"
+  url "https://github.com/facebookincubator/fizz/archive/refs/tags/v2025.11.10.00.tar.gz"
+  sha256 "ddfb59a15aac9b1091c5d7dfaaeba5690ae91d3e126194bc72d3bf7c5d7c27f7"
   license "BSD-3-Clause"
   revision 1
   head "https://github.com/facebookincubator/fizz.git", branch: "main"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Use tag archive not release artifact, similar to the other facebook opensources.