### PR TITLE
CODEOWNERS: add lead-maintainers for ffmpeg/imagemagick

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,10 +16,10 @@ tap_migrations.json               @Homebrew/lead-maintainers @MikeMcQuaid
 LICENSE.txt                       @Homebrew/lead-maintainers @MikeMcQuaid
 .github/workflows/                @Homebrew/core @MikeMcQuaid
 .github/workflows/triage.yml      @Homebrew/lead-maintainers
-Formula/f/ffmpeg.rb               @MikeMcQuaid
-Formula/f/ffmpeg-full.rb          @MikeMcQuaid
-Formula/i/imagemagick.rb          @MikeMcQuaid
-Formula/i/imagemagick-full.rb     @MikeMcQuaid
+Formula/f/ffmpeg.rb               @Homebrew/lead-maintainers @MikeMcQuaid
+Formula/f/ffmpeg-full.rb          @Homebrew/lead-maintainers @MikeMcQuaid
+Formula/i/imagemagick.rb          @Homebrew/lead-maintainers @MikeMcQuaid
+Formula/i/imagemagick-full.rb     @Homebrew/lead-maintainers @MikeMcQuaid
 
 audit_exceptions/linux_only_gcc_dependency_allowlist.json               @Homebrew/lead-maintainers
 audit_exceptions/permitted_formula_license_mismatches.json              @Homebrew/lead-maintainers @MikeMcQuaid


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

I think all lead maintainers are aware of goal for slimmed down formulae.