### PR TITLE
qsv: add more features

### DIFF
--- a/Formula/q/qsv.rb
+++ b/Formula/q/qsv.rb
@@ -15,12 +15,13 @@ class Qsv < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "57d455fd532a9ea9fbc4422938ac697efdf6b8470e48b829921002b1e823ec19"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "82fffc444012513f498345b2d952357ead0054005d97fad013ec1066d3571b4b"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "aa618a959a559614ed936def6fd7fd081cf4cb9b158145b11b4a642a6a01c466"
-    sha256 cellar: :any_skip_relocation, sonoma:        "5ad06bfe23bcbaeffab6fb85f3ebff5831b67420b08f4e94d1ec310654ee7bfc"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "5c9f75c99f8cde5e942024b31943b828b56f583124400cdef273b5d3e552c766"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1816f69a4d087da7dd5b1d3b4e9d1c4089d7ebe6a7244a090634d0f9e6446772"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "fb48228632918823f611655d06780fd974784336450bf469c0f090d145e34289"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "f5be130b3d9d16ca0d770bad911ab9f944474d4c0a51cf18b614d2cc8a5e08f5"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "d5212460a14e2df219bdb13b4df168bfae4249a357e67a45eac9b03a74d1c4e6"
+    sha256 cellar: :any_skip_relocation, sonoma:        "dc3ff552eaf7a4bba202bc662d60bcbac44a5fff5726ccbecc3605e1c31434f9"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "1afc3c4fe4a429e3e0d38c895681dfc4d7ce59905603aff191d73ce2f54a3a5d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e406c26735785262c1670a9c9d67bd00003343947ed804b0c40a3fb64a4f871c"
   end
 
   depends_on "cmake" => :build # for libz-ng-sys

--- a/Formula/q/qsv.rb
+++ b/Formula/q/qsv.rb
@@ -36,7 +36,9 @@ class Qsv < Formula
     # see discussion at https://github.com/briansmith/ring/discussions/2528#discussioncomment-13196576
     ENV.append_to_rustflags "-C target-cpu=apple-m1" if OS.mac? && Hardware::CPU.arm?
 
-    system "cargo", "install", *std_cargo_args, "--features", "apply,lens,luau,feature_capable"
+    features = %w[apply fetch foreach geocode lens luau to feature_capable]
+    system "cargo", "install", *std_cargo_args(features:)
+
     bash_completion.install "contrib/completions/examples/qsv.bash" => "qsv"
     fish_completion.install "contrib/completions/examples/qsv.fish"
     zsh_completion.install "contrib/completions/examples/qsv.zsh" => "_qsv"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

This adds some features missing to `qsv`, as I tried to use the `to` command (https://github.com/dathere/qsv/blob/master/docs/help/to.md) and discovered it was missing.

This was tested locally as is, however several points to note:
- There are more missing features than those I add, see https://github.com/dathere/qsv/blob/master/docs/FEATURES.md
- At first I tried to add all missing features excepted for the `self_update` one, this is what's covered by the feature `distrib_features` and explicitly advised on this page. That's also what's used by ArchLinux, see https://gitlab.archlinux.org/archlinux/packaging/packages/qsv/-/blob/main/PKGBUILD?ref_type=heads#L38
- Trying to compile with `distrib_features` however failed in the following way:
```
HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source qsv
==> Auto-updating Homebrew...
Adjust how often this is run with `$HOMEBREW_AUTO_UPDATE_SECS` or disable with
`$HOMEBREW_NO_AUTO_UPDATE=1`. Hide these hints with `$HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).
==> Auto-updated Homebrew!
Updated 2 taps (homebrew/core and homebrew/cask).

==> Fetching downloads for: qsv
✔︎ Formula qsv (16.1.0)                               Verified     52.9MB/ 52.9MB
==> cargo install --features distrib_features
Last 15 lines from /Users/clefevre/Library/Logs/Homebrew/qsv/01.cargo.log:
   Compiling polars-io v0.53.0 (https://github.com/pola-rs/polars?rev=ceb6366#ceb6366b)
   Compiling polars-mem-engine v0.53.0 (https://github.com/pola-rs/polars?rev=ceb6366#ceb6366b)
   Compiling polars-sql v0.53.0 (https://github.com/pola-rs/polars?rev=ceb6366#ceb6366b)
error: linking with `cc` failed: exit status: 1
  |
  = note:  "cc" "<1 object files omitted>" "/private/tmp/rustcc4CySF/{liblibmimalloc_sys-09e8db23a010d6db,liblibsqlite3_sys-a1e2dbc392959b71,libmlua_sys-1f2b811b9f6169fd,libblake3-b29f9abf3f311d43,libaws_lc_sys-cb0e8651f24275b1,libring-77335049f1145164,libzstd_sys-46dc9ded4ea727ac,liblz4_sys-99d7d54206ccd3eb,libpsm-5fa78de98d4187ba}.rlib" "<sysroot>/lib/rustlib/aarch64-apple-darwin/lib/libcompiler_builtins-*.rlib" "-framework" "CoreFoundation" "-framework" "SystemConfiguration" "-lpython3.9" "-lc++" "-lobjc" "-framework" "IOKit" "-framework" "Security" "-framework" "CoreFoundation" "-framework" "IOKit" "-framework" "CoreFoundation" "-liconv" "-lSystem" "-lc" "-lm" "-arch" "arm64" "-mmacosx-version-min=11.0.0" "-L" "/private/tmp/qsv-20260216-48225-ok223l/qsv-16.1.0/target/release/build/blake3-5530f674dc20dd9d/out" "-L" "/private/tmp/qsv-20260216-48225-ok223l/qsv-16.1.0/target/release/build/zstd-sys-39413dff1af9f5ff/out" "-L" "/private/tmp/qsv-20260216-48225-ok223l/qsv-16.1.0/target/release/build/psm-3cdd8ef341eac745/out" "-L" "/private/tmp/qsv-20260216-48225-ok223l/qsv-16.1.0/target/release/build/libsqlite3-sys-9db2936321388553/out" "-L" "/private/tmp/qsv-20260216-48225-ok223l/qsv-16.1.0/target/release/build/aws-lc-sys-c77751b8645d9f30/out" "-L" "/private/tmp/qsv-20260216-48225-ok223l/qsv-16.1.0/target/release/build/ring-8ea70f564a7fc049/out" "-L" "/private/tmp/qsv-20260216-48225-ok223l/qsv-16.1.0/target/release/build/libmimalloc-sys-6f34457842709838/out" "-L" "/private/tmp/qsv-20260216-48225-ok223l/qsv-16.1.0/target/release/build/mlua-sys-4efdf5f811d1f163/out/luau-build" "-L" "/private/tmp/qsv-20260216-48225-ok223l/qsv-16.1.0/target/release/build/lz4-sys-8113df7cf934c604/out" "-L" "/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.9/lib" "-o" "/private/tmp/qsv-20260216-48225-ok223l/qsv-16.1.0/target/release/deps/qsv-3b14cda58e1203c7" "-Wl,-dead_strip" "-nodefaultlibs" "-Wl,-rpath,@loader_path"
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: ld: warning: search path '/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.9/lib' not found
          ld: library 'python3.9' not found
          clang: error: linker command failed with exit code 1 (use -v to see invocation)


error: could not compile `qsv` (bin "qsv") due to 1 previous error
error: failed to compile `qsv v16.1.0 (/private/tmp/qsv-20260216-48225-ok223l/qsv-16.1.0)`, intermediate artifacts can be found at `/private/tmp/qsv-20260216-48225-ok223l/qsv-16.1.0/target`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.

READ THIS: https://docs.brew.sh/Troubleshooting
```
Here I don't know why does it try to link with system Python when Homebrew one is available this sure means it should be added as a dependency for people not having it, but if it was the only issue it should have worked on my system, right?
- Finally, audit in the current state is unhappy because line two characters too long; however I'm not sure what the best way to manage this would be (aside from being able to have `distrib_features` working!)
- EDIT: Also, I was unsure if this deserved a revision bump, but I'd think it doesn't?.

EDIT2: I could also verify that at least the `to` command worked as intended.

This is a bit offtopic, but I'll use the occasion to ask this question: for another Formula I was planning to open a PR for and in the end don't: doc clearly state core repo disallow optional and recommended dependencies (which is what I was planning to do, after discussing on an issue with the maintainer for another tool), but doesn't explain why?