### PR TITLE
hspell: update livecheck

### DIFF
--- a/Formula/h/hspell.rb
+++ b/Formula/h/hspell.rb
@@ -8,6 +8,7 @@ class Hspell < Formula
   livecheck do
     url "https://hspell.sourceforge.net/download.html"
     regex(/href=.*?hspell[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    strategy :page_match
   end
 
   no_autobump! because: :requires_manual_review


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `livecheck` block for `hspell` tries to check the upstream download page but the URL triggers the `Sourceforge` strategy and predictably fails. This updates the `livecheck` block to explicitly use the `PageMatch` strategy to override the detected strategy.