### PR TITLE
rustledger 0.8.8 (new formula)

### DIFF
--- a/Formula/r/rustledger.rb
+++ b/Formula/r/rustledger.rb
@@ -52,7 +52,7 @@ class Rustledger < Formula
     system bin/"bean-check", testpath/"test.beancount"
 
     # Test query functionality
-    output = shell_output("#{bin}/rledger query #{testpath}/test.beancount \"SELECT account, sum(position)\"")
+    output = shell_output("#{bin}/rledger query #{testpath/"test.beancount"} \"SELECT account, sum(position)\"")
     assert_match "Assets:Bank:Checking", output
   end
 end

--- a/Formula/r/rustledger.rb
+++ b/Formula/r/rustledger.rb
@@ -1,0 +1,58 @@
+class Rustledger < Formula
+  desc "Fast, pure Rust implementation of Beancount double-entry accounting"
+  homepage "https://rustledger.github.io"
+  url "https://github.com/rustledger/rustledger/archive/refs/tags/v0.8.8.tar.gz"
+  sha256 "3312b7ecab442844849ed0d618af1e21fc596ee0dd2d024925cc365335e6ea41"
+  license "GPL-3.0-only"
+  head "https://github.com/rustledger/rustledger.git", branch: "main"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
+  depends_on "rust" => :build
+
+  def install
+    # Build all binaries from the rustledger crate
+    system "cargo", "install", *std_cargo_args(path: "crates/rustledger")
+
+    # Build the LSP server
+    system "cargo", "install", *std_cargo_args(path: "crates/rustledger-lsp")
+
+    # Generate shell completions
+    generate_completions_from_executable(bin/"rledger", "completions")
+  end
+
+  test do
+    # Test version output
+    assert_match version.to_s, shell_output("#{bin}/rledger --version")
+
+    # Test basic ledger validation
+    (testpath/"test.beancount").write <<~BEANCOUNT
+      option "operating_currency" "USD"
+
+      2024-01-01 open Assets:Bank:Checking USD
+      2024-01-01 open Expenses:Food USD
+      2024-01-01 open Equity:Opening-Balances USD
+
+      2024-01-01 * "Opening Balance"
+        Assets:Bank:Checking  1000.00 USD
+        Equity:Opening-Balances
+
+      2024-01-15 * "Grocery Store" "Weekly groceries"
+        Expenses:Food  50.00 USD
+        Assets:Bank:Checking
+    BEANCOUNT
+
+    # Validate the ledger with rledger
+    system bin/"rledger", "check", testpath/"test.beancount"
+
+    # Test bean-check compatibility binary
+    system bin/"bean-check", testpath/"test.beancount"
+
+    # Test query functionality
+    output = shell_output("#{bin}/rledger query #{testpath}/test.beancount \"SELECT account, sum(position)\"")
+    assert_match "Assets:Bank:Checking", output
+  end
+end


### PR DESCRIPTION
## Description

[rustledger](https://github.com/rustledger/rustledger) is a fast, pure Rust implementation of Beancount double-entry accounting. It provides a 10-30x performance improvement over Python beancount while maintaining full syntax compatibility.

### Key Features
- **Drop-in replacement**: Compatible with existing Beancount files
- **Fast**: 10-30x faster than Python beancount
- **LSP server**: Included for editor integration
- **Bean-compatible binaries**: Includes `bean-check`, `bean-query`, `bean-format`, etc.

### Links
- **Homepage**: https://rustledger.github.io
- **Repository**: https://github.com/rustledger/rustledger
- **Documentation**: https://rustledger.github.io/docs

### Checklist
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`?
- [x] Does your build pass `brew audit --strict <formula>`?