### PR TITLE
newlisp: update urls

### DIFF
--- a/Formula/n/newlisp.rb
+++ b/Formula/n/newlisp.rb
@@ -1,12 +1,12 @@
 class Newlisp < Formula
   desc "Lisp-like, general-purpose scripting language"
-  homepage "http://www.newlisp.org/"
-  url "http://www.newlisp.org/downloads/newlisp-10.7.5.tgz"
+  homepage "https://www.newlisp.org/"
+  url "https://www.newlisp.org/downloads/newlisp-10.7.5.tgz"
   sha256 "dc2d0ff651c2b275bc4af3af8ba59851a6fb6e1eaddc20ae75fb60b1e90126ec"
   license "GPL-3.0-or-later"
 
   livecheck do
-    url "http://www.newlisp.org/index.cgi?Downloads"
+    url "https://www.newlisp.org/index.cgi?Downloads"
     regex(/href=.*?newlisp[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The homepage, stable, and `livecheck` block URLs for `newlisp` use HTTP and can use HTTPS, so this updates the URLs accordingly.