### PR TITLE
neomutt 20260105, bump version scheme

### DIFF
--- a/Formula/n/neomutt.rb
+++ b/Formula/n/neomutt.rb
@@ -8,12 +8,12 @@ class Neomutt < Formula
   head "https://github.com/neomutt/neomutt.git", branch: "main"
 
   bottle do
-    sha256 arm64_tahoe:   "3443bee6f0ecad425e4e96a88e56a840f81f0ea51b37aeb541a4622354e93290"
-    sha256 arm64_sequoia: "d3d7684c19f9a4ccaf59373026d7557e1d58885aba092d818f1a789dd92a85fe"
-    sha256 arm64_sonoma:  "a45e60a745416456fdb30d59fdbf1b38b1304caf300b253464a9c6ef8f6962de"
-    sha256 sonoma:        "89f90d143a74ab764d8ea02eee280563acfb5ff78ac3794f787d6a67c5565b60"
-    sha256 arm64_linux:   "427dbb135581eb3223d22e293edeed6a81e1a8adced0a10c5cb06272cc4e2e25"
-    sha256 x86_64_linux:  "c386e1cccd8b765f2247d315baaa4b0bc356ceb7b92c93733c23443d2577a210"
+    sha256 arm64_tahoe:   "ae40f7fe4d717d8f2ea1567c77a3ea7bbd6c5ce126e06a76d816ccbf49dfae2b"
+    sha256 arm64_sequoia: "daa57699dd78f7016360cf181bc5cd497bf19ad7c98339eb4b6cac7e521fe84c"
+    sha256 arm64_sonoma:  "5c1b3c7178751668b687fed01bd6667cd4821e0757f79c6f97f145af61b0f8f8"
+    sha256 sonoma:        "d937f33c75e4c2d2ad271e537ce3d555e481836284eb31f0ea1c9f219b8e31bb"
+    sha256 arm64_linux:   "a573bf0d996f6e4fca4c70e6f162183c122f276e96611e31594ab801ce9d5c6b"
+    sha256 x86_64_linux:  "98ebcb577ab3346242635d4ffb7f08d67ba28e7c7c8f7e1e9d1a46f5fc07452a"
   end
 
   depends_on "docbook-xsl" => :build

--- a/Formula/n/neomutt.rb
+++ b/Formula/n/neomutt.rb
@@ -1,9 +1,10 @@
 class Neomutt < Formula
   desc "E-mail reader with support for Notmuch, NNTP and much more"
   homepage "https://neomutt.org/"
-  url "https://github.com/neomutt/neomutt/archive/refs/tags/20260501.tar.gz"
-  sha256 "1c261b3bff6e67e5b46c1de0bd9dbfcb14ace9fc5e49d910582db7bc280616bd"
+  url "https://github.com/neomutt/neomutt/archive/refs/tags/20260105.tar.gz"
+  sha256 "a78e55a0df62b7f98566676d0ab9041aad89b2384bb5c6f3a96302a5cf49968d"
   license "GPL-2.0-or-later"
+  version_scheme 1
   head "https://github.com/neomutt/neomutt.git", branch: "main"
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Neomutt inadvertently used a tag of 20260501: https://github.com/neomutt/neomutt/issues/4759

This PR updates the version_scheme and uses the intended tag.