### PR TITLE
elan-init: declare indirect deps with linkage for linux build

### DIFF
--- a/Formula/e/elan-init.rb
+++ b/Formula/e/elan-init.rb
@@ -31,6 +31,10 @@ class ElanInit < Formula
   uses_from_macos "curl"
   uses_from_macos "zlib"
 
+  on_linux do
+    depends_on "xz"
+  end
+
   conflicts_with "lean-cli", because: "both install `lean` binaries"
 
   def install


### PR DESCRIPTION
seeing in https://github.com/Homebrew/homebrew-core/actions/runs/20775888386/job/59668769829?pr=261588#step:4:864

```
  Indirect dependencies with linkage:
    xz
```

- #261588