### PR TITLE
jadx: fix missing version number in build process

### DIFF
--- a/Formula/j/jadx.rb
+++ b/Formula/j/jadx.rb
@@ -6,6 +6,16 @@ class Jadx < Formula
   license "Apache-2.0"
   head "https://github.com/skylot/jadx.git", branch: "master"
 
+  bottle do
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "541d59a6f5ce07cb96cd9af180271ddf7a33e0b99bc9e2fca7343bfc5098209c"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "541d59a6f5ce07cb96cd9af180271ddf7a33e0b99bc9e2fca7343bfc5098209c"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "541d59a6f5ce07cb96cd9af180271ddf7a33e0b99bc9e2fca7343bfc5098209c"
+    sha256 cellar: :any_skip_relocation, sonoma:        "541d59a6f5ce07cb96cd9af180271ddf7a33e0b99bc9e2fca7343bfc5098209c"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "5d285501b24c38def6d142fcb016927df6a5786b83bcf34fd10fe2e85a00a7b0"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5d285501b24c38def6d142fcb016927df6a5786b83bcf34fd10fe2e85a00a7b0"
+  end
+
   depends_on "gradle" => :build
   depends_on "openjdk"
 

--- a/Formula/j/jadx.rb
+++ b/Formula/j/jadx.rb
@@ -6,14 +6,12 @@ class Jadx < Formula
   license "Apache-2.0"
   head "https://github.com/skylot/jadx.git", branch: "master"
 
-  bottle do
-    sha256 cellar: :any_skip_relocation, all: "4082ed1dc8f89c5ea94687be3c415c177d46d671376589621bfa6aa65416f914"
-  end
-
   depends_on "gradle" => :build
   depends_on "openjdk"
 
   def install
+    ENV["JADX_VERSION"] = version.to_s if build.stable?
+
     system "gradle", "clean", "dist"
     libexec.install Dir["build/jadx/*"]
     bin.install libexec/"bin/jadx"
@@ -22,6 +20,8 @@ class Jadx < Formula
   end
 
   test do
+    assert_match version.to_s, shell_output("#{bin}/jadx --version")
+
     resource "homebrew-test.apk" do
       url "https://raw.githubusercontent.com/facebook/redex/fa32d542d4074dbd485584413d69ea0c9c3cbc98/test/instr/redex-test.apk"
       sha256 "7851cf2a15230ea6ff076639c2273bc4ca4c3d81917d2e13c05edcc4d537cc04"


### PR DESCRIPTION
Jadx requires a version number to be specified as ENV variable at build time. Without the about dialog will just show "dev" as version.

Fixes issue https://github.com/skylot/jadx/issues/2793 that was mistakenly opened in the project repo instead of the brew repo.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
