### PR TITLE
git-cinnabar: declare indirect deps with linkage for linux build

### DIFF
--- a/Formula/g/git-cinnabar.rb
+++ b/Formula/g/git-cinnabar.rb
@@ -19,6 +19,7 @@ class GitCinnabar < Formula
   depends_on "rust" => :build
   depends_on "mercurial"
 
+  uses_from_macos "bzip2"
   uses_from_macos "curl"
   uses_from_macos "zlib"
 


### PR DESCRIPTION
seeing in https://github.com/Homebrew/homebrew-core/actions/runs/20775888386/job/59668769829?pr=261588#step:4:1060

```
  Indirect dependencies with linkage:
    bzip2
```

- #261588