### PR TITLE
pylint: fix pyvenv.cfg path for :all bottle

### DIFF
--- a/Formula/p/pylint.rb
+++ b/Formula/p/pylint.rb
@@ -45,6 +45,8 @@ class Pylint < Formula
 
   def install
     virtualenv_install_with_resources
+
+    inreplace libexec/"pyvenv.cfg", HOMEBREW_PREFIX, prefix
   end
 
   test do

--- a/Formula/p/pylint.rb
+++ b/Formula/p/pylint.rb
@@ -8,7 +8,8 @@ class Pylint < Formula
   license "GPL-2.0-or-later"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "e412985eb67330cb013068787d1f85f3d5b639cd69a4919ec6fb32a1109ae524"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "55c6e4cac20eba51829d3381bce3b8f43331b782ce770f84d19ff1dadb61d2fe"
   end
 
   depends_on "python@3.14"


### PR DESCRIPTION
Replace HOMEBREW_PREFIX with prefix in pyvenv.cfg during installation.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
Refs #191352
-----
