### PR TITLE
par: replace http tarball with bitbucket

### DIFF
--- a/Formula/p/par.rb
+++ b/Formula/p/par.rb
@@ -1,8 +1,8 @@
 class Par < Formula
   desc "Paragraph reflow for email"
   homepage "http://www.nicemice.net/par/"
-  url "http://www.nicemice.net/par/Par-1.53.0.tar.gz"
-  sha256 "c809c620eb82b589553ac54b9898c8da55196d262339d13c046f2be44ac47804"
+  url "https://bitbucket.org/amc-nicemice/par/get/1.53.0.tar.bz2"
+  sha256 "6109b1811630e1e0e76fc87bf60ad9140440a145c9b4c9412fb36b4f73726a04"
   # par.doc includes a custom license and alternatively allows usage under MIT license
   license any_of: [:cannot_represent, "MIT"]
 
@@ -39,6 +39,6 @@ class Par < Formula
 
   test do
     expected = "homebrew\nhomebrew\n"
-    assert_equal expected, pipe_output("#{bin}/par 10gqr", "homebrew homebrew")
+    assert_equal expected, pipe_output("#{bin}/par 10gqr", "homebrew homebrew", 0)
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Listed at http://www.nicemice.net/par/#package. Although clicking download uses commit, it is possible to use tag instead:
```
❯ curl -sL https://bitbucket.org/amc-nicemice/par/get/eb0590f6bafc4f9e44a5ad7e0baadc29c69e79e7.tar.bz2 | sha256
6109b1811630e1e0e76fc87bf60ad9140440a145c9b4c9412fb36b4f73726a04

❯ curl -sL https://bitbucket.org/amc-nicemice/par/get/1.53.0.tar.bz2 | sha256
6109b1811630e1e0e76fc87bf60ad9140440a145c9b4c9412fb36b4f73726a04
```