### PR TITLE
rust-script: fix `rust` is a runtime dependency with no linkage

### DIFF
--- a/Formula/r/rust-script.rb
+++ b/Formula/r/rust-script.rb
@@ -16,7 +16,7 @@ class RustScript < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "a621299898caf1365fe29b39303f41b4becbce8e6450db1a787b07e6de258307"
   end
 
-  depends_on "rust"
+  depends_on "rust" => :no_linkage
 
   def install
     system "cargo", "install", *std_cargo_args


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
