### PR TITLE
imagemagick: use `zlib-ng-compat` on Linux

### DIFF
--- a/Formula/i/imagemagick-full.rb
+++ b/Formula/i/imagemagick-full.rb
@@ -12,12 +12,13 @@ class ImagemagickFull < Formula
   end
 
   bottle do
-    sha256 arm64_tahoe:   "6a91f2a347da02311b254fcdf37e69ff8f899f379a5580b68cf2c996daf04ef4"
-    sha256 arm64_sequoia: "ad4848ac0979b84030694c89a426b442e6e867887c1239d505b61fdfdc41931f"
-    sha256 arm64_sonoma:  "9c537b700a26a6f378d2d65c7c0524804271ca7d0bad5017be60dacb97249991"
-    sha256 sonoma:        "abc62e6d5bcd298e41df72fe1fda9c51922de33c5a24182a8f82104d538d53cc"
-    sha256 arm64_linux:   "7e97adcb4891e653b17679669ac58e45db0fac1e700cc37331b44946024fbaba"
-    sha256 x86_64_linux:  "018aa4e2b0d9b1ec3da53ef8032bddc8ce4bcca1680f9cd97fea6267b3a5f1c9"
+    rebuild 1
+    sha256 arm64_tahoe:   "594843d2941241639b2eb322b0ccc61c8acc569da17f1a947240597acdd88c21"
+    sha256 arm64_sequoia: "a7bb2bbf74866fa57d26e9d0974e6e0ab28c917b93c8318c3c6aaaf4c8d067f5"
+    sha256 arm64_sonoma:  "b6f8295e97747d9dcd1ee76ac5f0233bc4f250b085c17e4892c95cb2898c8a17"
+    sha256 sonoma:        "911add98922fe58bc3761f5232396c99b5668dcaec0f1e553ab00a384a51166b"
+    sha256 arm64_linux:   "51e5d9d7a2acdcf90f131ed05e02953093de94b7ae673202457c45a1fe9bc6c3"
+    sha256 x86_64_linux:  "78786d6df4f03787cfbcb51820082738e71c9ecd7706284dd730578bf1b7a5a7"
   end
 
   keg_only :versioned_formula

--- a/Formula/i/imagemagick-full.rb
+++ b/Formula/i/imagemagick-full.rb
@@ -47,7 +47,6 @@ class ImagemagickFull < Formula
 
   uses_from_macos "bzip2"
   uses_from_macos "libxml2"
-  uses_from_macos "zlib"
 
   on_macos do
     depends_on "gdk-pixbuf"
@@ -59,6 +58,7 @@ class ImagemagickFull < Formula
   on_linux do
     depends_on "libx11"
     depends_on "libxext"
+    depends_on "zlib-ng-compat"
   end
 
   skip_clean :la

--- a/Formula/i/imagemagick.rb
+++ b/Formula/i/imagemagick.rb
@@ -39,11 +39,14 @@ class Imagemagick < Formula
 
   uses_from_macos "bzip2"
   uses_from_macos "libxml2"
-  uses_from_macos "zlib"
 
   on_macos do
     depends_on "gettext"
     depends_on "imath"
+  end
+
+  on_linux do
+    depends_on "zlib-ng-compat"
   end
 
   skip_clean :la

--- a/Formula/i/imagemagick.rb
+++ b/Formula/i/imagemagick.rb
@@ -12,12 +12,13 @@ class Imagemagick < Formula
   end
 
   bottle do
-    sha256 arm64_tahoe:   "dd0f5a36917d7860dae4ca09901cc13bdd7b88684fe7ed27e01ef7e9cb9eeb0c"
-    sha256 arm64_sequoia: "5768ee913f594f73f0c2a1b1b1794420fad388d86c77bb173f7cd892278053f2"
-    sha256 arm64_sonoma:  "c6be92f260927410a130f1260d52223decfb0929c39aa63975d404f7b9ec6834"
-    sha256 sonoma:        "82fa0f0f9f17443cbe62ea559c9e190c561bf7d2067fabc9b19f5fadf6b3476f"
-    sha256 arm64_linux:   "671b199d35ca623080ed8efe1c4c13795df6ce4201d09e0145e152e30accf38f"
-    sha256 x86_64_linux:  "d939187f111620c0974e700d6949062e2f3e4834f2d50e578f7706bafeb084af"
+    rebuild 1
+    sha256 arm64_tahoe:   "61f5c6b74543f9d7d4524fd7717da2896e506d137ddc3ebc09e095d477d3ae85"
+    sha256 arm64_sequoia: "5c22c4d9b3b7e85109db850558118a310d56b75d37d99e15485531f24cb593be"
+    sha256 arm64_sonoma:  "a3338f001b83b52472919da7280d56b9d3612f35076b65ecaaed2503a65ae714"
+    sha256 sonoma:        "a57d7833f8664d32dfa1e49f3f293a8cb9573b2f843470b377503e4215571bbb"
+    sha256 arm64_linux:   "da62bb92372775a6a6f82e60df9fdb024ff3afe9a7afaf78c24ae48980815af8"
+    sha256 x86_64_linux:  "6e66104d9fbf0cb911e1d85d24e0cc529131466c32650d8e92fa14ba57af93ce"
   end
 
   depends_on "pkgconf" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Reduces dependencies as all indirect usage of `zlib` has been migrated already.

`brew deps --tree --os linux imagemagick | grep zlib`