### PR TITLE
patchutils: update urls

### DIFF
--- a/Formula/p/patchutils.rb
+++ b/Formula/p/patchutils.rb
@@ -1,13 +1,13 @@
 class Patchutils < Formula
   desc "Small collection of programs that operate on patch files"
-  homepage "http://cyberelk.net/tim/software/patchutils/"
-  url "http://cyberelk.net/tim/data/patchutils/stable/patchutils-0.4.3.tar.xz"
+  homepage "https://cyberelk.net/tim/software/patchutils/"
+  url "https://cyberelk.net/tim/data/patchutils/stable/patchutils-0.4.3.tar.xz"
   mirror "https://deb.debian.org/debian/pool/main/p/patchutils/patchutils_0.4.3.orig.tar.xz"
   sha256 "0efc96a9565fd156fc1064fdcc54c82b6229db0d402827c4c48b02f6ef956445"
   license all_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later"]
 
   livecheck do
-    url "http://cyberelk.net/tim/data/patchutils/stable/"
+    url "https://cyberelk.net/tim/data/patchutils/stable/"
     regex(/href=.*?patchutils[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The homepage, stable, and `livecheck` block URLs for `patchutils` use HTTP and can use HTTPS, so this updates the URLs accordingly.