### PR TITLE
neovim: add tree-sitter-cli dependency

### DIFF
--- a/Formula/n/neovim.rb
+++ b/Formula/n/neovim.rb
@@ -78,6 +78,7 @@ class Neovim < Formula
   depends_on "lpeg"
   depends_on "luajit"
   depends_on "luv"
+  depends_on "tree-sitter-cli"
   depends_on "unibilium"
   depends_on "utf8proc"
 


### PR DESCRIPTION
The tree-sitter-cli package is required to compile tree-sitter parsers and is now listed as a dependency of the popular nvim-treesitter plugin.

Without tree-sitter-cli installed, the nvim-treesitter plugin will emit a message on every start as it tries and fails to compile the language parsers requested by the user.  Do the simple thing and add a dependency to the neovim package to provide the user with a sane environment for using tree-sitter.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
