### PR TITLE
yo: update test not depends on node version

### DIFF
--- a/Formula/y/yo.rb
+++ b/Formula/y/yo.rb
@@ -20,6 +20,7 @@ class Yo < Formula
 
   test do
     assert_match version.to_s, shell_output("#{bin}/yo --version")
-    assert_match "Everything looks all right!", shell_output("#{bin}/yo doctor")
+    assert_match "Couldn't find any generators", shell_output("#{bin}/yo --generators")
+    assert_match "Running sanity checks on your system", shell_output("#{bin}/yo doctor")
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/actions/runs/20964391919/job/60265220231?pr=262588

It fails during node version bump, so change test.