### PR TITLE
vpcs 0.8.3 (move to fork)

### DIFF
--- a/Formula/v/vpcs.rb
+++ b/Formula/v/vpcs.rb
@@ -6,19 +6,12 @@ class Vpcs < Formula
   license "BSD-2-Clause"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:    "158636f42e7e2b5c9bb55093d13dcedeb7513c17a003a3432741acde18e4402f"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "c720c9b26f940276b3431e88b4c8ce29cbe2fe616536d0b8419a6e378e09c3af"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "4a6670a2833658d64a9be4c0e42f07b7224ef2cf1ea50faafa982f8469a49052"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "5ad3049e60f55965753362c2d6b5d5919dbe4b5537b155a0d914614d4a0d8cf6"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "a039b6f432de6fe7fb3429b6ccad3a822e1249e6b11a3af0d916c98a908b4dc9"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "d673e17698f476b16e70b66227623b829779846d0f4b2246cf84c85f8427d8de"
-    sha256 cellar: :any_skip_relocation, sonoma:         "9d359b2fa18ff5dc0f8a1f34ef372d1d721fcc4400bf935ef743368a7ec05cf4"
-    sha256 cellar: :any_skip_relocation, ventura:        "c65377d546fbe8026e2a833918b2ef9cf10578a05f6f6f7a0141aa264b4875ef"
-    sha256 cellar: :any_skip_relocation, monterey:       "6f3e52b8fd8ee4aab736d67fc99ed39fc72364fa9a3ffc9db1b8bd0d8b27661f"
-    sha256 cellar: :any_skip_relocation, big_sur:        "75d81877dc7c7e8a07b5a1496e1264ac19fd8206f5dcc24de835931a0d1501eb"
-    sha256 cellar: :any_skip_relocation, catalina:       "180a02cc1bb06bb9e5f441688d6b1a51e5c531cd6dea68399aba55f3c5691dd9"
-    sha256 cellar: :any_skip_relocation, arm64_linux:    "5de5fc1e177ac3651f6c1ea17097307535b8735757ded9e3f693458db2e86827"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "5ee66bd58892962238c81873d186c5066fd53490328b2c0db6667532565db008"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "3b63b4dc350e0e33be9b151a3fe2a47385d4474fdc109087d8d04110dfd13aff"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "d951f1bdd6279046aa0443e1c950eb60f3c6b144a84a9f20fa8e56f857dc1153"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "841d5350b1c1a9086bb1fe1ec5d443dbdfc79676fa98c33f3d070f19eceae858"
+    sha256 cellar: :any_skip_relocation, sonoma:        "27946758ffa7ab9b03d92439362bfdaf9b622ca71adf1aa36724afb774cf4da7"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "558242139637e0815cdbfdaed4321ac10c971d349557432f72228f21798d0537"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d2a55d28182cfe00e2761fc39f7014cebf227cf98a019bca9cca6045de5529b2"
   end
 
   def install

--- a/Formula/v/vpcs.rb
+++ b/Formula/v/vpcs.rb
@@ -1,11 +1,9 @@
 class Vpcs < Formula
   desc "Virtual PC simulator for testing IP routing"
   homepage "https://vpcs.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/vpcs/0.8/vpcs-0.8-src.tbz"
-  sha256 "dca602d0571ba852c916632c4c0060aa9557dd744059c0f7368860cfa8b3c993"
+  url "https://github.com/GNS3/vpcs/archive/refs/tags/v0.8.3.tar.gz"
+  sha256 "73018c923fdb8bbd7d76ddf4877bb7b3babbabed014f409f6b78a2e2b0a33da7"
   license "BSD-2-Clause"
-
-  no_autobump! because: :requires_manual_review
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "158636f42e7e2b5c9bb55093d13dcedeb7513c17a003a3432741acde18e4402f"
@@ -24,17 +22,9 @@ class Vpcs < Formula
   end
 
   def install
-    cd "src" do
-      if OS.mac?
-        system "make", "-f", "Makefile.osx"
-      else
-        # Avoid conflicting getopt
-        rm "getopt.h"
-        # Use -fcommon to work around multiple definition of `vpc'
-        system "make", "-f", "Makefile.linux", "CCOPT=-fcommon"
-      end
-      bin.install "vpcs"
-    end
+    os = OS.mac? ? "osx" : OS.kernel_name.downcase
+    system "make", "-C", "src", "-f", "Makefile.#{os}"
+    bin.install "src/vpcs"
   end
 
   test do


### PR DESCRIPTION
From Repology[^1], the fork is used by 
- Alpine - https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/community/vpcs/APKBUILD#L11
- Debian - https://salsa.debian.org/debian/vpcs/-/blob/master/debian/watch?ref_type=heads#L3
- Nixpkgs - https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/vp/vpcs/package.nix#L14-L15

Also by OpenSUSE, Void, ALT and AUR, though some of these may be less common so may not impact our decision.

Outside of Homebrew, only MacPorts may still be on original SourceForge, but they are using an unstable SVN checkout

---

I think the above meets our criteria at https://docs.brew.sh/Acceptable-Formulae#not-a-fork-usually

[^1]: https://repology.org/project/vpcs/versions