### PR TITLE
doxygen: fix Python executable variable

### DIFF
--- a/Formula/d/doxygen.rb
+++ b/Formula/d/doxygen.rb
@@ -29,7 +29,7 @@ class Doxygen < Formula
 
   def install
     system "cmake", "-S", ".", "-B", "build",
-                    "-DPYTHON_EXECUTABLE=#{which("python3")}",
+                    "-DPython_EXECUTABLE=#{which("python3")}",
                     *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"


### PR DESCRIPTION
See https://github.com/doxygen/doxygen/commit/f535d0f3e44c8b3c0945adf80ce5d229d9ad017c. PYTHON_EXECUTABLE has been replaced by Python_EXECUTABLE, although it didn't influence the normal build.

However, it will throw the following warning at the end of the configuration phase:

> 
> CMake Warning:
>   Manually-specified variables were not used by the project:
>     BUILD_TESTING
>     PYTHON_EXECUTABLE



<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
