### PR TITLE
ucon64: update test resource url

### DIFF
--- a/Formula/u/ucon64.rb
+++ b/Formula/u/ucon64.rb
@@ -61,7 +61,7 @@ class Ucon64 < Formula
 
   test do
     resource "homebrew-super_bat_puncher_demo" do
-      url "http://morphcat.de/superbatpuncher/Super%20Bat%20Puncher%20Demo.zip"
+      url "https://morphcat.de/superbatpuncher/Super%20Bat%20Puncher%20Demo.zip"
       sha256 "d74cb3ba11a4ef5d0f8d224325958ca1203b0d8bb4a7a79867e412d987f0b846"
     end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The test resource URL for `ucon64` uses HTTP and can use HTTPS, so this updates the URL accordingly.