### PR TITLE
hl: harden update livecheck

### DIFF
--- a/Formula/h/hl.rb
+++ b/Formula/h/hl.rb
@@ -8,7 +8,7 @@ class Hl < Formula
 
   livecheck do
     url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    regex(/^v((?:0|[1-9]\d*)(?:\.(?:0|[1-9]\d*)){2})$/i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Here's a revised pull request description:

---

## Fix livecheck regex to require exactly 3 version components

### Problem

The auto-update workflow failed because `brew livecheck` detected version `1.0` as the latest release, which doesn't exist.  This caused the workflow to attempt downloading non-existent release assets from `https://github.com/pamburus/hl/releases/download/v1.0/hl-linux-x86_64-musl.tar.gz`, resulting in 404 errors.

**Root cause:** The current `livecheck` block (added in #261666) uses the regex `/^v?(\d+(?:\.\d+)+)$/i`, which accepts versions with **any number of components** (2, 3, 4, etc.). This allowed it to match `v1.0` from the `schema/theme/v1.0` tag.

**Hypothesis:** Homebrew's livecheck appears to extract version-like substrings from tags before applying the regex. So from the tag `schema/theme/v1.0`, it likely extracts `v1.0` or `1.0`, then applies the regex to that extracted substring. The `^` and `$` anchors only prevent prefixes/suffixes on the *extracted* substring, not on the original tag name.

When I deleted the `schema/theme/v1.0` tag, the problem disappeared immediately and livecheck correctly returned `0.34.1`.

### Solution

Update the regex to require **exactly 3 version components** and enforce semantic versioning without leading zeros: 

```ruby
livecheck do
  url : stable
  regex(/^v((?:0|[1-9]\d*)(?:\.(?:0|[1-9]\d*)){2})$/i)
end
```

**Key changes:**
- `(?:0|[1-9]\d*)` - Each component must be either `0` or a non-zero number without leading zeros
- `{2}` - Exactly 2 additional components (total of 3: major.minor.patch)
- Previous regex used `+` (one or more), which accepted 2, 3, 4+ components

**Now matches:**
- ✅ `v0.34.1`, `v0.35.0`, `v1.2.3` (3-component semantic versions)

**Now rejects:**
- ❌ `v1.0` (only 2 components)
- ❌ `v1.0.0.0` (4 components)
- ❌ `v01.2.3` (leading zero in version component)

### Request for feedback

**I would ideally like to forbid any form of prefix in tag names** (e.g., `schema/theme/v1.0.0`, `theme-v1.0.0`) to ensure only clean `v<major>.<minor>.<patch>` tags are matched. However, based on my observations, the `^` anchor in the regex doesn't prevent this because Homebrew appears to extract version substrings before applying the regex pattern.

If there's a way to configure livecheck to match only against the full tag name without substring extraction, or any other approach to prevent prefix matching, **I would greatly appreciate suggestions**. 

For now, requiring exactly 3 components prevents my theme versioning tags (which use 2 components) from being detected as software releases.
