### PR TITLE
knot-resolver@5 (new formula)

### DIFF
--- a/Formula/k/knot-resolver@5.rb
+++ b/Formula/k/knot-resolver@5.rb
@@ -1,0 +1,58 @@
+class KnotResolverAT5 < Formula
+  desc "Minimalistic, caching, DNSSEC-validating DNS resolver"
+  homepage "https://www.knot-resolver.cz"
+  url "https://secure.nic.cz/files/knot-resolver/knot-resolver-5.7.6.tar.xz"
+  sha256 "500ccd3a560300e547b8dc5aaff322f7c8e2e7d6f0d7ef5f36e59cb60504d674"
+  license all_of: ["CC0-1.0", "GPL-3.0-or-later", "LGPL-2.1-or-later", "MIT"]
+
+  livecheck do
+    url "https://www.knot-resolver.cz/download/"
+    regex(/href=.{10,100}knot-resolver[._-]v?5((?:\.\d+)+)\.t[^>]*?>[^<]*?stable/i)
+  end
+
+  keg_only :versioned_formula
+
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+  depends_on "pkgconf" => :build
+  depends_on "fstrm"
+  depends_on "gnutls"
+  depends_on "knot"
+  depends_on "libnghttp2"
+  depends_on "libuv"
+  depends_on "lmdb"
+  depends_on "luajit"
+  depends_on "protobuf-c"
+
+  uses_from_macos "libedit"
+
+  on_linux do
+    depends_on "libcap-ng"
+    depends_on "systemd"
+  end
+
+  def install
+    args = []
+    args << "-Dsystemd_files=enabled" if OS.linux?
+
+    system "meson", "setup", "build", *args, *std_meson_args
+    system "meson", "compile", "-C", "build", "--verbose"
+    system "meson", "install", "-C", "build"
+
+    (var/"knot-resolver").mkpath
+  end
+
+  service do
+    run [opt_sbin/"kresd", "-c", etc/"knot-resolver/kresd.conf", "-n"]
+    require_root true
+    working_dir var/"knot-resolver"
+    input_path File::NULL
+    log_path File::NULL
+    error_log_path var/"log/knot-resolver.log"
+  end
+
+  test do
+    assert_path_exists var/"knot-resolver"
+    system sbin/"kresd", "--version"
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is essentially the same formula as before knot-resolver.rb was upgraded to version 6.1.0 in PR #261861 and #261883.
