### PR TITLE
vitess: add go1.26 build patch

### DIFF
--- a/Formula/v/vitess.rb
+++ b/Formula/v/vitess.rb
@@ -6,12 +6,13 @@ class Vitess < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "f0527e0ec0169239cfce80fd83afc8dc7a3842dcf46b9bf6f04190a6a8b1a497"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "ef496ff7737cf572799801c4059d256b4ed1ac1ac01547afc638ff082e1c29d3"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "c6d79d861b8078513bd8cc9726491dde8370e2ddf33a5f07510e4c21d987ad0d"
-    sha256 cellar: :any_skip_relocation, sonoma:        "5699f4f1344bc9a1d36dcefea6408bf2ffeecc6ba45d9d440764b0a7213b2064"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "79b06c3c77949112420f47ddc3224c75497e657d79f92b5c9efec1fdffdb5d20"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "61fc570d8c084fc88cfa3c4170aff428a5503edd6ac9f666a1735e88f675acbe"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "1e5062c627f55690c1d508ae83d4701108b622e8b98f246827c32d52cfaa890c"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "0c0e5aaa0998b48dbdefbbcf78b9c2bbf6cf757b66499635e3ed9424c5f7b76d"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "8a1e98fcb3238e8a6ccf7732856194c9d8b3d6c30cf2023e924ceb0160bd59ca"
+    sha256 cellar: :any_skip_relocation, sonoma:        "88bb197ebcebef61867972adbb702f6941d4d8b6e53473f6ec9eb09d248d32fb"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "54145d2a4da2451a4b059a59504b5b09eaa810e4cbe611466e5744a06a46a498"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "31f4388df79ec234090e71ecf2601620263156d0dc2e816d6f92736d9d912753"
   end
 
   depends_on "go" => :build

--- a/Formula/v/vitess.rb
+++ b/Formula/v/vitess.rb
@@ -17,6 +17,13 @@ class Vitess < Formula
   depends_on "go" => :build
   depends_on "etcd"
 
+  # Support Go 1.26 and later with Swiss maps always enabled
+  # Upstream PR ref: https://github.com/vitessio/vitess/pull/19088
+  patch do
+    url "https://github.com/vitessio/vitess/commit/1e131ea41b87a047acff3b1977d9fece8e25bfff.patch?full_index=1"
+    sha256 "6dd13ffbde947a2c0d426c5a6361e3f0f708c9fc1bd1df7b000ad06fa8644a9c"
+  end
+
   def install
     # -buildvcs=false needed for build to succeed on Go 1.18.
     # It can be removed when this is no longer the case.


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Ref:
* Upstream https://github.com/vitessio/vitess/issues/19087
* Upstream https://github.com/vitessio/vitess/pull/19088
* https://github.com/Homebrew/homebrew-core/pull/258912