### PR TITLE
caire: update test to run assert_path_exists

### DIFF
--- a/Formula/c/caire.rb
+++ b/Formula/c/caire.rb
@@ -42,14 +42,9 @@ class Caire < Formula
   end
 
   test do
-    pid = fork do
-      system bin/"caire", "-in", test_fixtures("test.png"), "-out", testpath/"test_out.png",
-            "-width=1", "-height=1", "-perc=1"
-      assert_path_exists testpath/"test_out.png"
-    end
-
+    system bin/"caire", "-in", test_fixtures("test.png"), "-out", testpath/"test_out.png",
+                        "-width=1", "-height=1", "-perc=1", "-preview=false"
+    assert_path_exists testpath/"test_out.png"
     assert_match version.to_s, shell_output("#{bin}/caire -help 2>&1")
-  ensure
-    Process.kill("HUP", pid)
   end
 end


### PR DESCRIPTION
Previously test would block on preview window which meant nothing was actually verified. Just run with `-preview=false` for headless test.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
