### PR TITLE
Remove dasel no_autobump

### DIFF
--- a/Formula/d/dasel.rb
+++ b/Formula/d/dasel.rb
@@ -6,8 +6,6 @@ class Dasel < Formula
   license "MIT"
   head "https://github.com/TomWright/dasel.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "1cabd6f40da7d2b4207224112e732f913f3d5968e3e975360f8d163b787f389c"
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "1cabd6f40da7d2b4207224112e732f913f3d5968e3e975360f8d163b787f389c"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The addition of `no_autobump! because: :requires_manual_review` has broken my release processes.

My CD only creates a PR on the tag of a release and after a successful build, which only happens after my entire test suite runs.

If this must be here, can you explain how I can have automatic PR creation using https://github.com/dawidd6/action-homebrew-bump-formula please?