### PR TITLE
triage: reformat CI-build-dependents-from-source path matchers and add rust into `CI-skip-recursive-dependents` 

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -415,9 +415,10 @@ jobs:
                 glib|\
                 harfbuzz|\
                 openssl@3|\
-                wayland-protocols|\
+                rust|\
                 sqlite|\
-                systemd\
+                systemd|\
+                wayland-protocols\
                 ).rb"
               keep_if_no_match: true
               allow_any_match: true

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -384,8 +384,22 @@ jobs:
 
             - label: CI-build-dependents-from-source
               path:
-                - 'Formula/.+/(cabal-install|docbook-xsl|emscripten|erlang|ocaml|ocaml-findlib|ocaml-num|openjdk|pyqt-builder|rust)\.rb'
-                - 'Aliases/(ghc|go)(@[0-9.]+)?$'
+                - "Formula/.+/(\
+                    cabal-install|\
+                    docbook-xsl|\
+                    emscripten|\
+                    erlang|\
+                    ocaml|\
+                    ocaml-findlib|\
+                    ocaml-num|\
+                    openjdk|\
+                    pyqt-builder|\
+                    rust\
+                    )\\.rb"
+                - "Aliases/(\
+                    ghc|\
+                    go\
+                    )(@[0-9.]+)?$"
               missing_content: '\n  revision [0-9]+\n'
               keep_if_no_match: true
               allow_any_match: true


### PR DESCRIPTION
triage: reformat CI-build-dependents-from-source path matchers and add rust into `CI-skip-recursive-dependents` 

- https://github.com/Homebrew/homebrew-core/pull/264043