### PR TITLE
imagemagick: slim down formula

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,6 +18,8 @@ LICENSE.txt                       @Homebrew/lead-maintainers @MikeMcQuaid
 .github/workflows/triage.yml      @Homebrew/lead-maintainers
 Formula/f/ffmpeg.rb               @MikeMcQuaid
 Formula/f/ffmpeg-full.rb          @MikeMcQuaid
+Formula/i/imagemagick.rb          @MikeMcQuaid
+Formula/i/imagemagick-full.rb     @MikeMcQuaid
 
 audit_exceptions/linux_only_gcc_dependency_allowlist.json               @Homebrew/lead-maintainers
 audit_exceptions/permitted_formula_license_mismatches.json              @Homebrew/lead-maintainers @MikeMcQuaid

--- a/Formula/i/imagemagick-full.rb
+++ b/Formula/i/imagemagick-full.rb
@@ -1,0 +1,131 @@
+class ImagemagickFull < Formula
+  desc "Tools and libraries to manipulate images in many formats"
+  homepage "https://imagemagick.org/index.php"
+  url "https://imagemagick.org/archive/releases/ImageMagick-7.1.2-12.tar.xz"
+  sha256 "e22c5dc6cd3f8e708a2809483fd10f8e37438ef7831ec8d3a07951ccd70eceba"
+  license "ImageMagick"
+  revision 2
+  head "https://github.com/ImageMagick/ImageMagick.git", branch: "main"
+
+  livecheck do
+    url "https://imagemagick.org/archive/"
+    regex(/href=.*?ImageMagick[._-]v?(\d+(?:\.\d+)+-\d+)\.t/i)
+  end
+
+  keg_only :versioned_formula
+
+  depends_on "pkgconf" => :build
+  depends_on "cairo"
+  depends_on "fontconfig"
+  depends_on "freetype"
+  depends_on "ghostscript"
+  depends_on "glib"
+  depends_on "jpeg-turbo"
+  depends_on "jpeg-xl"
+  depends_on "libheif"
+  depends_on "liblqr"
+  depends_on "libpng"
+  depends_on "libraw"
+  depends_on "librsvg"
+  depends_on "libtiff"
+  depends_on "libtool"
+  depends_on "libultrahdr"
+  depends_on "libzip"
+  depends_on "little-cms2"
+  depends_on "openexr"
+  depends_on "openjpeg"
+  depends_on "webp"
+  depends_on "xz"
+
+  uses_from_macos "bzip2"
+  uses_from_macos "libxml2"
+  uses_from_macos "zlib"
+
+  on_macos do
+    depends_on "gdk-pixbuf"
+    depends_on "gettext"
+    depends_on "imath"
+    depends_on "libomp"
+  end
+
+  on_linux do
+    depends_on "libx11"
+    depends_on "libxext"
+  end
+
+  skip_clean :la
+
+  # Patch to fix build with LibRaw 0.22+
+  patch do
+    url "https://gitlab.archlinux.org/archlinux/packaging/packages/imagemagick/-/raw/ca9b35f767e1c4a166847fbfe17c2d715aa80582/libraw-0.22.patch"
+    sha256 "baed7cbfb378734d32d277b6e13882ac541932ef67e6aa8867b185ffef12f986"
+  end
+
+  def install
+    # Avoid references to shim
+    inreplace Dir["**/*-config.in"], "@PKG_CONFIG@", Formula["pkg-config"].opt_bin/"pkg-config"
+    # versioned stuff in main tree is pointless for us
+    inreplace "configure", "${PACKAGE_NAME}-${PACKAGE_BASE_VERSION}", "${PACKAGE_NAME}"
+
+    args = [
+      "--enable-osx-universal-binary=no",
+      "--disable-silent-rules",
+      "--disable-opencl",
+      "--enable-shared",
+      "--enable-static",
+      "--with-freetype=yes",
+      "--with-rsvg=yes",
+      "--with-gvc=no",
+      "--with-modules",
+      "--with-openjp2",
+      "--with-openexr",
+      "--with-webp=yes",
+      "--with-heic=yes",
+      "--with-raw=yes",
+      "--with-uhdr=yes",
+      "--with-zip=yes",
+      "--with-gslib",
+      "--with-gs-font-dir=#{HOMEBREW_PREFIX}/share/ghostscript/fonts",
+      "--with-lqr",
+      "--without-djvu",
+      "--without-fftw",
+      "--without-pango",
+      "--without-wmf",
+      "--enable-openmp",
+    ]
+    if OS.mac?
+      args += [
+        "--without-x",
+        # Work around "checking for clang option to support OpenMP... unsupported"
+        "ac_cv_prog_c_openmp=-Xpreprocessor -fopenmp",
+        "ac_cv_prog_cxx_openmp=-Xpreprocessor -fopenmp",
+        "LDFLAGS=-lomp -lz",
+      ]
+    end
+
+    system "./configure", *args, *std_configure_args
+    system "make", "install"
+  end
+
+  def caveats
+    <<~EOS
+      imagemagick-full includes additional tools and libraries that are not included in the regular imagemagick formula.
+    EOS
+  end
+
+  test do
+    assert_match "PNG", shell_output("#{bin}/identify #{test_fixtures("test.png")}")
+
+    # Check support for recommended features and delegates.
+    features = shell_output("#{bin}/magick -version")
+    %w[Modules freetype heic jpeg png raw rsvg tiff].each do |feature|
+      assert_match feature, features
+    end
+
+    # Check support for a few specific image formats, mostly to ensure LibRaw linked correctly.
+    formats = shell_output("#{bin}/magick -list format")
+    ["AVIF  HEIC      rw+", "ARW  DNG       r--", "DNG  DNG       r--"].each do |format|
+      assert_match format, formats
+    end
+  end
+end

--- a/Formula/i/imagemagick-full.rb
+++ b/Formula/i/imagemagick-full.rb
@@ -12,6 +12,15 @@ class ImagemagickFull < Formula
     regex(/href=.*?ImageMagick[._-]v?(\d+(?:\.\d+)+-\d+)\.t/i)
   end
 
+  bottle do
+    sha256 arm64_tahoe:   "4e4faf644af0d4b684c83f8775dd95eb713ab85c81940c394c4c8acf3fe6510f"
+    sha256 arm64_sequoia: "6761b474f366449e080554f241f2d5aeb966cff5e95a38af94d9858710bb4885"
+    sha256 arm64_sonoma:  "af102b8cb6925b4791de85cb5e0078e45ecd1cbb510e97cf37af1fa88d49a061"
+    sha256 sonoma:        "90d1e6abdd1d5b03e783fcc36fd42fbf614fd42cbb35fe2a742e1171164f2991"
+    sha256 arm64_linux:   "0c40dbe723e02769624a8068638b98e39868c77e6542c01fc90b1811351b27df"
+    sha256 x86_64_linux:  "8bd7821eff6ebb2325cbad886ae6992728539c42de2e4710e29ae49c4a50625e"
+  end
+
   keg_only :versioned_formula
 
   depends_on "pkgconf" => :build

--- a/Formula/i/imagemagick.rb
+++ b/Formula/i/imagemagick.rb
@@ -1,10 +1,10 @@
 class Imagemagick < Formula
-  desc "Tools and libraries to manipulate images in many formats"
+  desc "Tools and libraries to manipulate images in select formats"
   homepage "https://imagemagick.org/index.php"
   url "https://imagemagick.org/archive/releases/ImageMagick-7.1.2-12.tar.xz"
   sha256 "e22c5dc6cd3f8e708a2809483fd10f8e37438ef7831ec8d3a07951ccd70eceba"
   license "ImageMagick"
-  revision 1
+  revision 2
   head "https://github.com/ImageMagick/ImageMagick.git", branch: "main"
 
   livecheck do
@@ -22,23 +22,19 @@ class Imagemagick < Formula
   end
 
   depends_on "pkgconf" => :build
-  depends_on "cairo"
-  depends_on "fontconfig"
-  depends_on "freetype"
+
+  # Only add dependencies required for dependents in homebrew-core,
+  # recursive dependencies or INCREDIBLY widely used and light formats in the
+  # current year (2026).
+  # Add other dependencies to imagemagick-full formula or consider making
+  # formulae dependent on imagemagick-full.
+  depends_on "glib"
   depends_on "jpeg-turbo"
-  depends_on "jpeg-xl"
   depends_on "libheif"
-  depends_on "liblqr"
   depends_on "libpng"
-  depends_on "libraw"
-  depends_on "librsvg"
   depends_on "libtiff"
   depends_on "libtool"
-  depends_on "libultrahdr"
-  depends_on "libzip"
   depends_on "little-cms2"
-  depends_on "openexr"
-  depends_on "openjpeg"
   depends_on "webp"
   depends_on "xz"
 
@@ -47,26 +43,11 @@ class Imagemagick < Formula
   uses_from_macos "zlib"
 
   on_macos do
-    depends_on "gdk-pixbuf"
     depends_on "gettext"
-    depends_on "glib"
     depends_on "imath"
-    depends_on "libomp"
-  end
-
-  on_linux do
-    depends_on "glib"
-    depends_on "libx11"
-    depends_on "libxext"
   end
 
   skip_clean :la
-
-  # Patch to fix build with LibRaw 0.22+
-  patch do
-    url "https://gitlab.archlinux.org/archlinux/packaging/packages/imagemagick/-/raw/ca9b35f767e1c4a166847fbfe17c2d715aa80582/libraw-0.22.patch"
-    sha256 "baed7cbfb378734d32d277b6e13882ac541932ef67e6aa8867b185ffef12f986"
-  end
 
   def install
     # Avoid references to shim
@@ -80,33 +61,23 @@ class Imagemagick < Formula
       "--disable-opencl",
       "--enable-shared",
       "--enable-static",
-      "--with-freetype=yes",
-      "--with-rsvg=yes",
       "--with-gvc=no",
       "--with-modules",
-      "--with-openjp2",
-      "--with-openexr",
       "--with-webp=yes",
       "--with-heic=yes",
-      "--with-raw=yes",
-      "--with-uhdr=yes",
-      "--with-zip=yes",
+      "--with-raw=no",
       "--without-gslib",
-      "--with-gs-font-dir=#{HOMEBREW_PREFIX}/share/ghostscript/fonts",
       "--with-lqr",
       "--without-djvu",
       "--without-fftw",
       "--without-pango",
       "--without-wmf",
-      "--enable-openmp",
+      "--without-jxl",
+      "--without-openexr",
     ]
     if OS.mac?
       args += [
         "--without-x",
-        # Work around "checking for clang option to support OpenMP... unsupported"
-        "ac_cv_prog_c_openmp=-Xpreprocessor -fopenmp",
-        "ac_cv_prog_cxx_openmp=-Xpreprocessor -fopenmp",
-        "LDFLAGS=-lomp -lz",
       ]
     end
 
@@ -116,8 +87,7 @@ class Imagemagick < Formula
 
   def caveats
     <<~EOS
-      Ghostscript is not installed by default as a dependency.
-      If you need PS or PDF support, ImageMagick will still use the ghostscript formula if installed directly.
+      imagemagick-full includes additional tools and libraries that are not included in the regular imagemagick formula.
     EOS
   end
 
@@ -126,14 +96,8 @@ class Imagemagick < Formula
 
     # Check support for recommended features and delegates.
     features = shell_output("#{bin}/magick -version")
-    %w[Modules freetype heic jpeg png raw rsvg tiff].each do |feature|
+    %w[Modules heic jpeg png tiff].each do |feature|
       assert_match feature, features
-    end
-
-    # Check support for a few specific image formats, mostly to ensure LibRaw linked correctly.
-    formats = shell_output("#{bin}/magick -list format")
-    ["AVIF  HEIC      rw+", "ARW  DNG       r--", "DNG  DNG       r--"].each do |format|
-      assert_match format, formats
     end
   end
 end

--- a/Formula/i/imagemagick.rb
+++ b/Formula/i/imagemagick.rb
@@ -13,12 +13,12 @@ class Imagemagick < Formula
   end
 
   bottle do
-    sha256 arm64_tahoe:   "70a4007af2df1cbceee0f1d245b9c3b63610c7e47ea17bafb6722964b401c8b3"
-    sha256 arm64_sequoia: "aa09d81bf684995f2b039a6fea27b58c5fa68d69af3b1111bc4f659a691e55ba"
-    sha256 arm64_sonoma:  "3a6ab91642e7cd983422eddfc2535c56365dad208e4ecc10b2162fab2029e55d"
-    sha256 sonoma:        "126ce8dfc0ac26bcc92193f6c27d49a9d79a9fa652cf56bb37107f2789736940"
-    sha256 arm64_linux:   "0e44e1adc76f7985b20ef49cbeb1a96128b748fc27c2c8d52b3b2e192744c38d"
-    sha256 x86_64_linux:  "97bf08e3d0a9dc3adaed58d3b6142bee0542de0add7c7882ccebf28f783a8949"
+    sha256 arm64_tahoe:   "aad5fc7749d91edf4f9f8340a9a89b042368dc353e7751ab3fa463e2c78ec336"
+    sha256 arm64_sequoia: "cb1edb6b9073b44f9a9a9a96e88f2061be3332a8a933e329540764f8cc0f2983"
+    sha256 arm64_sonoma:  "068e0c8ba5387c15421a00265147b04c3afdff8aa7c56cb1841c9a9c4467955a"
+    sha256 sonoma:        "d5b690a4b989f732c022673dc1a76ee566a10d290c536435b7408f74ef96c1f5"
+    sha256 arm64_linux:   "724870b999a939457eb40326bdc8e8231b9a71f94a8b6cf50c19199b4b583df2"
+    sha256 x86_64_linux:  "f9f3f1107aa32df9e481fca5cf2ade56b6d22072283d83d9007d1234d724c78c"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/v/vapoursynth-imwri.rb
+++ b/Formula/v/vapoursynth-imwri.rb
@@ -11,14 +11,13 @@ class VapoursynthImwri < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    sha256 cellar: :any, arm64_tahoe:   "cc90cc4f2d65c9f885c7fe4557766fdfb19a868f1a6ef9166803851a3fb8d798"
-    sha256 cellar: :any, arm64_sequoia: "05e577ee12e4337fb9af5870c39c485e5e7a5ac4b56365361e9c2e7e35eca388"
-    sha256 cellar: :any, arm64_sonoma:  "2bbe0c55617799e49cfd693a838565894dc7ecb5fbcaef0b72e9103da674999d"
-    sha256 cellar: :any, arm64_ventura: "8795d8f3142e89ca1785f5d83312ab82ae4c24dc0e92b54aae294dbca1d14d0c"
-    sha256 cellar: :any, sonoma:        "6ffe0859ceae64e20741fb000a0319b456dd51d437e35e79f354eabcdface889"
-    sha256 cellar: :any, ventura:       "92866496e81b76604e8f4fbd5cab2d6d94d2f83cb4521e731802445ebcbd86e6"
-    sha256               arm64_linux:   "f90a76a7b71b8d829a4f90c0969b2f7321f849f1ab9616f136cf943ffe198d10"
-    sha256               x86_64_linux:  "099e77da73bbc6d8333e6067705d531ba193d3a496d8c99fc5287f7bec4f5ac2"
+    rebuild 1
+    sha256 cellar: :any, arm64_tahoe:   "7a8829c333c4d82d927f3cfc9c88a5d162b230924f17003b44b86f8b61966ff8"
+    sha256 cellar: :any, arm64_sequoia: "04dc93bb5a1c4a49b90f29800901f4c6cc00f6a024512e3a94f06864724524df"
+    sha256 cellar: :any, arm64_sonoma:  "90d9c3dbeceab3b486f1a73273079fff14e4b70ee85e70a766b672ffa25df7f2"
+    sha256 cellar: :any, sonoma:        "11435523067bbf5c1cfd7c9597b1340afe4f34c94c64f8d0667e3d580c84ebe5"
+    sha256               arm64_linux:   "b72bf4ebcdaade6cb9e1ac993c2334fda6aa69b54dab5c5deb58b804fd193d5d"
+    sha256               x86_64_linux:  "21b4c595a5528b6d61eaba2d223e2f51bdf2b69ff50d623a915fc55a98263513"
   end
 
   depends_on "meson" => :build

--- a/Formula/v/vapoursynth-imwri.rb
+++ b/Formula/v/vapoursynth-imwri.rb
@@ -26,11 +26,11 @@ class VapoursynthImwri < Formula
   depends_on "pkgconf" => :build
 
   depends_on "imagemagick"
+  depends_on "libheif"
   depends_on "vapoursynth"
 
   on_macos do
     depends_on "jpeg-xl"
-    depends_on "libheif"
     depends_on "libtiff"
   end
 

--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -32,6 +32,7 @@
   ["gmic", "cimg"],
   ["gnome-online-accounts", "libgoa"],
   ["hdf5", "hdf5-mpi"],
+  ["imagemagick", "imagemagick-full"],
   ["libmediainfo", "media-info"],
   ["libnetworkit", "networkit"],
   ["libnghttp2", "nghttp2"],


### PR DESCRIPTION
Also add `imagemagick-full`.

Similar to https://github.com/Homebrew/homebrew-core/pull/261303 but for `imagemagick`.

As we did with `ffmpeg`, if there are loud complaints, we can consider adding specific dependencies back as required.