### PR TITLE
maturin: fix `rust` runtime dependency

### DIFF
--- a/Formula/m/maturin.rb
+++ b/Formula/m/maturin.rb
@@ -15,11 +15,10 @@ class Maturin < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "f669a6d2987f00613e384ebea87ca7f2ccf95a766a37fcfc2fe8f72a24c42e7e"
   end
 
+  depends_on "pkgconf" => :build
+  depends_on "rust" => [:build, :test]
   depends_on "python@3.14" => :test
-  depends_on "rust"
-
-  uses_from_macos "bzip2"
-  uses_from_macos "xz"
+  depends_on "xz"
 
   def install
     # Work around an Xcode 15 linker issue which causes linkage against LLVM's


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Current macOS linkage:
```
System libraries:
  /usr/lib/libSystem.B.dylib
  /usr/lib/libiconv.2.dylib
Homebrew libraries:
  /opt/homebrew/opt/xz/lib/liblzma.5.dylib (xz)
Indirect dependencies with linkage:
  xz
```

Current Linux linkage:
```
System libraries:
  /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
  /lib/x86_64-linux-gnu/libc.so.6
  /lib/x86_64-linux-gnu/libgcc_s.so.1
  /lib/x86_64-linux-gnu/libm.so.6
Homebrew libraries:
  /home/linuxbrew/.linuxbrew/opt/xz/lib/liblzma.so.5 (xz)
```