### PR TITLE
utiluti 1.3 (new formula)

### DIFF
--- a/Formula/u/utiluti.rb
+++ b/Formula/u/utiluti.rb
@@ -1,0 +1,21 @@
+class Utiluti < Formula
+  desc "macOS command-line to work with default apps"
+  homepage "https://github.com/scriptingosx/utiluti"
+  url "https://github.com/scriptingosx/utiluti/archive/refs/tags/v1.3.tar.gz"
+  sha256 "98d72888421cf048d157da3b64dcc4bdc165c4899de987636a1cac022e5bd7ff"
+  license "Apache-2.0"
+  head "https://github.com/scriptingosx/utiluti.git", branch: "main"
+
+  depends_on :macos
+  uses_from_macos "swift"
+
+  def install
+    system "swift", "build", "--disable-sandbox", "--configuration", "release"
+    bin.install ".build/release/utiluti"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/utiluti --version")
+    assert_match "public.plain-text", shell_output("#{bin}/utiluti get-uti txt")
+  end
+end

--- a/style_exceptions/not_a_binary_url_prefix_allowlist.json
+++ b/style_exceptions/not_a_binary_url_prefix_allowlist.json
@@ -5,6 +5,7 @@
   "flashrom",
   "organize-tool",
   "reattach-to-user-namespace",
+  "utiluti",
   "wallpaper",
   "x264"
 ]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?


A note on the last task: I do receive the following offense, but this seems to be the same way other source-based formulas reference GitHub. If I'm misinterpreting how to do this, would a maintainer please advise?

```sh
brew audit --new utiluti
utiluti
  * line 4, col 3: https://github.com/scriptingosx/utiluti/archive/refs/tags/v1.3.tar.gz looks like a binary package, not a source archive; homebrew/core is source-only.
Error: 1 problem in 1 formula detected.
```

-----

replacing mistake in https://github.com/Homebrew/brew/pull/21355

closes https://github.com/scriptingosx/utiluti/issues/6