### PR TITLE
ad,netatalk: remove conflict between these two formulas

### DIFF
--- a/Formula/a/ad.rb
+++ b/Formula/a/ad.rb
@@ -17,8 +17,6 @@ class Ad < Formula
 
   depends_on "rust" => :build
 
-  conflicts_with "netatalk", because: "both install `ad` binaries"
-
   def install
     system "cargo", "install", *std_cargo_args
     man.install buildpath/"docs/man/ad.1"

--- a/Formula/n/netatalk.rb
+++ b/Formula/n/netatalk.rb
@@ -51,8 +51,6 @@ class Netatalk < Formula
     depends_on "linux-pam"
   end
 
-  conflicts_with "ad", because: "both install `ad` binaries"
-
   def install
     inreplace "distrib/initscripts/macos.netatalk.in", "@sbindir@", opt_sbin
     inreplace "distrib/initscripts/macos.netatalk.plist.in", "@bindir@", opt_bin


### PR DESCRIPTION
v4.4.0 of netatalk renamed its 'ad' binary to 'nad' so the conflict is no longer required

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
