### PR TITLE
zig@0.14: move out deprecation date

### DIFF
--- a/Formula/a/anyzig.rb
+++ b/Formula/a/anyzig.rb
@@ -16,6 +16,9 @@ class Anyzig < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "b96df77ca3f2ffd21ff157661045237683a954504516c300c8965232329446c3"
   end
 
+  # Aligned to `zig@0.14` formula. Can be removed if upstream updates to newer Zig.
+  deprecate! date: "2026-08-19", because: "does not build with Zig >= 0.15"
+
   depends_on "zig@0.14" => :build
 
   conflicts_with "zig", because: "both install `zig` binaries"

--- a/Formula/b/bold.rb
+++ b/Formula/b/bold.rb
@@ -14,6 +14,9 @@ class Bold < Formula
     sha256 cellar: :any_skip_relocation, ventura:       "c9f50e5f314cfaeb955778838e303f508167ac884b48846ff1c31c786dcd5644"
   end
 
+  # Aligned to `zig@0.14` formula. Can be removed if upstream updates to newer Zig.
+  deprecate! date: "2026-08-19", because: "does not build with Zig >= 0.15"
+
   depends_on "zig@0.14" => :build
   depends_on :macos # does not build on linux
 

--- a/Formula/g/glyph.rb
+++ b/Formula/g/glyph.rb
@@ -19,7 +19,7 @@ class Glyph < Formula
   end
 
   # Aligned to `zig@0.14` formula. Can be removed if upstream updates to newer Zig.
-  deprecate! date: "2026-02-19", because: "does not build with Zig >= 0.15"
+  deprecate! date: "2026-08-19", because: "does not build with Zig >= 0.15"
 
   depends_on "pkgconf" => :build
   depends_on "zig@0.14" => :build # https://github.com/seatedro/glyph/issues/32

--- a/Formula/l/lsr.rb
+++ b/Formula/l/lsr.rb
@@ -18,7 +18,7 @@ class Lsr < Formula
   end
 
   # Aligned to `zig@0.14` formula. Can be removed if upstream updates to newer Zig.
-  deprecate! date: "2026-02-19", because: "does not build with Zig >= 0.15"
+  deprecate! date: "2026-08-19", because: "does not build with Zig >= 0.15"
 
   depends_on "zig@0.14" => :build # https://tangled.sh/@rockorager.dev/lsr/issues/13
 

--- a/Formula/z/zig@0.14.rb
+++ b/Formula/z/zig@0.14.rb
@@ -24,9 +24,9 @@ class ZigAT014 < Formula
   keg_only :versioned_formula
 
   # Unsupported since Zig 0.15 was released on 2025-08-19, but we are
-  # giving an extra 6 months for dependents to migrate to newer Zig
-  deprecate! date: "2026-02-19", because: :unsupported
-  # disable! date: "2026-08-19", because: :unsupported
+  # giving an extra 1 year for dependents to migrate to newer Zig
+  deprecate! date: "2026-08-19", because: :unsupported
+  # disable! date: "2027-02-19", because: :unsupported
 
   depends_on "cmake" => :build
   depends_on "lld@19"

--- a/Formula/z/zigmod.rb
+++ b/Formula/z/zigmod.rb
@@ -19,8 +19,11 @@ class Zigmod < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "404076d214fae1b64dcc4f17ec37606fc303fa18f475342933cfd93331817323"
   end
 
+  # Aligned to `zig@0.14` formula. Can be removed if upstream updates to newer Zig.
+  deprecate! date: "2026-08-19", because: "does not build with Zig >= 0.15"
+
   depends_on "pkgconf" => :build
-  depends_on "zig@0.14"
+  depends_on "zig@0.14" # https://github.com/nektro/zigmod/issues/113
 
   def install
     # Fix illegal instruction errors when using bottles on older CPUs.

--- a/Formula/z/zigup.rb
+++ b/Formula/z/zigup.rb
@@ -27,6 +27,9 @@ class Zigup < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "ec4689d639d16b0ddc595eeecf71a24209d8d91bd8a4ffbcdbe2b18e6025715a"
   end
 
+  # Aligned to `zig@0.14` formula. Can be removed if upstream updates to newer Zig.
+  deprecate! date: "2026-08-19", because: "does not build with Zig >= 0.15"
+
   depends_on "zig@0.14" => :build
 
   def install


### PR DESCRIPTION
Move out the deprecation date to give 1 year given slow progress of dependents.

Also mark everything using `zig@0.14` with same deprecation date so that it doesn't block CI.