### PR TITLE
litra-autotoggle 1.1.1 (new formula)

### DIFF
--- a/Formula/l/litra-autotoggle.rb
+++ b/Formula/l/litra-autotoggle.rb
@@ -1,0 +1,40 @@
+class LitraAutotoggle < Formula
+  desc "Automatically turn your Logitech Litra device on when your webcam turns on, and off when your webcam turns off"
+  homepage "https://github.com/timrogers/litra-autotoggle"
+  url "https://github.com/timrogers/litra-autotoggle/archive/refs/tags/v1.1.1.tar.gz"
+  sha256 "bd5957e2c51b2a95da6af44c43076bcd75ee8f472f2cda98a872c98f4730f3ed"
+  license "MIT"
+
+  depends_on "pkgconf" => :build
+  depends_on "rust" => :build
+
+  on_linux do
+    depends_on "hidapi"
+    depends_on "openssl@3"
+    depends_on "systemd"
+  end
+
+  def install
+    system "cargo", "install", *std_cargo_args
+    etc.install 'litra-autotoggle.example.yml' => 'litra-autotoggle.yml'
+  end
+
+  def caveats
+    <<~EOS
+      To start litra-autotoggle in the background as a service, run:
+        brew services start litra-autotoggle
+
+      To customize the options for the background service, edit the configuration file:
+        #{etc}/litra-autotoggle.yml
+    EOS
+  end
+
+  service do
+    run [opt_bin / 'litra-autotoggle', '--config', etc / 'litra-autotoggle.yml']
+    keep_alive crashed: true
+  end
+
+  test do
+    assert_match "No Litra devices found", shell_output("#{bin}/litra-autotoggle").strip
+  end
+end


### PR DESCRIPTION
This introduces a new formula, `litra-autotoggle`, from the [`timrogers/litra-rs`][1] repository.

`litra-autotoggle` watches the state of your webcam, and turns you Logitech Litra keylight(s) on when the webcam turns on, and off when the webcam turns off.

It includes a Homebrew service for running in the background.

I believe it meets the criteria to be included in Homebrew since it is stable, maintainable, known (48 stars and an active OSS community), used by someone other than the author and it has a homepage.

[1]: https://github.com/timrogers/litra-autotoggle

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
