### PR TITLE
workflows: switch to `ubuntu-slim` where possible

### DIFF
--- a/.github/workflows/automerge-triggers.yml
+++ b/.github/workflows/automerge-triggers.yml
@@ -25,6 +25,6 @@ jobs:
       ((github.event_name == 'pull_request_review' && github.event.review.state == 'approved') ||
        (github.event_name == 'pull_request_target' &&
        (github.event.action == 'ready_for_review' || github.event.label.name == 'automerge-skip')))
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - run: true # This suffices to trigger `automerge.yml`.

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -25,7 +25,7 @@ env:
 
 jobs:
   status-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: >
       github.repository_owner == 'Homebrew' &&
       github.event.workflow_run.conclusion == 'success' &&

--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -344,7 +344,7 @@ jobs:
       pull-requests: write # for Homebrew/actions/post-comment
     needs: [bottle, upload]
     if: failure() && inputs.issue > 0
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Post comment on failure
         uses: Homebrew/actions/post-comment@main

--- a/.github/workflows/dispatch-rebottle.yml
+++ b/.github/workflows/dispatch-rebottle.yml
@@ -284,7 +284,7 @@ jobs:
       pull-requests: write # for Homebrew/actions/post-comment
     needs: [bottle, upload]
     if: failure() && inputs.issue > 0
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Post comment on failure
         uses: Homebrew/actions/post-comment@main

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -59,7 +59,7 @@ env:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       bottles: ${{steps.pr-branch-check.outputs.bottles}}
       head_sha: ${{steps.pr-branch-check.outputs.head_sha}}

--- a/.github/workflows/recreate-linux-runners.yml
+++ b/.github/workflows/recreate-linux-runners.yml
@@ -32,7 +32,7 @@ jobs:
     if: >
       github.repository_owner == 'Homebrew' &&
       (github.event_name != 'workflow_run' || github.event.workflow_run.event == 'pull_request')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       recreate: ${{ steps.check.outputs.recreate }}
     permissions:

--- a/.github/workflows/remove-disabled-packages.yml
+++ b/.github/workflows/remove-disabled-packages.yml
@@ -91,7 +91,7 @@ jobs:
       issues: write # for Homebrew/actions/create-or-update-issue
     needs: remove-disabled-packages
     if: always() && github.repository_owner == 'Homebrew'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Create issue on failure
         uses: Homebrew/actions/create-or-update-issue@main

--- a/.github/workflows/remove-unused-patches.yml
+++ b/.github/workflows/remove-unused-patches.yml
@@ -146,7 +146,7 @@ jobs:
       issues: write # for Homebrew/actions/create-or-update-issue
     needs: remove-unused-patches
     if: always() && github.repository_owner == 'Homebrew'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Create issue on failure
         uses: Homebrew/actions/create-or-update-issue@main

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -80,7 +80,7 @@ jobs:
   comment_on_failure:
     needs: create_matrix
     if: needs.create_matrix.result == 'failure'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       issues: write
     env:

--- a/.github/workflows/sync-default-branches.yml
+++ b/.github/workflows/sync-default-branches.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   sync:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: write
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,7 +93,7 @@ jobs:
         run: brew test-bot --only-bottles-fetch --testing-formulae="$TESTING_FORMULAE"
 
   report_analytics:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: formulae_detect
     if: github.repository_owner == 'Homebrew' && github.event_name == 'pull_request'
     steps:
@@ -132,7 +132,7 @@ jobs:
     permissions:
       pull-requests: read
     if: github.repository_owner == 'Homebrew' && github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: formulae_detect
     outputs:
       syntax-only: ${{ steps.check-labels.outputs.syntax-only }}
@@ -260,7 +260,7 @@ jobs:
     permissions:
       pull-requests: read
     if: github.repository_owner == 'Homebrew' && github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: [setup_tests, formulae_detect]
     outputs:
       syntax-only: ${{ steps.check-labels.outputs.syntax-only }}
@@ -392,7 +392,7 @@ jobs:
   conclusion:
     needs: [tests, test_deps, setup_tests, setup_runners]
     if: always() && github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Check `tests` result
         env:

--- a/.github/workflows/triage-ci.yml
+++ b/.github/workflows/triage-ci.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   comment:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: >
       github.repository_owner == 'Homebrew' &&
       github.event.workflow_run.conclusion == 'failure' &&

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -23,7 +23,7 @@ jobs:
     permissions:
       contents: read
     if: always() && github.repository_owner == 'Homebrew'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
@@ -36,7 +36,7 @@ jobs:
       issues: write
       pull-requests: write
     if: always() && github.repository_owner == 'Homebrew' && github.actor != 'BrewTestBot'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     env:
       PR: ${{ github.event.number }}
     steps:
@@ -115,7 +115,7 @@ jobs:
         run: gh pr comment "${PR}" --body "${BODY}" --repo "${GITHUB_REPOSITORY}"
 
   triage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: read
       issues: write
@@ -463,7 +463,7 @@ jobs:
       issues: write
       pull-requests: write
     if: always() && github.repository_owner == 'Homebrew'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     env:
       PR: ${{ github.event.number }}
     steps:


### PR DESCRIPTION
We've been moving some workflows from `ubuntu-latest` to `ubuntu-slim` for efficiency. Below is the output of [`gh-slimify`](https://github.com/fchimpan/gh-slimify):

```
✓ Scan complete

📄 .github/workflows/autobump.yml
  ❌ Cannot migrate (1 job(s)):
     • "autobump" (L29)
       ❌ uses container syntax
       .github/workflows/autobump.yml:29

📄 .github/workflows/cache.yml
  ❌ Cannot migrate (2 job(s)):
     • "determine-runners" (L35)
       ❌ uses container syntax
       .github/workflows/cache.yml:35
     • "${{ matrix.name }}" (L61)
       ❌ does not run on ubuntu-latest
       .github/workflows/cache.yml:61

📄 .github/workflows/scheduled.yml
  ✅ Safe to migrate (1 job(s)):
     • "comment_on_failure" (L83) - Last execution time: 0s
       .github/workflows/scheduled.yml:83
  ❌ Cannot migrate (2 job(s)):
     • "Online check: ${{ matrix.name }}" (L97)
       ❌ uses container syntax
       .github/workflows/scheduled.yml:97
     • "create_matrix" (L34)
       ❌ uses container syntax
       .github/workflows/scheduled.yml:34

📄 .github/workflows/sync-default-branches.yml
  ✅ Safe to migrate (1 job(s)):
     • "sync" (L24) - Last execution time: 9s
       .github/workflows/sync-default-branches.yml:24

📄 .github/workflows/tests.yml
  ✅ Safe to migrate (4 job(s)):
     • "report_analytics" (L96) - Last execution time: 5s
       .github/workflows/tests.yml:96
     • "setup_dep_tests" (L263) - Last execution time: 8s
       .github/workflows/tests.yml:263
     • "setup_tests" (L135) - Last execution time: 8s
       .github/workflows/tests.yml:135
     • "conclusion" (L395) - Last execution time: 3s
       .github/workflows/tests.yml:395
  ❌ Cannot migrate (6 job(s)):
     • "setup_runners" (L182)
       ❌ uses container syntax
       .github/workflows/tests.yml:182
     • "${{matrix.name}}" (L216)
       ❌ does not run on ubuntu-latest
       .github/workflows/tests.yml:216
     • "setup_dep_runners" (L311)
       ❌ uses container syntax
       .github/workflows/tests.yml:311
     • "${{matrix.name}} (deps)" (L350)
       ❌ does not run on ubuntu-latest
       .github/workflows/tests.yml:350
     • "tap_syntax${{ matrix.stable && ' (stable)' || '' }}" (L42)
       ❌ uses container syntax
       .github/workflows/tests.yml:42
     • "formulae_detect" (L68)
       ❌ uses container syntax
       .github/workflows/tests.yml:68

📄 .github/workflows/dispatch-rebottle.yml
  ✅ Safe to migrate (1 job(s)):
     • "comment" (L287) - Last execution time: 0s
       .github/workflows/dispatch-rebottle.yml:287
  ❌ Cannot migrate (3 job(s)):
     • "setup" (L60)
       ❌ uses container syntax
       .github/workflows/dispatch-rebottle.yml:60
     • "bottle" (L85)
       ❌ does not run on ubuntu-latest
       .github/workflows/dispatch-rebottle.yml:85
     • "upload" (L135)
       ❌ uses container syntax
       .github/workflows/dispatch-rebottle.yml:135

📄 .github/workflows/actionlint.yml
  ❌ Cannot migrate (2 job(s)):
     • "upload_sarif" (L83)
       ❌ does not run on ubuntu-latest
       .github/workflows/actionlint.yml:83
     • "workflow_syntax" (L29)
       ❌ uses container syntax
       .github/workflows/actionlint.yml:29

📄 .github/workflows/automerge-triggers.yml
  ✅ Safe to migrate (1 job(s)):
     • "check" (L28) - Last execution time: 2s
       .github/workflows/automerge-triggers.yml:28

📄 .github/workflows/clean-up-closed-prs.yml
  ⚠️  Can migrate but requires attention (1 job(s)):
     • "delete-branch" (L63)
       ⚠️  Last execution time: unknown
       .github/workflows/clean-up-closed-prs.yml:63
  ❌ Cannot migrate (1 job(s)):
     • "cancel-tests" (L28)
       ❌ uses container syntax
       .github/workflows/clean-up-closed-prs.yml:28

📄 .github/workflows/recreate-linux-runners.yml
  ✅ Safe to migrate (2 job(s)):
     • "recreate" (L0) - Last execution time: 0s
       .github/workflows/recreate-linux-runners.yml:0
     • "check" (L35) - Last execution time: 6s
       .github/workflows/recreate-linux-runners.yml:35

📄 .github/workflows/remove-disabled-packages.yml
  ✅ Safe to migrate (1 job(s)):
     • "create-issue" (L94) - Last execution time: 6s
       .github/workflows/remove-disabled-packages.yml:94
  ❌ Cannot migrate (1 job(s)):
     • "remove-disabled-packages" (L31)
       ❌ uses container syntax
       .github/workflows/remove-disabled-packages.yml:31

📄 .github/workflows/create-replacement-pr.yml
  ❌ Cannot migrate (1 job(s)):
     • "create" (L54)
       ❌ uses container syntax
       .github/workflows/create-replacement-pr.yml:54

📄 .github/workflows/publish-commit-bottles.yml
  ✅ Safe to migrate (1 job(s)):
     • "check" (L62) - Last execution time: 7s
       .github/workflows/publish-commit-bottles.yml:62
  ❌ Cannot migrate (1 job(s)):
     • "upload" (L276)
       ❌ does not run on ubuntu-latest
       .github/workflows/publish-commit-bottles.yml:276

📄 .github/workflows/manage-pull-request-labels.yml
  ⚠️  Can migrate but requires attention (2 job(s)):
     • "workflows-label" (L28)
       ⚠️  Last execution time: unknown
       .github/workflows/manage-pull-request-labels.yml:28
     • "concurrent-downloads-label" (L43)
       ⚠️  Last execution time: unknown
       .github/workflows/manage-pull-request-labels.yml:43

📄 .github/workflows/automerge-from-merge-queue.yml
  ⚠️  Can migrate but requires attention (1 job(s)):
     • "status-check" (L27)
       ⚠️  Last execution time: unknown
       .github/workflows/automerge-from-merge-queue.yml:27
  ❌ Cannot migrate (1 job(s)):
     • "merge" (L246)
       ❌ uses container syntax
       .github/workflows/automerge-from-merge-queue.yml:246

📄 .github/workflows/triage.yml
  ✅ Safe to migrate (4 job(s)):
     • "workflows-label" (L466) - Last execution time: 3s
       .github/workflows/triage.yml:466
     • "upload-metadata" (L26) - Last execution time: 3s
       .github/workflows/triage.yml:26
     • "check-base-branch" (L39) - Last execution time: 5s
       .github/workflows/triage.yml:39
     • "triage" (L118) - Last execution time: 7s
       .github/workflows/triage.yml:118
  ❌ Cannot migrate (1 job(s)):
     • "check-bottle-block" (L88)
       ❌ uses container syntax
       .github/workflows/triage.yml:88

📄 .github/workflows/stale-issues.yml
  ❌ Cannot migrate (2 job(s)):
     • "stale" (L34)
       ❌ does not run on ubuntu-latest
       .github/workflows/stale-issues.yml:34
     • "bump-pr-stale" (L64)
       ❌ does not run on ubuntu-latest
       .github/workflows/stale-issues.yml:64

📄 .github/workflows/remove-unused-patches.yml
  ✅ Safe to migrate (1 job(s)):
     • "create-issue" (L149) - Last execution time: 3s
       .github/workflows/remove-unused-patches.yml:149
  ❌ Cannot migrate (1 job(s)):
     • "remove-unused-patches" (L29)
       ❌ uses container syntax
       .github/workflows/remove-unused-patches.yml:29

📄 .github/workflows/dispatch-build-bottle.yml
  ✅ Safe to migrate (1 job(s)):
     • "comment" (L347) - Last execution time: 0s
       .github/workflows/dispatch-build-bottle.yml:347
  ❌ Cannot migrate (3 job(s)):
     • "prepare" (L55)
       ❌ uses container syntax
       .github/workflows/dispatch-build-bottle.yml:55
     • "bottle" (L144)
       ❌ does not run on ubuntu-latest
       .github/workflows/dispatch-build-bottle.yml:144
     • "upload" (L200)
       ❌ uses container syntax
       .github/workflows/dispatch-build-bottle.yml:200

📄 .github/workflows/triage-ci.yml
  ✅ Safe to migrate (1 job(s)):
     • "comment" (L27) - Last execution time: 6s
       .github/workflows/triage-ci.yml:27

📄 .github/workflows/automerge.yml
  ✅ Safe to migrate (1 job(s)):
     • "status-check" (L28) - Last execution time: 1m25s
       .github/workflows/automerge.yml:28
  ❌ Cannot migrate (1 job(s)):
     • "merge" (L176)
       ❌ uses container syntax
       .github/workflows/automerge.yml:176

✅ 20 job(s) can be safely migrated
⚠️  4 job(s) can be migrated but require attention
❌ 29 job(s) cannot be migrated
📊 Total: 24 job(s) eligible for migration
```