### PR TITLE
docbook: remove URI rewrite

### DIFF
--- a/Formula/d/docbook.rb
+++ b/Formula/d/docbook.rb
@@ -4,6 +4,7 @@ class Docbook < Formula
   url "https://github.com/docbook/docbook/releases/download/5.2/docbook-5.2.zip"
   sha256 "11992554a884786f1b78c6b478d6cec90352caf00bef54731c8d54f26751f2c5"
   license :cannot_represent
+  revision 1
 
   livecheck do
     url :stable
@@ -73,12 +74,6 @@ class Docbook < Formula
           end
         end
 
-        if ["44", "45", "50"].include?(version)
-          inreplace "catalog.xml" do |s|
-            s.gsub! "http://docbook.org", "http://archive.docbook.org"
-          end
-        end
-
         if version == "51"
           mv "schemas/catalog.xml", "catalog.xml"
           mv "schemas/docbook.nvdl", "docbook.nvdl"
@@ -88,7 +83,6 @@ class Docbook < Formula
 
           inreplace "catalog.xml" do |s|
             s.gsub! "5.1CR4", "5.1"
-            s.gsub! "http://docbook.org", "http://archive.docbook.org"
           end
         end
 

--- a/Formula/d/docbook.rb
+++ b/Formula/d/docbook.rb
@@ -14,7 +14,7 @@ class Docbook < Formula
   no_autobump! because: :incompatible_version_format
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "a0f63041884ef15e344abec96148793e2b18c011e3d72dbdb8bdb4d76d16deec"
+    sha256 cellar: :any_skip_relocation, all: "ba985d5405421cb25cffc5d94a824817b6a78b8387a20857e7bab0316bb61c6b"
   end
 
   uses_from_macos "libxml2"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

This change fixes an issue introduced in #263408; per feedback from @tsteven4 on that PR, the catalog.xml URIs should not be rewritten, even though the URL is no longer valid (404). This backs out the URI rewrite to improve compatibility.