### PR TITLE
kafka: update livecheck

### DIFF
--- a/Formula/k/kafka.rb
+++ b/Formula/k/kafka.rb
@@ -7,7 +7,7 @@ class Kafka < Formula
   license "Apache-2.0"
 
   livecheck do
-    url "https://kafka.apache.org/downloads"
+    url "https://kafka.apache.org/community/downloads/"
     regex(/href=.*?kafka[._-]v?\d+(?:\.\d+)+-(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `kafka` produces an "Unable to get versions" error because the URL redirects to /downloads/ and that includes minimal HTML with a `meta` redirection to /community/downloads/. curl only follows redirections from `Location` headers, so we don't reach the final URL. This updates the `livecheck` block URL to resolve the redirection.