### PR TITLE
percona-toolkit: install missing go tools

### DIFF
--- a/Formula/p/percona-toolkit.rb
+++ b/Formula/p/percona-toolkit.rb
@@ -23,12 +23,13 @@ class PerconaToolkit < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "1127bedad067c639c8fd94ec410db7124a4b0c2b1d8c97fb572c59df0d44e672"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "1127bedad067c639c8fd94ec410db7124a4b0c2b1d8c97fb572c59df0d44e672"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "1127bedad067c639c8fd94ec410db7124a4b0c2b1d8c97fb572c59df0d44e672"
-    sha256 cellar: :any_skip_relocation, sonoma:        "1127bedad067c639c8fd94ec410db7124a4b0c2b1d8c97fb572c59df0d44e672"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "175073257e991966b0f6ce20973b197c033f7000a3feec84b2980e7ac0ddb167"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "175073257e991966b0f6ce20973b197c033f7000a3feec84b2980e7ac0ddb167"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "05b3f3f28f2b13b7d4f7ba1b325d82a617a6d27447d6bc6262d5f00c735bae40"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "80bef441d4e161079ff09264e1c60b8de590aa1ffea7780fd1bd0bf393b9b4e1"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "9d4361cdd519c35383e8670636c42ca57617136638f85f1e5dc75cfce9be3b89"
+    sha256 cellar: :any_skip_relocation, sonoma:        "c3c89c731b466953de715f23f17798208ee16137d87fabd7d121f041ba445dc2"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "fac3d2a5ec59955b3a7296e6adc223e02fc63f23328686245f885695d9da979f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "989cfa41ec604acfb78a5625b686f0c0ab09b1d9b3a9f3d3db9855fa7c3c24f7"
   end
 
   depends_on "go" => :build

--- a/Formula/p/percona-toolkit.rb
+++ b/Formula/p/percona-toolkit.rb
@@ -1,10 +1,19 @@
 class PerconaToolkit < Formula
   desc "Command-line tools for MySQL, MariaDB and system tasks"
   homepage "https://www.percona.com/software/percona-toolkit/"
-  url "https://downloads.percona.com/downloads/percona-toolkit/3.7.1/source/tarball/percona-toolkit-3.7.1.tar.gz"
-  sha256 "d5abd944905e75800e29176aff7fdeb7062da212511e82c265be50ac03b4c19b"
   license any_of: ["GPL-2.0-only", "Artistic-1.0-Perl"]
   head "https://github.com/percona/percona-toolkit.git", branch: "3.x"
+
+  stable do
+    url "https://downloads.percona.com/downloads/percona-toolkit/3.7.1/source/tarball/percona-toolkit-3.7.1.tar.gz"
+    sha256 "d5abd944905e75800e29176aff7fdeb7062da212511e82c265be50ac03b4c19b"
+
+    # Fix Makefile.PL to also install go tools
+    patch do
+      url "https://github.com/percona/percona-toolkit/commit/23be00fca557c7812ee0adfd3f9519429096d2ac.patch?full_index=1"
+      sha256 "1431e42904411c5011e174f94d7c0c063f9e4d6a2744ec76b7bf92f14ef01fda"
+    end
+  end
 
   livecheck do
     url "https://www.percona.com/products-api.php", post_form: {


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Adding patch from https://github.com/Homebrew/homebrew-core/issues/261450#issuecomment-3729002230 to install missing binaries

Fixes #261450
Closes #261451
