### PR TITLE
formulae: no longer need ENV.llvm_clang

### DIFF
--- a/Formula/a/adios2.rb
+++ b/Formula/a/adios2.rb
@@ -64,8 +64,6 @@ class Adios2 < Formula
   end
 
   def install
-    ENV.llvm_clang if DevelopmentTools.clang_build_version == 1400
-
     # CMake FortranCInterface_VERIFY fails with LTO on Linux due to different GCC and GFortran versions
     ENV.append "FFLAGS", "-fno-lto" if OS.linux?
 

--- a/Formula/b/botan.rb
+++ b/Formula/b/botan.rb
@@ -55,8 +55,6 @@ class Botan < Formula
     args << "--with-commoncrypto" if OS.mac?
 
     if OS.mac? && DevelopmentTools.clang_build_version <= 1400
-      ENV.llvm_clang
-
       ldflags = %W[-L#{Formula["llvm"].opt_lib}/c++ -L#{Formula["llvm"].opt_lib}/unwind -lunwind]
       args << "--ldflags=#{ldflags.join(" ")}"
     end

--- a/Formula/c/clipboard.rb
+++ b/Formula/c/clipboard.rb
@@ -43,8 +43,6 @@ class Clipboard < Formula
   end
 
   def install
-    ENV.llvm_clang if OS.mac? && DevelopmentTools.clang_build_version <= 1300
-
     # `-Os` is slow and buggy.
     #   https://github.com/Homebrew/homebrew-core/issues/136551
     #   https://github.com/Slackadays/Clipboard/issues/147

--- a/Formula/f/fbthrift.rb
+++ b/Formula/f/fbthrift.rb
@@ -53,7 +53,6 @@ class Fbthrift < Formula
     # Issue ref: https://github.com/facebook/fbthrift/issues/607
     ENV.append "CXXFLAGS", "-fno-assume-unique-vtables" if DevelopmentTools.clang_build_version >= 1600
 
-    ENV.llvm_clang if OS.mac? && (DevelopmentTools.clang_build_version <= 1100)
     ENV["OPENSSL_ROOT_DIR"] = Formula["openssl@3"].opt_prefix
 
     # The static libraries are a bit annoying to build. If modifying this formula

--- a/Formula/f/folly.rb
+++ b/Formula/f/folly.rb
@@ -55,8 +55,6 @@ class Folly < Formula
   patch :DATA
 
   def install
-    ENV.llvm_clang if OS.mac? && (DevelopmentTools.clang_build_version <= 1100)
-
     args = %W[
       -DCMAKE_LIBRARY_ARCHITECTURE=#{Hardware::CPU.arch}
       -DFOLLY_USE_JEMALLOC=OFF


### PR DESCRIPTION
This is now automatically done via compiler selector if `fails_with` is used on macOS