### PR TITLE
octodns 1.15.0 (new formula)

### DIFF
--- a/Formula/o/octodns.rb
+++ b/Formula/o/octodns.rb
@@ -1,0 +1,89 @@
+class Octodns < Formula
+  include Language::Python::Virtualenv
+
+  desc "Tools for managing DNS across multiple providers"
+  homepage "https://github.com/octodns/octodns"
+  url "https://files.pythonhosted.org/packages/4d/f4/36bfd365e93d16cd1ec537f93d2197b1671d6d68be1547c489045d4497c5/octodns-1.15.0.tar.gz"
+  sha256 "cf8a04bc236f9aca1b72820615db47ad35930e29314ae0a707fc17d8d6cf2659"
+  license "MIT"
+  head "https://github.com/octodns/octodns.git", branch: "main"
+
+  depends_on "libyaml"
+  depends_on "python@3.14"
+
+  resource "dnspython" do
+    url "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz"
+    sha256 "181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f"
+  end
+
+  resource "fqdn" do
+    url "https://files.pythonhosted.org/packages/30/3e/a80a8c077fd798951169626cde3e239adeba7dab75deb3555716415bd9b0/fqdn-1.5.1.tar.gz"
+    sha256 "105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f"
+  end
+
+  resource "idna" do
+    url "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz"
+    sha256 "795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902"
+  end
+
+  resource "natsort" do
+    url "https://files.pythonhosted.org/packages/e2/a9/a0c57aee75f77794adaf35322f8b6404cbd0f89ad45c87197a937764b7d0/natsort-8.4.0.tar.gz"
+    sha256 "45312c4a0e5507593da193dedd04abb1469253b601ecaf63445ad80f0a1ea581"
+  end
+
+  resource "python-dateutil" do
+    url "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz"
+    sha256 "37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"
+  end
+
+  resource "pyyaml" do
+    url "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz"
+    sha256 "d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f"
+  end
+
+  resource "six" do
+    url "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz"
+    sha256 "ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"
+  end
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    %w[compare dump report sync validate versions].each do |cli|
+      assert_match version.to_s, shell_output("#{bin}/octodns-#{cli} --version")
+    end
+
+    zones_directory = testpath/"zones"
+    zones_directory.mkpath
+    (testpath/"config.yml").write <<~YAML
+      providers:
+        config:
+          class: octodns.provider.yaml.YamlProvider
+          directory: #{zones_directory}
+      zones:
+        example.org.:
+          sources:
+            - config
+    YAML
+
+    (testpath/"zones/example.org.yml").write <<~YAML
+      '':
+        type: A
+        value: 127.0.0.1
+    YAML
+
+    output = shell_output("#{bin}/octodns-validate --config-file #{testpath}/config.yml 2>&1", 1)
+    assert_match "ProviderException: no YAMLs found for example.org", output
+
+    (testpath/"invalid_config.yml").write <<~YAML
+      '':
+        type: INVALID_TYPE
+        value: not-valid
+    YAML
+
+    output = shell_output("#{bin}/octodns-validate --config-file #{testpath}/invalid_config.yml 2>&1", 1)
+    assert_match "KeyError", output
+  end
+end

--- a/Formula/o/octodns.rb
+++ b/Formula/o/octodns.rb
@@ -8,6 +8,15 @@ class Octodns < Formula
   license "MIT"
   head "https://github.com/octodns/octodns.git", branch: "main"
 
+  bottle do
+    sha256 cellar: :any,                 arm64_tahoe:   "c1061f5e2edc1f510078e849f33229f8982c20b2d7c4d247a202060fdc2b1cfe"
+    sha256 cellar: :any,                 arm64_sequoia: "b6568486aad3927a3846bda48072d1657f97f6ca30b056e96ed974bcf7c7df4a"
+    sha256 cellar: :any,                 arm64_sonoma:  "ff4bcac0dce9b61868919a337c116fdfee0775f5bc64f4f9d1bd60d5c95dfcf6"
+    sha256 cellar: :any,                 sonoma:        "ec06d5d4b8935b79f8cea55dd92b0168f3b0ad1371b012649c30edb4f5e5870d"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "903ae2c41cb66dd3f671f4ed6854079dfcf7e227a2a198470afb299966f70648"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c803d32de899f47f7f5208f74e499c1473d92c9314fcd1f0acc3f007691f73d0"
+  end
+
   depends_on "libyaml"
   depends_on "python@3.14"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/octodns/octodns is a commonly used infrastructure as code tool for managing DNS records across multiple providers. This PR adds a formula to homebrew for octodns, which normally requires installation via `pip`.

This is my first contribution to `homebrew`, so please let me know if this is in the wrong place or there's anything that needs changing!
