### PR TITLE
meson: backport fix for regression

### DIFF
--- a/Formula/m/meson.rb
+++ b/Formula/m/meson.rb
@@ -16,7 +16,8 @@ class Meson < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "cfaeb1188e74248f4a38e85c4b515a28371f59bca5ca830a4185523724f804af"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "1d795f4fb3d1f6f8046e95d58f8f47d5c95e15e4299a1789cd91677a9df45445"
   end
 
   depends_on "ninja"

--- a/Formula/m/meson.rb
+++ b/Formula/m/meson.rb
@@ -1,10 +1,19 @@
 class Meson < Formula
   desc "Fast and user friendly build system"
   homepage "https://mesonbuild.com/"
-  url "https://github.com/mesonbuild/meson/releases/download/1.10.0/meson-1.10.0.tar.gz"
-  sha256 "8071860c1f46a75ea34801490fd1c445c9d75147a65508cd3a10366a7006cc1c"
   license "Apache-2.0"
   head "https://github.com/mesonbuild/meson.git", branch: "master"
+
+  stable do
+    url "https://github.com/mesonbuild/meson/releases/download/1.10.0/meson-1.10.0.tar.gz"
+    sha256 "8071860c1f46a75ea34801490fd1c445c9d75147a65508cd3a10366a7006cc1c"
+
+    # Backport fix for https://github.com/mesonbuild/meson/issues/15360
+    patch do
+      url "https://github.com/mesonbuild/meson/commit/4bbd1ef923e995cd88c255cef65649ab8b07cfc6.patch?full_index=1"
+      sha256 "096b1d5c9c4121e64f188cf6775045c86f9e64c7787e7015ca6d182ba35e0771"
+    end
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "cfaeb1188e74248f4a38e85c4b515a28371f59bca5ca830a4185523724f804af"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Seen in https://github.com/Homebrew/homebrew-core/actions/runs/20607826934/job/59187157380#step:3:343