### PR TITLE
atf: update livecheck strategy

### DIFF
--- a/Formula/a/atf.rb
+++ b/Formula/a/atf.rb
@@ -8,7 +8,7 @@ class Atf < Formula
 
   livecheck do
     url :stable
-    regex(/^atf[._-]?v?(\d+(?:\.\d+)+)$/i)
+    strategy :github_latest
   end
 
   bottle do


### PR DESCRIPTION
Update to use the `:github_latest` strategy to ensure that the version built is always the released version.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----