### PR TITLE
workflows/triage: skip recursive deps for `alsa-lib`

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -391,6 +391,7 @@ jobs:
 
             - label: CI-skip-recursive-dependents
               path: "Formula/.+/(\
+                alsa-lib|\
                 ca-certificates|\
                 certifi|\
                 cmake|\
@@ -422,7 +423,6 @@ jobs:
 
             - label: CI-linux-self-hosted-deps
               path: "Formula/.+/(\
-                alsa-lib|\
                 glib|\
                 libcap|\
                 libva|\


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`alsa-lib` is a low level Linux-only dependency (essential for Linux audio support) so recursive dependent testing always times out (> 36 hour run needed)

In prior PRs, the manual application of label meant that the run doesn't actually use it unless restarted. This leads to occupying self-hosted for 36 hours which then backlogs our PRs (current situation).