### PR TITLE
axel: update license exception, fix head build

### DIFF
--- a/Formula/a/axel.rb
+++ b/Formula/a/axel.rb
@@ -3,7 +3,7 @@ class Axel < Formula
   homepage "https://github.com/axel-download-accelerator/axel"
   url "https://github.com/axel-download-accelerator/axel/releases/download/v2.17.14/axel-2.17.14.tar.xz"
   sha256 "938ee7c8c478bf6fcc82359bbf9576f298033e8b13908e53e3ea9c45c1443693"
-  license "GPL-2.0-or-later" => { with: "openvpn-openssl-exception" }
+  license "GPL-2.0-or-later" => { with: "cryptsetup-OpenSSL-exception" }
 
   bottle do
     sha256 cellar: :any, arm64_tahoe:    "1f8ad603fc44127acc3b97b453360043ffa0610d63248035509a8b9c70d93fdc"
@@ -24,7 +24,6 @@ class Axel < Formula
     depends_on "autoconf" => :build
     depends_on "autoconf-archive" => :build
     depends_on "automake" => :build
-    depends_on "gawk" => :build
     depends_on "gettext" => :build
     depends_on "txt2man" => :build
   end
@@ -37,7 +36,10 @@ class Axel < Formula
   end
 
   def install
-    system "autoreconf", "--force", "--install", "--verbose" if build.head?
+    if build.head?
+      ENV.append_path "ACLOCAL_PATH", Formula["gettext"].pkgshare/"m4"
+      system "autoreconf", "--force", "--install", "--verbose"
+    end
     system "./configure", "--disable-silent-rules",
                           "--sysconfdir=#{etc}",
                           *std_configure_args


### PR DESCRIPTION
License exception is https://github.com/axel-download-accelerator/axel/blob/v2.17.14/src/axel.c#L23-L27

>   In addition, as a special exception, the copyright holders give
>   permission to link the code of portions of this program with the
>   OpenSSL library under certain conditions as described in each
>   individual source file, and distribute linked combinations including
>   the two.

Which matches https://spdx.org/licenses/cryptsetup-OpenSSL-exception.html

The previous https://spdx.org/licenses/openvpn-openssl-exception.html includes terms on "modified versions of OpenSSL" and other differences.