### PR TITLE
xcsift 1.0.21 (new formula)

### DIFF
--- a/Formula/x/xcsift.rb
+++ b/Formula/x/xcsift.rb
@@ -1,0 +1,25 @@
+class Xcsift < Formula
+  desc "Swift tool to parse xcodebuild output for coding agents"
+  homepage "https://github.com/ldomaradzki/xcsift"
+  url "https://github.com/ldomaradzki/xcsift/archive/refs/tags/v1.0.21.tar.gz"
+  sha256 "b7d5fe3d1838a59545aa5ec3948227c64aaf0bdb92b760661d4f0ec546476db1"
+  license "MIT"
+  head "https://github.com/ldomaradzki/xcsift.git", branch: "master"
+
+  depends_on xcode: ["16.0", :build]
+  depends_on :macos
+
+  def install
+    inreplace "Sources/main.swift", "VERSION_PLACEHOLDER", version.to_s
+    system "swift", "build", "--disable-sandbox", "-c", "release"
+    bin.install ".build/release/xcsift"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/xcsift --version")
+
+    output = pipe_output(bin/"xcsift", "Build succeeded")
+    assert_match "status", output
+    assert_match "summary", output
+  end
+end

--- a/Formula/x/xcsift.rb
+++ b/Formula/x/xcsift.rb
@@ -6,6 +6,13 @@ class Xcsift < Formula
   license "MIT"
   head "https://github.com/ldomaradzki/xcsift.git", branch: "master"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "240ec668972a5a83df0ac37f542cc558cc36524540a50ed901f458b19fbc1c6a"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "9ef6a6748671d597ad42e919a64efda975e3307fe8b73574f64f8ebc64edd1ae"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "7df94b05a736f9b983554dd02e731e7fa36c9acda0f3f493183ec58826008666"
+    sha256 cellar: :any_skip_relocation, sonoma:        "ca743d4ba4082fb938512aa34092380e12662be2164db3a5af9d551a36fe44f8"
+  end
+
   depends_on xcode: ["16.0", :build]
   depends_on :macos
 


### PR DESCRIPTION
## Summary

- Adds **xcsift**, a Swift tool to parse xcodebuild/SPM output for coding agents
- Outputs structured JSON/TOON format optimized for LLM consumption (30-60% fewer tokens)
- Supports build status, warnings, errors, test results, code coverage, and slow test detection

**Homepage**: https://github.com/ldomaradzki/xcsift
**License**: MIT
**Stars**: 200+

## Installation

```bash
brew install xcsift
```

## Usage

```bash
xcodebuild build 2>&1 | xcsift
swift test 2>&1 | xcsift --warnings --coverage
```

## Test plan

- [x] `brew audit --strict --online --new xcsift` passes
- [x] `brew style xcsift` passes  
- [x] `brew install --build-from-source xcsift` succeeds
- [x] `brew test xcsift` passes
- [x] Binary runs correctly and produces expected JSON output