### PR TITLE
rtmpdump 2.6, curl: drop `rtmpdump` dependency

### DIFF
--- a/Formula/c/curl.rb
+++ b/Formula/c/curl.rb
@@ -8,6 +8,7 @@ class Curl < Formula
   mirror "http://fresh-center.net/linux/www/legacy/curl-8.18.0.tar.bz2"
   sha256 "ffd671a3dad424fb68e113a5b9894c5d1b5e13a88c6bdf0d4af6645123b31faf"
   license "curl"
+  revision 1
 
   livecheck do
     url "https://curl.se/download/"
@@ -40,7 +41,6 @@ class Curl < Formula
   depends_on "libngtcp2"
   depends_on "libssh2"
   depends_on "openssl@3"
-  depends_on "rtmpdump"
   depends_on "zstd"
 
   uses_from_macos "krb5"
@@ -70,7 +70,6 @@ class Curl < Formula
       --without-ca-path
       --with-ca-fallback
       --with-default-ssl-backend=openssl
-      --with-librtmp
       --with-libssh2
       --with-nghttp3
       --with-ngtcp2
@@ -122,7 +121,7 @@ class Curl < Formula
       assert_includes curl_features, feature
     end
     curl_protocols = shell_output("#{bin}/curl-config --protocols").split("\n")
-    %w[LDAPS RTMP SCP SFTP].each do |protocol|
+    %w[LDAPS SCP SFTP].each do |protocol|
       assert_includes curl_protocols, protocol
     end
 

--- a/Formula/c/curl.rb
+++ b/Formula/c/curl.rb
@@ -16,12 +16,12 @@ class Curl < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "9dbc8f63a6f2b3072b581e82af81e4584f0660054c159a04f394bb323d877c85"
-    sha256 cellar: :any,                 arm64_sequoia: "25b88ee069901c2e6e1f18fdbeb1560484121485f9c5498627bbeb7af6870f93"
-    sha256 cellar: :any,                 arm64_sonoma:  "06de4b7375fdbf85bff231ad3dec139009ae09f424915509457286e84e08c549"
-    sha256 cellar: :any,                 sonoma:        "50c8f7444348af7fe33657f6d800c82bd7667fd45f2d0d12be863de130a56a98"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "199866d8520d22048f9a0786a21f5587dc8f763ed6c676c7df970a8cca1f9c6e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "35ef31a606d6dc10cfc1b5b062cd18048e68d8c4b77b95638429b2d98e554460"
+    sha256 cellar: :any,                 arm64_tahoe:   "0010096e5411d8db05ec17625068aa0fec40aee224e41bfe1eb8b8ce8c1e2442"
+    sha256 cellar: :any,                 arm64_sequoia: "d073691913a4a377d1c3d2d94e81d4e4f3ad6c7f87270c8f29be29b9b41c8a0d"
+    sha256 cellar: :any,                 arm64_sonoma:  "1305356a18829ce9c98dcd6a667207df2e6771de4eaf16cfea5de53b5032db3d"
+    sha256 cellar: :any,                 sonoma:        "214d8087142f91f4875aa422d78a7bc869174a3109579c231539f0332a360d3f"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "fa419134f3e7c17e56f6c712fb99ddbf2bfe01849618ab2a6c05559937398df3"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c46c4970a7b53ffe0ca5a488233dcb31eea0fd96066c315d7fd04e125205c470"
   end
 
   head do

--- a/Formula/r/rtmpdump.rb
+++ b/Formula/r/rtmpdump.rb
@@ -1,20 +1,11 @@
 class Rtmpdump < Formula
   desc "Tool for downloading RTMP streaming media"
   homepage "https://rtmpdump.mplayerhq.hu/"
-  url "https://deb.debian.org/debian/pool/main/r/rtmpdump/rtmpdump_2.4+20151223.gitfa8646d.1.orig.tar.gz"
-  mirror "http://deb.debian.org/debian/pool/main/r/rtmpdump/rtmpdump_2.4+20151223.gitfa8646d.1.orig.tar.gz"
-  version "2.4-20151223"
-  sha256 "5c032f5c8cc2937eb55a81a94effdfed3b0a0304b6376147b86f951e225e3ab5"
+  url "https://git.ffmpeg.org/rtmpdump.git",
+      tag:      "v2.6",
+      revision: "138fdb258d9fc26f1843fd1b891180416c9dc575"
   license all_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later"]
-  revision 3
   head "https://git.ffmpeg.org/rtmpdump.git", branch: "master"
-
-  livecheck do
-    url "https://cdn-aws.deb.debian.org/debian/pool/main/r/rtmpdump/"
-    regex(/href=.*?rtmpdump[._-]v?(\d+(?:[.+]\d+)+)[^"' >]*?\.orig\.t/i)
-  end
-
-  no_autobump! because: :requires_manual_review
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "5b227da74ef1d3c1338e803ac514d9576cb5892680460d24f35074d6243d0038"
@@ -36,13 +27,6 @@ class Rtmpdump < Formula
   uses_from_macos "zlib"
 
   conflicts_with "flvstreamer", because: "both install 'rtmpsrv', 'rtmpsuck' and 'streams' binary"
-
-  # Patch for OpenSSL 1.1 compatibility
-  # Taken from https://github.com/DJ-Huntress/RTMPDump-OpenSSL-1.1
-  patch :p0 do
-    url "https://raw.githubusercontent.com/Homebrew/homebrew-core/1cf441a0/Patches/rtmpdump/openssl-1.1.diff"
-    sha256 "3c9167e642faa9a72c1789e7e0fb1ff66adb11d721da4bd92e648cb206c4a2bd"
-  end
 
   def install
     ENV.deparallelize

--- a/Formula/r/rtmpdump.rb
+++ b/Formula/r/rtmpdump.rb
@@ -8,18 +8,12 @@ class Rtmpdump < Formula
   head "https://git.ffmpeg.org/rtmpdump.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:    "5b227da74ef1d3c1338e803ac514d9576cb5892680460d24f35074d6243d0038"
-    sha256 cellar: :any,                 arm64_sequoia:  "4d88c286ea074e6dc9612679d33f1e25910dce5cd4c4a3f9f2dcdec8ad950516"
-    sha256 cellar: :any,                 arm64_sonoma:   "fc5748b95d47c39bb4d633090cc0a7b5fe90bda5ef163fa5b8809272c9bf4618"
-    sha256 cellar: :any,                 arm64_ventura:  "1dec5a57d0173f54cb1f38efb6bfbd0bc416bdb298289ebaac1dce3a41bdd6fb"
-    sha256 cellar: :any,                 arm64_monterey: "5151b4682fa17d931e6383dd06b584d822df647fd454b22ddf498525606cff39"
-    sha256 cellar: :any,                 arm64_big_sur:  "b548e2d6b53bc0d03bdc73fb01a175c8ef2338f80a3ca0c1963af625f0baa523"
-    sha256 cellar: :any,                 sonoma:         "5d019561203c8b1c1c1e69c48b3987d531c55fa806bd83f0a462b6b7da732f48"
-    sha256 cellar: :any,                 ventura:        "b27c24194ded10a47b93a379efae8ead4b04a6d3e8e34bc3a70942380b1ed68b"
-    sha256 cellar: :any,                 monterey:       "b942d0dee2c95a00b3fd080c50d1f0d715448ae3147bbb18cf5adb758cb63798"
-    sha256 cellar: :any,                 big_sur:        "794073edbf7402af7750b21fbcb44c5df038d6d3606450bd6a453dc92b6b3b09"
-    sha256 cellar: :any_skip_relocation, arm64_linux:    "d3f2a6eb1d6c8409c69a89db67cb545acf7c6c568f0a57f6df7d7108cce87df8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "0ab7f054fd0b01975be1893437235c61e2761ed9fb54e7880a854ca37809d57e"
+    sha256 cellar: :any,                 arm64_tahoe:   "6da0c98fc9ec24bc43ef856f523ac07746b7612d9ff9e95089957c79578f6550"
+    sha256 cellar: :any,                 arm64_sequoia: "8eafa2bb31efb613a6dc317042ef72b72f6732cc8188bfbee84ad63732e06266"
+    sha256 cellar: :any,                 arm64_sonoma:  "01c87c00b31444f8d52e257a4023ffa42747f57a9e03228686bb52e3578ce42f"
+    sha256 cellar: :any,                 sonoma:        "526ac3a9d62403dbbb2cd2917c9e6c89d64a718897f26e11e23f762aaff0e0fe"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "b50bb89c9c4b6684266523fca57729bf10ffb1855d81846b9a972fa67d333ee8"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d157b751c5de5997aeeb24acb57d4d296fb715a50ae42f0a4e1f793fbde641a8"
   end
 
   depends_on "openssl@3"


### PR DESCRIPTION
Homepage https://rtmpdump.mplayerhq.hu/ mentions:
> The latest release is 2.6 which you can check out from git.

---

Need to drop dependency in curl and revision bump to avoid broken linkage. Curl dependencies have an HTTP mirror requirement, but brew does not support mirrors for git urls (the webpage gets fetched as file).

From glance at other repositories, RTMP support doesn't seem common in cURL, e.g. not used in
- Alpine - https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/main/curl/APKBUILD
- Arch - https://archlinux.org/packages/core/x86_64/curl/
- Fedora - https://packages.fedoraproject.org/pkgs/curl/libcurl/fedora-rawhide.html#dependencies
- Gentoo (for default build, i.e. `rtmp` lacks `+`) - https://packages.gentoo.org/packages/net-misc/curl
- MacPorts (for default build) - https://github.com/macports/macports-ports/blob/master/net/curl/Portfile#L52

Only Debian had it enabled - https://packages.debian.org/trixie/libcurl4t64