### PR TITLE
docbook 5.2

### DIFF
--- a/Formula/d/docbook.rb
+++ b/Formula/d/docbook.rb
@@ -1,14 +1,13 @@
 class Docbook < Formula
   desc "Standard XML representation system for technical documents"
   homepage "https://docbook.org/"
-  url "https://docbook.org/xml/5.1/docbook-v5.1-os.zip"
-  sha256 "b3f3413654003c1e773360d7fc60ebb8abd0e8c9af8e7d6c4b55f124f34d1e7f"
+  url "https://github.com/docbook/docbook/releases/download/5.2/docbook-5.2.zip"
+  sha256 "11992554a884786f1b78c6b478d6cec90352caf00bef54731c8d54f26751f2c5"
   license :cannot_represent
-  revision 1
 
   livecheck do
-    url "https://docbook.org/xml/"
-    regex(%r{href=["']?v?(\d+(?:\.\d+)+)/?["' >]}i)
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   no_autobump! because: :requires_manual_review
@@ -21,45 +20,50 @@ class Docbook < Formula
   uses_from_macos "libxml2"
 
   resource "xml412" do
-    url "https://docbook.org/xml/4.1.2/docbkx412.zip"
+    url "https://archive.docbook.org/xml/4.1.2/docbkx412.zip"
     version "4.1.2"
     sha256 "30f0644064e0ea71751438251940b1431f46acada814a062870f486c772e7772"
   end
 
   resource "xml42" do
-    url "https://docbook.org/xml/4.2/docbook-xml-4.2.zip"
+    url "https://archive.docbook.org/xml/4.2/docbook-xml-4.2.zip"
     sha256 "acc4601e4f97a196076b7e64b368d9248b07c7abf26b34a02cca40eeebe60fa2"
   end
 
   resource "xml43" do
-    url "https://docbook.org/xml/4.3/docbook-xml-4.3.zip"
+    url "https://archive.docbook.org/xml/4.3/docbook-xml-4.3.zip"
     sha256 "23068a94ea6fd484b004c5a73ec36a66aa47ea8f0d6b62cc1695931f5c143464"
   end
 
   resource "xml44" do
-    url "https://docbook.org/xml/4.4/docbook-xml-4.4.zip"
+    url "https://archive.docbook.org/xml/4.4/docbook-xml-4.4.zip"
     sha256 "02f159eb88c4254d95e831c51c144b1863b216d909b5ff45743a1ce6f5273090"
   end
 
   resource "xml45" do
-    url "https://docbook.org/xml/4.5/docbook-xml-4.5.zip"
+    url "https://archive.docbook.org/xml/4.5/docbook-xml-4.5.zip"
     sha256 "4e4e037a2b83c98c6c94818390d4bdd3f6e10f6ec62dd79188594e26190dc7b4"
   end
 
   resource "xml50" do
-    url "https://docbook.org/xml/5.0/docbook-5.0.zip"
+    url "https://archive.docbook.org/xml/5.0/docbook-5.0.zip"
     sha256 "3dcd65e1f5d9c0c891b3be204fa2bb418ce485d32310e1ca052e81d36623208e"
   end
 
   resource "xml51" do
-    url "https://docbook.org/xml/5.1/docbook-v5.1-os.zip"
+    url "https://archive.docbook.org/xml/5.1/docbook-v5.1-os.zip"
     sha256 "b3f3413654003c1e773360d7fc60ebb8abd0e8c9af8e7d6c4b55f124f34d1e7f"
+  end
+
+  resource "xml52" do
+    url "https://github.com/docbook/docbook/releases/download/5.2/docbook-5.2.zip"
+    sha256 "11992554a884786f1b78c6b478d6cec90352caf00bef54731c8d54f26751f2c5"
   end
 
   def install
     (etc/"xml").mkpath
 
-    %w[42 412 43 44 45 50 51].each do |version|
+    %w[42 412 43 44 45 50 51 52].each do |version|
       resource("xml#{version}").stage do |r|
         if version == "412"
           cp prefix/"docbook/xml/4.2/catalog.xml", "catalog.xml"
@@ -67,6 +71,25 @@ class Docbook < Formula
           inreplace "catalog.xml" do |s|
             s.gsub! "V4.2 ..", "V4.1.2 "
             s.gsub! "4.2", "4.1.2"
+          end
+        end
+
+        if ["44", "45", "50"].include?(version)
+          inreplace "catalog.xml" do |s|
+            s.gsub! "http://docbook.org", "http://archive.docbook.org"
+          end
+        end
+
+        if version == "51"
+          mv "schemas/catalog.xml", "catalog.xml"
+          mv "schemas/docbook.nvdl", "docbook.nvdl"
+          mv "schemas/rng", "rng"
+          mv "schemas/sch", "sch"
+          rmdir "schemas"
+
+          inreplace "catalog.xml" do |s|
+            s.gsub! "5.1CR4", "5.1"
+            s.gsub! "http://docbook.org", "http://archive.docbook.org"
           end
         end
 
@@ -86,7 +109,7 @@ class Docbook < Formula
     # by other formulae to be removed
     system xmlcatalog, "--noout", "--create", etc_catalog unless etc_catalog.file?
 
-    %w[4.2 4.1.2 4.3 4.4 4.5 5.0 5.1].each do |version|
+    %w[4.2 4.1.2 4.3 4.4 4.5 5.0 5.1 5.2].each do |version|
       catalog = opt_prefix/"docbook/xml/#{version}/catalog.xml"
 
       system xmlcatalog, "--noout", "--del",

--- a/Formula/d/docbook.rb
+++ b/Formula/d/docbook.rb
@@ -13,8 +13,7 @@ class Docbook < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, all: "ca237485ebe0b9ab1fc84d87b01b2f322fb285b085133ef727857818283d6d43"
+    sha256 cellar: :any_skip_relocation, all: "a0f63041884ef15e344abec96148793e2b18c011e3d72dbdb8bdb4d76d16deec"
   end
 
   uses_from_macos "libxml2"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

As mentioned in https://github.com/orgs/Homebrew/discussions/6663, the docbook website was rewritten in November 2025. This PR updates the URLs so that building from source works again, fixes a problem with installation of docbook 5.1, where the `catalog.xml` was in the wrong location, and fixes links in `catalog.xml` file by replacing docbook.org with archive.docbook.org.

A new release of docbook is available on [Maven](https://central.sonatype.com/artifact/org.docbook/schemas-docbook/5.2) (official) and on [GitHub](https://github.com/docbook/docbook/releases/tag/5.2) (unofficial). This PR is a necessary first step before upgrading to 5.2. Given the complexity of the changes, it seemed that this was best addressed through two separate PRs.

Caveat: in order to build from source, I had to disable concurrent downloads:

```sh
HOMEBREW_DOWNLOAD_CONCURRENCY=1 HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source docbook
```

Feedback welcome.