### PR TITLE
freeradius-server: indirect deps from python

### DIFF
--- a/Formula/f/freeradius-server.rb
+++ b/Formula/f/freeradius-server.rb
@@ -33,11 +33,15 @@ class FreeradiusServer < Formula
   uses_from_macos "libpcap"
   uses_from_macos "libxcrypt"
   uses_from_macos "perl"
-  uses_from_macos "sqlite"
+
+  # Links to macOS sqlite and libedit prior to Tahoe
+  on_system :linux, macos: :tahoe_or_newer do
+    depends_on "readline"
+    depends_on "sqlite"
+  end
 
   on_linux do
     depends_on "gdbm"
-    depends_on "readline"
   end
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

These are getting linked in newer builds from Python dependency.

Interestingly, only started happening recently as Sequoia didn't have linkage. Could be change in superenv that is prioritizing these now.