### PR TITLE
gnu-prolog: use GNU https urls rather than http

### DIFF
--- a/Formula/g/gnu-prolog.rb
+++ b/Formula/g/gnu-prolog.rb
@@ -1,7 +1,8 @@
 class GnuProlog < Formula
   desc "Prolog compiler with constraint solving"
   homepage "http://www.gprolog.org/"
-  url "http://www.gprolog.org/gprolog-1.5.0.tar.gz"
+  url "https://ftpmirror.gnu.org/gnu/gprolog/gprolog-1.5.0.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/gprolog/gprolog-1.5.0.tar.gz"
   sha256 "670642b43c0faa27ebd68961efb17ebe707688f91b6809566ddd606139512c01"
   license any_of: ["LGPL-3.0-or-later", "GPL-2.0-or-later"]
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Official alternate location http://www.gprolog.org/#download
> Some of these files can also be downloaded from the primary [GNU ftp site](https://ftp.gnu.org/gnu/gprolog/) or from any [mirror](https://ftpmirror.gnu.org/).