### PR TITLE
workflows/scrips/check-labels: add `CI-skip-online-checks` label

### DIFF
--- a/.github/workflows/scripts/check-labels.js
+++ b/.github/workflows/scripts/check-labels.js
@@ -146,6 +146,13 @@ module.exports = async ({github, context, core}, formulae_detect, dependent_test
       console.log('No CI-skip-new-formulae-strict label found. Not passing --skip-new-strict to brew test-bot.')
     }
 
+    if (label_names.includes('CI-skip-online-checks')) {
+      console.log('CI-skip-online-checks label found. Passing --skip-online-checks to brew test-bot.')
+      test_bot_formulae_args.push('--skip-online-checks')
+    } else {
+      console.log('No CI-skip-online-checks label found. Not passing --skip-online-checks to brew test-bot.')
+    }
+
     core.setOutput('test-bot-formulae-args', test_bot_formulae_args.join(" "))
     core.setOutput('test-bot-dependents-args', test_bot_dependents_args.join(" "))
 }


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
`--skip-online-checks` flag is supported by `brew test-bot`, but there is no way to use this option right now:
https://github.com/Homebrew/brew/blob/8d25ecaf43aec1fe8fc53aa198fff7452eb40602/Library/Homebrew/test_bot/formulae.rb#L452

It would be useful for GNU formulae, as we use mirrors for the main URL, which are not always reliable