### PR TITLE
dockerfilegraph: update checksum for 0.19.2 release

### DIFF
--- a/Formula/d/dockerfilegraph.rb
+++ b/Formula/d/dockerfilegraph.rb
@@ -2,7 +2,7 @@ class Dockerfilegraph < Formula
   desc "Visualize your multi-stage Dockerfiles"
   homepage "https://github.com/patrickhoefler/dockerfilegraph"
   url "https://github.com/patrickhoefler/dockerfilegraph/archive/refs/tags/v0.19.2.tar.gz"
-  sha256 "ec714828af7cf290fb69942c4bd65debf8d8fa08034f54389c3d32395c4951ea"
+  sha256 "809fafc2fc5ea97a4c32e01568c82a1698b85b8f303405993b28cd91c5363515"
   license "MIT"
   head "https://github.com/patrickhoefler/dockerfilegraph.git", branch: "main"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Found in
* https://github.com/Homebrew/homebrew-core/pull/258912

Log https://github.com/Homebrew/homebrew-core/actions/runs/21056619831/job/60555592960?pr=258912#step:3:7597 :
```
==> brew fetch --build-from-source --retry dockerfilegraph
==> FAILED
Full fetch --build-from-source dockerfilegraph output
  ✘ Formula dockerfilegraph (0.19.2)
  Error: Formula reports different checksum:  ec714828af7cf290fb69942c4bd65debf8d8fa08034f54389c3d32395c4951ea
         SHA-256 checksum of downloaded file: 809fafc2fc5ea97a4c32e01568c82a1698b85b8f303405993b28cd91c5363515
```

Release workflow logs https://github.com/patrickhoefler/dockerfilegraph/actions/workflows/release.yml
indicate that the tag was moved:
<img width="1305" height="247" alt="image" src="https://github.com/user-attachments/assets/535fc0e7-3703-428f-9c46-dbe3df78e9b5" />
...after
* https://github.com/Homebrew/homebrew-core/pull/262668

To fix failing release workflow:
* https://github.com/patrickhoefler/dockerfilegraph/pull/760

DIff https://github.com/patrickhoefler/dockerfilegraph/compare/233555f5c56feada5f0698654c9ea8e91bfcb172...5e17c60433556f2beac76903795ae1bc9ca52952 indicates no bottle update is needed.