### PR TITLE
colgrep 1.0.7 (new formula)

### DIFF
--- a/Formula/c/colgrep.rb
+++ b/Formula/c/colgrep.rb
@@ -1,0 +1,36 @@
+class Colgrep < Formula
+  desc "Semantic code search powered by late-interaction models"
+  homepage "https://github.com/lightonai/next-plaid"
+  url "https://github.com/lightonai/next-plaid/archive/refs/tags/1.0.7.tar.gz"
+  sha256 "5a5449ac01b9d2e7301d02c7f74097d1f38a90265a4106113429328aa35bb21d"
+  license "Apache-2.0"
+  head "https://github.com/lightonai/next-plaid.git", branch: "main"
+
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
+  depends_on "pkgconf" => :build
+  depends_on "rust" => :build
+  depends_on "openssl@3"
+
+  def install
+    features = []
+    if OS.mac?
+      features << "accelerate"
+      features << "coreml" if Hardware::CPU.arm?
+    end
+
+    args = std_cargo_args(path: "colgrep")
+    if features.any?
+      system "cargo", "install", "--features", features.join(","), *args
+    else
+      system "cargo", "install", *args
+    end
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/colgrep --version")
+  end
+end


### PR DESCRIPTION
Hi released [ColGREP](https://github.com/lightonai/next-plaid) this week, it receive positive feedbacks, would love to make it accessible using brew 😊

Semantic code search tool powered by late-interaction models (ColBERT).
Indexes your codebase and lets you search with natural language queries,
regex patterns, or both combined.

https://github.com/lightonai/next-plaid

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>`? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. Claude Code was used to scaffold the formula. The formula was manually verified: built from source, tested, and audited locally on macOS ARM (Apple Silicon).

-----