### PR TITLE
mad 0.16.4

### DIFF
--- a/Formula/m/mad.rb
+++ b/Formula/m/mad.rb
@@ -6,20 +6,12 @@ class Mad < Formula
   license "GPL-2.0-or-later"
 
   bottle do
-    rebuild 2
-    sha256 cellar: :any,                 arm64_tahoe:    "9a1152870f52ef9a390360849c4aad6882cd04e059283b4b24327cc487930fd9"
-    sha256 cellar: :any,                 arm64_sequoia:  "1facd8abee7e62bba7c7e445d2cbc5900dfe2dc7903be43a40b128c68f519b02"
-    sha256 cellar: :any,                 arm64_sonoma:   "ccc2d73926af48cbc320bbe9d029a8d7043c6a8b3375cecc5d9d031cee83b245"
-    sha256 cellar: :any,                 arm64_ventura:  "9d6ef63d6de6de6a1fecf34c3f5be58952ca778829c93df51e4ec491b97b0fa3"
-    sha256 cellar: :any,                 arm64_monterey: "e6a54111ab617580c360bfa07c8503cddf52b1df5bda2cd51da086e4e9470223"
-    sha256 cellar: :any,                 arm64_big_sur:  "ee9a37f6202a784c1564ac92613821e9bfd0f75fca8ef24262e444e5ec424ca6"
-    sha256 cellar: :any,                 sonoma:         "fd9ab67d8f1b77a62a47b0308eb0b9275f331162079de54b600f7226638c8145"
-    sha256 cellar: :any,                 ventura:        "435f04d35968bb228b0f9078190f5895d90d5a46db66d5731b02cf916b1014a3"
-    sha256 cellar: :any,                 monterey:       "912da077a9ff47e8e0b19ed160646c8a365e448b81786fbc2f64a2813c8d6b33"
-    sha256 cellar: :any,                 big_sur:        "0ad06329f73d5dc15cba262feca6e1c582e10ad3b9ca0476e46c37e6d878d0ab"
-    sha256 cellar: :any,                 catalina:       "5416172dc7ccd3c5a5065b3f7dc18c00e83a7e20dfc6b09e0586afc4a76c5722"
-    sha256 cellar: :any_skip_relocation, arm64_linux:    "668e0c8d4351150999731a1dd2072f503ac4fac27e6e215df78a795743535260"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "05670a88d2d0a50d03407a39987c573806c8bf9b7d67f2df4db3d121328123ae"
+    sha256 cellar: :any,                 arm64_tahoe:   "c2f1263d0123e856bc3b10b59ec49ce8533a75f8bf46c9829a19a482134a8b33"
+    sha256 cellar: :any,                 arm64_sequoia: "3f9a2384ea3a1c732897a5759b0a4c1dba5f3bc484e89288d7472f55ea1f7152"
+    sha256 cellar: :any,                 arm64_sonoma:  "a46ffe14f2184a90ca8e60d0b30978cd673e9f943c55e9554bea0e7646e1f4f3"
+    sha256 cellar: :any,                 sonoma:        "4e6025e114bad469457fd64a2710501afcdb3309c1d5c663cfccc90a9f7c37fb"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "6f504b4d003538ab8007b64bba565fee86f8610a7107bf682c6e72ebaea4f30f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a05120955044b8c9a997b7084b5a08f5d913e5a48f7575ea72d4ff07cd620fab"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
Fork of original project.

Similar situation to `libid3tag` which we switched to fork back in #91931
- both `mad` and `libid3tag` were from same SourceForge - https://sourceforge.net/projects/mad/files/
- both forks are owned by same team for Tenacity - https://tenacityaudio.org/

Current adoption at https://repology.org/project/libmad/versions is:
- Fedora switched a while back (~3 years ago)
- Debian has updated their repo with fork and moved it to sid.
- Others include FreeBSD and Vcpkg

Gentoo hasn't adopted it yet, but there is an open tracker for it: https://bugs.gentoo.org/810583