### PR TITLE
offlineimap: add keyring dependency

### DIFF
--- a/Formula/o/offlineimap.rb
+++ b/Formula/o/offlineimap.rb
@@ -10,12 +10,12 @@ class Offlineimap < Formula
   head "https://github.com/OfflineIMAP/offlineimap3.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "f251f42c4fa68a9fbc3f3b8778f96d5b64753cd5f9c1ca0c3d8ed563239f3acf"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "f251f42c4fa68a9fbc3f3b8778f96d5b64753cd5f9c1ca0c3d8ed563239f3acf"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "f251f42c4fa68a9fbc3f3b8778f96d5b64753cd5f9c1ca0c3d8ed563239f3acf"
-    sha256 cellar: :any_skip_relocation, sonoma:        "965d0ae92184e0f04e1739fef4fff253affbced651c03646b777d0b360d4c869"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "965d0ae92184e0f04e1739fef4fff253affbced651c03646b777d0b360d4c869"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "965d0ae92184e0f04e1739fef4fff253affbced651c03646b777d0b360d4c869"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "89057fbe4e4bd0da45e4b7b015e62e9d5f5b4944251b3f9b1d91370ae0e8644e"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "89057fbe4e4bd0da45e4b7b015e62e9d5f5b4944251b3f9b1d91370ae0e8644e"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "89057fbe4e4bd0da45e4b7b015e62e9d5f5b4944251b3f9b1d91370ae0e8644e"
+    sha256 cellar: :any_skip_relocation, sonoma:        "9888a2ec89503b3b0ccc2b6fea20251edfdf4d4c1f9f48e7bff8a0b14bd129e3"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "9888a2ec89503b3b0ccc2b6fea20251edfdf4d4c1f9f48e7bff8a0b14bd129e3"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "9888a2ec89503b3b0ccc2b6fea20251edfdf4d4c1f9f48e7bff8a0b14bd129e3"
   end
 
   depends_on "certifi"

--- a/Formula/o/offlineimap.rb
+++ b/Formula/o/offlineimap.rb
@@ -6,6 +6,7 @@ class Offlineimap < Formula
   url "https://github.com/OfflineIMAP/offlineimap3/archive/refs/tags/v8.0.1.tar.gz"
   sha256 "82ce54136465ea1cce62f4e961e8c155ac3eee2149fa812763629448902d7d69"
   license "GPL-2.0-or-later"
+  revision 1
   head "https://github.com/OfflineIMAP/offlineimap3.git", branch: "master"
 
   bottle do
@@ -22,7 +23,8 @@ class Offlineimap < Formula
 
   uses_from_macos "krb5"
 
-  pypi_packages exclude_packages: "certifi"
+  pypi_packages exclude_packages: "certifi",
+                extra_packages:   "keyring"
 
   resource "distro" do
     url "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz"
@@ -38,6 +40,31 @@ class Offlineimap < Formula
       url "https://github.com/jazzband/imaplib2/commit/da0097f6b421c4b826416ea09b4802c163391330.patch?full_index=1"
       sha256 "ff60f720cfc61bfee9eec0af4d79d307e3a8703e575a19c18d05ef3477cf3a64"
     end
+  end
+
+  resource "jaraco-classes" do
+    url "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz"
+    sha256 "47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd"
+  end
+
+  resource "jaraco-context" do
+    url "https://files.pythonhosted.org/packages/cb/9c/a788f5bb29c61e456b8ee52ce76dbdd32fd72cd73dd67bc95f42c7a8d13c/jaraco_context-6.1.0.tar.gz"
+    sha256 "129a341b0a85a7db7879e22acd66902fda67882db771754574338898b2d5d86f"
+  end
+
+  resource "jaraco-functools" do
+    url "https://files.pythonhosted.org/packages/0f/27/056e0638a86749374d6f57d0b0db39f29509cce9313cf91bdc0ac4d91084/jaraco_functools-4.4.0.tar.gz"
+    sha256 "da21933b0417b89515562656547a77b4931f98176eb173644c0d35032a33d6bb"
+  end
+
+  resource "keyring" do
+    url "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz"
+    sha256 "fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b"
+  end
+
+  resource "more-itertools" do
+    url "https://files.pythonhosted.org/packages/ea/5d/38b681d3fce7a266dd9ab73c66959406d565b3e85f21d5e66e1181d93721/more_itertools-10.8.0.tar.gz"
+    sha256 "f638ddf8a1a0d134181275fb5d58b086ead7c6a72429ad725c67503f13ba30bd"
   end
 
   resource "rfc6555" do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

`keyring` is listed as a dependency for `offlineimap` in the upstream `README` but it isn't picked up by `brew update-python-resources` and `offlineimap` can fail at runtime without it. This adds `keyring` as a resource along with its dependencies.