### PR TITLE
mysqltuner 2.8.29 (move to fork)

### DIFF
--- a/Formula/m/mysqltuner.rb
+++ b/Formula/m/mysqltuner.rb
@@ -7,7 +7,7 @@ class Mysqltuner < Formula
   head "https://github.com/jmrenouard/MySQLTuner-perl.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "4ea0ce49f647faa0f8f21867bc67604c4e3e38b3eb2a332c1958695de925d330"
+    sha256 cellar: :any_skip_relocation, all: "ad198a5d87d6addde221cf4a552b2065f18ead7b63b1e74a5a538506e2137eee"
   end
 
   def install

--- a/Formula/m/mysqltuner.rb
+++ b/Formula/m/mysqltuner.rb
@@ -1,10 +1,10 @@
 class Mysqltuner < Formula
   desc "Increase performance and stability of a MySQL installation"
-  homepage "https://raw.github.com/major/MySQLTuner-perl/master/mysqltuner.pl"
-  url "https://github.com/major/MySQLTuner-perl/archive/refs/tags/v2.7.0.tar.gz"
-  sha256 "dcd789c25f450ab128c050525705396f183a57b117eabdba470653f2ab9dd53e"
+  homepage "https://mysqltuner.com/"
+  url "https://github.com/jmrenouard/MySQLTuner-perl/archive/refs/tags/v2.8.29.tar.gz"
+  sha256 "5de9b127abe7455c942b2790fe0558a5c415c07582121ed59c9761bf26b0c9c3"
   license "GPL-3.0-or-later"
-  head "https://github.com/major/MySQLTuner-perl.git", branch: "master"
+  head "https://github.com/jmrenouard/MySQLTuner-perl.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "4ea0ce49f647faa0f8f21867bc67604c4e3e38b3eb2a332c1958695de925d330"


### PR DESCRIPTION
I think we can consider fork official here as it is owned by the active developer/maintainer of original repo who has been creating official releases since 1.6.0 - https://github.com/major/MySQLTuner-perl/releases/tag/1.6.0

Also, all URLs in original repo have been updated to fork, e.g. https://github.com/major/MySQLTuner-perl/blob/master/mysqltuner.pl#L8
```pl
# Git repository available at https://github.com/jmrenouard/MySQLTuner-perl/
```

It looks like moving releases to fork was done as part of:
- https://github.com/major/MySQLTuner-perl/issues/739#issuecomment-3764564906

---

Currently, only Debian has updated to fork (https://packages.debian.org/sid/source/mysqltuner) but I think this can be considered official successor given all URLs in code, README.md, etc point to fork.