### PR TITLE
lm-sensors 3.6.2 (move to fork)

### DIFF
--- a/Formula/l/lm-sensors.rb
+++ b/Formula/l/lm-sensors.rb
@@ -7,9 +7,8 @@ class LmSensors < Formula
   license any_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later"]
 
   bottle do
-    rebuild 1
-    sha256 arm64_linux:  "43d3fcb049210f0b67b6341f5e65645c69ddbfa3ecc8bf5926d612990f3fac35"
-    sha256 x86_64_linux: "9edce5d98c2e1541cba56961443f4bdb01ea6ab8b7bfd8aa4515c7eec9d17541"
+    sha256 arm64_linux:  "05d1a0969a84d7ed3f9b95effe63bc9378452f2a1a1e367b8c8ef1efde275af9"
+    sha256 x86_64_linux: "24aa125e2b8fe32e1600b64c0c5d8a32a575db9ef4dea9e17d31c6a02a48087f"
   end
 
   depends_on "bison" => :build

--- a/Formula/l/lm-sensors.rb
+++ b/Formula/l/lm-sensors.rb
@@ -1,12 +1,10 @@
 class LmSensors < Formula
   desc "Tools for monitoring the temperatures, voltages, and fans"
-  homepage "https://github.com/lm-sensors/lm-sensors"
-  url "https://github.com/lm-sensors/lm-sensors/archive/refs/tags/V3-6-0.tar.gz"
-  version "3.6.0"
-  sha256 "0591f9fa0339f0d15e75326d0365871c2d4e2ed8aa1ff759b3a55d3734b7d197"
+  homepage "https://github.com/hramrach/lm-sensors"
+  url "https://github.com/hramrach/lm-sensors/archive/refs/tags/V3-6-2.tar.gz"
+  version "3.6.2"
+  sha256 "c6a0587e565778a40d88891928bf8943f27d353f382d5b745a997d635978a8f0"
   license any_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later"]
-
-  no_autobump! because: :requires_manual_review
 
   bottle do
     rebuild 1


### PR DESCRIPTION
This fork satisfies our policy[^1] as it has been used by:
* Arch Linux[^2]
* Debian[^3]
* Gentoo[^4]

[^1]: https://docs.brew.sh/Acceptable-Formulae#not-a-fork-usually
[^2]: https://gitlab.archlinux.org/archlinux/packaging/packages/lm_sensors/-/commit/4f2b3ee2caba24c53d140feed0e1b58350223b35
[^3]: https://salsa.debian.org/aurel32/lm-sensors/-/commit/6698ffe1f1a2d90a549e10e8a1e78ec931ce649e
[^4]: https://gitweb.gentoo.org/repo/gentoo.git/commit/sys-apps/lm-sensors?id=f56aea21925aea56d034732190345a1deae63b31

