### PR TITLE
yewtube: remove caveat as renamed, 3rd-party mpv cask

### DIFF
--- a/Formula/y/yewtube.rb
+++ b/Formula/y/yewtube.rb
@@ -92,18 +92,7 @@ class Yewtube < Formula
     (libexec/"share/applications").install "yewtube.desktop" if OS.mac?
   end
 
-  def caveats
-    <<~EOS
-      Install the optional mpv app with Homebrew Cask:
-        brew install --cask mpv
-    EOS
-  end
-
   test do
-    console = fork do
-      assert_match "checkupdate set to False", shell_output("#{bin}/yt set checkupdate false")
-    end
-    sleep 1
-    Process.kill("TERM", console)
+    assert_match "checkupdate set to False", shell_output("#{bin}/yt set checkupdate false, exit")
   end
 end


### PR DESCRIPTION
`mpv` Cask was renamed to `stolendata-mpv` as it is a 3rd-party build. If it was 1st party, may be okay to recommend but 3rd-party seems like something to avoid in caveats where users may just copy-paste.

Also actually run the test. Currently it just starts a process and kills it since the process waits on user input so assert_match is never run and nothing is actually verified.