### PR TITLE
mingw-w64: Incorporate the licenses for binutils and gcc.

### DIFF
--- a/Formula/m/mingw-w64.rb
+++ b/Formula/m/mingw-w64.rb
@@ -3,7 +3,14 @@ class MingwW64 < Formula
   homepage "https://sourceforge.net/projects/mingw-w64/"
   url "https://downloads.sourceforge.net/project/mingw-w64/mingw-w64/mingw-w64-release/mingw-w64-v13.0.0.tar.bz2"
   sha256 "5afe822af5c4edbf67daaf45eec61d538f49eef6b19524de64897c6b95828caf"
-  license "ZPL-2.1"
+  license all_of: [
+    # mingw-w64
+    "ZPL-2.1",
+    # binutils
+    { all_of: ["GPL-2.0-or-later", "GPL-3.0-or-later", "LGPL-2.0-or-later", "LGPL-3.0-only"] },
+    # gcc
+    "GPL-3.0-or-later" => { with: "GCC-exception-3.1" },
+  ]
   revision 2
 
   livecheck do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

mingw-w64 incorporates both binutils and gcc, it seems to me the license should reflect this rather than just being the license for mingw-w64.