### PR TITLE
formulae: no longer need ENV.llvm_clang

### DIFF
--- a/Formula/d/dwarfs.rb
+++ b/Formula/d/dwarfs.rb
@@ -85,8 +85,6 @@ class Dwarfs < Formula
       # No ASAN for folly
       ENV.append "CXXFLAGS", "-D_LIBCPP_HAS_NO_ASAN"
 
-      ENV.llvm_clang
-
       # Needed in order to find the C++ standard library
       # See: https://github.com/Homebrew/homebrew-core/issues/178435
       ENV.prepend "LDFLAGS", "-L#{Formula["llvm"].opt_lib}/unwind -lunwind"

--- a/Formula/g/grpc.rb
+++ b/Formula/g/grpc.rb
@@ -60,7 +60,6 @@ class Grpc < Formula
   end
 
   def install
-    ENV.llvm_clang if OS.mac? && (DevelopmentTools.clang_build_version <= 1100)
     args = %W[
       -DCMAKE_CXX_STANDARD=17
       -DCMAKE_CXX_STANDARD_REQUIRED=TRUE
@@ -82,7 +81,7 @@ class Grpc < Formula
     system "cmake", "--build", "_build"
     system "cmake", "--install", "_build"
 
-    # `grpc_cli` fails to build on Linux. In any case, it looks like it isn't meant to be be installed.
+    # `grpc_cli` fails to build on Linux. In any case, it looks like it isn't meant to be installed.
     # TODO: consider dropping this on macOS too.
     return unless OS.mac?
 

--- a/Formula/g/gsmartcontrol.rb
+++ b/Formula/g/gsmartcontrol.rb
@@ -51,8 +51,6 @@ class Gsmartcontrol < Formula
   end
 
   def install
-    ENV.llvm_clang if OS.mac? && DevelopmentTools.clang_build_version <= 1500
-
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"

--- a/Formula/m/mavsdk.rb
+++ b/Formula/m/mavsdk.rb
@@ -62,8 +62,6 @@ class Mavsdk < Formula
   end
 
   def install
-    ENV.llvm_clang if OS.mac? && (DevelopmentTools.clang_build_version <= 1100)
-
     # Fix version being reported as `v#{version}-dirty`
     inreplace "CMakeLists.txt", "OUTPUT_VARIABLE VERSION_STR", "OUTPUT_VARIABLE VERSION_STR_IGNORED"
 

--- a/Formula/m/micromamba.rb
+++ b/Formula/m/micromamba.rb
@@ -56,8 +56,6 @@ class Micromamba < Formula
   end
 
   def install
-    ENV.llvm_clang if OS.mac? && DevelopmentTools.clang_build_version <= 1600
-
     args = %W[
       -DBUILD_LIBMAMBA=ON
       -DBUILD_LIBMAMBA_SPDLOG=ON


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
