### PR TITLE
emacs: fix libxml2 header when building from source in Linux

### DIFF
--- a/Formula/e/emacs.rb
+++ b/Formula/e/emacs.rb
@@ -65,6 +65,13 @@ class Emacs < Formula
       system "./autogen.sh"
     end
 
+    # when building from source, sometimes the libxml2 include path is not
+    # picked up by the compiler's system search path (<...>).
+    unless OS.mac?
+      ENV["LIBXML2_CFLAGS"] = "-isystem #{Formula["libxml2"].opt_include}/libxml2 \
+      -I#{Formula["zlib"].opt_include}/zlib"
+    end
+
     File.write "lisp/site-load.el", <<~EOS
       (setq exec-path (delete nil
         (mapcar


### PR DESCRIPTION
When building from source on non-Ubuntu systems, the compiler sometimes leaves Homebrew's libxml2 includes out of the system header search path, leading to a compilation failure for src/xml.c.

Explicitly add Homebrew's libxml2 include path for ./configure to pick up when not building on macOS.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
