### PR TITLE
whosthere 0.6.0

### DIFF
--- a/Formula/w/whosthere.rb
+++ b/Formula/w/whosthere.rb
@@ -11,12 +11,12 @@ class Whosthere < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "136a4a9932cbcf9c21f123853afed1774a87529dd480ee27984b408b8ec0a9a4"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "03805cb76a36dca0aa61e1ff00834def004db87d1e1a4be860670b4d35a85d39"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "3b485d842deb281905241897aaeaa0c1d86035c07c46346d1e2438bf2609550d"
-    sha256 cellar: :any_skip_relocation, sonoma:        "1a22961ebdef5f72b697a62c6a0225c63f952382f448bcee9f66bfe15a2a245b"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "3c90485e6adcd3fdefddbdd98c5d3d01072ad3b9060d1e0aafd4a5e22ba826eb"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f71111888eb72c2b6ee2561ba90a36fddcc5c858eac1c17ada779bf9e3a91764"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "a67755e7b6b2d7d0a43e2f3bb3e6abeed9e6d3c555d2484d21ca0ba3015ab014"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "f90fc9589d7e70dc3dc529a9597d3e33101db7ae57abad6416fd43ff1f69e5ee"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "fce4c776f6ee7d3ab109429bea0f0f34b07f4218c4bf261eb80161c84de90ca1"
+    sha256 cellar: :any_skip_relocation, sonoma:        "3632e83b7ac53fd1da174b183668e2e6810badf391b61fcbd90469adbc01f964"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "29ec8df058d8df7b0cb85446cbd8e52aa5280f6b73e3d7d11fd2810b2b6246a3"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "936a68600a03812db3dda707b62527a361a32713440c59c4c60253d2d89eb679"
   end
 
   depends_on "go" => :build

--- a/Formula/w/whosthere.rb
+++ b/Formula/w/whosthere.rb
@@ -1,8 +1,8 @@
 class Whosthere < Formula
   desc "LAN discovery tool with a modern TUI written in Go"
   homepage "https://github.com/ramonvermeulen/whosthere"
-  url "https://github.com/ramonvermeulen/whosthere/archive/refs/tags/v0.5.1.tar.gz"
-  sha256 "4cac844f7e43bd397b2d3145448aa90a0a11ffee5488e75197b3e082fea86ee1"
+  url "https://github.com/ramonvermeulen/whosthere/archive/refs/tags/v0.6.0.tar.gz"
+  sha256 "d60367a6c51a7a59b2d282e547fced3393c7a6b4918b262aa015caf1211e1c91"
   license "Apache-2.0"
   head "https://github.com/ramonvermeulen/whosthere.git", branch: "main"
 
@@ -35,6 +35,6 @@ class Whosthere < Formula
   test do
     assert_match version.to_s, shell_output("#{bin}/whosthere --version")
     output = shell_output("#{bin}/whosthere --interface non_existing 2>&1", 1)
-    assert_match "no such network interface", output
+    assert_match "network_interface does not exist", output
   end
 end


### PR DESCRIPTION
fix failing test in https://github.com/Homebrew/homebrew-core/pull/267055

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

```console
╰─❯ HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source whosthere                                                                                          ─╯
==> Auto-updating Homebrew...
Adjust how often this is run with `$HOMEBREW_AUTO_UPDATE_SECS` or disable with
`$HOMEBREW_NO_AUTO_UPDATE=1`. Hide these hints with `$HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).
==> Auto-updated Homebrew!
Updated 1 tap (homebrew/cask).

You have 1 outdated cask installed.

==> Fetching downloads for: whosthere
✔︎ Formula whosthere (0.6.0)                                                                                                                    Verified      3.6MB/  3.6MB
Warning: A newer Command Line Tools release is available.
Update them from Software Update in System Settings.

If that doesn't show you any updates, run:
  sudo rm -rf /Library/Developer/CommandLineTools
  sudo xcode-select --install

Alternatively, manually download them from:
  https://developer.apple.com/download/all/.
You should download the Command Line Tools for Xcode 16.4.



This is a Tier 2 configuration:
  https://docs.brew.sh/Support-Tiers#tier-2
You can report Tier 2 unrelated issues to Homebrew/* repositories!
Read the above document before opening any issues or PRs.

==> go build -ldflags=-s -w -X main.versionStr=0.6.0 -X main.dateStr=2026-02-11T21:13:30Z
🍺  /opt/homebrew/Cellar/whosthere/0.6.0: 6 files, 16.5MB, built in 2 seconds
==> Running `brew cleanup whosthere`...
Disable this behaviour by setting `HOMEBREW_NO_INSTALL_CLEANUP=1`.
Hide these hints with `HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).
Removing: /Users/ramon/Library/Caches/Homebrew/whosthere_bottle_manifest--0.5.1... (7.5KB)
Removing: /Users/ramon/Library/Caches/Homebrew/whosthere--0.5.1... (5.9MB)
Removing: /Users/ramon/Library/Caches/Homebrew/whosthere--0.5.1.tar.gz... (3.6MB)
brew is being executed via personal brew wrapper - be aware
dumping Brewfile to /Users/ramon/.config/brew/Brewfile
```


```console
╰─❯ brew test whosthere                                                                                                                                                ─╯
==> Testing whosthere
==> /opt/homebrew/Cellar/whosthere/0.6.0/bin/whosthere --version
==> /opt/homebrew/Cellar/whosthere/0.6.0/bin/whosthere --interface non_existing 2>&1
```

```console
╰─❯ brew audit --strict whosthere                                                                                                                                      ─╯

╰─❯ echo $?                                                                                                                                                            ─╯
0
```