### PR TITLE
gromacs: add GMX_USE_RDTSCP=OFF for more compatibility

### DIFF
--- a/Formula/g/gromacs.rb
+++ b/Formula/g/gromacs.rb
@@ -12,13 +12,12 @@ class Gromacs < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256                               arm64_tahoe:   "416fb4578d2f6dd801674f76017cd0f04230cb99af6547f34749297eb4c4adbf"
-    sha256                               arm64_sequoia: "00ed7dc686a83c6ef1136d2d4546023a8322bcfd8f4b87d036c71c9ed89a3c7e"
-    sha256                               arm64_sonoma:  "bbe7052b9d5e56d0a71c9c71d0c834fb7138f95eb695d5f3aa63a5ad7865108d"
-    sha256                               sonoma:        "528825ebe6e5b5923e67f4c14df053932fd40cbcf259a767e96a5ad1aa2f8945"
-    sha256                               arm64_linux:   "e81669bc46f0c677bf3f45714031a92aa29b7acaa0836d433015c149dd92e332"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e30b8041b642f69ddcf978325c108dfd276d3bfabc673849cf9dbacdb4b88d54"
+    sha256                               arm64_tahoe:   "57452e0f118659212779bc6894ccb2118ba734e85ba28200e3c5047987517362"
+    sha256                               arm64_sequoia: "f06af4fb2423904a89b34dd170dc5caf7e9f1b657894086cebbc580e6ada6ba8"
+    sha256                               arm64_sonoma:  "89d5d37ab5e8c05467768d9e0200f2846f74ee74b19832591dcd03fd8bc3ad55"
+    sha256                               sonoma:        "5f746ad229917637e50096f9d2707248f44821dd37e3b3a555671d1b75922987"
+    sha256                               arm64_linux:   "d6c0ad55ec35e7795269bac6ea259d12fc4daca851482d8168d2c75abb3f76b6"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8f0256f9b880711ebb297ff85b8d283d4862ae7f73eb95130d46dc501fa5b562"
   end
 
   depends_on "cmake" => :build

--- a/Formula/g/gromacs.rb
+++ b/Formula/g/gromacs.rb
@@ -4,7 +4,7 @@ class Gromacs < Formula
   url "https://ftp.gromacs.org/pub/gromacs/gromacs-2026.0.tar.gz"
   sha256 "229726f436cc515bfd8c4aa7af3a97b18072f71b5ebd0b08daf6565571e2d9eb"
   license "LGPL-2.1-or-later"
-  revision 1
+  revision 2
 
   livecheck do
     url "https://ftp.gromacs.org/pub/gromacs/"
@@ -73,6 +73,7 @@ class Gromacs < Formula
       -DGMX_USE_LMFIT=EXTERNAL
       -DGMX_USE_MUPARSER=EXTERNAL
       -DGMX_SIMD=#{gmx_simd}
+      -DGMX_USE_RDTSCP=OFF
     ]
 
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args, *args


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
See https://github.com/votca/votca/pull/1207#issuecomment-3842099963