### PR TITLE
bookokrat 0.3.0

### DIFF
--- a/Formula/b/bookokrat.rb
+++ b/Formula/b/bookokrat.rb
@@ -1,9 +1,9 @@
 class Bookokrat < Formula
   desc "Terminal EPUB Book Reader"
   homepage "https://bugzmanov.github.io/bookokrat/index.html"
-  url "https://github.com/bugzmanov/bookokrat/archive/refs/tags/v0.2.4.tar.gz"
-  sha256 "da68d99262eecd45219187cb5683bd90a7403206b842f910ff9b429fbf98cffb"
-  license "MIT"
+  url "https://github.com/bugzmanov/bookokrat/archive/refs/tags/v0.3.0.tar.gz"
+  sha256 "8b25e29b9ac5d9fba29b96e3ac733c4d0798dd0e7be8bb9826842fd34855b587"
+  license "AGPL-3.0-or-later"
   head "https://github.com/bugzmanov/bookokrat.git", branch: "main"
 
   bottle do
@@ -15,7 +15,14 @@ class Bookokrat < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "b1379eccb4b228e79774fd0306483bcaa2ef5092d67b649f793056e1449963eb"
   end
 
+  depends_on "pkgconf" => :build
   depends_on "rust" => :build
+
+  uses_from_macos "llvm" => :build
+
+  on_linux do
+    depends_on "fontconfig"
+  end
 
   def install
     system "cargo", "install", *std_cargo_args

--- a/Formula/b/bookokrat.rb
+++ b/Formula/b/bookokrat.rb
@@ -7,12 +7,12 @@ class Bookokrat < Formula
   head "https://github.com/bugzmanov/bookokrat.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "1a24a167728755f0a36296a13fa622a2927fe87883cd7d3f3247272b6546ff56"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "1cb5cd3d90bf132b240fe8f6bde8b0f9ce85a5c4842ace9456fd18918f3dd3ac"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "f360908027023e1d513100cf606d30f5ba88746f06638ca17dbaaec43ea1ac7d"
-    sha256 cellar: :any_skip_relocation, sonoma:        "751665b8423de2a0479b766e9fda01ed8b6ca7c2326d572acc9ab3bca1f12735"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "c8345c004217255d01de708ed819f061d54337410e25b417abf7bb9ccb777214"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b1379eccb4b228e79774fd0306483bcaa2ef5092d67b649f793056e1449963eb"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "53fc52bb66bfeaac1165c0468df257d658fb4999c646de5ff293da6babaec7a6"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "8107e9102e318936906e770c3e782b1a084024db5e152eee6020b4fcb5bedce4"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "c9c714447f5647ca1f4c6df59bc61732b0189b957b935fb2aecfc129fbc53739"
+    sha256 cellar: :any_skip_relocation, sonoma:        "41058ddfeff0945f8bd3564d0a9208dae0b30112437ab7659bfcfe74662415cc"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "178b939960fdb37ed5e4ea8dadda4a09303af67af066b54a955222cd74f48b96"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "db68803146e066862f027ff231c6138d8e526a71caab301a67bb4fd841433646"
   end
 
   depends_on "pkgconf" => :build


### PR DESCRIPTION
Add missing build/runtime deps needed for Linux CI with PDF support enabled by default.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI helped identify the minimal formula changes needed. I manually validated and run everything on macOS and in the Homebrew Ubuntu 22.04 Docker container

-----

Supersedes Homebrew/homebrew-core#265445.