### PR TITLE
argtable3: use official tarball, enable autobump

### DIFF
--- a/Formula/a/argtable3.rb
+++ b/Formula/a/argtable3.rb
@@ -1,20 +1,16 @@
 class Argtable3 < Formula
   desc "ANSI C library for parsing GNU-style command-line options"
   homepage "https://www.argtable.org"
-  url "https://github.com/argtable/argtable3/archive/refs/tags/v3.3.1.tar.gz"
-  sha256 "8b28a4fb2cd621d8d16f34e30e1956aa488077f6a6b902e7fc9f07883e1519c1"
+  url "https://github.com/argtable/argtable3/releases/download/v3.3.1/argtable-v3.3.1.tar.gz"
+  sha256 "c08bca4b88ddb9234726b75455b3b1670d7c864d8daf198eaa7a3b4d41addf2c"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/argtable/argtable3.git", branch: "master"
 
-  # Upstream uses a tag format including a version and hash (e.g.
-  # `v3.2.2.f25c624`) and we only use the version part in the formula, so this
-  # omits the hash part to match.
   livecheck do
     url :stable
-    regex(/^v?(\d+(?:\.\d+)+)(?:\.\h+)?$/i)
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
-
-  no_autobump! because: :incompatible_version_format
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "02841c4514ec0b016351a3f513bcb7b529f78e0fbe3e4dbab89b9734d084244e"

--- a/Formula/a/argtable3.rb
+++ b/Formula/a/argtable3.rb
@@ -13,14 +13,12 @@ class Argtable3 < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "02841c4514ec0b016351a3f513bcb7b529f78e0fbe3e4dbab89b9734d084244e"
-    sha256 cellar: :any,                 arm64_sequoia: "08c1d4c1b1caf0027f5965d8f4a33a8634de5d1d2db97215c4cae4dd35a21d83"
-    sha256 cellar: :any,                 arm64_sonoma:  "d12329601f98832b51f7d0887754b353116fc91389d7427526f2c7f2d493de64"
-    sha256 cellar: :any,                 arm64_ventura: "f49951ca0b688eadaac7d390a5f4cba099dd801c8e1fa772eae1bbd223ee955a"
-    sha256 cellar: :any,                 sonoma:        "81aa7acce60ed7c0fbb3f7becf7b93065640a23accbace7b0b98758cc4b034b0"
-    sha256 cellar: :any,                 ventura:       "e54312fdc0437c0fac0f877c1f644cea428c82174025607e23e31133a594a51d"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "8a6bd561754762b0b1c295c6d99882e4c98a11783675260c8a99dd3135789b7f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "569f0abb77d2e4b88ab0e948309bbb78858387ecc9ed8544942020a4bc868ad4"
+    sha256 cellar: :any,                 arm64_tahoe:   "81744f4898904ac8875efc23088a93fe96a5a2a006e38c8c0d85c4829191a79e"
+    sha256 cellar: :any,                 arm64_sequoia: "10573b21ace23e3660cf5377e121b52359f70553e819ea2a0b0557550d01552d"
+    sha256 cellar: :any,                 arm64_sonoma:  "ac1030006031bf18e5203703e907eacade6f3dfca5090185ef3c7d09cb88c92d"
+    sha256 cellar: :any,                 sonoma:        "cf6d9f2e1097682bed94e5d18749fd68707f108c3faf8536fbcbfdd5a6479331"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "1cb5824b74df9c9d01460afcb252e9812d4365e4e5135e10248d24e9dba3546d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "ec7221f8528359814a9f3a6eb20b7d8b53677edb6f97fddd6ca64371b9c1dda8"
   end
 
   depends_on "cmake" => :build

--- a/Formula/a/astroterm.rb
+++ b/Formula/a/astroterm.rb
@@ -8,12 +8,12 @@ class Astroterm < Formula
   head "https://github.com/da-luce/astroterm.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "5f0ff05dcecdc0944f4045f3b1cf594bdf7149db7aa065bd98c7ee9ef362ddf7"
-    sha256 cellar: :any,                 arm64_sequoia: "cf9275621d4798eed54c0868642318c99d98861d2e908345a92abc5fa0d9a106"
-    sha256 cellar: :any,                 arm64_sonoma:  "09a8f21cfa607a1939ac6a2c02a228195a3a9fafe797a24edde1105e5ea1480d"
-    sha256 cellar: :any,                 sonoma:        "0a6cdc47c6fd7d61e5a0d1a5719fd774a0bd8ab3270ac50d9f0c0f1f7926b612"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "902def22bd133694b3b93047ebc186975b957ee005188e6e786350a33372b722"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "433fccc43feab752ae53de01b02d12930c1ce0e97f4d2efcab5e8d3d136c43ee"
+    sha256 cellar: :any,                 arm64_tahoe:   "b96bb83bb335486ec6ca0fbae19a71c86d13c43a74aa249e9c06440825d42732"
+    sha256 cellar: :any,                 arm64_sequoia: "ab43710f896fd0e1774bc3d5f61a39f91938a18da5bf352e54b86e989e759ec9"
+    sha256 cellar: :any,                 arm64_sonoma:  "93e425799689e9205f5c33ede3bfe2f6df9f60bcdf4f090f870691eb784aa068"
+    sha256 cellar: :any,                 sonoma:        "39ba609a32145bcaa97c553cd1862019720b5020ded6c4ac26aed6183c5dfb34"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "0980a46121da8061234713a8d5d233273eff08a1257477f609d89adf4e3fe038"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f4dbe1cb9db8ebd6096aa44e5d5364583d111564b8fdec8ca8c4990cfb5775b0"
   end
 
   depends_on "meson" => :build

--- a/Formula/a/astroterm.rb
+++ b/Formula/a/astroterm.rb
@@ -4,6 +4,7 @@ class Astroterm < Formula
   url "https://github.com/da-luce/astroterm/archive/refs/tags/v1.0.10.tar.gz"
   sha256 "6d9d61b818b01bd951d5340f09486bdc66aa107259acf78dfa8c3f875a36ea1f"
   license "MIT"
+  revision 1
   head "https://github.com/da-luce/astroterm.git", branch: "main"
 
   bottle do

--- a/Formula/b/blisp.rb
+++ b/Formula/b/blisp.rb
@@ -8,14 +8,12 @@ class Blisp < Formula
   head "https://github.com/pine64/blisp.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "6848a685d16c4a25a770a11a1059474540579f47a0af7b87bd0a907c3fc70275"
-    sha256 cellar: :any,                 arm64_sequoia: "ff28997c11bce2736f54cdb6e31fae1ef5ba7637443203d29ce8b7b5d947cfce"
-    sha256 cellar: :any,                 arm64_sonoma:  "b034d4d4510b4d817547caf94730a1a6262608759849ea5782c957b4e8bc157a"
-    sha256 cellar: :any,                 arm64_ventura: "8429a988fc4858c21db8bbb87150e1aad7d1d11a306d4a90566c831f3b9b3dcc"
-    sha256 cellar: :any,                 sonoma:        "67b1c5420ba76d82760abab0fafa97b343aeba0331a086ab755262f5165c3b1f"
-    sha256 cellar: :any,                 ventura:       "185fa7b68d7301e70936fb7b0740a9e672ba89ff9fe51780febd8ebffd33247b"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "473ecf51999b00ebacaaa0950602ccd9fa544fbabc13c2a912e4a9b5475b6a52"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "ec80b8a1aa1b9271d6600f34e3d1e7de3ce029d7a87e232787d3e5f7e9405496"
+    sha256 cellar: :any,                 arm64_tahoe:   "6b3ac4526e3d5b4976bfa347dbf8fb4c2050c1cafda73cecf53d13becec5ad3b"
+    sha256 cellar: :any,                 arm64_sequoia: "2c907746d0ed584ef5b384fe5807e6a5b630a12a9e76730b937c936de354bec6"
+    sha256 cellar: :any,                 arm64_sonoma:  "09eb4602269062dfbd6fe95eb6a5e3af59f68c855a8f8b9348843f3cf4c78ade"
+    sha256 cellar: :any,                 sonoma:        "c3cfa32d909c0388870fc62c0cb15694134762f6cbd1009b5883de7c1213408b"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "6b53d6fcac18f5378f08e26e822ca3bf6522eced20476180cb426ffb4ce94690"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d705101f8ca10303654bd4ae6e59e34763debb3e66736699a1c7885ae0100804"
   end
 
   depends_on "cmake" => :build

--- a/Formula/b/blisp.rb
+++ b/Formula/b/blisp.rb
@@ -4,6 +4,7 @@ class Blisp < Formula
   url "https://github.com/pine64/blisp/archive/refs/tags/v0.0.5.tar.gz"
   sha256 "79f87fbbb66f1d9ddf250cdc15dc16638d95e0905665003b08920a4b1fda9f96"
   license "MIT"
+  revision 1
   head "https://github.com/pine64/blisp.git", branch: "master"
 
   bottle do


### PR DESCRIPTION
Official tarball is needed to fix version numbers. See https://github.com/argtable/argtable3/releases/tag/v3.3.1
> The GitHub-generated archives do not include the `version.tag` file in the root directory. Without this file, generating `argtable3.pc` with the correct version number may fail.

Release tags no longer include git hash so can be autobumped.
- https://github.com/argtable/argtable3/issues/127