### PR TITLE
commandbox: pin to java 21

### DIFF
--- a/Formula/c/commandbox.rb
+++ b/Formula/c/commandbox.rb
@@ -12,7 +12,7 @@ class Commandbox < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "4095dd421f363b85ed73ace5321c56f6a8a6054b53eb2c93d1b78cf0e8cda19a"
+    sha256 cellar: :any_skip_relocation, all: "d480d8d137307a6345253304e5f9f3a4d862350aefdeb89ca0ba990ea65e6759"
   end
 
   # Keep pinned to Java 21 until https://ortussolutions.atlassian.net/browse/COMMANDBOX-1685 is resolved

--- a/Formula/c/commandbox.rb
+++ b/Formula/c/commandbox.rb
@@ -4,6 +4,7 @@ class Commandbox < Formula
   url "https://downloads.ortussolutions.com/ortussolutions/commandbox/6.3.2/commandbox-bin-6.3.2.zip"
   sha256 "f1f271a15d4c2281c6adb145972d963d44f4624ab52fce44dad326f32f283e56"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     url :homepage
@@ -14,7 +15,8 @@ class Commandbox < Formula
     sha256 cellar: :any_skip_relocation, all: "4095dd421f363b85ed73ace5321c56f6a8a6054b53eb2c93d1b78cf0e8cda19a"
   end
 
-  depends_on "openjdk"
+  # Keep pinned to Java 21 until https://ortussolutions.atlassian.net/browse/COMMANDBOX-1685 is resolved
+  depends_on "openjdk@21"
 
   resource "apidocs" do
     url "https://downloads.ortussolutions.com/ortussolutions/commandbox/6.3.2/commandbox-apidocs-6.3.2.zip"
@@ -29,7 +31,7 @@ class Commandbox < Formula
     odie "apidocs resource needs to be updated" if version != resource("apidocs").version
 
     (libexec/"bin").install "box"
-    (bin/"box").write_env_script libexec/"bin/box", Language::Java.java_home_env
+    (bin/"box").write_env_script libexec/"bin/box", Language::Java.java_home_env("21")
     doc.install resource("apidocs")
   end
 


### PR DESCRIPTION
Java 25 is causing some issues in CommandBox.  New JDK deprecations dump a bunch of warnings in the console when it starts.  Pinning this back to Java 21 LTS release for now until we can refactor the code causing the warnings.  I'm the CommandBox Lead Developer.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
