### PR TITLE
utf8cpp 4.0.9

### DIFF
--- a/Formula/u/utf8cpp.rb
+++ b/Formula/u/utf8cpp.rb
@@ -1,9 +1,10 @@
 class Utf8cpp < Formula
   desc "UTF-8 with C++ in a Portable Way"
   homepage "https://github.com/nemtrif/utfcpp"
-  url "https://github.com/nemtrif/utfcpp/archive/refs/tags/v4.09.tar.gz"
-  sha256 "0902218f606e942ccc10724df8a988fc993c12da4b3adeace28a7f0211970e08"
+  url "https://github.com/nemtrif/utfcpp/archive/refs/tags/v4.0.9.tar.gz"
+  sha256 "397a9a2a6ed5238f854f490b0177b840abc6b62571ec3e07baa0bb94d3f14d5a"
   license "BSL-1.0"
+  version_scheme 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "68e034076d7c7bafa63e645d0779ab2c01efe283217f0d09edaea21f6541e3fc"

--- a/Formula/u/utf8cpp.rb
+++ b/Formula/u/utf8cpp.rb
@@ -7,7 +7,7 @@ class Utf8cpp < Formula
   version_scheme 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "68e034076d7c7bafa63e645d0779ab2c01efe283217f0d09edaea21f6541e3fc"
+    sha256 cellar: :any_skip_relocation, all: "5e326ac5dcf874a01fe9feab70c26db351f7cf272b07c127f8af2aca5dd98e72"
   end
 
   depends_on "cmake" => [:build, :test]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The 4.09 release of `utf8cpp` appears to have been a [one-off typo](https://github.com/nemtrif/utfcpp/issues/135), so the tag and release were removed and replaced with 4.0.9. The `stable` URL currently returns a 404 (Not Found) response as a result. This updates the `stable` URL and bumps the `version_scheme`, as `Version` treats 4.09 as 4.9, so 4.0.9 will be seen as lower.