### PR TITLE
comby: deprecate

### DIFF
--- a/Formula/c/comby.rb
+++ b/Formula/c/comby.rb
@@ -21,6 +21,12 @@ class Comby < Formula
     sha256               x86_64_linux:   "6a87649180d98f7555771ceb9d6062a1ce98f2aaaff996f52f9f8249bf300a8c"
   end
 
+  # https://github.com/comby-tools/comby/issues/358
+  # https://github.com/comby-tools/comby/issues/381
+  # https://github.com/comby-tools/comby/issues/392
+  deprecate! date: "2026-01-13", because: "needs EOL `pcre`, OCaml < 5 and multiple workarounds to build"
+  disable! date: "2027-01-13", because: "needs EOL `pcre`, OCaml < 5 and multiple workarounds to build"
+
   depends_on "autoconf" => :build
   depends_on "gmp" => :build
   depends_on "ocaml@4" => :build # https://github.com/comby-tools/comby/issues/358


### PR DESCRIPTION
Almost 3 years now since upstream issue for OCaml 5 support.

Ocaml 4.14 is approaching EOL. Originally planned to be EOL with 5.4.0 release, but deferred until at least 5.5.0 release (it seems likely that 4.14.3 will be final release):
- https://github.com/ocaml/ocaml/commit/077920a58406fad184b19f191d3c756e100b3c51

Can always undeprecate if upstream resolves listed issues. They have an extra 2 years before removal.

