### PR TITLE
liblzf: update urls

### DIFF
--- a/Formula/lib/liblzf.rb
+++ b/Formula/lib/liblzf.rb
@@ -1,7 +1,7 @@
 class Liblzf < Formula
   desc "Very small, very fast data compression library"
-  homepage "http://oldhome.schmorp.de/marc/liblzf.html"
-  url "http://dist.schmorp.de/liblzf/liblzf-3.6.tar.gz"
+  homepage "https://oldhome.schmorp.de/marc/liblzf.html"
+  url "https://dist.schmorp.de/liblzf/liblzf-3.6.tar.gz"
   mirror "https://deb.debian.org/debian/pool/main/libl/liblzf/liblzf_3.6.orig.tar.gz"
   sha256 "9c5de01f7b9ccae40c3f619d26a7abec9986c06c36d260c179cedd04b89fb46a"
   license all_of: [
@@ -10,7 +10,7 @@ class Liblzf < Formula
   ]
 
   livecheck do
-    url "http://dist.schmorp.de/liblzf/"
+    url "https://dist.schmorp.de/liblzf/"
     regex(/href=.*?liblzf[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing homepage, stable, and `livecheck` block URLs for `liblzf` use HTTP and can use HTTPS, so this updates the URLs accordingly.