### PR TITLE
luvit: use newer `luvi` for `pcre2` support

### DIFF
--- a/Formula/l/luvit.rb
+++ b/Formula/l/luvit.rb
@@ -25,7 +25,7 @@ class Luvit < Formula
   depends_on "luajit"
   # TODO: depends_on "luv"
   depends_on "openssl@3"
-  depends_on "pcre"
+  depends_on "pcre2"
 
   conflicts_with "lit", because: "both install `lit` binaries"
 
@@ -44,9 +44,10 @@ class Luvit < Formula
 
   # To update this resource, check LUVI_VERSION in
   # https://github.com/luvit/lit/raw/$(LIT_VERSION)/get-lit.sh
+  # NOTE: Moved up to 2.15.0 for pcre2 and openssl@3 support
   resource "luvi" do
-    url "https://github.com/luvit/luvi/releases/download/v2.12.0/luvi-src-v2.12.0.tar.gz"
-    sha256 "4149c87646f487f9076c29e9861f64468637b1d1361b777b093e6204a83e1ed9"
+    url "https://github.com/luvit/luvi/releases/download/v2.15.0/luvi-source.tar.gz"
+    sha256 "91f40fb6421888c2ee403de80248250c234f3bfb6dd1edbbc9188a89e4b9708a"
 
     livecheck do
       url "https://raw.githubusercontent.com/luvit/luvit/#{LATEST_VERSION}/Makefile"
@@ -63,47 +64,13 @@ class Luvit < Formula
         get_lit_page[:content][/LUVI_VERSION:-v?(\d+(?:\.\d+)+)/i, 1]
       end
     end
-
-    # Remove outdated linker flags that break the ARM build.
-    # https://github.com/luvit/luvi/pull/261
-    patch do
-      url "https://github.com/luvit/luvi/commit/b2e501deb407c44a9a3e7f4d8e4b5dc500e7a196.patch?full_index=1"
-      sha256 "be3315f7cf8a9e43f1db39d0ef55698f09e871bea0f508774d0135c6375f4291"
-    end
-  end
-
-  # Needed for OpenSSL 3 support. Remove when the `luvi`
-  # resource has a new enough version as a submodule.
-  resource "lua-openssl" do
-    url "https://github.com/zhaozg/lua-openssl/releases/download/0.8.3-1/openssl-0.8.3-1.tar.gz"
-    sha256 "d8c50601cb0a04e2dfbd8d8e57f4cf16a4fe59bdca8036deb8bc26f700f2eb8c"
   end
 
   def install
-    if DevelopmentTools.clang_build_version >= 1500
-      # Work around build error in current `lua-openssl` resource with newer Clang
-      ENV.append_to_cflags "-Wno-incompatible-function-pointer-types"
-      # Use ld_classic to work around 'ld: multiple errors: LINKEDIT overlap of start of
-      # LINKEDIT and symbol table in '.../jitted_tmp/src/lua/luvibundle.lua_luvi_generated.o'
-      ENV.append "LDFLAGS", "-Wl,-ld_classic"
-    end
-
     ENV["PREFIX"] = prefix
     luajit = Formula["luajit"]
 
     resource("luvi").stage do
-      # Build scripts set LUA_PATH before invoking LuaJIT, but that causes errors.
-      # Reported at https://github.com/luvit/luvi/issues/242
-      inreplace "cmake/Modules/LuaJITAddExecutable.cmake",
-                "COMMAND \"LUA_PATH=${LUA_PATH}\" luajit", "COMMAND luajit"
-
-      # Build scripts double the prefix of this directory, so we set it manually.
-      # Reported in the issue linked above.
-      ENV["LPEGLIB_DIR"] = "deps/lpeg"
-
-      rm_r "deps/lua-openssl"
-      Pathname("deps/lua-openssl").install resource("lua-openssl")
-
       # Build the bundled `luv` as `luvi` is not compatible with newer version.
       # We cannot use `-DWithSharedLibluv=OFF` as it will bundle `luajit` too.
       # TODO: Restore brew `luv` once support is available
@@ -122,15 +89,14 @@ class Luvit < Formula
       # CMake flags adapted from
       # https://github.com/luvit/luvi/blob/#{luvi_version}/Makefile#L73-L74
       luvi_args = %W[
-        -DCMAKE_POLICY_VERSION_MINIMUM=3.5
         -DWithOpenSSL=ON
         -DWithSharedOpenSSL=ON
-        -DWithPCRE=ON
+        -DWithPCRE2=ON
         -DWithLPEG=ON
-        -DWithSharedPCRE=ON
+        -DWithSharedPCRE2=ON
         -DWithSharedLibluv=ON
-        -DLIBLUV_INCLUDE_DIR=#{libexec}/include/luv
-        -DLIBLUV_LIBRARIES=#{libexec}/lib/#{shared_library("libluv")}
+        -DLUV_INCLUDE_DIR=#{libexec}/include/luv
+        -DLUV_LIBRARY=#{libexec}/lib/#{shared_library("libluv")}
         -DLUAJIT_INCLUDE_DIR=#{luajit.opt_include}/luajit-2.1
         -DLUAJIT_LIBRARIES=#{luajit.opt_lib/shared_library("libluajit")}
       ]

--- a/Formula/l/luvit.rb
+++ b/Formula/l/luvit.rb
@@ -10,13 +10,13 @@ class Luvit < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    rebuild 3
-    sha256 cellar: :any,                 arm64_tahoe:   "17d057bd4ad2a454a31b24662102fff392681e72675de5d64e5deb1dfe7af479"
-    sha256 cellar: :any,                 arm64_sequoia: "50c277e8b5c4ac5d75481e09e520a8d119d997d7ab420ab01c5d2e9e700f08a7"
-    sha256 cellar: :any,                 arm64_sonoma:  "0ef80abb496d68a40c367126cfc343da468e67161b18f96bd239914166ce5875"
-    sha256 cellar: :any,                 sonoma:        "2a28032e61257c09d6282ae24a2e0cd64b97de9279a3337a7966b4cf36afedae"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "8c7531ea1451526770ec5f04853cc6cc1b9a9db3803418bb3d8d5e36000f8456"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "7c7587270f4a47365d876feb28f09e2be713dea9bf8dd666e019071b93738d2c"
+    rebuild 4
+    sha256 cellar: :any,                 arm64_tahoe:   "d1e0e16c87a8b221d4408ff878ffa7389fa3f718073d29e2ca5159b48af6fe4b"
+    sha256 cellar: :any,                 arm64_sequoia: "d11505fcc3846d0e0a60eac5dd556f8ac586791ce7a4bb3110423bf2e4525e82"
+    sha256 cellar: :any,                 arm64_sonoma:  "bf5880e2bd02b7e42e13aa343eaa206e60bf56e3237d4d9756b7c95585d6eb7f"
+    sha256 cellar: :any,                 sonoma:        "9310c05dcfed32c3755617a078497e7bab9ff92185006867b2af25728aa565aa"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "f5532c8f6059d548a09b29be24f3f2da71a1e7ab3c4ed1c97a5dbeac5276bb54"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "519b09540eb5b7a824ac52135c5d82863ed0dc6e9e719c24867a0f4221f1ec44"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
