### PR TITLE
reposurgeon: remove brew git dependency

### DIFF
--- a/Formula/r/reposurgeon.rb
+++ b/Formula/r/reposurgeon.rb
@@ -19,7 +19,6 @@ class Reposurgeon < Formula
 
   depends_on "asciidoctor" => :build
   depends_on "go" => :build
-  depends_on "git" # requires >= 2.19.2
 
   uses_from_macos "ruby"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Git should be new enough on supported macOS.

On Linux, all Tier 1 (standard support) distros should have new enough git.

Only lower Tier users on extended support distro like Ubuntu 18.04 (git 2.17.1) would need a newer git. However, given `reposurgeon` 90 day analytics (21 installs) and Ubuntu 18.04 90 day analytics (`27,915 - 0.05%`), there is close to 0 users in the intersection.

Perhaps we could improve brew support for handling Linux system packages which we allow using as implicit dependencies (e.g. bash, coreutils, git, etc.), but not a high priority.