### PR TITLE
antidote: install antidote function into pkgshare

### DIFF
--- a/Formula/a/antidote.rb
+++ b/Formula/a/antidote.rb
@@ -12,6 +12,7 @@ class Antidote < Formula
   uses_from_macos "zsh"
 
   def install
+    pkgshare.install "antidote"
     pkgshare.install "antidote.zsh"
     pkgshare.install "functions"
     man.install "man/man1"

--- a/Formula/a/antidote.rb
+++ b/Formula/a/antidote.rb
@@ -6,7 +6,8 @@ class Antidote < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "3a19f334b85a2f9f92261f841ffb2caf871eb006cef7d9645441b202baf5ca22"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "974e2b7322e3fe842a7211da40afbfda61d4457e23b7474e234537d537b8928a"
   end
 
   uses_from_macos "zsh"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.
-----

The [antidote](https://github.com/mattmc3/antidote/blob/84f1bcb/antidote) function is needed if we want to load antidote in a lazy way, like here: https://github.com/mattmc3/zdotdir/blob/164d340/lib/antidote.zsh#L29-L39