### PR TITLE
fatsort 1.7.679

### DIFF
--- a/Formula/f/fatsort.rb
+++ b/Formula/f/fatsort.rb
@@ -2,16 +2,13 @@ class Fatsort < Formula
   desc "Sorts FAT16 and FAT32 partitions"
   homepage "https://fatsort.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/fatsort/fatsort-1.7.679.tar.xz"
-  version "1.7"
   sha256 "1012f551382639d69e194eabfbe99342ede7c856b1cd6788287f9dfd4bd8d122"
   license "GPL-2.0-or-later"
 
   livecheck do
     url :stable
-    regex(%r{url=.*?/fatsort[._-]v?(\d+(?:\.\d+)+)\.\d+\.t}i)
+    regex(%r{url=.*?/fatsort[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
-
-  no_autobump! because: :incompatible_version_format
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "bf6f852b979722c1ee0872145e63a023fa6158208171ba6b09d0b6a37592a484"

--- a/Formula/f/fatsort.rb
+++ b/Formula/f/fatsort.rb
@@ -11,12 +11,12 @@ class Fatsort < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "bf6f852b979722c1ee0872145e63a023fa6158208171ba6b09d0b6a37592a484"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e4f6537b80d60554df73f54ed1a54b5b6d83750c846df7268d59926e890bc9f3"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "080c536f78906bd19a2d01047f00f56a3595cb8549eae90eebaec620885cd510"
-    sha256 cellar: :any_skip_relocation, sonoma:        "6de023bfeb092ada2d2c2383a42ce7b1e05a27726dbfe8da14768ceefdeb4479"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "a0847ede369e638a6ccdd1eeb2d4f9326eda6f5985797cca203fcbd13c8d9150"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "7c24a2626f64986a87fa2b9933bac0b029632c684e25ec20ee1fa5156bd4e8b6"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "0a364630ad4617dfd97e5af2275f62c91d1371b1452a2cdc5a9cae4c9724b058"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "145bea2b1961c492f9adc4d52df66a1c4e74465388470f320f30378418e81742"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "aaacef942c280d2dee9d1e2fb1a5f1e4dc90ee452d34f1162e52d8b074fb1f54"
+    sha256 cellar: :any_skip_relocation, sonoma:        "2c0bbb896f82db81e5213de928f8d02742d0e8e02506f5746260dcd229d7c8e4"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "03406b3c7d87b1bfa493be10a02b0ba72898ee5d2277749ff02f39e4bcd5c59b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2e8c2792669cf23c3a31e553e513cc6de53ea82dba27bc079074da74101c3fd0"
   end
 
   depends_on "help2man"


### PR DESCRIPTION
This is the same version but just changing version scheme as all other distros/repositories are including the SVN revision number. Modifying this should avoid our version being seen as outdated at:
- https://repology.org/project/fatsort/versions

And also allow us to autobump formula