### PR TITLE
various: use `Pathname#glob` instead of `Dir[]`

### DIFF
--- a/Formula/a/action-docs.rb
+++ b/Formula/a/action-docs.rb
@@ -15,7 +15,7 @@ class ActionDocs < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/a/addons-linter.rb
+++ b/Formula/a/addons-linter.rb
@@ -13,7 +13,7 @@ class AddonsLinter < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/a/aicommit2.rb
+++ b/Formula/a/aicommit2.rb
@@ -13,7 +13,7 @@ class Aicommit2 < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/a/aicommits.rb
+++ b/Formula/a/aicommits.rb
@@ -16,7 +16,7 @@ class Aicommits < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/a/airtable-mcp-server.rb
+++ b/Formula/a/airtable-mcp-server.rb
@@ -13,7 +13,7 @@ class AirtableMcpServer < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/a/alexjs.rb
+++ b/Formula/a/alexjs.rb
@@ -23,7 +23,7 @@ class Alexjs < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/a/allure.rb
+++ b/Formula/a/allure.rb
@@ -21,7 +21,7 @@ class Allure < Formula
     rm(Dir["bin/*.bat"])
 
     libexec.install Dir["*"]
-    bin.install Dir["#{libexec}/bin/*"]
+    bin.install libexec.glob("bin/*")
     bin.env_script_all_files libexec/"bin", JAVA_HOME: Formula["openjdk"].opt_prefix
   end
 

--- a/Formula/a/alluxio.rb
+++ b/Formula/a/alluxio.rb
@@ -26,9 +26,9 @@ class Alluxio < Formula
 
   def install
     libexec.install Dir["*"]
-    bin.install Dir["#{libexec}/bin/*"]
+    bin.install libexec.glob("bin/*")
     bin.env_script_all_files libexec/"bin", Language::Java.overridable_java_home_env("11")
-    chmod "+x", Dir["#{libexec}/bin/*"]
+    chmod "+x", libexec.glob("bin/*")
 
     rm_r(Dir["#{etc}/alluxio/*"])
 

--- a/Formula/a/angular-cli.rb
+++ b/Formula/a/angular-cli.rb
@@ -13,7 +13,7 @@ class AngularCli < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/a/ansible-language-server.rb
+++ b/Formula/a/ansible-language-server.rb
@@ -24,7 +24,7 @@ class AnsibleLanguageServer < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/a/ant.rb
+++ b/Formula/a/ant.rb
@@ -30,7 +30,7 @@ class Ant < Formula
     rm Dir["bin/*.{bat,cmd,dll,exe}"]
 
     libexec.install Dir["*"]
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
     rm bin/"ant"
     (bin/"ant").write <<~SHELL
       #!/bin/bash

--- a/Formula/a/ant@1.9.rb
+++ b/Formula/a/ant@1.9.rb
@@ -22,7 +22,7 @@ class AntAT19 < Formula
   def install
     rm Dir["bin/*.{bat,cmd,dll,exe}"]
     libexec.install Dir["*"]
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
     rm bin/"ant"
     (bin/"ant").write <<~SHELL
       #!/bin/sh

--- a/Formula/a/apache-drill.rb
+++ b/Formula/a/apache-drill.rb
@@ -20,7 +20,7 @@ class ApacheDrill < Formula
   def install
     rm(Dir["bin/*.bat"])
     libexec.install Dir["*"]
-    bin.install Dir["#{libexec}/bin/*"]
+    bin.install libexec.glob("bin/*")
     bin.env_script_all_files(libexec/"bin", Language::Java.java_home_env("21"))
     rm(Dir["#{bin}/*.txt"])
   end

--- a/Formula/a/apidoc.rb
+++ b/Formula/a/apidoc.rb
@@ -26,7 +26,7 @@ class Apidoc < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/a/apify-cli.rb
+++ b/Formula/a/apify-cli.rb
@@ -15,7 +15,7 @@ class ApifyCli < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/a/appium.rb
+++ b/Formula/a/appium.rb
@@ -41,7 +41,7 @@ class Appium < Formula
     ENV["SHARP_FORCE_GLOBAL_LIBVIPS"] = "1"
 
     system "npm", "install", *std_npm_args(ignore_scripts: false), *resources.map(&:cached_download)
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     # Remove prebuilts which still get installed as optional dependencies
     rm_r(libexec.glob("lib/node_modules/appium/node_modules/@img/sharp-*"))

--- a/Formula/a/artillery.rb
+++ b/Formula/a/artillery.rb
@@ -23,7 +23,7 @@ class Artillery < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/a/asyncapi.rb
+++ b/Formula/a/asyncapi.rb
@@ -20,7 +20,7 @@ class Asyncapi < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     # Cleanup .pnpm folder
     node_modules = libexec/"lib/node_modules/@asyncapi/cli/node_modules"

--- a/Formula/a/autocode.rb
+++ b/Formula/a/autocode.rb
@@ -28,7 +28,7 @@ class Autocode < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/a/autorest.rb
+++ b/Formula/a/autorest.rb
@@ -14,7 +14,7 @@ class Autorest < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/a/aws-cdk.rb
+++ b/Formula/a/aws-cdk.rb
@@ -18,7 +18,7 @@ class AwsCdk < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     node_modules = libexec/"lib/node_modules/aws-cdk/node_modules"
     deuniversalize_machos node_modules/"fsevents/fsevents.node" if OS.mac?

--- a/Formula/b/backlog-md.rb
+++ b/Formula/b/backlog-md.rb
@@ -18,7 +18,7 @@ class BacklogMd < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/b/basex.rb
+++ b/Formula/b/basex.rb
@@ -26,7 +26,7 @@ class Basex < Formula
     rm_r("etc")
 
     libexec.install Dir["*"]
-    bin.install Dir["#{libexec}/bin/*"]
+    bin.install libexec.glob("bin/*")
     bin.env_script_all_files libexec/"bin", JAVA_HOME: Formula["openjdk"].opt_prefix
   end
 

--- a/Formula/b/bash-language-server.rb
+++ b/Formula/b/bash-language-server.rb
@@ -13,7 +13,7 @@ class BashLanguageServer < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/b/basti.rb
+++ b/Formula/b/basti.rb
@@ -18,7 +18,7 @@ class Basti < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     # Remove incompatible pre-built binary, session-manager-plugin
     node_modules = libexec/"lib/node_modules/basti/node_modules"

--- a/Formula/b/bcoin.rb
+++ b/Formula/b/bcoin.rb
@@ -32,7 +32,7 @@ class Bcoin < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/b/bibtex-tidy.rb
+++ b/Formula/b/bibtex-tidy.rb
@@ -13,7 +13,7 @@ class BibtexTidy < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/b/bower.rb
+++ b/Formula/b/bower.rb
@@ -27,7 +27,7 @@ class Bower < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/b/bumpp.rb
+++ b/Formula/b/bumpp.rb
@@ -13,7 +13,7 @@ class Bumpp < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/b/busted.rb
+++ b/Formula/b/busted.rb
@@ -26,7 +26,7 @@ class Busted < Formula
 
   def install
     system "luarocks", "make", "--tree=#{libexec}", "--local", "--lua-dir=#{Formula["lua"].opt_prefix}"
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/c/calm-cli.rb
+++ b/Formula/c/calm-cli.rb
@@ -13,7 +13,7 @@ class CalmCli < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/c/ccusage.rb
+++ b/Formula/c/ccusage.rb
@@ -13,7 +13,7 @@ class Ccusage < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/c/cdk8s.rb
+++ b/Formula/c/cdk8s.rb
@@ -13,7 +13,7 @@ class Cdk8s < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/c/chalk-cli.rb
+++ b/Formula/c/chalk-cli.rb
@@ -15,7 +15,7 @@ class ChalkCli < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/c/changelogen.rb
+++ b/Formula/c/changelogen.rb
@@ -13,7 +13,7 @@ class Changelogen < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/c/chrome-devtools-mcp.rb
+++ b/Formula/c/chrome-devtools-mcp.rb
@@ -13,7 +13,7 @@ class ChromeDevtoolsMcp < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     node_modules = libexec/"lib/node_modules/chrome-devtools-mcp/node_modules"
 

--- a/Formula/c/claude-cmd.rb
+++ b/Formula/c/claude-cmd.rb
@@ -13,7 +13,7 @@ class ClaudeCmd < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/c/claude-code-router.rb
+++ b/Formula/c/claude-code-router.rb
@@ -13,7 +13,7 @@ class ClaudeCodeRouter < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/c/claude-code-templates.rb
+++ b/Formula/c/claude-code-templates.rb
@@ -13,7 +13,7 @@ class ClaudeCodeTemplates < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/c/claude-hooks.rb
+++ b/Formula/c/claude-hooks.rb
@@ -13,7 +13,7 @@ class ClaudeHooks < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/c/claudekit.rb
+++ b/Formula/c/claudekit.rb
@@ -13,7 +13,7 @@ class Claudekit < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/c/coffeescript.rb
+++ b/Formula/c/coffeescript.rb
@@ -19,7 +19,7 @@ class Coffeescript < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/c/commitlint.rb
+++ b/Formula/c/commitlint.rb
@@ -13,7 +13,7 @@ class Commitlint < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/c/contentful-cli.rb
+++ b/Formula/c/contentful-cli.rb
@@ -18,7 +18,7 @@ class ContentfulCli < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/c/context7-mcp.rb
+++ b/Formula/c/context7-mcp.rb
@@ -13,7 +13,7 @@ class Context7Mcp < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/c/corepack.rb
+++ b/Formula/c/corepack.rb
@@ -22,7 +22,7 @@ class Corepack < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/c/cortexso.rb
+++ b/Formula/c/cortexso.rb
@@ -33,7 +33,7 @@ class Cortexso < Formula
 
   def install
     system "npm", "install", "--sqlite=#{Formula["sqlite"].opt_prefix}", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     # Replace pre-built binaries
     rm_r(libexec/"lib/node_modules/cortexso/node_modules/cpu-instructions/prebuilds")

--- a/Formula/c/cqlkit.rb
+++ b/Formula/c/cqlkit.rb
@@ -17,7 +17,7 @@ class Cqlkit < Formula
   def install
     libexec.install %w[bin lib]
     rm(Dir["#{libexec}/bin/*.bat"])
-    bin.install Dir["#{libexec}/bin/*"]
+    bin.install libexec.glob("bin/*")
     bin.env_script_all_files libexec/"bin", Language::Java.overridable_java_home_env
   end
 

--- a/Formula/c/cubejs-cli.rb
+++ b/Formula/c/cubejs-cli.rb
@@ -19,7 +19,7 @@ class CubejsCli < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     node_modules = libexec/"lib/node_modules/cubejs-cli/node_modules"
     deuniversalize_machos node_modules/"fsevents/fsevents.node" if OS.mac?

--- a/Formula/c/czg.rb
+++ b/Formula/c/czg.rb
@@ -13,7 +13,7 @@ class Czg < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/d/dbml-cli.rb
+++ b/Formula/d/dbml-cli.rb
@@ -18,7 +18,7 @@ class DbmlCli < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     # Remove incompatible pre-built binaries
     os = OS.kernel_name.downcase

--- a/Formula/d/devcontainer.rb
+++ b/Formula/d/devcontainer.rb
@@ -13,7 +13,7 @@ class Devcontainer < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/d/dicebear.rb
+++ b/Formula/d/dicebear.rb
@@ -39,7 +39,7 @@ class Dicebear < Formula
   def install
     ENV["SHARP_FORCE_GLOBAL_LIBVIPS"] = "1"
     system "npm", "install", *std_npm_args, *resources.map(&:cached_download)
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     # Remove prebuilts which still get installed as optional dependencies
     rm_r(libexec.glob("lib/node_modules/dicebear/node_modules/@img/sharp-*"))

--- a/Formula/d/docker-compose-langserver.rb
+++ b/Formula/d/docker-compose-langserver.rb
@@ -13,7 +13,7 @@ class DockerComposeLangserver < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/d/dockerfile-language-server.rb
+++ b/Formula/d/dockerfile-language-server.rb
@@ -13,7 +13,7 @@ class DockerfileLanguageServer < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/d/dockly.rb
+++ b/Formula/d/dockly.rb
@@ -24,7 +24,7 @@ class Dockly < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     clipboardy_fallbacks_dir = libexec/"lib/node_modules/#{name}/node_modules/clipboardy/fallbacks"
     rm_r(clipboardy_fallbacks_dir) # remove pre-built binaries

--- a/Formula/d/docmd.rb
+++ b/Formula/d/docmd.rb
@@ -14,7 +14,7 @@ class Docmd < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     # Remove pre-built binaries
     rm_r(libexec/"lib/node_modules/@mgks/docmd/node_modules/@esbuild")

--- a/Formula/d/dtsroll.rb
+++ b/Formula/d/dtsroll.rb
@@ -20,7 +20,7 @@ class Dtsroll < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/e/e2b.rb
+++ b/Formula/e/e2b.rb
@@ -13,7 +13,7 @@ class E2b < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/e/eask-cli.rb
+++ b/Formula/e/eask-cli.rb
@@ -13,7 +13,7 @@ class EaskCli < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/e/eleventy.rb
+++ b/Formula/e/eleventy.rb
@@ -14,7 +14,7 @@ class Eleventy < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/e/eslint_d.rb
+++ b/Formula/e/eslint_d.rb
@@ -14,7 +14,7 @@ class EslintD < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   service do

--- a/Formula/f/fantom.rb
+++ b/Formula/f/fantom.rb
@@ -21,8 +21,8 @@ class Fantom < Formula
     inreplace "etc/build/config.props", %r{//jdkHome=/System.*$}, "jdkHome=#{java_home}"
 
     libexec.install Dir["*"]
-    chmod 0755, Dir["#{libexec}/bin/*"]
-    bin.install Dir["#{libexec}/bin/*"]
+    chmod 0755, libexec.glob("bin/*")
+    bin.install libexec.glob("bin/*")
     bin.env_script_all_files libexec/"bin", JAVA_HOME: java_home
   end
 

--- a/Formula/f/flamebearer.rb
+++ b/Formula/f/flamebearer.rb
@@ -16,7 +16,7 @@ class Flamebearer < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/g/gemini-cli.rb
+++ b/Formula/g/gemini-cli.rb
@@ -22,7 +22,7 @@ class GeminiCli < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     # Remove incompatible pre-built binaries
     os = OS.kernel_name.downcase

--- a/Formula/g/generate-json-schema.rb
+++ b/Formula/g/generate-json-schema.rb
@@ -17,7 +17,7 @@ class GenerateJsonSchema < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/g/git-mob.rb
+++ b/Formula/g/git-mob.rb
@@ -14,7 +14,7 @@ class GitMob < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/g/git-split-diffs.rb
+++ b/Formula/g/git-split-diffs.rb
@@ -13,7 +13,7 @@ class GitSplitDiffs < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/g/glassfish.rb
+++ b/Formula/g/glassfish.rb
@@ -26,7 +26,7 @@ class Glassfish < Formula
     rm_r(Dir["bin/*.bat", "glassfish/bin/*.bat"])
 
     libexec.install Dir["*"]
-    bin.install Dir["#{libexec}/bin/*"]
+    bin.install libexec.glob("bin/*")
 
     env = Language::Java.overridable_java_home_env("21")
     env["GLASSFISH_HOME"] = libexec

--- a/Formula/g/grails.rb
+++ b/Formula/g/grails.rb
@@ -25,7 +25,7 @@ class Grails < Formula
     rm Dir["bin/*.bat"]
 
     libexec.install Dir["*"]
-    bin.install Dir["#{libexec}/bin/*"]
+    bin.install libexec.glob("bin/*")
     bin.env_script_all_files libexec/"bin", Language::Java.java_home_env(java_version)
   end
 

--- a/Formula/g/graphql-cli.rb
+++ b/Formula/g/graphql-cli.rb
@@ -24,7 +24,7 @@ class GraphqlCli < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/g/graphql-inspector.rb
+++ b/Formula/g/graphql-inspector.rb
@@ -13,7 +13,7 @@ class GraphqlInspector < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/g/graphqlviz.rb
+++ b/Formula/g/graphqlviz.rb
@@ -16,7 +16,7 @@ class Graphqlviz < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/g/graphqurl.rb
+++ b/Formula/g/graphqurl.rb
@@ -14,7 +14,7 @@ class Graphqurl < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     # Build an `:all` bottle by removing log file.
     node_modules = libexec/"lib/node_modules/graphqurl/node_modules"

--- a/Formula/g/groovy.rb
+++ b/Formula/g/groovy.rb
@@ -23,7 +23,7 @@ class Groovy < Formula
     rm(Dir["bin/*.bat"])
 
     libexec.install "bin", "conf", "lib"
-    bin.install Dir["#{libexec}/bin/*"] - ["#{libexec}/bin/groovy.ico"]
+    bin.install libexec.glob("bin/*") - ["#{libexec}/bin/groovy.ico"]
     bin.env_script_all_files libexec/"bin", Language::Java.overridable_java_home_env
   end
 

--- a/Formula/g/grunt-cli.rb
+++ b/Formula/g/grunt-cli.rb
@@ -16,7 +16,7 @@ class GruntCli < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/g/gulp-cli.rb
+++ b/Formula/g/gulp-cli.rb
@@ -14,7 +14,7 @@ class GulpCli < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/h/haraka.rb
+++ b/Formula/h/haraka.rb
@@ -18,7 +18,7 @@ class Haraka < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/h/heroku.rb
+++ b/Formula/h/heroku.rb
@@ -22,7 +22,7 @@ class Heroku < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     node_modules = libexec/"lib/node_modules/heroku/node_modules"
     # Remove vendored pre-built binary `terminal-notifier`

--- a/Formula/h/hexo.rb
+++ b/Formula/h/hexo.rb
@@ -15,7 +15,7 @@ class Hexo < Formula
   def install
     mkdir_p libexec/"lib"
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/h/hf-mcp-server.rb
+++ b/Formula/h/hf-mcp-server.rb
@@ -18,7 +18,7 @@ class HfMcpServer < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     node_modules = libexec/"lib/node_modules/@llmindset/hf-mcp-server/node_modules"
     deuniversalize_machos node_modules/"fsevents/fsevents.node" if OS.mac?

--- a/Formula/h/htmlhint.rb
+++ b/Formula/h/htmlhint.rb
@@ -13,7 +13,7 @@ class Htmlhint < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/h/http-server.rb
+++ b/Formula/h/http-server.rb
@@ -19,7 +19,7 @@ class HttpServer < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/i/immich-cli.rb
+++ b/Formula/i/immich-cli.rb
@@ -13,7 +13,7 @@ class ImmichCli < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/i/install-peerdeps.rb
+++ b/Formula/i/install-peerdeps.rb
@@ -13,7 +13,7 @@ class InstallPeerdeps < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/i/ios-sim.rb
+++ b/Formula/i/ios-sim.rb
@@ -18,7 +18,7 @@ class IosSim < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     # Build an `:all` bottle
     node_modules = libexec/"lib/node_modules/ios-sim/node_modules"

--- a/Formula/j/jhipster.rb
+++ b/Formula/j/jhipster.rb
@@ -21,7 +21,7 @@ class Jhipster < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install Dir["#{libexec}/bin/*"]
+    bin.install libexec.glob("bin/*")
     bin.env_script_all_files libexec/"bin", Language::Java.overridable_java_home_env
   end
 

--- a/Formula/j/jolie.rb
+++ b/Formula/j/jolie.rb
@@ -16,7 +16,7 @@ class Jolie < Formula
     "-jar", "jolie-#{version}.jar",
     "--jolie-home", libexec,
     "--jolie-launchers", libexec/"bin"
-    bin.install Dir["#{libexec}/bin/*"]
+    bin.install libexec.glob("bin/*")
     bin.env_script_all_files libexec/"bin",
       JOLIE_HOME: "${JOLIE_HOME:-#{libexec}}",
       JAVA_HOME:  "${JAVA_HOME:-#{Formula["openjdk"].opt_prefix}}"

--- a/Formula/j/jruby.rb
+++ b/Formula/j/jruby.rb
@@ -38,7 +38,7 @@ class Jruby < Formula
     # Only keep the macOS native libraries
     rm_r(Dir["lib/jni/*"] - ["lib/jni/Darwin"])
     libexec.install Dir["*"]
-    bin.install Dir["#{libexec}/bin/*"]
+    bin.install libexec.glob("bin/*")
     bin.env_script_all_files libexec/"bin", Language::Java.overridable_java_home_env
 
     # Remove incompatible libfixposix library

--- a/Formula/j/jscpd.rb
+++ b/Formula/j/jscpd.rb
@@ -14,7 +14,7 @@ class Jscpd < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/j/jsdoc3.rb
+++ b/Formula/j/jsdoc3.rb
@@ -13,7 +13,7 @@ class Jsdoc3 < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/j/json2ts.rb
+++ b/Formula/j/json2ts.rb
@@ -13,7 +13,7 @@ class Json2ts < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/j/json5.rb
+++ b/Formula/j/json5.rb
@@ -16,7 +16,7 @@ class Json5 < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/j/jsonlint.rb
+++ b/Formula/j/jsonlint.rb
@@ -16,7 +16,7 @@ class Jsonlint < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/k/kirimase.rb
+++ b/Formula/k/kirimase.rb
@@ -14,7 +14,7 @@ class Kirimase < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/k/kubevious.rb
+++ b/Formula/k/kubevious.rb
@@ -14,7 +14,7 @@ class Kubevious < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/k/kuto.rb
+++ b/Formula/k/kuto.rb
@@ -14,7 +14,7 @@ class Kuto < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/l/leapp-cli.rb
+++ b/Formula/l/leapp-cli.rb
@@ -32,7 +32,7 @@ class LeappCli < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   def caveats

--- a/Formula/l/lerna.rb
+++ b/Formula/l/lerna.rb
@@ -18,7 +18,7 @@ class Lerna < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/l/luacheck.rb
+++ b/Formula/l/luacheck.rb
@@ -26,7 +26,7 @@ class Luacheck < Formula
 
   def install
     system "luarocks", "make", "--tree=#{libexec}", "--local", "--lua-dir=#{Formula["lua"].opt_prefix}"
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/m/mahout.rb
+++ b/Formula/m/mahout.rb
@@ -44,7 +44,7 @@ class Mahout < Formula
       libexec.install Dir["*.jar"]
     end
 
-    bin.install Dir["#{libexec}/bin/*"]
+    bin.install libexec.glob("bin/*")
     bin.env_script_all_files libexec/"bin", JAVA_HOME: ENV["JAVA_HOME"]
   end
 

--- a/Formula/m/mailsy.rb
+++ b/Formula/m/mailsy.rb
@@ -14,7 +14,7 @@ class Mailsy < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/m/mako.rb
+++ b/Formula/m/mako.rb
@@ -18,7 +18,7 @@ class Mako < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     # Remove incompatible pre-built binaries
     os = OS.kernel_name.downcase

--- a/Formula/m/mallet.rb
+++ b/Formula/m/mallet.rb
@@ -20,7 +20,7 @@ class Mallet < Formula
     rm Dir["bin/*.{bat,dll,exe}"] # Remove all windows files
 
     libexec.install Dir["*"]
-    bin.install Dir["#{libexec}/bin/*"]
+    bin.install libexec.glob("bin/*")
     bin.env_script_all_files(libexec/"bin", JAVA_HOME: Formula["openjdk"].opt_prefix)
   end
 

--- a/Formula/m/mapscii.rb
+++ b/Formula/m/mapscii.rb
@@ -13,7 +13,7 @@ class Mapscii < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/m/markdown-toc.rb
+++ b/Formula/m/markdown-toc.rb
@@ -16,7 +16,7 @@ class MarkdownToc < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/m/markdownlint-cli.rb
+++ b/Formula/m/markdownlint-cli.rb
@@ -13,7 +13,7 @@ class MarkdownlintCli < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/m/markdownlint-cli2.rb
+++ b/Formula/m/markdownlint-cli2.rb
@@ -13,7 +13,7 @@ class MarkdownlintCli2 < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/m/marked.rb
+++ b/Formula/m/marked.rb
@@ -13,7 +13,7 @@ class Marked < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/m/marp-cli.rb
+++ b/Formula/m/marp-cli.rb
@@ -20,7 +20,7 @@ class MarpCli < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     # Remove incompatible pre-built binaries
     os = OS.kernel_name.downcase

--- a/Formula/m/mcp-get.rb
+++ b/Formula/m/mcp-get.rb
@@ -13,7 +13,7 @@ class McpGet < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/m/mcp-inspector.rb
+++ b/Formula/m/mcp-inspector.rb
@@ -13,7 +13,7 @@ class McpInspector < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/m/mcp-server-chart.rb
+++ b/Formula/m/mcp-server-chart.rb
@@ -13,7 +13,7 @@ class McpServerChart < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/m/mcp-server-kubernetes.rb
+++ b/Formula/m/mcp-server-kubernetes.rb
@@ -18,7 +18,7 @@ class McpServerKubernetes < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     # Remove incompatible pre-built binaries
     os = OS.kernel_name.downcase

--- a/Formula/m/mermaid-cli.rb
+++ b/Formula/m/mermaid-cli.rb
@@ -18,7 +18,7 @@ class MermaidCli < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     node_modules = libexec/"lib/node_modules/@mermaid-js/mermaid-cli/node_modules"
 

--- a/Formula/m/mjml.rb
+++ b/Formula/m/mjml.rb
@@ -18,7 +18,7 @@ class Mjml < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     node_modules = libexec/"lib/node_modules/mjml/node_modules"
     deuniversalize_machos node_modules/"fsevents/fsevents.node" if OS.mac?

--- a/Formula/m/mongosh.rb
+++ b/Formula/m/mongosh.rb
@@ -20,7 +20,7 @@ class Mongosh < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/n/nativefier.rb
+++ b/Formula/n/nativefier.rb
@@ -23,7 +23,7 @@ class Nativefier < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/n/ncc.rb
+++ b/Formula/n/ncc.rb
@@ -13,7 +13,7 @@ class Ncc < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/n/neonctl.rb
+++ b/Formula/n/neonctl.rb
@@ -18,7 +18,7 @@ class Neonctl < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     %w[neonctl neon].each do |cmd|
       generate_completions_from_executable(bin/cmd, "completion", shells: [:bash, :zsh])

--- a/Formula/n/netlistsvg.rb
+++ b/Formula/n/netlistsvg.rb
@@ -17,7 +17,7 @@ class Netlistsvg < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/n/newman.rb
+++ b/Formula/n/newman.rb
@@ -14,7 +14,7 @@ class Newman < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/n/nexus.rb
+++ b/Formula/n/nexus.rb
@@ -61,7 +61,7 @@ class Nexus < Formula
     assembly = "assemblies/nexus-repository-core/target/assembly"
     rm(Dir["#{assembly}/bin/*.bat"])
     libexec.install Dir["#{assembly}/*"]
-    chmod "+x", Dir["#{libexec}/bin/*"]
+    chmod "+x", libexec.glob("bin/*")
     (bin/"nexus").write_env_script libexec/"bin/nexus", java_env
 
     (var/"log/nexus").mkpath
@@ -94,12 +94,12 @@ index 9b8325fd98..2a58a07afe 100644
 @@ -172,7 +172,7 @@
          <artifactId>karaf-maven-plugin</artifactId>
        </plugin>
- 
+
 -      <plugin>
 +      <!--plugin>
          <groupId>com.github.eirslett</groupId>
          <artifactId>frontend-maven-plugin</artifactId>
- 
+
 @@ -212,12 +212,12 @@
              </goals>
              <phase>test</phase>
@@ -114,7 +114,7 @@ index 9b8325fd98..2a58a07afe 100644
 +      </plugin-->
      </plugins>
    </build>
- 
+
 diff --git a/pom.xml b/pom.xml
 index 6647497628..d99148b421 100644
 --- a/pom.xml
@@ -122,7 +122,7 @@ index 6647497628..d99148b421 100644
 @@ -877,7 +877,7 @@
            </executions>
          </plugin>
- 
+
 -        <plugin>
 +        <!--plugin>
            <groupId>com.github.eirslett</groupId>
@@ -134,6 +134,6 @@ index 6647497628..d99148b421 100644
            </executions>
 -        </plugin>
 +        </plugin-->
- 
+
          <plugin>
            <groupId>com.mycila</groupId>

--- a/Formula/n/ni.rb
+++ b/Formula/n/ni.rb
@@ -14,7 +14,7 @@ class Ni < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     generate_completions_from_executable(bin/"nr", shell_parameter_format: "--completion-")
   end

--- a/Formula/n/node-red.rb
+++ b/Formula/n/node-red.rb
@@ -18,7 +18,7 @@ class NodeRed < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   service do

--- a/Formula/n/node-sass.rb
+++ b/Formula/n/node-sass.rb
@@ -18,7 +18,7 @@ class NodeSass < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/n/notion-mcp-server.rb
+++ b/Formula/n/notion-mcp-server.rb
@@ -13,7 +13,7 @@ class NotionMcpServer < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/n/npm-check-updates.rb
+++ b/Formula/n/npm-check-updates.rb
@@ -13,7 +13,7 @@ class NpmCheckUpdates < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/n/npq.rb
+++ b/Formula/n/npq.rb
@@ -13,7 +13,7 @@ class Npq < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/n/nrm.rb
+++ b/Formula/n/nrm.rb
@@ -14,7 +14,7 @@ class Nrm < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/n/nuxi.rb
+++ b/Formula/n/nuxi.rb
@@ -14,7 +14,7 @@ class Nuxi < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/n/nx.rb
+++ b/Formula/n/nx.rb
@@ -19,7 +19,7 @@ class Nx < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/o/opencode.rb
+++ b/Formula/o/opencode.rb
@@ -19,7 +19,7 @@ class Opencode < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     # Remove binaries for other architectures, `-musl`, `-baseline`, and `-baseline-musl`
     arch = Hardware::CPU.arm? ? "arm64" : "x64"

--- a/Formula/o/org-formation.rb
+++ b/Formula/o/org-formation.rb
@@ -13,7 +13,7 @@ class OrgFormation < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/o/oxlint.rb
+++ b/Formula/o/oxlint.rb
@@ -18,7 +18,7 @@ class Oxlint < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/p/pandemics.rb
+++ b/Formula/p/pandemics.rb
@@ -24,7 +24,7 @@ class Pandemics < Formula
     system "npm", "install", *std_npm_args
     # - call install script manually to ensure ENV is respected
     system "npm", "run", "--prefix", libexec/"lib/node_modules/pandemics", "install"
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/p/passenger.rb
+++ b/Formula/p/passenger.rb
@@ -69,7 +69,7 @@ class Passenger < Formula
     cp_r necessary_files, libexec, preserve: true
 
     # Allow Homebrew to create symlinks for the Phusion Passenger commands.
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     # Ensure that the Phusion Passenger commands can always find their library
     # files.

--- a/Formula/p/patch-package.rb
+++ b/Formula/p/patch-package.rb
@@ -13,7 +13,7 @@ class PatchPackage < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/p/payara.rb
+++ b/Formula/p/payara.rb
@@ -30,7 +30,7 @@ class Payara < Formula
                              "AS_INSTALL=#{libexec}/glassfish"
 
     libexec.install Dir["*"]
-    bin.install Dir["#{libexec}/bin/*"]
+    bin.install libexec.glob("bin/*")
     bin.env_script_all_files(libexec/"bin", Language::Java.java_home_env)
   end
 

--- a/Formula/p/phantom.rb
+++ b/Formula/p/phantom.rb
@@ -13,7 +13,7 @@ class Phantom < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     generate_completions_from_executable(bin/"phantom", "completion", shells: [:fish, :zsh])
   end

--- a/Formula/p/playwright-mcp.rb
+++ b/Formula/p/playwright-mcp.rb
@@ -18,7 +18,7 @@ class PlaywrightMcp < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     node_modules = libexec/"lib/node_modules/@playwright/mcp/node_modules"
     deuniversalize_machos node_modules/"fsevents/fsevents.node" if OS.mac?

--- a/Formula/p/postgraphile.rb
+++ b/Formula/p/postgraphile.rb
@@ -17,7 +17,7 @@ class Postgraphile < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/p/preevy.rb
+++ b/Formula/p/preevy.rb
@@ -20,7 +20,7 @@ class Preevy < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/p/prettier.rb
+++ b/Formula/p/prettier.rb
@@ -14,7 +14,7 @@ class Prettier < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/p/prettierd.rb
+++ b/Formula/p/prettierd.rb
@@ -13,7 +13,7 @@ class Prettierd < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/p/promptfoo.rb
+++ b/Formula/p/promptfoo.rb
@@ -24,7 +24,7 @@ class Promptfoo < Formula
     ENV.llvm_clang if OS.mac? && (DevelopmentTools.clang_build_version < 1700)
 
     system "npm", "install", *std_npm_args(ignore_scripts: false)
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     os = OS.mac? ? "apple-darwin" : "unknown-linux-musl"
     arch = Hardware::CPU.arm? ? "aarch64" : "x86_64"

--- a/Formula/p/pulp.rb
+++ b/Formula/p/pulp.rb
@@ -23,7 +23,7 @@ class Pulp < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/p/purescript-language-server.rb
+++ b/Formula/p/purescript-language-server.rb
@@ -14,7 +14,7 @@ class PurescriptLanguageServer < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/p/pwned.rb
+++ b/Formula/p/pwned.rb
@@ -15,7 +15,7 @@ class Pwned < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/p/pyright.rb
+++ b/Formula/p/pyright.rb
@@ -13,7 +13,7 @@ class Pyright < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/q/qnm.rb
+++ b/Formula/q/qnm.rb
@@ -20,7 +20,7 @@ class Qnm < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/q/quicktype.rb
+++ b/Formula/q/quicktype.rb
@@ -14,7 +14,7 @@ class Quicktype < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/q/quint.rb
+++ b/Formula/q/quint.rb
@@ -13,7 +13,7 @@ class Quint < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/q/qwen-code.rb
+++ b/Formula/q/qwen-code.rb
@@ -19,7 +19,7 @@ class QwenCode < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     # Remove incompatible pre-built binaries
     rm_r(libexec/"lib/node_modules/@qwen-code/qwen-code/vendor/ripgrep")

--- a/Formula/r/react-native-cli.rb
+++ b/Formula/r/react-native-cli.rb
@@ -16,7 +16,7 @@ class ReactNativeCli < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/r/release-it.rb
+++ b/Formula/r/release-it.rb
@@ -18,7 +18,7 @@ class ReleaseIt < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/r/renovate.rb
+++ b/Formula/r/renovate.rb
@@ -26,7 +26,7 @@ class Renovate < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/r/repomix.rb
+++ b/Formula/r/repomix.rb
@@ -22,7 +22,7 @@ class Repomix < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     clipboardy_fallbacks_dir = libexec/"lib/node_modules/#{name}/node_modules/clipboardy/fallbacks"
     rm_r(clipboardy_fallbacks_dir) # remove pre-built binaries

--- a/Formula/r/retire.rb
+++ b/Formula/r/retire.rb
@@ -13,7 +13,7 @@ class Retire < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/r/reveal-md.rb
+++ b/Formula/r/reveal-md.rb
@@ -20,7 +20,7 @@ class RevealMd < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     # Remove incompatible pre-built `bare-fs`/`bare-os`/`bare-url` binaries
     os = OS.kernel_name.downcase

--- a/Formula/r/roblox-ts.rb
+++ b/Formula/r/roblox-ts.rb
@@ -13,7 +13,7 @@ class RobloxTs < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/r/rollup.rb
+++ b/Formula/r/rollup.rb
@@ -18,7 +18,7 @@ class Rollup < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     # Replace universal binaries with their native slices
     node_modules = libexec/"lib/node_modules/rollup/node_modules"

--- a/Formula/r/rulesync.rb
+++ b/Formula/r/rulesync.rb
@@ -13,7 +13,7 @@ class Rulesync < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/s/saf-cli.rb
+++ b/Formula/s/saf-cli.rb
@@ -18,7 +18,7 @@ class SafCli < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     node_modules = libexec/"lib/node_modules/@mitre/saf/node_modules"
     deuniversalize_machos node_modules/"fsevents/fsevents.node" if OS.mac?

--- a/Formula/s/salesforce-mcp.rb
+++ b/Formula/s/salesforce-mcp.rb
@@ -13,7 +13,7 @@ class SalesforceMcp < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/s/seam.rb
+++ b/Formula/s/seam.rb
@@ -14,7 +14,7 @@ class Seam < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     # Build an `:all` bottle by removing workflow files
     node_modules = libexec/"lib/node_modules"

--- a/Formula/s/semver.rb
+++ b/Formula/s/semver.rb
@@ -12,7 +12,7 @@ class Semver < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/s/sf.rb
+++ b/Formula/s/sf.rb
@@ -20,7 +20,7 @@ class Sf < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/s/sherif.rb
+++ b/Formula/s/sherif.rb
@@ -18,7 +18,7 @@ class Sherif < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/s/shortest.rb
+++ b/Formula/s/shortest.rb
@@ -18,7 +18,7 @@ class Shortest < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/s/sloc.rb
+++ b/Formula/s/sloc.rb
@@ -14,7 +14,7 @@ class Sloc < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/s/snyk-cli.rb
+++ b/Formula/s/snyk-cli.rb
@@ -19,7 +19,7 @@ class SnykCli < Formula
   def install
     # Highly dependents on npm scripts to install wrapper bin files
     system "npm", "install", *std_npm_args(ignore_scripts: false)
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     # Remove x86-64 ELF binaries on incompatible platforms
     # TODO: Check if these should be built from source

--- a/Formula/s/solhint.rb
+++ b/Formula/s/solhint.rb
@@ -13,7 +13,7 @@ class Solhint < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/s/spectral-cli.rb
+++ b/Formula/s/spectral-cli.rb
@@ -14,7 +14,7 @@ class SpectralCli < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/s/sql-lint.rb
+++ b/Formula/s/sql-lint.rb
@@ -14,7 +14,7 @@ class SqlLint < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/s/stepci.rb
+++ b/Formula/s/stepci.rb
@@ -14,7 +14,7 @@ class Stepci < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/s/style-dictionary.rb
+++ b/Formula/s/style-dictionary.rb
@@ -13,7 +13,7 @@ class StyleDictionary < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     # Build an `:all` bottle by removing example files
     examples = libexec/"lib/node_modules/style-dictionary/examples"

--- a/Formula/s/stylelint.rb
+++ b/Formula/s/stylelint.rb
@@ -13,7 +13,7 @@ class Stylelint < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/s/svgo.rb
+++ b/Formula/s/svgo.rb
@@ -13,7 +13,7 @@ class Svgo < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/t/taskline.rb
+++ b/Formula/t/taskline.rb
@@ -22,7 +22,7 @@ class Taskline < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     clipboardy_fallbacks_dir = libexec/"lib/node_modules/@perryrh0dan/#{name}/node_modules/clipboardy/fallbacks"
     rm_r(clipboardy_fallbacks_dir) # remove pre-built binaries

--- a/Formula/t/taze.rb
+++ b/Formula/t/taze.rb
@@ -14,7 +14,7 @@ class Taze < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/t/tdd-guard.rb
+++ b/Formula/t/tdd-guard.rb
@@ -18,7 +18,7 @@ class TddGuard < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     # Remove incompatible pre-built binaries
     node_modules = libexec/"lib/node_modules/tdd-guard/node_modules"

--- a/Formula/t/terrahub.rb
+++ b/Formula/t/terrahub.rb
@@ -25,7 +25,7 @@ class Terrahub < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/t/triton.rb
+++ b/Formula/t/triton.rb
@@ -25,7 +25,7 @@ class Triton < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
     generate_completions_from_executable(bin/"triton", "completion", shells: [:bash])
   end
 

--- a/Formula/t/tweakcc.rb
+++ b/Formula/t/tweakcc.rb
@@ -18,7 +18,7 @@ class Tweakcc < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     # Remove binaries for other architectures and musl
     os = OS.linux? ? "linux" : "darwin"

--- a/Formula/t/typescript-language-server.rb
+++ b/Formula/t/typescript-language-server.rb
@@ -19,7 +19,7 @@ class TypescriptLanguageServer < Formula
     typescript = Formula["typescript"].opt_libexec/"lib/node_modules/typescript"
     ln_sf typescript.relative_path_from(node_modules), node_modules
 
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/t/typescript.rb
+++ b/Formula/t/typescript.rb
@@ -13,7 +13,7 @@ class Typescript < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/u/uffizzi.rb
+++ b/Formula/u/uffizzi.rb
@@ -192,7 +192,7 @@ class Uffizzi < Formula
       system "gem", "install", r.cached_download, "--no-document", "--install-dir", libexec
     end
 
-    bin.install Dir["#{libexec}/bin/*"]
+    bin.install libexec.glob("bin/*")
 
     bin.env_script_all_files(libexec, GEM_HOME: ENV["GEM_HOME"], GEM_PATH: ENV["GEM_PATH"])
   end

--- a/Formula/v/varlock.rb
+++ b/Formula/v/varlock.rb
@@ -13,7 +13,7 @@ class Varlock < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/v/vault-cli.rb
+++ b/Formula/v/vault-cli.rb
@@ -22,7 +22,7 @@ class VaultCli < Formula
     rm(Dir["bin/*.bat"])
 
     libexec.install Dir["*"]
-    bin.install Dir["#{libexec}/bin/*"]
+    bin.install libexec.glob("bin/*")
     bin.env_script_all_files(libexec/"bin", JAVA_HOME: Formula["openjdk"].opt_prefix)
   end
 

--- a/Formula/v/vercel-cli.rb
+++ b/Formula/v/vercel-cli.rb
@@ -20,7 +20,7 @@ class VercelCli < Formula
     inreplace "dist/index.js", "${await getUpdateCommand()}",
                                "brew upgrade vercel-cli"
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     # Remove incompatible deasync modules
     os = OS.kernel_name.downcase

--- a/Formula/v/vite.rb
+++ b/Formula/v/vite.rb
@@ -18,7 +18,7 @@ class Vite < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     node_modules = libexec/"lib/node_modules/vite/node_modules"
     deuniversalize_machos node_modules/"fsevents/fsevents.node" if OS.mac?

--- a/Formula/v/vscode-langservers-extracted.rb
+++ b/Formula/v/vscode-langservers-extracted.rb
@@ -14,7 +14,7 @@ class VscodeLangserversExtracted < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/w/web-ext.rb
+++ b/Formula/w/web-ext.rb
@@ -22,7 +22,7 @@ class WebExt < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     # Remove vendored pre-built binary `terminal-notifier`
     node_notifier_vendor_dir = libexec/"lib/node_modules/web-ext/node_modules/node-notifier/vendor"

--- a/Formula/w/webpod.rb
+++ b/Formula/w/webpod.rb
@@ -16,7 +16,7 @@ class Webpod < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/w/webtorrent-cli.rb
+++ b/Formula/w/webtorrent-cli.rb
@@ -28,7 +28,7 @@ class WebtorrentCli < Formula
     ENV["CMAKE_POLICY_VERSION_MINIMUM"] = "3.5"
 
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     nm = libexec/"lib/node_modules/webtorrent-cli/node_modules"
 

--- a/Formula/w/whistle.rb
+++ b/Formula/w/whistle.rb
@@ -13,7 +13,7 @@ class Whistle < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/w/wikibase-cli.rb
+++ b/Formula/w/wikibase-cli.rb
@@ -13,7 +13,7 @@ class WikibaseCli < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/w/write-good.rb
+++ b/Formula/w/write-good.rb
@@ -16,7 +16,7 @@ class WriteGood < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/w/wuchale.rb
+++ b/Formula/w/wuchale.rb
@@ -13,7 +13,7 @@ class Wuchale < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/y/yaml-language-server.rb
+++ b/Formula/y/yaml-language-server.rb
@@ -13,7 +13,7 @@ class YamlLanguageServer < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/y/yamlresume.rb
+++ b/Formula/y/yamlresume.rb
@@ -13,7 +13,7 @@ class Yamlresume < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/y/yo.rb
+++ b/Formula/y/yo.rb
@@ -15,7 +15,7 @@ class Yo < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do

--- a/Formula/y/yuque-dl.rb
+++ b/Formula/y/yuque-dl.rb
@@ -18,7 +18,7 @@ class YuqueDl < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     node_modules = libexec/"lib/node_modules/yuque-dl/node_modules"
     deuniversalize_machos node_modules/"fsevents/fsevents.node" if OS.mac?

--- a/Formula/z/zsh-history-enquirer.rb
+++ b/Formula/z/zsh-history-enquirer.rb
@@ -17,7 +17,7 @@ class ZshHistoryEnquirer < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
     zsh_function.install "zsh-history-enquirer.plugin.zsh" => "history_enquire"
   end
 

--- a/Formula/z/zx.rb
+++ b/Formula/z/zx.rb
@@ -13,7 +13,7 @@ class Zx < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do


### PR DESCRIPTION
Follow up to https://github.com/Homebrew/brew/pull/21318. This updates affected formulae to use `libexec.glob` instead of `Dir[]`, aligning with our current recommendations.