### PR TITLE
gurk: Improve the test on Linux

### DIFF
--- a/Formula/g/gurk.rb
+++ b/Formula/g/gurk.rb
@@ -30,8 +30,6 @@ class Gurk < Formula
   test do
     assert_match version.to_s, shell_output("#{bin}/gurk --version")
 
-    return if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"]
-
     begin
       output_log = testpath/"output.log"
       pid = spawn bin/"gurk", "--relink", [:out, :err] => output_log.to_s


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- I was inspired by @cho-m's recent PRs, so I looked for `return if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"]` in tests. This one didn't have a comment explaining why, so let's try removing it and see what happens. 🤷🏻