### PR TITLE
itstool: drop --with-http and --with-icu

### DIFF
--- a/Formula/i/itstool.rb
+++ b/Formula/i/itstool.rb
@@ -57,8 +57,6 @@ class Itstool < Formula
       # Run configure to generate setup.py and Doxygen XML
       system "./configure", "--disable-silent-rules",
                             "--with-history",
-                            "--with-http",
-                            "--with-icu",
                             "--with-legacy", # https://gitlab.gnome.org/GNOME/libxml2/-/issues/751#note_2157870
                             "--with-python",
                             *std_configure_args(prefix: libexec)


### PR DESCRIPTION
Fix the "ICU not found" error

==> ./configure --disable-silent-rules --with-history --with-http --with-icu … […]
Enabling ICU support
checking for icu-uc... no
checking for unicode/ucnv.h... no
configure: error: ICU not found

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
