### PR TITLE
dynare: use libomp on macOS, backport fix for suite-sparse detection

### DIFF
--- a/Formula/d/dynare.rb
+++ b/Formula/d/dynare.rb
@@ -20,12 +20,12 @@ class Dynare < Formula
   end
 
   bottle do
-    sha256 cellar: :any, arm64_tahoe:   "1bf69c806c2c1290531de6f8f0fcd71c410740c063f38376668104e6f6ad4eea"
-    sha256 cellar: :any, arm64_sequoia: "e39d637e33dc4d90102ce164f42f7e039c01ed2fb651ce99c8cba0defecea304"
-    sha256 cellar: :any, arm64_sonoma:  "2228a8d6fb4009ced166372f97cdf50de578bdca0ef9eb5a4e10f7c42098e5bc"
-    sha256 cellar: :any, sonoma:        "6d8285f8ce189ca8f7b79b8950e7384431ded27e1665b2b34dcfa4a7b3cd7ce3"
-    sha256               arm64_linux:   "ac3cde07a02a160d4487d727b8930f26105154c4bd590d7fec19f57fa104bf69"
-    sha256               x86_64_linux:  "59fe01949122963831745b16e44a75f4c2eb1b82c980cc7a1cc6436b3917a8ed"
+    sha256 cellar: :any, arm64_tahoe:   "dc134e24cfec558ec656922f57084189483493291b2bf9642fef3c48df043034"
+    sha256 cellar: :any, arm64_sequoia: "b52fa22efd2173dd73b63854ec2571d8c6241ad72dfbee53492a01c8c7102790"
+    sha256 cellar: :any, arm64_sonoma:  "2b00d6af8fa2389af4abb060745d8b4743e13e3d5860e16a5811b2a5d0f94e9d"
+    sha256 cellar: :any, sonoma:        "8d4ebac67c8efa3dde83d3d5e5102c3dbdce67732acd9167d527a0d77d70b78f"
+    sha256               arm64_linux:   "27d50a92a985e9c5aa32575fd8b05509e17aaed6f90af582bdcb50a12704a343"
+    sha256               x86_64_linux:  "7e7fc5e2c8e7009c16d6660020343495d96c050b3e8e80e5a978acfa7cf4cb8c"
   end
 
   depends_on "bison" => :build

--- a/Formula/d/dynare.rb
+++ b/Formula/d/dynare.rb
@@ -1,11 +1,18 @@
 class Dynare < Formula
   desc "Platform for economic models, particularly DSGE and OLG models"
   homepage "https://www.dynare.org/"
-  url "https://www.dynare.org/release/source/dynare-6.5.tar.xz"
-  sha256 "56a6f934f5d2ded57206d2f109975324b39586394f4e8ce23b3c72aadcd5cd4a"
   license "GPL-3.0-or-later"
-  revision 1
+  revision 2
   head "https://git.dynare.org/Dynare/dynare.git", branch: "master"
+
+  stable do
+    url "https://www.dynare.org/release/source/dynare-6.5.tar.xz"
+    sha256 "56a6f934f5d2ded57206d2f109975324b39586394f4e8ce23b3c72aadcd5cd4a"
+
+    # backport fix for finding suite-sparse
+    # https://git.dynare.org/Dynare/dynare/-/commit/b3a50696bf7b8ef97cd8900c4941b479fd27dd2e
+    patch :DATA
+  end
 
   livecheck do
     url "https://www.dynare.org/download/"
@@ -36,21 +43,34 @@ class Dynare < Formula
   depends_on "slicot"
   depends_on "suite-sparse"
 
+  on_macos do
+    depends_on "llvm" => :build if DevelopmentTools.clang_build_version <= 1699
+    depends_on "libomp"
+
+    # Work around LLVM issue with structured bindings[^1] by partly reverting commit[^2].
+    # Upstream isn't planning to support Clang build[^3] but we need it to use a consistent OpenMP.
+    # [^1]: https://github.com/llvm/llvm-project/issues/33025
+    # [^2]: https://git.dynare.org/Dynare/dynare/-/commit/6ff7d4c56c26a2b7546de633dbcfe2f163bf846d
+    # [^3]: https://git.dynare.org/Dynare/dynare/-/issues/1977
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/homebrew-core/c49717c390cb2e587793b2db757c1f445f096219/Patches/dynare/clang.diff"
+      sha256 "2d174336fc8db4d8989cda214a972ef49c6302bb12a64d717140869e546e17d0"
+    end
+  end
+
+  on_sequoia do
+    depends_on xcode: ["26.0", :build] # for std::jthreads
+  end
+
   fails_with :clang do
-    cause <<~EOS
-      GCC is the only compiler supported by upstream
-      https://git.dynare.org/Dynare/dynare/-/blob/master/README.md#general-instructions
-    EOS
+    build 1699
+    cause "needs C++20 std::jthreads"
   end
 
   def install
     # This needs a bit of extra help in finding the Octave libraries on Linux.
     octave = Formula["octave"]
     ENV.append "LDFLAGS", "-Wl,-rpath,#{octave.opt_lib}/octave/#{octave.version.major_minor_patch}" if OS.linux?
-
-    # Help meson find `boost` and `suite-sparse`
-    ENV["BOOST_ROOT"] = Formula["boost"].opt_prefix
-    ENV.append_path "LIBRARY_PATH", Formula["suite-sparse"].opt_lib
 
     system "meson", "setup", "build", "-Dbuild_for=octave", *std_meson_args
     system "meson", "compile", "-C", "build", "--verbose"
@@ -92,3 +112,50 @@ class Dynare < Formula
            "--no-history", "--path", "#{lib}/dynare/matlab", "dyn_test.m"
   end
 end
+
+__END__
+diff --git a/meson.build b/meson.build
+index 435293bae021218d63aaf5c88e7ef8d9ad0a3762..7256ff96ff5693423099ae0e4d8143ceb7266194 100644
+--- a/meson.build
++++ b/meson.build
+@@ -260,21 +260,9 @@ else # Octave build
+   lapack_dep = declare_dependency(link_args : run_command(mkoctfile_exe, '-p', 'LAPACK_LIBS', check : true).stdout().split(),
+                                   dependencies : blas_dep)
+ 
+-  # Create a dependency object for UMFPACK.
+-  # The dependency returned by find_library('umfpack') is not enough, because we also want the define
+-  # that indicates the location of umfpack.h, so we construct a new dependency object.
+-  if cpp_compiler.has_header('suitesparse/umfpack.h', args : octave_incflags)
+-    umfpack_def = '-DHAVE_SUITESPARSE_UMFPACK_H'
+-  elif cpp_compiler.has_header('umfpack.h', args : octave_incflags)
+-    umfpack_def = '-DHAVE_UMFPACK_H'
+-  else
+-    error('Can’t find umfpack.h')
+-  endif
+   # Do not enforce static linking even if prefer_static is true, since that library is shipped
+   # with Octave.
+-  # The “dirs” argument is useful when cross-compiling.
+-  umfpack_dep_tmp = cpp_compiler.find_library('umfpack', dirs : octlibdir / '../..', static : false)
+-  umfpack_dep = declare_dependency(compile_args : umfpack_def, dependencies : [ umfpack_dep_tmp, blas_dep ])
++  umfpack_dep = dependency('UMFPACK', static : false)
+ 
+   # This library does not exist under Octave
+   ut_dep = []
+diff --git a/mex/sources/dynumfpack.h b/mex/sources/dynumfpack.h
+index ae3e11c94be51cbf9ee7249db80526712e55e469..c73fa5f8c0b1ab50b9e1b165719e27f1278f1ca8 100644
+--- a/mex/sources/dynumfpack.h
++++ b/mex/sources/dynumfpack.h
+@@ -25,12 +25,7 @@
+ #define DYNUMFPACK_H
+ 
+ #ifdef OCTAVE_MEX_FILE
+-# ifdef HAVE_SUITESPARSE_UMFPACK_H
+-#  include <suitesparse/umfpack.h>
+-# endif
+-# ifdef HAVE_UMFPACK_H
+-#  include <umfpack.h>
+-# endif
++# include <umfpack.h>
+ #else
+ 
+ /* Under MATLAB, we have to provide our own header file for functions in

--- a/Patches/dynare/clang.diff
+++ b/Patches/dynare/clang.diff
@@ -1,0 +1,30 @@
+diff --git a/mex/sources/local_state_space_iterations/local_state_space_iteration_2.cc b/mex/sources/local_state_space_iterations/local_state_space_iteration_2.cc
+index 5d0b0800b..97708e607 100644
+--- a/mex/sources/local_state_space_iterations/local_state_space_iteration_2.cc
++++ b/mex/sources/local_state_space_iterations/local_state_space_iteration_2.cc
+@@ -69,8 +69,10 @@ ss2Iteration_pruning(double* y2, double* y1, const double* yhat2, const double*
+   const double one = 1.0;
+   const blas_int ONE = 1;
+ #endif
+-  auto [ii1, ii2, ii3] = set_vector_of_indices(n, m); // vector indices for ghxx
+-  auto [jj1, jj2, jj3] = set_vector_of_indices(q, m); // vector indices for ghuu
++  std::vector<int> ii1, ii2, ii3;// vector indices for ghxx
++  std::tie(ii1, ii2, ii3) = set_vector_of_indices(n, m);
++  std::vector<int> jj1, jj2, jj3;// vector indices for ghuu
++  std::tie(jj1, jj2, jj3) = set_vector_of_indices(q, m);
+ #pragma omp parallel for num_threads(number_of_threads)
+   for (int particle = 0; particle < s; particle++)
+     {
+@@ -148,8 +150,10 @@ ss2Iteration(double* y, const double* yhat, const double* epsilon, const double*
+   const double one = 1.0;
+   const blas_int ONE = 1;
+ #endif
+-  auto [ii1, ii2, ii3] = set_vector_of_indices(n, m); // vector indices for ghxx
+-  auto [jj1, jj2, jj3] = set_vector_of_indices(q, m); // vector indices for ghuu
++  std::vector<int> ii1, ii2, ii3;// vector indices for ghxx
++  std::tie(ii1, ii2, ii3) = set_vector_of_indices(n, m);
++  std::vector<int> jj1, jj2, jj3;// vector indices for ghuu
++  std::tie(jj1, jj2, jj3) = set_vector_of_indices(q, m);
+ #pragma omp parallel for num_threads(number_of_threads)
+   for (int particle = 0; particle < s; particle++)
+     {


### PR DESCRIPTION
Dynare was already mixing OpenMP (i.e. suite-spare uses libomp) so may as well switch to libomp now and as we align dependency tree. 

Also avoids mixing compilers given Octave uses Clang on macOS. Reduces chances of C++ implementation issues.