### PR TITLE
helix-db: fix `rust` runtime dependency

### DIFF
--- a/Formula/h/helix-db.rb
+++ b/Formula/h/helix-db.rb
@@ -14,7 +14,9 @@ class HelixDb < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "7ac4a19092115426443ac3b839dab285cd255b3749cef82e7b7987a5960a30eb"
   end
 
-  depends_on "rust"
+  depends_on "pkgconf" => :build
+  depends_on "rust" => :build
+
   on_linux do
     depends_on "openssl@3"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
