### PR TITLE
util-linux: split out `libblkid` and `libuuid`

### DIFF
--- a/Formula/k/krb5.rb
+++ b/Formula/k/krb5.rb
@@ -24,6 +24,7 @@ class Krb5 < Formula
     "OpenVision",
     any_of: ["BSD-2-Clause", "GPL-2.0-or-later"],
   ]
+  revision 1
 
   livecheck do
     url :homepage
@@ -45,9 +46,10 @@ class Krb5 < Formula
   depends_on "openssl@3"
 
   uses_from_macos "bison" => :build
-  uses_from_macos "libedit"
 
   on_linux do
+    depends_on "pkgconf" => :build
+    depends_on "e2fsprogs"
     depends_on "keyutils"
   end
 
@@ -55,6 +57,8 @@ class Krb5 < Formula
     cd "src" do
       system "./configure", "--disable-nls",
                             "--disable-silent-rules",
+                            "--with-system-et",
+                            "--with-system-ss",
                             "--without-system-verto",
                             *std_configure_args
       system "make"

--- a/Formula/lib/libblkid.rb
+++ b/Formula/lib/libblkid.rb
@@ -1,0 +1,60 @@
+class Libblkid < Formula
+  desc "Block device identification library"
+  homepage "https://en.wikipedia.org/wiki/Util-linux"
+  url "https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.41/util-linux-2.41.3.tar.xz"
+  sha256 "3330d873f0fceb5560b89a7dc14e4f3288bbd880e96903ed9b50ec2b5799e58b"
+  license all_of: [
+    "LGPL-2.1-or-later",
+    "BSD-2-Clause", # lib/xxhash.c
+    "BSD-3-Clause", # lib/randutils.c
+    "MIT",          # lib/crc64.c
+    :public_domain, # lib/
+  ]
+
+  livecheck do
+    formula "util-linux"
+  end
+
+  on_macos do
+    depends_on "gettext"
+  end
+
+  link_overwrite "include/blkid/blkid.h", "lib/libblkid.*", "lib/pkgconfig/blkid.pc", "share/man/man3/libblkid.3"
+
+  def install
+    system "./configure", "--disable-all-programs",
+                          "--disable-silent-rules",
+                          "--enable-libblkid",
+                          *std_configure_args
+    system "make", "install"
+
+    # Remove files that conflict with `util-linux`
+    rm_r(share/"locale")
+    rm(man5/"terminal-colors.d.5")
+
+    # Install the correct main license and avoid duplicating `util-linux` metafiles
+    prefix.install "libblkid/COPYING", "Documentation/licenses/COPYING.LGPL-2.1-or-later"
+    rm(buildpath.children.select(&:file?))
+  end
+
+  test do
+    (testpath/"test.c").write <<~C
+      #include <stdio.h>
+      #include <blkid.h>
+
+      int main(void) {
+        blkid_probe pr = blkid_new_probe_from_filename("./data");
+        if (!pr) {
+          printf("failed to create a new libblkid probe");
+          return 1;
+        }
+        printf("size: %jd", (intmax_t)blkid_probe_get_size(pr));
+        return 0;
+      }
+    C
+
+    (testpath/"data").write "homebrew"
+    system ENV.cc, "test.c", "-o", "test", "-I#{include}/blkid", "-L#{lib}", "-lblkid"
+    assert_equal "size: 8", shell_output("./test")
+  end
+end

--- a/Formula/lib/libuuid.rb
+++ b/Formula/lib/libuuid.rb
@@ -1,0 +1,71 @@
+class Libuuid < Formula
+  desc "Universally unique id library"
+  homepage "https://en.wikipedia.org/wiki/Util-linux"
+  url "https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.41/util-linux-2.41.3.tar.xz"
+  sha256 "3330d873f0fceb5560b89a7dc14e4f3288bbd880e96903ed9b50ec2b5799e58b"
+  license all_of: [
+    "BSD-3-Clause",
+    :public_domain, # lib/
+  ]
+
+  livecheck do
+    formula "util-linux"
+  end
+
+  keg_only :shadowed_by_macos, "macOS provides libuuid in libSystem and the uuid.h header"
+
+  on_macos do
+    depends_on "gettext"
+  end
+
+  # conflicts_with "ossp-uuid", because: "both install `libuuid.a`"
+
+  link_overwrite "include/uuid/uuid.h", "lib/libuuid.*", "lib/pkgconfig/uuid.pc", "share/man/man3/uuid*.3"
+
+  def install
+    system "./configure", "--disable-all-programs",
+                          "--disable-silent-rules",
+                          "--enable-libuuid",
+                          *std_configure_args
+    system "make", "install"
+
+    # Remove files that conflict with `util-linux`
+    rm_r(share/"locale")
+    rm(man5/"terminal-colors.d.5")
+
+    # Install the correct main license and avoid duplicating `util-linux` metafiles
+    prefix.install "libuuid/COPYING", "Documentation/licenses/COPYING.BSD-3-Clause"
+    rm(buildpath.children.select(&:file?))
+  end
+
+  test do
+    # https://github.com/util-linux/util-linux/blob/master/libuuid/src/test_uuid.c
+    (testpath/"test.c").write <<~'C'
+      #include <stdio.h>
+      #include <uuid.h>
+
+      static int test_uuid(const char * uuid, int isValid) {
+        static const char * validStr[2] = {"invalid", "valid"};
+        uuid_t uuidBits;
+        int parsedOk;
+
+        parsedOk = uuid_parse(uuid, uuidBits) == 0;
+
+        printf("%s is %s", uuid, validStr[isValid]);
+        if (parsedOk != isValid) {
+          printf(" but uuid_parse says %s\n", validStr[parsedOk]);
+          return 1;
+        }
+        printf(", OK\n");
+        return 0;
+      }
+
+      int main(void) {
+        return test_uuid("84949cc5-4701-4a84-895b-354c584a981b", 1);
+      }
+    C
+
+    system ENV.cc, "test.c", "-o", "test", "-I#{include}/uuid", "-L#{lib}", "-luuid"
+    assert_match "OK", shell_output("./test")
+  end
+end

--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -33,6 +33,7 @@
   ["gnome-online-accounts", "libgoa"],
   ["hdf5", "hdf5-mpi"],
   ["imagemagick", "imagemagick-full"],
+  ["libblkid", "libuuid", "util-linux"],
   ["libmediainfo", "media-info"],
   ["libnetworkit", "networkit"],
   ["libnghttp2", "nghttp2"],


### PR DESCRIPTION
Exploring this to unbundle `e2fsprogs` from `krb5` without pulling in unnecessary dependencies. Also avoids pulling in unused GPLv3 licenses which are some of main licenses that users may want to forbid.

Linux usually uses split packages here, but *BSD sometimes provides these as separate packages, e.g. https://repology.org/project/libblkid/versions (NetBSD and FreeBSD).

---

This will likely fail on dependents due to indirect linkage to `libuuid`.