### PR TITLE
ffmpeg@2.8: deprecate due to versioned formulae policy

### DIFF
--- a/Formula/f/ffmpeg@2.8.rb
+++ b/Formula/f/ffmpeg@2.8.rb
@@ -28,6 +28,16 @@ class FfmpegAT28 < Formula
 
   keg_only :versioned_formula
 
+  # On deprecation date, we had over 5 versions of FFmpeg and `ffmpeg@2.8` was
+  # the least popular with 280 installs in 90 days. This means it no longer
+  # satisfies https://docs.brew.sh/Versions#acceptable-versioned-formulae
+  #
+  # > No more than five versions of a formula (including the main one)
+  # > will be supported at any given time, unless they are popular
+  # > (e.g. have over 1000 analytics 90 days installs of usage)
+  deprecate! date: "2026-01-17", because: :versioned_formula
+  disable! date: "2027-01-17", because: :versioned_formula
+
   depends_on "pkgconf" => :build
   depends_on "texi2html" => :build
   depends_on "yasm" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Ignoring variants (e.g. full) and just looking at versions that show up for https://formulae.brew.sh/formula/ffmpeg, the current formulae considered for the 5 version limit are:

- `ffmpeg` - 357,635 installs
- `ffmpeg@6` - 5,940 installs - 2 dependents
- `ffmpeg@7` - 4,593 installs - 5 dependents
- `ffmpeg@4` - 3,542 installs - 2 dependents
- `ffmpeg@5` - 2,256 installs - 0 dependents
- `ffmpeg@2.8` - 280 installs - 0 dependents

