### PR TITLE
haskell-language-server: remove GHC 9.8 support

### DIFF
--- a/Formula/h/haskell-language-server.rb
+++ b/Formula/h/haskell-language-server.rb
@@ -25,7 +25,6 @@ class HaskellLanguageServer < Formula
   depends_on "cabal-install" => [:build, :test]
   depends_on "ghc" => [:build, :test]
   depends_on "ghc@9.10" => [:build, :test]
-  depends_on "ghc@9.8" => [:build, :test]
   depends_on "gmp"
 
   uses_from_macos "libffi"


### PR DESCRIPTION
This brings down GHC dependencies to 2 which aligns with how we handle multiple versions in other formulae (Python, Postgresql).

It also reduces usage of GHC 9.8 which is essentially finished release train (listed as "None planned"[^1] for next release so may still be open for critical security fix but more likely will just become EOL as upstream has released GHC 9.14 and is working on GHC 9.16)

Each build of HLS is slow and requires rebuild with every GHC patch release, so keeping number down is better for us.

Maybe if we split formula up and dynamically link GHC then could be easier to keep variants around.

[^1]: https://gitlab.haskell.org/ghc/ghc/-/wikis/GHC%20Status#most-recent-ghc-major-versions