### PR TITLE
amazon-ecs-cli: deprecate by repo archived

### DIFF
--- a/Formula/a/amazon-ecs-cli.rb
+++ b/Formula/a/amazon-ecs-cli.rb
@@ -6,8 +6,6 @@ class AmazonEcsCli < Formula
   license "Apache-2.0"
   head "https://github.com/aws/amazon-ecs-cli.git", branch: "mainline"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "9a98803f22995cb9fd3ccfff0d9ac6bcb8de73df88e94c9bf60f16181ffab227"
@@ -24,6 +22,9 @@ class AmazonEcsCli < Formula
     sha256 cellar: :any_skip_relocation, arm64_linux:    "5c02a7a6f0510165209dd1770595340906f5c0165084dd88801ef76916c61270"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "4bfbca5701b37d685a0f5da1a135e736e4a594079e2368262c498396f4446261"
   end
+
+  deprecate! date: "2025-12-25", because: :repo_archived
+  disable! date: "2026-12-25", because: :repo_archived
 
   depends_on "go" => :build
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Upstream repo archived