### PR TITLE
glibc: Use `#HOMEBREW_TEMP`

### DIFF
--- a/Formula/g/glibc.rb
+++ b/Formula/g/glibc.rb
@@ -165,7 +165,7 @@ class Glibc < Formula
     # Automatic bootstrapping is only supported for x86_64 and aarch64.
     if (Hardware::CPU.intel? || Hardware::CPU.arm?) && Hardware::CPU.is_64_bit?
       # Set up bootstrap resources in /tmp/homebrew.
-      bootstrap_dir = Pathname.new("/tmp/homebrew")
+      bootstrap_dir = Pathname.new("#{HOMEBREW_TEMP}/bootstrap")
       bootstrap_dir.mkpath
 
       resources.each do |r|


### PR DESCRIPTION
bugfix: Use `#HOMEBREW_TEMP`


**Summary**

This PR fixes a bootstrap path issue by updating the glibc compile step to use `#HOMEBREW_TEMP/bootstrap` rather than the hard-coded `/tmp/homebrew` directory. On systems where `/tmp` is mounted with `noexec`, common in hardened or enterprise environments—the previous behavior caused many Homebrew package installs to fail. Using the Homebrew-managed temporary directory ensures the bootstrap process works reliably across more secure system configurations.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
