### PR TITLE
energy: test fix

### DIFF
--- a/Formula/e/energy.rb
+++ b/Formula/e/energy.rb
@@ -26,7 +26,7 @@ class Energy < Formula
   end
 
   test do
-    assert_match version.to_s, shell_output("#{bin}/energy cli -v")
+    assert_match version.to_s, shell_output("#{bin}/energy cli")
 
     assert_match "https://energy.yanghy.cn", shell_output("#{bin}/energy env")
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Found in
* https://github.com/Homebrew/homebrew-core/pull/258912

```
$ energy cli -v
ERROR Get "https://energy.yanghy.cn/data/command-line-tools.json": tls: failed
                      │   to verify certificate: x509: certificate is valid for *.gitee.com,
                      │   gitee.com, not energy.yanghy.cn
```

Just check the local version without any remote connection, without "-v" parameter:
```
$ energy cli
v2.5.6
```