### PR TITLE
async-profiler 4.3 (new formula)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,7 @@ env:
   HOMEBREW_TEST_BOT_ANALYTICS: 1
   HOMEBREW_ENFORCE_SBOM: 1
   HOMEBREW_NO_BUILD_ERROR_ISSUES: 1
+  HOMEBREW_ARM64_TESTING: 1
   GH_REPO: ${{github.repository}}
   GH_NO_UPDATE_NOTIFIER: 1
   GH_PROMPT_DISABLED: 1
@@ -40,7 +41,7 @@ jobs:
         stable: [false, true]
     name: tap_syntax${{ matrix.stable && ' (stable)' || '' }}
     runs-on: ubuntu-latest
-    continue-on-error: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'CI-no-fail-fast-syntax') }}
+    continue-on-error: ${{ matrix.stable }}
     container:
       image: ghcr.io/homebrew/ubuntu22.04:${{ matrix.stable && 'latest' || 'main'}}
     env:
@@ -55,7 +56,7 @@ jobs:
           stable: ${{ matrix.stable }}
 
       - name: Cache style cache
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: /home/linuxbrew/.cache/Homebrew/style
           key: style-cache-${{ matrix.stable && 'stable-' || 'main-' }}${{ github.sha }}
@@ -93,7 +94,7 @@ jobs:
         run: brew test-bot --only-bottles-fetch --testing-formulae="$TESTING_FORMULAE"
 
   report_analytics:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     needs: formulae_detect
     if: github.repository_owner == 'Homebrew' && github.event_name == 'pull_request'
     steps:
@@ -132,7 +133,7 @@ jobs:
     permissions:
       pull-requests: read
     if: github.repository_owner == 'Homebrew' && github.event_name == 'pull_request'
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     needs: formulae_detect
     outputs:
       syntax-only: ${{ steps.check-labels.outputs.syntax-only }}
@@ -142,9 +143,8 @@ jobs:
       long-timeout: ${{ steps.check-labels.outputs.long-timeout }}
       test-bot-formulae-args: ${{ steps.check-labels.outputs.test-bot-formulae-args }}
       test-bot-dependents-args: ${{ steps.check-labels.outputs.test-bot-dependents-args }}
-      download-concurrency: ${{ steps.check-labels.outputs.download-concurrency }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
 
@@ -240,7 +240,6 @@ jobs:
             --deleted-formulae="$DELETED_FORMULAE" \
             <<<"$TEST_BOT_FORMULAE_ARGS"
         env:
-          HOMEBREW_DOWNLOAD_CONCURRENCY: ${{ needs.setup_tests.outputs.download-concurrency }}
           TEST_BOT_FORMULAE_ARGS: ${{ needs.setup_tests.outputs.test-bot-formulae-args }}
           TESTING_FORMULAE: ${{ needs.formulae_detect.outputs.testing_formulae }}
           ADDED_FORMULAE: ${{ needs.formulae_detect.outputs.added_formulae }}
@@ -260,7 +259,7 @@ jobs:
     permissions:
       pull-requests: read
     if: github.repository_owner == 'Homebrew' && github.event_name == 'pull_request'
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     needs: [setup_tests, formulae_detect]
     outputs:
       syntax-only: ${{ steps.check-labels.outputs.syntax-only }}
@@ -270,9 +269,8 @@ jobs:
       long-timeout: ${{ steps.check-labels.outputs.long-timeout }}
       test-bot-formulae-args: ${{ steps.check-labels.outputs.test-bot-formulae-args }}
       test-bot-dependents-args: ${{ steps.check-labels.outputs.test-bot-dependents-args }}
-      download-concurrency: ${{ steps.check-labels.outputs.download-concurrency }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
 
@@ -331,8 +329,7 @@ jobs:
         run: brew determine-test-runners --dependents --eval-all "$TESTING_FORMULAE"
 
   test_deps:
-    needs:
-      [tap_syntax, formulae_detect, setup_dep_tests, setup_dep_runners, tests]
+    needs: [tap_syntax, formulae_detect, setup_dep_tests, setup_dep_runners, tests]
     if: >
       (success() ||
       (failure() &&
@@ -374,7 +371,6 @@ jobs:
             --tested-formulae="$TESTED_FORMULAE" \
             <<<"$TEST_BOT_DEPENDENTS_ARGS"
         env:
-          HOMEBREW_DOWNLOAD_CONCURRENCY: ${{ needs.setup_dep_tests.outputs.download-concurrency }}
           TEST_BOT_DEPENDENTS_ARGS: ${{ needs.setup_dep_tests.outputs.test-bot-dependents-args }}
           TESTED_FORMULAE: ${{ needs.formulae_detect.outputs.testing_formulae }}
         working-directory: ${{ env.BOTTLES_DIR }}
@@ -392,7 +388,7 @@ jobs:
   conclusion:
     needs: [tests, test_deps, setup_tests, setup_runners]
     if: always() && github.event_name == 'pull_request'
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     steps:
       - name: Check `tests` result
         env:

--- a/Formula/a/async-profiler.rb
+++ b/Formula/a/async-profiler.rb
@@ -1,0 +1,59 @@
+class AsyncProfiler < Formula
+  desc "Sampling CPU & HEAP profiler for Java using AsyncGetCallTrace + perf_events"
+  homepage "https://github.com/async-profiler/async-profiler"
+  url "https://github.com/async-profiler/async-profiler/archive/refs/tags/v4.3.tar.gz"
+  sha256 "50f65033df0b999d0ae80c82d09827b595ad06051406ff7ec322fd1a40c1d328"
+  license "Apache-2.0"
+  head "https://github.com/async-profiler/async-profiler.git", branch: "master"
+
+  depends_on "cmake" => :build
+  depends_on "openjdk" => [:build, :test]
+
+  def install
+    args = []
+    args << "COMMIT_TAG=#{Utils.git_head}" if build.head?
+
+    system "make", *args, "all"
+
+    bin.install Dir["build/bin/*"]
+    lib.install Dir["build/lib/*"]
+    libexec.install Dir["build/jar/*"]
+  end
+
+  test do
+    # Set JAVA_HOME for tools that need it (like jfrconv)
+    ENV["JAVA_HOME"] = Formula["openjdk"].opt_prefix
+
+    # Verify version output
+    output = shell_output("#{bin}/asprof --version")
+
+    if build.head?
+      assert_match(/^Async-profiler #{version}-#{Utils.git_head}.+/, output)
+    else
+      assert_match("Async-profiler #{version}", output)
+    end
+
+    # Create a simple Java program that sleeps for testing
+    (testpath/"Main.java").write <<~JAVA
+      public class Main {
+        public static void main(String[] args) throws Exception {
+          Thread.sleep(Integer.parseInt(args[0]));
+        }
+      }
+    JAVA
+
+    # The profiler can begin started as a JVMTI agent
+    agent_lib = OS.mac? ? "libasyncProfiler.dylib" : "libasyncProfiler.so"
+    system Formula["openjdk"].bin/"java",
+           "-agentpath:#{lib}/#{agent_lib}=start,event=cpu,lock=10ms,file=test-profile-via-lib.jfr",
+           testpath/"Main.java", "2"
+    assert_path_exists testpath/"test-profile-via-lib.jfr"
+
+    # JFR converter can convert the JFR file to pprof
+    system bin/"jfrconv",
+           "-o", "pprof",
+           testpath/"test-profile-via-lib.jfr",
+           testpath/"test-profile-via-lib.pprof"
+    assert_path_exists testpath/"test-profile-via-lib.pprof"
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Tool: https://github.com/async-profiler/async-profiler

> [!NOTE]
> This PR is a retry of #222217, but without the async-profiler attachment test ; I wasn't able to complete this PR because I couldn't find a way to workaround the sandbox to run the attach test, locally the following test works perfectly locally on macOs 26.2 at least.
> 
> <details><summary>jvm process attachment test</summary>
> 
> Well I left some the debug instructions there
> 
> ```ruby
>     # The profiler can be attached to a running JVM process
>     pid = spawn Formula["openjdk"].bin/"java", "-XX:+StartAttachListener", testpath/"Main.java", "100"
>     begin
>       # Debug: show open file descriptors
>       ohai shell_output("lsof -p #{pid}")
>       sleep 1
>       system bin/"asprof",
>              "-d", "2",
>              "-f", testpath/"test-profile-via-attach.html",
>              "jps"
>       assert_path_exists testpath/"test-profile-via-attach.html"
>     ensure
>       Process.kill("TERM", pid)
>       Process.wait(pid)
>     end
> ```
> 
> ```
>   ==> /home/linuxbrew/.linuxbrew/Cellar/async-profiler/4.3/bin/asprof -d 2 -f /var/tmp/async-profiler-test-20260216-12691-86cled/test-profile-via-attach.html jps
>   Could not start attach mechanism: No such file or directory
>   Error: async-profiler: failed
> ```
> 
> </details>