### PR TITLE
git-flow: deprecate

### DIFF
--- a/Formula/g/git-flow.rb
+++ b/Formula/g/git-flow.rb
@@ -41,6 +41,8 @@ class GitFlow < Formula
     end
   end
 
+  deprecate! date: "2025-12-19", because: :repo_archived
+
   def install
     (buildpath/"shFlags").install resource("shFlags")
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Repository archived 2025-10-14.
[git-flow-next](https://github.com/gittower/git-flow-next) is linked by archived repo as a replacement, but does not yet have a formula in homebrew-core.