### PR TITLE
aldo atool dvdrtools icoutils: update source url

### DIFF
--- a/Formula/a/aldo.rb
+++ b/Formula/a/aldo.rb
@@ -1,7 +1,7 @@
 class Aldo < Formula
   desc "Morse code learning tool released under GPL"
   homepage "https://www.nongnu.org/aldo/"
-  url "https://savannah.nongnu.org/download/aldo/aldo-0.7.7.tar.bz2"
+  url "https://download.savannah.gnu.org/releases/aldo/aldo-0.7.7.tar.bz2"
   sha256 "f1b8849d09267fff3c1f5122097d90fec261291f51b1e075f37fad8f1b7d9f92"
   license "GPL-2.0-or-later"
 

--- a/Formula/a/atool.rb
+++ b/Formula/a/atool.rb
@@ -1,7 +1,7 @@
 class Atool < Formula
   desc "Archival front-end"
   homepage "https://savannah.nongnu.org/projects/atool/"
-  url "https://savannah.nongnu.org/download/atool/atool-0.39.0.tar.gz"
+  url "https://download.savannah.gnu.org/releases/atool/atool-0.39.0.tar.gz"
   sha256 "aaf60095884abb872e25f8e919a8a63d0dabaeca46faeba87d12812d6efc703b"
   license "GPL-2.0-or-later"
 

--- a/Formula/d/dvdrtools.rb
+++ b/Formula/d/dvdrtools.rb
@@ -1,7 +1,7 @@
 class Dvdrtools < Formula
   desc "Fork of cdrtools DVD writer support"
   homepage "https://savannah.nongnu.org/projects/dvdrtools/"
-  url "https://savannah.nongnu.org/download/dvdrtools/dvdrtools-0.2.1.tar.gz"
+  url "https://download.savannah.gnu.org/releases/dvdrtools/dvdrtools-0.2.1.tar.gz"
   sha256 "053d0f277f69b183f9c8e8c8b09b94d5bb4a1de6d9b122c0e6c00cc6593dfb46"
   license "GPL-2.0-or-later"
 

--- a/Formula/i/icoutils.rb
+++ b/Formula/i/icoutils.rb
@@ -1,7 +1,7 @@
 class Icoutils < Formula
   desc "Create and extract MS Windows icons and cursors"
   homepage "https://www.nongnu.org/icoutils/"
-  url "https://savannah.nongnu.org/download/icoutils/icoutils-0.32.3.tar.bz2"
+  url "https://download.savannah.gnu.org/releases/icoutils/icoutils-0.32.3.tar.bz2"
   sha256 "17abe02d043a253b68b47e3af69c9fc755b895db68fdc8811786125df564c6e0"
   license "GPL-3.0-or-later"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

It seems that the url https://savannah.nongnu.org/download is no longer valid, so change to https://download.savannah.gnu.org/releases.

- https://github.com/Homebrew/homebrew-core/issues/139929#issuecomment-3795806023