### PR TITLE
pake: fix `rust` runtime dependency

### DIFF
--- a/Formula/p/pake.rb
+++ b/Formula/p/pake.rb
@@ -14,9 +14,9 @@ class Pake < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "bfaa1aae34c48a1355d63bed7b4aec5d70341d30ec314a6332e396f5ccdd5197"
   end
 
+  depends_on "rust" => :build
   depends_on "node"
   depends_on "pnpm"
-  depends_on "rust"
   depends_on "vips"
 
   # Resources needed to build sharp from source to avoid bundled vips


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
@bevanjkay Can any other of these dependencies be removed or marked build-only? I was consistently able to get this to build locally with only `depends_on "node"`.