### PR TITLE
pstoedit 4.3

### DIFF
--- a/Formula/p/pstoedit.rb
+++ b/Formula/p/pstoedit.rb
@@ -6,14 +6,12 @@ class Pstoedit < Formula
   license "GPL-2.0-or-later"
 
   bottle do
-    sha256 arm64_tahoe:   "e773007c11d92ed03d522da9acddabe00010345187e10dcf2b8921bdcac62cb4"
-    sha256 arm64_sequoia: "4577e541a3d69e7c9fdc3291b552e4cfb50a8a3603c080a3c2c2d1f9ea7e96a6"
-    sha256 arm64_sonoma:  "b17eff3c581194a6bf0290507456b75edbbad20cde4c01793cc9754425e59712"
-    sha256 arm64_ventura: "355cc44f552bd82c5cf39915449de0a4051eb2f9efba352323b87eb0403f15db"
-    sha256 sonoma:        "6353b2d9287a6e0524047a32cafb61f8c09d4d476d1bc13d40b73289aace060c"
-    sha256 ventura:       "bd4b577c2ed8b2f4c1b9ded0ed953365f445b29bff62e262caef589cb49d049c"
-    sha256 arm64_linux:   "ae82c51bc2186d4b32fa75d8b8bceff7bec7f2da0bf20c4cf51d669d0c5a4cec"
-    sha256 x86_64_linux:  "c2c8d0315852f2dca193e34433526f2635f9a8b3b6fd02ccca85646f92cbf56a"
+    sha256 arm64_tahoe:   "ec621b279a29d7d40d7b5a0be2c1f3bb670afa6db0db269421b5f5bf65c984b3"
+    sha256 arm64_sequoia: "042b5b95fe959b9e09d4e407a3502f8be31239b012295c1aa7a070682e405a7e"
+    sha256 arm64_sonoma:  "1c949cb1b0dd899c1b70db1bf662d288c0cb3173facb72bd74483399a709c0b4"
+    sha256 sonoma:        "04eede4a48448503f79ab9a9a52d23982f956bf315a31147dc90d29332b4bea8"
+    sha256 arm64_linux:   "1c23ba09ab213722081cae59fe165f8bad1af2f3f8d26d950c11f55ba309eb9b"
+    sha256 x86_64_linux:  "ccbe027ead36fd375a176f7631bbccfdd2268277c16b21f22eb9900d43f1fec4"
   end
 
   depends_on "autoconf" => :build


### PR DESCRIPTION
pstoedit has become a bit outdated. the current sources have been migrated to github. This pull request may contain a somewhat crude port, but I believe also with the upcoming depreciation of icu4c@76 on which the current bottled version depends, pstoedit should be updated

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
