### PR TITLE
apr-util: remove `mawk` dependency

### DIFF
--- a/Formula/a/apr-util.rb
+++ b/Formula/a/apr-util.rb
@@ -34,17 +34,15 @@ class AprUtil < Formula
   uses_from_macos "sqlite"
 
   on_linux do
-    depends_on "mawk"
     depends_on "unixodbc"
   end
 
   def install
-    system "./configure", *std_configure_args,
-                          "--with-apr=#{Formula["apr"].opt_prefix}",
+    system "./configure", "--with-apr=#{Formula["apr"].opt_prefix}",
                           "--with-crypto",
                           "--with-openssl=#{Formula["openssl@3"].opt_prefix}",
-                          "--without-pgsql"
-
+                          "--without-pgsql",
+                          *std_configure_args
     system "make"
     system "make", "install"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

No `mawk` usage in source code. There is awk usage, but that isn't provided by `mawk` in Homebrew (I think Debian defaults to `mawk` and adds symlink via update-alternatives)