### PR TITLE
mpv: depend on ffmpeg-full instead of ffmpeg

### DIFF
--- a/Formula/m/mpv.rb
+++ b/Formula/m/mpv.rb
@@ -20,7 +20,7 @@ class Mpv < Formula
   depends_on "ninja" => :build
   depends_on "pkgconf" => [:build, :test]
   depends_on xcode: :build
-  depends_on "ffmpeg"
+  depends_on "ffmpeg-full"
   depends_on "jpeg-turbo"
   depends_on "libarchive"
   depends_on "libass"
@@ -71,8 +71,9 @@ class Mpv < Formula
     # force meson find ninja from homebrew
     ENV["NINJA"] = which("ninja")
 
-    # libarchive is keg-only
+    # ffmpeg-full and libarchive are keg-only
     ENV.prepend_path "PKG_CONFIG_PATH", Formula["libarchive"].opt_lib/"pkgconfig" if OS.mac?
+    ENV.append_path "PKG_CONFIG_PATH", Formula["ffmpeg-full"].opt_lib/"pkgconfig"
 
     args = %W[
       -Dbuild-date=false


### PR DESCRIPTION
PR #261303 slimmed down the ffmpeg formula and created a new ffmpeg-full that contains all of the things the old ffmpeg formula enabled. As an mpv maintainer, I have at least some insight to what users want and the expectation in this space is for the player to be able to play back as many formats and codecs that can reasonably be thrown at the player. Since mpv directly leverages ffmpeg libraries to support these things, make it depend on ffmpeg-full instead which offers the full, wide range of codec support that users want.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
