### PR TITLE
vapor: make `swift` build-only

### DIFF
--- a/Formula/v/vapor.rb
+++ b/Formula/v/vapor.rb
@@ -13,9 +13,10 @@ class Vapor < Formula
     sha256                               x86_64_linux:  "7d4caa94d7be2095ee335b2c954bea42d308e4f79aa641bf4d345671bb8445f1"
   end
 
+  depends_on xcode: ["26.0", :build]
   depends_on macos: :sequoia
 
-  uses_from_macos "swift", since: :tahoe # Swift 6.1
+  uses_from_macos "swift" => :build
 
   def install
     args = if OS.mac?


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Sequoia also has Xcode 26 so can drop the `since`.