### PR TITLE
workflows/scheduled: fix "value too great for base"

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -69,7 +69,7 @@ jobs:
           day="$(date +%j)"
           testing_formulae=()
           for (( i=0; i < TEST_COUNT; i++ )); do
-            index="$(( (day + i * DAYS_PER_YEAR - 1) % formulae_count ))"
+            index="$(( (10#$day + i * DAYS_PER_YEAR - 1) % formulae_count ))"
             testing_formulae+=("${formulae[${index}]}")
           done
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Currently day=008 is handled as octal resulting in error at https://github.com/Homebrew/homebrew-core/actions/runs/20802312110/job/59749537355#step:4:49
```
line 20: 008: value too great for base (error token is "008")
```

Can try converting to decimal, e.g.
```console
❯ /bin/bash -c 'day=008 && echo $((day + 1))'
/bin/bash: 008: value too great for base (error token is "008")

❯ /bin/bash -c 'day=008 && echo $((10#$day + 1))'
9
```