### PR TITLE
yle-dl: depend on ffmpeg-full for GnuTLS support

### DIFF
--- a/Formula/y/yle-dl.rb
+++ b/Formula/y/yle-dl.rb
@@ -19,7 +19,7 @@ class YleDl < Formula
   end
 
   depends_on "certifi"
-  depends_on "ffmpeg"
+  depends_on "ffmpeg-full"
   depends_on "python@3.14"
   depends_on "rtmpdump"
 


### PR DESCRIPTION
yle-dl downloads HLS streams from Yle's Akamai CDN via ffmpeg. The standard `ffmpeg` formula uses macOS SecureTransport for TLS, which Akamai's edge servers reject with error `-9806` (`errSSLClosedAbort`). This makes yle-dl completely non-functional on macOS.

`ffmpeg-full` includes GnuTLS, which works correctly with Akamai's CDN. This follows the `ffmpeg` formula's own guidance: "Add other dependencies to ffmpeg-full formula or consider making formulae dependent on ffmpeg-full."

The yle-dl maintainer has confirmed support for this change: https://github.com/aajanki/yle-dl/issues/387#issuecomment-2597901050

Ref: https://github.com/aajanki/yle-dl/issues/387