### PR TITLE
rure 0.2.4 (version scheme change)

### DIFF
--- a/Formula/r/rure.rb
+++ b/Formula/r/rure.rb
@@ -1,12 +1,13 @@
 class Rure < Formula
   desc "C API for RUst's REgex engine"
   homepage "https://github.com/rust-lang/regex/tree/HEAD/regex-capi"
-  url "https://github.com/rust-lang/regex/archive/refs/tags/1.12.2.tar.gz"
-  sha256 "36b5e4c56045a83ad34557a93c2a158efc302101741479e5568403b21b74cf2f"
+  url "https://static.crates.io/crates/rure/rure-0.2.4.crate"
+  sha256 "e76c0d9cbe885d29bf9a65974d9230e4d67c066ccfa07ab791926e73a181bcfc"
   license all_of: [
     "Unicode-TOU",
     any_of: ["Apache-2.0", "MIT"],
   ]
+  version_scheme 1
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "2b547a58eeaee0300651c51732926185ac7980a3db0f96f8bb9293c9b4814ab9"
@@ -20,11 +21,10 @@ class Rure < Formula
   depends_on "rust" => :build
 
   def install
-    system "cargo", "build", "--jobs", ENV.make_jobs, "--lib", "--manifest-path", "regex-capi/Cargo.toml", "--release"
-    include.install "regex-capi/include/rure.h"
+    system "cargo", "build", "--jobs", ENV.make_jobs, "--lib", "--release"
+    include.install "include/rure.h"
     lib.install "target/release/#{shared_library("librure")}"
     lib.install "target/release/librure.a"
-    prefix.install "regex-capi/README.md" => "README-capi.md"
   end
 
   test do

--- a/Formula/r/rure.rb
+++ b/Formula/r/rure.rb
@@ -10,12 +10,12 @@ class Rure < Formula
   version_scheme 1
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "2b547a58eeaee0300651c51732926185ac7980a3db0f96f8bb9293c9b4814ab9"
-    sha256 cellar: :any,                 arm64_sequoia: "c18fe191416b5476dd21fcb82e692f1b9500ee81b1137faa77f5d17127960ea2"
-    sha256 cellar: :any,                 arm64_sonoma:  "7c62227e56370461779551cc709eef19a0d32722e934eb790838e0d08d9e23db"
-    sha256 cellar: :any,                 sonoma:        "7e13a0d626d1dd0f67766bc44d13a0def8adcdf60ef4653f57a1757df5d7bea9"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "a9886fefaea72497fd7ab3b94c8ed90d804b59456541df6f2270bda8025c21c4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "062c9130b42d3fcc9db37c902413dd13effefcfb828c540b3001d050d8bf47d9"
+    sha256 cellar: :any,                 arm64_tahoe:   "0bbccbb0da7678208955a3dd006c5bf25efd87d129a722d4802b77da7c59c7cb"
+    sha256 cellar: :any,                 arm64_sequoia: "514dcfe048fe80c4e61b7f484b953047a6c53c8f086bf15f77d508b77dc44900"
+    sha256 cellar: :any,                 arm64_sonoma:  "d621df2afaad9172d36278dd75734ffb613fa438932fe437e863528eb04c2651"
+    sha256 cellar: :any,                 sonoma:        "498127073bc6ef31463cabcca924cb45fb0f2374b48c59eb1440cd2d3efc3c18"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "e630eb9736bec9f81a47d1b3f02d1058ede85f5934a1bace4057ae8c30074ccc"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4186d8a985246308ff68d373504be7c12e6ddcdb6250742e674a832bf40df6ee"
   end
 
   depends_on "rust" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We were using versioning of `regex` (https://crates.io/crates/regex) rather than `rure` (https://crates.io/crates/rure)

Trying out crates.io tarball as it should work better with brew's metadata installation. Could consider switching to `rure-*` git tags if there is any advantage.