### PR TITLE
lastpass-cli: require homebrew curl on macos

### DIFF
--- a/Formula/l/lastpass-cli.rb
+++ b/Formula/l/lastpass-cli.rb
@@ -4,7 +4,7 @@ class LastpassCli < Formula
   url "https://github.com/lastpass/lastpass-cli/releases/download/v1.6.1/lastpass-cli-1.6.1.tar.gz"
   sha256 "5e4ff5c9fef8aa924547c565c44e5b4aa31e63d642873847b8e40ce34558a5e1"
   license "GPL-2.0-or-later" => { with: "openvpn-openssl-exception" }
-  revision 2
+  revision 3
   head "https://github.com/lastpass/lastpass-cli.git", branch: "master"
 
   bottle do
@@ -20,10 +20,10 @@ class LastpassCli < Formula
   depends_on "cmake" => :build
   depends_on "docbook-xsl" => :build
   depends_on "pkgconf" => :build
+  depends_on "curl"
   depends_on "openssl@3"
   depends_on "pinentry"
 
-  uses_from_macos "curl"
   uses_from_macos "libxml2"
   uses_from_macos "libxslt"
 

--- a/Formula/l/lastpass-cli.rb
+++ b/Formula/l/lastpass-cli.rb
@@ -8,12 +8,12 @@ class LastpassCli < Formula
   head "https://github.com/lastpass/lastpass-cli.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "c2a5f02a4ca98532c55385ebacc3539000fa5c6b5a4682f3e5cd5124ff1d6cff"
-    sha256 cellar: :any,                 arm64_sequoia: "569c58eb35aeb7992dc6fe294bc12ffb9080a583bc84d135ddd93bab2d3995ec"
-    sha256 cellar: :any,                 arm64_sonoma:  "e13a16eda126d0829f53904319b45663deb23d226af8ec7906e82a66bfc7d5ca"
-    sha256 cellar: :any,                 sonoma:        "e23cb4d80dee3fa976237e1df4305538652531ab1a9d1b13d22d583c330b7898"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "ce94668af616a6b2f3ef80f465e1da9e4537998e2ff886e1a0f1b4b06dd6502d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "7e72da4920d9db53e2c8cc5b4fd99c2ba72c55dce8721e90fac8657c777ebb58"
+    sha256 cellar: :any,                 arm64_tahoe:   "e547490a82141e4d65e5a86beb319e69e0969a00613ea77562d4d1db33c878a0"
+    sha256 cellar: :any,                 arm64_sequoia: "482c55695d8aa4c7c50306e02025282e2946ad725743fe3edae073bcf8268fc4"
+    sha256 cellar: :any,                 arm64_sonoma:  "47b6ce505c464f48dfa1f9fb46aeb6cf1545c6d784a0aeb8894414fcebbac780"
+    sha256 cellar: :any,                 sonoma:        "0008f85381696f35fd6260696c2b622e588cd6f43e13512156963c3c69b51e6a"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "935451a0d264d9bb0a412f7769ad0c72c2d595ab553e17cfe9d081f1b48f8d0f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "82b5d5939c16538205466a3ebf07fd6c9d349825a190699ab9f5954859899dd3"
   end
 
   depends_on "asciidoc" => :build


### PR DESCRIPTION
It seems that there is an incompatibility between the homebrew openssl and the stock MacOS libcurl that causes lpass to occasionally(?!) crash with:

```
lpass(82349,0x2056b2240) malloc: *** error for object 0x600000000001: pointer being freed was not allocated
lpass(82349,0x2056b2240) malloc: *** set a breakpoint in malloc_error_break to debug
```

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
