### PR TITLE
ibazel 0.28.0: update formula

### DIFF
--- a/Formula/i/ibazel.rb
+++ b/Formula/i/ibazel.rb
@@ -29,6 +29,7 @@ class Ibazel < Formula
 
     # Write MODULE.bazel with Bazel module dependencies
     (testpath/"MODULE.bazel").write <<~STARLARK
+      bazel_dep(name = "rules_cc", version = "0.2.16")
       bazel_dep(name = "rules_go", version = "0.59.0")
 
       # Register brewed go


### PR DESCRIPTION
*  add rules_cc for Bazel 9 compatibility
*  bazel 9 removes c++ rules from built-ins
*  This fixes the dependency test failure in homebrew-core#266499.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
