### PR TITLE
rubyfmt: use tarball, remove workaround

### DIFF
--- a/Formula/r/rubyfmt.rb
+++ b/Formula/r/rubyfmt.rb
@@ -17,12 +17,13 @@ class Rubyfmt < Formula
   no_autobump! because: :bumped_by_upstream
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "0d4825a2aaf18c4d14d339190e26fd6042cd2312dd1953c5844c114def6700b9"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "df96caa4ae7cc5d2fc1f5cd0a0e9c790cc1f9fc48001fcf26c37f6162107a879"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "723d4db76a00d239154f8106ddfee3dd5e50557fe0221ab70c2e38a05900670e"
-    sha256 cellar: :any_skip_relocation, sonoma:        "2ccdacf5cbbe5cfc0e5ec9632de656ca88120506a7cf24042b8185a0c307f3c3"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "bccac8730df069393705d544a155d731f85bec4896da35cdc2e2d1fd22e530ef"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5269e94181e4aff93945f2f681e29096f077b9e17fd9b470e431765e2a59491f"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "c1ae4924754e4f83c5911314dec2ec3ff4dd4c1cfdf5257223e86742e9c3f842"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "4ae3190fb8ad78610482263d7c3ae7b3b5b8377aded523633a9a9a2237ccb977"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "c7aef931acdfdf3e26dc32a5cbe679d51d8e291011d05b2c6089b34445202d17"
+    sha256 cellar: :any_skip_relocation, sonoma:        "3c4a05cd5fc646ad2fdf873a63fff26b14b4b2299157065691e881445a5bc4e3"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "a2637212bf431afef2a0ae70cea03375fa53cb6602f39b7d88a9deb0f4c2dd7a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "de56de3073592a683d1f8b29dd696eb723b8a818ee57fc2d237052fdd3133e4b"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/r/rubyfmt.rb
+++ b/Formula/r/rubyfmt.rb
@@ -1,9 +1,8 @@
 class Rubyfmt < Formula
   desc "Ruby autoformatter"
   homepage "https://github.com/fables-tales/rubyfmt"
-  url "https://github.com/fables-tales/rubyfmt.git",
-      tag:      "v0.12.0",
-      revision: "6221b009587c39f326b376085c931eed25f42ebc"
+  url "https://github.com/fables-tales/rubyfmt/archive/refs/tags/v0.12.0.tar.gz"
+  sha256 "6972f8083a199bee4825ba03805baebd6e4203c543b5f96b716d6964f5628a87"
   license "MIT"
   head "https://github.com/fables-tales/rubyfmt.git", branch: "trunk"
 
@@ -41,12 +40,8 @@ class Rubyfmt < Formula
   uses_from_macos "zlib"
 
   def install
-    # Work around build failure with recent Rust
-    # Issue ref: https://github.com/fables-tales/rubyfmt/issues/467
-    ENV.append_to_rustflags "--allow dead_code"
-
     system "cargo", "install", *std_cargo_args
-    bin.install "target/release/rubyfmt-main" => "rubyfmt"
+    bin.install bin/"rubyfmt-main" => "rubyfmt"
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This previously was a git checkout for submodules, which have now been removed: https://github.com/fables-tales/rubyfmt/commit/cdb4ebb40eaead9b67f38edd7a5db8325c398b26

Also, stop installing `rubyfmt-main` in favor of `rubyfmt` as expected: https://github.com/fables-tales/rubyfmt?tab=readme-ov-file#build-from-source