### PR TITLE
tiff2png: declare indirect deps with linkage for linux build

### DIFF
--- a/Formula/t/tiff2png.rb
+++ b/Formula/t/tiff2png.rb
@@ -27,6 +27,8 @@ class Tiff2png < Formula
   depends_on "libpng"
   depends_on "libtiff"
 
+  uses_from_macos "zlib"
+
   def install
     bin.mkpath
     system "make", "INSTALL=#{prefix}", "CC=#{ENV.cc}", "install"


### PR DESCRIPTION
tiff2png: declare indirect deps with linkage for linux build

- https://github.com/Homebrew/homebrew-core/actions/runs/20957968558/job/60228560662?pr=262522#step:4:1400
- #262522