### PR TITLE
astra: add livecheck

### DIFF
--- a/Formula/a/astra.rb
+++ b/Formula/a/astra.rb
@@ -5,6 +5,11 @@ class Astra < Formula
   sha256 "21404f4d26b9608a85d8cd65d52c93555bc6030398cb1208b6d2e7ee07aed542"
   license "Apache-2.0"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "05f012277104085caa7577de3031dbef897ad77c6b3ead1c77cdd099310cd4aa"
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "eea64e938f064b8efb6ace7cd542c56858351185056536f43d040761124066a2"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

`astra`'s version isn't being automatically updated (e.g. it's still on `1.0.2` even though `1.0.3` is released), even though `bump-formula-pr` and `livecheck` both claimed it's being autobumped. I'm hoping this change would fix the issue?