### PR TITLE
fcrackzip: update urls

### DIFF
--- a/Formula/f/fcrackzip.rb
+++ b/Formula/f/fcrackzip.rb
@@ -1,12 +1,12 @@
 class Fcrackzip < Formula
   desc "Zip password cracker"
-  homepage "http://oldhome.schmorp.de/marc/fcrackzip.html"
-  url "http://oldhome.schmorp.de/marc/data/fcrackzip-1.0.tar.gz"
+  homepage "https://oldhome.schmorp.de/marc/fcrackzip.html"
+  url "https://oldhome.schmorp.de/marc/data/fcrackzip-1.0.tar.gz"
   sha256 "4a58c8cb98177514ba17ee30d28d4927918bf0bdc3c94d260adfee44d2d43850"
   license "GPL-2.0-or-later"
 
   livecheck do
-    url "http://oldhome.schmorp.de/marc/data/"
+    url "https://oldhome.schmorp.de/marc/data/"
     regex(/href=.*?fcrackzip[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing homepage, stable, and `livecheck` block URLs for `fcrackzip` use HTTP and can use HTTPS, so this updates the URLs accordingly.