### PR TITLE
kubescape: checksum update for 3.0.47 release

### DIFF
--- a/Formula/k/kubescape.rb
+++ b/Formula/k/kubescape.rb
@@ -2,7 +2,7 @@ class Kubescape < Formula
   desc "Kubernetes testing according to Hardening Guidance by NSA and CISA"
   homepage "https://kubescape.io"
   url "https://github.com/kubescape/kubescape/archive/refs/tags/v3.0.47.tar.gz"
-  sha256 "3782a959a87ea9b0f3409f335e87edda54b0f1d7285c1113e5ec220ff998aef3"
+  sha256 "1d8c4820f341823dc1fc50d575044099dbf5cbfe2a05fc9e12976715efb41ae9"
   license "Apache-2.0"
   head "https://github.com/kubescape/kubescape.git", branch: "master"
 

--- a/Formula/k/kubescape.rb
+++ b/Formula/k/kubescape.rb
@@ -12,12 +12,13 @@ class Kubescape < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "6c8efae31ff5c90c30b7450069c1c04d14ca8aac7d380fafe66167eb3308fcfb"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "080cf638391911824d14c0741282d423ca99067e97abcd09a4e06fc4d05c8d0d"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "9fef080c009c116480db5a37fd644cc85c44896af7413372fc8ce53a35cce719"
-    sha256 cellar: :any_skip_relocation, sonoma:        "f320caa10f69f0ae7a4d5f13f3442840e5711faf7858256694603cb908ea20c1"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "5e756ec986db859d0504543c2ccc5d7ff5cb8d778741587f71ca5b2d5290f971"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a6366b595cbd0b546d89a0d4dfdbbe12fb1827a5811deed8a2a0bd548adfdd28"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "b46e8475527e5d40b919e3519afa2d8668ae6cca36c15c9f021a6ad2bb560c55"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "27546ff27da864fe1f13c8f1ce3b6b19e022370a08f489cb7f11d60f1d6ddcf8"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "6e5cf5c97d7d05b4398c08f906a2d535174bde8dfeef5c719748ceb08c952e75"
+    sha256 cellar: :any_skip_relocation, sonoma:        "f9107219c9f85191e3a4fbf4bc942a4905ace30750b4532811724a39063f4e1b"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "32dc28f0d6a50f43b15597ea883e25c185709d42887ac0d26866602bfa0099e3"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "89ce05132e8c310885b052c5de0fc3875e52cbab1a5b8fd2441f0abed1a01e97"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Noticed in 
* https://github.com/Homebrew/homebrew-core/pull/258912