### PR TITLE
libsepol: remove macOS-specific args

### DIFF
--- a/Formula/lib/libsepol.rb
+++ b/Formula/lib/libsepol.rb
@@ -29,20 +29,7 @@ class Libsepol < Formula
   end
 
   def install
-    args = %W[
-      PREFIX=#{prefix}
-      SHLIBDIR=#{lib}
-    ]
-
-    # Submitted to upstream mailing list at https://lore.kernel.org/selinux/20250912132911.63623-1-calebcenter@live.com/T/#u
-    if OS.mac?
-      args += %w[
-        TARGET=libsepol.dylib
-        LIBSO=libsepol.$(LIBVERSION).dylib
-      ]
-    end
-
-    system "make", "install", *args
+    system "make", "install", "PREFIX=#{prefix}", "SHLIBDIR=#{lib}"
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Corresponding changes were already included in the 3.10 release via https://github.com/SELinuxProject/selinux/commit/d69b0e13c40fdbead47db61b522f1d5a656a99d4.