### PR TITLE
a*: remove no_autobump! manual review

### DIFF
--- a/Formula/a/a52dec.rb
+++ b/Formula/a/a52dec.rb
@@ -10,8 +10,6 @@ class A52dec < Formula
     regex(/href=.*?a52dec[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "ca731a1b2d531c0e169e56a7d02c72dc18e0fb163fac344f7476fe0e399bec7b"
     sha256 cellar: :any,                 arm64_sequoia:  "bb6e3408f39a404770529cfce548dc2666e861077acd173825cb3138c27c205a"

--- a/Formula/a/aamath.rb
+++ b/Formula/a/aamath.rb
@@ -11,8 +11,6 @@ class Aamath < Formula
     regex(/href=.*?aamath[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "587054f7e1107e61554956c8ba147c9560af1e7138547651ba82d32464c0862c"

--- a/Formula/a/aarch64-elf-gdb.rb
+++ b/Formula/a/aarch64-elf-gdb.rb
@@ -11,8 +11,6 @@ class Aarch64ElfGdb < Formula
     formula "gdb"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 arm64_tahoe:   "bdcf835bdcd3bbb5c88485b7d83b0fc63ec8786ee0a5004d9c30c61c02bdbb54"

--- a/Formula/a/abcl.rb
+++ b/Formula/a/abcl.rb
@@ -15,8 +15,6 @@ class Abcl < Formula
     regex(/href=.*?abcl[._-]v?(\d+(?:\.\d+)+)\.orig\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "3231aead5669b78ca3b23ad314c5bc1135178182fcab8ec84da66ecdef470350"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "d3b54e12b38b7736c33fe43c677c4d396337617e4f0647a2d5522bde43e31fc0"

--- a/Formula/a/abnfgen.rb
+++ b/Formula/a/abnfgen.rb
@@ -10,8 +10,6 @@ class Abnfgen < Formula
     regex(%r{href=.*?/abnfgen[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "eab87d7376a80c7f80ea531c0d416ffd17c8382339891c38158763e67cab67e3"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "e2396295b6a6b0952355321d37830f2a2f42b2b2deda9a7ec9162d7f224f0c98"

--- a/Formula/a/acl.rb
+++ b/Formula/a/acl.rb
@@ -10,8 +10,6 @@ class Acl < Formula
     regex(/href=.*?acl[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 arm64_linux:  "df5af5425e87eda102251eacdf2a56622bfbda1b285441d438186d471cbd4cb7"

--- a/Formula/a/activemq-cpp.rb
+++ b/Formula/a/activemq-cpp.rb
@@ -7,8 +7,6 @@ class ActivemqCpp < Formula
   license "Apache-2.0"
   revision 2
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "a0f11adf35cbc7f7295a0d056b8255af8d54bab66c242fa31704f54070aaa1a7"
     sha256 cellar: :any,                 arm64_sequoia:  "9662d2f91d16d3077aabec66a532efde437d18987dd1a7be434e3c118a5e1eb9"

--- a/Formula/a/aescrypt.rb
+++ b/Formula/a/aescrypt.rb
@@ -10,8 +10,6 @@ class Aescrypt < Formula
     regex(/href=.*?aescrypt[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "9b39aab473142edc7f8e5eaea2122edcd3bebcea70810914d8d9735a4d82fd0f"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "b4ec90c9ff44239c6cf43b35377e7ff709983c1b76577ea84cd8dbc638d763ee"

--- a/Formula/a/aften.rb
+++ b/Formula/a/aften.rb
@@ -13,8 +13,6 @@ class Aften < Formula
     regex(%r{url=.*?/aften[._-]v?(\d+(?:\.\d+){2,})\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "98174738f94e5b13f3814dca23e803878017f9d719e0eb7d5f3ebb82e7819db7"
     sha256 cellar: :any,                 arm64_sequoia:  "c158dd1b9124db377e0119b6d4dc34ce9ecb14e458379ab023165ce6b83715fb"

--- a/Formula/a/agedu.rb
+++ b/Formula/a/agedu.rb
@@ -12,8 +12,6 @@ class Agedu < Formula
     regex(/href=.*?agedu[._-]v?(\d+(?:\.\d+)*)(?:[._-][\da-z]+)?\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "41f04708967fca0cee916a7361fc5aa4dd9c5bd3e639f1a1a9b83715d626e48d"
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "d779cddebf2f281e0ac4ae36def487c0068283d2be92002709f23fd6f81d9d44"

--- a/Formula/a/ahcpd.rb
+++ b/Formula/a/ahcpd.rb
@@ -10,8 +10,6 @@ class Ahcpd < Formula
     regex(/href=.*?ahcpd[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "7eb4adae6d9931eb81c4241ddb5475152e5908ba3fa4f1e3903aeb2f36f050ee"

--- a/Formula/a/aircrack-ng.rb
+++ b/Formula/a/aircrack-ng.rb
@@ -15,8 +15,6 @@ class AircrackNg < Formula
     regex(/href=.*?aircrack-ng[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 3
     sha256                               arm64_tahoe:   "c1461024ee7d85a1f0024b7e79aee529a2ffc577b4e7f55df1b93bce01a4a9c0"

--- a/Formula/a/akku.rb
+++ b/Formula/a/akku.rb
@@ -14,8 +14,6 @@ class Akku < Formula
     end
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:    "525ddcc47892beb6922d45852f96cd4cdb3b7981605acf5d415216a2e728b44e"
     sha256 arm64_sequoia:  "0f13478e5f6f3b41e6e75beac905b2aaae1df9d9a1eb7d600bf0f6bf70b076f0"

--- a/Formula/a/aldo.rb
+++ b/Formula/a/aldo.rb
@@ -10,8 +10,6 @@ class Aldo < Formula
     regex(/href=.*?aldo[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:    "c79608f02c4c17db23e84db17545e895475a4a38e46419b37d7b518a40363e73"

--- a/Formula/a/align.rb
+++ b/Formula/a/align.rb
@@ -10,8 +10,6 @@ class Align < Formula
     regex(/href=.*?align[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 3
     sha256 cellar: :any_skip_relocation, all: "8322889bf3e340cda1b21c32ff73ad718bde32ead186bf7b4b69f0f88f280066"

--- a/Formula/a/alloy-analyzer.rb
+++ b/Formula/a/alloy-analyzer.rb
@@ -10,8 +10,6 @@ class AlloyAnalyzer < Formula
     regex(%r{<version>(\d+(?:\.\d+)+)</version>}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, all: "e6b7ea99c4d94c851e458306d370fcdd49b32426042bc21618972e37f3c5a907"
   end

--- a/Formula/a/allureofthestars.rb
+++ b/Formula/a/allureofthestars.rb
@@ -7,8 +7,6 @@ class Allureofthestars < Formula
   revision 6
   head "https://github.com/AllureOfTheStars/Allure.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:   "786bcd9f1837c4e3c9c5f4663251c4b10ea6e60cfb31adb8b0532e6e575edbf8"

--- a/Formula/a/alpine.rb
+++ b/Formula/a/alpine.rb
@@ -13,8 +13,6 @@ class Alpine < Formula
     regex(/href=.*?alpine[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 arm64_tahoe:    "62301d0e5eb9290a24fb3ab3d9117f9dccc45160fbdee0ee7a176e9d02a21f2e"

--- a/Formula/a/ant-contrib.rb
+++ b/Formula/a/ant-contrib.rb
@@ -10,8 +10,6 @@ class AntContrib < Formula
     regex(%r{url=.*?/ant-contrib[._-]v?(\d+(?:\.\d+)+(?:[a-z]\d+)?)-bin\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "11f6456cf47128a33054e067467dd8186dfd6db33c85cf60bb8620e4a269fced"

--- a/Formula/a/apcupsd.rb
+++ b/Formula/a/apcupsd.rb
@@ -10,8 +10,6 @@ class Apcupsd < Formula
     regex(%r{url=.*?/apcupsd%20-%20Stable/[^/]+/apcupsd[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 4
     sha256 arm64_tahoe:    "b3ee569355dc3304f2efdf334b2b130088427c6cb9001213c73837ec7ef26160"

--- a/Formula/a/apng2gif.rb
+++ b/Formula/a/apng2gif.rb
@@ -5,8 +5,6 @@ class Apng2gif < Formula
   sha256 "9a07e386017dc696573cd7bc7b46b2575c06da0bc68c3c4f1c24a4b39cdedd4d"
   license all_of: ["libpng-2.0", "Zlib"]
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:    "ed45a01466de66b866f9b894a9a12299c51b2f663facd8af4d262429b9507ada"

--- a/Formula/a/apr-util.rb
+++ b/Formula/a/apr-util.rb
@@ -7,8 +7,6 @@ class AprUtil < Formula
   license "Apache-2.0"
   revision 1
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:    "c1b6ca1239679046b74a5ea73032f87a83cbc9c503455a0cf3bc12a54777a03d"
     sha256 arm64_sequoia:  "6d3282873dffcfed602c5cfb7eb5ddad4b7115aaa954e191dfd4b733a58ef43e"

--- a/Formula/a/argtable.rb
+++ b/Formula/a/argtable.rb
@@ -6,8 +6,6 @@ class Argtable < Formula
   sha256 "8f77e8a7ced5301af6e22f47302fdbc3b1ff41f2b83c43c77ae5ca041771ddbf"
   license "LGPL-2.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "0f6b3a1af259640264644f92286a3d96e4fb4ca0dd4f16aabbdcf608117bf116"
     sha256 cellar: :any,                 arm64_sequoia:  "ac1c99cc90796da54dcfa48415939944d6608a1284d6c1eb2650d43717a4d622"

--- a/Formula/a/aribb24.rb
+++ b/Formula/a/aribb24.rb
@@ -5,8 +5,6 @@ class Aribb24 < Formula
   sha256 "88b58dd760609372701087e25557ada9f7c6d973306c017067c5dcaf9e2c9710"
   license "LGPL-3.0-only"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "68aed54c8d78b72dcc8306e91e004c2afcf193563be22adca2774fa094121ee5"
     sha256 cellar: :any,                 arm64_sequoia:  "4f5a5fb9f91e28f11bbf33dda14a54b36510cecc834a29f0ba28d980a57760fc"

--- a/Formula/a/arm-linux-gnueabihf-binutils.rb
+++ b/Formula/a/arm-linux-gnueabihf-binutils.rb
@@ -10,8 +10,6 @@ class ArmLinuxGnueabihfBinutils < Formula
     formula "binutils"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:   "0cfc6f6aa9caa4d26566113476e9e6363a26728d4f23cfe7735f21f7ffb5383c"
     sha256 arm64_sequoia: "38948864d8d2bd66854fa4b9c7c912e62685add57394bb51f9ccaf876f4ecc39"

--- a/Formula/a/arm-none-eabi-gdb.rb
+++ b/Formula/a/arm-none-eabi-gdb.rb
@@ -11,8 +11,6 @@ class ArmNoneEabiGdb < Formula
     formula "gdb"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 arm64_tahoe:   "493c701535ef53e4243eb5e516f6d94f667c277f0a60b7d8e0eb5d8b8ba6a42f"

--- a/Formula/a/arpoison.rb
+++ b/Formula/a/arpoison.rb
@@ -13,8 +13,6 @@ class Arpoison < Formula
     regex(/href=.*?arpoison[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "befc347407af6f1c5581b82628c49605b87c84b2ce0b2d75f4641496c9ad8789"
     sha256 cellar: :any,                 arm64_sequoia:  "5290454e5c88457099cf20619c7bbb8368c13c8a33365791781c7ef693fa6a1e"

--- a/Formula/a/arss.rb
+++ b/Formula/a/arss.rb
@@ -5,8 +5,6 @@ class Arss < Formula
   sha256 "e2faca8b8a3902226353c4053cd9ab71595eec6ead657b5b44c14b4bef52b2b2"
   license "GPL-2.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "bfe57aa3bd356a8a7d3b616e96f854b484a92be45620cbf9ce3729a7ded493bb"
     sha256 cellar: :any,                 arm64_sequoia:  "02051c251dcf51557823a6ae6effb432c9c892a42a3ab19e80c9b8f0e61327ad"

--- a/Formula/a/arx-libertatis.rb
+++ b/Formula/a/arx-libertatis.rb
@@ -11,8 +11,6 @@ class ArxLibertatis < Formula
     regex(%r{href=["']?arx-libertatis[._-]v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 arm64_tahoe:   "d56d81aaee01fa139752c15b0fbc8332ed44443c94a9826771be22cc2544a77f"

--- a/Formula/a/ascii2binary.rb
+++ b/Formula/a/ascii2binary.rb
@@ -10,8 +10,6 @@ class Ascii2binary < Formula
     regex(/href=.*?ascii2binary[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "04f82b33a8a3806b57864a4295dc727744275e1d57494803780ea373cadaff54"
     sha256 cellar: :any,                 arm64_sequoia:  "5fa97a3db89565045338e7d0a725a0dfe87995651b8987d271bfb5eeb07e7728"

--- a/Formula/a/asciiquarium.rb
+++ b/Formula/a/asciiquarium.rb
@@ -11,8 +11,6 @@ class Asciiquarium < Formula
     regex(/href=.*?asciiquarium[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "3a1be21d11ec20615ff2c00ab0e5de809faac013935caefb4806e3760371768b"
     sha256 cellar: :any,                 arm64_sequoia: "394e9653d05e18f7dd1e482fd327fd8c6ac44a924aa2ac09e3d238bc0651e7b2"

--- a/Formula/a/asciitex.rb
+++ b/Formula/a/asciitex.rb
@@ -5,8 +5,6 @@ class Asciitex < Formula
   sha256 "abf964818833d8b256815eb107fb0de391d808fe131040fb13005988ff92a48d"
   license "GPL-2.0-only"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "5b71c04bd0a92fe7d693aff5674b9464532b0a6160b918832dcf299354b2adc5"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "d70918544a7191e90ce55d8b2cc02b5602ef6210dc6f0269e9667bdc0fce8a26"

--- a/Formula/a/atkmm.rb
+++ b/Formula/a/atkmm.rb
@@ -5,8 +5,6 @@ class Atkmm < Formula
   sha256 "6ec264eaa0c4de0adb7202c600170bde9a7fbe4d466bfbe940eaf7faaa6c5974"
   license "LGPL-2.1-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any, arm64_tahoe:    "a0084966800d7cf115466eb824f41e5c4c8fa269437abdc7d874f1ba5d52c04d"
     sha256 cellar: :any, arm64_sequoia:  "7b9d9f8002ad938aeefbdad02a83210e5e0b9e76cfba58cf5754d6d72bf48c45"

--- a/Formula/a/atkmm@2.28.rb
+++ b/Formula/a/atkmm@2.28.rb
@@ -10,8 +10,6 @@ class AtkmmAT228 < Formula
     regex(/atkmm-(2\.28(?:\.\d+)*)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any, arm64_tahoe:    "e8931497dd646ec78caf0f60b31040f777a584af67d3b46439f4811812c0645c"
     sha256 cellar: :any, arm64_sequoia:  "666a7ab1c48c5013fe80065747861be3df354221fd8f2dc4fa6fc312961f3edc"

--- a/Formula/a/atool.rb
+++ b/Formula/a/atool.rb
@@ -10,8 +10,6 @@ class Atool < Formula
     regex(/href=.*?atool[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 4
     sha256 cellar: :any_skip_relocation, all: "7bdc1cec48daaf7c140aa3ebb5e32ea863e560947ff2ed110339f84bdcea25c4"

--- a/Formula/a/ats2-postiats.rb
+++ b/Formula/a/ats2-postiats.rb
@@ -11,8 +11,6 @@ class Ats2Postiats < Formula
     regex(%r{url=.*?/ATS2-Postiats[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "d971aa331b5bb0f2efb3e34658fbc4fdf590dbfaffc3c257f4c16ac177ff6821"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "32296b820ff276f1de0eed59460f9dd48ca47132a77fdee78ee19fed9ba46923"

--- a/Formula/a/attr.rb
+++ b/Formula/a/attr.rb
@@ -11,8 +11,6 @@ class Attr < Formula
     regex(/href=.*?attr[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 arm64_linux:  "6d22ffeb1ac124b47032e96cfc44264b228f3fcabe9746a426e46a5f7db45c3a"

--- a/Formula/a/aubio.rb
+++ b/Formula/a/aubio.rb
@@ -11,8 +11,6 @@ class Aubio < Formula
     regex(/href=.*?aubio[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 arm64_tahoe:   "54adb27d46e507c9fa6dd57b9da19b11fc435dc706d1a79a2835e83137813a05"

--- a/Formula/a/augeas.rb
+++ b/Formula/a/augeas.rb
@@ -22,8 +22,6 @@ class Augeas < Formula
     strategy :github_latest
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:   "a08a4025060f11bc910787a5d6b162574eade8ff34e7356993a350ddb1e8513e"
     sha256 arm64_sequoia: "61ecffdbb3274cba9dadd7dd5ec7228ee5f295657770e51bdd373e10c218649e"

--- a/Formula/a/autobench.rb
+++ b/Formula/a/autobench.rb
@@ -11,8 +11,6 @@ class Autobench < Formula
     regex(/href=.*?autobench[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "3647ac7b205e7a115aae29fc33d72dc21ab5465b98081711240899fdbde2c096"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "e205a771a8b315d263fbfb8cac87e6cf90dec528afeb9d755908a9139a2499cd"

--- a/Formula/a/autoconf.rb
+++ b/Formula/a/autoconf.rb
@@ -9,8 +9,6 @@ class Autoconf < Formula
     "GPL-3.0-or-later" => { with: "Autoconf-exception-3.0" },
   ]
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "3374908e36c28948511beea4bdb005556f3d3c382a1377301c9b8eba2bf8ee77"

--- a/Formula/a/autogen.rb
+++ b/Formula/a/autogen.rb
@@ -12,8 +12,6 @@ class Autogen < Formula
     regex(%r{href=.*?rel(\d+(?:\.\d+)+)/?["' >]}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:   "11f0bdd04ae3db9ab2d6f2e12d2554db59111391ded8f941cd2bf08f79475f8a"
     sha256 arm64_sequoia: "4d986c1d9d478a402348836169d0a35f56a6fc9f7ad7f5d14acfd1bcd101b9c9"

--- a/Formula/a/avanor.rb
+++ b/Formula/a/avanor.rb
@@ -5,8 +5,6 @@ class Avanor < Formula
   sha256 "8f55be83d985470b9a5220263fc87d0a0a6e2b60dbbc977c1c49347321379ef3"
   license "GPL-2.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:    "f4e7392f6932b4478f15b384de5435734302d9758907fac70bb02d70e8307ea6"
     sha256 arm64_sequoia:  "88abecffbb226843739fc147a93b4ba8d7feeb105f4ae7f3580ceb719c16ce8f"

--- a/Formula/a/avce00.rb
+++ b/Formula/a/avce00.rb
@@ -12,8 +12,6 @@ class Avce00 < Formula
     regex(/href=.*?avce00[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "380d933d3d32aa65c7afd933544c0f8a3d4b9fd349288627eeb6211753ad8c0c"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "cbfe81486e3dc61f284643a89726e5d94927eaa359f3fe63664baaae8c9bc0ec"

--- a/Formula/a/avimetaedit.rb
+++ b/Formula/a/avimetaedit.rb
@@ -10,8 +10,6 @@ class Avimetaedit < Formula
     regex(/href=.*?avimetaedit[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "a3354d0e2c79d26a44be8eaa5297b6d3142b8a2754b2e9b4103a521f0209bcc4"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "d4a0e40875df5de8808e670967741dfbf1587d033d3262754e99ab43213f63d0"


### PR DESCRIPTION
#267571

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI assisted with candidate discovery and patch generation (removing `no_autobump! because: :requires_manual_review`) for eligible `a*` formulas. I manually verified eligibility constraints (livecheck status and URL/versioning sanity), re-ran `brew style` and `brew audit --strict` across edited formulas, and confirmed the `c*` scope is already covered by an open PR.

-----
