### PR TITLE
ca-certificates: fix purpose verification

### DIFF
--- a/Formula/c/ca-certificates.rb
+++ b/Formula/c/ca-certificates.rb
@@ -46,8 +46,8 @@ class CaCertificates < Formula
       certificates.select! do |certificate|
         begin
           Utils.safe_popen_write("/usr/bin/openssl", "x509", "-inform", "pem",
-                                                            "-checkend", "0",
-                                                            "-noout") do |openssl_io|
+                                                             "-checkend", "0",
+                                                             "-noout") do |openssl_io|
             openssl_io.write(certificate)
           end
         rescue ErrorDuringExecution
@@ -56,12 +56,12 @@ class CaCertificates < Formula
         end
 
         # Only include certificates that are designed to act as a SSL root.
-        purpose = Utils.safe_popen_write("/usr/bin/openssl", "x509", "-inform", "pem",
-                                                                    "-purpose",
-                                                                    "-noout") do |openssl_io|
+        openssl_purpose = Utils.safe_popen_write("/usr/bin/openssl", "x509", "-inform", "pem",
+                                                                     "-purpose",
+                                                                     "-noout") do |openssl_io|
           openssl_io.write(certificate)
         end
-        purpose.include?("SSL server CA : Yes")
+        openssl_purpose.include?("SSL server CA : Yes")
       end
 
       # Check that the certificate is trusted in keychain

--- a/Formula/c/ca-certificates.rb
+++ b/Formula/c/ca-certificates.rb
@@ -11,7 +11,8 @@ class CaCertificates < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "dd8e78402d2feff017ecf5dd9b8a7f3edea2310631323f24b093ebc85727dd21"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "7e5322e973b9d34d60db5d33ed54f12c8b1867d84a55b00232d9a78d2d4eb79a"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `purpose` variable in `keychains.each` block is unintentionally overwritten by the `openssl x509 -purpose` command output, causing the later `security verify-cert` command to fail. The problem was introduced in #253144 and fixed here by renaming the inner variable.