### PR TITLE
dart-sass 1.97.3 (new formula)

### DIFF
--- a/Formula/d/dart-sass.rb
+++ b/Formula/d/dart-sass.rb
@@ -1,0 +1,53 @@
+class DartSass < Formula
+  desc "Reference implementation of Sass, written in Dart"
+  homepage "https://sass-lang.com/dart-sass"
+  url "https://github.com/sass/dart-sass/archive/refs/tags/1.97.3.tar.gz"
+  sha256 "22ea1f689060edf10ee533047f553ad1c558209ea642687998f4ccb465faa9fc"
+  license "MIT"
+
+  depends_on "buf" => :build
+  depends_on "dart-sdk" => :build
+
+  resource "language" do
+    url "https://github.com/sass/sass/archive/refs/tags/embedded-protocol-3.2.0.tar.gz"
+    sha256 "4e1f81684bc1666f03e52ddc790d0c2c22d99a5313fa2efe1dde4a5b5733c186"
+  end
+
+  def install
+    # Tell the pub server where these installations are coming from.
+    ENV["PUB_ENVIRONMENT"] = "homebrew:sass"
+
+    (buildpath/"build/language").install resource("language")
+
+    system "dart", "pub", "get"
+    with_env(UPDATE_SASS_PROTOCOL: "false") do
+      system "dart", "run", "grinder", "protobuf"
+    end
+
+    system "dart", "compile", "exe",
+                   "-Dversion=#{version}",
+                   "-Dcompiler-version=#{version}",
+                   "-Dprotocol-version=#{resource("language").version}",
+                   "bin/sass.dart",
+                   "--output", "sass"
+    bin.install "sass"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/sass --version") if OS.mac?
+
+    (testpath/"test.scss").write(".class {property: 1 + 1}")
+    assert_match "property: 2;", shell_output("#{bin}/sass test.scss 2>&1")
+
+    (testpath/"input.scss").write <<~EOS
+      div {
+        img {
+          border: 0px;
+        }
+      }
+    EOS
+
+    assert_equal "div img{border:0px}",
+    shell_output("#{bin}/sass --style compressed input.scss").strip
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

- https://github.com/Homebrew/homebrew-core/issues/139929#issuecomment-3905990874

`sassc` and `libsass` have been deprecated several years ago and finally the repo is archived. We have only two dependents `gtk4` and `libadwaita` for this and they are still looking for a way to use sass without complication.
- https://gitlab.gnome.org/GNOME/gtk/-/issues/7895
- https://gitlab.gnome.org/GNOME/libadwaita/-/issues/484

Anyway official replacement for `sassc` is `dart-sass` and so I add this without deprecation of `sassc` for now. 