### PR TITLE
gcc: fix __GTHREAD_COND_INIT for glibc 2.41

### DIFF
--- a/Formula/g/gcc.rb
+++ b/Formula/g/gcc.rb
@@ -59,9 +59,7 @@ class Gcc < Formula
   on_linux do
     depends_on "binutils"
 
-    patch do
-      url "file://#{HOMEBREW_REPOSITORY}/Patches/gcc/glibc-2.41-gthread-cond-init.patch"
-    end
+    patch :DATA
   end
 
   def version_suffix
@@ -316,3 +314,18 @@ class Gcc < Formula
     assert_equal "Hello, world!\n", shell_output("./hello-m2")
   end
 end
+__END__
+diff --git a/libgcc/gthr-posix.h b/libgcc/gthr-posix.h
+index 0000000..1111111 100644
+--- a/libgcc/gthr-posix.h
++++ b/libgcc/gthr-posix.h
+@@ -50,6 +50,14 @@
+ #include <pthread.h>
+ #include <unistd.h>
+
++/* glibc 2.41 changed pthread_cond_t layout */
++#if defined(__GLIBC__) && defined(__GLIBC_PREREQ)
++#if __GLIBC_PREREQ(2, 41)
++#undef __GTHREAD_COND_INIT
++#define __GTHREAD_COND_INIT PTHREAD_COND_INITIALIZER
++#endif

--- a/Formula/g/gcc.rb
+++ b/Formula/g/gcc.rb
@@ -58,6 +58,10 @@ class Gcc < Formula
 
   on_linux do
     depends_on "binutils"
+
+    patch do
+      url "file://#{HOMEBREW_REPOSITORY}/Patches/gcc/glibc-2.41-gthread-cond-init.patch"
+    end
   end
 
   def version_suffix

--- a/Patches/gcc/glibc-2.41-gthread-cond-init.patch
+++ b/Patches/gcc/glibc-2.41-gthread-cond-init.patch
@@ -1,0 +1,15 @@
+diff --git a/libgcc/gthr-posix.h b/libgcc/gthr-posix.h
+--- a/libgcc/gthr-posix.h
++++ b/libgcc/gthr-posix.h
+@@ -50,6 +50,14 @@
+ #include <pthread.h>
+ #include <unistd.h>
+
++/* glibc 2.41 changed pthread_cond_t layout */
++#if defined(__GLIBC__) && defined(__GLIBC_PREREQ)
++#if __GLIBC_PREREQ(2, 41)
++#undef __GTHREAD_COND_INIT
++#define __GTHREAD_COND_INIT PTHREAD_COND_INITIALIZER
++#endif
++#endif
++


### PR DESCRIPTION
Fixes GCC build failure on systems using glibc 2.41.

glibc 2.41 changed the pthread_cond_t layout, which caused
__GTHREAD_COND_INIT to be undefined when building GCC.

This patch defines __GTHREAD_COND_INIT as
PTHREAD_COND_INITIALIZER when building with glibc >= 2.41,
restoring successful GCC builds on Linux.

Fixes #261062