### PR TITLE
Can gcal be restored?

### DIFF
--- a/Formula/g/gcal.rb
+++ b/Formula/g/gcal.rb
@@ -1,0 +1,7 @@
+class Gcal < Formula
+  desc "Program for calculating and printing calendars"
+  homepage "https://www.gnu.org/software/gcal/"
+  url "https://www.alteholz.dev/gnu/gcal-4.2.0.tar.gz"
+  sha256 "b670e21bf0972c91f18f5b1311521038bd950d96428ab58f509dd4e4a7c5b185"
+  license "GPL-3.0-or-later"
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Hi Homebrew team,

This pull request is not complete and does not follow guidelines, so I will
understand if it needs to be closed. However, I could not find another way to
submit this request to restore the gcal formula.

### Background

gcal[^1] is a GNU program for calculating and printing calendars. The formula
was deprecated on July 28, 2023[^2] because it failed to compile on macOS 13 or
later[^3], and was eventually deleted on August 4, 2025[^4].

### Recent News

On September 2, 2025, gcal version 4.2.0 was released[^5]. I tried to compiled
this version locally on macOS 15.7.1 but did not succeed. I asked AI "make it
happen" and after a few changes (2 lines of code) I was able to compile it. The
C is not my field, so I cannot validate the correctness of these changes.

### Other Stuff

The new download link points to the developer's website rather that the official
GNU FTP server because[^6]:

> As there are problems uploading to the main GNU download server, you can get
> gcal only from my site at the moment.

The previously mentioned issue[^7] in the bug-gcal tracker may no longer be
relevant, as they have migrated to a new bug tracker[^8] and I do not see this
issues listed there[^9].

<!-- Footnotes -->

[^1]: https://www.gnu.org/software/gcal/
[^2]: https://github.com/Homebrew/homebrew-core/pull/137834/commits/27a7cbf00a69f143ff1048fae1e4a5e2fd57eb1
[^3]: https://github.com/Homebrew/homebrew-core/issues/188196#issuecomment-2346578221
[^4]: https://github.com/Homebrew/homebrew-core/commit/8be123e70bbd3367a849306c79f81ca856bc9745
[^5]: https://www.alteholz.dev/gnu/
[^6]: https://www.gnu.org/software/gcal/#:~:text=Downloads
[^7]: https://lists.gnu.org/archive/html/bug-gcal/2022-11/msg00000.html
[^8]: https://lists.gnu.org/archive/html/bug-gcal/2025-10/msg00000.html
[^9]: https://savannah.gnu.org/bugs/?group=gcal&func=browse