### PR TITLE
glooctl: update livecheck

### DIFF
--- a/Formula/g/glooctl.rb
+++ b/Formula/g/glooctl.rb
@@ -8,10 +8,11 @@ class Glooctl < Formula
 
   # Upstream creates releases that use a stable tag (e.g., `v1.2.3`) but are
   # labeled as "pre-release" on GitHub before the version is released, so it's
-  # necessary to use the `GithubLatest` strategy.
+  # necessary to use the `GithubReleases` strategy.
   livecheck do
     url :stable
-    strategy :github_latest
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :github_releases
   end
 
   bottle do


### PR DESCRIPTION
Update livecheck as GitHub latest is set to beta tags:
```console
❯ curl -sI https://github.com/solo-io/gloo/releases/latest | grep location
location: https://github.com/solo-io/gloo/releases/tag/v1.21.0-beta11
```

After change:
```console
❯ brew lc glooctl --autobump --debug

Formula:          glooctl
livecheck block?: Yes

URL (stable):     https://github.com/solo-io/gloo/archive/refs/tags/v1.20.7.tar.gz
Strategy:         GithubReleases
Regex:            /^v?(\d+(?:\.\d+)+)$/i
URL (strategy):   https://api.github.com/repos/solo-io/gloo/releases

Matched Versions:
1.20.7, 1.20.6, 1.20.5, 1.19.10, 1.18.31, 1.17.36, 1.20.4, 1.19.9, 1.20.3, 1.19.8, 1.18.30, 1.17.35, 1.20.2, 1.20.1, 1.19.7, 1.18.28, 1.17.34, 1.20.0

glooctl: 1.20.7 ==> 1.20.7
```