### PR TITLE
lrzip 0.651 including transition to github sources and patch for decompression

### DIFF
--- a/Formula/l/lrzip.rb
+++ b/Formula/l/lrzip.rb
@@ -87,13 +87,14 @@ __END__
 diff --git a/stream.c b/stream.c
 --- stream.c
 +++ stream.c
-@@ -100,8 +100,26 @@
+@@ -100,6 +100,23 @@
 
  bool lock_mutex(rzip_control *control, pthread_mutex_t *mutex)
  {
--	if (unlikely(pthread_mutex_lock(mutex)))
--		fatal_return(("Failed to pthread_mutex_lock\n"), false);
-+	/* HB_MUTEX_DIAG v1 */
++	/*
++	 * macOS is strict: a zeroed pthread_mutex_t is not a valid initialized mutex.
++	 * Ensure the control mutex is initialized before first use.
++	 */
 +	if (control && mutex == &control->control_lock) {
 +		static pthread_mutex_t init_lock = PTHREAD_MUTEX_INITIALIZER;
 +		static int did_init = 0;
@@ -107,11 +108,6 @@ diff --git a/stream.c b/stream.c
 +		}
 +	}
 +
-+	{
-+		int rc = pthread_mutex_lock(mutex);
-+		if (unlikely(rc)) {
-+			failure_return(("HB_MUTEX_DIAG: pthread_mutex_lock rc=%d\n", rc), false);
-+		}
-+	}
+ 	if (unlikely(pthread_mutex_lock(mutex)))
+ 		fatal_return(("Failed to pthread_mutex_lock\n"), false);
  	return true;
- }

--- a/Formula/l/lrzip.rb
+++ b/Formula/l/lrzip.rb
@@ -1,9 +1,14 @@
 class Lrzip < Formula
   desc "Compression program with a very high compression ratio"
-  homepage "http://lrzip.kolivas.org"
-  url "http://ck.kolivas.org/apps/lrzip/lrzip-0.641.tar.xz"
-  sha256 "2c6389a513a05cba3bcc18ca10ca820d617518f5ac6171e960cda476b5553e7e"
+  homepage "https://github.com/ckolivas/lrzip"
+  url "https://github.com/ckolivas/lrzip/archive/v0.651.tar.gz"
+  sha256 "f4c84de778a059123040681fd47c17565fcc4fec0ccc68fcf32d97fad16cd892"
   license "GPL-2.0-or-later"
+
+  patch do
+    url "https://github.com/ckolivas/lrzip/commit/3495188cd8f2215a9feea201f3e05c1341ed95fb.patch"
+    sha256 "8573ff8dd049c91cd0e6d754683e889ae439119cb9e738241dedd369c280a6fc"
+  end
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "7ba040424b61861e2e583c5797cde65885622182d4a99a20a38be74e0c4b86b9"
@@ -20,9 +25,11 @@ class Lrzip < Formula
     sha256 cellar: :any_skip_relocation, arm64_linux:    "3f8dfe3dd08b7231d134922f66dca8c88575590259bc3646d6582f2b4c6fb011"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "5515b974789a0665b67ceb99c09d7c2b4edae560c5d7e4d7aee765fe95a563e0"
   end
-
-  # Newer versions also don't build
-  deprecate! date: "2026-01-05", because: "is not available via HTTPS"
+  
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build

--- a/Formula/l/lrzip.rb
+++ b/Formula/l/lrzip.rb
@@ -1,13 +1,13 @@
 class Lrzip < Formula
   desc "Compression program with a very high compression ratio"
   homepage "https://github.com/ckolivas/lrzip"
-  url "https://github.com/ckolivas/lrzip/archive/v0.651.tar.gz"
+  url "https://github.com/ckolivas/lrzip/archive/refs/tags/v0.651.tar.gz"
   sha256 "f4c84de778a059123040681fd47c17565fcc4fec0ccc68fcf32d97fad16cd892"
   license "GPL-2.0-or-later"
 
-  patch do
-    url "https://github.com/ckolivas/lrzip/commit/3495188cd8f2215a9feea201f3e05c1341ed95fb.patch"
-    sha256 "8573ff8dd049c91cd0e6d754683e889ae439119cb9e738241dedd369c280a6fc"
+  livecheck do
+    url :stable
+    strategy :github_latest
   end
 
   bottle do
@@ -25,11 +25,6 @@ class Lrzip < Formula
     sha256 cellar: :any_skip_relocation, arm64_linux:    "3f8dfe3dd08b7231d134922f66dca8c88575590259bc3646d6582f2b4c6fb011"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "5515b974789a0665b67ceb99c09d7c2b4edae560c5d7e4d7aee765fe95a563e0"
   end
-  
-  livecheck do
-    url :stable
-    strategy :github_latest
-  end
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
@@ -46,6 +41,13 @@ class Lrzip < Formula
   end
 
   conflicts_with "lrzsz", because: "both install `lrz` binaries"
+
+  patch do
+    url "https://github.com/ckolivas/lrzip/commit/3495188cd8f2215a9feea201f3e05c1341ed95fb.patch?full_index=1"
+    sha256 "ef3a9b0b0fab990e4d46ed31cf23ac7f1b698162dd662c188d7a201dfdea2620"
+  end
+
+  patch :DATA
 
   def install
     # Attempting to build the ASM/x86 folder as a compilation unit fails (even on Intel). Removing this compilation
@@ -80,3 +82,36 @@ class Lrzip < Formula
     assert_equal original_contents, path.read
   end
 end
+
+__END__
+diff --git a/stream.c b/stream.c
+--- stream.c
++++ stream.c
+@@ -100,8 +100,26 @@
+
+ bool lock_mutex(rzip_control *control, pthread_mutex_t *mutex)
+ {
+-	if (unlikely(pthread_mutex_lock(mutex)))
+-		fatal_return(("Failed to pthread_mutex_lock\n"), false);
++	/* HB_MUTEX_DIAG v1 */
++	if (control && mutex == &control->control_lock) {
++		static pthread_mutex_t init_lock = PTHREAD_MUTEX_INITIALIZER;
++		static int did_init = 0;
++		if (!did_init) {
++			pthread_mutex_lock(&init_lock);
++			if (!did_init) {
++				(void)pthread_mutex_init(&control->control_lock, NULL);
++				did_init = 1;
++			}
++			pthread_mutex_unlock(&init_lock);
++		}
++	}
++
++	{
++		int rc = pthread_mutex_lock(mutex);
++		if (unlikely(rc)) {
++			failure_return(("HB_MUTEX_DIAG: pthread_mutex_lock rc=%d\n", rc), false);
++		}
++	}
+ 	return true;
+ }


### PR DESCRIPTION
This patch:
bumps the version of lrzip from 0.641 to 0.651
retrieves the code from github via https
includes a CVE patch (suggestion taken from the Arch Linux package)
Includes a patch to fix a decompression error on macOS

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
