### PR TITLE
uutils-coreutils: change prefix to `uu-` matching upstream README.md

### DIFF
--- a/Formula/u/uutils-coreutils.rb
+++ b/Formula/u/uutils-coreutils.rb
@@ -12,12 +12,13 @@ class UutilsCoreutils < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "a7e6ede7d3ad3a672b96ecef95a59c2b58d2f7c464a622e5dd012f01402f9ac9"
-    sha256 cellar: :any,                 arm64_sequoia: "dae4bcc0bbf4d9f494fd6e6cbea3d3bba92a86955eccb48b1e0ade2e8e6f6820"
-    sha256 cellar: :any,                 arm64_sonoma:  "9515adc230eefd728da61076ca7b3495b2e856d6ee42f0fbde60905145bba791"
-    sha256 cellar: :any,                 sonoma:        "bb29bee913ea9aa7a13a20b6c166c0031a2d7d4a260b81231ee3933335121105"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "d14184736f28708907f717244b630f0d54e1447b0ef0d0416fa84cb27806d420"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "72dacb73146170a00cf6194e80203d67e6548a9c30c4062a4bf3886bee4a8800"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "ecd5c8b5a9baac32ff72cea0148b6d876529b27e621906ac66261ed165f62307"
+    sha256 cellar: :any,                 arm64_sequoia: "7beabd22b863f3a0b859c61926e9feb621a634819e4d4edc52e5f6c21ab542fb"
+    sha256 cellar: :any,                 arm64_sonoma:  "04ce2557e67eaeb97cca9f0e833a5153630fe6421b214ab16e1552b897c53947"
+    sha256 cellar: :any,                 sonoma:        "bc43f96580b14794f9d6558d9c9d3624825b85a4a47cfea831953557ada76c0d"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "0d10e01be67fe6a234cf1049113ba45482ce5b5417060e5c979e0ece129e0030"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "bd1a2ff2d4d111577c1ae9f1c216bc0e72bd85ad7d86fcfcb11e84e8715deda8"
   end
 
   depends_on "make" => :build

--- a/Formula/u/uutils-coreutils.rb
+++ b/Formula/u/uutils-coreutils.rb
@@ -25,9 +25,11 @@ class UutilsCoreutils < Formula
   depends_on "sphinx-doc" => :build
 
   on_macos do
+    # TODO: remove conflict in follow-up CI-syntax-only PR
     conflicts_with "coreutils", because: "uutils-coreutils and coreutils install the same binaries"
   end
 
+  # TODO: remove in follow-up to 0.8.0 bump PR
   conflicts_with "unp", because: "both install `ucat` binaries"
 
   def install
@@ -37,47 +39,54 @@ class UutilsCoreutils < Formula
     inreplace "GNUmakefile", "$(SELINUX_PROGS)", ""
 
     args = %W[
-      PROG_PREFIX=u
+      PROG_PREFIX=uu-
       PREFIX=#{prefix}
       SPHINXBUILD=#{Formula["sphinx-doc"].opt_bin}/sphinx-build
     ]
     # Call `make` as `gmake` to use Homebrew `make`.
     system "gmake", "install", *args
 
-    # Symlink all commands into libexec/uubin without the 'u' prefix
+    # Symlink all commands into libexec/uubin without the 'uu-' prefix
     coreutils_filenames(bin).each do |cmd|
-      (libexec/"uubin").install_symlink bin/"u#{cmd}" => cmd
+      uu_cmd = bin/"uu-#{cmd}"
+      (libexec/"uubin").install_symlink uu_cmd.realpath => cmd
+
+      # Fix symlinked commands which require running with non-prefixed name, e.g. sha1sum
+      if uu_cmd.symlink?
+        rm(uu_cmd)
+        bin.write_exec_script libexec/"uubin"/cmd
+        bin.install bin/cmd => "uu-#{cmd}"
+      end
+
+      # Create a temporary compatibility executable for previous 'u' prefix.
+      # All users should get the warning in 0.6.0. Similar to brew's odeprecate
+      # timeframe, the removal can be done after 2 minor releases, i.e. 0.8.0.
+      odie "Remove compatibility exec scripts!" if build.stable? && version >= "0.8.0"
+      (bin/"u#{cmd}").write <<~SHELL
+        #!/bin/bash
+        echo "WARNING: u#{cmd} has been renamed to uu-#{cmd} and will be removed in 0.8.0" >&2
+        exec "#{uu_cmd}" "$@"
+      SHELL
     end
 
-    # Symlink all man(1) pages into libexec/uuman without the 'u' prefix
+    # Symlink all man(1) pages into libexec/uuman without the 'uu-' prefix
     coreutils_filenames(man1).each do |cmd|
-      (libexec/"uuman/man1").install_symlink man1/"u#{cmd}" => cmd
+      (libexec/"uuman/man1").install_symlink man1/"uu-#{cmd}" => cmd
     end
 
     (libexec/"uubin").install_symlink "../uuman" => "man"
 
     # Symlink non-conflicting binaries
-    no_conflict = if OS.mac?
-      %w[
-        base32 dircolors factor hashsum hostid nproc numfmt pinky ptx realpath
-        shred shuf stdbuf tac timeout truncate
-      ]
-    else
-      %w[hashsum]
-    end
+    no_conflict = %w[hashsum]
     no_conflict.each do |cmd|
-      bin.install_symlink "u#{cmd}" => cmd
-      man1.install_symlink "u#{cmd}.1.gz" => "#{cmd}.1.gz"
+      bin.install_symlink "uu-#{cmd}" => cmd
+      man1.install_symlink "uu-#{cmd}.1.gz" => "#{cmd}.1.gz"
     end
   end
 
   def caveats
-    provided_by = "coreutils"
-    on_macos do
-      provided_by = "macOS"
-    end
     <<~EOS
-      Commands also provided by #{provided_by} have been installed with the prefix "u".
+      Commands have been installed with the prefix "uu-".
       If you need to use these commands with their normal names, you
       can add a "uubin" directory to your PATH from your bashrc like:
         PATH="#{opt_libexec}/uubin:$PATH"
@@ -89,7 +98,7 @@ class UutilsCoreutils < Formula
     dir.find do |path|
       next if path.directory? || path.basename.to_s == ".DS_Store"
 
-      filenames << path.basename.to_s.sub(/^u/, "")
+      filenames << path.basename.to_s.sub(/^uu-/, "")
     end
     filenames.sort
   end
@@ -97,7 +106,9 @@ class UutilsCoreutils < Formula
   test do
     (testpath/"test").write("test")
     (testpath/"test.sha1").write("a94a8fe5ccb19ba61c4c0873d391e987982fbbd3 test")
-    system bin/"uhashsum", "--sha1", "-c", "test.sha1"
-    system bin/"uln", "-f", "test", "test.sha1"
+    system bin/"uhashsum", "--sha1", "-c", "test.sha1" # TODO: remove in 0.8.0
+    system bin/"uu-hashsum", "--sha1", "-c", "test.sha1"
+    system bin/"uu-sha1sum", "-c", "test.sha1"
+    system bin/"uu-ln", "-f", "test", "test.sha1"
   end
 end

--- a/Formula/u/uutils-findutils.rb
+++ b/Formula/u/uutils-findutils.rb
@@ -7,14 +7,13 @@ class UutilsFindutils < Formula
   head "https://github.com/uutils/findutils.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "9c59351876b4d6de586972073bc02e141ac57804b24e933399e10844774eafde"
-    sha256 cellar: :any,                 arm64_sequoia: "c197c5ae51adde63a7d0a3770d89156032935597db27883e24d912043411bd9f"
-    sha256 cellar: :any,                 arm64_sonoma:  "3cd43adf157c7f4ffe8ff244b90b7d01a42206cf3cf7dd55d314e815a2462da9"
-    sha256 cellar: :any,                 arm64_ventura: "5edf7fd9d0c8f2be1ee7cb0ed463225bc1fa36dd31b04bb3127448cdd35001a0"
-    sha256 cellar: :any,                 sonoma:        "f3518a5685deaf7be0e4f12d5ea7f84eeaaedcc6ec1c0d1280810a7678ee302e"
-    sha256 cellar: :any,                 ventura:       "aa9cc3375d6bda074e8fb1011ef52f3ae0d0f99bcc952aa27e93e834e16af145"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "e1d8413308ed4eb7a6001c5dde07faaf73a96aa26e5e9d0aa6a382bcb6a64918"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d595a82a20897f5ec7fbe852d50fca44f05d20e537913bf9b86aab9e2ef4e4c5"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "6eb3e88da89772a813c0147b7c3a0f62832b7661ff428c6c2fdbf52a03d63593"
+    sha256 cellar: :any,                 arm64_sequoia: "0a7c3c5b37302609771a28be11cc84443a759ecd8825c3ee1532f578d3428ba6"
+    sha256 cellar: :any,                 arm64_sonoma:  "1e2926212ba80f571e8a9c9a4e240e2418c828d28a4c73afd11263771c78f522"
+    sha256 cellar: :any,                 sonoma:        "4504ecdf9e500e9bc9c56ebacd087bd056fab8d0e039e7cdc6021e9d3ac82afb"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "1a3d9faebb6fa34813ab9f17a87f2a10e68a5f08267791487d70e1a09376da5e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2edddc168292e0f75bde8380d1e6ff5f11c053f9aeb9d25752ce327410083bd2"
   end
 
   depends_on "pkgconf" => :build


### PR DESCRIPTION
This helps avoid conflicts with other formulae like `unp` and helps reduce variations across repositories. Currently,
* Arch Linux, Gentoo and MacPorts use `uu-`
* Fedora uses `uu_`
* NixOS uses `uutils-`

Other changes:
* Keep around temporary `u`-prefixed exec scripts until 0.8.0.
* Fix broken `usha*sum` binaries which need to be run without prefix
* Drop conflicts with `coreutils`. Part of reason for prefixing these commands is to avoid conflicts. Also, this lacks the special handling in `coreutils` which avoids problematic binaries (e.g. `dircolors`) and new macOS executables (e.g. `realpath`).

---

Also update `uutils-findutils` to align change.

Will handle `uutils-diffutils` separately as it doesn't actually shadow any GNU/macOS commands yet.