### PR TITLE
grizzly: deprecate and replaced by `grafanactl`

### DIFF
--- a/Formula/g/grizzly.rb
+++ b/Formula/g/grizzly.rb
@@ -17,6 +17,10 @@ class Grizzly < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "a1cd0d526f55b71f84e88c4bda49551c661b56f7dcace86fbbbb637a27fd4274"
   end
 
+  # https://github.com/grafana/grizzly/pull/613
+  deprecate! date: "2026-02-17", because: :repo_archived, replacement_formula: "grafanactl"
+  disable! date: "2027-02-17", because: :repo_archived, replacement_formula: "grafanactl"
+
   depends_on "go" => :build
 
   def install


### PR DESCRIPTION
grizzly: deprecate

<img width="1197" height="308" alt="image" src="https://github.com/user-attachments/assets/70f32dae-6128-4a8d-bb04-a8b673402dab" />
