### PR TITLE
rxvt-unicode: update urls

### DIFF
--- a/Formula/r/rxvt-unicode.rb
+++ b/Formula/r/rxvt-unicode.rb
@@ -1,13 +1,13 @@
 class RxvtUnicode < Formula
   desc "Rxvt fork with Unicode support"
-  homepage "http://software.schmorp.de/pkg/rxvt-unicode.html"
-  url "http://dist.schmorp.de/rxvt-unicode/rxvt-unicode-9.31.tar.bz2"
+  homepage "https://software.schmorp.de/pkg/rxvt-unicode.html"
+  url "https://dist.schmorp.de/rxvt-unicode/rxvt-unicode-9.31.tar.bz2"
   sha256 "aaa13fcbc149fe0f3f391f933279580f74a96fd312d6ed06b8ff03c2d46672e8"
   license "GPL-3.0-only"
   revision 2
 
   livecheck do
-    url "http://dist.schmorp.de/rxvt-unicode/"
+    url "https://dist.schmorp.de/rxvt-unicode/"
     regex(/href=.*?rxvt-unicode[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
@@ -42,7 +42,7 @@ class RxvtUnicode < Formula
   end
 
   resource "libptytty" do
-    url "http://dist.schmorp.de/libptytty/libptytty-2.0.tar.gz"
+    url "https://dist.schmorp.de/libptytty/libptytty-2.0.tar.gz"
     sha256 "8033ed3aadf28759660d4f11f2d7b030acf2a6890cb0f7926fb0cfa6739d31f7"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The homepage, stable, `livecheck` block, and resource URLs for `rxvt-unicode` use HTTP and can use HTTPS, so this updates the URLs accordingly.