### PR TITLE
fzf-tab 1.1.2 (new formula)

### DIFF
--- a/Formula/f/fzf-tab.rb
+++ b/Formula/f/fzf-tab.rb
@@ -1,0 +1,25 @@
+class FzfTab < Formula
+  desc "Replace zsh completion selection menu with fzf"
+  homepage "https://github.com/Aloxaf/fzf-tab"
+  url "https://github.com/Aloxaf/fzf-tab/archive/refs/tags/v1.1.2.tar.gz"
+  sha256 "c83cdf6d50fe6af8bf4343bd27162949852041bdfe6e444e16db5e0be0cf7c74"
+  license "MIT"
+
+  uses_from_macos "zsh"
+
+  def install
+    pkgshare.install "fzf-tab.zsh", "lib", "modules"
+  end
+
+  def caveats
+    <<~EOS
+      To activate fzf-tab, add the following to your .zshrc:
+        source "#{opt_pkgshare}/fzf-tab.zsh"
+    EOS
+  end
+
+  test do
+    assert_path_exists pkgshare/"fzf-tab.zsh"
+    system "zsh", "-c", "source #{pkgshare}/fzf-tab.zsh && (( $+functions[fzf-tab-complete] ))"
+  end
+end

--- a/Formula/f/fzf-tab.rb
+++ b/Formula/f/fzf-tab.rb
@@ -5,6 +5,10 @@ class FzfTab < Formula
   sha256 "c83cdf6d50fe6af8bf4343bd27162949852041bdfe6e444e16db5e0be0cf7c74"
   license "MIT"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, all: "24223cd008a939bd2cc6bbca48e8fa942ff8ef91dd304e35206fa9852e7ced2c"
+  end
+
   uses_from_macos "zsh"
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
"This adds the popular fzf-tab Zsh plugin, which currently requires manual
  installation or a third-party plugin manager. This formula allows it to be
  managed natively by Homebrew."