### PR TITLE
mdvi 0.1.0 (new formula)

### DIFF
--- a/Formula/m/mdvi.rb
+++ b/Formula/m/mdvi.rb
@@ -1,0 +1,17 @@
+class Mdvi < Formula
+  desc "Terminal markdown viewer with Vim-style navigation"
+  homepage "https://github.com/taf2/mdvi"
+  url "https://github.com/taf2/mdvi/archive/refs/tags/v0.1.0.tar.gz"
+  sha256 "792b17d15dd007a75c86af90723994c7bbfe349403f79f0462c860803b180aca"
+  license "MIT"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/mdvi --version")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [Contributing guidelines](https://github.com/Homebrew/homebrew-core/blob/main/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula?

Adds `mdvi`, a terminal markdown viewer written in Rust with Vim-style navigation, search, and reload support.

Project: https://github.com/taf2/mdvi
Release: https://github.com/taf2/mdvi/releases/tag/v0.1.0
