### PR TITLE
mlx: remove from `not_a_binary_url_prefix_allowlist`

### DIFF
--- a/style_exceptions/not_a_binary_url_prefix_allowlist.json
+++ b/style_exceptions/not_a_binary_url_prefix_allowlist.json
@@ -3,7 +3,6 @@
   "cpm",
   "cspice",
   "flashrom",
-  "mlx",
   "organize-tool",
   "reattach-to-user-namespace",
   "wallpaper",


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
This is no longer necessary.

```
╰─ brew audit --online --strict mlx && echo $?
0
```