### PR TITLE
lastpass-cli: require homebrew curl on macos

### DIFF
--- a/Formula/l/lastpass-cli.rb
+++ b/Formula/l/lastpass-cli.rb
@@ -4,7 +4,7 @@ class LastpassCli < Formula
   url "https://github.com/lastpass/lastpass-cli/releases/download/v1.6.1/lastpass-cli-1.6.1.tar.gz"
   sha256 "5e4ff5c9fef8aa924547c565c44e5b4aa31e63d642873847b8e40ce34558a5e1"
   license "GPL-2.0-or-later" => { with: "openvpn-openssl-exception" }
-  revision 2
+  revision 3
   head "https://github.com/lastpass/lastpass-cli.git", branch: "master"
 
   bottle do

--- a/Formula/l/lastpass-cli.rb
+++ b/Formula/l/lastpass-cli.rb
@@ -20,10 +20,10 @@ class LastpassCli < Formula
   depends_on "cmake" => :build
   depends_on "docbook-xsl" => :build
   depends_on "pkgconf" => :build
+  depends_on "curl"
   depends_on "openssl@3"
   depends_on "pinentry"
 
-  uses_from_macos "curl"
   uses_from_macos "libxml2"
   uses_from_macos "libxslt"
 


### PR DESCRIPTION
It seems that there is an incompatibility between the homebrew openssl and the stock MacOS libcurl that causes lpass to occasionally(?!) crash with:

```
lpass(82349,0x2056b2240) malloc: *** error for object 0x600000000001: pointer being freed was not allocated
lpass(82349,0x2056b2240) malloc: *** set a breakpoint in malloc_error_break to debug
```

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
