### PR TITLE
ralph 0.1.0 (new formula)

### DIFF
--- a/Formula/r/ralph.rb
+++ b/Formula/r/ralph.rb
@@ -1,0 +1,20 @@
+class Ralph < Formula
+  desc "Autonomous AI agent loop using Claude Code"
+  homepage "https://github.com/kcirtapfromspace/ralph-machineo"
+  url "https://github.com/kcirtapfromspace/ralph-machineo/archive/refs/tags/v0.1.0.tar.gz"
+  sha256 "363d0e06c6dc4a6609423ad095db8d0f5a848ccc3daaa42fc10b9c2762bd8c9c"
+  license "MIT"
+  head "https://github.com/kcirtapfromspace/ralph-machineo.git", branch: "main"
+
+  depends_on "rust" => :build
+  depends_on "jq"
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    ENV["NO_COLOR"] = "1"
+    assert_match "RALPH", shell_output("#{bin}/ralph --version --no-color")
+  end
+end


### PR DESCRIPTION
## Summary\n- add new ralph formula (0.1.0)\n- set NO_COLOR in test and use --no-color to avoid ANSI output\n- order dependencies per audit\n\n## Testing\n- HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source kcirtapfromspace/ralph-test/ralph\n- brew test kcirtapfromspace/ralph-test/ralph\n- brew audit --new kcirtapfromspace/ralph-test/ralph\n- brew style /tmp/homebrew-core/Formula/r/ralph.rb