### PR TITLE
async-profiler 4.3 (new formula)

### DIFF
--- a/Formula/a/async-profiler.rb
+++ b/Formula/a/async-profiler.rb
@@ -1,0 +1,55 @@
+class AsyncProfiler < Formula
+  desc "Sampling CPU & HEAP profiler for Java using AsyncGetCallTrace + perf_events"
+  homepage "https://github.com/async-profiler/async-profiler"
+  url "https://github.com/async-profiler/async-profiler/archive/refs/tags/v4.3.tar.gz"
+  sha256 "50f65033df0b999d0ae80c82d09827b595ad06051406ff7ec322fd1a40c1d328"
+  license "Apache-2.0"
+  head "https://github.com/async-profiler/async-profiler.git", branch: "master"
+
+  depends_on "cmake" => :build
+  depends_on "openjdk" => [:build, :test]
+
+  def install
+    args = []
+    args << "COMMIT_TAG=#{Utils.git_head}" if build.head?
+
+    system "make", *args, "all"
+
+    bin.install Dir["build/bin/*"]
+    lib.install Dir["build/lib/*"]
+    libexec.install Dir["build/jar/*"]
+  end
+
+  test do
+    # Set JAVA_HOME for tools that need it (like jfrconv)
+    ENV["JAVA_HOME"] = Formula["openjdk"].opt_prefix
+
+    # Verify version output
+    output = shell_output("#{bin}/asprof --version")
+
+    assert_match version.to_s, output
+
+    # Create a simple Java program that sleeps for testing
+    (testpath/"Main.java").write <<~JAVA
+      public class Main {
+        public static void main(String[] args) throws Exception {
+          Thread.sleep(Integer.parseInt(args[0]));
+        }
+      }
+    JAVA
+
+    # The profiler can begin started as a JVMTI agent
+    agent_lib = shared_library("libasyncProfiler")
+    system Formula["openjdk"].bin/"java",
+           "-agentpath:#{lib}/#{agent_lib}=start,event=cpu,lock=10ms,file=test-profile-via-lib.jfr",
+           testpath/"Main.java", "2"
+    assert_path_exists testpath/"test-profile-via-lib.jfr"
+
+    # JFR converter can convert the JFR file to pprof
+    system bin/"jfrconv",
+           "-o", "pprof",
+           testpath/"test-profile-via-lib.jfr",
+           testpath/"test-profile-via-lib.pprof"
+    assert_path_exists testpath/"test-profile-via-lib.pprof"
+  end
+end

--- a/Formula/a/async-profiler.rb
+++ b/Formula/a/async-profiler.rb
@@ -6,6 +6,15 @@ class AsyncProfiler < Formula
   license "Apache-2.0"
   head "https://github.com/async-profiler/async-profiler.git", branch: "master"
 
+  bottle do
+    sha256 cellar: :any,                 arm64_tahoe:   "a22cc696b639d326786fb71cd8a1dc121aba26962aaa87e5ec68057795edccc2"
+    sha256 cellar: :any,                 arm64_sequoia: "c339e4e5c3463a45ecdb4a93633854559e40ff128ba3eaa7dae2665935d8285f"
+    sha256 cellar: :any,                 arm64_sonoma:  "976d7a9057d97a490aaa95ea0e908f8066ce0629114cdc64f25ba4df7e7495b6"
+    sha256 cellar: :any,                 sonoma:        "eaa11bd51896193995a0902f7bc5ad698154169cc01920793d1270f95bce7fce"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "cb5b1bb4f00674a12985f31b5aa79f9fd9a33f62b96a640c3b57bfdcfe877ba4"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e2b7eb1b4d1c8704e028f8e4ea609de3b94c84348da76d65d765b525a4904f93"
+  end
+
   depends_on "cmake" => :build
   depends_on "openjdk" => [:build, :test]
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Tool: https://github.com/async-profiler/async-profiler

> [!NOTE]
> This PR is a retry of #222217, but without the async-profiler attachment test ; I wasn't able to complete this PR because I couldn't find a way to workaround the sandbox to run the attach test, locally the following test works perfectly locally on macOs 26.2 at least.
>
> <details><summary>jvm process attachment test</summary>
>
> Well I left some the debug instructions there
>
> ```ruby
>     # The profiler can be attached to a running JVM process
>     pid = spawn Formula["openjdk"].bin/"java", "-XX:+StartAttachListener", testpath/"Main.java", "100"
>     begin
>       # Debug: show open file descriptors
>       ohai shell_output("lsof -p #{pid}")
>       sleep 1
>       system bin/"asprof",
>              "-d", "2",
>              "-f", testpath/"test-profile-via-attach.html",
>              "jps"
>       assert_path_exists testpath/"test-profile-via-attach.html"
>     ensure
>       Process.kill("TERM", pid)
>       Process.wait(pid)
>     end
> ```
>
> ```
>   ==> /home/linuxbrew/.linuxbrew/Cellar/async-profiler/4.3/bin/asprof -d 2 -f /var/tmp/async-profiler-test-20260216-12691-86cled/test-profile-via-attach.html jps
>   Could not start attach mechanism: No such file or directory
>   Error: async-profiler: failed
> ```
>
> </details>

Also, I retried in #267844 but I mistakenly pushed my _debug changes in the test workflow_ to help understand the issue with the JVM process attachment. This PR only proposes the new async-profiler formula as it should be.