### PR TITLE
make-guile 4.4.1 (new formula)

### DIFF
--- a/Formula/m/make-guile.rb
+++ b/Formula/m/make-guile.rb
@@ -1,0 +1,77 @@
+class MakeGuile < Formula
+  desc "Utility for directing compilation with Guile support enabled"
+  homepage "https://www.gnu.org/software/make/"
+  url "https://ftpmirror.gnu.org/gnu/make/make-4.4.1.tar.lz"
+  mirror "https://ftp.gnu.org/gnu/make/make-4.4.1.tar.lz"
+  sha256 "8814ba072182b605d156d7589c19a43b89fc58ea479b9355146160946f8cf6e9"
+  license "GPL-3.0-only"
+
+  head do
+    url "https://git.savannah.gnu.org/git/make.git", branch: "master"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "gettext" => :build # for autopoint
+    depends_on "libtool" => :build
+    depends_on "texinfo" => :build
+    depends_on "wget" => :build # used by autopull
+
+    uses_from_macos "m4" => :build
+
+    fails_with :clang # fails with invalid arguments sent to compiler
+  end
+
+  depends_on "pkgconf" => :build
+  depends_on "bdw-gc"
+  depends_on "guile"
+
+  def install
+    if build.head?
+      system "./autopull.sh" # downloads gnulib files from git that autogen.sh needs
+      system "./autogen.sh"
+    end
+
+    args = %W[
+      --disable-dependency-tracking
+      --prefix=#{prefix}
+      --with-guile
+    ]
+
+    args << "--program-prefix=g" if OS.mac?
+    system "./configure", *args
+    system "make", "install"
+
+    if OS.mac?
+      (libexec/"gnubin").install_symlink bin/"gmake" =>"make"
+      (libexec/"gnuman/man1").install_symlink man1/"gmake.1" => "make.1"
+    end
+
+    (libexec/"gnubin").install_symlink "../gnuman" => "man"
+  end
+
+  def caveats
+    on_macos do
+      <<~EOS
+        GNU "make" has been installed as "gmake".
+        If you need to use it as "make", you can add a "gnubin" directory
+        to your PATH from your bashrc like:
+
+            PATH="#{opt_libexec}/gnubin:$PATH"
+      EOS
+    end
+  end
+
+  test do
+    (testpath/"Makefile").write <<~MAKE
+      default:
+      \t@echo guile $(if $(findstring guile,$(.FEATURES)),found,not found)
+    MAKE
+
+    if OS.mac?
+      assert_equal "guile found\n", shell_output(bin/"gmake")
+      assert_equal "guile found\n", shell_output(libexec/"gnubin/make")
+    else
+      assert_equal "guile found\n", shell_output(bin/"make")
+    end
+  end
+end


### PR DESCRIPTION
Build GNU Make with support for the [GNU Ubiquitous Intelligent Language for Extensions (Guile)](https://www.gnu.org/software/guile/) extension language.

The [Debian](https://packages.debian.org/trixie/make-guile)/[Ubuntu](https://packages.ubuntu.com/questing/make-guile) convention is to create a new package ('make-guile') to provide the binary to those who want guile support enabled. I am assuming this would be preferable in Homebrew as well, rather than baking this into the default `Make` install.

Guile is already provided as a [Homebrew formula](https://formulae.brew.sh/formula/guile#default)

There is one aspect I am unclear on. I copied the Make formula as the basis for this formula, and I left the binary naming and aliasing unchanged (i.e. the macos binary is still `gmake`).

1. Should I change the binary name to something else?
2. If `no`, what should happen if someone tries to `brew install make make-guile`? Should the formula handle deconfliction somehow?

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
