### PR TITLE
qrupdate 1.1.5 (move to fork)

### DIFF
--- a/Formula/q/qrupdate.rb
+++ b/Formula/q/qrupdate.rb
@@ -6,19 +6,12 @@ class Qrupdate < Formula
   license "GPL-3.0-or-later"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:    "06f87282b23c5f3cec4efedea8259122807837de4e2fa0928ca380a69357ab74"
-    sha256 cellar: :any,                 arm64_sequoia:  "5ea96ebb5b0af96ca5976f5c0a188c772eadc46fa52edb44cdb89f3d2e69436c"
-    sha256 cellar: :any,                 arm64_sonoma:   "30d96fead1ad674156f1ca3121c2c5df27f3a2e42d226425ca6f83554628a86b"
-    sha256 cellar: :any,                 arm64_ventura:  "883c11e84b2dcdd6ed46344697e8363a2c61e68d26aa6439d4684bc1a7abc76b"
-    sha256 cellar: :any,                 arm64_monterey: "c8c154ece840edeeb4b4d0fe76383b60177ada3a525d96a124dc3fac80d9ae34"
-    sha256 cellar: :any,                 arm64_big_sur:  "349ff7a34aacf021f8df3d129fa7e8897bd1b87a41d7df6b270fa98d73039ab4"
-    sha256 cellar: :any,                 sonoma:         "117263ab5d0be7513bd9f5eebf3f32abfce63fcee8e5b3cfbd43d3325943a99b"
-    sha256 cellar: :any,                 ventura:        "eae9333e11a79c651d8313e0b9c969c104a083edc3f6c835d484b10394f1f32b"
-    sha256 cellar: :any,                 monterey:       "20e6d9ac347bc1903177aa5273e25ac2fd1f6dd56211e4170d46741ebdbd0b4d"
-    sha256 cellar: :any,                 big_sur:        "12240dfe307818f58b11e495c81258979570e55640173382d3be77e39ee8dd0a"
-    sha256 cellar: :any,                 catalina:       "b5a26e72c3d49e5b8b70432c11c93ffb392325c4a8a16cce2497b203bd23559d"
-    sha256 cellar: :any_skip_relocation, arm64_linux:    "0b06dc5dc420eec5a92256e31369688142112ce6c5ddf4b4bb07c638fe8e7f62"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "bf21846969fac2323ea2d8762b04c7f090bb0d9092c98636a853c50aaab49230"
+    sha256 cellar: :any,                 arm64_tahoe:   "5c305f32f4639a5bfeab6e16899d57b376ab2a0189d83ca0a5c89addd61839f9"
+    sha256 cellar: :any,                 arm64_sequoia: "b5a428039a1d6c17443eabf02c6273d8a2a753079b4155c8f3eee289363f3210"
+    sha256 cellar: :any,                 arm64_sonoma:  "b118290be4e025f4b887416a344c2c382a9349f6766cfed8310d02a14762694a"
+    sha256 cellar: :any,                 sonoma:        "c74d34091a406df0680a9d1d208aea0a28ecf43c8552402eb5b1ee83d13d431f"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "2b7905dc60adfb1d09b1fc453916fd4b4040c65c3cb08bdc33bdfca133a77f47"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3ccc86cd597cfb5746a133ec69dca7e2745106447ac9dcc586b21c862e8d252f"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
Meets https://docs.brew.sh/Acceptable-Formulae#not-a-fork-usually as Arch Linux[^1] and Debian[^2] have switched to fork. Also used by Alpine and nixpkgs.

[^1]: https://gitlab.archlinux.org/archlinux/packaging/packages/qrupdate/-/commit/2c99d4bf186b313f670765bb0357f1a72b24fb92
[^2]: https://salsa.debian.org/science-team/qrupdate/-/commit/990edd8f501b9fd8e9b782535bd2976d902f7828

---

Source code can also a found at GitHub mirror (https://github.com/mpimd-csc/qrupdate-ng) but went with upstream's hosted GitLab as it looks like the main repo.

Could switch if needed based on download performance. Current URL does have smaller bz2 but not sure how many servers there are.