### PR TITLE
goshs 1.1.3

### DIFF
--- a/Formula/g/goshs.rb
+++ b/Formula/g/goshs.rb
@@ -1,8 +1,8 @@
 class Goshs < Formula
   desc "Simple, yet feature-rich web server written in Go"
   homepage "https://goshs.de/en/index.html"
-  url "https://github.com/patrickhener/goshs/archive/refs/tags/v1.1.2.tar.gz"
-  sha256 "ea521af316dac8acac4a98c977b3d65400d9867ef36008ea3ecd1843c09555a8"
+  url "https://github.com/patrickhener/goshs/archive/refs/tags/1.1.3.tar.gz"
+  sha256 "f6b62e2161161c368538b0911c0f1ccfc16ce68d0531495ce8d1ffd4d9110a9f"
   license "MIT"
   head "https://github.com/patrickhener/goshs.git", branch: "main"
 

--- a/Formula/g/goshs.rb
+++ b/Formula/g/goshs.rb
@@ -7,12 +7,12 @@ class Goshs < Formula
   head "https://github.com/patrickhener/goshs.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "d6a30e570cb2b179fcfb163bd53ff2f422a99c4e86565bb4e3e2b3657b9f6484"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "d6a30e570cb2b179fcfb163bd53ff2f422a99c4e86565bb4e3e2b3657b9f6484"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "d6a30e570cb2b179fcfb163bd53ff2f422a99c4e86565bb4e3e2b3657b9f6484"
-    sha256 cellar: :any_skip_relocation, sonoma:        "c92c7b62617c11e5ae5e372fe98d7dffea0e387b16afa2ae9c8a4846d51edd5a"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "2d3a84ab88ac2469ef4fba85a7a307bd13b65f5f61d42aa454965bff4702eb68"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "51c146f4c3a51221294df1bdaea052661a5e4679edb5a28b825c73c5bca5da65"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "53a33b2135b2badf0530d5fd3ec4cc09d170e79cd8ec590174295f9327952b7e"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "53a33b2135b2badf0530d5fd3ec4cc09d170e79cd8ec590174295f9327952b7e"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "53a33b2135b2badf0530d5fd3ec4cc09d170e79cd8ec590174295f9327952b7e"
+    sha256 cellar: :any_skip_relocation, sonoma:        "407c85ce4ac2b51e2172e60523df14aea6d59bbea23290bc0503bd6f5b7532b4"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "fcd11471619fc6e1e73f3e94a64db521b2dc0f76ba7f8df9ed516af0f16afc54"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c89a25d370dd64cb1ce997d12af0de43fa5a074a5630761e6057824cfdc6a3dc"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
goshs 1.1.3

---

failed to autobump due to missing `v`, https://github.com/Homebrew/homebrew-core/actions/runs/20265351280/job/58187141880#step:6:6925

