### PR TITLE
workflows/triage: `dotnet` needs self-hosted Linux again

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -408,6 +408,7 @@ jobs:
             - label: CI-linux-self-hosted
               path: "Formula/.+/(\
                 dart-sdk|\
+                dotnet|\
                 envoy|\
                 qt@5|\
                 qtwebengine|\


### PR DESCRIPTION
Due to building with LLVM, we don't have enough disk space

LLVM adds 3.2GB = 2.7GB (installed) + 0.5GB (tarball)

I wonder if there is a way to purge some stuff from GitHub runner prior to spinning up the container as we only need Docker installed and there is dozens of extra GB pre-installed.
