### PR TITLE
node: fix npm completion for Zsh

### DIFF
--- a/Formula/n/node.rb
+++ b/Formula/n/node.rb
@@ -187,9 +187,21 @@ class Node < Formula
     ln_s libexec/"lib/node_modules/npm/bin/npm-cli.js", bin/"npm"
     ln_s libexec/"lib/node_modules/npm/bin/npx-cli.js", bin/"npx"
 
+    # TODO: check if Bash completion needs a similar patch
     generate_completions_from_executable(bin/"npm", "completion",
                                          shells:                 [:bash, :zsh],
                                          shell_parameter_format: :none)
+
+    # Patch generated zsh completion as it's for explicit sourcing, e.g.
+    # `source <(npm completion)`. This difference is missing from the
+    # npm v11 doc, see https://github.com/npm/cli/issues/4620.
+    inreplace zsh_completion/"_npm", /\A/, "#compdef npm\n"
+    (zsh_completion/"_npm").append_lines <<~EOF
+
+      if [ "$funcstack[1]" = "_npm" ]; then
+        _npm_completion "$@"
+      fi
+    EOF
   end
 
   def post_install


### PR DESCRIPTION
The completion generated by `npm completion` is for explicit sourcing.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

I manually checked that
- The suggested changes to `zsh_completion/"_npm"` works for me locally.
  1. Apply proposed patch to `/usr/local/share/zsh/site-functions/_npm`
  2. Run `rm ~/.zcompdump*` to clear completion cache
  3. Reopen shell
  4. Type `npm <tab>` and check that the completion works
- Saving the modified `node.rb` to a local Tap, `git add . && brew lgtm` passes.
- Similar usages are found in other core formulae.

Bash completions for other commands installed via Homebrew never work for me, so `npm`'s Bash completion is left as-is.

5607d0a (awscli: fix zsh compdef wrapper and remove windows file, 2017-09-28) fixed the similar issue differently:
- first save the shell script to be sourced in `zsh_completion` directory,
- then make a wrapper `zsh_completion/"_aws"` to actually source that shell script.