### PR TITLE
qtmultimedia: recipe fixes

### DIFF
--- a/Formula/q/qtmultimedia.rb
+++ b/Formula/q/qtmultimedia.rb
@@ -63,6 +63,13 @@ class Qtmultimedia < Formula
     args = ["-DCMAKE_STAGING_PREFIX=#{prefix}"]
     args << "-DQT_NO_APPLE_SDK_AND_XCODE_CHECK=ON" if OS.mac?
 
+    if OS.mac?
+      args << "-DQT_NO_APPLE_SDK_AND_XCODE_CHECK=ON"
+
+      # Qt uses deprecated macOS SDK APIs that have been removed in macOS 15 (QTBUG-136989)
+      args << "-DCMAKE_OSX_DEPLOYMENT_TARGET=14.0" if MacOS.version >= :sequoia
+    end
+
     system "cmake", "-S", ".", "-B", "build", "-G", "Ninja",
                     *args, *std_cmake_args(install_prefix: HOMEBREW_PREFIX, find_framework: "FIRST")
     system "cmake", "--build", "build"

--- a/Formula/q/qtmultimedia.rb
+++ b/Formula/q/qtmultimedia.rb
@@ -55,6 +55,7 @@ class Qtmultimedia < Formula
     depends_on "libxext"
     depends_on "libxrandr"
     depends_on "mesa"
+    depends_on "pipewire"
     depends_on "pulseaudio"
   end
 

--- a/Formula/q/qtmultimedia.rb
+++ b/Formula/q/qtmultimedia.rb
@@ -11,7 +11,7 @@ class Qtmultimedia < Formula
     "Apache-2.0",   # bundled resonance-audio
     "BSD-3-Clause", # bundled pffft; *.cmake
     "GPL-3.0-only", # Qt6MultimediaTestLib
-    "MIT",          # bundled signalsmith-stretch (Linux)
+    "MIT",          # bundled signalsmith-stretch
   ]
   head "https://code.qt.io/qt/qtmultimedia.git", branch: "dev"
 
@@ -34,6 +34,7 @@ class Qtmultimedia < Formula
   depends_on "vulkan-headers" => :build
   depends_on "pkgconf" => :test
 
+  depends_on "ffmpeg"
   depends_on macos: :ventura
   depends_on "qtbase"
   depends_on "qtdeclarative"
@@ -48,7 +49,6 @@ class Qtmultimedia < Formula
   end
 
   on_linux do
-    depends_on "ffmpeg"
     depends_on "glib"
     depends_on "gstreamer"
     depends_on "libx11"
@@ -60,10 +60,7 @@ class Qtmultimedia < Formula
 
   def install
     args = ["-DCMAKE_STAGING_PREFIX=#{prefix}"]
-    if OS.mac?
-      args << "-DQT_FEATURE_ffmpeg=OFF"
-      args << "-DQT_NO_APPLE_SDK_AND_XCODE_CHECK=ON"
-    end
+    args << "-DQT_NO_APPLE_SDK_AND_XCODE_CHECK=ON" if OS.mac?
 
     system "cmake", "-S", ".", "-B", "build", "-G", "Ninja",
                     *args, *std_cmake_args(install_prefix: HOMEBREW_PREFIX, find_framework: "FIRST")


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

i'm still in the process of setting up a homebrew build environment locally. This is part of the push to bring binary distributions of QtMultimedia in line with the recommended build configurations