### PR TITLE
lazycontainer: apply upstream patch

### DIFF
--- a/Formula/l/lazycontainer.rb
+++ b/Formula/l/lazycontainer.rb
@@ -19,6 +19,17 @@ class Lazycontainer < Formula
 
   depends_on "go" => :build
 
+  # limited by Apple Containers support:
+  depends_on arch: :arm64
+  depends_on macos: :tahoe
+  depends_on :macos
+
+  # ref https://github.com/andreybleme/lazycontainer/pull/11
+  patch do
+    url "https://github.com/andreybleme/lazycontainer/commit/cc9ad42bce4a28d662726c41b55dc28d2cb6eaae.patch?full_index=1"
+    sha256 "7b1703ab7e11a1b655845ad98647fb01feb815db5caa1c42498169ec83f99ddd"
+  end
+
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w"), "./cmd"
   end

--- a/Formula/l/lazycontainer.rb
+++ b/Formula/l/lazycontainer.rb
@@ -7,14 +7,8 @@ class Lazycontainer < Formula
   head "https://github.com/andreybleme/lazycontainer.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "0dc4071f1c199b099256ecbfae20165aefbeef9e9df7a0262d485f346039d13c"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "0dc4071f1c199b099256ecbfae20165aefbeef9e9df7a0262d485f346039d13c"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "0dc4071f1c199b099256ecbfae20165aefbeef9e9df7a0262d485f346039d13c"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "0dc4071f1c199b099256ecbfae20165aefbeef9e9df7a0262d485f346039d13c"
-    sha256 cellar: :any_skip_relocation, sonoma:        "9ce2b590419deecde11f0a99a3cb3a22591ddc7a80a6074c867394baa7d8da66"
-    sha256 cellar: :any_skip_relocation, ventura:       "9ce2b590419deecde11f0a99a3cb3a22591ddc7a80a6074c867394baa7d8da66"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "b396694656fa99e4ac1eae3d55e9d4976ba3c009afa3d248bdc63cd31345c5f5"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b28e111c6514af466fa079101c6b027f543f7c23193dd3c65056429c7e933122"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe: "8104055ed3ee692a36571f79db76e927b9ae43e7fec301c9c8d859ced6687d90"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Ref:
* Core reason: https://github.com/apple/container/pull/597
* Upstream: https://github.com/andreybleme/lazycontainer/pull/11
* Downstream: https://github.com/Homebrew/homebrew-core/pull/258912