### PR TITLE
vunnel: migrate to `python@3.14`

### DIFF
--- a/Formula/v/vunnel.rb
+++ b/Formula/v/vunnel.rb
@@ -9,12 +9,13 @@ class Vunnel < Formula
   head "https://github.com/anchore/vunnel.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "7af98800520ceeee4979a37c47685bc42dd6759a217aca34c55c9c2cee467910"
-    sha256 cellar: :any,                 arm64_sequoia: "3e7dc5befe5331a15c251a93aa7c68df75976b8a4d778d9cddf59ef94191291f"
-    sha256 cellar: :any,                 arm64_sonoma:  "30b4703ba45815ba53e8b35bfca12a702c5b3d46f641908b038cd98f41e41a1d"
-    sha256 cellar: :any,                 sonoma:        "c6fe3495e0c98cee2acce95edc7bfe528a937c93eb7207c991d95fc54155dd43"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "4be0a6bf6c50615b80f844125556bc882007f63c041dbbe6b7174b6dfc9bcee2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d27926c5b79f53731d93d14ae39051e2dbfea385be24b7a84734f9fcf3886dfe"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "ee32fb242a74fe369a828256e569c3591b6f49dc1d0d73f9b7feaa38fe331d2d"
+    sha256 cellar: :any,                 arm64_sequoia: "9b1a15f138c2c69540d24b3a177082d45d9e1601076bba670d7c7ec438d1d9e6"
+    sha256 cellar: :any,                 arm64_sonoma:  "791739507fbbce771cdd80a970f0f689eee6b287a62abc6a5ff69f05c9afc1b0"
+    sha256 cellar: :any,                 sonoma:        "a748af84d70b5a6215631701aeacc2e3c4d0f356ca8a23e2aa55c196ed528697"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "987af1c7cab1da0c1c756ee19e8ee739cf476b3f88749cc7d8df912d2a7de966"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4c0d970977a5b7d3b47d0e37c8a970cc43027cd451917fd7d6ba299477ee7bb4"
   end
 
   depends_on "rust" => :build

--- a/Formula/v/vunnel.rb
+++ b/Formula/v/vunnel.rb
@@ -20,7 +20,7 @@ class Vunnel < Formula
   depends_on "rust" => :build
   depends_on "certifi" => :no_linkage
   depends_on "libyaml"
-  depends_on "python@3.13" # requires-python = "<3.14,>=3.13", https://github.com/anchore/vunnel/issues/952
+  depends_on "python@3.14"
   depends_on "rpds-py" => :no_linkage
 
   uses_from_macos "libxml2", since: :ventura
@@ -56,11 +56,6 @@ class Vunnel < Formula
   resource "defusedxml" do
     url "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz"
     sha256 "1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69"
-  end
-
-  resource "greenlet" do
-    url "https://files.pythonhosted.org/packages/8a/99/1cd3411c56a410994669062bd73dd58270c00cc074cac15f385a1fd91f8a/greenlet-3.3.1.tar.gz"
-    sha256 "41848f3230b58c08bb43dee542e74a2a2e34d3c59dc3076cec9151aeeedcae98"
   end
 
   resource "idna" do
@@ -237,11 +232,6 @@ class Vunnel < Formula
     # hatch does not support a SOURCE_DATE_EPOCH before 1980.
     # Remove after https://github.com/pypa/hatch/pull/1999 is released.
     ENV["SOURCE_DATE_EPOCH"] = "1451574000"
-
-    # Fix compilation of ijson native extensions, note:
-    # This would not be needed if latest ijson version is used upstream, but there are reasons it is
-    # currently held back: https://github.com/anchore/vunnel/pull/103
-    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     virtualenv_install_with_resources
 


### PR DESCRIPTION
vunnel: migrate to `python@3.14`

---

Fixed since https://github.com/anchore/vunnel/commit/39e2cd77dec2ab1f6e740632564c02d8c633b717