### PR TITLE
mrbayes 3.2.7a

### DIFF
--- a/Formula/m/mrbayes.rb
+++ b/Formula/m/mrbayes.rb
@@ -13,19 +13,12 @@ class Mrbayes < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:    "68e1a37bb0f6aef713da87dc8345bda73b464a7d255e5fe3a8d3ca21d0827dc8"
-    sha256 cellar: :any,                 arm64_sequoia:  "bc112b0be314f46b96f507ec3741b7f915b7b384e162ff88d98076a0370a728f"
-    sha256 cellar: :any,                 arm64_sonoma:   "e671f59ccb6371a26c1ff58c6bbb800a2bf7472f625ac83d756eeb8b281fd6a9"
-    sha256 cellar: :any,                 arm64_ventura:  "67537897e78b18147e0a793ee201b270940fad606d3143ced31782e3fee12ef4"
-    sha256 cellar: :any,                 arm64_monterey: "56f6d18191f9e66a4cd485f3b1831b8037fccae239ccf6dab3289cf2bf4f22e6"
-    sha256 cellar: :any,                 arm64_big_sur:  "c79fa2b377c5f8757040bb3ec2e55b88ba0d01f3085784c0d8c03dbb745b98fc"
-    sha256 cellar: :any,                 sonoma:         "fb4866da8b44dcca56aa7b59d92d299d70882321919f46fa013a7b68889ea60f"
-    sha256 cellar: :any,                 ventura:        "0f00c4d31388e52785795c9cffee3124d8662d1b25648a2cef38e80ff1d46609"
-    sha256 cellar: :any,                 monterey:       "868362e98f0a1ebe8bf2a71f45fa96d6fd4d474e581f52e88e27192cc0086815"
-    sha256 cellar: :any,                 big_sur:        "f00054f1f4fd5c3c7835ece867a6ce6d1a5156517a0a08233fe4548717b6a41e"
-    sha256 cellar: :any,                 catalina:       "4239d03c3d4cf4e2b82b7b91dec3486836695da2770397238b7c8c4182930d20"
-    sha256 cellar: :any_skip_relocation, arm64_linux:    "2a4ec915301ae658e00a5fc302f84124e69ae54af8c0bfbc6167701fbe60d69f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "102eb61f76273eb1345ca920c8e0e4dc4cec0ccba93c56a9a2634376b727e3e6"
+    sha256 cellar: :any,                 arm64_tahoe:   "7e0813e7f10eb1abadd4172e54fc18d7fac02f2a2521d3034217ea8ee99ffa04"
+    sha256 cellar: :any,                 arm64_sequoia: "098da5cbc7c3371cbc845399356634f3373723ab9a10813af39420706adc495b"
+    sha256 cellar: :any,                 arm64_sonoma:  "3297974985b7c483dad355decca53663b6dd88f9aff0571200997b491a44d582"
+    sha256 cellar: :any,                 sonoma:        "4e22bb908f3d2fabacebe0f1896de5cc05f74b5a1bcd224fb2fa85585db5074c"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "4b2aaf7489371e64e11bc0dde781218fd8b4a85a41cd7db039f2a8c377f726c1"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5b7379add8dcffcc268785b68f80f88fb0478f10c76ef139b43b0c6983e30675"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/m/mrbayes.rb
+++ b/Formula/m/mrbayes.rb
@@ -2,17 +2,15 @@ class Mrbayes < Formula
   desc "Bayesian inference of phylogenies and evolutionary models"
   homepage "https://nbisweden.github.io/MrBayes/"
   url "https://github.com/NBISweden/MrBayes/archive/refs/tags/v3.2.7a.tar.gz"
+  version "3.2.7a"
   sha256 "3eed2e3b1d9e46f265b6067a502a89732b6f430585d258b886e008e846ecc5c6"
   license "GPL-3.0-or-later"
-  revision 3
   head "https://github.com/NBISweden/MrBayes.git", branch: "develop"
 
   livecheck do
-    url :stable
-    strategy :github_latest
+    url "https://nbisweden.github.io/MrBayes/download.html"
+    regex(%r{href=\s*.*?/NBISweden/MrBayes/archive/v?(\d+(?:\.\d+)+[a-z]?)\.t}i)
   end
-
-  no_autobump! because: :requires_manual_review
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "68e1a37bb0f6aef713da87dc8345bda73b464a7d255e5fe3a8d3ca21d0827dc8"


### PR DESCRIPTION
Same release but updating version number to match upstream - https://nbisweden.github.io/MrBayes/download.html

The `3.2.7a` was a fix on `3.2.7`.

Also upstream has been messing with tags so GitHub latest off. Can see following that 3.2.7a is still newer than 3.2.7 even though the date of 3.2.7 shows up newer:
- https://github.com/NBISweden/MrBayes/compare/v3.2.7...v3.2.7a
- https://github.com/NBISweden/MrBayes/compare/v3.2.7a...v3.2.7