### PR TITLE
atuin-server 18.12.1 (new formula)

### DIFF
--- a/Formula/a/atuin-server.rb
+++ b/Formula/a/atuin-server.rb
@@ -6,6 +6,15 @@ class AtuinServer < Formula
   license "MIT"
   head "https://github.com/atuinsh/atuin.git", branch: "main"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "b91b45a76e0bac77a47e71f924f23ee840c8c520a856c4f13e6cd6f0a710a937"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "219c1f3d7660a2c59a212d65472b3e2bc4537fdba03c04efbffeff60cb93ab20"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "719d5004795c9677551cfd5f89ec6e825f4717941eb382c9e3406cb1d886159c"
+    sha256 cellar: :any_skip_relocation, sonoma:        "675b9c09cc3fa2921442bb263e1da5788c46913b58fae0206b5294da89db6b95"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "0cdf861bd78efe32114c907f7a01ab88a8c52cf5c60bb8af79d82a31275361dd"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "45611e30436438d07d9fbd3d3fbaee7208789676815fddf6f7acdd93d60ab458"
+  end
+
   depends_on "protobuf" => :build
   depends_on "rust" => :build
 

--- a/Formula/a/atuin-server.rb
+++ b/Formula/a/atuin-server.rb
@@ -1,0 +1,35 @@
+class AtuinServer < Formula
+  desc "Sync server for atuin - Improved shell history for zsh, bash, fish and nushell"
+  homepage "https://atuin.sh"
+  url "https://github.com/atuinsh/atuin/releases/download/v18.12.1/source.tar.gz"
+  sha256 "94b38e6031bad2409c176beae63580da35a1c3a1c129cc7c4c8f74f1e2965638"
+  license "MIT"
+  head "https://github.com/atuinsh/atuin.git", branch: "main"
+
+  depends_on "protobuf" => :build
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args(path: "crates/atuin-server")
+    pkgetc.install "crates/atuin-server/server.toml"
+  end
+
+  service do
+    run [opt_bin/"atuin-server", "start"]
+    environment_variables ATUIN_CONFIG_DIR: etc/"atuin-server"
+    keep_alive true
+    log_path var/"log/atuin-server.log"
+    error_log_path var/"log/atuin-server.log"
+  end
+
+  def caveats
+    <<~EOS
+      The configuration file is located at:
+        #{pkgetc}/server.toml
+    EOS
+  end
+
+  test do
+    assert_match "Atuin sync server", shell_output("#{bin}/atuin-server 2>&1", 2)
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Add atuin-server formula for self-hosting the server for atuin. Homebrew already supports the client via atuin.rb.

atuin separated the client and the server into different rust crates and binaries in version 18.12.0, so this PR adds the server component separately, including a service.

This is my first contribution, so let me know if there are any errors or style issues.