### PR TITLE
structurizr-cli: deprecate

### DIFF
--- a/Formula/s/structurizr-cli.rb
+++ b/Formula/s/structurizr-cli.rb
@@ -9,6 +9,9 @@ class StructurizrCli < Formula
     sha256 cellar: :any_skip_relocation, all: "0825af5401fa205d327c343adbbae0868cf9c0c91ec83182110a99f62239a8aa"
   end
 
+  deprecate! date: "2026-02-17", because: :repo_archived
+  disable! date: "2027-02-17", because: :repo_archived
+
   depends_on "openjdk"
 
   def install


### PR DESCRIPTION
structurizr-cli: deprecate


<img width="1254" height="375" alt="image" src="https://github.com/user-attachments/assets/f61b849a-7d03-4bb9-8972-f0e652310b8b" />
