### PR TITLE
Remove `ffmpeg-full` dependencies

### DIFF
--- a/Formula/a/auto-editor.rb
+++ b/Formula/a/auto-editor.rb
@@ -4,6 +4,7 @@ class AutoEditor < Formula
   url "https://github.com/WyattBlue/auto-editor/archive/refs/tags/29.6.2.tar.gz"
   sha256 "71144d2deb1796ba289853507d15e74a45099d250d606eba2d6d8e3aaf3ed6a1"
   license "Unlicense"
+  revision 1
   head "https://github.com/WyattBlue/auto-editor.git", branch: "master"
 
   bottle do
@@ -18,7 +19,7 @@ class AutoEditor < Formula
   depends_on "nim" => :build
   depends_on "pkgconf" => :build
   depends_on "dav1d"
-  depends_on "ffmpeg-full"
+  depends_on "ffmpeg"
   depends_on "lame"
   depends_on "libvpx"
   depends_on "llama.cpp"

--- a/Formula/a/auto-editor.rb
+++ b/Formula/a/auto-editor.rb
@@ -8,12 +8,12 @@ class AutoEditor < Formula
   head "https://github.com/WyattBlue/auto-editor.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "0b9c9e0669e62b122557ed985dee9524a023697708ca9cceb02c2200731240ac"
-    sha256 cellar: :any,                 arm64_sequoia: "2de38428b4047e204289dae1c3d143a4a378228b03a83a0b2350b97b37f74a4b"
-    sha256 cellar: :any,                 arm64_sonoma:  "a8da6938c000bd0c9370bb73a4f85bb483d7308dc2b17c675c6f1c98f3f9fa50"
-    sha256 cellar: :any,                 sonoma:        "9d789b2940bfd79902e73167597dcf44ac9092e2bd36a71939db5790ade10027"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "9f996d39ca5b186b2b429ab08ef7888ca1010c934de574e0332dc5956f9559b8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "22dc08f58ddf72b513648660d38991d6fe1011c8cf92027cc63889aad67514b7"
+    sha256 cellar: :any,                 arm64_tahoe:   "85933df5bf14f3485c41425a68d07e1f093f001176b86faf19e7c6c6318bf9cd"
+    sha256 cellar: :any,                 arm64_sequoia: "41ba20cc7431a8c899e7294a209d13ccc33dd5dc94b21bb479185e3213c27c0f"
+    sha256 cellar: :any,                 arm64_sonoma:  "8578eb90c12cbb1ffddba3f38bce01949fc91de0dfc4e3cf4159c41cd98071b7"
+    sha256 cellar: :any,                 sonoma:        "19e534f5a2a204749d513095b3f7db7e1ddd8dfadec59a9a0c9c351f26414c39"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "ff8ad76c0714c482857e1dd8e599fd8c6d7a41c81cbfd702c52c0cc271a754da"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "cc3e53a1011284d2b9818faeb7542381fd43e2c4b8380d75f4cff351f0e68324"
   end
 
   depends_on "nim" => :build

--- a/Formula/m/mpv.rb
+++ b/Formula/m/mpv.rb
@@ -8,13 +8,12 @@ class Mpv < Formula
   head "https://github.com/mpv-player/mpv.git", branch: "master"
 
   bottle do
-    rebuild 1
-    sha256               arm64_tahoe:   "564a30afb1b03beb488917ccd2759b6d9e8b3083f41245ae0512a29c2b6ab18d"
-    sha256               arm64_sequoia: "13bdd939815343f1352cef1ec987ea97fc1fd99b697d8e466eb1602b4735bd08"
-    sha256               arm64_sonoma:  "88b9c084aa04c0eb29e6351709a0b4022ccf27198048ac2afa61315747afcfd2"
-    sha256 cellar: :any, sonoma:        "37965c940f710111b0f7af0ed67b140c979148ac9a00adc579ce2a3f0f8ce4fe"
-    sha256               arm64_linux:   "1aa15f14db12fdc770942a1ac450378407f516325e0ac21e1f533f48ddcf5456"
-    sha256               x86_64_linux:  "a93d1eacfec60583dceb4b48d8aa98c9e6d3fd28ff701cd31457830776cb6459"
+    sha256               arm64_tahoe:   "0ff98843bdf59e26cfe7c32fba419ad94e293d04fc327064e7070848eddd4d91"
+    sha256               arm64_sequoia: "f831d29c24e5f96b5a06ac37deb1cab56850656dbc09da0e8d1534cb497e47d3"
+    sha256               arm64_sonoma:  "2f45230e29fee9676e4a3f945b2d11871f5e3a63acad8de189cbd72bc97aa072"
+    sha256 cellar: :any, sonoma:        "501b6d1fe876b8c25129671538b66be34c0b998d6b68bce6d673ed41a7915e15"
+    sha256               arm64_linux:   "ff3a3ea88a8335bc8910f810ce183fb88fb611222ee03092e0f5309b35f9fd07"
+    sha256               x86_64_linux:  "5fc074ab939efde3b808b71c0a3ec8911b99d75b813caa914f50427ca8808b63"
   end
 
   depends_on "docutils" => :build

--- a/Formula/m/mpv.rb
+++ b/Formula/m/mpv.rb
@@ -4,6 +4,7 @@ class Mpv < Formula
   url "https://github.com/mpv-player/mpv/archive/refs/tags/v0.41.0.tar.gz"
   sha256 "ee21092a5ee427353392360929dc64645c54479aefdb5babc5cfbb5fad626209"
   license :cannot_represent
+  revision 1
   head "https://github.com/mpv-player/mpv.git", branch: "master"
 
   bottle do
@@ -21,7 +22,7 @@ class Mpv < Formula
   depends_on "ninja" => :build
   depends_on "pkgconf" => [:build, :test]
   depends_on xcode: :build
-  depends_on "ffmpeg-full"
+  depends_on "ffmpeg"
   depends_on "jpeg-turbo"
   depends_on "libarchive"
   depends_on "libass"
@@ -120,7 +121,6 @@ class Mpv < Formula
     assert_match "vapoursynth", shell_output("#{bin}/mpv --vf=help")
 
     # Make sure `pkgconf` can parse `mpv.pc` after the `inreplace`.
-    ENV.append_path "PKG_CONFIG_PATH", Formula["ffmpeg-full"].opt_lib/"pkgconfig"
     system "pkgconf", "--print-errors", "mpv"
   end
 end


### PR DESCRIPTION
See conversation on https://github.com/Homebrew/homebrew-core/pull/263348.

This change has disappointed as many people as it's made happy, it seems, so let's revert https://github.com/Homebrew/homebrew-core/pull/263348 and the same change for `auto-editor` before this spreads everywhere.

We should provide `*-full` formulae and we should never depend on them (`rubocop` incoming in https://github.com/Homebrew/brew/pull/21471)

It is (relatively) easy to maintain a (`*-full` perhaps) version of a formula that depends on e.g. `ffmpeg-full` in a tap. It is much harder for people who wish to avoid `ffmpeg-full` to do so we end up making random other formulae depend on it.

As we have done elsewhere and with options in the distant past: we should make the formulae in Homebrew rely on what their dependents in Homebrew _need_ rather than the maximal version. This helps to avoid the perception and the reality of Homebrew being "slow" by installing far more packages than users need.
