### PR TITLE
brag: deprecate

### DIFF
--- a/Formula/b/brag.rb
+++ b/Formula/b/brag.rb
@@ -12,6 +12,10 @@ class Brag < Formula
     sha256 cellar: :any_skip_relocation, all: "112ddb2485aa0730c63d109081ccf086ca5c83c0de724cb1914722f63e4ea8ad"
   end
 
+  # Last release on 2004-03-20, unlikely to get TCL 9 support and low installs
+  deprecate! date: "2026-02-04", because: :unmaintained
+  disable! date: "2027-02-04", because: :unmaintained
+
   depends_on "uudeview"
 
   on_linux do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Deprecating now to reduce our TCL 8 usage.

Brag has been inactive for over 20 years. Also (excluding Homebrew) only Debian-related distros still have it (https://repology.org/project/brag/versions)