### PR TITLE
mcp-atlassian: downgrade to Python 3.13 to autobump

### DIFF
--- a/Formula/m/mcp-atlassian.rb
+++ b/Formula/m/mcp-atlassian.rb
@@ -8,12 +8,13 @@ class McpAtlassian < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "a0b98e46582b19c8c2d9c0ee28d3b07c5af6b74e6cf95808a0111ac91853a7d3"
-    sha256 cellar: :any,                 arm64_sequoia: "62c412f4c37a9c72c8b6ff45aeccbf8cc0278665c4d69d43313568918bf42d3e"
-    sha256 cellar: :any,                 arm64_sonoma:  "73a8d8fe4f127ecb481aaa82b265bc215b76e534a829b63d5ab0fbbdf52e3812"
-    sha256 cellar: :any,                 sonoma:        "a4b1aff3c8d63ba82ff1546a2c23d2a2205c131ee0b6a328d19680a11d6cfbdd"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "64259e27ba6a54a8c4ed9f7e95541f3d7eafced71a2c12f6dc3c7d221b0949dd"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "bf5c5fac3569b00baed8d277a8275b23ed82b9d13edfdbcd8053b5e9f0165a9e"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "34a1ad4e3fe3ef95c2a7ca0b8a81155f9a9bbfffc81e48daea2519692c827312"
+    sha256 cellar: :any,                 arm64_sequoia: "bc4e1eb9f1962035b479dff46a9283f47682a3be4d7dede0d38cc4fd579b356e"
+    sha256 cellar: :any,                 arm64_sonoma:  "e6502c6c94cc95a56b5ef39de066b216f207c042d12cf8a86f6dba0933acd338"
+    sha256 cellar: :any,                 sonoma:        "0e88ce474e811ec4d7fcf288044a55452bc2e7017d5a38ff3a5e4bc5489060d8"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "744f541b10d6bff78faca1cbe7c626b7315cedbf07898af9ffc0784fe19804bf"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "cfbfb3f9b1cc2121fe1dfd7fb5d97df5c5ce21dfd846788ac9606d4aecdb2b10"
   end
 
   depends_on "rust" => :build # for py_key_value_aio > uv_build > maturin

--- a/Formula/m/mcp-atlassian.rb
+++ b/Formula/m/mcp-atlassian.rb
@@ -21,7 +21,7 @@ class McpAtlassian < Formula
   depends_on "cryptography" => :no_linkage
   depends_on "libyaml"
   depends_on "pydantic" => :no_linkage
-  depends_on "python@3.14"
+  depends_on "python@3.13"
   depends_on "rpds-py" => :no_linkage
 
   uses_from_macos "libxml2", since: :ventura


### PR DESCRIPTION
Due to 
- https://github.com/sooperset/mcp-atlassian/commit/5416efe22663a308de6d5218303af3892023bea0