### PR TITLE
sdl2_sound: drop HEAD

### DIFF
--- a/Formula/s/sdl2_sound.rb
+++ b/Formula/s/sdl2_sound.rb
@@ -7,7 +7,6 @@ class Sdl2Sound < Formula
     "Zlib",
     any_of: ["Artistic-1.0-Perl", "LGPL-2.1-or-later"], # timidity
   ]
-  head "https://github.com/icculus/SDL_sound.git", branch: "main"
 
   livecheck do
     url :stable


### PR DESCRIPTION
It should have broke over a year ago (https://github.com/icculus/SDL_sound/commit/da0bc4df6392ba97d1bf46aae12e4b9cb7ffa50b). Going to just drop it as unused and to remove from https://repology.org/project/sdl-sound-unclassified/versions