### PR TITLE
libgig: update livecheck

### DIFF
--- a/Formula/lib/libgig.rb
+++ b/Formula/lib/libgig.rb
@@ -5,8 +5,9 @@ class Libgig < Formula
   sha256 "ca2be8ce5e0969f90c2df76e03d499f5e27fb5021edbc587de182ff27e8efddd"
   license "GPL-2.0-or-later"
 
+  # Using HTTP rather than HTTPS to avoid SSL connection timeout
   livecheck do
-    url "https://download.linuxsampler.org/packages/"
+    url "http://download.linuxsampler.org/packages/"
     regex(/href=.*?libgig[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
Looking into this as one of autobump "unable to get versions" formulae. 

From local attempts, keeps timing out on HTTPS:
```
❯ brew lc --autobump libgig
Error: libgig: curl: (28) Failed to connect to download.linuxsampler.org port 443 after 10003 ms: Timeout was reached

❯ brew lc --autobump libgig
Error: libgig: curl: (28) SSL connection timeout
```

Seems better with HTTP:
```
❯ brew lc --autobump libgig
libgig: 4.5.2 ==> 4.5.2
```