### PR TITLE
pony-language-server 0.2.2 (new formula)

### DIFF
--- a/Formula/p/pony-language-server.rb
+++ b/Formula/p/pony-language-server.rb
@@ -1,0 +1,37 @@
+class PonyLanguageServer < Formula
+  desc "Language server for Pony"
+  homepage "https://github.com/ponylang/pony-language-server"
+  url "https://github.com/ponylang/pony-language-server/archive/refs/tags/0.2.2.tar.gz"
+  sha256 "80697b23d7aa8e98a474e4aa6cb552c59171217ab0fa400c9f912fa8a08d0cae"
+  license "MIT"
+  head "https://github.com/ponylang/pony-language-server.git", branch: "main"
+
+  depends_on "corral" => :build
+  depends_on "ponyc" => :build
+
+  def install
+    system "make", "language_server"
+    bin.install "build/release/pony-lsp"
+  end
+
+  test do
+    require "open3"
+
+    json = <<~JSON
+      {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+          "rootUri": null,
+          "capabilities": {}
+        }
+      }
+    JSON
+
+    Open3.popen3(bin/"pony-lsp") do |stdin, stdout|
+      stdin.write "Content-Length: #{json.size}\r\n\r\n#{json}"
+      assert_match(/^Content-Length: \d+/i, stdout.readline)
+    end
+  end
+end

--- a/Formula/p/pony-language-server.rb
+++ b/Formula/p/pony-language-server.rb
@@ -6,6 +6,15 @@ class PonyLanguageServer < Formula
   license "MIT"
   head "https://github.com/ponylang/pony-language-server.git", branch: "main"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "4f60d5a06961779fc4e76ec4812e0dd5b5f2c2b47e0ba5de68ede41e7a9145cc"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e2fd0cb00af203cd447072ca33793e773b2e10cf893568b8bdbec29b56456d81"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "a3e32a0caa61451f6c6ae5e7817be7a72db317932d33a93bc3c3b0bdeeb8d558"
+    sha256 cellar: :any_skip_relocation, sonoma:        "11b338e57a2671b0187a4ef14332ee6729390dbc5d3497e8a1fd7392c203ab77"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "ee42c413ed4c9377b2277d93dd955c5b17ade08ebafa47d2e0d8d27b36ff612a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "364ecccee334c255b515a75e868708a6c0ac4e0eb4cfe1ba98db7fe46fc29874"
+  end
+
   depends_on "corral" => :build
   depends_on "ponyc" => :build
 


### PR DESCRIPTION
The language server (LSP) for the Pony programming language.

https://github.com/ponylang/pony-language-server

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

```
❯ brew audit --new pony-language-server
pony-language-server
  * GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)
Error: 1 problem in 1 formula detected.
```

Given there are formulae for `ponyc` and `corral`, I propose we add the LSP for the Pony language (https://github.com/ponylang), even though the GitHub repository is 'not notable enough'.
