### PR TITLE
aldo 0.7.8

### DIFF
--- a/Formula/a/aldo.rb
+++ b/Formula/a/aldo.rb
@@ -1,8 +1,9 @@
 class Aldo < Formula
   desc "Morse code learning tool released under GPL"
   homepage "https://www.nongnu.org/aldo/"
-  url "https://download.savannah.gnu.org/releases/aldo/aldo-0.7.7.tar.bz2"
-  sha256 "f1b8849d09267fff3c1f5122097d90fec261291f51b1e075f37fad8f1b7d9f92"
+  url "https://https.git.savannah.gnu.org/git/aldo.git",
+      tag:      "v0.7.8",
+      revision: "c2cbeb215a66a606ed01b58fc0be513ebb373e7c"
   license "GPL-2.0-or-later"
 
   livecheck do
@@ -29,6 +30,8 @@ class Aldo < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "660548eb8c93e2c78a50b925143a9b24400ee578790b62e7acde1d1aed360a98"
   end
 
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
   depends_on "libao"
 
   # Reported upstream:
@@ -39,7 +42,12 @@ class Aldo < Formula
   end
 
   def install
-    system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
+    system "sh", "bootstrap"
+    # Remove the COPYING file which is a symlink to automake's file so fails to install.
+    # Also remove the VERSION file as it causes issues on case-insensitive macOS.
+    rm(["COPYING", "VERSION"])
+
+    system "./configure", *std_configure_args
     system "make", "install"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

This was tagged in git repo but not provided as tarball.  The v0.7.8 mainly adds a fix:
- https://gitweb.git.savannah.gnu.org/gitweb/?p=aldo.git;a=commitdiff;h=c2cbeb215a66a606ed01b58fc0be513ebb373e7c;hp=ed6884f9295066d60d47cc4ae0967af6d907d34c
- https://savannah.nongnu.org/bugs/?38301

At this point in time, software looks unmaintained so might as well move to last "release" tag:
- https://gitweb.git.savannah.gnu.org/gitweb/?p=aldo.git;a=tag;h=refs/tags/v0.7.8

Debian and nixpkgs have been providing it for a while now: https://repology.org/project/aldo/versions