### PR TITLE
dump1090-mutability: fetch over HTTPS

### DIFF
--- a/Formula/d/dump1090-mutability.rb
+++ b/Formula/d/dump1090-mutability.rb
@@ -1,7 +1,7 @@
 class Dump1090Mutability < Formula
   desc "ADS-B Ground Station System for RTL-SDR"
   homepage "https://packages.ubuntu.com/jammy/dump1090-mutability"
-  url "http://archive.ubuntu.com/ubuntu/pool/universe/d/dump1090-mutability/dump1090-mutability_1.15~20180310.4a16df3+dfsg.orig.tar.gz"
+  url "https://archive.ubuntu.com/ubuntu/pool/universe/d/dump1090-mutability/dump1090-mutability_1.15~20180310.4a16df3+dfsg.orig.tar.gz"
   version "1.15_20180310-4a16df3-dfsg"
   sha256 "778f389508eccbce6c90d7f56cd01568fad2aaa5618cb5e7c41640a2473905a6"
   license "GPL-2.0-or-later"
@@ -11,8 +11,6 @@ class Dump1090Mutability < Formula
     url :homepage
     regex(/href=.*?dump1090-mutability[._-]v?(\d+(?:\.\d+)+(?:~\d{8})?(?:\.\h+)?(?:\+\w+)?)\.orig\.t/i)
   end
-
-  no_autobump! because: :requires_manual_review
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "00215d003f5feb6d06804af98583d30188d88272597822635e40defb033f9655"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
