### PR TITLE
qtwebview: check on Linux

### DIFF
--- a/Formula/q/qtwebview.rb
+++ b/Formula/q/qtwebview.rb
@@ -60,7 +60,7 @@ class Qtwebview < Formula
           url: "https://brew.sh/"
         }
         Timer {
-          interval: 2000
+          interval: 5000
           running: true
           onTriggered: Qt.quit()
         }


### PR DESCRIPTION
Just checking on Linux test failure.
```
  ==> /home/linuxbrew/.linuxbrew/opt/qtdeclarative/bin/qml test.qml
  This plugin does not support createPlatformOpenGLContext!
  QRhiGles2: Failed to create temporary context
  This plugin does not support createPlatformOpenGLContext!
  This plugin does not support createPlatformOpenGLContext!
  QRhiGles2: Failed to create context
  This plugin does not support createPlatformVulkanInstance
  QVulkanInstance: Failed to initialize Vulkan
  Unable to detect GPU vendor.
  [406653:406664:0110/092124.787009:ERROR:bus.cc(408)] Failed to connect to the bus: Failed to connect to socket /home/linuxbrew/.linuxbrew/var/run/dbus/system_bus_socket: No such file or directory
```