### PR TITLE
go@1.24: add patch to fix pkg-config flag sanitization

### DIFF
--- a/Formula/g/go@1.24.rb
+++ b/Formula/g/go@1.24.rb
@@ -5,6 +5,7 @@ class GoAT124 < Formula
   mirror "https://fossies.org/linux/misc/go1.24.13.src.tar.gz"
   sha256 "639a6204c2486b137df1eb6e78ee3ed038f9877d0e4b5a465e796a2153f858d7"
   license "BSD-3-Clause"
+  revision 1
 
   livecheck do
     url "https://go.dev/dl/?mode=json"
@@ -31,6 +32,12 @@ class GoAT124 < Formula
   keg_only :versioned_formula
 
   depends_on "go" => :build
+
+  # patch to fix pkg-config flag sanitization
+  patch do
+    url "https://github.com/golang/go/commit/28fbdf7acb4146b5bc3d88128e407d1344691839.patch?full_index=1"
+    sha256 "2e05f7e16f2320685547a7ebb240163a8b7f1c7bf9d2f6dc4872ff8b27707a35"
+  end
 
   def install
     libexec.install Dir["*"]

--- a/Formula/g/go@1.24.rb
+++ b/Formula/g/go@1.24.rb
@@ -21,12 +21,12 @@ class GoAT124 < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "a2f5e66c177e5c2efd0d83e9fceabb8191163518d94d93caabfa0b8e700f9154"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "a2f5e66c177e5c2efd0d83e9fceabb8191163518d94d93caabfa0b8e700f9154"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "a2f5e66c177e5c2efd0d83e9fceabb8191163518d94d93caabfa0b8e700f9154"
-    sha256 cellar: :any_skip_relocation, sonoma:        "892c108c02ebddd0fabe372dd172334a2ab35e4523f6d5c96ce4347e8ac03d9b"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "1e7d330f1c8a92f0fbf768b83af03a476b92ed929d011ba1db4ef78cca698b22"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "9c59e725d0c7d7c5ab05ab81575c084dceb3cd22078baa3984b27f85af428894"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "c5e92d0e6854fce804752c6f1d45620e77467bea4b3c0d608637e518fdf73476"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "c5e92d0e6854fce804752c6f1d45620e77467bea4b3c0d608637e518fdf73476"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "c5e92d0e6854fce804752c6f1d45620e77467bea4b3c0d608637e518fdf73476"
+    sha256 cellar: :any_skip_relocation, sonoma:        "616b47e950116307c0ae4d65268b71e402e8aa3e929682b305b3efe63e2c3391"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "93b46017e4b747affbf00aef9430b83542af6b0d7d976051cbbec640e2db3fc0"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "dca0a28ed7d6045be29ce5f632513d33302302706ef6e6f64cb90f1ff60fe446"
   end
 
   keg_only :versioned_formula


### PR DESCRIPTION
go@1.24: add patch to fix pkg-config flag sanitization

---

- https://github.com/golang/go/issues/77437
- https://github.com/golang/go/issues/77387
- https://github.com/golang/go/commit/28fbdf7acb4146b5bc3d

---
- https://github.com/Homebrew/homebrew-core/pull/265724