### PR TITLE
whosthere 0.4.0 (new formula)

### DIFF
--- a/Formula/w/whosthere.rb
+++ b/Formula/w/whosthere.rb
@@ -1,0 +1,31 @@
+class Whosthere < Formula
+  desc "LAN discovery tool with a modern TUI written in Go"
+  homepage "https://github.com/ramonvermeulen/whosthere"
+  url "https://github.com/ramonvermeulen/whosthere/archive/refs/tags/v0.4.0.tar.gz"
+  sha256 "5133bb75c0e8fd7296910012f1a7cf576ecf438771593a074e40e7eee4330d38"
+  license "Apache-2.0"
+  head "https://github.com/ramonvermeulen/whosthere.git", branch: "main"
+
+  livecheck do
+    url :stable
+  end
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = %W[
+      -s -w
+      -X main.versionStr=#{version}
+      -X main.dateStr=#{Time.now.utc.iso8601}
+    ]
+
+    ldflags << "-X main.commitStr=#{Utils.git_short_head}" if build.head?
+    system "go", "build", *std_go_args(ldflags: ldflags)
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/whosthere --version")
+    output = shell_output("#{bin}/whosthere --interface non_existing 2>&1", 1)
+    assert_match "no such network interface", output
+  end
+end

--- a/Formula/w/whosthere.rb
+++ b/Formula/w/whosthere.rb
@@ -10,6 +10,15 @@ class Whosthere < Formula
     url :stable
   end
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "9228dc2810f10451a9e6173b3a8eb200156d5e312e840ec4e917cfcb93816695"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "ce632d0329eaa9c397a302658b44428bdfe95004c3d17494fa903e9bd213b0c4"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "f54868acb906e2dcb424a5f358ebe2f719a0a2ae4e8f1ab6094e8efc84913400"
+    sha256 cellar: :any_skip_relocation, sonoma:        "876b609a050475bd0dba9586da15b448dffc9841e05c77322d1888c53f12ec8c"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "628a33c866af25fdceac8083095f32e02d000eba83675c7fe553c9e2be444a84"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b9162a8facce338d131e38f37f648a4ea2abcc1f6d18f550a7ffee41d14b6d4a"
+  end
+
   depends_on "go" => :build
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

I couldn't figure out how to get the git commit so that it can be used as linker flag, e.g. to show in the `whosthere version` command. For this I used AI to generate the config that first tries to fetch the sha from the GitHub API and otherwise falls back to "unknown" as value. I tested this locally, and it seems to work but want to validate if this is a common approach. It won't always work, because a client can for example have hit the rate limit on the GitHub API.

It is a "nice to have" to get the git commit in there as linker flag, if it is not recommended I will remove the GitHub API call from the config.

-----

- Adds https://github.com/ramonvermeulen/whosthere to `homebrew/core`

**brew install**

```console
╰─❯ HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source $(brew --repository homebrew/core)/Formula/w/whosthere.rb                                                                                                                                                ─╯
==> Auto-updating Homebrew...
Adjust how often this is run with `$HOMEBREW_AUTO_UPDATE_SECS` or disable with
`$HOMEBREW_NO_AUTO_UPDATE=1`. Hide these hints with `$HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).
Error: Failed to load cask: /opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/w/whosthere.rb
Cask 'whosthere' is unreadable: wrong constant name #<Class:0x000000011fc75dd8>
Warning: Treating /opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/w/whosthere.rb as a formula.
==> Fetching downloads for: whosthere
✔︎ Formula whosthere (0.3.1)                                                                                                                                                                                                                          Verified      3.6MB/  3.6MB
Warning: A newer Command Line Tools release is available.
Update them from Software Update in System Settings.

If that doesn't show you any updates, run:
  sudo rm -rf /Library/Developer/CommandLineTools
  sudo xcode-select --install

Alternatively, manually download them from:
  https://developer.apple.com/download/all/.
You should download the Command Line Tools for Xcode 16.4.



This is a Tier 2 configuration:
  https://docs.brew.sh/Support-Tiers#tier-2
You can report Tier 2 unrelated issues to Homebrew/* repositories!
Read the above document before opening any issues or PRs.

==> go build -ldflags=-s -w -X main.versionStr=0.3.1 -X main.commitStr=unknown -X main.dateStr=2026-01-25T19:01:35Z
🍺  /opt/homebrew/Cellar/whosthere/0.3.1: 6 files, 16.7MB, built in 3 seconds
==> Running `brew cleanup whosthere`...
Disable this behaviour by setting `HOMEBREW_NO_INSTALL_CLEANUP=1`.
Hide these hints with `HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).
```

**brew test**

```console
╰─❯ brew test whosthere                                                                                                                                                                                                                                                      ─╯
==> Testing whosthere
==> /opt/homebrew/Cellar/whosthere/0.3.1/bin/whosthere --version


╰─❯ echo $?                                                                                                                                                                                                                                                                  ─╯
0
```

**brew audit --new**
```console
╰─❯ brew audit --new whosthere                                                                                                                                                                                                                                               ─╯

╰─❯ echo $?                                                                                                                                                                                                                                                                  ─╯
0
```