### PR TITLE
usage: add manpage installation

### DIFF
--- a/Formula/u/usage.rb
+++ b/Formula/u/usage.rb
@@ -7,12 +7,13 @@ class Usage < Formula
   head "https://github.com/jdx/usage.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "815f59f73442d7eafd6f6322f1164776771b2619106d97ef0a1fdd4611ecd2af"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "2fadbd411df69c855105782e9b0ffd656bca5d3f23836464f3cbb310ec047cd4"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "6bcbaa454c883b9f31c10f5f122cc8263a343825571ec05587a80227f32c78b6"
-    sha256 cellar: :any_skip_relocation, sonoma:        "7df6421d668dc5ba8c4106d936abf3b29e1cdd9bcad02035baa880edac1f1aac"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "5b21179984ed5cd3a71a230bfa92a759019d39c948432461980ab34059baaceb"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "6936355baaaf8ee93917ae78ca3905a80879828a72f0770c4bfb244b683ae10e"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "9937c8afa51ee2cd031967375a6ce95d26d1904c605c12a98f381471616e8e42"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "684e32d2f32c58ad1eac07cd071a7e40174f099cfbcd39be2de414b995962dc4"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "582504e61d773f854c33fa6097eb0f362322a120491298598cb22a5b7c57242a"
+    sha256 cellar: :any_skip_relocation, sonoma:        "f70cdf124bc860ecda41424fc7ed795b4a54484d4eee041ca840dd493818a995"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "5f849002d7a9e55ddeb8a463ebe3d7baa696cfd8c5655a0d2fadb81a54be8a39"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "00da4f5f5f8ee0b933f0186339372fac5d4ea6b3765c4142b5b8dff577641293"
   end
 
   depends_on "rust" => :build

--- a/Formula/u/usage.rb
+++ b/Formula/u/usage.rb
@@ -19,6 +19,7 @@ class Usage < Formula
 
   def install
     system "cargo", "install", *std_cargo_args(path: "cli")
+    man1.install "cli/assets/usage.1"
     generate_completions_from_executable(bin/"usage", "--completions")
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Similar to `mise` which is created by the same author, `usage` maintains a `usage.1`. See https://github.com/jdx/usage/blob/main/cli/assets/usage.1.
https://github.com/Homebrew/homebrew-core/blob/82b4dbddfe529f317481ddbcdfe143f258dfef8c/Formula/m/mise.rb#L42