### PR TITLE
vaulted: update test to use assert_equal

### DIFF
--- a/Formula/v/vaulted.rb
+++ b/Formula/v/vaulted.rb
@@ -34,7 +34,6 @@ class Vaulted < Formula
   test do
     (testpath/".local/share/vaulted").mkpath
     touch(".local/share/vaulted/test_vault")
-    output = IO.popen([bin/"vaulted", "ls"], &:read)
-    output == "test_vault\n"
+    assert_equal "test_vault\n", shell_output("#{bin}/vaulted ls")
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Deprecate boolean returns in block in favor of exceptions (e.g. minitest) which provide more useful error messages