### PR TITLE
r3: apply backport patch for `pcre2` support

### DIFF
--- a/Formula/r/r3.rb
+++ b/Formula/r/r3.rb
@@ -1,10 +1,19 @@
 class R3 < Formula
   desc "High-performance URL router library"
   homepage "https://github.com/c9s/r3"
-  url "https://github.com/c9s/r3/archive/refs/tags/1.3.4.tar.gz"
-  sha256 "db1fb91e51646e523e78b458643c0250231a2640488d5781109f95bd77c5eb82"
   license "MIT"
   head "https://github.com/c9s/r3.git", branch: "master"
+
+  stable do
+    url "https://github.com/c9s/r3/archive/refs/tags/1.3.4.tar.gz"
+    sha256 "db1fb91e51646e523e78b458643c0250231a2640488d5781109f95bd77c5eb82"
+
+    # Backport of https://github.com/c9s/r3/commit/c105117b40d1a7b2b9ddf1672cd08b11bd565bd9
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/homebrew-core/7ecb03ef6d73f3ed71546fb0c34023f9a23dbd74/Patches/r3/1.3.4.patch"
+      sha256 "c00d9af0b30d94d918cf438834f2ca06e1f756ee56ed0205f9f6f82bf909cb0e"
+    end
+  end
 
   livecheck do
     url :stable
@@ -34,7 +43,7 @@ class R3 < Formula
   depends_on "libtool" => :build
   depends_on "pkgconf" => :build
   depends_on "jemalloc"
-  depends_on "pcre"
+  depends_on "pcre2"
 
   def install
     system "./autogen.sh"

--- a/Formula/r/r3.rb
+++ b/Formula/r/r3.rb
@@ -23,19 +23,13 @@ class R3 < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:    "b6f7a41b6a7f3197243733ce8a7bd9837f0d96b3b1d78046e8ed135db7a7109b"
-    sha256 cellar: :any,                 arm64_sequoia:  "0e983875043e6a6111ce6f46615faf14adb57a8fa96c7a1cf5ae10d7d415a879"
-    sha256 cellar: :any,                 arm64_sonoma:   "9648d6bd8f125398cc101581e8ee3b8b304fa6e8ab92f018dc538843c04fd920"
-    sha256 cellar: :any,                 arm64_ventura:  "fa1e649709ce6c6d16c631a2192d2dd7fea34b7398e55eabe5f7bd51953745ab"
-    sha256 cellar: :any,                 arm64_monterey: "2f26748893003e7e0b99a574126c06c451222144979b0230babe37128328214f"
-    sha256 cellar: :any,                 arm64_big_sur:  "be0883f3dfc67b2469eef537376a04bbae36ec3aab8ca58ffb66491a81e6db5d"
-    sha256 cellar: :any,                 sonoma:         "bdf44bc7e03016c2b5c4b2f414d2c4560d6b6a502023f5225dfb98cbd615d9fb"
-    sha256 cellar: :any,                 ventura:        "95f67c8b6bd1c106e6c61623df3ea82a5faf030928bb4a996fb1bea738f27679"
-    sha256 cellar: :any,                 monterey:       "a33cc32d0cfb9190bb99931d5dc9dba21899df9103ef7d892b8b083672d78662"
-    sha256 cellar: :any,                 big_sur:        "c9fa16048947ebd0c297b700ff7a528c7e45f46bd719cd196d4f7c74de7b491d"
-    sha256 cellar: :any,                 catalina:       "96787f402bbc3a37207c3d5c3468d3b98028a12335a66d176d18d268e2406462"
-    sha256 cellar: :any_skip_relocation, arm64_linux:    "0d5a55e6af91f035641e99ced2f417050df5bb6d782922cb7270866659fe105d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "36037bda00ae1253fb158f5cdf2619c2194a33a6ddb6598f9fb7901f37928348"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "ee6d57c13ed2ec24283ad9837f731a7964943070535d903206e8b7481a73dfad"
+    sha256 cellar: :any,                 arm64_sequoia: "a6aaba3f459b35b6ef04844f558fc82886c589159e406ad206a0a62e6b15cc1d"
+    sha256 cellar: :any,                 arm64_sonoma:  "8a3ba999410ade8c4c63d420e75f480a6c655172f462da5ed1e61ef4614b2861"
+    sha256 cellar: :any,                 sonoma:        "6ab1c2ef8e37e2d55981cb55fb8ea9556521f4cd9df65792f909573e72d05bc0"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "b947da0474e0674ab147aa19a3e7d6a5adbf6f22eeb99445be3e43e6af89ff58"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "06edf11bc09dab6f013e3d3ec0c2789572bd64fbdabcb546e6b87600d3c48d4b"
   end
 
   depends_on "autoconf" => :build

--- a/Patches/r3/1.3.4.patch
+++ b/Patches/r3/1.3.4.patch
@@ -1,0 +1,256 @@
+commit 8f8adb387ccc3ff968bcc1d044810893e7a426fc
+Author: Björn Svensson <bjorn.a.svensson@est.tech>
+Date:   Mon Oct 23 12:38:24 2023 +0200
+
+    Use PCRE2 instead of PCRE (#153)
+    
+    PCRE is now at end of life and is no longer actively maintained.
+    Lift the dependency to the next major version, i.e. PCRE2.
+    
+    Implementation notes:
+    - Removed the pcre study option since:
+      "The new API ... was simplified by abolishing the separate "study" optimizing
+      function; in PCRE2, patterns are automatically optimized where possible."
+    - If asprintf() fails the content of the 'strp' variable is undefined.
+      Lets check the return value and return NULL upon error.
+    - Pattern and subject can straightforwardly be cast to PCRE2_SPTR since we
+      only work with 8-bit code units.
+
+diff --git a/configure.ac b/configure.ac
+index df52731..ba58ca7 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -74,7 +74,7 @@ AM_CONDITIONAL(USE_JEMALLOC, test "x$have_jemalloc" = "xyes")
+ # AC_DEFINE(USE_JEMALLOC, test "x$found_jemalloc" = "xyes" , "use jemalloc")
+ 
+ 
+-PKG_CHECK_MODULES(DEPS, [libpcre])
++PKG_CHECK_MODULES(DEPS, [libpcre2-8])
+ AC_SUBST(DEPS_CFLAGS)
+ AC_SUBST(DEPS_LIBS)
+ 
+diff --git a/include/r3.h b/include/r3.h
+index f8732a2..347bb2b 100644
+--- a/include/r3.h
++++ b/include/r3.h
+@@ -10,7 +10,8 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
+-#include <pcre.h>
++#define PCRE2_CODE_UNIT_WIDTH 8
++#include <pcre2.h>
+ #include <stdbool.h>
+ #include "r3_define.h"
+ #include "str_array.h"
+@@ -31,17 +32,16 @@ struct _node {
+     edge  ** edges;
+     // edge  ** edge_table;
+     char * combined_pattern;
+-    pcre * pcre_pattern;
++    pcre2_code * pcre_pattern;
+ 
+ // #ifdef PCRE_STUDY_JIT_COMPILE
+-    pcre_extra * pcre_extra;
++    pcre2_match_data * match_data;
+ // #endif
+ 
+     // edges are mostly less than 255
+     unsigned int edge_len;
+     unsigned int compare_type; // compare_type: pcre, opcode, string
+     unsigned char    endpoint; // endpoint, should be zero for non-endpoint nodes
+-    unsigned char    ov_cnt; // capture vector array size for pcre
+ 
+     // almost less than 255
+     unsigned char      edge_cap;
+diff --git a/r3.pc.in b/r3.pc.in
+index 6f2ffb9..d82ddf8 100644
+--- a/r3.pc.in
++++ b/r3.pc.in
+@@ -6,6 +6,6 @@ libdir=@libdir@
+ Name: r3
+ Description: High-performance URL router library
+ Version: @PACKAGE_VERSION@
+-Requires: libpcre
++Requires: libpcre2-8
+ Libs: -L${libdir} -lr3
+ CFlags: -I${includedir}
+diff --git a/src/edge.c b/src/edge.c
+index c42415e..48aefba 100644
+--- a/src/edge.c
++++ b/src/edge.c
+@@ -13,8 +13,6 @@
+ // Jemalloc memory management
+ // #include <jemalloc/jemalloc.h>
+ 
+-// PCRE
+-#include <pcre.h>
+ #include "r3.h"
+ #include "r3_str.h"
+ #include "slug.h"
+diff --git a/src/match_entry.c b/src/match_entry.c
+index 54854ae..ff39efc 100644
+--- a/src/match_entry.c
++++ b/src/match_entry.c
+@@ -7,7 +7,6 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
+-#include <pcre.h>
+ #include <assert.h>
+ #include <stdbool.h>
+ 
+diff --git a/src/node.c b/src/node.c
+index 82d4412..34897df 100644
+--- a/src/node.c
++++ b/src/node.c
+@@ -5,9 +5,6 @@
+ #include <assert.h>
+ #include <ctype.h>
+ 
+-// PCRE
+-#include <pcre.h>
+-
+ #include "r3.h"
+ #include "r3_str.h"
+ #include "slug.h"
+@@ -59,7 +56,7 @@ node * r3_tree_create(int cap) {
+     n->endpoint = 0;
+     n->combined_pattern = NULL;
+     n->pcre_pattern = NULL;
+-    n->pcre_extra = NULL;
++    n->match_data = NULL;
+     n->data = NULL;
+     return n;
+ }
+@@ -73,13 +70,11 @@ void r3_tree_free(node * tree) {
+     zfree(tree->edges);
+     zfree(tree->routes);
+     if (tree->pcre_pattern) {
+-        pcre_free(tree->pcre_pattern);
++        pcre2_code_free(tree->pcre_pattern);
+     }
+-#ifdef PCRE_STUDY_JIT_COMPILE
+-    if (tree->pcre_extra) {
+-        pcre_free_study(tree->pcre_extra);
++    if (tree->match_data) {
++        pcre2_match_data_free(tree->match_data);
+     }
+-#endif
+     zfree(tree->combined_pattern);
+     zfree(tree);
+     tree = NULL;
+@@ -221,39 +216,44 @@ int r3_tree_compile_patterns(node * n, char **errstr) {
+ 
+     n->combined_pattern = cpat;
+ 
+-    const char *pcre_error;
+-    int pcre_erroffset;
++    int pcre_errorcode = 0;
++    PCRE2_SIZE pcre_erroffset = 0;
+     unsigned int option_bits = 0;
+ 
+-    n->ov_cnt = (1 + n->edge_len) * 3;
+-
+     if (n->pcre_pattern) {
+-        pcre_free(n->pcre_pattern);
++        pcre2_code_free(n->pcre_pattern);
+     }
+-    n->pcre_pattern = pcre_compile(
+-            n->combined_pattern,              /* the pattern */
++    n->pcre_pattern = pcre2_compile(
++            (PCRE2_SPTR)n->combined_pattern,  /* the pattern, 8-bit code units */
++            PCRE2_ZERO_TERMINATED,
+             option_bits,                                /* default options */
+-            &pcre_error,               /* for error message */
++            &pcre_errorcode,           /* for error code */
+             &pcre_erroffset,           /* for error offset */
+-            NULL);                /* use default character tables */
++            NULL);                     /* compile context */
+     if (n->pcre_pattern == NULL) {
+         if (errstr) {
+-            asprintf(errstr, "PCRE compilation failed at offset %d: %s, pattern: %s", pcre_erroffset, pcre_error, n->combined_pattern);
++            PCRE2_UCHAR buf[128];
++            pcre2_get_error_message(pcre_errorcode, buf, sizeof(buf));
++            int r = asprintf(errstr, "PCRE compilation failed at offset %ld: %s, pattern: %s", pcre_erroffset, buf, n->combined_pattern);
++            if (r < 0) {
++                *errstr = NULL; /* the content of errstr is undefined when asprintf() fails */
++            }
+         }
+         return -1;
+     }
+-#ifdef PCRE_STUDY_JIT_COMPILE
+-    if (n->pcre_extra) {
+-        pcre_free_study(n->pcre_extra);
++    if (n->match_data) {
++        pcre2_match_data_free(n->match_data);
+     }
+-    n->pcre_extra = pcre_study(n->pcre_pattern, 0, &pcre_error);
+-    if (n->pcre_extra == NULL) {
++    n->match_data = pcre2_match_data_create_from_pattern(n->pcre_pattern, NULL);
++    if (n->match_data == NULL) {
+         if (errstr) {
+-            asprintf(errstr, "PCRE study failed at offset %s, pattern: %s", pcre_error, n->combined_pattern);
++            int r = asprintf(errstr, "Failed to allocate match data block");
++            if (r < 0) {
++                *errstr = NULL; /* the content of errstr is undefined when asprintf() fails */
++            }
+         }
+         return -1;
+     }
+-#endif
+     return 0;
+ }
+ 
+@@ -323,20 +323,18 @@ node * r3_tree_matchl(const node * n, const char * path, int path_len, match_ent
+     if (n->pcre_pattern) {
+         const char *substring_start = NULL;
+         int   substring_length = 0;
+-        int   ov[ n->ov_cnt ];
+         int   rc;
+ 
+         info("pcre matching %s on %s\n", n->combined_pattern, path);
+ 
+-        rc = pcre_exec(
++        rc = pcre2_match(
+                 n->pcre_pattern, /* the compiled pattern */
+-                n->pcre_extra,
+-                path,         /* the subject string */
++                (PCRE2_SPTR)path,/* the subject string, 8-bit code units */
+                 path_len,     /* the length of the subject */
+                 0,            /* start at offset 0 in the subject */
+                 0,            /* default options */
+-                ov,           /* output vector for substring information */
+-                n->ov_cnt);      /* number of elements in the output vector */
++                n->match_data,/* match data results */
++                NULL);        /* match context */
+ 
+         // does not match all edges, return NULL;
+         if (rc < 0) {
+@@ -344,7 +342,7 @@ node * r3_tree_matchl(const node * n, const char * path, int path_len, match_ent
+             printf("pcre rc: %d\n", rc );
+             switch(rc)
+             {
+-                case PCRE_ERROR_NOMATCH:
++                case PCRE2_ERROR_NOMATCH:
+                     printf("pcre: no match '%s' on pattern '%s'\n", path, n->combined_pattern);
+                     break;
+ 
+@@ -357,7 +355,7 @@ node * r3_tree_matchl(const node * n, const char * path, int path_len, match_ent
+             return NULL;
+         }
+ 
+-
++        PCRE2_SIZE *ov = pcre2_get_ovector_pointer(n->match_data);
+ 
+         restlen = path_len - ov[1]; // if it's fully matched to the end (rest string length)
+ 
+@@ -465,7 +463,7 @@ node * r3_node_create() {
+     n->endpoint = 0;
+     n->combined_pattern = NULL;
+     n->pcre_pattern = NULL;
+-    n->pcre_extra = NULL;
++    n->match_data = NULL;
+     n->data = NULL;
+     return n;
+ }


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
