### PR TITLE
legitify: deprecate

### DIFF
--- a/Formula/l/legitify.rb
+++ b/Formula/l/legitify.rb
@@ -21,7 +21,9 @@ class Legitify < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "467b678a47f512a636ab25c2d14106c7371b2917670c0fa01fb7f51d6796b006"
   end
 
-  # Use "go" when https://github.com/Legit-Labs/legitify/pull/350 is merged and released:
+  # no release since 2024-07-09, fails with go 1.25+ https://github.com/Legit-Labs/legitify/pull/350
+  deprecate! date: "2026-01-15", because: :unmaintained
+
   depends_on "go@1.24" => :build
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

go 1.26 will be released next month, at which point we'll deprecate go 1.24 (per https://go.dev/doc/devel/release#policy). meanwhile, this is stuck on 1.24 without any response to https://github.com/Legit-Labs/legitify/pull/350 and hasn't had a release since 2024

```
==> Analytics
install: 17 (30 days), 29 (90 days), 128 (365 days)
install-on-request: 17 (30 days), 29 (90 days), 128 (365 days)
build-error: 0 (30 days)
```