### PR TITLE
gcc: link with -headerpad_max_install_names

### DIFF
--- a/Formula/g/gcc.rb
+++ b/Formula/g/gcc.rb
@@ -113,7 +113,10 @@ class Gcc < Formula
       # Avoid this semi-random failure:
       # "Error: Failed changing install name"
       # "Updated load commands do not fit in the header"
-      make_args = %w[BOOT_LDFLAGS=-Wl,-headerpad_max_install_names]
+      make_args = %w[
+        BOOT_LDFLAGS=-Wl,-headerpad_max_install_names
+        LDFLAGS_FOR_TARGET=-Wl,-headerpad_max_install_names
+      ]
     else
       # Fix Linux error: gnu/stubs-32.h: No such file or directory.
       args << "--disable-multilib"

--- a/Formula/g/gcc.rb
+++ b/Formula/g/gcc.rb
@@ -25,14 +25,15 @@ class Gcc < Formula
   end
 
   bottle do
-    sha256 arm64_tahoe:   "144b48c317fe5406a36b57ca30171c78c0eddf91cd236b56246c3cf523f7d202"
-    sha256 arm64_sequoia: "924a3b36fe34a4ac9e2d281ef139cb0d331a0e36c41aac738ef6b4aac9a35421"
-    sha256 arm64_sonoma:  "6a17969b924c2dc491180f5bccf466339b4a7849f86c58bdf13d4d4f02ba4849"
-    sha256 tahoe:         "05c7d066d2bff334d820c221803ae27dd14dd59340e4fd23eccde2f1fd9b13b0"
-    sha256 sequoia:       "01b8293a065c6328517f4243f50c432ebcda7912b5b25e95767d6f6d8e8a4902"
-    sha256 sonoma:        "16a6a69c8c2a390272bb0a751b7e2dac7b11457192db807797f68c867b036166"
-    sha256 arm64_linux:   "a5cbd6e7bd013cb8f81fb79b65c46c3841f1d76b3a962a8b89d0a13417ed84a1"
-    sha256 x86_64_linux:  "a0ea9c0f9d2090ce7d3cce85c2f0c62566837d966d953edae48104613348c418"
+    rebuild 1
+    sha256 arm64_tahoe:   "39faa08c413c043b9f44a6be5beb260d5acf7fd0bf035688c2579d3be48a8463"
+    sha256 arm64_sequoia: "083223989b47d242c7c42366abaf3e8509f7bdde84a370cb7381c9267a199847"
+    sha256 arm64_sonoma:  "9d4be966090f2585d27a717c96208077059e43c5ab5b510f1525b0efc2a21bb7"
+    sha256 tahoe:         "e60ded6de95e31669e493a2fa327bd308b205c272d696f61954ed860a7709bde"
+    sha256 sequoia:       "e47fbf21a46d5143dee9f944a6ae0059a40968460fd767c3693cc9cd8119c68f"
+    sha256 sonoma:        "b1d7ab5a739178d4b475438c128646256c1759205a4047cd83b7b53c87c8b9e4"
+    sha256 arm64_linux:   "235350076566b5b4db7e0bb1acf08c06f2ef4eff6a9a5879d0ceb3e2c48deafe"
+    sha256 x86_64_linux:  "c03913f7c701d33bb1faad0c8e576c8ee4e6af410eb4951bb89258b239d55be5"
   end
 
   # The bottles are built on systems with the CLT installed, and do not work


### PR DESCRIPTION
Fixes an issue when using a non-default brew prefix where the postinstall step can fail:

    Error: Failed changing dylib ID of /Users/example/homebrew/Cellar/gcc/15.2.0_1/lib/gcc/current/libatomic.1.dylib
      from @rpath/libatomic.1.dylib
        to /Users/example/homebrew/opt/gcc/lib/gcc/current/libatomic.1.dylib
    Error: Failed to fix install linkage
    Updated load commands do not fit in the header of /Users/example/homebrew/Cellar/gcc/15.2.0_1/lib/gcc/current/libatomic.1.dylib. /Users/example/homebrew/Cellar/gcc/15.2.0_1/lib/gcc/current/libatomic.1.dylib needs to be relinked, possibly with -headerpad or -headerpad_max_install_names

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

I used an LLM to find the `LDFLAGS_FOR_TARGET` environment variable which propagates `LDFLAGS` when building the target libraries. I read the makefile to confirm that `LDFLAGS_FOR_TARGET` is used to set `LDFLAGS=$$(LDFLAGS_FOR_TARGET)` when calling libatomic's sub-make via `EXTRA_TARGET_FLAGS`.

I used `otool -D "$(brew --prefix gcc)"/lib/gcc/current/libatomic.1.dylib` before and after the change to verify that the install name is correct instead of `@rpath/libatomic.1.dylib`.