### PR TITLE
icp-cli: add ic-wasm dependency

### DIFF
--- a/Formula/i/icp-cli.rb
+++ b/Formula/i/icp-cli.rb
@@ -16,6 +16,7 @@ class IcpCli < Formula
   end
 
   depends_on "rust" => :build
+  depends_on "ic-wasm"
   depends_on "openssl@3"
 
   on_linux do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

I asked Grok whether `revision 1` was required, and it said that it wasn't. I verified the [existing PR it linked](https://github.com/Homebrew/homebrew-core/pull/251510) modified dependencies (that did not require relinking) without revisioning.

-----

This is present in [our tap](https://github.com/dfinity/homebrew-tap/blob/d85cbb4bafea6bbe0a5a04139efd783d994932e3/Formula/icp-cli.rb) and should have survived the migration to homebrew/core. It (as an executable) is a dependency of the `icp build` command in almost all cases.