### PR TITLE
ccextractor 0.96.3 (new formula)

### DIFF
--- a/Formula/c/ccextractor.rb
+++ b/Formula/c/ccextractor.rb
@@ -5,6 +5,15 @@ class Ccextractor < Formula
   sha256 "17037e8cc52773d3c9a88dcaeb1921cec9a0e4f92ff355fcc318585da41c25b4"
   license "GPL-2.0-only"
 
+  bottle do
+    sha256 cellar: :any,                 arm64_tahoe:   "2f0aa09821576492695638e9a18ad46146bcf707b1d05fb21acaee0366bf47fc"
+    sha256 cellar: :any,                 arm64_sequoia: "d82db02d25dfcb70c32a72c9e9c6776fc554b2e454330d1c954229f801b1a052"
+    sha256 cellar: :any,                 arm64_sonoma:  "8772c66a99b20e38da45853be84661b6afab8f6c82786f00742535c984dc0278"
+    sha256 cellar: :any,                 sonoma:        "c05af963b7e418702626652d8a1d692b6ededdeede9f93744b72a447f1a7ad11"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "28ee674242b720a3393c2f1b0da9262a0f80e494f74478bc0675fb730a677052"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e845311c9f2490dd8548b3154b10d44dd2a1e46a9e563107204fa9c8565c3030"
+  end
+
   depends_on "pkgconf" => :build
   depends_on "rust" => :build
   depends_on "freetype"

--- a/Formula/c/ccextractor.rb
+++ b/Formula/c/ccextractor.rb
@@ -1,0 +1,41 @@
+class Ccextractor < Formula
+  desc "Tool for extracting closed captions from video files"
+  homepage "https://www.ccextractor.org"
+  url "https://github.com/CCExtractor/ccextractor/archive/refs/tags/v0.96.3.tar.gz"
+  sha256 "17037e8cc52773d3c9a88dcaeb1921cec9a0e4f92ff355fcc318585da41c25b4"
+  license "GPL-2.0-only"
+
+  depends_on "pkgconf" => :build
+  depends_on "rust" => :build
+  depends_on "freetype"
+  depends_on "gpac"
+  depends_on "libpng"
+  depends_on "protobuf-c"
+  depends_on "utf8proc"
+
+  uses_from_macos "zlib"
+
+  on_linux do
+    depends_on "llvm" => :build
+    depends_on "leptonica"
+    depends_on "tesseract"
+  end
+
+  def install
+    if OS.mac?
+      cd "mac" do
+        system "./build.command", "-system-libs"
+        bin.install "ccextractor"
+      end
+    else
+      cd "linux" do
+        system "./build", "-system-libs"
+        bin.install "ccextractor"
+      end
+    end
+  end
+
+  test do
+    assert_match "CCExtractor", shell_output("#{bin}/ccextractor --version")
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

## Re-introduces **CCExtractor** to `homebrew-core` with full system library support on both macOS and Linux.

CCExtractor is a command-line tool for extracting closed captions and subtitles from video streams, supporting `EIA-608`/`CEA-708`, DVB, Teletext, and multiple container formats.

### Background

CCExtractor was removed from `homebrew-core` in December 2023 (#158204) due to bundled third-party libraries. A
previous reintroduction attempt ([#260163](https://github.com/Homebrew/homebrew-core/pull/260163)) identified that, while macOS supported `-system-libs`, the Linux build script did not yet provide an equivalent option. Upstream has now resolved this in [`v0.96.2`](https://github.com/CCExtractor/ccextractor/releases/tag/v0.96.2).

## What Changed Upstream

Upstream has added explicit support for system library builds on **both platforms**:

**macOS:**
- CCExtractor/ccextractor#1862 — Introduced the `-system-libs` build mode
- CCExtractor/ccextractor#1893 — Documentation for system library builds

**Linux:**
- CCExtractor/ccextractor#1907 — Introduced the `-system-libs` build mode

### Build Details

- **macOS**: Builds using `./build.command -system-libs` to avoid bundled dependencies and comply with Homebrew policies.
- **Linux**: Builds using `./build -system-libs` to link against system libraries via `pkg-config`.

Both platforms link exclusively against system-provided libraries with no vendored code.

### Verification

**Tested on macOS `15.2` (Apple Silicon):**

- `brew install --build-from-source ccextractor`
- `brew test ccextractor`
- `brew audit --strict  ccextractor`
- `brew linkage --test ccextractor` — Confirms system library usage

**Tested on Linux (Ubuntu `22.04`):**

- `brew install --build-from-source ccextractor`
- `ldd $(brew --prefix)/bin/ccextractor | grep -E "libpng|freetype|utf8proc"`
- `readelf -d` confirms no bundled libraries
- `brew audit --strict ccextractor` 
- `brew test ccextractor`

The resulting binaries on both platforms link against Homebrew-provided libraries and run correctly.
