### PR TITLE
git-annex-remote-rclone: use assert_predicate in test

### DIFF
--- a/Formula/g/git-annex-remote-rclone.rb
+++ b/Formula/g/git-annex-remote-rclone.rb
@@ -30,10 +30,10 @@ class GitAnnexRemoteRclone < Formula
     system "git", "annex", "init"
 
     (testpath/"Hello.txt").write "Hello!"
-    assert !File.symlink?("Hello.txt")
+    refute_predicate testpath/"Hello.txt", :symlink?
     assert_match(/^add Hello.txt.*ok.*\(recording state in git\.\.\.\)/m, shell_output("git annex add ."))
     system "git", "commit", "-a", "-m", "Initial Commit"
-    assert File.symlink?("Hello.txt")
+    assert_predicate testpath/"Hello.txt", :symlink?
 
     ENV["RCLONE_CONFIG_TMPLOCAL_TYPE"]="local"
     system "git", "annex", "initremote", "testremote", "type=external", "externaltype=rclone",


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Failure message is better than `assert`