### PR TITLE
formulae(a*, b*, c*): remove `no_autobump!`

### DIFF
--- a/Formula/a/abduco.rb
+++ b/Formula/a/abduco.rb
@@ -6,8 +6,6 @@ class Abduco < Formula
   license "ISC"
   head "https://github.com/martanne/abduco.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "c2c4bcd34f6b83f1a2b3a04e223b7eab8b29d6a39043127f422f59d7c38c7e6e"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "216c0c4a4ac3e537b0846cb998b36ea986de0d42fb3b2c50b0dfdd4da38a7418"

--- a/Formula/a/aces_container.rb
+++ b/Formula/a/aces_container.rb
@@ -5,8 +5,6 @@ class AcesContainer < Formula
   sha256 "cbbba395d2425251263e4ae05c4829319a3e399a0aee70df2eb9efb6a8afdbae"
   license "AMPAS"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "99edd15fca4a15e40dfac78586b15c5c86fb13ae9d05024f837fc7b28aa7abde"
     sha256 cellar: :any,                 arm64_sequoia:  "470a323cfa40f185682a38aa7ecb04256cebf17b0b854e444cb89d02c09c7d0c"

--- a/Formula/a/actions-batch.rb
+++ b/Formula/a/actions-batch.rb
@@ -6,8 +6,6 @@ class ActionsBatch < Formula
   license "MIT"
   head "https://github.com/alexellis/actions-batch.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "59536a5a9f181ae349d14c6c2b55d6a8e022365f1ae425321e6ceccb43d9f4b5"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "275c7fbcf663d2acb91d05bde500b7138a1cb7f5df5f1247c887ca7bbe823019"

--- a/Formula/a/afuse.rb
+++ b/Formula/a/afuse.rb
@@ -5,8 +5,6 @@ class Afuse < Formula
   sha256 "87284e3f7973f5a61eea4a37880512c01f0b8bf1d37a8988447efbe806ec3414"
   license "GPL-2.0-only"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_linux:  "22032cf3dd5fe4a2aa623d7bc1f542eebd796f749a63e62907bf1006b2f42d26"

--- a/Formula/a/aha.rb
+++ b/Formula/a/aha.rb
@@ -6,8 +6,6 @@ class Aha < Formula
   license any_of: ["LGPL-2.0-or-later", "MPL-1.1"]
   head "https://github.com/theZiz/aha.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "c5c635a3945439e2666c6387fc7adf040ae53448b69cdd10ead335c19238abe0"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "16696aeddc832f4f9f7c61ce7d3e6a8327f229bdeb941aded1bce4b2285f8470"

--- a/Formula/a/alass.rb
+++ b/Formula/a/alass.rb
@@ -5,8 +5,6 @@ class Alass < Formula
   sha256 "ce88f92c7a427b623edcabb1b64e80be70cca2777f3da4b96702820a6cdf1e26"
   license "GPL-3.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "de4af244ed90c2a2b9c309340cb5d47e926ce1f2012001524d1674dd4213b1fc"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "efa1a388ee9ecf5193edd9c9003af0f035ed138bf6a79b45e6b22654c32888e4"

--- a/Formula/a/alejandra.rb
+++ b/Formula/a/alejandra.rb
@@ -6,8 +6,6 @@ class Alejandra < Formula
   license "Unlicense"
   head "https://github.com/kamadorueda/alejandra.git", branch: "main"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "ee21f9015c2853fb4ccd0b5e8b8674c7d1c27ef9c17ff73771ca33f035a4eddd"
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "a105b8e8c06f4e240b052d62e5b271e4a1c196f8367780ae22fe4bf705ad65b1"

--- a/Formula/a/alexjs.rb
+++ b/Formula/a/alexjs.rb
@@ -5,8 +5,6 @@ class Alexjs < Formula
   sha256 "0c41d5d72c0101996aecb88ae2f423d6ac7a2fc57f93384d1a193d2ce67c4ffb"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "f8e7666f1bbca1055363b542c7937cfcfdcf2ce1667f8e01a3013353a0b32ab8"

--- a/Formula/a/amfora.rb
+++ b/Formula/a/amfora.rb
@@ -9,8 +9,6 @@ class Amfora < Formula
   ]
   head "https://github.com/makew0rld/amfora.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "00e4da529415b5a5b02c68c987828c996e1b044e8de4bdd3bd91aff35d472396"
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "aea294662496a802b0b372ac96c71b78a6df62ff654855c243677b5d7d4e4803"

--- a/Formula/a/analog.rb
+++ b/Formula/a/analog.rb
@@ -6,8 +6,6 @@ class Analog < Formula
   license "GPL-2.0-only"
   head "https://github.com/c-amie/analog-ce.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:   "f7dcb27fbb927e223eb5de35e0121ed04978d431cbda451bc90d514db6f91898"
     sha256 arm64_sequoia: "cf6b6b5922287fd9aad880021dbc161e361b3e1a485ae29ebba5a205085c9bd1"

--- a/Formula/a/ansible-cmdb.rb
+++ b/Formula/a/ansible-cmdb.rb
@@ -8,8 +8,6 @@ class AnsibleCmdb < Formula
   license "GPL-3.0-or-later"
   revision 1
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:   "b6be47954b66a7ecc04bfff866f4417a531171c2bfa3dcf1ac7c17ed5bac7e5c"

--- a/Formula/a/apt-dater.rb
+++ b/Formula/a/apt-dater.rb
@@ -7,8 +7,6 @@ class AptDater < Formula
   revision 2
   version_scheme 1
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:   "ca8d65020e488e692c5785619fda1d960a49f88b2f80e2213f1d56f39b6f40de"
     sha256 arm64_sequoia: "e9a104010e991369030ef2f6b060658977e33252724fb5a1891a69242a8c3fc8"

--- a/Formula/a/argp-standalone.rb
+++ b/Formula/a/argp-standalone.rb
@@ -9,8 +9,6 @@ class ArgpStandalone < Formula
     :public_domain,      # mempcpy.c, strchrnul.c
   ]
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "4e16dcc9c857334ef0c9edee97b5063ead0f3f8dddc428ccb9cbeec6881a104c"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "b71de47f10a604629ded46675494d28ec5189153afe353425a4f6f52ab879f29"

--- a/Formula/a/arpack.rb
+++ b/Formula/a/arpack.rb
@@ -7,8 +7,6 @@ class Arpack < Formula
   revision 1
   head "https://github.com/opencollab/arpack-ng.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "49cef98cf7475c671e5826e23a50d8c093a34685d6a98ed55614916f2196408b"
     sha256 cellar: :any,                 arm64_sequoia: "476f1c28808b3115fa9cf72d17bda20b989dc60d911d3abe85be50a92bd1d6a1"

--- a/Formula/a/as-tree.rb
+++ b/Formula/a/as-tree.rb
@@ -5,8 +5,6 @@ class AsTree < Formula
   sha256 "2af03a2b200041ac5c7a20aa1cea0dcc21fb83ac9fe9a1cd63cb02adab299456"
   license "BlueOak-1.0.0"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "21036f05ea5294ef3b8f2fb17517631a76c8d2c2ed521311322a55ba2320a28e"

--- a/Formula/a/asimov.rb
+++ b/Formula/a/asimov.rb
@@ -6,8 +6,6 @@ class Asimov < Formula
   license "MIT"
   head "https://github.com/stevegrunwell/asimov.git", branch: "develop"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, all: "86f8b1f739784ed4e90e99090a27454e9b2852787fe6110f9bf15b991e3fe4c4"

--- a/Formula/a/asmfmt.rb
+++ b/Formula/a/asmfmt.rb
@@ -6,8 +6,6 @@ class Asmfmt < Formula
   license "MIT"
   head "https://github.com/klauspost/asmfmt.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "d9bde3ea9f89546ebccfec0cd65ee0afa6b9a11656285d71c21fdbf37bbec50f"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "2c6bd7b97cd140278a84fc6f839c13b5ec3f6baced91eb0cba54601959f87d5e"

--- a/Formula/a/asn1c.rb
+++ b/Formula/a/asn1c.rb
@@ -5,8 +5,6 @@ class Asn1c < Formula
   sha256 "8007440b647ef2dd9fb73d931c33ac11764e6afb2437dbe638bb4e5fc82386b9"
   license "BSD-2-Clause"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 arm64_tahoe:    "101f876e913d345e99ac08ef2e9144b578e3979491f8338a62cf3c0e0d346144"

--- a/Formula/a/aspcud.rb
+++ b/Formula/a/aspcud.rb
@@ -5,8 +5,6 @@ class Aspcud < Formula
   sha256 "4dddfd4a74e4324887a1ddd7f8ff36231774fc1aa78b383256546e83acdf516c"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:    "38a5c5010a8e9f38e95233d7b20dcdb75b76c33e1cb3f80410dc01b277ddc17e"
     sha256 arm64_sequoia:  "429008eb29edff4d08e840bd0eb373ea061c357d01ebab4e416f9d4681b95b0a"

--- a/Formula/a/asroute.rb
+++ b/Formula/a/asroute.rb
@@ -6,8 +6,6 @@ class Asroute < Formula
   license "MIT"
   head "https://github.com/stevenpack/asroute.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "c6742a4381bdb0de6f208dfcaba3e95ca02ffa9c7ff2263ed492ac082af55d24"

--- a/Formula/a/ata.rb
+++ b/Formula/a/ata.rb
@@ -5,8 +5,6 @@ class Ata < Formula
   sha256 "a70498492fce7b46a2a62175886a801f61f9f530c5c6d01b664af2750d3af555"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "61e1c7235e1db8bd6b2dca88f24e1dce32658c60817c274a8a3a74f8e93865f0"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "e4e98e4c055e41cc706441024e03f621e29598cf9889dd8735542dea055a34e1"

--- a/Formula/a/aurora.rb
+++ b/Formula/a/aurora.rb
@@ -6,8 +6,6 @@ class Aurora < Formula
   license "MIT"
   head "https://github.com/xuri/aurora.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "d851326e81898d1d2e48168b6bfdfaa7a9073361543e2fca53be0d0bb28a27ed"

--- a/Formula/a/authoscope.rb
+++ b/Formula/a/authoscope.rb
@@ -5,8 +5,6 @@ class Authoscope < Formula
   sha256 "fd70d3d86421ac791362bf8d1063a1d5cd4f5410b0b8f5871c42cb48c8cc411a"
   license "GPL-3.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "c6eaad5b4287b9e44492653bd7d5996f61c1b29d996e6ca4a045c6eb5019a10e"

--- a/Formula/a/avra.rb
+++ b/Formula/a/avra.rb
@@ -5,8 +5,6 @@ class Avra < Formula
   sha256 "cc56837be973d1a102dc6936a0b7235a1d716c0f7cd053bf77e0620577cff986"
   license "GPL-2.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "00e1f1cfce097d5ffae9d1c99fec5a225eddc92bf806227ee55aa50c585d442f"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "761db2506786dee44f9e36284b588b38692bdef86870ebacf6d90472585627cd"

--- a/Formula/b/bash-git-prompt.rb
+++ b/Formula/b/bash-git-prompt.rb
@@ -6,8 +6,6 @@ class BashGitPrompt < Formula
   license "BSD-2-Clause"
   head "https://github.com/magicmonty/bash-git-prompt.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "5049efb01e5ceb83df920dfe1c5dd23595401e3c700064fee74afbf9949d4f8f"

--- a/Formula/b/bash-snippets.rb
+++ b/Formula/b/bash-snippets.rb
@@ -5,8 +5,6 @@ class BashSnippets < Formula
   sha256 "59b784e714ba34a847b6a6844ae1703f46db6f0a804c3e5f2de994bbe8ebe146"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, all: "d22507e71365355dc20eba3747a10f575f80ff3dc86103d1a2f9be08a08932d9"

--- a/Formula/b/beanstalkd.rb
+++ b/Formula/b/beanstalkd.rb
@@ -5,8 +5,6 @@ class Beanstalkd < Formula
   sha256 "26292dcdc0a7011d2f8ad968612f2cd8b2ef07687224876015399ae85e9e5263"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "3822e7705185398f263482d69e922ffee29ccc195eb491bcc765a020ac6728ac"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "74b984c41b74f63386b6125681be1f37529341179a754f0556ed9d2d621b9088"

--- a/Formula/b/benerator.rb
+++ b/Formula/b/benerator.rb
@@ -5,8 +5,6 @@ class Benerator < Formula
   sha256 "5d1b3de2344f0c2a1719eed5ab8154a75597a5d7693c373734e0603a45e5f96d"
   license "Apache-2.0"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, all: "f36cf8f7f24ff1551582eb0e052ea5365709c807b642c8fc38c8ef551e974e67"

--- a/Formula/b/betty.rb
+++ b/Formula/b/betty.rb
@@ -6,8 +6,6 @@ class Betty < Formula
   license "Apache-2.0"
   revision 1
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, all: "6e05c82883d813ce98372d8ed15bf2e4b9cd11cd91f36483a07e37ccec8204ee"

--- a/Formula/b/bgrep.rb
+++ b/Formula/b/bgrep.rb
@@ -6,8 +6,6 @@ class Bgrep < Formula
   license "BSD-2-Clause"
   head "https://github.com/tmbinc/bgrep.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "cb6e6a68d53feffbff679a734db6345a373556ddd3f2d76e2f073b4d3f84d452"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "e9084b991c90bd70740bce59c399d55365789b5226d8883067f552d2601fa0b2"

--- a/Formula/b/bioawk.rb
+++ b/Formula/b/bioawk.rb
@@ -5,8 +5,6 @@ class Bioawk < Formula
   sha256 "5cbef3f39b085daba45510ff450afcf943cfdfdd483a546c8a509d3075ff51b5"
   license "HPND"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "dc8c77af3f46588cab03f40541d48dfa09fe06115be3be5c42495213ad7fa003"

--- a/Formula/b/bitwise.rb
+++ b/Formula/b/bitwise.rb
@@ -5,8 +5,6 @@ class Bitwise < Formula
   sha256 "806271fa5bf31de0600315e8720004a8f529954480e991ca84a9868dc1cae97e"
   license "GPL-3.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "9f6712da2de2e93861c008540f524f5b60be33054db0acb064d82a26322c361d"
     sha256 cellar: :any,                 arm64_sequoia:  "d7659a60e6cad87bc0dd72921475005c50340e66d7a6ba822a5769a67df1b91d"

--- a/Formula/b/blahtexml.rb
+++ b/Formula/b/blahtexml.rb
@@ -6,8 +6,6 @@ class Blahtexml < Formula
   license "BSD-3-Clause"
   revision 1
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "ff3728fa3b6cd2729e13bf73a0f4bf9bd7be61b9296f3ec524a9898a4722a256"
     sha256 cellar: :any,                 arm64_sequoia: "60f47cf24ae5bd4f52cf4aa2030b663593416a2af1a4cb8777eb62c9c372b6f6"

--- a/Formula/b/blitzwave.rb
+++ b/Formula/b/blitzwave.rb
@@ -5,8 +5,6 @@ class Blitzwave < Formula
   sha256 "edb0b708a0587e77b8e0aa3387b44f4e838855c17e896a8277bb80fbe79b9a63"
   license "GPL-2.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "af9617a5b1ac77f4118d9bed451601510403a32d7e45c1c0b0c67073f36a724b"
     sha256 cellar: :any,                 arm64_sequoia:  "6ddfd2d5b7388e38647c23c2556e37258da48bbb0408290ccc1e54c5970fc68f"

--- a/Formula/b/bloaty.rb
+++ b/Formula/b/bloaty.rb
@@ -17,8 +17,6 @@ class Bloaty < Formula
     end
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any, arm64_tahoe:   "f85173bbc4a31ca284b044dbfa8cb91264cfccda9b1fbd5416182179f3664420"
     sha256 cellar: :any, arm64_sequoia: "4222979bfeeb62af2b0eb659ddb10db09a4ed53d606a68fd13a034611194bdfa"

--- a/Formula/b/blockhash.rb
+++ b/Formula/b/blockhash.rb
@@ -7,8 +7,6 @@ class Blockhash < Formula
   revision 4
   head "https://github.com/commonsmachinery/blockhash.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "67363b29a30df42d320f72595bd81ce0dc7e41ec7cf0ec5f620bc90e6256a681"
     sha256 cellar: :any,                 arm64_sequoia: "da404e78c996ce8a8cc0f39fb53c7b98de1df04a20f3f04224ef34d181d427e1"

--- a/Formula/b/blogc.rb
+++ b/Formula/b/blogc.rb
@@ -6,8 +6,6 @@ class Blogc < Formula
   license "BSD-3-Clause"
   head "https://github.com/blogc/blogc.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "54a616937c29e0fa6c68db2372e4d577e26632bf6ef9c3454f8f3571a9b28251"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "1550db3be9b6c9bd21d1a522550644fbf0d524f51126ed55560c2e3d01b4444f"

--- a/Formula/b/bmon.rb
+++ b/Formula/b/bmon.rb
@@ -6,8 +6,6 @@ class Bmon < Formula
   license "BSD-2-Clause"
   revision 2
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:    "93cdadcf5fec7072cb986a15fb5f6f3e405d09da4dbeb2048eff7b561b0b8af8"

--- a/Formula/b/boom-completion.rb
+++ b/Formula/b/boom-completion.rb
@@ -6,8 +6,6 @@ class BoomCompletion < Formula
   license "MIT"
   head "https://github.com/holman/boom.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, all: "3804dd1b6ac824126d7b5a3456482ccfa6a84afb568b3528cd9fc9be939b157d"

--- a/Formula/b/bower-mail.rb
+++ b/Formula/b/bower-mail.rb
@@ -7,8 +7,6 @@ class BowerMail < Formula
   revision 1
   head "https://github.com/wangp/bower.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "6c529955bcdd18e610441bd154d41cdbb03e164ea51aee9be99db4d4fa388553"
     sha256 cellar: :any,                 arm64_sequoia: "d47f47f021948b197519c8153299af29c6daf61303ec3271202a3db295d778fa"

--- a/Formula/b/brename.rb
+++ b/Formula/b/brename.rb
@@ -5,8 +5,6 @@ class Brename < Formula
   sha256 "a16bceb25a75afa14c5dae2248c1244f1083b80b62783ce5dbf3e46ff68867d5"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "de768e5762a8564a275a8bc3f06407d3b17e8eb22cfb7619baa517815aefa460"
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "39e2df7de67e853a566edaa7a2ba0f092013367b2efcea51d3c5c5d311b8fd94"

--- a/Formula/b/brightness.rb
+++ b/Formula/b/brightness.rb
@@ -6,8 +6,6 @@ class Brightness < Formula
   license "BSD-2-Clause"
   head "https://github.com/nriley/brightness.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "0e6517dcfe7a3a982012ed8311ab590f4d071382d9e80ff60c8dba7dc0075e0a"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "92e87e26e1e82ded8087e37e6e94624f80af2b1d84248fb70653da8c86688396"

--- a/Formula/b/bsdconv.rb
+++ b/Formula/b/bsdconv.rb
@@ -6,8 +6,6 @@ class Bsdconv < Formula
   license "BSD-2-Clause"
   head "https://github.com/buganini/bsdconv.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:    "4975475d7d550693334c6abef8a0c8c1ee3f87552e3310f333f6a7e3b1548240"
     sha256 arm64_sequoia:  "eb27911fad713a1d8d36146105cb0abffcf7a6c78bdd358c09e5ff64c207e3fd"

--- a/Formula/b/btpd.rb
+++ b/Formula/b/btpd.rb
@@ -6,8 +6,6 @@ class Btpd < Formula
   license "BSD-2-Clause"
   revision 2
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:    "9670afe44796531465fa7394a409a946f16512995eaa9405ad263fcb72bd469f"

--- a/Formula/b/buildapp.rb
+++ b/Formula/b/buildapp.rb
@@ -7,8 +7,6 @@ class Buildapp < Formula
   revision 3
   head "https://github.com/xach/buildapp.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 3
     sha256 arm64_tahoe:   "1b91e415cf7ddeab7dc5585efe5b7e58d4798f336ae19bd8c33ebd4d24b19e58"

--- a/Formula/b/bundler-completion.rb
+++ b/Formula/b/bundler-completion.rb
@@ -11,8 +11,6 @@ class BundlerCompletion < Formula
     formula "ruby-completion"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, all: "eba47de2a5fee4ae57cc2e1eec146d6b8602819de68ab8865a092cfbfe8aa2e8"
   end

--- a/Formula/b/burst.rb
+++ b/Formula/b/burst.rb
@@ -6,8 +6,6 @@ class Burst < Formula
   license "BSL-1.0"
   head "https://github.com/izvolov/burst.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, all: "f9f985b7be3eee4cd5a80bb0a32064f454e66345085f46b302f3312f767260a1"

--- a/Formula/b/bwm-ng.rb
+++ b/Formula/b/bwm-ng.rb
@@ -6,8 +6,6 @@ class BwmNg < Formula
   license "GPL-2.0-or-later"
   head "https://github.com/vgropp/bwm-ng.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "ec3ddaf321252ebe934527a12aa3e1addb76f797cf5a618f8a9565c3d248d5af"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "75b60058b57ac9733b0b3f0b7d83fd14bf2a23c5ef2b05fccc3c0494d773aab7"

--- a/Formula/c/c10t.rb
+++ b/Formula/c/c10t.rb
@@ -6,8 +6,6 @@ class C10t < Formula
   license "BSD-3-Clause"
   revision 13
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:   "008b33ff7cc9eec1c4fce9a3fac4d9e5b3f30ad9a66b29edf911ab97f81e5238"

--- a/Formula/c/camlp-streams.rb
+++ b/Formula/c/camlp-streams.rb
@@ -6,8 +6,6 @@ class CamlpStreams < Formula
   license "LGPL-2.1-only" => { with: "OCaml-LGPL-linking-exception" }
   revision 5
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "e7fe4bfbf60135b74ed63cd5430c8aaa06afc4b6755562448b43061c33dc92bb"
     sha256 cellar: :any,                 arm64_sequoia: "bb52bd02f32203ab2afd5ba95e31870d7a1434958b1c738a05d9b74d4d5d8117"

--- a/Formula/c/caracal.rb
+++ b/Formula/c/caracal.rb
@@ -6,8 +6,6 @@ class Caracal < Formula
   license "AGPL-3.0-only"
   head "https://github.com/crytic/caracal.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "736248b14af4194e38b8d5d8103f2f649cc1293391d0ca147f1ead5529e2d3d4"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "b8b9b99080c463030eb02044b0db946992bba13ef79f693498b6f154a41d5407"

--- a/Formula/c/cargo-docset.rb
+++ b/Formula/c/cargo-docset.rb
@@ -6,8 +6,6 @@ class CargoDocset < Formula
   license "Apache-2.0"
   head "https://github.com/Robzz/cargo-docset.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "760e1422ff6844a8f4133e095dd22f59d046ba01b0eb9f880548b7af7a02ffe2"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "5c4351f68e1d7fb4997246d0a1ff54e85b3aae4524bcb0cdc0bac379a88ecf54"

--- a/Formula/c/ccat.rb
+++ b/Formula/c/ccat.rb
@@ -6,8 +6,6 @@ class Ccat < Formula
   license "MIT"
   head "https://github.com/owenthereal/ccat.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "21843d1726a746b8fcfffac1d1cfb9f28c56ecaa54d596ee041f531d78e02cdd"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "57638eda46f68bfaf966e488fb3f7f49c7fde0386cda8f751af2669186abc1e5"

--- a/Formula/c/cereal.rb
+++ b/Formula/c/cereal.rb
@@ -16,8 +16,6 @@ class Cereal < Formula
     end
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, all: "dc981dc92c83e4642a9ae88b2f9c19df8eed192e09c458ff80d4ad7216c71f25"
   end

--- a/Formula/c/chadwick.rb
+++ b/Formula/c/chadwick.rb
@@ -10,8 +10,6 @@ class Chadwick < Formula
     strategy :github_latest
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "a25e4a468f0a8202822cbed14f6b357e9bb08d39ac2ab2b6440b76a1a5fbd468"
     sha256 cellar: :any,                 arm64_sequoia: "7f2f912f0bd0d1e01b9c5c79756c1871ee38ca5db5867eb00a8b329a964c6e4a"

--- a/Formula/c/charls.rb
+++ b/Formula/c/charls.rb
@@ -6,8 +6,6 @@ class Charls < Formula
   license "BSD-3-Clause"
   head "https://github.com/team-charls/charls.git", branch: "main"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "a1c092740b2d8128a1c4bfe89a332c4bc132a936a6f058d34af8470c465d429c"
     sha256 cellar: :any,                 arm64_sequoia:  "4c5a430f93616eee0bbf2464f5b950ebced3874e71fe95dd8c50c78d30752af8"

--- a/Formula/c/check.rb
+++ b/Formula/c/check.rb
@@ -5,8 +5,6 @@ class Check < Formula
   sha256 "a8de4e0bacfb4d76dd1c618ded263523b53b85d92a146d8835eb1a52932fa20a"
   license "LGPL-2.1-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "ce6a229334822ebeb404ea91776ddb2727e76754724dbc6b7dae91cc274748cd"
     sha256 cellar: :any,                 arm64_sequoia:  "11f6f6c67483ebc4a230480a1b068882a8476afc52517d2d68de0ecc24ea305b"

--- a/Formula/c/chinadns-c.rb
+++ b/Formula/c/chinadns-c.rb
@@ -5,8 +5,6 @@ class ChinadnsC < Formula
   sha256 "abfd433e98ac0f31b8a4bd725d369795181b0b6e8d1b29142f1bb3b73bbc7230"
   license "GPL-3.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "3ad68ee0eade8b16d3698f5f38f91dedb795c40f6776be6458feb36576fc3e48"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "d7f5135d04a85b3d2eb3db7d807d091f45b6c7047613d73538fe8e3fd92d2fcd"

--- a/Formula/c/cig.rb
+++ b/Formula/c/cig.rb
@@ -6,8 +6,6 @@ class Cig < Formula
   license "MIT"
   head "https://github.com/stevenjack/cig.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 3
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "24af56532b56382a0a26334284d11ace630a49d376ae8af4f808aede18cf17a5"

--- a/Formula/c/clblas.rb
+++ b/Formula/c/clblas.rb
@@ -6,8 +6,6 @@ class Clblas < Formula
   license "Apache-2.0"
   revision 1
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "e6c3905b2128cd5fece2722262321cf7b446cb8119cc0c96f33e87a0e534a9d1"
     sha256 cellar: :any,                 arm64_sequoia:  "e01b9a3b09dc996c6feb5b474e99f463b4079417aa0c24c69d5ace2cb896b036"

--- a/Formula/c/clip.rb
+++ b/Formula/c/clip.rb
@@ -13,8 +13,6 @@ class Clip < Formula
     patch :DATA
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "db658e6fcb0e356d9c460e6a9d68a284b7cfc259410427072fe0a3e980a79c3b"
     sha256 cellar: :any,                 arm64_sequoia: "39474a5890b2367e6ef4e94946bfd9298d939b124cca416f7c497a9594c767b0"

--- a/Formula/c/clipper.rb
+++ b/Formula/c/clipper.rb
@@ -6,8 +6,6 @@ class Clipper < Formula
   license "BSD-2-Clause"
   head "https://github.com/wincent/clipper.git", branch: "main"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "3c0df619d149a439aa768fe0ad2f378c814df645516f1b97e7208af8570e9bc4"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "5ba6f81698c0137f48012644d531c866531753698d1401afbf4812ac6afac002"

--- a/Formula/c/clitest.rb
+++ b/Formula/c/clitest.rb
@@ -6,8 +6,6 @@ class Clitest < Formula
   license "MIT"
   head "https://github.com/aureliojargas/clitest.git", branch: "main"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "f1cbfc94748a8712ab8a8845fd800d0009519c4d5ffbbcf03efce267406b91e5"

--- a/Formula/c/cmatrix.rb
+++ b/Formula/c/cmatrix.rb
@@ -5,8 +5,6 @@ class Cmatrix < Formula
   sha256 "ad93ba39acd383696ab6a9ebbed1259ecf2d3cf9f49d6b97038c66f80749e99a"
   license "GPL-3.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "3e9a355625f0fde46f71845797d28ee84f3613df8ede85373b754f13ca156170"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "4dc801fdcf6bbf449a1b6a73a68c1ab8cfe990de6d9fbcf686c40998cd5c9f31"

--- a/Formula/c/cmrc.rb
+++ b/Formula/c/cmrc.rb
@@ -15,8 +15,6 @@ class Cmrc < Formula
     end
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, all: "bccb869a3fb9486fbd2594d68a8be7fb57819f27764bbf9b3888cdc54d746ce7"

--- a/Formula/c/cmusfm.rb
+++ b/Formula/c/cmusfm.rb
@@ -5,8 +5,6 @@ class Cmusfm < Formula
   sha256 "17aae8fc805e79b367053ad170854edceee5f4c51a9880200d193db9862d8363"
   license "GPL-3.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "844a2f8e9ddbf09e79945a32979812f92c35e5db032bcf204bd50c1af307ee81"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "f9de4e6485544f8cbe0c2fb56acde11a3f0e689ee244f6ae40048739c36c12f4"

--- a/Formula/c/cobra-cli.rb
+++ b/Formula/c/cobra-cli.rb
@@ -6,8 +6,6 @@ class CobraCli < Formula
   license "Apache-2.0"
   head "https://github.com/spf13/cobra-cli.git", branch: "main"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "390cda2b8ba89e754ff53a554bd607688676c1f5e8e0c62af31921186e389a77"

--- a/Formula/c/colfer.rb
+++ b/Formula/c/colfer.rb
@@ -6,8 +6,6 @@ class Colfer < Formula
   license "CC0-1.0"
   head "https://github.com/pascaldekloe/colfer.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "6753b9901bb37c362353210bd3fb81d2330d08285934c9fe54f79abdf644cd2f"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "46194d5083a34ae3e54cdd690610c1dd5fa385e2311cb1bd61e852029a53ec85"

--- a/Formula/c/collada-dom.rb
+++ b/Formula/c/collada-dom.rb
@@ -7,8 +7,6 @@ class ColladaDom < Formula
   revision 15
   head "https://github.com/rdiankov/collada-dom.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "571dd57bc1c55e2136dcca7348eb4ff31aee95a3d20178ea87a36061fe655a6a"
     sha256 cellar: :any,                 arm64_sequoia: "506e14ad369e4dbb9014a15b29f50ffe2b1d453877939de55a8112b3cb279d0d"

--- a/Formula/c/colormake.rb
+++ b/Formula/c/colormake.rb
@@ -6,8 +6,6 @@ class Colormake < Formula
   license "GPL-2.0-or-later"
   head "https://github.com/pagekite/Colormake.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "a628cc6cde2a938abc044ae867405b3232bc9c999b10729652fbe3088535da44"

--- a/Formula/c/colortail.rb
+++ b/Formula/c/colortail.rb
@@ -5,8 +5,6 @@ class Colortail < Formula
   sha256 "8d259560c6f4a4aaf1f4bbdb2b62d3e1053e7e19fefad7de322131b7e80e294d"
   license "GPL-2.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "9862416bf5401f2a2a61f90bdac87795f7445e95cf4baf6e0d0d73e984740a99"
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "46881ac8087481d7f575b911883807e424a02ab942a7af58d9c38b4d2b73ef85"

--- a/Formula/c/configen.rb
+++ b/Formula/c/configen.rb
@@ -6,8 +6,6 @@ class Configen < Formula
   license "MIT"
   head "https://github.com/theappbusiness/ConfigGenerator.git", branch: "main"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "6065f7176f6749015d33a8b03a07fd9d4274686f797b8aadc81e2632669b242c"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "f4afca8fd4567771c799d14425f4085ddc23a1ca5f89e32890dba233919e3ae9"

--- a/Formula/c/coordgen.rb
+++ b/Formula/c/coordgen.rb
@@ -5,8 +5,6 @@ class Coordgen < Formula
   sha256 "f67697434f7fec03bca150a6d84ea0e8409f6ec49d5aab43badc5833098ff4e3"
   license "BSD-3-Clause"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "b6016edb22f9c1467d088684311a5de1a03f156031c99884f5a04bd55b4b368f"
     sha256 cellar: :any,                 arm64_sequoia: "f3291f603f1f55c41163e4acab534a3fc8fb192582deff462ec8894764ba5bb9"

--- a/Formula/c/counts.rb
+++ b/Formula/c/counts.rb
@@ -6,8 +6,6 @@ class Counts < Formula
   license "Unlicense"
   head "https://github.com/nnethercote/counts.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "24d9ace69ae8a6c2bdb85fcb5c1c42b53f73209bb2a9958cd02e2b1aaff40fe4"
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "104e0c1a70c346de9a881f3604a940409c21292be6f728bad0d317423d7e3302"

--- a/Formula/c/cpptoml.rb
+++ b/Formula/c/cpptoml.rb
@@ -7,8 +7,6 @@ class Cpptoml < Formula
   revision 1
   head "https://github.com/skystrife/cpptoml.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "c7277d9959d90daba22c6e5e464e5d9877c6dce18d25932a5a7d53feac061139"

--- a/Formula/c/cpulimit.rb
+++ b/Formula/c/cpulimit.rb
@@ -6,8 +6,6 @@ class Cpulimit < Formula
   license "GPL-2.0-or-later"
   head "https://github.com/opsengine/cpulimit.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "b5d88d4e5afdf6bf19d2069b78a12afb77e1f5e2ddf3b34b1cae55528a8f7bd6"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "7eca714845ccc7a47497489a5075812b50700960acc1eb7eeefbfd5921851a76"

--- a/Formula/c/cql.rb
+++ b/Formula/c/cql.rb
@@ -6,8 +6,6 @@ class Cql < Formula
   license "Apache-2.0"
   head "https://github.com/CovenantSQL/CovenantSQL.git", branch: "develop"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "b2ed7ce113b81fa92f86a376923fd42bd294320b892005b8996f8950fe40e19a"

--- a/Formula/c/cqlkit.rb
+++ b/Formula/c/cqlkit.rb
@@ -5,8 +5,6 @@ class Cqlkit < Formula
   sha256 "0574b4b6fe893078e993a80f95a183b89955129ab8929f5032b7faacf611952c"
   license "Apache-2.0"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, all: "d046672e2ea78accbef7eb841a473b6074a2b42f683d6c9b4e07979f63c60c29"

--- a/Formula/c/crc32c.rb
+++ b/Formula/c/crc32c.rb
@@ -6,8 +6,6 @@ class Crc32c < Formula
   license "BSD-3-Clause"
   head "https://github.com/google/crc32c.git", branch: "main"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "8e3aaa27057bb4e44a84d7fcdef9f8fea950c18d34017a3212f4f4ee9d0e6f03"
     sha256 cellar: :any,                 arm64_sequoia:  "8ea83fd9714095d17ddcb3b8a8f70d2c5694f35b7b6edc17aa8b32e6952295c8"

--- a/Formula/c/crcany.rb
+++ b/Formula/c/crcany.rb
@@ -6,8 +6,6 @@ class Crcany < Formula
   license "Zlib"
   head "https://github.com/madler/crcany.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "310705bfcb672936583047b27aa427f521040ed64ac1caf7857658f0ad573bb5"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "edc3456fd296ee992ccd6dc5f64082b1b52789679ea5068c8326874ec600863c"

--- a/Formula/c/create-api.rb
+++ b/Formula/c/create-api.rb
@@ -7,8 +7,6 @@ class CreateApi < Formula
   revision 1
   head "https://github.com/CreateAPI/CreateAPI.git", branch: "main"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "669393e0173057f300559c44055716228c89dbf1dd91a0d898eef408c98ec184"

--- a/Formula/c/crfsuite.rb
+++ b/Formula/c/crfsuite.rb
@@ -5,8 +5,6 @@ class Crfsuite < Formula
   sha256 "ab83084ed5d4532ec772d96c3e964104d689f2c295915e80299ea3c315335b00"
   license "BSD-3-Clause"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "65a13d4653a19e899bdbcec57f9d7dc4852dce18c753e31c42102f7ce734bda6"
     sha256 cellar: :any,                 arm64_sequoia:  "a927557fa509ed7f639826d4ba8c469eb580b53dcceeab6268a6519fc1b41813"

--- a/Formula/c/ctail.rb
+++ b/Formula/c/ctail.rb
@@ -5,8 +5,6 @@ class Ctail < Formula
   sha256 "864efb235a5d076167277c9f7812ad5678b477ff9a2e927549ffc19ed95fa911"
   license "Apache-2.0"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:    "90852c66651a883f061c0c6d2b2c1281e6b8e1cad687fd14e94a056f4fb62554"

--- a/Formula/c/ctpv.rb
+++ b/Formula/c/ctpv.rb
@@ -5,8 +5,6 @@ class Ctpv < Formula
   sha256 "29e458fbc822e960f052b47a1550cb149c28768615cc2dddf21facc5c86f7463"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "891ba106991bf7d6a64f1216540cb3332c5eed558e8b7c30733d1d47b766d5dc"
     sha256 cellar: :any,                 arm64_sequoia:  "37152d389946123d23de9ee5d1bcda011032a94ba42e1df5ce82363c4224ae56"

--- a/Formula/c/cubeb.rb
+++ b/Formula/c/cubeb.rb
@@ -12,8 +12,6 @@ class Cubeb < Formula
     depends_on "libtool" => :build
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "527ff86b71c3491f320043c8143e5c52542fc498577a31dbede4c285bb3ed639"
     sha256 cellar: :any,                 arm64_sequoia:  "82458e11a000c10cb1268c1e9118c0d0e447fc40d49bb6e0426288ea87d05e1b"

--- a/Formula/c/curseofwar.rb
+++ b/Formula/c/curseofwar.rb
@@ -6,8 +6,6 @@ class Curseofwar < Formula
   license "GPL-3.0-or-later"
   head "https://github.com/a-nikolaev/curseofwar.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "0cdb7f580eebe419880f3cfc725410eb05f0f10ec349f48c4c9cd68dfed8d368"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "e7cb41ed1daf26dfe62143dec8cc795d6fe88d2748eac64f6ec5df187f8695b9"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
These formulae use git tags with simple semver names and can be easily autobumped

See #267571