### PR TITLE
ola: change caveat for upcoming Python support removal

### DIFF
--- a/Formula/o/ola.rb
+++ b/Formula/o/ola.rb
@@ -6,6 +6,7 @@ class Ola < Formula
   homepage "https://github.com/OpenLightingProject/ola"
   license all_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later"]
   revision 8
+  head "https://github.com/OpenLightingProject/ola.git", branch: "master"
 
   stable do
     # TODO: Check if we can use unversioned `protobuf` at version bump
@@ -35,17 +36,6 @@ class Ola < Formula
     sha256 sonoma:        "2840580cf7483896ea140328cd7e966c9169d1bb6ea6bb816b79e02137a44cee"
     sha256 arm64_linux:   "6b42431dccfa85cb7d6537fadb668c5c487f27cc112b6db052ab34880b2430bc"
     sha256 x86_64_linux:  "32730886d9c85ba3eb30461beb1d161642be7dd9f229d674b7cc22b2babaa5ce"
-  end
-
-  head do
-    url "https://github.com/OpenLightingProject/ola.git", branch: "master"
-
-    # Apply open PR to fix macOS HEAD build
-    # PR ref: https://github.com/OpenLightingProject/ola/pull/1983
-    patch do
-      url "https://github.com/OpenLightingProject/ola/commit/b8134b82e15f19266c79620b9c3c012bc515357d.patch?full_index=1"
-      sha256 "d168118436186f0a30f4f7f2fdfcde69a5d20a8dcbef61c586d89cfd8f513e33"
-    end
   end
 
   depends_on "autoconf" => :build
@@ -150,8 +140,8 @@ class Ola < Formula
 
   def caveats
     <<~EOS
-      To use the bundled Python libraries:
-        #{Utils::Shell.export_value("PYTHONPATH", extra_python_path)}
+      Python support will be removed due to:
+        https://github.com/OpenLightingProject/ola/issues/2008
     EOS
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Updating caveat to no longer advertise Python libraries and instead mention planned removal.

Adding support for newer Protobuf C++ isn't too difficult, but Python libraries requires a larger rewrite so just dropping. 