### PR TITLE
tronbyt-server 2.0.0 (new formula)

### DIFF
--- a/Formula/t/tronbyt-server.rb
+++ b/Formula/t/tronbyt-server.rb
@@ -6,6 +6,15 @@ class TronbytServer < Formula
   license "Apache-2.0"
   head "https://github.com/tronbyt/server.git", branch: "main"
 
+  bottle do
+    sha256 cellar: :any,                 arm64_tahoe:   "86dd78a8619d0133c1ebeca1cb2a756a437ed2f65dd8e8e6dc79b53c25452e9f"
+    sha256 cellar: :any,                 arm64_sequoia: "926d6424760354e0b3261b0271b2ff62ee80b5fcdc7cd4ad68006de9ed9b6848"
+    sha256 cellar: :any,                 arm64_sonoma:  "b001f37a0f15f03ac9d89ba0a96d60fcffb78a65ae8f99aa4072fa044feb07be"
+    sha256 cellar: :any,                 sonoma:        "4ad66c3652911b4f6b7826a0349556e9e7e64efa3c5639791f6dc97ab8f8fb63"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "942d32e8273792f90e4694488abcffa35f91deb8c7ab4462e98e1d9dafeb74ec"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1b413339961fd7bf1b31b3c0cabc39935053a032dbaefef5c040a343e9a48e56"
+  end
+
   depends_on "go" => :build
   depends_on "pkgconf" => :build
   depends_on "webp"

--- a/Formula/t/tronbyt-server.rb
+++ b/Formula/t/tronbyt-server.rb
@@ -1,0 +1,71 @@
+class TronbytServer < Formula
+  desc "Manage your apps on your Tronbyt (flashed Tidbyt) completely locally"
+  homepage "https://github.com/tronbyt/server"
+  url "https://github.com/tronbyt/server/archive/refs/tags/v2.0.0.tar.gz"
+  sha256 "aa8c9a5723edc79b78fd0dd94f50a1f5f0cdaa3a489fb623d072cc02e191be3a"
+  license "Apache-2.0"
+  head "https://github.com/tronbyt/server.git", branch: "main"
+
+  depends_on "go" => :build
+  depends_on "pkgconf" => :build
+  depends_on "webp"
+
+  def install
+    ENV["CGO_ENABLED"] = "1" if OS.linux? && Hardware::CPU.arm?
+
+    commit = build.head? ? Utils.git_short_head : tap.user.to_s
+    ldflags = %W[
+      -s -w
+      -X tronbyt-server/internal/version.Version=#{version}
+      -X tronbyt-server/internal/version.Commit=#{commit}
+      -X tronbyt-server/internal/version.BuildDate=#{time.iso8601}
+    ]
+    system "go", "build", *std_go_args(ldflags:), "./cmd/server"
+
+    (var/"tronbyt-server/.env").write <<~EOS
+      # Add application configuration here.
+      # For example:
+      # LOG_LEVEL=INFO
+    EOS
+  end
+
+  def caveats
+    <<~EOS
+      Application configuration should be placed in:
+        #{var}/tronbyt-server/.env
+    EOS
+  end
+
+  service do
+    run opt_bin/"tronbyt-server"
+    keep_alive true
+    log_path var/"log/tronbyt-server.log"
+    error_log_path var/"log/tronbyt-server.log"
+    working_dir var/"tronbyt-server"
+  end
+
+  test do
+    port = free_port
+    log_file = testpath/"tronbyt_server.log"
+    (testpath/"data").mkpath
+    File.open(log_file, "w") do |file|
+      pid = spawn(
+        {
+          "PRODUCTION"   => "0",
+          "TRONBYT_PORT" => port.to_s,
+        },
+        bin/"tronbyt-server",
+        out: file,
+        err: file,
+      )
+      sleep 5
+      30.times do
+        sleep 1
+        break if log_file.read.include?("Listening on TCP")
+      end
+    ensure
+      Process.kill("TERM", pid)
+      Process.wait(pid)
+    end
+  end
+end


### PR DESCRIPTION
The Tronbyt Server is a Go-based application designed to manage apps on Tronbyt devices locally, without relying on Tidbyt's backend servers. It offers a web UI for app discoverability and operates independently of cloud dependencies, ensuring continued functionality even if Tidbyt's servers are offline. The server also enables some APIs that were previously blocked by Tidbyt's servers, such as Surfline apps, and supports custom hardware.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
