### PR TITLE
watch: update test for dep test

### DIFF
--- a/Formula/w/watch.rb
+++ b/Formula/w/watch.rb
@@ -56,15 +56,20 @@ class Watch < Formula
   test do
     assert_match version.to_s, shell_output("#{bin}/watch --version")
 
-    cmd = "#{bin}/watch --errexit --chgexit --interval 1 date"
-    output = if OS.mac?
-      shell_output(cmd)
-    else
-      require "pty"
-      r, _w, pid = PTY.spawn(cmd)
+    require "pty"
+    output = []
+    PTY.spawn("#{bin}/watch --errexit --chgexit --interval 1 date") do |r, w, pid|
+      r.winsize = [24, 80]
+      begin
+        r.each_char { |char| output << char }
+      rescue Errno::EIO
+        # GNU/Linux raises EIO when read is done on closed pty
+      end
+    ensure
+      r.close
+      w.close
       Process.wait(pid)
-      r.read_nonblock(4096)
     end
-    assert_match "Every 1.0s: date", output
+    assert_match "Every 1.0s: date", output.join
   end
 end


### PR DESCRIPTION
Trying PTY everywhere to see if it helps on macOS dependent tests which runs on GitHub action runner rather than our self-hosted.

May need further changes as impossible to test in PR given we can't trigger a dependent test at same time as modifying formula.