### PR TITLE
depot: downgrade to 2.100.14

### DIFF
--- a/Formula/d/depot.rb
+++ b/Formula/d/depot.rb
@@ -1,24 +1,25 @@
 class Depot < Formula
   desc "Build your Docker images in the cloud"
   homepage "https://depot.dev/"
-  url "https://github.com/depot/cli/archive/refs/tags/v2.101.0.tar.gz"
-  sha256 "2e69bf9263de9003d934a40887d45c4ceeef1a7339f0ee61e329dd5fdfae7ab6"
+  url "https://github.com/depot/cli/archive/refs/tags/v2.100.14.tar.gz"
+  sha256 "a0c37e6498e883a796ab2eda9eeb9503c0e83c606ae626048c4094ad52ad2624"
   license "MIT"
   head "https://github.com/depot/cli.git", branch: "main"
 
+  # Upstream sometimes creates a tag with a stable version format but does not
+  # create a release on GitHub.
   livecheck do
     url :stable
     strategy :github_latest
   end
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "05c4e6f34fa2d6ac922f4500bd200e6a86dc6e524ba56eeb0282def15d199991"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "05c4e6f34fa2d6ac922f4500bd200e6a86dc6e524ba56eeb0282def15d199991"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "05c4e6f34fa2d6ac922f4500bd200e6a86dc6e524ba56eeb0282def15d199991"
-    sha256 cellar: :any_skip_relocation, sonoma:        "41784c0c000f1c15b68538ce17c9f26e64b4a3d45136110438050da2fb51198d"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "0ee55bd1ef10a6e52ac5b4497335df3d6d58f4ee3adce6a3090b5c563d2f22f5"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b5ae6a40f1520b3572bdbf238bc11fcb06d5063c7789ceee344355dfc6afadc9"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "3115ffca86d2c1c09fc4e2eef5142fd99c7f490bdc5cbdd585c5d2529e15ce6c"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "3115ffca86d2c1c09fc4e2eef5142fd99c7f490bdc5cbdd585c5d2529e15ce6c"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "3115ffca86d2c1c09fc4e2eef5142fd99c7f490bdc5cbdd585c5d2529e15ce6c"
+    sha256 cellar: :any_skip_relocation, sonoma:        "f35ca9173c5d53078a5cb6c06a96ff05c6176ac0758fb0c5fb6bda9e43e075cc"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "882079f04c7b6fdfcb5acae7f976597ba9b680b81b5eb5221a87287d94a8a26a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "499a85f61374d08e7ef6980404b93f4b4afa3b2a6a93d50cd3745e1c2dfd643c"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The latest release of `depot` is 2.100.14 and this is also the version that the upstream depot/tap/depot formula is using. The 2.101.0 version is currently only tagged with no corresponding release and there have been three subsequent versions (2.100.12, 2.100.13, and 2.100.14) since it was tagged on 2025-10-27.

This downgrades the `depot` formula to 2.100.14, as that appears to be the current stable version. The `livecheck` block  is already using the `GithubLatest` strategy, so we shouldn't have to worry about versions that are tagged but a release isn't created.