### PR TITLE
container: fix services not stopping in different `launchd` domains

### DIFF
--- a/Formula/c/container.rb
+++ b/Formula/c/container.rb
@@ -4,6 +4,7 @@ class Container < Formula
   url "https://github.com/apple/container/archive/refs/tags/0.8.0.tar.gz"
   sha256 "f2673cf3c3ce95dfd07068d802873a4a0a0dd8b449c7a20819a75787865a24a1"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/apple/container.git", branch: "main"
 
   bottle do
@@ -14,6 +15,13 @@ class Container < Formula
   depends_on arch: :arm64
   depends_on macos: :tahoe
   depends_on :macos
+
+  # Fixes services not stopping in different launchd domains
+  # PR ref: https://github.com/apple/container/pull/1077
+  patch do
+    url "https://github.com/apple/container/commit/048bdac921ccd8395b6c5f1305fe2473616a40fc.patch?full_index=1"
+    sha256 "1a02b062531cab7852768b724d2f57e26f37e1173f9e5b86f70e3b7171d8c331"
+  end
 
   def install
     if build.head?
@@ -71,7 +79,7 @@ class Container < Formula
   # so we stop the system service to ensure no components are out of sync.
   # Ref: https://github.com/apple/container/issues/551#issuecomment-3246928923
   def post_install
-    system libexec/"ensure-container-stopped.sh"
+    system libexec/"ensure-container-stopped.sh", "-a"
   end
 
   service do

--- a/Formula/c/container.rb
+++ b/Formula/c/container.rb
@@ -8,7 +8,7 @@ class Container < Formula
   head "https://github.com/apple/container.git", branch: "main"
 
   bottle do
-    sha256 arm64_tahoe: "b123d7d7b9e78ae8236e2779445e224a6a7ea0b8bb797ff5c438fe1261161ca6"
+    sha256 arm64_tahoe: "09c752e1322377203240406ae5f4aeb595fbc1a2391ffc11982830a43183a2b9"
   end
 
   depends_on xcode: ["26.0", :build]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
Upgrading `container` succeeds, but the `post_install` doesn't work correctly since the script may be run in a different `launchd` domain. This leads to opaque failures due to breaking API changes upstream.

The revision bump is to handle existing upgrades that most likely have breakage in `container network` like I experienced.