### PR TITLE
litra 3.1.0 (new formula)

### DIFF
--- a/Formula/l/litra.rb
+++ b/Formula/l/litra.rb
@@ -1,0 +1,31 @@
+class Litra < Formula
+  desc "Control Logitech Litra lights from the command-line"
+  homepage "https://github.com/timrogers/litra-rs"
+  url "https://github.com/timrogers/litra-rs/archive/refs/tags/v3.1.0.tar.gz"
+  sha256 "65cdeee13f75b18711f3217e788fa0396644e8f582fc8830313f81cd294eb685"
+  license "MIT"
+  head "https://github.com/timrogers/litra-rs.git", branch: "main"
+
+  depends_on "pkgconf" => :build
+  depends_on "rust" => :build
+
+  on_linux do
+    depends_on "hidapi"
+  end
+
+  def install
+    # Update to use system hidapi for linux build, upstream pr, https://github.com/timrogers/litra-rs/pull/210
+    if OS.linux?
+      inreplace "Cargo.toml",
+                /^(\s*hidapi\s*=\s*)"([^"]+)"\s*$/,
+                '\1{ version = "\2", default-features = false, features = ["linux-shared-hidraw"] }'
+    end
+
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/litra --version")
+    assert_match "No Logitech Litra devices found", shell_output("#{bin}/litra devices")
+  end
+end

--- a/Formula/l/litra.rb
+++ b/Formula/l/litra.rb
@@ -6,6 +6,15 @@ class Litra < Formula
   license "MIT"
   head "https://github.com/timrogers/litra-rs.git", branch: "main"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "7c6f2b88475cb118a19e3668b15ce928bf2e4fa31c2124409ff04af1a0eafc67"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "cac5f7dae722ea35cd485cad20d67675f3e52ad5028cdc45c77b0ee625b47970"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "369766ce4d20c5be2d25f770a716a1f65fb1f82d40a9afc80b57e29bfef269d4"
+    sha256 cellar: :any_skip_relocation, sonoma:        "f56c0417c7b63273a7886469dc99cf2c2fcccab270dca2cba4b2b5b384dacabf"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "80bacf3f67b49fc6a1b78aa63475e917cd2a0ca2d5a258ea196b348314cdea3b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8115333877484cbfa51207c607d8b2fa66aacd5de27d4a37f7a652870308f60b"
+  end
+
   depends_on "pkgconf" => :build
   depends_on "rust" => :build
 


### PR DESCRIPTION
This introduces a new formula, `litra`, from the [`timrogers/litra-rs`][1] repository.

`litra` is a lightweight command line tool for controlling Logitech Litra key lights.

I believe it meets the criteria to be included in Homebrew since it is stable, maintainable, known (113 stars and an active OSS community), used by someone other than the author and it has a homepage.

[1]: https://docs.brew.sh/Formula-Cookbook#commit

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
