### PR TITLE
formulae: disable on 2026-02-dd

### DIFF
--- a/Formula/g/go@1.22.rb
+++ b/Formula/g/go@1.22.rb
@@ -22,6 +22,7 @@ class GoAT122 < Formula
   # EOL with Go 1.24 release (2025-02-11)
   # Ref: https://go.dev/doc/devel/release#policy
   deprecate! date: "2025-02-16", because: :unsupported
+  disable! date: "2026-02-16", because: :unsupported
 
   depends_on "go" => :build
 

--- a/Formula/r/ruff-lsp.rb
+++ b/Formula/r/ruff-lsp.rb
@@ -19,6 +19,7 @@ class RuffLsp < Formula
   end
 
   deprecate! date: "2025-02-06", because: :deprecated_upstream, replacement_formula: "ruff"
+  disable! date: "2026-02-06", because: :deprecated_upstream, replacement_formula: "ruff"
 
   depends_on "python@3.14"
   depends_on "ruff"

--- a/Formula/s/spdx-sbom-generator.rb
+++ b/Formula/s/spdx-sbom-generator.rb
@@ -22,6 +22,7 @@ class SpdxSbomGenerator < Formula
   end
 
   deprecate! date: "2025-02-13", because: :repo_archived
+  disable! date: "2026-02-13", because: :repo_archived
 
   depends_on "go" => [:build, :test]
 

--- a/Formula/t/terrahub.rb
+++ b/Formula/t/terrahub.rb
@@ -20,6 +20,7 @@ class Terrahub < Formula
   end
 
   deprecate! date: "2025-02-13", because: :unmaintained
+  disable! date: "2026-02-13", because: :unmaintained
 
   depends_on "node"
 

--- a/Formula/t/tunnel.rb
+++ b/Formula/t/tunnel.rb
@@ -24,6 +24,7 @@ class Tunnel < Formula
 
   # `https://tunnel.labstack.com/docs` is no longer accessible
   deprecate! date: "2025-02-23", because: :unmaintained
+  disable! date: "2026-02-23", because: :unmaintained
 
   depends_on "go" => :build
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
