### PR TITLE
joyce: add livecheck

### DIFF
--- a/Formula/j/joyce.rb
+++ b/Formula/j/joyce.rb
@@ -5,6 +5,14 @@ class Joyce < Formula
   sha256 "85659a6ac9b94fdf78c28d5d8d65a4f69e7520e1c02a915b971c2754695ab82c"
   license "GPL-2.0-or-later"
 
+  # Upstream indicates stable releases with an even-numbered minor (e.g., 1.2.3)
+  # and the regex below only matches these versions as a way of avoiding the
+  # development tarball on the download page.
+  livecheck do
+    url "https://www.seasip.info/Unix/Joyce/download.html"
+    regex(/href=.*?joyce[._-]v?(\d+\.\d*[02468](?:\.\d+)*)\.t/i)
+  end
+
   bottle do
     sha256 arm64_tahoe:   "20c5f21b6b676f4519154d1102c52754dd27dabdc86b315608606df1c3ba37b4"
     sha256 arm64_sequoia: "ae0fdeaa3809a10e27b240f1f29e70d158f88534129099ec6d99217486def25a"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck is unable to identify versions for  `joyce`, so this adds a `livecheck` block that checks the upstream download page. Based on the version history, it appears that upstream uses an even-numbered minor version to indicate stable releases, so this regex only matches those versions as a way of avoiding the development version tarball on the download page.