### PR TITLE
speedtest-cli: deprecate

### DIFF
--- a/Formula/s/speedtest-cli.rb
+++ b/Formula/s/speedtest-cli.rb
@@ -16,6 +16,10 @@ class SpeedtestCli < Formula
     sha256 cellar: :any_skip_relocation, all: "93487be757c9b3763deeb1b1415ee8ad10c5a80fcc9ebaeacbb8fbac3e9b9474"
   end
 
+  # see issue in https://github.com/sivel/speedtest-cli/pull/796
+  deprecate! date: "2026-01-18", because: :unmaintained
+  disable! date: "2027-01-18", because: :unmaintained
+
   depends_on "python@3.14"
 
   # Support Python 3.10, remove on next release


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
speedtest-cli has failed to work for me for the past year. It seems it tries to fetch from an old list of servers, which tends to 429 very often. [Fixes have been available for a while](https://github.com/sivel/speedtest-cli/pull/796), but the maintainer of the project hasn't sent any message about them or touched the repository for the past 5 years. This could probably be fixed with patches, but first I think it is logical in that state to deprecate the formula.