### PR TITLE
xmodmap: test with spawn

### DIFF
--- a/Formula/x/xmodmap.rb
+++ b/Formula/x/xmodmap.rb
@@ -35,9 +35,7 @@ class Xmodmap < Formula
   end
 
   test do
-    fork do
-      exec Formula["xorg-server"].bin/"Xvfb", ":1"
-    end
+    spawn Formula["xorg-server"].bin/"Xvfb", ":1"
     ENV["DISPLAY"] = ":1"
     sleep 10
     sleep 10 if OS.mac? && Hardware::CPU.intel?


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

~~macOS runners usually have a DISPLAY and xvfb-run can avoid the sleep as it will run command after DISPLAY is ready.~~

EDIT: Looks like macOS still needs a DISPLAY