### PR TITLE
re2 2025-11-05 (version scheme change)

### DIFF
--- a/Formula/r/re2.rb
+++ b/Formula/r/re2.rb
@@ -13,12 +13,12 @@ class Re2 < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "fcfe114f9aee2fa6475c6f33cfdcf28cdcaa3541a52c5920bbbc70aeda67988d"
-    sha256 cellar: :any,                 arm64_sequoia: "641887401a7eda45a625cc261028c49d56201bf36fab51ceb659960d598d507c"
-    sha256 cellar: :any,                 arm64_sonoma:  "6b011837ff4b94803354ef61e7e01704cf601ac1795bb0373d70a2e844481c50"
-    sha256 cellar: :any,                 sonoma:        "23e7c11d34e75bf179f0e538a75a7e96b4e2b821ad34773fe25e3ea13df435ee"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "8a78b637b87c698826c3c7afe7e2741496403c0b64a0c9b8679198fc230ae813"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "9ebbd0be34db042d26aaabd84f79b1c94980e1911578879accb9b93b88f016a2"
+    sha256 cellar: :any,                 arm64_tahoe:   "c3d8133e1af82433fd8491050aafc3cdf81e2728c1d171818e187001f5c5efb1"
+    sha256 cellar: :any,                 arm64_sequoia: "9dfd8e748444eb04b1180dfa861cef831d720588d016051c60bf1b9bc77bea4f"
+    sha256 cellar: :any,                 arm64_sonoma:  "2417787aad7998e86107097674b67fa1f32bed1eadc7a60261f6f1a024a1c55a"
+    sha256 cellar: :any,                 sonoma:        "336269669bfd8cab867b5ea69d99706e2b73dc0fa796ac987f5ad665010735cf"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "74f2417e6840a1af5020085db3513cdc047e5dbe24bf9213871eb388b2af6bcc"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5d2b0fa3b0b1954bd06ca343641936d0d0833d0a80a7aa543eaca0a95332c055"
   end
 
   depends_on "cmake" => :build

--- a/Formula/r/re2.rb
+++ b/Formula/r/re2.rb
@@ -1,25 +1,16 @@
 class Re2 < Formula
   desc "Alternative to backtracking PCRE-style regular expression engines"
   homepage "https://github.com/google/re2"
-  url "https://github.com/google/re2/archive/refs/tags/2025-11-05.tar.gz"
-  version "20251105"
+  url "https://github.com/google/re2/releases/download/2025-11-05/re2-2025-11-05.tar.gz"
   sha256 "87f6029d2f6de8aa023654240a03ada90e876ce9a4676e258dd01ea4c26ffd67"
   license "BSD-3-Clause"
-  revision 1
+  version_scheme 1
   head "https://github.com/google/re2.git", branch: "main"
 
-  # The `strategy` block below is used to massage upstream tags into the
-  # YYYYMMDD format used in the `version`. This is necessary for livecheck
-  # to be able to do proper `Version` comparison.
   livecheck do
     url :stable
-    regex(/^(\d{2,4}-\d{2}-\d{2})$/i)
-    strategy :git do |tags, regex|
-      tags.filter_map { |tag| tag[regex, 1]&.gsub(/\D/, "") }
-    end
+    regex(/^(\d{4}-\d{2}-\d{2})$/i)
   end
-
-  no_autobump! because: :incompatible_version_format
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "fcfe114f9aee2fa6475c6f33cfdcf28cdcaa3541a52c5920bbbc70aeda67988d"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates version scheme to match upstream[^1] and repology[^2], which allows us to enable autobump.

It also switches tarball to uploaded asset which avoids possible breakage from autogenerated GitHub archive.

[^1]: https://github.com/google/re2/blob/2025-11-05/MODULE.bazel#L9
[^2]: https://github.com/repology/repology-rules/commit/f91933990203d2f0682d58a219ac6213aa0256eb

---

No need for `version` stanza:
```console
❯ brew info re2 --json | jq '.[].versions'
{
  "stable": "2025-11-05",
  "head": "HEAD",
  "bottle": true
}

❯ brew lc re2
re2: 2025-11-05 ==> 2025-11-05
```