### PR TITLE
ollama: add MLX support on Apple silicon

### DIFF
--- a/Formula/o/ollama.rb
+++ b/Formula/o/ollama.rb
@@ -16,12 +16,13 @@ class Ollama < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "6e2cc46b5563959d274c35e439f0aba64036023170a5aabe892d076df638d0b7"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "84d1659bf21d2fa9795592f9d62be4cc2bb2b557514f2b736289eff76a175003"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "a2f67a2b27b611da42b76aa630a4c9c17d758d0ae04726284e4c8a937bfe25ad"
-    sha256 cellar: :any_skip_relocation, sonoma:        "31f2901519f23203d60ecfbd7586f1bd616ff6f38ab04ee98e28faa5b3137206"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "14375690eff2c3eab38fa81b1522f5019605fddbf0997934b6d898cc3781fbb6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a84a20303bae0a01b980e9e86d5c9149842f02dced71b26894f15d6130ffb535"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "60b65805b9db4b7a95ce127d839ada458c20e6f678d66e5b7ad0266c2b14563c"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "14b47c31e394c20af47cda53e1e03df20fa315b91e714478775db924519d3c32"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "2baf66743a486bda085140b1a6fb57976dd5486738bb981c9f006f4d1dba60cb"
+    sha256 cellar: :any_skip_relocation, sonoma:        "74aedc0b16277909ca09375986a498000b1b2d4f6591328db641c4c5babcb736"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "bb27f916aeecfcc118e9e09130ce0a0052eca36e635eaa2bbd58b52f879c8761"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "07c0b1a6a6fea4654dc50228c865d19fb814761390ad125d230c4f81fab5b7c8"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
This PR adds MLX support to `ollama`. See discussion with upstream in https://github.com/Homebrew/homebrew-core/issues/263759.

~~`brew audit` fails because the MLX libraries need to be colocated with the binary for `dlopen` to find them. We'll need to create an allowlist for this case, or find another way to handle it.~~ Thanks @Bo98 for figuring out the `rpath` stuff!