### PR TITLE
rubyfmt: Remove unneeded dependencies

### DIFF
--- a/Formula/r/rubyfmt.rb
+++ b/Formula/r/rubyfmt.rb
@@ -26,19 +26,8 @@ class Rubyfmt < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "de56de3073592a683d1f8b29dd696eb723b8a818ee57fc2d237052fdd3133e4b"
   end
 
-  depends_on "autoconf" => :build
-  depends_on "automake" => :build
-  depends_on "bison" => :build
   depends_on "rust" => :build
-  # https://bugs.ruby-lang.org/issues/18616
-  # error: '__declspec' attributes are not enabled;
-  # use '-fdeclspec' or '-fms-extensions' to enable support for __declspec attributes
-  depends_on macos: :monterey
-
   uses_from_macos "llvm" => :build # for libclang to build ruby-prism-sys
-  uses_from_macos "libxcrypt"
-  uses_from_macos "ruby"
-  uses_from_macos "zlib"
 
   def install
     system "cargo", "install", *std_cargo_args


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`rubyfmt` used to include a whole host of dependencies because it needed to build and link Ruby, but [this commit](https://github.com/fables-tales/rubyfmt/commit/cdb4ebb40eaead9b67f38edd7a5db8325c398b26) in the latest release removed that dependency. Now it should only really need `llvm` (for `libclang`) as part of building [Prism](https://github.com/ruby/prism) and plain Rust, so we can remove the remaining explicit dependencies.
