### PR TITLE
lsix: make `bash` macOS-only, update license

### DIFF
--- a/Formula/l/lsix.rb
+++ b/Formula/l/lsix.rb
@@ -3,22 +3,26 @@ class Lsix < Formula
   homepage "https://github.com/hackerb9/lsix"
   url "https://github.com/hackerb9/lsix/archive/refs/tags/1.9.1.tar.gz"
   sha256 "310e25389da13c19a0793adcea87f7bc9aa8acc92d9534407c8fbd5227a0e05d"
-  license "GPL-3.0-only"
+  # https://github.com/hackerb9/lsix/blob/1.9.1/lsix#L333-L341
+  license any_of: ["GPL-3.0-or-later", "X11"]
 
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "1236a71809bd24fd1cedb055f51286a8af6ce959d54c6669b8849eee706b050e"
   end
 
-  depends_on "bash"
   depends_on "imagemagick"
+
+  on_macos do
+    depends_on "bash"
+  end
 
   def install
     bin.install "lsix"
   end
 
   test do
-    output = shell_output "#{bin}/lsix 2>&1"
+    output = shell_output("#{bin}/lsix 2>&1")
     assert_match "Error: Your terminal does not report having sixel graphics support.", output
   end
 end


### PR DESCRIPTION
https://github.com/hackerb9/lsix/blob/1.9.1/lsix#L333-L341
```
# Dual license:
# * You have all the freedoms permitted to you under the
#   GNU GPL >=3. (See the included LICENSE file).

# * Additionally, this program can be used under the terms of whatever
#   license 'xterm' is using (now or in the future). This is primarily
#   so that, if the xterm maintainer (currently Thomas E. Dickey) so
#   wishes, this program may be included with xterm as a Sixel test.
#   However, anyone who wishes to take advantage of this is free to do so.
```

So adding extra alternatives to license, i.e. `-or-later` for first option and `xterm` license (X11)