### PR TITLE
xk6: improve test robustness

### DIFF
--- a/Formula/x/xk6.rb
+++ b/Formula/x/xk6.rb
@@ -38,9 +38,9 @@ class Xk6 < Formula
       system "git", "commit", "-m", "init commit"
       system "git", "tag", "v0.0.1"
 
-      lint_output = shell_output("#{bin}/xk6 lint")
+      lint_output = shell_output("#{bin}/xk6 lint --disable=vulnerability")
       assert_match "✔ security", lint_output
-      assert_match "✔ vulnerability", lint_output
+      assert_match "✔ build", lint_output
     end
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Test often starts failing as soon as there is some new vulnerability found in one of the dependancies.

Ref:
* https://github.com/Homebrew/homebrew-core/pull/258912 (failing as a dependancy in most RC and release builds)
* https://github.com/Homebrew/homebrew-core/pull/266923 (failing as a dependancy, disabled dependancy builds with PR lable)
* https://github.com/grafana/xk6/pull/401 (one of many pre-release fixes, but not often enough to expect it to be vulnerability-free all the time)
* ...