### PR TITLE
rig-r 0.7.1 (new formula)

### DIFF
--- a/Formula/r/rig-r.rb
+++ b/Formula/r/rig-r.rb
@@ -5,6 +5,15 @@ class RigR < Formula
   sha256 "23f30bff14026141c82000b5e085f05410d30dace04ed383a6445981cebb3989"
   license "MIT"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "4a1036df99991fe7a75a97f9597eacdb97831ec77154fec34c5d161b1db1f70c"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "7e4ba5e6c0c9355b7e9662fb85c6c0ce9bd2048fdca32ccee2c42205cec68202"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "e47bc29145a28f48c26f72eb8769e15018a0426375255f4eb027b3cf27179f44"
+    sha256 cellar: :any_skip_relocation, sonoma:        "0b852f137a8505a9b1336e1a6b140fa43e52dde797024c00bdbc8a448225eccf"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "0da71bb0532251d9eb59a4ee896da94f778fd1ebf3d20c001364dfed0120ee81"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1e1618090f52d92e8cbfcc3524933798ef54db747bcb956fa6c5df3f9a5e74d6"
+  end
+
   depends_on "rust" => :build
 
   def install

--- a/Formula/r/rig-r.rb
+++ b/Formula/r/rig-r.rb
@@ -1,0 +1,19 @@
+class RigR < Formula
+  desc "R Installation Manager"
+  homepage "https://github.com/r-lib/rig"
+  url "https://github.com/r-lib/rig/archive/refs/tags/v0.7.1.tar.gz"
+  sha256 "23f30bff14026141c82000b5e085f05410d30dace04ed383a6445981cebb3989"
+  license "MIT"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/rig --version")
+    output = shell_output("#{bin}/rig default 2>&1", 1)
+    assert_match "No default R version is set", output
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Notes


- This ``conflicts_with "rig", because: "both install `rig` binaries"``, but adding it without modifying the `rig` formula causes the audit to fail