### PR TITLE
form: add flint and zstd as dependencies

### DIFF
--- a/Formula/f/form.rb
+++ b/Formula/f/form.rb
@@ -19,10 +19,14 @@ class Form < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "7452db7be5b86008708893949d2bc6435e13ec7dd9e620ab54fe5c43d00edaae"
   end
 
+  depends_on "flint"
   depends_on "gmp"
   depends_on "mpfr"
+  depends_on "zstd"
 
-  uses_from_macos "zlib"
+  on_linux do
+    depends_on "zlib-ng-compat"
+  end
 
   def install
     system "./configure", *std_configure_args, "--disable-silent-rules", "--disable-native"

--- a/Formula/f/form.rb
+++ b/Formula/f/form.rb
@@ -11,12 +11,13 @@ class Form < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "2a51453b7d9db299d5e3a952ef662df7fff36998798529e0e521e187acb944b0"
-    sha256 cellar: :any,                 arm64_sequoia: "67c1e4e94dab3c4e15240846106c7c324649440406571491448ac7b12202eaf3"
-    sha256 cellar: :any,                 arm64_sonoma:  "fe7861af0557ce649d0ddfa2d5519fef77ba640683eba01c42df6da3f5a5128c"
-    sha256 cellar: :any,                 sonoma:        "7d1945e672162a5aca46fdf069a224c83fdc498f62dc06fc47fec612744b83f0"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "f37e47b7e8e866f1a05744ebd993ca8db1d3c5f59f01c9cb9e2a4393dda21604"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "7452db7be5b86008708893949d2bc6435e13ec7dd9e620ab54fe5c43d00edaae"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "c7f21024418e6cfa0e6dd9915e4ac38566cb583e9acf0df3d1994393abb91f43"
+    sha256 cellar: :any,                 arm64_sequoia: "33d30949b241289875fba956536d17180c56a377c56181100b04efd87c5832cf"
+    sha256 cellar: :any,                 arm64_sonoma:  "6d9766a69f1b07bb9562f5be2ea4ef6f1f51ac859751c1b9ac145bbb05bcd4c5"
+    sha256 cellar: :any,                 sonoma:        "affb7cf3d41487583b89a94296ae4fa6431d9d3e28e4868463898e94317dd8a6"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "552e5c787b81c28ff3a2c7ff80dfaa191b713fb1fa19eb95ad4ed24315389717"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "aa27050572d29b865752d49abdd41a501b16bedb244d2a05f4b530eb35c27f05"
   end
 
   depends_on "flint"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

The current bottled binaries are built without `flint` and `zstd`:
```bash
form -vv
```
```
FORM 5.0.0 (Jan 27 2026, v5.0.0)
-backtrace  -flint  +gmp=6.3.0   -mpi    -pthreads  +zlib=1.3.1
-debugging  +float  +mpfr=4.2.2  +posix  -windows   -zstd
Compiler: GCC 12.3.0
Architecture: x86_64
```

This PR adds dependencies on `flint` and `zstd`, which enable features introduced in FORM 5 when present at build time, improving performance for polynomial arithmetic and compression.

For reference:
- https://github.com/form-dev/form/blob/9b0d11c594628b64f9f8298c2ddb98b8a6447cbe/INSTALL#L41-L44
 
  > As a default, FORM tries to use the GMP and MPFR libraries for fast numerics, the zlib
and Zstandard (zstd) libraries for fast compression, and the FLINT library for fast
polynomial arithmetic. If any of these libraries is not available, the corresponding
feature will be deactivated.

- https://github.com/form-dev/form/wiki/Installation#building-from-the-source-distribution

  > We recommend building FORM with the external libraries, [GMP](https://gmplib.org/), [MPFR](https://www.mpfr.org/), [zlib](https://zlib.net/), [zstd](https://github.com/facebook/zstd) and [FLINT](https://flintlib.org/) (note that FLINT >= v3.2 is required, which may not yet be provided by your package repository).