### PR TITLE
monitoring-plugins: update livecheck

### DIFF
--- a/Formula/m/monitoring-plugins.rb
+++ b/Formula/m/monitoring-plugins.rb
@@ -6,7 +6,7 @@ class MonitoringPlugins < Formula
   license "GPL-3.0-or-later"
 
   livecheck do
-    url "https://www.monitoring-plugins.org/download.html"
+    url "https://www.monitoring-plugins.org/download/"
     regex(/href=.*?monitoring-plugins[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
A bit of an odd situation where upstream is listing RCs as stable so this is breaking livecheck.
```
❯ brew lc --autobump monitoring-plugins
Error: monitoring-plugins: Unable to get versions
```

From 3.0.0-rc1 (https://www.monitoring-plugins.org/news/release-3-0-0-rc1.html)
> Due the a significant refactoring and the unintented side effect this may have, the "real" release will be following release candidates which are intented to for early adapters and testing.

---

Likely safer to just ignore these until stabilized so just changing URL rather than regex so we stay on 2.4.0 for now.
