### PR TITLE
rbenv-ctags: migrate to maintained `universal-ctags`

### DIFF
--- a/Formula/r/rbenv-ctags.rb
+++ b/Formula/r/rbenv-ctags.rb
@@ -14,8 +14,8 @@ class RbenvCtags < Formula
     sha256 cellar: :any_skip_relocation, all: "93ff69e4515aae2a296578472b395c3bc8721fc711327c6f2a9126111910700e"
   end
 
-  depends_on "ctags"
   depends_on "rbenv"
+  depends_on "universal-ctags"
 
   def install
     prefix.install Dir["*"]

--- a/Formula/r/rbenv-ctags.rb
+++ b/Formula/r/rbenv-ctags.rb
@@ -10,8 +10,8 @@ class RbenvCtags < Formula
   no_autobump! because: :requires_manual_review
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, all: "93ff69e4515aae2a296578472b395c3bc8721fc711327c6f2a9126111910700e"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, all: "b002adad54827245a53792a5da722075e8662e65cde9ce26a628510a6b1b3ee6"
   end
 
   depends_on "rbenv"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Last formula still using older `ctags` (exuberant-ctags). Since all other formulae use `universal-ctags` may as well update this too.
