### PR TITLE
qtmultimedia: set deployment target to 14.0

### DIFF
--- a/Formula/q/qtmultimedia.rb
+++ b/Formula/q/qtmultimedia.rb
@@ -62,7 +62,9 @@ class Qtmultimedia < Formula
     args = ["-DCMAKE_STAGING_PREFIX=#{prefix}"]
     if OS.mac?
       args << "-DQT_FEATURE_ffmpeg=OFF"
-      args << "-DQT_NO_APPLE_SDK_AND_XCODE_CHECK=ON"
+
+      # Qt uses deprecated macOS SDK APIs that have been removed in macOS 15 (QTBUG-136989)
+      args << "-DCMAKE_OSX_DEPLOYMENT_TARGET=14.0" if MacOS.version >= :sequoia
     end
 
     system "cmake", "-S", ".", "-B", "build", "-G", "Ninja",


### PR DESCRIPTION
As a workaround for QTBUG-136989, we need to set a minimum deployment target of 14.0, otherwise we will have a compile error.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?

-----

broken out of #265441