### PR TITLE
gromacs fftw: build with libomp on macOS

### DIFF
--- a/Formula/f/fftw.rb
+++ b/Formula/f/fftw.rb
@@ -12,15 +12,12 @@ class Fftw < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_tahoe:   "fd117eeb3d95627adacba7ac0acf898f85d0fb1abbcc9b2d3a4dd60e40de0d11"
-    sha256 cellar: :any,                 arm64_sequoia: "f6a6799b0982ed9e7941d8e98061fd286a5062971d9b8d24ea5dbf31b16e01fe"
-    sha256 cellar: :any,                 arm64_sonoma:  "e10f62334e9400d2206f97f27341f40a6a00313b3ba0841273719a378da72e92"
-    sha256 cellar: :any,                 arm64_ventura: "7a199712be0d1f3f939bd6b87713bce221a971a478490be5f0b9ab7957fcdcf7"
-    sha256 cellar: :any,                 sonoma:        "9da96486f698487496f226fac865a83be03898621e336030c9af62ff2330eff5"
-    sha256 cellar: :any,                 ventura:       "51f48b1e29b2fdea49be26e90a65644ed6983839d565b0b071a9ac12f1cc2d6a"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "05293e1ec5bbf794d245cb750566afe30bab65fbcae78b6201b109832a19691b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5508eb65401d0b5df3c9e8ebe3e8474a4d5b91e10e03132e4f5032008926fdcf"
+    sha256 cellar: :any,                 arm64_tahoe:   "5cd394c2c385450a83f767935d5d6678aa5a8fb1eb6c687b26477370a881cb5f"
+    sha256 cellar: :any,                 arm64_sequoia: "09266ec049017eb0e54ee29249d66e44bde84081f7379a683acaba378c2834e8"
+    sha256 cellar: :any,                 arm64_sonoma:  "fffda09169aeed7f83343d88e8d7abe0f33c436fa3aa34a18c59093009aba067"
+    sha256 cellar: :any,                 sonoma:        "01d05e976e388312e41888856168f914c0c0e0fd4fd628cdc4159dbb25a614db"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "0518314dfcdfbc7926812980da07121706708ffda83cf0f600df909945d4a4f5"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "062535068e14404ec86b816c0c1987d9d90213d05c27cfaaa9767c22c7c8b636"
   end
 
   depends_on "open-mpi"

--- a/Formula/g/gromacs.rb
+++ b/Formula/g/gromacs.rb
@@ -12,12 +12,12 @@ class Gromacs < Formula
   end
 
   bottle do
-    sha256                               arm64_tahoe:   "769850bfcb2c206941c31109107d6651f2627ad86b301ad473a3b33f0e12f5ac"
-    sha256                               arm64_sequoia: "c269bcf77c61b27fe58bd21bbdd54f824d0b10dfcd100e49b57e898d3018e486"
-    sha256                               arm64_sonoma:  "0c23078e1b96847eff00223efb758e3ed1c86f7bb87c869e45a748b35930c051"
-    sha256                               sonoma:        "d688d04c13f506fc22724aec6e59aab1c4cb83b184dc12e28d897ecc9b4e1383"
-    sha256                               arm64_linux:   "3724609388020fd8775179ada2bee950bbcd7a5ba2328c86bc05284cd56ec95a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "bbe6d9f3474b7001ac8e567bec80328dbd19ffe9adafb063208bd4cccfb4dc94"
+    sha256                               arm64_tahoe:   "785f5b5ddef0da296239ad358d8a168a0dd770d5c4ce69c320279db5973e0225"
+    sha256                               arm64_sequoia: "0b2e8c932507739b0473fbdaf4ce0362d98e212dd66c09f6c6a08ff866a8bfef"
+    sha256                               arm64_sonoma:  "bc1c5f92f0b19e63feede5752e31dff510e1cfd2cc1c2027acd840b797313b06"
+    sha256                               sonoma:        "3f365cbc801bf9f5706aad95bc827bf6017353f583bbff72e21df544928d2cbb"
+    sha256                               arm64_linux:   "d0902f4b969478ca8d1ef49de8ea5997775b40498d12338e5f40e3a32457dfaa"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2b0e06bc9c5b70b78aef5cdc5dbef9a88b70d64efdcea0a7d840cb211cc175b8"
   end
 
   depends_on "cmake" => :build

--- a/Formula/g/gromacs.rb
+++ b/Formula/g/gromacs.rb
@@ -4,6 +4,7 @@ class Gromacs < Formula
   url "https://ftp.gromacs.org/pub/gromacs/gromacs-2026.0.tar.gz"
   sha256 "229726f436cc515bfd8c4aa7af3a97b18072f71b5ebd0b08daf6565571e2d9eb"
   license "LGPL-2.1-or-later"
+  revision 1
 
   livecheck do
     url "https://ftp.gromacs.org/pub/gromacs/"
@@ -22,21 +23,15 @@ class Gromacs < Formula
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
   depends_on "fftw"
-  depends_on "gcc" # for OpenMP
   depends_on "lmfit"
+  depends_on "muparser"
   depends_on "openblas"
 
   uses_from_macos "zlib"
 
   on_macos do
-    conflicts_with "muparser", because: "gromacs ships its own copy of muparser"
+    depends_on "libomp"
   end
-
-  on_linux do
-    depends_on "muparser"
-  end
-
-  fails_with :clang
 
   def install
     # Non-executable GMXRC files should be installed in DATADIR
@@ -44,9 +39,9 @@ class Gromacs < Formula
                                         "CMAKE_INSTALL_DATADIR"
 
     # Avoid superenv shim reference
-    gcc = Formula["gcc"]
-    cc = gcc.opt_bin/"gcc-#{gcc.any_installed_version.major}"
-    cxx = gcc.opt_bin/"g++-#{gcc.any_installed_version.major}"
+    cc = DevelopmentTools.locate(ENV.cc)
+    cxx = DevelopmentTools.locate(ENV.cxx)
+
     inreplace "src/gromacs/gromacs-hints.in.cmake" do |s|
       s.gsub! "@CMAKE_LINKER@", "/usr/bin/ld"
       s.gsub! "@CMAKE_C_COMPILER@", cc
@@ -69,20 +64,13 @@ class Gromacs < Formula
     end
 
     args = %W[
-      -DGROMACS_CXX_COMPILER=#{cxx}
       -DGMX_VERSION_STRING_OF_FORK=#{tap.user}
       -DGMX_INSTALL_LEGACY_API=ON
       -DGMX_EXTERNAL_ZLIB=ON
       -DGMX_USE_LMFIT=EXTERNAL
+      -DGMX_USE_MUPARSER=EXTERNAL
       -DGMX_SIMD=#{gmx_simd}
     ]
-    args << if OS.mac?
-      # Use bundled `muparser` as brew formula is linked to libc++ on macOS but we need libstdc++.
-      # TODO: Try switching `gromacs` and its dependency tree to use Apple Clang + `libomp`
-      "-DFETCHCONTENT_SOURCE_DIR_MUPARSER=#{buildpath}/src/external/muparser"
-    else
-      "-DGMX_USE_MUPARSER=EXTERNAL"
-    end
 
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args, *args
     system "cmake", "--build", "build"

--- a/Formula/m/muparser.rb
+++ b/Formula/m/muparser.rb
@@ -8,14 +8,13 @@ class Muparser < Formula
   head "https://github.com/beltoforion/muparser.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "cc39c1ae9eafc52f447f685e3441fb31f980efd0fb0345c969871c9cc8d807f2"
-    sha256 cellar: :any,                 arm64_sequoia: "11733a36d494bbd6ff343b30f8e0ed776660c41e5e1ea88ffedc9eedadca2ce7"
-    sha256 cellar: :any,                 arm64_sonoma:  "b1b39c12aa16a0a6fd45b232594448b7c180a16f182246d9cf7e884a019be577"
-    sha256 cellar: :any,                 arm64_ventura: "c8f1479dae9c99b52c1e0efa102eeb876c5e721741fd805963e4f1694eba772c"
-    sha256 cellar: :any,                 sonoma:        "316542316198bbd354327695a2b3a1e8094e0f05b8f314c0cb3470e8d45c527e"
-    sha256 cellar: :any,                 ventura:       "d6854bf7ee7a512856309611cbbe6ae0aa5da588c6a886c70499779f34397dc0"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "ba22f437decb80c8ed700338c1213c2a19e4e260122acfe1732f1ca54f836ec4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "aff0ff2ecd2d9717123b66a7d8cb5ac087519a198085e14c22ce5ed682c2fe19"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "23a51e97ef3d4ff02c8d8d6fb5dd53b142e89899927a9204eb4dd0018d21afe5"
+    sha256 cellar: :any,                 arm64_sequoia: "533245424ca9045f9e246b1c2092466b11b26fb13545b19d82469c8fd36eb2c6"
+    sha256 cellar: :any,                 arm64_sonoma:  "6e95b519ddaac7419352a19803d374262d8edf9780e942b287046be0e2e5c9c5"
+    sha256 cellar: :any,                 sonoma:        "62577464227b08a4c38a09c93f7438e21c55cd3438fdf67f227ee6bc5c2a51ee"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "d9b39ed5b616e3f67f8429a33ed9c42b3f404c74881c4718e4f12444153611ca"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "9e7935fbf6a0c3698082df30fb1b5e7140e45c9b98d16377810efd80585691d5"
   end
 
   depends_on "cmake" => :build

--- a/Formula/m/muparser.rb
+++ b/Formula/m/muparser.rb
@@ -22,12 +22,11 @@ class Muparser < Formula
 
   on_macos do
     depends_on "libomp"
-    conflicts_with "gromacs", because: "gromacs ships its own copy of muparser"
   end
 
-  def install
-    ENV.cxx11 if OS.linux?
+  link_overwrite "lib/libmuparser.dylib", "lib/libmuparser.2.dylib"
 
+  def install
     system "cmake", "-S", ".", "-B", "build", "-DENABLE_OPENMP=ON", *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"

--- a/Formula/v/votca.rb
+++ b/Formula/v/votca.rb
@@ -7,12 +7,13 @@ class Votca < Formula
   revision 3
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "067055a10061071812d04bda29a0730da6e743fa6a9ec932ce18b4e4af5e9e57"
-    sha256 cellar: :any,                 arm64_sequoia: "86797174e26f6397651832504cb2ab99fda48280306843842f42afe455e94376"
-    sha256 cellar: :any,                 arm64_sonoma:  "b0580e45b89242251411af42e05d1bd95b59ac2c13d93e5febe0bccb36de51a5"
-    sha256 cellar: :any,                 sonoma:        "ead1dce31be6f1f57e960091c5dd09abbea1b792f158f2d8bf3a6ddeed2e26a2"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "04b5af079dcacba0b47bfdad2b1ffb470f44a367fcb64040e087c6159f8a22c2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d0f1100d6640b0dd64ed6479fd8a19338dd179f299af5e808ed39e873d1e39fe"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "ebedfd7a8f4a4a958f45c48b33f78d03e6689f90b0a5d1ab604adf7cece29ac1"
+    sha256 cellar: :any,                 arm64_sequoia: "4a1ccb8ae3de07ee243281f08d476a76aeff2ba65c2d4eaa1efd3576c4214d91"
+    sha256 cellar: :any,                 arm64_sonoma:  "2a18f6145466daa3bed03fc6bfdec3b0930612342708cb14c3d1701681033dc9"
+    sha256 cellar: :any,                 sonoma:        "caec123f9f6ddad1fcbdfacfcbf5d7d284d61f0c7f52f727c51b626c6d93021b"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "6cf0d5b39648c54d4f6aca3f671d56d4f58e2f4a6ec62db9ad28ae6983c40b71"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f75816e6fe38c61a7b2647e1dcb40f856b39f92c12b0be29e33f20c7b0031fe2"
   end
 
   depends_on "cmake" => :build

--- a/Formula/v/votca.rb
+++ b/Formula/v/votca.rb
@@ -21,7 +21,7 @@ class Votca < Formula
   depends_on "boost"
   depends_on "eigen" => :no_linkage
   depends_on "fftw"
-  # add gromacs dep back once it was built with clang
+  depends_on "gromacs"
   depends_on "hdf5"
   depends_on "libecpint"
   depends_on "libint"
@@ -45,7 +45,6 @@ class Votca < Formula
       "-DINSTALL_RC_FILES=OFF",
       "-DINSTALL_CSGAPPS=ON",
       "-DBUILD_XTP=ON",
-      "-DCMAKE_DISABLE_FIND_PACKAGE_GROMACS=ON",
       "-DENABLE_RPATH_INJECT=ON",
       "-DPYrdkit_FOUND=OFF",
     ]


### PR DESCRIPTION
I was thinking over this again and may as well migrate subset of these formulae now.

Originally handling these with OpenBLAS PR (blocked) but we've been mixing OpenMP in stuff like `lammps`, `siril`, `synfig`, `votca` anyway. Given problem exists in current formulae, may as well start migrating everything to uniform OpenMP.

Will revisit OpenBLAS in a future PR.

---

This also changes following:
* `fftw` - updates build to consolidate steps to loop, adds --enable-armv8-cntvct-el0 on arm64 to avoid warning during configure (verified `make check` locally)
* `gromacs` - unbundles `muparser`
* `votca` - applies comment changes