### PR TITLE
formulae: no longer need ENV.llvm_clang

### DIFF
--- a/Formula/p/podofo.rb
+++ b/Formula/p/podofo.rb
@@ -43,7 +43,6 @@ class Podofo < Formula
 
   def install
     if OS.mac? && MacOS.version <= :ventura
-      ENV.llvm_clang
       # When using Homebrew's superenv shims, we need to use HOMEBREW_LIBRARY_PATHS
       # rather than LDFLAGS for libc++ in order to correctly link to LLVM's libc++.
       ENV.prepend_path "HOMEBREW_LIBRARY_PATHS", Formula["llvm"].opt_lib/"c++"

--- a/Formula/q/qca.rb
+++ b/Formula/q/qca.rb
@@ -47,7 +47,6 @@ class Qca < Formula
 
   def install
     if OS.mac? && DevelopmentTools.clang_build_version <= 1400
-      ENV.llvm_clang
       ENV.append "LDFLAGS", "-L#{Formula["llvm"].opt_lib}/c++ -L#{Formula["llvm"].opt_lib}/unwind -lunwind"
     end
 

--- a/Formula/s/snappy.rb
+++ b/Formula/s/snappy.rb
@@ -37,8 +37,6 @@ class Snappy < Formula
   patch :DATA
 
   def install
-    ENV.llvm_clang if OS.mac? && (DevelopmentTools.clang_build_version <= 1100)
-
     args = %w[
       -DSNAPPY_BUILD_TESTS=OFF
       -DSNAPPY_BUILD_BENCHMARKS=OFF
@@ -54,9 +52,6 @@ class Snappy < Formula
   end
 
   test do
-    # Force use of Clang on Mojave
-    ENV.clang if OS.mac?
-
     (testpath/"test.cpp").write <<~CPP
       #include <assert.h>
       #include <snappy.h>

--- a/Formula/s/synergy-core.rb
+++ b/Formula/s/synergy-core.rb
@@ -70,7 +70,6 @@ class SynergyCore < Formula
     (buildpath/"ext/synergy-extra").install resource("synergy-extra")
 
     if OS.mac?
-      ENV.llvm_clang if DevelopmentTools.clang_build_version <= 1402
       # Disable macdeployqt to prevent copying dylibs.
       inreplace "src/gui/CMakeLists.txt",
                 /"execute_process\(COMMAND \${MACDEPLOYQT_CMD}.*\)"/,

--- a/Formula/v/vapoursynth.rb
+++ b/Formula/v/vapoursynth.rb
@@ -38,10 +38,7 @@ class Vapoursynth < Formula
   end
 
   def install
-    if OS.mac? && MacOS.version <= :ventura
-      ENV.llvm_clang
-      ENV.prepend "LDFLAGS", "-L#{Formula["llvm"].opt_lib}/c++"
-    end
+    ENV.prepend "LDFLAGS", "-L#{Formula["llvm"].opt_lib}/c++" if OS.mac? && MacOS.version <= :ventura
 
     system "./autogen.sh"
     inreplace "Makefile.in", "pkglibdir = $(libdir)", "pkglibdir = $(exec_prefix)"

--- a/Formula/x/xgboost.rb
+++ b/Formula/x/xgboost.rb
@@ -36,8 +36,6 @@ class Xgboost < Formula
   end
 
   def install
-    ENV.llvm_clang if OS.mac? && (DevelopmentTools.clang_build_version <= 1100)
-
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
