### PR TITLE
git: fix git-credential-osxkeychain build for v2.53.0 (v3)

### DIFF
--- a/Formula/g/git.rb
+++ b/Formula/g/git.rb
@@ -66,8 +66,8 @@ class Git < Formula
 
   # https://lore.kernel.org/git/pull.2046.v2.git.1770775169908.gitgitgadget@gmail.com/
   patch do
-    url "https://raw.githubusercontent.com/Homebrew/homebrew-core/46d746f92167fd0559af22f4ccb79c9ff35fbe33/Patches/git/2.53.0-osxkeychain-top-level-makefile.patch"
-    sha256 "d640f0105be66631634123de1a2cd6d950efe62b4d51c7c889fa57521a0a60cd"
+    url "https://raw.githubusercontent.com/Homebrew/homebrew-core/532a668f0f725a69342cbac3414475a28bd0575d/Patches/git/2.53.0-osxkeychain-top-level-makefile.patch"
+    sha256 "ef3f390f940e080548474950380edb008f31e5fd500c8ad1d470fc764b6e65ac"
   end
 
   def install

--- a/Patches/git/2.53.0-osxkeychain-top-level-makefile.patch
+++ b/Patches/git/2.53.0-osxkeychain-top-level-makefile.patch
@@ -1,7 +1,7 @@
 From 8c5d75f0c63f294cf4d7236e5d9f6204f0f5f7f7 Mon Sep 17 00:00:00 2001
 From: Koji Nakamaru <koji.nakamaru@gree.net>
-Date: Wed, 11 Feb 2026 01:59:29 +0000
-Subject: [PATCH] osxkeychain: define build targets in the top-level Makefile.
+Date: Wed, 18 Feb 2026 05:14:10 +0000
+Subject: [PATCH v3] osxkeychain: define build targets in the top-level Makefile.
 
 The fix for git-credential-osxkeychain in 4580bcd235 (osxkeychain: avoid
 incorrectly skipping store operation) introduced linkage with libgit.a,
@@ -25,17 +25,18 @@ Define the build targets for git-credential-osxkeychain in the top-level
 Makefile and modify its local Makefile to simply rely on those targets.
 
 Helped-by: Junio C Hamano <gitster@pobox.com>
+Reported-by: D. Ben Knoble <ben.knoble@gmail.com>
 Signed-off-by: Koji Nakamaru <koji.nakamaru@gree.net>
 ---
- Makefile                                | 17 +++++++
- contrib/credential/osxkeychain/Makefile | 65 ++++--------------------
- 2 files changed, 23 insertions(+), 59 deletions(-)
+ Makefile                                | 18 +++++++
+ contrib/credential/osxkeychain/Makefile | 65 +++----------------------
+ 2 files changed, 24 insertions(+), 59 deletions(-)
 
 diff --git a/Makefile b/Makefile
-index 4ac44331ea..97196c6afa 100644
+index 4ac44331ea..1c2019a4cb 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -4060,3 +4060,20 @@ $(LIBGIT_HIDDEN_EXPORT): $(LIBGIT_PARTIAL_EXPORT)
+@@ -4060,3 +4060,21 @@ $(LIBGIT_HIDDEN_EXPORT): $(LIBGIT_PARTIAL_EXPORT)
  
  contrib/libgit-sys/libgitpub.a: $(LIBGIT_HIDDEN_EXPORT)
  	$(AR) $(ARFLAGS) $@ $^
@@ -45,6 +46,7 @@ index 4ac44331ea..97196c6afa 100644
 +		$(filter %.o,$^) $(LIB_FILE) $(EXTLIBS) -framework Security -framework CoreFoundation
 +
 +contrib/credential/osxkeychain/git-credential-osxkeychain.o: contrib/credential/osxkeychain/git-credential-osxkeychain.c GIT-CFLAGS
++	@mkdir -p contrib/credential/osxkeychain/.depend
 +	$(QUIET_LINK)$(CC) -o $@ -c $(dep_args) $(compdb_args) $(ALL_CFLAGS) $(EXTRA_CPPFLAGS) $<
 +
 +install-git-credential-osxkeychain: contrib/credential/osxkeychain/git-credential-osxkeychain
@@ -57,7 +59,7 @@ index 4ac44331ea..97196c6afa 100644
 +		contrib/credential/osxkeychain/git-credential-osxkeychain \
 +		contrib/credential/osxkeychain/git-credential-osxkeychain.o
 diff --git a/contrib/credential/osxkeychain/Makefile b/contrib/credential/osxkeychain/Makefile
-index c68445b82d..2044a33f41 100644
+index c68445b82d..219b0d7f49 100644
 --- a/contrib/credential/osxkeychain/Makefile
 +++ b/contrib/credential/osxkeychain/Makefile
 @@ -1,66 +1,13 @@
@@ -68,7 +70,7 @@ index c68445b82d..2044a33f41 100644
 --include ../../../config.mak.autogen
 --include ../../../config.mak
 +git-credential-osxkeychain:
-+	$(MAKE) -C  ../../.. contrib/credential/osxkeychain/git-credential-osxkeychain
++	$(MAKE) -C ../../.. contrib/credential/osxkeychain/git-credential-osxkeychain
  
 -ifdef ZLIB_NG
 -	BASIC_CFLAGS += -DHAVE_ZLIB_NG
@@ -125,11 +127,11 @@ index c68445b82d..2044a33f41 100644
 -../../../libgit.a:
 -	cd ../../..; make libgit.a
 +install:
-+	$(MAKE) -C  ../../.. install-git-credential-osxkeychain
++	$(MAKE) -C ../../.. install-git-credential-osxkeychain
  
  clean:
 -	$(RM) git-credential-osxkeychain git-credential-osxkeychain.o
-+	$(MAKE) -C  ../../.. clean-git-credential-osxkeychain
++	$(MAKE) -C ../../.. clean-git-credential-osxkeychain
  
 -.PHONY: all install clean
 +.PHONY: all git-credential-osxkeychain install clean


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
This updates the commit https://github.com/Homebrew/homebrew-core/pull/265538/changes/46d746f92167fd0559af22f4ccb79c9ff35fbe33 in [1] to incorporate the latest fix for older versions of clang discussed in [2].

* [1] https://github.com/Homebrew/homebrew-core/pull/265538
* [2] https://lore.kernel.org/git/pull.2046.git.1770746461307.gitgitgadget@gmail.com/T/#mabb89b43ffc04ce2679752300791f0416e4ac40d