### PR TITLE
ngs: deprecate

### DIFF
--- a/Formula/n/ngs.rb
+++ b/Formula/n/ngs.rb
@@ -17,6 +17,10 @@ class Ngs < Formula
     sha256 x86_64_linux:  "9c4e5283fc854c1e1489d98ef5d234163222567da81348d751084d2ba138ac11"
   end
 
+  # Analytics on deprecation date: "install: 3 (30 days), 8 (90 days), 83 (365 days)"
+  deprecate! date: "2026-01-12", because: "needs EOL `pcre`"
+  disable! date: "2027-01-12", because: "needs EOL `pcre`"
+
   depends_on "cmake" => :build
   depends_on "pandoc" => :build
   depends_on "pkgconf" => :build


### PR DESCRIPTION
Hard dependency on `pcre` (https://github.com/ngs-lang/ngs/blob/master/CMakeLists.txt#L31) and no upstream activity related to PCRE2.

Doesn't seem very popular based on:
1. https://repology.org/project/ngs-lang/versions
    - None of major Linux distros, e.g. Debian/Ubuntu, Fedora, Gentoo, Arch Linux (not AUR).
    - Alpine can also be ignored as it is only in their Edge/testing repository but never made it to a release
2. Low installs in Homebrew

So just deprecating.

If anyone has interest, then they can upstream a fix to use `pcre2`, `std::regex` or any other maintained alternative.