### PR TITLE
hg-fast-export: use resource for older `mercurial`

### DIFF
--- a/Formula/h/hg-fast-export.rb
+++ b/Formula/h/hg-fast-export.rb
@@ -10,6 +10,15 @@ class HgFastExport < Formula
   revision 2
   head "https://github.com/frej/fast-export.git", branch: "master"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "26cbfd49c68c6f13eadcd0d6365eaa554aae4ea236b78780a87664f6795be7e5"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e452579006d0079f87d4d472b2932ce585a2730058996782cf0b6054cd8e422e"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "6aa8a9b701199c436905cfa33617ac33bf918e08fbc6c820defdded2dd83c9e8"
+    sha256 cellar: :any_skip_relocation, sonoma:        "22d6c095c84ff4fdee418459f3aa0e9ceeef33de364dda42d24bd90232a7cf65"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "03cc5550a9adbe61efadcf56051885cc423d933ecf75bf43d74914090d9d4c57"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f7799b942685a7fa60d59a8e9b77c2d8865a681c55ddcefa2d5b23c05fbb2360"
+  end
+
   depends_on "mercurial" => :test
   depends_on "python@3.14"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

In order to ship newer Mercurial