### PR TITLE
docker-credential-helper: install pass helper for macos

### DIFF
--- a/Formula/d/docker-credential-helper.rb
+++ b/Formula/d/docker-credential-helper.rb
@@ -24,15 +24,17 @@ class DockerCredentialHelper < Formula
   end
 
   def install
+    ENV["CGO_ENABLED"] = "1" if OS.linux? && Hardware::CPU.arm?
+
     if OS.mac?
       system "make", "osxkeychain"
       bin.install "bin/build/docker-credential-osxkeychain"
     else
-      system "make", "pass"
       system "make", "secretservice"
-      bin.install "bin/build/docker-credential-pass"
       bin.install "bin/build/docker-credential-secretservice"
     end
+    system "make", "pass"
+    bin.install "bin/build/docker-credential-pass"
   end
 
   test do
@@ -40,11 +42,10 @@ class DockerCredentialHelper < Formula
       run_output = shell_output("#{bin}/docker-credential-osxkeychain", 1)
       assert_match "Usage: docker-credential-osxkeychain", run_output
     else
-      run_output = shell_output("#{bin}/docker-credential-pass list")
-      assert_match "{}", run_output
-
       run_output = shell_output("#{bin}/docker-credential-secretservice list", 1)
       assert_match "Cannot autolaunch D-Bus without X11", run_output
     end
+    run_output = shell_output("#{bin}/docker-credential-pass list")
+    assert_match "{}", run_output
   end
 end

--- a/Formula/d/docker-credential-helper.rb
+++ b/Formula/d/docker-credential-helper.rb
@@ -7,12 +7,13 @@ class DockerCredentialHelper < Formula
   head "https://github.com/docker/docker-credential-helpers.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "2b95477e4ef5163a38e72ca7b622c5b3f5f2cb5eb38b7c99b8950f16e55e936e"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "ff0a53237392b5a24e0727d8c45a041210cc745b61e09a530ad637a4741ecc46"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "f0c869867e03018a03b4a7dcd8a68a85ad24c05ee5cc739f8631534865393dbe"
-    sha256 cellar: :any_skip_relocation, sonoma:        "da785d8c64ad263cccb3378927b3bf4f1e059f17e95407a0fc5eb31c77da3510"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "b796438e486677e81ecc9cb60ad572ee4ba24c21bd0f9d81579b0d961345a3c2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "009a3b5b8130a1e8de00518ccf96ba57b1445a710308dd41aeffd283e6d14308"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "4614b00d81a1c68c68600bef64c4f8d81a7c686bbeac3740c39a0a0fb4bac6c2"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "b3ddc91f467c56c380e7451f75b858ef84fd920415461ca81aa3fcd7ca29a78c"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "d0f64396575b904f164e27b104d0e1cb5c71655dc80858016e9ea7d5533742e2"
+    sha256 cellar: :any_skip_relocation, sonoma:        "a9114a80fe4cf2a5b41269f03e9b5ebb52a205b14284e98734d11ccc6a537bdf"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "4891ab7c2706fdfdd7d2760e1684379fcf81ca5b0049cc3141bdf31fc4971270"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "22aa2d14d8dfdbc7796d54a8c86803493f8a1127cd78ff44ddd0154a11594178"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
the pass helper does support darwin-amd64 & darwin-arm64

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
