### PR TITLE
ffmpeg adds (restores) libx265

### DIFF
--- a/Formula/f/ffmpeg.rb
+++ b/Formula/f/ffmpeg.rb
@@ -33,6 +33,7 @@ class Ffmpeg < Formula
   depends_on "sdl2"
   depends_on "svt-av1"
   depends_on "x264"
+  depends_on "x265"
 
   uses_from_macos "bzip2"
   uses_from_macos "libxml2"
@@ -66,6 +67,7 @@ class Ffmpeg < Formula
       --enable-libsvtav1
       --enable-libopus
       --enable-libx264
+      --enable-libx265
       --enable-libmp3lame
     ]
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)? _yes._
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)? _yes._
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change? _yes._
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew reinstall --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? _yes._
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting? _yes._
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? yes. If this is a new formula, does it pass `brew audit --new <formula>`? _existing formula._

-----

This PR restores `libx265` to the ["ffmpeg: slim down formula. #261303](https://github.com/Homebrew/homebrew-core/pull/261303).

Below are some key points to consider regarding the inclusion/retention of `libx265` for `H.265 HEVC` video processing with `FFmpeg`:

- `H.265 HEVC` is a widely used/supported format.
- FFmpeg `hevc_videotoolbox` not an interchangeable (acceptable) replacement for `libx265` for workflows which require a higher quality-per-filesize outcome. `libx265` produced significally smaller files for the same visual quality of resulting video.
- `hevc_videotoolbox` and `libx265` have some significantly different `H.265 HEVC` use cases differentiators …

| Feature              | hevc_videotoolbox                          | libx265                                      | Winner (most cases)     |
|----------------------|--------------------------------------------|----------------------------------------------|--------------------------|
| **Encoder type**     | Hardware (Apple Silicon / T2 / Intel Mac)  | Software (CPU)                               | —                       |
| **Encoding speed**   | Very fast (5–20× faster, often real-time or better) | Very slow (especially slow/veryslow presets) | **hevc_videotoolbox**   |
| **Compression efficiency** | Moderate → poor (needs higher bitrate)     | Excellent → best in class                    | **libx265**             |
| **File size** @ same quality | Larger (usually 30–100%+)                  | Much smaller                                 | **libx265**             |
| **Quality @ same bitrate** | Worse (more artifacts, banding in 8-bit)   | Clearly superior (especially slow presets)   | **libx265**             |
| **Constant Quality mode** | Yes (-q:v 0–100 or CQ mode, Apple Silicon) | Excellent CRF (18–28 typical range)          | libx265 (more precise)  |
| **Presets/tuning**   | Very limited                               | Many presets + tons of fine-tuning options   | **libx265**             |
| **Power consumption** | Very low                                   | High (especially on long encodes)            | **hevc_videotoolbox**   |
| **Best for**         | Quick encodes, temporary files, drafts, preview, live streaming | Archiving, highest quality, smallest size, final masters | Depends on priority     |


