### PR TITLE
ponyc: workaround for GCC

### DIFF
--- a/Formula/p/ponyc.rb
+++ b/Formula/p/ponyc.rb
@@ -7,12 +7,13 @@ class Ponyc < Formula
   license "BSD-2-Clause"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "6ac487b53bb7995e41d4da3e816d1678e2ac581817a28eb62c2e347325f70239"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e3bbc75214d3fb75a693c2bfc4fb2633d6cc56dda92d93db2069880ef473c13e"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "3c4ae708cbe92306ddea79495376682d78b27a84d5f0c2f6741738bc4fb00f7e"
-    sha256 cellar: :any_skip_relocation, sonoma:        "d1acb73969bd4dc9b4ac615e5964619b4dd161b360a77a9832280eaff2b4a1e9"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "0deae9922ecedca2ee066c23f8c72cf218ca0af7c57a2ae7b5acf9036037a977"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a8b422add393d475acf45ab83cde9e897aa9ccb9a966cf91b07264faf1302cba"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "7288dc31f830460534f3e6e9e6a663ed2ed9a2c992362c938d16d211ea2e1ff7"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e189f5726e29936da00cbb00e62513d4a287d409cc764c269f93f9a6ff5b4b39"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "43aca5251489b73177f2d7980e9d0b3c031457e71253fcb4502d2b6e2dbec152"
+    sha256 cellar: :any_skip_relocation, sonoma:        "c99999e253d92a804e3c93fb02e1e9ad9189c28f8ffdbd2ef4217ebb2f444d37"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "3ca4cdec044da1f75553b8f4137f67eb6687fbde506c28771a21d5a375ad8b12"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "af363926ddaff00352bedd762e54a2766acc92cb849b8f9e49e2d7dacf559699"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
Same workaround as our `google-benchmark` formula

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
