### PR TITLE
dotnet@9: replace workaround with backport

### DIFF
--- a/Formula/d/dotnet@9.rb
+++ b/Formula/d/dotnet@9.rb
@@ -74,6 +74,13 @@ class DotnetAT9 < Formula
     end
   end
 
+  # Backport fix for https://github.com/dotnet/dotnet/issues/4037
+  patch do
+    url "https://github.com/dotnet/source-build-externals/commit/509ae3f3bf4e405e55b635699970a2d8014fba59.patch?full_index=1"
+    sha256 "83174ff071f181f720a77c01df46340c4410bc56908d7c10700498649734bda7"
+    directory "src/source-build-externals"
+  end
+
   def install
     odie "Update release.json resource!" if resource("release.json").version != version
     buildpath.install resource("release.json")
@@ -100,11 +107,6 @@ class DotnetAT9 < Formula
                 '"$(DotnetTool) build-server shutdown --vbcscompiler"',
                 '"true"'
     end
-
-    # Work around https://github.com/dotnet/dotnet/issues/4037 using the last
-    # valid version (2025-12-31 => 61231). Remove when upstream issue is fixed.
-    f = "src/source-build-externals/src/azure-activedirectory-identitymodel-extensions-for-dotnet/build/common.props"
-    inreplace f, '.$([System.DateTime]::Now.AddYears(-2019).Year)$([System.DateTime]::Now.ToString("MMdd"))', ".61231"
 
     args = %w[
       --clean-while-building


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
