### PR TITLE
undercutf1 4.0.51: packaging changes and dotnet 10

### DIFF
--- a/Formula/u/undercutf1.rb
+++ b/Formula/u/undercutf1.rb
@@ -7,12 +7,12 @@ class Undercutf1 < Formula
   head "https://github.com/JustAman62/undercut-f1.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "4fc68891a534638218604c7c01baec8acc61c581357e22715f12df0a9d393991"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "9e228fa87e578f3049427dfc59586e38b1f1d6cfca29169c1ee27fd03b0e3fda"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "e265140152d66e401b4ee41d7eda1756235cc341fd05cc3901e72a02375a0d77"
-    sha256 cellar: :any_skip_relocation, sonoma:        "943bacbb0c6d4ffed72770b51c8b5228ba735e1c8d2736f64be2f327e53c4f6a"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "8217e2a97d90119c30a47d8f8369fb7bf9c6d07401bf0f46be8deb94662b9018"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3674c96f9266e772f647e8bf73f47b6ae3622fc5b9042d1ffe1f5b12b3bd1451"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "4b7a5f5b53e0c5553c84fe4490cef6ccdafc55145665f0e87645087fe6850c21"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "3b516d1b359779eac22910c1f2326c2fd5eb224abe3bbadd1a5e188e7089e6de"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "26674eee940ac4ab72d0a6f30d8e732cf1cc110905eb3ce5fd9cb13515a0c938"
+    sha256 cellar: :any_skip_relocation, sonoma:        "3b49db28c4dcde729a4bbb4e09bfff9caebf594b3dc3fb834c0fef708c3c3a9c"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "0cf95b851d59f25d78028d86c58e41d9142c6b42aebae3e0c4a7854e091968bb"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f4376ea7d47c46563d49a5110bc4e653019a1c305c500093c9c20e39d2363d4f"
   end
 
   depends_on "dotnet"

--- a/Formula/u/undercutf1.rb
+++ b/Formula/u/undercutf1.rb
@@ -1,10 +1,9 @@
 class Undercutf1 < Formula
   desc "F1 Live Timing TUI for all F1 sessions with variable delay to sync to your TV"
   homepage "https://github.com/JustAman62/undercut-f1"
-  url "https://github.com/JustAman62/undercut-f1/archive/refs/tags/v3.4.32.tar.gz"
-  sha256 "3e90ccd0c7f02240c9ff8b175c84a37b62cb82774a62d46b44ee7103996dd30a"
+  url "https://github.com/JustAman62/undercut-f1/archive/refs/tags/v4.0.51.tar.gz"
+  sha256 "6a184d20b7b702460fb98235117458100975a98a779c65a7f1e1c1268001fabd"
   license "GPL-3.0-only"
-  revision 1
   head "https://github.com/JustAman62/undercut-f1.git", branch: "master"
 
   bottle do
@@ -20,12 +19,6 @@ class Undercutf1 < Formula
   depends_on "ffmpeg"
   depends_on "fontconfig"
   depends_on "mpg123"
-
-  # Support dotnet 10 - remove in next release
-  patch do
-    url "https://github.com/JustAman62/undercut-f1/commit/2ae7e47daab9250d31878a92943864fabd04db59.patch?full_index=1"
-    sha256 "b51d288893a1ce6e5abfe759f498ce79d2ebcc5c17ab6b328c16d5ad8f2a1a06"
-  end
 
   def install
     ENV["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1"
@@ -43,6 +36,8 @@ class Undercutf1 < Formula
       -p:EnableCompressionInSingleFile=false
       -p:DebugType=None
       -p:PublicRelease=true
+      -p:PublishTrimmed=false
+      -p:PublishAot=false
     ]
 
     # Version override is not needed if cloning from HEAD
@@ -56,7 +51,7 @@ class Undercutf1 < Formula
   test do
     assert_match version.to_s, shell_output("#{bin}/undercutf1 --version")
 
-    output = shell_output("#{bin}/undercutf1 import 2025")
+    output = shell_output("#{bin}/undercutf1 import 2026")
     assert_match "Available Meetings", output
   end
 end


### PR DESCRIPTION
undercutf1 v4 included some application packaging changes (self contained AOT publishing) which I've applied here for consistency with the way the application is packaged for other platforms.

This release also supports dotnet10, so taking this opportunity to remove the manual patch that was used for that support.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
