### PR TITLE
dapico-tools 0.1.4 (new formula)

### DIFF
--- a/Formula/d/dapico-tools.rb
+++ b/Formula/d/dapico-tools.rb
@@ -1,0 +1,20 @@
+class DapicoTools < Formula
+  desc "macOS USB tools for RP2040-based boards"
+  homepage "https://github.com/nanoscopic/dapico-tools"
+  url "https://github.com/nanoscopic/dapico-tools/archive/refs/tags/0.1.4.tar.gz"
+  sha256 "b39fa950f4080d5702ab00bc77ccc3c3ce057dc1b8963a1e3496607f0faccb29"
+  license "BSD-3-Clause"
+  depends_on "cmake" => :build
+  depends_on :macos
+
+  def install
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    system "#{bin}/dapico-reboot", "--help"
+    system "#{bin}/dapico-load", "--help"
+  end
+end


### PR DESCRIPTION
## Summary
This PR adds dapico-tools, a small third-party utility providing
dapico-load and dapico-reboot for RP2040-based boards.

dapico-reboot reboots a connected device into BOOTSEL or normal
run mode. dapico-load loads an ELF image directly over USB.

The tools are macOS-only and use native IOKit USB APIs.
They are intentionally minimal and independent of the official
Raspberry Pi SDK and picotool.

## Testing
- Ran locally via a homebrew tap. ( on arm )
- Tested functionality on both arm and x86 with a pi pico board.
- Checked forumla with brew audit --strict
- Ran brew test ( which are just tests help runs as it needs a pi pico board )