### PR TITLE
gradle: update livecheck

### DIFF
--- a/Formula/g/gradle.rb
+++ b/Formula/g/gradle.rb
@@ -6,7 +6,7 @@ class Gradle < Formula
   license "Apache-2.0"
 
   livecheck do
-    url "https://gradle.org/install/"
+    url "https://gradle.org/releases/"
     regex(/href=.*?gradle[._-]v?(\d+(?:\.\d+)+)-all\.(?:zip|t)/i)
   end
 


### PR DESCRIPTION
Fix livecheck/autobump.

Old:
```
❯ brew lc --autobump gradle
Error: gradle: Unable to get versions
```

New:
```
❯ brew lc --autobump gradle
gradle: 9.3.1 ==> 9.3.1
```