### PR TITLE
mypaint-brushes: fix api errors

### DIFF
--- a/Formula/m/mypaint-brushes.rb
+++ b/Formula/m/mypaint-brushes.rb
@@ -17,6 +17,11 @@ class MypaintBrushes < Formula
 
   depends_on "libmypaint"
 
+  patch do
+    url "https://github.com/mypaint/mypaint-brushes/commit/ff9d830d78fcec17d87d5259ecfaa254c2a27276.patch?full_index=1"
+    sha256 "fac16aed9f9d6d35358d17cf8d83388f42bb03f5c8646bfd284f636df80a241b"
+  end
+
   def install
     ENV["ACLOCAL"] = "aclocal"
     ENV["AUTOMAKE"] = "automake"


### PR DESCRIPTION


<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`? **No**. It says `line 20, col 3: Patch is missing __END__` but seems to be unharmful

-----

Similarly to https://github.com/macports/macports-ports/pull/29233. Already patched on MSYS2 too.

It turns out some my paint brushes have lines that forgot to be updated to the new API and mypaint-brushes does not have releases anymore so the best approach is to patch here downstream.