### PR TITLE
vineyard: deprecate

### DIFF
--- a/Formula/v/vineyard.rb
+++ b/Formula/v/vineyard.rb
@@ -15,6 +15,12 @@ class Vineyard < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "898b18380f4cc4dd14a07b242a0764379d41f4b412c3c4b843b4f685d7aa46de"
   end
 
+  # Multiple workarounds needed to build. No response to upstream issues/PRs:
+  # - https://github.com/v6d-io/v6d/issues/2041
+  # - https://github.com/v6d-io/v6d/pull/2066
+  deprecate! date: "2026-02-13", because: :unsupported
+  disable! date: "2027-02-13", because: :unsupported
+
   depends_on "cmake" => [:build, :test]
   depends_on "llvm" => :build # for clang Python bindings
   depends_on "openssl@3" => :build # indirect (not linked) but CMakeLists.txt checks for it


### PR DESCRIPTION
Vineyard has been a maintenance burden. It frequently breaks on dependency updates (e.g. Boost, Glog, Apache Arrow) and requires numerous workarounds/patches as upstream hasn't responded.

It is also the of few formulae using `cpprestsdk` which is also in an unmaintained state (officially listed as maintenance mode but no activity in years and just a growing issue/PR count without any response).

Also doesn't seem like anyone else is providing this (https://repology.org/project/vineyard/versions).