### PR TITLE
utf8cpp: add version check to test

### DIFF
--- a/Formula/u/utf8cpp.rb
+++ b/Formula/u/utf8cpp.rb
@@ -19,6 +19,8 @@ class Utf8cpp < Formula
   end
 
   test do
+    assert_match("PACKAGE_VERSION \"#{version}\"", (share/"utf8cpp/cmake/utf8cppConfigVersion.cmake").read)
+
     (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 4.0 FATAL_ERROR)
       project(utf8_append LANGUAGES CXX)


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is a follow-up to the [`utf8cpp` 4.0.9 PR](https://github.com/Homebrew/homebrew-core/pull/260890) to introduce a simple version check in the `test` block ([as suggested in the previous PR](https://github.com/Homebrew/homebrew-core/pull/260890#pullrequestreview-3621919279)), as this would have caught the 4.09 version format mismatch. Hopefully upstream will be careful about this going forward but checking a 2 KB file for the version should be a simple guard.