### PR TITLE
mat2: change homepage url

### DIFF
--- a/Formula/m/mat2.rb
+++ b/Formula/m/mat2.rb
@@ -2,7 +2,7 @@ class Mat2 < Formula
   include Language::Python::Virtualenv
 
   desc "Metadata anonymization toolkit"
-  homepage "https://0xacab.org/jvoisin/mat2"
+  homepage "https://github.com/jvoisin/mat2"
   url "https://files.pythonhosted.org/packages/ba/e1/9a8abf4f5ab3c3e214197e310e3f33418d79769ee89911da939a6c891d4f/mat2-0.14.0.tar.gz"
   sha256 "7f07db8c587f91bdfb15fb384bca05d741edc31888bd9844b9e91290c0f529c3"
   license "LGPL-3.0-or-later"


### PR DESCRIPTION
See https://dustri.org/b/mat2-0140.html for details:

> Another important change is that the main repository for mat2 moved from 0xacab to github, for multiple reasons.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
