### PR TITLE
libid3tag: add git head

### DIFF
--- a/Formula/lib/libid3tag.rb
+++ b/Formula/lib/libid3tag.rb
@@ -1,9 +1,19 @@
 class Libid3tag < Formula
   desc "ID3 tag manipulation library"
-  homepage "https://www.underbit.com/products/mad/"
-  url "https://codeberg.org/tenacityteam/libid3tag/archive/0.16.3.tar.gz"
-  sha256 "0561009778513a95d91dac33cee8418d6622f710450a7cb56a74636d53b588cb"
+  homepage "https://codeberg.org/tenacityteam/libid3tag"
   license "GPL-2.0-only"
+  head "https://codeberg.org/tenacityteam/libid3tag.git", branch: "main"
+
+  stable do
+    url "https://codeberg.org/tenacityteam/libid3tag/archive/0.16.3.tar.gz"
+    sha256 "0561009778513a95d91dac33cee8418d6622f710450a7cb56a74636d53b588cb"
+    # Allow build with CMake 4.0.0
+    # Remove on next release.
+    patch do
+      url "https://codeberg.org/tenacityteam/libid3tag/commit/eee94b22508a066f7b9bc1ae05d2d85982e73959.patch"
+      sha256 "f4278e88cb23b0a2aa2bb2c074c6fc2e61029b6d0d77856f4439c3f75f888cbc"
+    end
+  end
 
   no_autobump! because: :requires_manual_review
 
@@ -24,15 +34,8 @@ class Libid3tag < Formula
   depends_on "cmake" => :build
   depends_on "pkgconf" => :test
 
-  uses_from_macos "gperf"
+  uses_from_macos "gperf" => :build
   uses_from_macos "zlib"
-
-  # Allow build with CMake 4.0.0
-  # Remove on next release.
-  patch do
-    url "https://codeberg.org/tenacityteam/libid3tag/commit/eee94b22508a066f7b9bc1ae05d2d85982e73959.patch"
-    sha256 "f4278e88cb23b0a2aa2bb2c074c6fc2e61029b6d0d77856f4439c3f75f888cbc"
-  end
 
   def install
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args
@@ -44,7 +47,7 @@ class Libid3tag < Formula
     (testpath/"test.c").write <<~C
       #include <id3tag.h>
 
-      int main(int n, char** c) {
+      int main() {
         struct id3_file *fp = id3_file_open("#{test_fixtures("test.mp3")}", ID3_FILE_MODE_READONLY);
         struct id3_tag *tag = id3_file_tag(fp);
         struct id3_frame *frame = id3_tag_findframe(tag, ID3_FRAME_TITLE, 0);


### PR DESCRIPTION
Also:

* Update homepage to point at more up-to-date codeberg URL.   The old underbit project has been unmaintained for decades so basically all package managers (including homebrew) long ago switched to shipping the "tenacityteam" fork. Referring people to the underbit.com homepage is just going to confuse them since it only links to the original SourceForge project where they can find version 0.15.1b from 2004

The `README.md `viewable at codeberg.org includes a link to the old underbit website so nothing is lost by this switch.

This is also what Debian already uses as the project's website; see https://packages.debian.org/source/sid/libid3tag

* Tiny cleanups to the test code and `uses_from_macos` specification

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
