### PR TITLE
scm-manager: test with spawn, use curl retry rather than sleep

### DIFF
--- a/Formula/s/scm-manager.rb
+++ b/Formula/s/scm-manager.rb
@@ -42,10 +42,11 @@ class ScmManager < Formula
       s.gsub! "port: 8080", "port: #{port}"
     end
     ENV["JETTY_BASE"] = testpath
-    pid = fork { exec bin/"scm-server" }
-    sleep 15
-    assert_match "<title>SCM-Manager</title>", shell_output("curl http://localhost:#{port}/scm/")
+    pid = spawn bin/"scm-server"
+    output = shell_output("curl --silent --retry 5 --retry-connrefused http://localhost:#{port}/scm/")
+    assert_match "<title>SCM-Manager</title>", output
   ensure
     Process.kill "TERM", pid
+    Process.wait pid
   end
 end


### PR DESCRIPTION
Curl retry could allow some faster runners to finish earlier while still waiting for slower runners. It uses exponential backoff so 4th retry is about 15s.