### PR TITLE
libxsd-frontend: add livecheck

### DIFF
--- a/Formula/lib/libxsd-frontend.rb
+++ b/Formula/lib/libxsd-frontend.rb
@@ -5,7 +5,25 @@ class LibxsdFrontend < Formula
   sha256 "98321b9c2307d7c4e1eba49da6a522ffa81bdf61f7e3605e469aa85bfcab90b1"
   license "GPL-2.0-only"
 
-  no_autobump! because: :requires_manual_review
+  # Versions of libxsd-frontend beyond 2.0.0 (from 2014) are provided as XSD
+  # dependencies, so we have to check within XSD releases.
+  livecheck do
+    url "https://www.codesynthesis.com/products/xsd/download.xhtml"
+    regex(/href=.*?libxsd-frontend[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    strategy :page_match do |page, regex|
+      # Identify the "XSD dependencies" URL on the XSD download page
+      xsd_url = page[%r{href=["']?(["' >]*?/download/xsd/v?\d+(?:\.\d+)+)/?["' >]}i, 1]
+      next unless xsd_url
+
+      # Fetch the directory listing page for the XSD version
+      xsd_page = Homebrew::Livecheck::Strategy.page_content(
+        URI.join(@url, xsd_url).to_s,
+      )[:content]
+      next unless xsd_page
+
+      xsd_page.scan(regex).map(&:first)
+    end
+  end
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "d0932306261002d469d9a0a9a5071134841b5820b9e2880883e3f9c06f5b4e82"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

livecheck is unable to check `libxsd-frontend` by default, so this adds a `livecheck` block to identify the newest version. `libxsd-frontend` versions beyond 2.0.0 (from 2014) are provided as XSD dependencies, so we have to identify the "XSD dependencies" URL on the XSD download page and then match the tarball version on that directory listing page. This is a potentially fragile setup but we have to jump through these hoops because the `libxsd-frontend` version isn't linked on the XSD download page.