### PR TITLE
iproute2mac: add missing `ss` command

### DIFF
--- a/Formula/i/iproute2mac.rb
+++ b/Formula/i/iproute2mac.rb
@@ -6,6 +6,7 @@ class Iproute2mac < Formula
   url "https://github.com/brona/iproute2mac/releases/download/v1.7.0/iproute2mac-1.7.0.tar.gz"
   sha256 "48bd7b0a6e9a8015dde2cf30f54f42750ffb5ac2f60a47530c7c6205d23a257e"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "a2e962a30265ba70ff55de27f31a494d54dcf027c304f6a97d2e0d2beea8f323"
@@ -18,8 +19,9 @@ class Iproute2mac < Formula
     libexec.install "src/iproute2mac.py"
     libexec.install "src/ip.py" => "ip"
     libexec.install "src/bridge.py" => "bridge"
-    rewrite_shebang detected_python_shebang, libexec/"ip", libexec/"bridge", libexec/"iproute2mac.py"
-    bin.write_exec_script (libexec/"ip"), (libexec/"bridge")
+    libexec.install "src/ss.py" => "ss"
+    rewrite_shebang detected_python_shebang, libexec/"ip", libexec/"bridge", libexec/"iproute2mac.py", libexec/"ss"
+    bin.write_exec_script (libexec/"ip"), (libexec/"bridge"), (libexec/"ss")
   end
 
   test do
@@ -28,5 +30,6 @@ class Iproute2mac < Formula
     system bin/"ip", "address"
     system bin/"ip", "neigh"
     system bin/"bridge", "link"
+    system bin/"ss"
   end
 end

--- a/Formula/i/iproute2mac.rb
+++ b/Formula/i/iproute2mac.rb
@@ -9,7 +9,7 @@ class Iproute2mac < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "a2e962a30265ba70ff55de27f31a494d54dcf027c304f6a97d2e0d2beea8f323"
+    sha256 cellar: :any_skip_relocation, all: "bb881198c78b4833e6c02ef8c1d22e187292f1a34cbbf09b190bfb078f682f30"
   end
 
   depends_on :macos


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Version  bump of `iproute2mac` with new symlink for `ss` command.