### PR TITLE
fftw: make `open-mpi` build-only to reduce dependency tree

### DIFF
--- a/Formula/f/fftw.rb
+++ b/Formula/f/fftw.rb
@@ -20,7 +20,7 @@ class Fftw < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "062535068e14404ec86b816c0c1987d9d90213d05c27cfaaa9767c22c7c8b636"
   end
 
-  depends_on "open-mpi"
+  depends_on "open-mpi" => :build
 
   on_macos do
     depends_on "libomp"


### PR DESCRIPTION
Dependents that use the FFTW MPI library will already have an `open-mpi` dependency so this dependency mainly propagates `open-mpi` to formulae that don't use MPI.

---

There doesn't seem to be linkage so this is easiest option to minimize dependency tree.

The alternative I was looking at is splitting out the MPI library to separate formula (e.g. `fftw-mpi`), but this requires patches and increases maintenance burden.