### PR TITLE
temporal: fix HEAD install version string

### DIFF
--- a/Formula/t/temporal.rb
+++ b/Formula/t/temporal.rb
@@ -23,7 +23,8 @@ class Temporal < Formula
   depends_on "go" => :build
 
   def install
-    ldflags = "-s -w -X github.com/temporalio/cli/internal/temporalcli.Version=#{version}"
+    v = build.head? ? "0.0.0-HEAD+#{Utils.git_short_head}" : version.to_s
+    ldflags = "-s -w -X github.com/temporalio/cli/internal/temporalcli.Version=#{v}"
     system "go", "build", *std_go_args(ldflags:), "./cmd/temporal"
 
     generate_completions_from_executable(bin/"temporal", shell_parameter_format: :cobra)


### PR DESCRIPTION
When installing with `--head`, use a valid semver version (`0.0.0-HEAD+sha`) instead of the non-semver HEAD string. This fixes an issue where the Temporal server fails to parse the client version.

**Before:** `temporal version HEAD-f843757`
**After:** `temporal version 0.0.0-HEAD+f843757`

Fixes temporalio/cli#350