### PR TITLE
links: update urls

### DIFF
--- a/Formula/l/links.rb
+++ b/Formula/l/links.rb
@@ -1,12 +1,12 @@
 class Links < Formula
   desc "Lynx-like WWW browser that supports tables, menus, etc."
-  homepage "http://links.twibright.com/"
-  url "http://links.twibright.com/download/links-2.30.tar.bz2"
+  homepage "https://links.twibright.com/"
+  url "https://links.twibright.com/download/links-2.30.tar.bz2"
   sha256 "c4631c6b5a11527cdc3cb7872fc23b7f2b25c2b021d596be410dadb40315f166"
   license "GPL-2.0-or-later" => { with: "openvpn-openssl-exception" }
 
   livecheck do
-    url "http://links.twibright.com/download.php"
+    url "https://links.twibright.com/download.php"
     regex(/Current version is v?(\d+(?:\.\d+)+)\. /i)
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing homepage, stable, and `livecheck` block URLs for `links` use HTTP and can use HTTPS, so this updates the URLs accordingly.