### PR TITLE
bats-core: remove dependency on coreutils

### DIFF
--- a/Formula/b/bats-core.rb
+++ b/Formula/b/bats-core.rb
@@ -14,8 +14,6 @@ class BatsCore < Formula
     sha256 cellar: :any_skip_relocation, all: "9e117b2e74af3e8a6edf752036fb1622382d7fc8861076cdc49e372cc9f991fb"
   end
 
-  depends_on "coreutils"
-
   uses_from_macos "bc" => :test
 
   def install

--- a/Formula/b/bats-core.rb
+++ b/Formula/b/bats-core.rb
@@ -11,7 +11,8 @@ class BatsCore < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "9e117b2e74af3e8a6edf752036fb1622382d7fc8861076cdc49e372cc9f991fb"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "b1d947f6f436990be319ec03d9b147c58dd385d1c77c1f541410c1f0aa776fad"
   end
 
   uses_from_macos "bc" => :test


### PR DESCRIPTION
Dependency removed in 1.2.1

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

PR where this was fixed: https://github.com/bats-core/bats-core/pull/217
Release notes: https://github.com/bats-core/bats-core/releases/tag/v1.2.1