### PR TITLE
ansifilter: replace http tarball with gitlab archive

### DIFF
--- a/Formula/a/ansifilter.rb
+++ b/Formula/a/ansifilter.rb
@@ -1,7 +1,7 @@
 class Ansifilter < Formula
   desc "Strip or convert ANSI codes into HTML, (La)Tex, RTF, or BBCode"
   homepage "http://andre-simon.de/doku/ansifilter/en/ansifilter.php"
-  url "http://andre-simon.de/zip/ansifilter-2.22.tar.bz2"
+  url "https://gitlab.com/saalen/ansifilter/-/archive/2.22/ansifilter-2.22.tar.bz2"
   sha256 "ccff41ca740b813bf9103868b5000f4243d32a75304ea929a214c49b943ecc93"
   license "GPL-3.0-or-later"
 


### PR DESCRIPTION
Official repo listed at http://andre-simon.de/doku/ansifilter/en/sfnet.php

There's also the SourceForge page (which could have more stable tarballs than GitLab archive); however, upstream randomly skips some versions, e.g. 2.21 is missing:
- https://sourceforge.net/projects/ansifilter/files/

So trying GitLab archive which appears to be the same tarball used given sha256.
