### PR TITLE
addlicense: test fix

### DIFF
--- a/Formula/a/addlicense.rb
+++ b/Formula/a/addlicense.rb
@@ -26,6 +26,6 @@ class Addlicense < Formula
   test do
     (testpath/"test.go").write("package main\\n")
     system bin/"addlicense", "-c", "Random LLC", testpath/"test.go"
-    assert_match "// Copyright 2025 Random LLC", (testpath/"test.go").read
+    assert_match "// Copyright #{Time.now.year} Random LLC", (testpath/"test.go").read
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Test with hardcoded year failing now in 2026, found in:
* https://github.com/Homebrew/homebrew-core/pull/258912