### PR TITLE
arpoison: use Gentoo mirror for url

### DIFF
--- a/Formula/a/arpoison.rb
+++ b/Formula/a/arpoison.rb
@@ -1,7 +1,9 @@
 class Arpoison < Formula
   desc "UNIX arp cache update utility"
   homepage "http://www.arpoison.net/"
-  url "http://www.arpoison.net/arpoison-0.7.tar.gz"
+  # Upstream is only available via HTTP, so we use Gentoo's HTTPS mirror
+  url "https://dev.gentoo.org/~jsmolic/distfiles/arpoison-0.7.tar.gz"
+  mirror "http://www.arpoison.net/arpoison-0.7.tar.gz"
   sha256 "63571633826e413a9bdaab760425d0fab76abaf71a2b7ff6a00d1de53d83e741"
   license "GPL-2.0-only"
   revision 1


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

[Repology](https://repology.org/project/arpoison/versions) doesn't have a lot of sources for this (no Debian), so used Gentoo's ebuild URL.  Drop in replacement with no modifications needed.