### PR TITLE
mdk: update ENV.llvm_clang usage to only Linux

### DIFF
--- a/Formula/m/mdk.rb
+++ b/Formula/m/mdk.rb
@@ -37,14 +37,15 @@ class Mdk < Formula
   depends_on "pango"
   depends_on "readline"
 
+  uses_from_macos "ncurses"
+
   on_macos do
     depends_on "llvm" => :build if DevelopmentTools.clang_build_version <= 1599
-
     depends_on "gettext"
   end
 
   on_linux do
-    depends_on "ncurses"
+    depends_on "llvm" => :build if DevelopmentTools.gcc_version < 13
   end
 
   fails_with :clang do
@@ -53,12 +54,12 @@ class Mdk < Formula
   end
 
   fails_with :gcc do
-    version "11"
+    version "12"
     cause "Requires relaxed variadic args"
   end
 
   def install
-    ENV.llvm_clang if DevelopmentTools.clang_build_version <= 1599
+    ENV.llvm_clang if OS.linux? && deps.map(&:name).any?("llvm")
     system "./configure", "--disable-silent-rules", *std_configure_args
     system "make", "CFLAGS=-std=gnu2x"
     system "make", "install"


### PR DESCRIPTION
May be needed on Linux so draft until I see CI output.