### PR TITLE
zlib-ng-compat: link on Linux

### DIFF
--- a/Formula/z/zlib-ng-compat.rb
+++ b/Formula/z/zlib-ng-compat.rb
@@ -14,12 +14,12 @@ class ZlibNgCompat < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "c68344fcda141002ce8baefbfc4b9cd89da914794d9045f7e677ec0a6cd517a9"
-    sha256 cellar: :any,                 arm64_sequoia: "48de3de7772bd13eee2a371fc3a39377962682e325e7deaa6ec5ed4503ef4048"
-    sha256 cellar: :any,                 arm64_sonoma:  "46ccc739bfabf38f5b8dfbe7348679a0931ce83c470d396a3d1c2802b2ca5e0d"
-    sha256 cellar: :any,                 sonoma:        "2a8f6d23e346425ab4e1cabb04694080447a1f486326cc93cab5af4091053912"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "ac366c1fa7ffa88ee7b22e6f820ebd45a865eca7bea812b4751294840e5971aa"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "68ae6d39b4674cecdb6de15180dd613779ee391f90623fa6d10ab2d45c9d2dd0"
+    sha256 cellar: :any,                 arm64_tahoe:   "b54f4ab67f4956e7d0ede376704746985e5e8cfaa97ec299b311c74eb49708a6"
+    sha256 cellar: :any,                 arm64_sequoia: "cf654aacfa54b53a5d1d3fbb73e3053fe43349253de8515f05b7070b430ba4ae"
+    sha256 cellar: :any,                 arm64_sonoma:  "b61f5de1a8bff94d6161b1289e6d4b093842cdce1b6cfdeb768f48ddd4c4dc78"
+    sha256 cellar: :any,                 sonoma:        "e449db4f2bd6dfa5bf1931f053ed2be4406a04408754e300323a8de68156a2a9"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "eb6df814b35273cecd7caf4291ee1a972ab1ac20d11a126b0e2db556dfc50d84"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "eb72c27ca6918fb29af89b1287471e381e15156212ccd0e99661ee393bde872d"
   end
 
   keg_only :shadowed_by_macos, "macOS provides zlib"

--- a/Formula/z/zlib-ng-compat.rb
+++ b/Formula/z/zlib-ng-compat.rb
@@ -6,6 +6,7 @@ class ZlibNgCompat < Formula
   mirror "http://fresh-center.net/linux/misc/legacy/zlib-ng-2.3.3.tar.gz"
   sha256 "f9c65aa9c852eb8255b636fd9f07ce1c406f061ec19a2e7d508b318ca0c907d1"
   license "Zlib"
+  revision 1
   head "https://github.com/zlib-ng/zlib-ng.git", branch: "develop"
 
   livecheck do
@@ -25,9 +26,7 @@ class ZlibNgCompat < Formula
 
   depends_on "cmake" => :build
 
-  on_linux do
-    keg_only "it conflicts with zlib"
-  end
+  link_overwrite "include/zconf.h", "include/zlib.h", "lib/libz.*", "lib/pkgconfig/zlib.pc"
 
   def install
     ENV.runtime_cpu_detection
@@ -45,17 +44,17 @@ class ZlibNgCompat < Formula
 
   test do
     # https://zlib.net/zlib_how.html
-    resource "homebrew-test_artifact" do
-      url "https://zlib.net/zpipe.c"
-      version "20051211"
-      sha256 "68140a82582ede938159630bca0fb13a93b4bf1cb2e85b08943c26242cf8f3a6"
+    resource "zpipe.c" do
+      url "https://raw.githubusercontent.com/madler/zlib/3f5d21e8f573a549ffc200e17dd95321db454aa1/examples/zpipe.c"
+      mirror "http://zlib.net/zpipe.c"
+      sha256 "e79717cefd20043fb78d730fd3b9d9cdf8f4642307fc001879dc82ddb468509f"
     end
 
-    testpath.install resource("homebrew-test_artifact")
+    testpath.install resource("zpipe.c")
     system ENV.cc, "zpipe.c", "-I#{include}", lib/shared_library("libz"), "-o", "zpipe"
 
     text = "Hello, Homebrew!"
-    compressed = pipe_output("./zpipe", text)
-    assert_equal text, pipe_output("./zpipe -d", compressed)
+    compressed = pipe_output("./zpipe", text, 0)
+    assert_equal text, pipe_output("./zpipe -d", compressed, 0)
   end
 end

--- a/Formula/z/zlib.rb
+++ b/Formula/z/zlib.rb
@@ -7,6 +7,7 @@ class Zlib < Formula
   mirror "http://fresh-center.net/linux/misc/legacy/zlib-1.3.1.tar.gz"
   sha256 "9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23"
   license "Zlib"
+  revision 1
   head "https://github.com/madler/zlib.git", branch: "develop"
 
   livecheck do
@@ -29,12 +30,8 @@ class Zlib < Formula
 
   keg_only :provided_by_macos
 
-  # https://zlib.net/zlib_how.html
-  resource "test_artifact" do
-    url "https://zlib.net/zpipe.c"
-    mirror "http://zlib.net/zpipe.c"
-    version "20051211"
-    sha256 "68140a82582ede938159630bca0fb13a93b4bf1cb2e85b08943c26242cf8f3a6"
+  on_linux do
+    keg_only "it conflicts with zlib-ng-compat"
   end
 
   def install
@@ -46,11 +43,18 @@ class Zlib < Formula
   end
 
   test do
-    testpath.install resource("test_artifact")
+    # https://zlib.net/zlib_how.html
+    resource "zpipe.c" do
+      url "https://raw.githubusercontent.com/madler/zlib/3f5d21e8f573a549ffc200e17dd95321db454aa1/examples/zpipe.c"
+      mirror "http://zlib.net/zpipe.c"
+      sha256 "e79717cefd20043fb78d730fd3b9d9cdf8f4642307fc001879dc82ddb468509f"
+    end
+
+    testpath.install resource("zpipe.c")
     system ENV.cc, "zpipe.c", "-I#{include}", "-L#{lib}", "-lz", "-o", "zpipe"
 
     text = "Hello, Homebrew!"
-    compressed = pipe_output("./zpipe", text)
-    assert_equal text, pipe_output("./zpipe -d", compressed)
+    compressed = pipe_output("./zpipe", text, 0)
+    assert_equal text, pipe_output("./zpipe -d", compressed, 0)
   end
 end

--- a/Formula/z/zlib.rb
+++ b/Formula/z/zlib.rb
@@ -16,16 +16,12 @@ class Zlib < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:    "b1f6105bc71a21cad7eb7015d9d363ec1097bf80f91fd3c0d56bc0bece086364"
-    sha256 cellar: :any,                 arm64_sequoia:  "a801a93f88dba4df7319e46cd9ea5939351e73f7aa62a5153a2f7a0b0d79404d"
-    sha256 cellar: :any,                 arm64_sonoma:   "f867540472a59ab3fb1201625df546593e5fae2e98948c4c16c6154b0468b682"
-    sha256 cellar: :any,                 arm64_ventura:  "9033eedbd240076116fea9fa181882e75edee7fe0c5d2e3850258a185c52792f"
-    sha256 cellar: :any,                 arm64_monterey: "ebf10e203575beb64d6a8637ec2dc31774fa3141cfccab8ae7039f88b9efa7f6"
-    sha256 cellar: :any,                 sonoma:         "217f4245cd1da65a3388f512530089f526cd63a38d49ee5f29a90576dfeb3bb7"
-    sha256 cellar: :any,                 ventura:        "6012d7831245716d8507da3d1eb14ad274f8aa0b71b59275fe6bbbd6cebd787f"
-    sha256 cellar: :any,                 monterey:       "56bbfa3d7bd6a5ccf17ffa53ab926e67f24e74bd64b4740b56fd96c312e37c44"
-    sha256 cellar: :any_skip_relocation, arm64_linux:    "8f5d3038615e17d8de3a4b92895a151388e7adfe608f295f89aa669604541f39"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "38f2469db2ce63b70855a98e5ee27b5b5a92874e52542cbdc0b230bba1e7195f"
+    sha256 cellar: :any,                 arm64_tahoe:   "d02341630db7995cc3fbab2fbc4c972a5f3234e06e2ea7d66befe77b648af7a4"
+    sha256 cellar: :any,                 arm64_sequoia: "a9c3e660b585126eeb798217e9974f8657224cc48c4e7ea7bc76fae95ab04a14"
+    sha256 cellar: :any,                 arm64_sonoma:  "93836f9d2dd4d0e28f09d616fb64e6890d3fdf8644d6134915134da0dca283f2"
+    sha256 cellar: :any,                 sonoma:        "d8486be76c60648958734b10999fefa078e094738734e20594d3c654f44bf5be"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "7c3c57e35dd35f2ae6443cd03dbf5962a6f347c8943b39091410a66f1d2f6c38"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2dc996403a69700b568d92d9283a02b530e9349e5771019f226ee35505d26bd9"
   end
 
   keg_only :provided_by_macos


### PR DESCRIPTION
This should help avoid Meson RPATH rewrite problems and avoid having to add PKG_CONFIG_PATH to various dependent tests.

Also majority have been migrated so makes sense to swap linkage now.