### PR TITLE
misc: remove `no_autobump!`

### DIFF
--- a/Formula/a/action-docs.rb
+++ b/Formula/a/action-docs.rb
@@ -5,8 +5,6 @@ class ActionDocs < Formula
   sha256 "f7d93433a6d3e532b30b3fc068fa263d16f7c38da91422450507b469bd36a64a"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, all: "89a129206e1fd2a3bb48e3f7923ba2bbb98c3533d28332c2511c6ff093807f51"
   end

--- a/Formula/a/aicommits.rb
+++ b/Formula/a/aicommits.rb
@@ -5,8 +5,6 @@ class Aicommits < Formula
   sha256 "b74cf25eb31eb7098d01f482cd64a87e2f59d7efa11f5273fbb353f35e850c5d"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, all: "605e05c0b7da41359670b8ed4b085303685c3398bf624db9cdde9b2fb38a38aa"

--- a/Formula/a/ansible-language-server.rb
+++ b/Formula/a/ansible-language-server.rb
@@ -5,8 +5,6 @@ class AnsibleLanguageServer < Formula
   sha256 "3182960a35f229f453d520cfb6c9624ca18104653457eca99dc1406690fa5aa2"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "55e9dfc3173ac49bd6499e5186f4483a79f448141bf3933a5248a6a3169b76c5"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "f77d8d03dd3d1c02a29ba66785d2628274f5478363f8fce75a41ca3e6febcc32"

--- a/Formula/a/autocannon.rb
+++ b/Formula/a/autocannon.rb
@@ -5,8 +5,6 @@ class Autocannon < Formula
   sha256 "470ac762b261d8eca3d8069be8776b25fc111e4caa962bc144a85e9631fd07fa"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, all: "802f0328259fdee67f34d0f613897abf2d1a665654a7b26fcd5dca49b053c103"
   end

--- a/Formula/a/autocode.rb
+++ b/Formula/a/autocode.rb
@@ -5,8 +5,6 @@ class Autocode < Formula
   sha256 "952364766e645d4ddae30f9d6cc106fdb74d05afc4028066f75eeeb17c4b0247"
   license "Apache-2.0"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "abf59dcf5fe4c66882ff2e33b395fd733f43b831e983592b530160dd3bb94c1e"

--- a/Formula/b/bit.rb
+++ b/Formula/b/bit.rb
@@ -7,8 +7,6 @@ class Bit < Formula
   revision 1
   head "https://github.com/teambit/bit.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256                               arm64_tahoe:    "82201904fa2ec0416232bc8e3fa85b60945f07b58dbfa69566c800c96947fb7f"

--- a/Formula/b/bower.rb
+++ b/Formula/b/bower.rb
@@ -5,8 +5,6 @@ class Bower < Formula
   sha256 "00df3dcc6e8b3a4dd7668934a20e60e6fc0c4269790192179388c928553a3f7e"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "18bbc17742b8e6765f4aa0b104dcbea6d21c5fd28b072d10d838febef745bff0"

--- a/Formula/c/chalk-cli.rb
+++ b/Formula/c/chalk-cli.rb
@@ -5,8 +5,6 @@ class ChalkCli < Formula
   sha256 "480a85e48da024092e1b63fe260f810880f5f82322d82f62304f32e970112216"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, all: "888e67d06c5fbe66c72de1de9f759ed9f32fd7a88d9f2158c3626b13f9ecbca6"
   end

--- a/Formula/c/coffeescript.rb
+++ b/Formula/c/coffeescript.rb
@@ -6,8 +6,6 @@ class Coffeescript < Formula
   license "MIT"
   head "https://github.com/jashkenas/coffeescript.git", branch: "main"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, all: "8b60f70c34df82c6fb506f905b11ecf0cda8421c03fb775e19ac0a2e9f348edf"

--- a/Formula/f/flamebearer.rb
+++ b/Formula/f/flamebearer.rb
@@ -5,8 +5,6 @@ class Flamebearer < Formula
   sha256 "e787b71204f546f79360fd103197bc7b68fb07dbe2de3a3632a3923428e2f5f1"
   license "ISC"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, all: "fa4b1af3c1cbdce03df418410f78ada2b106c7383539b2f7a9e5183ba2b75b71"

--- a/Formula/g/generate-json-schema.rb
+++ b/Formula/g/generate-json-schema.rb
@@ -6,8 +6,6 @@ class GenerateJsonSchema < Formula
   license "MIT"
   head "https://github.com/Nijikokun/generate-schema.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 3
     sha256 cellar: :any_skip_relocation, all: "455469fbc5354030c4c7e62fcaba25fb9610bd32078ced0b95502195f9b6972a"

--- a/Formula/g/graphql-cli.rb
+++ b/Formula/g/graphql-cli.rb
@@ -13,8 +13,6 @@ class GraphqlCli < Formula
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, all: "9acfbbbc98a9212677f8cda3b773d20958ddb1cd5503d2c9894e531e44861832"

--- a/Formula/g/graphqlviz.rb
+++ b/Formula/g/graphqlviz.rb
@@ -5,8 +5,6 @@ class Graphqlviz < Formula
   sha256 "1ede0553fe61ca6f59876b31a7d86f8f9aa692456255c1acf91c204feb2e1ef3"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, all: "4db2299d2acc437a3c3603bd69bca3baceade220abde52ae69b2146c9746cdd9"

--- a/Formula/g/grunt-cli.rb
+++ b/Formula/g/grunt-cli.rb
@@ -5,8 +5,6 @@ class GruntCli < Formula
   sha256 "4f7f52cf9f3bc62ebc7ae60d2db5c7f896cb0915ad1202dab9285d6117d7536d"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, all: "0c39a24d633b89cf96aa864478ab95418b1003408d92ecfa446719ff4751df24"

--- a/Formula/g/gtop.rb
+++ b/Formula/g/gtop.rb
@@ -5,8 +5,6 @@ class Gtop < Formula
   sha256 "a8e90b828e33160c6a0ac4fb11231f292496e8049c0dac814e46fdd0c90817c1"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "aeecdb4bbb42c07c1a990d31f2cc69bc6dd861897ce5e6f29cc69b6c4a5ea3ad"

--- a/Formula/h/http-server.rb
+++ b/Formula/h/http-server.rb
@@ -6,8 +6,6 @@ class HttpServer < Formula
   license "MIT"
   head "https://github.com/http-party/http-server.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, all: "255fa4f7d541f2485fc11af34b8d240785fd6b364d7e98eae44800da7dcf87d1"

--- a/Formula/l/localtunnel.rb
+++ b/Formula/l/localtunnel.rb
@@ -5,8 +5,6 @@ class Localtunnel < Formula
   sha256 "6fb76f0ac6b92989669a5b7bb519361e07301965ea1f5a04d813ed59ab2e0c34"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "b5425789666cab50aa13978b6bec08b978f7be5d53e13b9e447ed712dc2b3c60"

--- a/Formula/m/markdown-toc.rb
+++ b/Formula/m/markdown-toc.rb
@@ -5,8 +5,6 @@ class MarkdownToc < Formula
   sha256 "4a5bf3efafb21217889ab240caacd795a1101bfbe07cd8abb228cc44937acd9c"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, all: "2817812b6a1d6a1e613ad337524dbd04afcc3ee306c8ddecab56c6835468d11c"

--- a/Formula/m/mongosh.rb
+++ b/Formula/m/mongosh.rb
@@ -5,8 +5,6 @@ class Mongosh < Formula
   sha256 "d2a3f47bdde82e4eb68dc33e08ec521b0884cee9797bdcbf3d283b711a63f6ce"
   license "Apache-2.0"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "14de0fa668c3fc36afdb2e7a1b0b9bb9ff67cf65e9a9a3af29d006470c56e851"
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "14de0fa668c3fc36afdb2e7a1b0b9bb9ff67cf65e9a9a3af29d006470c56e851"

--- a/Formula/p/pandemics.rb
+++ b/Formula/p/pandemics.rb
@@ -5,8 +5,6 @@ class Pandemics < Formula
   sha256 "9be418ec78ca512cc66d57a7533a5acda003c8bc488d7fff7fa2905c9ad39e29"
   license "BSD-3-Clause"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, all: "56f5dfc850d49885e631d590e330b5555985312ec11a483ac8001b3ca9f5be46"

--- a/Formula/p/postgraphile.rb
+++ b/Formula/p/postgraphile.rb
@@ -5,8 +5,6 @@ class Postgraphile < Formula
   sha256 "131cb5c572c68a42a6c612b65041a4fa656a5364a75f7384f1446f62a684c9fc"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "50536d0d0000e441a09373ba89a497efda82318192103e59f212814dcc3ee20b"

--- a/Formula/p/pulp.rb
+++ b/Formula/p/pulp.rb
@@ -10,8 +10,6 @@ class Pulp < Formula
     regex(%r{href=.*?/package/pulp/v/(\d+(?:[.-]\d+)+)["']}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, all: "0de9300b253bf5fa068c578ff479fc02a5371a7367bfaf9b3563122b8163ae4a"

--- a/Formula/r/react-native-cli.rb
+++ b/Formula/r/react-native-cli.rb
@@ -5,8 +5,6 @@ class ReactNativeCli < Formula
   sha256 "f1039232c86c29fa0b0c85ad2bfe0ff455c3d3cd9af9d9ddb8e9c560231a8322"
   license "BSD-3-Clause"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 4
     sha256 cellar: :any_skip_relocation, all: "405acef03b37460580b26bc0184b0891653cb58f130b25bcf1f454c0968a8e70"

--- a/Formula/s/standard.rb
+++ b/Formula/s/standard.rb
@@ -6,8 +6,6 @@ class Standard < Formula
   license "MIT"
   head "https://github.com/standard/standard.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "7a14e2bf791bc2e08a00dad45552c4fdac41dd10d576c034257475139e6e9e3f"

--- a/Formula/t/truffle.rb
+++ b/Formula/t/truffle.rb
@@ -5,8 +5,6 @@ class Truffle < Formula
   sha256 "bbc24698fc9964cd80acc8952500f708ef18984096eba9e75f40db3486392347"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256                               arm64_tahoe:    "8f995c388105f622043e56ba9ab48c436004b9aea99a3580b67a70ee504cb84a"

--- a/Formula/w/webpod.rb
+++ b/Formula/w/webpod.rb
@@ -5,8 +5,6 @@ class Webpod < Formula
   sha256 "99b123e8d9f49b06d2dd0b886b81d2c2c64e510ba50eac2ba229e60b36719a7e"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "ef076e7974529c853c352407873ff5cd53c23fccd374510778b508983995bd3a"

--- a/Formula/w/write-good.rb
+++ b/Formula/w/write-good.rb
@@ -5,8 +5,6 @@ class WriteGood < Formula
   sha256 "f54db3db8db0076fd1c05411c7f3923f055176632c51dc4046ab216e51130221"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "ce08c97d8a8666ed1721ab835d166e1ff865e2ee2ab23c58018021baf89cf360"

--- a/Formula/z/zsh-history-enquirer.rb
+++ b/Formula/z/zsh-history-enquirer.rb
@@ -5,8 +5,6 @@ class ZshHistoryEnquirer < Formula
   sha256 "dab146c955f167089bbe8f24a79b4a6cabe4c9ce2b8b246eb9fca27eca2bc4ae"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, all: "c61e96873b75859cd6d6a9a634df6f432914b96b893b739a14f8579a637ca81f"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Trying to chip away at the remaining `:requires_manual_review`. These are all simple npm-hosted formulae and thus should be autobump-able
