### PR TITLE
classifier 2.3.2 (new formula)

### DIFF
--- a/Formula/c/classifier.rb
+++ b/Formula/c/classifier.rb
@@ -1,0 +1,57 @@
+class Classifier < Formula
+  desc "Text classification with Bayesian, LSI, Logistic Regression, and kNN"
+  homepage "https://rubyclassifier.com"
+  url "https://github.com/cardmagic/classifier/archive/refs/tags/v2.3.2.tar.gz"
+  sha256 "fc4ccdb302ead4758f8a2687c815250e050aa407145745150a92be474107d93f"
+  license "LGPL-2.1-or-later"
+
+  depends_on "ruby"
+
+  resource "fast-stemmer" do
+    url "https://rubygems.org/gems/fast-stemmer-1.0.2.gem"
+    sha256 "d0aa9fd9cfbca836a09d8abb122552ac8234130271a3b0da1cb077323d650819"
+  end
+
+  resource "mutex_m" do
+    url "https://rubygems.org/gems/mutex_m-0.3.0.gem"
+    sha256 "cfcb04ac16b69c4813777022fdceda24e9f798e48092a2b817eb4c0a782b0751"
+  end
+
+  resource "matrix" do
+    url "https://rubygems.org/gems/matrix-0.4.3.gem"
+    sha256 "a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b"
+  end
+
+  resource "rake" do
+    url "https://rubygems.org/gems/rake-13.2.1.gem"
+    sha256 "46cb38dae65d7d74b6020a4ac9d48afed8eb8149c040eccf0523bec91907059d"
+  end
+
+  def install
+    ENV["GEM_HOME"] = libexec
+
+    resources.each do |r|
+      r.fetch
+      system "gem", "install", r.cached_download, "--ignore-dependencies",
+             "--no-document", "--install-dir", libexec
+    end
+
+    system "gem", "build", "classifier.gemspec"
+    system "gem", "install", "--ignore-dependencies", "classifier-#{version}.gem",
+           "--install-dir", libexec
+
+    bin.install libexec/"bin/classifier"
+    bin.env_script_all_files(libexec/"bin", GEM_HOME: ENV["GEM_HOME"])
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/classifier --version")
+
+    # Test with pre-trained remote model (SMS spam detection)
+    output = shell_output("#{bin}/classifier -r sms-spam-filter 'You won a free iPhone'")
+    assert_match "spam", output.downcase
+
+    output = shell_output("#{bin}/classifier -r sms-spam-filter 'Meeting at 3pm tomorrow'")
+    assert_match "ham", output.downcase
+  end
+end

--- a/Formula/c/classifier.rb
+++ b/Formula/c/classifier.rb
@@ -5,6 +5,15 @@ class Classifier < Formula
   sha256 "fc4ccdb302ead4758f8a2687c815250e050aa407145745150a92be474107d93f"
   license "LGPL-2.1-or-later"
 
+  bottle do
+    sha256 cellar: :any,                 arm64_tahoe:   "19c7d40ed22261b05749e5a52ff43da0ef76227ae71ab08122df19ac8a92c6a3"
+    sha256 cellar: :any,                 arm64_sequoia: "e1acfc4764c8ff12231bc6296e71b9da3053b67401d06077da86b51f840b2c7b"
+    sha256 cellar: :any,                 arm64_sonoma:  "23f71b12e668e9fe3c13df7895ce0d78ddc3185c321d4cac8beff539d193c0c7"
+    sha256 cellar: :any,                 sonoma:        "8a94fc5ddb9dd37f9b5fc70b9c235c6f0ebb6210665028008666abf1a316771c"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "4d3da13cbd9672dda25f43e2f21bc851c0ae68c6ba9ce2579b3856764bf46abf"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "226f342aede197ee58be92f02d971e5f03df3e9759418713c6ac9193098fa0f1"
+  end
+
   depends_on "ruby"
 
   def install

--- a/Formula/c/classifier.rb
+++ b/Formula/c/classifier.rb
@@ -7,38 +7,14 @@ class Classifier < Formula
 
   depends_on "ruby"
 
-  resource "fast-stemmer" do
-    url "https://rubygems.org/gems/fast-stemmer-1.0.2.gem"
-    sha256 "d0aa9fd9cfbca836a09d8abb122552ac8234130271a3b0da1cb077323d650819"
-  end
-
-  resource "mutex_m" do
-    url "https://rubygems.org/gems/mutex_m-0.3.0.gem"
-    sha256 "cfcb04ac16b69c4813777022fdceda24e9f798e48092a2b817eb4c0a782b0751"
-  end
-
-  resource "matrix" do
-    url "https://rubygems.org/gems/matrix-0.4.3.gem"
-    sha256 "a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b"
-  end
-
-  resource "rake" do
-    url "https://rubygems.org/gems/rake-13.2.1.gem"
-    sha256 "46cb38dae65d7d74b6020a4ac9d48afed8eb8149c040eccf0523bec91907059d"
-  end
-
   def install
+    ENV["BUNDLE_VERSION"] = "system"
+    ENV["BUNDLE_WITHOUT"] = "development:test"
     ENV["GEM_HOME"] = libexec
 
-    resources.each do |r|
-      r.fetch
-      system "gem", "install", r.cached_download, "--ignore-dependencies",
-             "--no-document", "--install-dir", libexec
-    end
-
+    system "bundle", "install"
     system "gem", "build", "classifier.gemspec"
-    system "gem", "install", "--ignore-dependencies", "classifier-#{version}.gem",
-           "--install-dir", libexec
+    system "gem", "install", "classifier-#{version}.gem"
 
     bin.install libexec/"bin/classifier"
     bin.env_script_all_files(libexec/"bin", GEM_HOME: ENV["GEM_HOME"])

--- a/audit_exceptions/provided_by_macos_depends_on_allowlist.json
+++ b/audit_exceptions/provided_by_macos_depends_on_allowlist.json
@@ -6,5 +6,6 @@
   "llvm",
   "openblas",
   "openssl@3.0",
-  "openssl@3"
+  "openssl@3",
+  "ruby"
 ]


### PR DESCRIPTION
## Description

Text classification CLI and library for Ruby featuring:
- Naive Bayesian classification
- Latent Semantic Indexing (LSI) with native C extension
- Logistic Regression
- k-Nearest Neighbors

## Pre-trained Models

The CLI includes access to pre-trained models for common tasks:
```bash
classifier -r sms-spam-filter "You won a free iPhone"
# => spam

classifier -r imdb-sentiment "Great movie"
# => positive
```

## Stats

- **GitHub**: 664 stars, 123 forks
- **RubyGems**: 1.1M+ downloads
- **Maintained since**: 2005

## Checklist

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`?
- [x] Does your build pass `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>`?

Note: `depends_on "ruby"` is required because the gem requires Ruby >= 3.1, while macOS ships with Ruby 2.6.