### PR TITLE
formulae: no longer need ENV.llvm_clang

### DIFF
--- a/Formula/m/mold.rb
+++ b/Formula/m/mold.rb
@@ -50,8 +50,6 @@ class Mold < Formula
   end
 
   def install
-    ENV.llvm_clang if OS.mac? && (DevelopmentTools.clang_build_version <= 1500)
-
     # Avoid embedding libdir in the binary.
     # This helps make the bottle relocatable.
     inreplace "lib/config.h.in", "@CMAKE_INSTALL_FULL_LIBDIR@", ""
@@ -73,9 +71,7 @@ class Mold < Formula
   end
 
   def caveats
-    <<~EOS
-      Support for Mach-O targets has been removed.
-    EOS
+    "Support for Mach-O targets has been removed."
   end
 
   test do

--- a/Formula/m/mono.rb
+++ b/Formula/m/mono.rb
@@ -65,8 +65,6 @@ class Mono < Formula
   link_overwrite "lib/cli"
 
   def install
-    ENV.llvm_clang if DevelopmentTools.clang_build_version >= 1600
-
     # Replace hardcoded /usr/share directory. Paths like /usr/share/.mono,
     # /usr/share/.isolatedstorage, and /usr/share/template are referenced in code.
     inreplace_files = %w[

--- a/Formula/m/mpd.rb
+++ b/Formula/m/mpd.rb
@@ -81,7 +81,6 @@ class Mpd < Formula
   def install
     if OS.mac? && MacOS.version <= :ventura
       remove_brew_expat
-      ENV.llvm_clang
       ENV.append "LDFLAGS", "-L#{Formula["llvm"].opt_lib}/unwind -lunwind"
       # When using Homebrew's superenv shims, we need to use HOMEBREW_LIBRARY_PATHS
       # rather than LDFLAGS for libc++ in order to correctly link to LLVM's libc++.

--- a/Formula/m/mysql-client.rb
+++ b/Formula/m/mysql-client.rb
@@ -56,12 +56,8 @@ class MysqlClient < Formula
   end
 
   def install
-    if OS.linux?
-      # Disable ABI checking
-      inreplace "cmake/abi_check.cmake", "RUN_ABI_CHECK 1", "RUN_ABI_CHECK 0"
-    elsif MacOS.version <= :ventura
-      ENV.llvm_clang
-    end
+    # Disable ABI checking
+    inreplace "cmake/abi_check.cmake", "RUN_ABI_CHECK 1", "RUN_ABI_CHECK 0" if OS.linux?
 
     # -DINSTALL_* are relative to `CMAKE_INSTALL_PREFIX` (`prefix`)
     args = %W[

--- a/Formula/o/openmsx.rb
+++ b/Formula/o/openmsx.rb
@@ -62,7 +62,6 @@ class Openmsx < Formula
 
   def install
     if OS.mac? && MacOS.version <= :ventura
-      ENV.llvm_clang
       ENV.prepend "LDFLAGS", "-L#{Formula["llvm"].opt_lib}/unwind -lunwind"
       # When using Homebrew's superenv shims, we need to use HOMEBREW_LIBRARY_PATHS
       # rather than LDFLAGS for libc++ in order to correctly link to LLVM's libc++.


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
