### PR TITLE
trafficserver: deprecate

### DIFF
--- a/Formula/t/trafficserver.rb
+++ b/Formula/t/trafficserver.rb
@@ -11,6 +11,11 @@ class Trafficserver < Formula
     depends_on "pcre" # PCRE2 issue: https://github.com/apache/trafficserver/issues/8780
   end
 
+  # Allow livechecking for new releases while deprecated.
+  livecheck do
+    url :stable
+  end
+
   bottle do
     sha256 arm64_tahoe:   "f1f228335aa43ef6fc7ff8e68c2777dc3ff42335cb0b9b71bc74deac28998ab3"
     sha256 arm64_sequoia: "bd0435227b8259ad3ddb4f0e2554fa80313afc5534a216727907e93ed4449154"
@@ -27,6 +32,10 @@ class Trafficserver < Formula
 
     depends_on "zstd"
   end
+
+  # Can be undeprecated with 10.2.0 release.
+  # Backporting PCRE2 support requires 30+ commits and resolving conflicts, so not worth it.
+  deprecate! date: "2026-01-14", because: "needs EOL `pcre`"
 
   depends_on "cmake" => :build
   depends_on "ninja" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

10.2.0 will likely be out sometime this year so can undeprecate then.

I did try backporting PCRE2 support which required 30+ commits including some manual conflict resolved patches making it quite messy and with a higher risk of something being broken.

In alignment with Debian removal from Trixie:
- https://packages.debian.org/bookworm/trafficserver
