### PR TITLE
cabal-install: avoid GHC runtime dependency

### DIFF
--- a/Formula/c/cabal-install.rb
+++ b/Formula/c/cabal-install.rb
@@ -29,7 +29,7 @@ class CabalInstall < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "ebe5f10854e5a41d1d2f515f83852605a215cdaf5e22113b5bcd8abbed9958c4"
   end
 
-  depends_on "ghc"
+  depends_on "ghc" => [:build, :test]
   depends_on "gmp"
 
   uses_from_macos "libffi"


### PR DESCRIPTION
We use `cabal-install` with multiple different GHC formulae to build Haskell projects. Each GHC takes up over 2GB of disk space so this can add unnecessary network downloads and occupy our limited CI disk space when building dependents.

---

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
