### PR TITLE
flash: use pipe_output rather than `shell_output("echo ... |`

### DIFF
--- a/Formula/f/flash.rb
+++ b/Formula/f/flash.rb
@@ -18,7 +18,10 @@ class Flash < Formula
   test do
     cp test_fixtures("test.dmg.gz"), "test.dmg.gz"
     system "gunzip", "test.dmg"
-    output = shell_output("echo foo | #{bin}/flash --device /dev/disk42 test.dmg", 1)
-    assert_match "Please answer yes or no.", output
+    output = pipe_output("#{bin}/flash --device /dev/disk42 test.dmg", "foo\n", 1)
+    # On Linux, need `hdparm` installed by system package manager as it is run
+    # via `sudo` which will not have Homebrew's bin in PATH.
+    expected = OS.mac? ? "Please answer yes or no." : "No 'hdparm' command found"
+    assert_match expected, output
   end
 end


### PR DESCRIPTION
For Linux, `flash` checks
```bash
if ! sudo sh -c 'command -v hdparm' > /dev/null; then
```

Which means this needs a 1st-party package manager installed `hdparm` to be available in `sudo` PATH.

Could alternatively be made `depends_on :macos`.