### PR TITLE
sendemail: switch to HTTPS Debian source and deprecate

### DIFF
--- a/Formula/s/sendemail.rb
+++ b/Formula/s/sendemail.rb
@@ -1,18 +1,18 @@
 class Sendemail < Formula
   desc "Email program for sending SMTP mail"
   homepage "http://caspian.dotconf.net/menu/Software/SendEmail/"
-  url "http://caspian.dotconf.net/menu/Software/SendEmail/sendEmail-v1.56.tar.gz"
+  url "https://deb.debian.org/debian/pool/main/s/sendemail/sendemail_1.56.orig.tar.gz"
+  mirror "http://caspian.dotconf.net/menu/Software/SendEmail/sendEmail-v1.56.tar.gz"
   sha256 "6dd7ef60338e3a26a5e5246f45aa001054e8fc984e48202e4b0698e571451ac0"
   license "GPL-2.0-or-later"
-
-  livecheck do
-    skip "Not actively developed or maintained"
-  end
 
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, all: "113001c5e97ed667b4f8401c335b3a337a7354b1562ca8b40b6499e6cdb68278"
   end
+
+  # Upstream homepage is gone
+  deprecate! date: "2026-01-05", because: :repo_removed
 
   # Reported upstream: https://web.archive.org/web/20191013154932/caspian.dotconf.net/menu/Software/SendEmail/#comment-1119965648
   patch do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
