### PR TITLE
neo4j-mcp 1.1.0 (new formula)

### DIFF
--- a/Formula/n/neo4j-mcp.rb
+++ b/Formula/n/neo4j-mcp.rb
@@ -1,0 +1,27 @@
+class Neo4jMcp < Formula
+  desc "Neo4j official Model Context Protocol server for AI tools"
+  homepage "https://neo4j.com/docs/mcp/current/"
+  url "https://github.com/neo4j/mcp/archive/refs/tags/v1.1.0.tar.gz"
+  sha256 "ae622058f73f862162b2a0c51f33b3f50ae972844af3218c62ae7136e864b5d2"
+  license "GPL-3.0-or-later"
+  head "https://github.com/neo4j/mcp.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = "-s -w -X main.Version=v#{version}"
+    system "go", "build", *std_go_args(ldflags:), "./cmd/neo4j-mcp"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/neo4j-mcp --version")
+
+    json = <<~JSON
+      {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26"}}
+      {"jsonrpc":"2.0","id":2,"method":"tools/list"}
+    JSON
+
+    output = pipe_output("#{bin}/neo4j-mcp 2>&1", json, 1)
+    assert_match "Neo4j URI is required", output
+  end
+end

--- a/Formula/n/neo4j-mcp.rb
+++ b/Formula/n/neo4j-mcp.rb
@@ -6,6 +6,15 @@ class Neo4jMcp < Formula
   license "GPL-3.0-or-later"
   head "https://github.com/neo4j/mcp.git", branch: "main"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "4653e1c9c0371dad6334d7ea51a7e427542e0c9a0fdcabc4cb559b899892e15a"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "4653e1c9c0371dad6334d7ea51a7e427542e0c9a0fdcabc4cb559b899892e15a"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "4653e1c9c0371dad6334d7ea51a7e427542e0c9a0fdcabc4cb559b899892e15a"
+    sha256 cellar: :any_skip_relocation, sonoma:        "9e66bedaf4466a34ae710406c8c3b361db1c06b698718b6ece9aa62d74671811"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "06d300cf80367db388b918f5be88ddce3d1563cdcf82a0025091964ce5841482"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "ae61bebd506468e003c70d96178e11650f26d9c3c011807d7add7cc61d56815b"
+  end
+
   depends_on "go" => :build
 
   def install


### PR DESCRIPTION
## Description

Add Homebrew formula for [neo4j-mcp](https://github.com/neo4j/mcp), the official Neo4j Model Context Protocol server.

This enables AI tools to interact with Neo4j graph databases using the [Model Context Protocol](https://modelcontextprotocol.io/).

## Checklist

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`?
- [x] Have you verified the formula audit is passing with `brew audit --strict --new <formula>`?
- [x] Have you verified the formula is passing with `brew test <formula>`?

## Related

Requested by Neo4j community: https://github.com/neo4j/mcp/issues/137