### PR TITLE
netcdf-fortran: clean up build, make `hdf5` build-only

### DIFF
--- a/Formula/n/netcdf-fortran.rb
+++ b/Formula/n/netcdf-fortran.rb
@@ -17,17 +17,12 @@ class NetcdfFortran < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "hdf5" => :build
   depends_on "gcc" # for gfortran
-  depends_on "hdf5"
   depends_on "netcdf"
 
   def install
     args = std_cmake_args + %w[-DENABLE_TESTS=OFF -DENABLE_DOXYGEN=OFF]
-
-    # Help netcdf-fortran find netcf
-    # https://github.com/Unidata/netcdf-fortran/issues/301#issuecomment-1183204019
-    args << "-DnetCDF_LIBRARIES=#{Formula["netcdf"].opt_lib}/#{shared_library("libnetcdf")}"
-    args << "-DnetCDF_INCLUDE_DIR=#{Formula["netcdf"].opt_include}"
 
     system "cmake", "-S", ".", "-B", "build_shared", *args, "-DBUILD_SHARED_LIBS=ON"
     system "cmake", "--build", "build_shared"
@@ -61,8 +56,7 @@ class NetcdfFortran < Formula
         end subroutine check
       end program test
     FORTRAN
-    system "gfortran", "test.f90", "-L#{lib}", "-I#{include}", "-lnetcdff",
-                       "-o", "testf"
+    system "gfortran", "test.f90", "-L#{lib}", "-I#{include}", "-lnetcdff", "-o", "testf"
     system "./testf"
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

HDF5 is mainly searched at build time as indirect dependency for Netcdf.