### PR TITLE
kubefwd 1.25.9 (new formula)

### DIFF
--- a/Formula/k/kubefwd.rb
+++ b/Formula/k/kubefwd.rb
@@ -1,0 +1,30 @@
+class Kubefwd < Formula
+  desc "Bulk port forwarding Kubernetes services for local development"
+  homepage "https://kubefwd.com"
+  url "https://github.com/txn2/kubefwd/archive/refs/tags/v1.25.9.tar.gz"
+  sha256 "29b8ef02f18e0b398d6aed059cc9ef59471b7f713e6616c8c64b32bfa9e630e5"
+  license "Apache-2.0"
+  head "https://github.com/txn2/kubefwd.git", branch: "master"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = "-s -w -X main.Version=#{version}"
+    system "go", "build", *std_go_args(ldflags:), "./cmd/kubefwd"
+
+    generate_completions_from_executable(bin/"kubefwd", shell_parameter_format: :cobra)
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/kubefwd version")
+    assert_match "This program requires superuser privileges to run.", shell_output("#{bin}/kubefwd services")
+
+    output_log = testpath/"output.log"
+    pid = spawn bin/"kubefwd", "mcp", [:out, :err] => output_log.to_s
+    sleep 2
+    assert_match "Cannot connect to kubefwd API", output_log.read
+  ensure
+    Process.kill("TERM", pid)
+    Process.wait(pid)
+  end
+end


### PR DESCRIPTION
 kubefwd is a Kubernetes port-forwarding utility (originally developed in 2018) that forwards multiple services from one or more namespaces, adding `/etc/hosts` entries for local development. Unlike `kubectl port-forward`, each service gets its own unique loopback IP (127.x.x.x), allowing multiple services to use the same port simultaneously and their cluster hostnames.

  **Key features:**
  - Bulk port forwarding with automatic `/etc/hosts` management
  - Unique loopback IPs per service (no port conflicts)
  - Auto-reconnect on pod restarts
  - Interactive TUI mode
  - MCP mode for AI agent integration
  - Shell completions (bash, zsh, fish, powershell)

  **Project stats:**
  - ~4,000 GitHub stars, 219 forks
  - Active since 2018, featured in "essential Kubernetes developer tools" lists
  - Apache-2.0 license

  **Previous submission:** PR #45721 was submitted by a community member in 2019 and closed due to lack of follow-through. This submission is from the project maintainer and I will be responsive to feedback.
  -----

  - [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
  - [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
  - [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
  - [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
  - [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
  - [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

  All items are checked because I verified them:
  - Built from source (28 seconds)
  - brew test passed
  - brew audit --strict --new --online passed
  - Commit format: kubefwd 1.25.7 (new formula)
  - No other open PRs for kubefwd
