### PR TITLE
cargo-shuttle: disable due to shuttle.dev is shutdown

### DIFF
--- a/Formula/c/cargo-shuttle.rb
+++ b/Formula/c/cargo-shuttle.rb
@@ -15,6 +15,10 @@ class CargoShuttle < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "32ed2953148966df0689a01238a4b1122337cafbc037f4bbaf26798d27084ff8"
   end
 
+  # shuttle.dev is shutdown, https://docs.shuttle.dev/docs/shuttle-shutdown
+  # currently, there is no self-hosting option, https://github.com/shuttle-hq/shuttle/issues/2136
+  disable! date: "2026-02-06", because: :unmaintained
+
   depends_on "pkgconf" => :build
   depends_on "rust" => :build
   depends_on "libgit2"


### PR DESCRIPTION
shuttle.dev was shutdown, and there is [no self-hosting option](https://github.com/shuttle-hq/shuttle/issues/2136), thus directly disabling the formula. 

- https://github.com/shuttle-hq/shuttle/issues/2132 (currently, you cannot login either)

seeing the failure in regression check, https://github.com/Homebrew/homebrew-core/actions/runs/21754541752/job/62764306330?pr=266165#step:3:146

```
    Minitest::Assertion: Expected /Unauthorized/ to match "Error: \e[1m503 Service Unavailable\e[0m\nMessage: \e[38;5;9mFailed to parse error response from the server:\n<html>\r\n<head><title>503 Service Temporarily Unavailable</title></head>\r\n<body>\r\n<center><h1>503 Service Temporarily Unavailable</h1></center>\r\n</body>\r\n</html>\r\n\e[39m\n\nStack backtrace:\n   0: std::backtrace::Backtrace::create\n   1: anyhow::error::<impl core::convert::From<E> for anyhow::Error>::from\n   2: <reqwest::async_impl::response::Response as shuttle_api_client::util::ToBodyContent>::to_json::{{closure}}\n   3: shuttle_api_client::ShuttleApiClient::get_current_user::{{closure}}\n   4: cargo_shuttle::Shuttle::run::{{closure}}\n   5: tokio::runtime::park::CachedParkThread::block_on\n   6: tokio::runtime::context::runtime::enter_runtime\n   7: tokio::runtime::runtime::Runtime::block_on\n   8: shuttle::main\n   9: std::sys::backtrace::__rust_begin_short_backtrace\n  10: std::rt::lang_start::{{closure}}\n  11: std::rt::lang_start_internal\n  12: _main\n".
```

- #266165