### PR TITLE
cookcli: add missing JS build step

### DIFF
--- a/Formula/c/cookcli.rb
+++ b/Formula/c/cookcli.rb
@@ -23,9 +23,10 @@ class Cookcli < Formula
     ENV["OPENSSL_NO_VENDOR"] = "1"
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
 
-    # Install npm dependencies and build CSS
+    # Install npm dependencies and build assets
     system "npm", "install", *std_npm_args(prefix: false)
     system "npm", "run", "build-css"
+    system "npm", "run", "build-js"
 
     # Build and install the binary
     system "cargo", "install", *std_cargo_args


### PR DESCRIPTION
Add `npm run build-js` to the install method to match the upstream release pipeline. This bundles the CodeMirror editor JavaScript that was previously missing from the Homebrew build.

Built and tested locally on macOS Ventura.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other [open](https://github.com/Homebrew/homebrew-core/pulls) or [closed](https://github.com/Homebrew/homebrew-core/pulls?q=is%3Apr+is%3Aclosed) pull requests for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Does your build pass `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>`?

- [x] AI used to assist with this PR (identified the missing build step by comparing with upstream release pipeline; manual verification performed)