### PR TITLE
openbao: fix version reporting and simplify build

### DIFF
--- a/Formula/o/openbao.rb
+++ b/Formula/o/openbao.rb
@@ -13,12 +13,13 @@ class Openbao < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "8f0e7c834e6dce0cf00128593516c0f600f8a5f63941ba5cdc5af4fac101f89e"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "a21513f1c682beba9555549dec65bb052c0b4911784985d2487e91b3c1d4dde1"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "fa115e2a8cdbcc979ae939d874f169ab11c3290dc00715b9a3d12343ce0c1fcf"
-    sha256 cellar: :any_skip_relocation, sonoma:        "cbe4fe7600d30c316be5789116fd2f91299f0b3986613c6bdf3932801e81ba47"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "75f06a3e8035b9f0f8288dbea4e4ef7115ae92ab4739fdb1b84fc2d173081730"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "16a548408a29fa19ae80ac8e81cb90c22f5589ad5888f80a02d960b51786bc55"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "8999fa214ae6d762b4a220a4f50962446163fe41b1fee27b219a24654efa5397"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "f68a8e8b14b413aa61647add948f8012222f7b11a33be605bfaf62c1610fac79"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "82e7b1d677857025887ba8d7e27295705b53589927a88b1cfcd671ca5d064d1c"
+    sha256 cellar: :any_skip_relocation, sonoma:        "170749bba9981bcee3d88ce4e73fc6a4edbcd22c0d0abccc580d548e2f44b99e"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "e16e7abfa3a9107c25dd26b0d5d0361bd1e25278f75e5ab96a1235d012338c29"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8fde949f5478f711a4a67dfaf406e3081b6cec60f42e789f53fdf1cb1cad779f"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
  - Fix `bao --version` reporting incorrect version (`2.0.0-HEAD` instead of actual version)
  - Remove UI build (node, yarn dependencies) to match official OpenBao releases
  - Add ldflags to inject version info during Go build

## Problem

  The current formula runs `make dev-ui` which:
  1. Doesn't pass ldflags to set version variables, causing `bao --version` to show `2.0.0-HEAD`
  2. Attempts to build the Ember UI which has known build failures and is not included in official OpenBao binaries

## Details

Before:

```sh
bao --version
OpenBao v2.0.0-HEAD ('4bfd70723d4f9b82be00e87b8c018ac661dd9b99'), built 2025-11-24T14:37:04Z
```

2025-11-24 is the release date of v2.4.4.

After the patch:

```sh
go build -ldflags=-s -w -X github.com/openbao/openbao/version.fullVersion=2.4.4 -X github.com/openbao/openbao/version.GitCommit=4bfd70723d4f9b82be00e87b8c018ac66
==> Caveats
To start pjs/local/openbao now and restart at login:
  brew services start pjs/local/openbao
Or, if you don't want/need a background service you can just run:
  /opt/homebrew/opt/openbao/bin/bao server -dev
==> Summary
🍺  /opt/homebrew/Cellar/openbao/2.4.4: 9 files, 118.4MB, built in 1 minute 20 seconds
==> Running `brew cleanup openbao`...

❯ bao --version
OpenBao v2.4.4 (4bfd70723d4f9b82be00e87b8c018ac661dd9b99), built 2025-11-24T19:37:04Z (cgo)
```

Note: Current binaries still reference the wrong version as they were built without the required LDFLAGS.

See also https://github.com/openbao/openbao/pull/401

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
