### PR TITLE
libiptcdata 1.0.5 (move to fork)

### DIFF
--- a/Formula/lib/libiptcdata.rb
+++ b/Formula/lib/libiptcdata.rb
@@ -8,19 +8,12 @@ class Libiptcdata < Formula
   no_autobump! because: :incompatible_version_format
 
   bottle do
-    sha256 arm64_tahoe:    "1c4ed377f24990f0602ed171149c4da26c7986f746c7aa5c5486fc753dfc49e9"
-    sha256 arm64_sequoia:  "ccdaa3847cffb9073eba5796d92eb08f1dd1c9b1bcda21f45d64a654f0dcfdac"
-    sha256 arm64_sonoma:   "e7b09d218f871a5252b465841f6001896d867247175f228c3d50164cd9fefa1a"
-    sha256 arm64_ventura:  "5543254a38d990ac3eabb48f51dda1eacd65fbea211200d825063385affcc014"
-    sha256 arm64_monterey: "479e59e0cffe5a692546ef0bee8552cdbd43fdf6353c5c04721e92372d92f671"
-    sha256 arm64_big_sur:  "45d61d51cb3e5607763ed374d5cc88e4a7c6dc8b1ba08ccd276c3379a20646bf"
-    sha256 sonoma:         "b65a559689911c0a84e3d7f8a1a4255dd411bb03b2d8b00355f453b28ccf99f3"
-    sha256 ventura:        "66ab47a907199d944b1af5b10efdd6a90b255a35395cdb69ac637253648d9d20"
-    sha256 monterey:       "e93e2ffd79bb784e528ed8f8b197b808090f3cc0b653da0cc880f88db984094f"
-    sha256 big_sur:        "5bb2bce1d8a877c84abb51f3b9d9e0c40588bdeb2d6ea8d66c6de230d2e35e8d"
-    sha256 catalina:       "1dbcf1dd89b05f7f1fdc1a15d9c56b7e726f7296d8096ccae22fed9adf36790a"
-    sha256 arm64_linux:    "c9c24c8b0b36c40568552242ede97e1efd500063008dc546b84ac6d2451bc455"
-    sha256 x86_64_linux:   "4e929a2391eb2733d481f84b82cc925a1d0cf943bed4f99af876f4240b62c9c0"
+    sha256 arm64_tahoe:   "56f886ae4863583e9c8d911dd0f312b1ddb7330043e3296eb5cdeeb14cdf13f2"
+    sha256 arm64_sequoia: "b05cc07d640693e52679619487e236f3685a1d35ad1af434d44f231a1d26601f"
+    sha256 arm64_sonoma:  "4768dd0ed241d95b8b309564e91ef6dcaeeadc6d5f3a177822f693dd668ee0c2"
+    sha256 sonoma:        "3f94564c26a2283a245b5593d1e9082440932730071ae8527ba51f927b1997c5"
+    sha256 arm64_linux:   "b9007e8fd2a48d129709d296367e69eaa4c6d5b20a3682590f91fe5110c153e8"
+    sha256 x86_64_linux:  "5118f85e9d7a8cdc95465502824841fa6dc745d481dabc5f5d09686ba8872534"
   end
 
   on_macos do

--- a/Formula/lib/libiptcdata.rb
+++ b/Formula/lib/libiptcdata.rb
@@ -1,12 +1,11 @@
 class Libiptcdata < Formula
   desc "Virtual package provided by libiptcdata0"
   homepage "https://libiptcdata.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/libiptcdata/libiptcdata/1.0.4/libiptcdata-1.0.4.tar.gz"
-  sha256 "79f63b8ce71ee45cefd34efbb66e39a22101443f4060809b8fc29c5eebdcee0e"
+  url "https://github.com/ianw/libiptcdata/releases/download/release_1_0_5/libiptcdata-1.0.5.tar.gz"
+  sha256 "c094d0df4595520f194f6f47b13c7652b7ecd67284ac27ab5f219bc3985ea29e"
   license "LGPL-2.0-only"
-  revision 1
 
-  no_autobump! because: :requires_manual_review
+  no_autobump! because: :incompatible_version_format
 
   bottle do
     sha256 arm64_tahoe:    "1c4ed377f24990f0602ed171149c4da26c7986f746c7aa5c5486fc753dfc49e9"
@@ -28,15 +27,14 @@ class Libiptcdata < Formula
     depends_on "gettext"
   end
 
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/homebrew-core/1cf441a0/Patches/libtool/configure-big_sur.diff"
+    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+  end
+
   def install
-    # Fix flat namespace usage
-    inreplace "configure", "${wl}-flat_namespace ${wl}-undefined ${wl}suppress", "${wl}-undefined ${wl}dynamic_lookup"
-
-    args = []
-    # Help old config scripts identify arm64 linux
-    args << "--build=aarch64-unknown-linux-gnu" if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-
-    system "./configure", *args, *std_configure_args
+    system "./configure", *std_configure_args
     system "make", "install"
   end
 


### PR DESCRIPTION
This meets our policy at https://docs.brew.sh/Acceptable-Formulae#not-a-fork-usually 

All listed distros are on this version https://repology.org/project/libiptcdata/versions
- Arch[^1]
- Debian[^2]
- Gentoo[^3]
- Fedora[^4]

[^1]: https://gitlab.archlinux.org/archlinux/packaging/packages/libiptcdata/-/blob/main/PKGBUILD?ref_type=heads#L18
[^2]: https://salsa.debian.org/debian/libiptcdata/-/blob/master/debian/control?ref_type=heads#L13
[^3]: https://packages.gentoo.org/packages/media-libs/libiptcdata
[^4]: https://src.fedoraproject.org/rpms/libiptcdata/blob/rawhide/f/libiptcdata.spec#_14