### PR TITLE
elm: workaround to build with GHC 9.14

### DIFF
--- a/Formula/e/elm.rb
+++ b/Formula/e/elm.rb
@@ -44,10 +44,15 @@ class Elm < Formula
   end
 
   def install
-    # Work around build failure due to incompatibility with newer `tls` package
-    # Ref: https://github.com/elm/compiler/pull/2325
-    args = ["--constraint=tls<2"]
-    odie "Check if `tls` constraint can be removed!" if version > "0.19.1"
+    # Workaround to build with GHC 9.14. Related issues:
+    # https://github.com/well-typed/cborg/issues/373
+    # https://github.com/haskellari/these/issues/211
+    args = %w[
+      --allow-newer=cborg:base,cborg:containers,serialise:base,serialise:containers
+      --allow-newer=these:base
+      --allow-newer=snap-server:containers
+      --constraint=tls>=2
+    ]
 
     system "cabal", "v2-update"
     system "cabal", "v2-install", *args, *std_cabal_v2_args


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
