### PR TITLE
dotnet@9 9.0.112 (new formula)

### DIFF
--- a/Aliases/dotnet@9
+++ b/Aliases/dotnet@9
@@ -1,1 +1,0 @@
-../Formula/d/dotnet.rb

--- a/Formula/d/dotnet@9.rb
+++ b/Formula/d/dotnet@9.rb
@@ -1,0 +1,186 @@
+class DotnetAT9 < Formula
+  desc ".NET Core"
+  homepage "https://dotnet.microsoft.com/"
+  # Source-build tag announced at https://github.com/dotnet/source-build/discussions
+  url "https://github.com/dotnet/dotnet/archive/refs/tags/v9.0.112.tar.gz"
+  sha256 "6b0d297661f16ad272212f491516f9932a93eab1c68af622b94190a566eb4d6f"
+  license "MIT"
+
+  livecheck do
+    url :stable
+    regex(/^v?(9(?:\.\d+)+)$/i)
+  end
+
+  keg_only :versioned_formula
+
+  # https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core#lifecycle
+  deprecate! date: "2026-11-10", because: :unsupported
+
+  depends_on "cmake" => :build
+  depends_on "pkgconf" => :build
+  depends_on "rapidjson" => :build
+  depends_on "brotli"
+  depends_on "icu4c@78"
+  depends_on "openssl@3"
+
+  uses_from_macos "python" => :build
+  uses_from_macos "krb5"
+  uses_from_macos "zlib"
+
+  on_macos do
+    depends_on "grep" => :build # grep: invalid option -- P
+  end
+
+  on_linux do
+    depends_on "libunwind"
+    depends_on "lttng-ust"
+
+    on_intel do
+      depends_on "llvm" => :build
+
+      fails_with :gcc do
+        cause "Illegal instruction when running crossgen2"
+      end
+
+      # Backport fix for Clang 21
+      patch do
+        url "https://github.com/dotnet/runtime/commit/d4ff34564bcaf4ec5a02ecdca17ea63e5481cc42.patch?full_index=1"
+        sha256 "6b2485ca234b6dbab8ae5e2e5007c8e8d28130d14213cd5c5546cdefc27d8373"
+        directory "src/runtime"
+      end
+    end
+  end
+
+  on_intel do
+    # Building on Intel Sonoma or later results in stack overflow on restore.
+    # See https://github.com/Homebrew/homebrew-core/issues/197546
+    depends_on maximum_macos: [:ventura, :build]
+  end
+
+  resource "release.json" do
+    url "https://github.com/dotnet/dotnet/releases/download/v9.0.112/release.json"
+    sha256 "420355ac27b4756ad45c497c42361fbff02921fa78718ee36dcf6e2632259786"
+
+    livecheck do
+      formula :parent
+    end
+  end
+
+  def install
+    odie "Update release.json resource!" if resource("release.json").version != version
+    buildpath.install resource("release.json")
+
+    # Make sure CoreCLR builds with our compiler shims
+    ENV["CLR_CC"] = which(ENV.cc)
+    ENV["CLR_CXX"] = which(ENV.cxx)
+
+    if OS.mac?
+      # Need GNU grep (Perl regexp support) to use release manifest rather than git repo
+      ENV.prepend_path "PATH", Formula["grep"].libexec/"gnubin"
+
+      # Avoid mixing CLT and Xcode.app when building CoreCLR component which can
+      # cause undefined symbols, e.g. __swift_FORCE_LOAD_$_swift_Builtin_float
+      ENV["SDKROOT"] = MacOS.sdk_for_formula(self).path
+    else
+      icu4c_dep = deps.find { |dep| dep.name.match?(/^icu4c(@\d+)?$/) }
+      ENV.append_path "LD_LIBRARY_PATH", icu4c_dep.to_formula.opt_lib
+
+      # Work around build script getting stuck when running shutdown command on Linux
+      # Ref: https://github.com/dotnet/source-build/discussions/3105#discussioncomment-4373142
+      inreplace "build.sh", '"$CLI_ROOT/dotnet" build-server shutdown', ""
+      inreplace "repo-projects/Directory.Build.targets",
+                '"$(DotnetTool) build-server shutdown --vbcscompiler"',
+                '"true"'
+    end
+
+    # Work around https://github.com/dotnet/dotnet/issues/4037 using the last
+    # valid version (2025-12-31 => 61231). Remove when upstream issue is fixed.
+    f = "src/source-build-externals/src/azure-activedirectory-identitymodel-extensions-for-dotnet/build/common.props"
+    inreplace f, '.$([System.DateTime]::Now.AddYears(-2019).Year)$([System.DateTime]::Now.ToString("MMdd"))', ".61231"
+
+    args = %w[
+      --clean-while-building
+      --release-manifest release.json
+      --source-build
+      --with-system-libs brotli+libunwind+rapidjson+zlib
+    ]
+
+    system "./prep-source-build.sh"
+    # We unset "CI" environment variable to work around aspire build failure
+    # error MSB4057: The target "GitInfo" does not exist in the project.
+    # Ref: https://github.com/Homebrew/homebrew-core/pull/154584#issuecomment-1815575483
+    with_env(CI: nil) do
+      system "./build.sh", *args
+    end
+
+    libexec.mkpath
+    tarball = buildpath.glob("artifacts/*/Release/dotnet-sdk-*.tar.gz").first
+    system "tar", "--extract", "--file", tarball, "--directory", libexec
+    doc.install libexec.glob("*.txt")
+    (bin/"dotnet").write_env_script libexec/"dotnet", DOTNET_ROOT: libexec
+
+    bash_completion.install "src/sdk/scripts/register-completions.bash" => "dotnet"
+    zsh_completion.install "src/sdk/scripts/register-completions.zsh" => "_dotnet"
+    man1.install Utils::Gzip.compress(*buildpath.glob("src/sdk/documentation/manpages/sdk/*.1"))
+    man7.install Utils::Gzip.compress(*buildpath.glob("src/sdk/documentation/manpages/sdk/*.7"))
+  end
+
+  def caveats
+    <<~CAVEATS
+      For other software to find dotnet you may need to set:
+        export DOTNET_ROOT="#{opt_libexec}"
+    CAVEATS
+  end
+
+  test do
+    target_framework = "net#{version.major_minor}"
+
+    (testpath/"test.cs").write <<~CS
+      using System;
+
+      namespace Homebrew
+      {
+        public class Dotnet
+        {
+          public static void Main(string[] args)
+          {
+            var joined = String.Join(",", args);
+            Console.WriteLine(joined);
+          }
+        }
+      }
+    CS
+
+    (testpath/"test.csproj").write <<~XML
+      <Project Sdk="Microsoft.NET.Sdk">
+        <PropertyGroup>
+          <OutputType>Exe</OutputType>
+          <TargetFrameworks>#{target_framework}</TargetFrameworks>
+          <PlatformTarget>AnyCPU</PlatformTarget>
+          <RootNamespace>Homebrew</RootNamespace>
+          <PackageId>Homebrew.Dotnet</PackageId>
+          <Title>Homebrew.Dotnet</Title>
+          <Product>$(AssemblyName)</Product>
+          <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+        </PropertyGroup>
+        <ItemGroup>
+          <Compile Include="test.cs" />
+        </ItemGroup>
+      </Project>
+    XML
+
+    system bin/"dotnet", "build", "--framework", target_framework, "--output", testpath, testpath/"test.csproj"
+    output = shell_output("#{bin}/dotnet run --framework #{target_framework} #{testpath}/test.dll a b c")
+    assert_equal "#{testpath}/test.dll,a,b,c\n", output
+
+    # Test to avoid uploading broken Intel Sonoma bottle which has stack overflow on restore.
+    # See https://github.com/Homebrew/homebrew-core/issues/197546
+    resource "docfx" do
+      url "https://github.com/dotnet/docfx/archive/refs/tags/v2.78.4.tar.gz"
+      sha256 "255f71f4a6fc7b9ffd0c598d0eba11630dc01262f1fa45ec4f1794508f7033cf"
+    end
+    resource("docfx").stage do
+      system bin/"dotnet", "restore", "src/docfx", "--disable-build-servers", "--no-cache"
+    end
+  end
+end

--- a/Formula/d/dotnet@9.rb
+++ b/Formula/d/dotnet@9.rb
@@ -11,6 +11,14 @@ class DotnetAT9 < Formula
     regex(/^v?(9(?:\.\d+)+)$/i)
   end
 
+  bottle do
+    sha256 cellar: :any,                 arm64_tahoe:   "a4746785b5f969bd7a8824efffbd32b08545650d7f12cb2cf314292dc85a0b26"
+    sha256 cellar: :any,                 arm64_sequoia: "a027d7eb2089f1c7736c83fad3b3f89dcaa885c0939713a0655ac67dc4005b8e"
+    sha256 cellar: :any,                 arm64_sonoma:  "2b82449cbb7cae0cf24ab243dfc43f74fb0d90e923bfbbf974d4df8c4c37269f"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "647ba2c7ec49b03a1ca226767f135482c6cd1a8ccdaef84e088cc36be52466cf"
+    sha256                               x86_64_linux:  "65971dc8d44c8d0d739b3349e69be6bf2e24aebd07be37b8645a177815f78f88"
+  end
+
   keg_only :versioned_formula
 
   # https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core#lifecycle


### PR DESCRIPTION
Creating versioned .NET 9 first to simplify update to .NET 10.

Main changes from existing `dotnet` formulae:
1. add `depends_on maximum_macos: [:ventura, :build]` for Intel macOS similar to `dotnet@8`. May be fixed in .NET 10 but same issue in .NET 8 and 9
2. workaround for https://github.com/dotnet/dotnet/issues/4037 by using last fixed version number (8.0.0.61231) to avoid overflow on final part since new year, e.g. 8.0.0.70101 
3. update test following TODO message