### PR TITLE
gnunet: make `gettext` runtime dependency macOS-only

### DIFF
--- a/Formula/g/gnunet.rb
+++ b/Formula/g/gnunet.rb
@@ -15,10 +15,10 @@ class Gnunet < Formula
     sha256               x86_64_linux:  "7bd8dec99aad1a7e10c9a88935715f929819d59c5ec3955216400d1dfa52cd5c"
   end
 
+  depends_on "gettext" => :build
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkgconf" => :build
-  depends_on "gettext"
   depends_on "gmp"
   depends_on "gnutls"
   depends_on "jansson"
@@ -35,6 +35,7 @@ class Gnunet < Formula
   uses_from_macos "zlib"
 
   on_macos do
+    depends_on "gettext"
     depends_on "libgpg-error"
   end
 
@@ -49,11 +50,11 @@ class Gnunet < Formula
   end
 
   test do
-    (testpath/"gnunet.conf").write <<~EOS
+    (testpath/"gnunet.conf").write <<~INI
       [arm]
       START_DAEMON = YES
       START_SERVICES = "dns,hostlist,ats"
-    EOS
+    INI
 
     system bin/"gnunet-arm", "-c", "gnunet.conf", "-s"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
