### PR TITLE
crystal: no longer need to depend on libevent

### DIFF
--- a/Formula/c/crystal.rb
+++ b/Formula/c/crystal.rb
@@ -37,15 +37,13 @@ class Crystal < Formula
   end
 
   depends_on "bdw-gc"
-  depends_on "gmp" # std uses it but it's not linked
-  depends_on "libevent"
+  depends_on "gmp" => :no_linkage # std uses it but it's not linked
+  depends_on "libffi" # for the interpreter
   depends_on "libyaml"
   depends_on "llvm"
   depends_on "openssl@3" # std uses it but it's not linked
   depends_on "pcre2"
   depends_on "pkgconf" # @[Link] will use pkg-config if available
-
-  uses_from_macos "libffi" # for the interpreter
 
   # It used to be the case that every new crystal release was built from a
   # previous release, except patches. Crystal is updating its policy to


### PR DESCRIPTION
Since Crystal 1.15.0:
https://crystal-lang.org/2024/11/05/lifetime-event-loop/

I had to switch from

    uses_from_macos "libffi"

to

    depends_on "libevent"

to be able to build locally (macOS 15.7.2).

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
