### PR TITLE
spry 1.7.4 (new formula)

### DIFF
--- a/Formula/s/spry.rb
+++ b/Formula/s/spry.rb
@@ -25,6 +25,6 @@ class Spry < Formula
   end
 
   test do
-    system "#{bin}/spry", "--version"
+    system bin/"spry", "--version"
   end
 end

--- a/Formula/s/spry.rb
+++ b/Formula/s/spry.rb
@@ -1,0 +1,30 @@
+class Spry < Formula
+  desc "Declarative web application framework"
+  homepage "https://github.com/programmablemd/packages"
+  license "MIT"
+
+  if OS.mac?
+    url "https://github.com/programmablemd/packages/releases/download/v1.7.4/spry-macos.tar.gz"
+    sha256 "08b5519d337ca1e8c13ad9ae9a176560bd8281e63c735326896398662f8ef3a7"
+    version "1.7.4"
+  elsif OS.linux?
+    url "https://github.com/programmablemd/packages/releases/download/v1.7.4/spry_1.7.4-ubuntu22.04u1_amd64.deb"
+    sha256 "0b98bbdbdc9f77bee3ce03f56d5f695a636c8265db150d3bfb62512804161fe1"
+    version "1.7.4"
+  end
+
+  def install
+    if OS.mac?
+      bin.install "spry-macos" => "spry"
+    elsif OS.linux?
+      # For Linux, extract the DEB package using dpkg-deb
+      system "dpkg-deb", "-x", "spry_1.7.4-ubuntu22.04u1_amd64.deb", "."
+      bin.install "usr/bin/spry"
+      man1.install Dir["usr/share/man/man1/*.1.gz"]
+    end
+  end
+
+  test do
+    system "#{bin}/spry", "--version"
+  end
+end


### PR DESCRIPTION
Add spry formula for declarative web framework.

Spry is a declarative web application framework built on Deno. This formula provides platform-specific binary installations for macOS and Linux

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
