### PR TITLE
universal-ctags 6.2.1

### DIFF
--- a/Formula/u/universal-ctags.rb
+++ b/Formula/u/universal-ctags.rb
@@ -1,15 +1,13 @@
 class UniversalCtags < Formula
   desc "Maintained ctags implementation"
   homepage "https://ctags.io/"
-  url "https://github.com/universal-ctags/ctags/archive/refs/tags/p6.2.20260125.0.tar.gz"
-  version "p6.2.20260125.0"
-  sha256 "ba5a4dbd4132f9e11f6e38fdbc3960874ebdb61af7ede074de0b8c23a4a8dd6e"
+  url "https://github.com/universal-ctags/ctags/releases/download/v6.2.1/universal-ctags-6.2.1.tar.gz"
+  sha256 "2c63efe9e0e083dc50e6fdd8c5414781cc8873d8c8940cf553c01870ed962f8c"
   license "GPL-2.0-only"
-  head "https://github.com/universal-ctags/ctags.git", branch: "master"
 
   livecheck do
     url :stable
-    regex(/^(p\d+(?:\.\d+)+)$/i)
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do
@@ -21,8 +19,13 @@ class UniversalCtags < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "295d8b4be91bd542854afbe09ec71bc56cb1fe07a99f34e8528baf6e2ee37535"
   end
 
-  depends_on "autoconf" => :build
-  depends_on "automake" => :build
+  head do
+    url "https://github.com/universal-ctags/ctags.git", branch: "master"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+  end
+
   depends_on "docutils" => :build
   depends_on "pkgconf" => :build
   depends_on "python@3.14" => :build
@@ -35,7 +38,7 @@ class UniversalCtags < Formula
   conflicts_with "ctags", because: "both install `ctags` binaries"
 
   def install
-    system "./autogen.sh"
+    system "./autogen.sh" if build.head?
     system "./configure", *std_configure_args
     system "make"
     system "make", "install"

--- a/Formula/u/universal-ctags.rb
+++ b/Formula/u/universal-ctags.rb
@@ -11,12 +11,12 @@ class UniversalCtags < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "997619dc5d8a09df1cd353bbe24fa9d0a6246dc7ab87c2f1850ca7d969f6bb4d"
-    sha256 cellar: :any,                 arm64_sequoia: "3f4b8cd92b67750b15963cfc6011915c96528f2a87207ff9b2963c41e51bd2d9"
-    sha256 cellar: :any,                 arm64_sonoma:  "d0aba5fba5032ac9b829e0a108cd8226d5d6066c67ba5623e1d39655bef0ed93"
-    sha256 cellar: :any,                 sonoma:        "8399abb0635d1846504913c106b710385ec0c1409d0e4c682c27bc1e939a313c"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "51140552e4970aace5cfdcff7b1eedc76e7cb5ad8fcbde19195182c6cd6c3b5e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "295d8b4be91bd542854afbe09ec71bc56cb1fe07a99f34e8528baf6e2ee37535"
+    sha256 cellar: :any,                 arm64_tahoe:   "04462c7b1fad942219dd2eabd936b74d882663299c9463774cb0f903ddb1aaa0"
+    sha256 cellar: :any,                 arm64_sequoia: "25fe4f06afaa90e2ae0a9ff5db65907d7b10661277d1a059fc4acafdf903ec5c"
+    sha256 cellar: :any,                 arm64_sonoma:  "abac0bf20153b9a1cbdccf1f95ab8fee907adf4607873b5b63fda6758d47edd6"
+    sha256 cellar: :any,                 sonoma:        "b0b3270037bd744571517a734136213474ba9aaa304977137d4f78cc35490d62"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "b4529f5ea92739c6a603e9d8a301e7f2fdd5c0ee07aeeeb39f9852f50d805de9"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2970ae4a8b7332e017abf1f4e0286864ef48ca5f6f7f0c93224347f26c05458a"
   end
 
   head do


### PR DESCRIPTION
This switches us from weekly snapshots to stable release tags.

Due to `p`-prefix, the version change is seen as an upgrade so should be able to avoid version scheme change:
```console
❯ brew lc universal-ctags --autobump --newer-only
universal-ctags: p6.2.20260125.0 ==> 6.2.1
```

Checking https://repology.org/project/universal-ctags/versions, can see majority of repositories have switched including
- Alpine Linux 3.23+
- Arch Linux
- Debian 14+ / Ubuntu 26+
- Fedora 38+ 
- Gentoo (since ctags 6.2.0)
- GNU Guix
- nixpkgs
- OpenBSD Ports
- openSUSE Tumbleweed
- Scoop
- SlackBuilds

Repositories still on snapshots include:
- FreeBSD Ports
- MacPorts
- Spack
- Void

