### PR TITLE
formulae: use macOS `bc-gh`

### DIFF
--- a/Formula/a/ansiweather.rb
+++ b/Formula/a/ansiweather.rb
@@ -13,7 +13,7 @@ class Ansiweather < Formula
     sha256 cellar: :any_skip_relocation, all: "1d6a9dc83687c62774d4adb2da6302dac16f29a985a0eca62cb2a7fcc564a594"
   end
 
-  uses_from_macos "bc"
+  uses_from_macos "bc-gh"
   uses_from_macos "jq", since: :sequoia
 
   def install

--- a/Formula/b/bmake.rb
+++ b/Formula/b/bmake.rb
@@ -19,7 +19,7 @@ class Bmake < Formula
     sha256                               x86_64_linux:  "05ad36b4ab08784d9a3063c8dab2d705f8d36710a4a499ff87bdd05c7c3fe151"
   end
 
-  uses_from_macos "bc" => :build
+  uses_from_macos "bc-gh" => :build
 
   def install
     # -DWITHOUT_PROG_LINK means "don't symlink as bmake-VERSION."

--- a/Formula/f/funcoeszz.rb
+++ b/Formula/f/funcoeszz.rb
@@ -18,7 +18,7 @@ class Funcoeszz < Formula
   end
 
   depends_on "bash"
-  uses_from_macos "bc" => :test
+  uses_from_macos "bc-gh" => :test
 
   def install
     bin.install "funcoeszz-#{version}.sh" => "funcoeszz"

--- a/Formula/g/gifify.rb
+++ b/Formula/g/gifify.rb
@@ -16,7 +16,7 @@ class Gifify < Formula
   depends_on "ffmpeg"
   depends_on "imagemagick"
 
-  uses_from_macos "bc"
+  uses_from_macos "bc-gh"
 
   def install
     bin.install "gifify.sh" => "gifify"

--- a/Formula/l/lmod.rb
+++ b/Formula/l/lmod.rb
@@ -19,7 +19,7 @@ class Lmod < Formula
   depends_on "lua"
   depends_on "tcl-tk"
 
-  uses_from_macos "bc" => :build
+  uses_from_macos "bc-gh" => :build
   uses_from_macos "libxcrypt"
 
   on_macos do
@@ -59,6 +59,7 @@ class Lmod < Formula
     ENV["TCL_PKG_CONFIG_DIR"] = ENV["PKG_CONFIG_PATH"]
 
     system "./configure", "--with-siteControlPrefix=yes", "--prefix=#{prefix}"
+    ENV.deparallelize # Work around "install: mkdir .../share/man: File exists"
     system "make", "install"
 
     # Remove man page which conflicts with `modules` formula

--- a/Formula/n/nickle.rb
+++ b/Formula/n/nickle.rb
@@ -24,7 +24,7 @@ class Nickle < Formula
   depends_on "pkgconf" => :build
   depends_on "gmp"
 
-  uses_from_macos "bc" => :build
+  uses_from_macos "bc-gh" => :build
   uses_from_macos "bison" => :build
   uses_from_macos "flex" => :build
   uses_from_macos "libedit"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Will look into switch dependency to be more accurate (i.e. macOS has BSD-licensed bc-gh not GPL-licensed GNU bc). May follow up with replacing `provided_by_macos` with `shadowed_by_macos` for GNU `bc`.

Also GPL-3.0 is a common license that users may want to forbid so using more permissively licensed bc is nicer.