### PR TITLE
tronbyt-server: handle existing config files

### DIFF
--- a/Formula/t/tronbyt-server.rb
+++ b/Formula/t/tronbyt-server.rb
@@ -7,12 +7,13 @@ class TronbytServer < Formula
   head "https://github.com/tronbyt/server.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "27a2e16e65d019ddfca118b6a605f4269c51b480e7ddad61542bb67baa4bd661"
-    sha256 cellar: :any,                 arm64_sequoia: "68a6401915ca2ea4a25942ca19af3cfc25a4ceee17ab329ecc0b492ce5d1ea26"
-    sha256 cellar: :any,                 arm64_sonoma:  "694fb1c30f88ca46ab4cd9fd2b771f5fb70abdc7b304b4cb8a622ae17b49194d"
-    sha256 cellar: :any,                 sonoma:        "2c3019d83299ac73baa7d716cb685e08146227deadfb4d4943540c851118bebb"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "3197e73468d9479d115daa38ddbfc2b096b92894d8d872ea4f8d8aa6c821db1f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a3a48a5ff884660e3f54ffa2f0c539638bf783ef5f38fa7691f328e8c7f287a1"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "2abc50ddf450310e259a0c96158706e8cdde12fb9e9730e9e5ab76ad2ce6fb40"
+    sha256 cellar: :any,                 arm64_sequoia: "0b9d5e001f84ea4d411766a35d235c2028cee58be7464ad6572e6178cd187901"
+    sha256 cellar: :any,                 arm64_sonoma:  "31cfe7c54eb8bf45cb2218ff23fb0f073aef847b218de9bc491611edb3836aed"
+    sha256 cellar: :any,                 sonoma:        "e42d555585c5c621ee39f717f39e887fdc411e47294ec7752280504ba47cb13b"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "49b31d97fe3cc84cec4ad6ad7aaeaf81e2921d18e3bacd5a0ee7e8d8a0e344a1"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "eb2b2a67ea78646c53edb69ece17ae068e18558c7bd0188fb4bfcabd0d9dd789"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
Quick follow up on
https://github.com/Homebrew/homebrew-core/pull/259630: only create the .env file if it doesn't exist to avoid this error on upgrades:

```
Error: An exception occurred within a child process:
  RuntimeError: Will not overwrite /opt/homebrew/var/tronbyt-server/.env
```

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
