### PR TITLE
device-mapper: use release tarball

### DIFF
--- a/Formula/d/device-mapper.rb
+++ b/Formula/d/device-mapper.rb
@@ -1,18 +1,16 @@
 class DeviceMapper < Formula
   desc "Userspace library and tools for logical volume management"
   homepage "https://sourceware.org/dm"
-  url "https://sourceware.org/git/lvm2.git",
-      tag:      "v2_03_38",
-      revision: "657e10bd75fcb3dffbd40bb1ffc6f1bfd768a10e"
+  url "https://sourceware.org/pub/lvm2/releases/LVM2.2.03.38.tgz"
+  version "2.03.38"
+  sha256 "322d44bf40de318e6e6b52c56999aaeb86b16c8267187ac2e01a44d4dc526960"
   license "LGPL-2.1-only"
+  head "https://gitlab.com/lvmteam/lvm2.git", branch: "main"
 
   livecheck do
-    url :stable
-    regex(/href=.*?;a=tag;.*?>Release (\d+(?:\.\d+)+)</i)
-    strategy :page_match
+    url "https://sourceware.org/pub/lvm2/releases/"
+    regex(/href=.*?LVM2[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
-
-  no_autobump! because: :incompatible_version_format
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_linux:  "c45e5431a10e40be3f485b58b39253f002b5f6e9585d5bdbf83a98a92e437981"

--- a/Formula/d/device-mapper.rb
+++ b/Formula/d/device-mapper.rb
@@ -13,8 +13,9 @@ class DeviceMapper < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_linux:  "c45e5431a10e40be3f485b58b39253f002b5f6e9585d5bdbf83a98a92e437981"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "521f27696d917df2d0f19399092b2536cba464aa783e9a4c14631a848d9bebc9"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_linux:  "d2aee4bf5e1d751dc34b70f7f66c1e099d7c0de5aa7b11c4c61839d128ba17b7"
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "386ed70dd25c7a97c1a66f46fc9c328c5292988542da6330f3e56aee2771a389"
   end
 
   depends_on "pkgconf" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

From https://sourceware.org/git/?p=lvm2.git;a=blob;f=README
> Tarballs are available from:
>   https://sourceware.org/pub/lvm2/releases/
>   ftp://sourceware.org/pub/lvm2/
> 
> The source code is stored in git:
>   https://gitlab.com/lvmteam/lvm2
