### PR TITLE
freeimage: deprecate due to outstanding CVEs

### DIFF
--- a/Formula/f/freeimage.rb
+++ b/Formula/f/freeimage.rb
@@ -26,6 +26,11 @@ class Freeimage < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "a6c63d08f4adf2395f983ad5f8a51f36ac1e749de9fe6428d056859b199ac6e6"
   end
 
+  # Last release on 2018-07-31 which has 16 outstanding CVEs as of deprecation date:
+  # https://nvd.nist.gov/vuln/search#/nvd/home?cpeFilterMode=cpe&cpeName=cpe:2.3:a:freeimage_project:freeimage:3.18.0:*:*:*:*:*:*:*&resultType=records
+  deprecate! date: "2026-01-10", because: "has outstanding CVEs and requires patches to build"
+  disable! date: "2027-01-10", because: "has outstanding CVEs and requires patches to build"
+
   patch do
     on_macos do
       url "https://raw.githubusercontent.com/Homebrew/homebrew-core/1cf441a0/Patches/freeimage/3.17.0.patch"

--- a/Formula/p/perceptualdiff.rb
+++ b/Formula/p/perceptualdiff.rb
@@ -18,6 +18,9 @@ class Perceptualdiff < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "2d9a1e10f07e3467e60a855f18c75a07fee4c238d746dc0b91652c147733e9c8"
   end
 
+  deprecate! date: "2026-01-10", because: "uses deprecated `freeimage`"
+  disable! date: "2027-01-10", because: "uses deprecated `freeimage`"
+
   depends_on "cmake" => :build
   depends_on "freeimage"
 


### PR DESCRIPTION
Pending on 
- #262234

Same decision made by Arch Linux - https://archlinux.org/todo/drop-freeimage/

---

This PR follows our policy at https://docs.brew.sh/Deprecating-Disabling-and-Removing-Formulae#deprecation
> * the software installed by the formula has outstanding CVEs
> * the software installed by the formula has been discontinued or abandoned upstream

As FreeImage is a 7 year old release with over a dozen CVEs that doesn't even build correctly without patches.

PerceptualDiff is built on top of FreeImage so no choice but to deprecate.

---

All other usage was removed last year,
- #251915
- #251842
- #251834
- #251833