### PR TITLE
renovate: update livecheck

### DIFF
--- a/Formula/r/renovate.rb
+++ b/Formula/r/renovate.rb
@@ -5,14 +5,15 @@ class Renovate < Formula
   sha256 "fc23f96d6cdda3b19eddbc44280136d1d9b994e5e8175407dad678492d8561e4"
   license "AGPL-3.0-only"
 
-  # There are thousands of renovate releases on npm and the page the `Npm`
-  # strategy checks is several MB in size and can time out before the request
-  # resolves. This checks the first page of tags on GitHub (to minimize data
-  # transfer).
+  # livecheck needs to surface multiple versions for version throttling but
+  # there are thousands of renovate releases on npm. The package page showing
+  # versions is several MB in size (and the registry response is 10x that),
+  # so curl can time out before the response finishes. This checks releases on
+  # GitHub as a workaround, as it provides information on multiple versions
+  # but has a much smaller size.
   livecheck do
-    url "https://github.com/renovatebot/renovate/tags"
-    regex(%r{href=["']?[^"' >]*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
-    strategy :page_match
+    url :homepage
+    strategy :github_releases
     throttle 10
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Try switching to releases page to avoid non-release tags, which are currently causing autobump failure. 
```console
❯ brew lc renovate --autobump --json
[
  {
    "formula": "renovate",
    "version": {
      "current": "42.84.0",
      "latest": "42.85.4",
      "latest_throttled": "42.84.0",
      "outdated": true,
      "newer_than_upstream": false
    }
  }
]
```

Page size is still reasonable:
```console
❯ curl -sL https://github.com/renovatebot/renovate/releases | wc -c
  418591

❯ curl -sL https://github.com/renovatebot/renovate/tags | wc -c
  302729
```