### PR TITLE
abi-dumper 1.4

### DIFF
--- a/Formula/a/abi-dumper.rb
+++ b/Formula/a/abi-dumper.rb
@@ -7,8 +7,7 @@ class AbiDumper < Formula
   head "https://github.com/lvc/abi-dumper.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_linux:  "dfe5724c38317949620260b45f44131625434adb3ba62f2b4c778f7f87c409e5"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "4e69d56bf0f10ea4b9f0bea25e8a860823ff0f08846cea20ca1212f06b9d09b5"
+    sha256 cellar: :any_skip_relocation, all: "14aca33685e8f65c9ebbdf53768ce137170dfb150ae31413b43a1b28279558c7"
   end
 
   depends_on "elfutils"

--- a/Formula/a/abi-dumper.rb
+++ b/Formula/a/abi-dumper.rb
@@ -1,8 +1,8 @@
 class AbiDumper < Formula
   desc "Dump ABI of an ELF object containing DWARF debug info"
   homepage "https://github.com/lvc/abi-dumper"
-  url "https://github.com/lvc/abi-dumper/archive/refs/tags/1.2.tar.gz"
-  sha256 "8a9858c91b4e9222c89b676d59422053ad560fa005a39443053568049bd4d27e"
+  url "https://github.com/lvc/abi-dumper/archive/refs/tags/1.4.tar.gz"
+  sha256 "aa7a52bf913ab1a64743551d64575f921df3faa4a592a0f6614e047bc228708a"
   license "LGPL-2.1-or-later"
   head "https://github.com/lvc/abi-dumper.git", branch: "master"
 
@@ -11,12 +11,9 @@ class AbiDumper < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux: "4e69d56bf0f10ea4b9f0bea25e8a860823ff0f08846cea20ca1212f06b9d09b5"
   end
 
-  deprecate! date: "2024-06-05", because: :unmaintained
-  disable! date: "2025-06-21", because: :unmaintained
-
-  depends_on "abi-compliance-checker"
   depends_on "elfutils"
   depends_on :linux
+  depends_on "perl"
   depends_on "universal-ctags"
   depends_on "vtable-dumper"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Release used by major distros - https://repology.org/project/abi-dumper/versions

Looking at distros' packaging, the dependency is usually reversed for `abi-compliance-checker`, e.g. https://archlinux.org/packages/extra/any/abi-dumper/
