### PR TITLE
go-parquet-tools: set build metadata to fit refactored code

### DIFF
--- a/Formula/g/go-parquet-tools.rb
+++ b/Formula/g/go-parquet-tools.rb
@@ -7,12 +7,13 @@ class GoParquetTools < Formula
   head "https://github.com/hangxie/parquet-tools.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "a2753a23acfe3a28f4e6f7edde9acd666340342eba50dfbb0696c0f11c8cf0ca"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "a2753a23acfe3a28f4e6f7edde9acd666340342eba50dfbb0696c0f11c8cf0ca"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "a2753a23acfe3a28f4e6f7edde9acd666340342eba50dfbb0696c0f11c8cf0ca"
-    sha256 cellar: :any_skip_relocation, sonoma:        "afe966978613d1886c097f91e87c89a95d5cb76a1a4ed474ea7624794b9e58cc"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "8468421a0f87cdab5e63e35922aee53639e99ee32655df116913f42380cf36fb"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "105f1f37c23ed971b06385dea08dde0ac694c584ab3bb823c13504fca7dddaed"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "17e50f3e2d443af52e1fe9483a1074d1f24907ab0d6870018039116d3b78a68e"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "17e50f3e2d443af52e1fe9483a1074d1f24907ab0d6870018039116d3b78a68e"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "17e50f3e2d443af52e1fe9483a1074d1f24907ab0d6870018039116d3b78a68e"
+    sha256 cellar: :any_skip_relocation, sonoma:        "5312a5febc3125f3f07df992cdacaf39fbdbb29f574547e1beb48776380b2a86"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "b487b0f338c7bcc9a63d31f5b80a198332f90f3ba25572ae94cd9d0cbdfae2d7"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a99d5ad5134609599e4959c71eeb9c5d2d837cbbb97ba5aae54fc3ba95bab070"
   end
 
   depends_on "go" => :build

--- a/Formula/g/go-parquet-tools.rb
+++ b/Formula/g/go-parquet-tools.rb
@@ -20,14 +20,16 @@ class GoParquetTools < Formula
   def install
     ldflags = %W[
       -s -w
-      -X github.com/hangxie/parquet-tools/cmd.version=v#{version}
-      -X github.com/hangxie/parquet-tools/cmd.build=#{time.iso8601}
-      -X github.com/hangxie/parquet-tools/cmd.source=#{tap.user}
+      -X github.com/hangxie/parquet-tools/cmd/version.version=v#{version}
+      -X github.com/hangxie/parquet-tools/cmd/version.build=#{time.iso8601}
+      -X github.com/hangxie/parquet-tools/cmd/version.source=#{tap.user}
     ]
     system "go", "build", *std_go_args(ldflags:, output: bin/"parquet-tools")
   end
 
   test do
+    assert_match version.to_s, shell_output("#{bin}/parquet-tools version")
+
     resource("test-parquet") do
       url "https://github.com/hangxie/parquet-tools/raw/950d21759ff3bd398d2432d10243e1bace3502c5/testdata/good.parquet"
       sha256 "daf5090fbc5523cf06df8896cf298dd5e53c058457e34766407cb6bff7522ba5"


### PR DESCRIPTION
Source repo layout was changed so the build command needs to be changed accordingly to take build variables.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
