### PR TITLE
b*: remove no_autobump! manual review

### DIFF
--- a/Formula/b/b43-fwcutter.rb
+++ b/Formula/b/b43-fwcutter.rb
@@ -11,8 +11,6 @@ class B43Fwcutter < Formula
     regex(/href=.*?b43-fwcutter[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "5e27ebebb8d25a8d3c1ddd0e03b4a9f174117c1cb977c590b1c5300f5b45629f"

--- a/Formula/b/babeld.rb
+++ b/Formula/b/babeld.rb
@@ -11,8 +11,6 @@ class Babeld < Formula
     regex(/href=.*?babeld[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "f977cf0194b8bb8a3a60a434904a2a858b0b9f336176327800a731ef007ab1a1"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "62f048341c61438f5d7fade7659f694402543ca20d8fa7d06d42e87e42144e0c"

--- a/Formula/b/backupninja.rb
+++ b/Formula/b/backupninja.rb
@@ -10,8 +10,6 @@ class Backupninja < Formula
     regex(/^backupninja[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "d9df3e07340b1c7c046d9d83009c271cb27105940e6be345a50013abcd04357b"

--- a/Formula/b/bas55.rb
+++ b/Formula/b/bas55.rb
@@ -10,8 +10,6 @@ class Bas55 < Formula
     regex(/href=.*?bas55[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "4ee22532aeb40b552f0bcdad959ea9790db7a1256a562d032ea17ec3abf5774c"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "478a5356e46bd76319db391d95aff282e41a3864225cede8f1da17a18eeeb055"

--- a/Formula/b/base64.rb
+++ b/Formula/b/base64.rb
@@ -10,8 +10,6 @@ class Base64 < Formula
     regex(/href=.*?base64[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "fbf459526bc50316ed55f1e5ea972f22658ba26aa8e0b4b5db5b984bc0fbceb8"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "17aef54e36b9c3ce2cd832c59d4cacbac0584a1a9db7af45e1728d6fceeb760e"

--- a/Formula/b/base91.rb
+++ b/Formula/b/base91.rb
@@ -5,8 +5,6 @@ class Base91 < Formula
   sha256 "02cfae7322c1f865ca6ce8f2e0bb8d38c8513e76aed67bf1c94eab1343c6c651"
   license "BSD-3-Clause"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "3c288d4a7310b87b44e080c9b10ae3f541945cc7ba1e990edd1006df84c6ad9e"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "c592a7056137ae37fd39f580b4f5b94abb84943d2c9910854ddf149d4099becf"

--- a/Formula/b/bashish.rb
+++ b/Formula/b/bashish.rb
@@ -5,8 +5,6 @@ class Bashish < Formula
   sha256 "3de48bc1aa69ec73dafc7436070e688015d794f22f6e74d5c78a0b09c938204b"
   license "GPL-2.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "593a8963d32a22c3c7a65c3d1f9f8ae8fec9a0a85dffe8ad5c71baba839091ca"

--- a/Formula/b/bbe.rb
+++ b/Formula/b/bbe.rb
@@ -5,8 +5,6 @@ class Bbe < Formula
   sha256 "baaeaf5775a6d9bceb594ea100c8f45a677a0a7d07529fa573ba0842226edddb"
   license "GPL-2.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "8fd3005bedec280a143b22eb15bb126055e121ba0e1db118108c0878104263c9"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "a207fd77fb072a948ca2261b0b2968e98932bea8c7afa112d310c6a6d9739d39"

--- a/Formula/b/bbftp-client.rb
+++ b/Formula/b/bbftp-client.rb
@@ -15,8 +15,6 @@ class BbftpClient < Formula
     end
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "18d463140dea6d3abd1361442b054a2cd01020e40c55ca2e6046c5760944d689"

--- a/Formula/b/bcrypt.rb
+++ b/Formula/b/bcrypt.rb
@@ -10,8 +10,6 @@ class Bcrypt < Formula
     regex(/href=.*?bcrypt[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "d49aa09bacc40f805eba8376e5b444b9c7824737b8beaffea99a15b9a1fe58b3"

--- a/Formula/b/beecrypt.rb
+++ b/Formula/b/beecrypt.rb
@@ -6,8 +6,6 @@ class Beecrypt < Formula
   license "LGPL-2.1-or-later"
   revision 7
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "19bbdbe37b8f9c59abd5ed8ce3a6c5c0fa4ac50734b445bc9f6a8bb05666c890"
     sha256 cellar: :any,                 arm64_sequoia:  "9d436aea574fc90b56ebdd14da2f08d7484209ddc553ad9a9928bb1b0e2ec28e"

--- a/Formula/b/befunge93.rb
+++ b/Formula/b/befunge93.rb
@@ -12,8 +12,6 @@ class Befunge93 < Formula
     regex(/href=.*?befunge-93[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "e7cb6bafad0910e0180d079e0915876d138ad0ab1a7d5bdb7051d41ad1c5a9e1"

--- a/Formula/b/bento4.rb
+++ b/Formula/b/bento4.rb
@@ -12,8 +12,6 @@ class Bento4 < Formula
     regex(/href=.*?Bento4-SRC[._-]v?(\d+(?:[.-]\d+)+)\.zip/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "5367dba6956a756d81d778166578f003e29d2509b16e84a8fb0118b8bc387560"
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "3be0b7e4aa10081340266b8c4ecd5ff536ea75489fc739cfd3948195d94508af"

--- a/Formula/b/berkeley-db.rb
+++ b/Formula/b/berkeley-db.rb
@@ -12,8 +12,6 @@ class BerkeleyDb < Formula
     regex(/Berkeley\s*DB[^(]*?\(\s*v?(\d+(?:\.\d+)+)\s*\)/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "8ab6e76001b5a945ed16eaa85a4a5676bd3a7f54365c2255c90565d73096ff0e"
     sha256 cellar: :any,                 arm64_sequoia:  "422be2c8877f981442a27bd80d7a4494de3a515b54b1d206e51c4e710f9d83eb"

--- a/Formula/b/bfg.rb
+++ b/Formula/b/bfg.rb
@@ -10,8 +10,6 @@ class Bfg < Formula
     regex(%r{<version>v?(\d+(?:\.\d+)+)</version>}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, all: "e6ab06431b47f90f783c186032521800d0fffb1f9fffb842c0de85e624d54d2d"
   end

--- a/Formula/b/bibclean.rb
+++ b/Formula/b/bibclean.rb
@@ -10,8 +10,6 @@ class Bibclean < Formula
     regex(/href=.*?bibclean[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:    "879cc1d92309684de3e1d3aac3f3ceae0751b013e52bee638c67c18fd63dbf92"
     sha256 arm64_sequoia:  "13c1d6444ba0a4dd09e6840c29240a230d4d5bab8946912b275fc53fca9558bc"

--- a/Formula/b/bibtex2html.rb
+++ b/Formula/b/bibtex2html.rb
@@ -10,8 +10,6 @@ class Bibtex2html < Formula
     regex(/href=.*?bibtex2html[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "261c680993c384f4739fb747b85d0c6b346e5075a0450c588d4cd25093359d30"

--- a/Formula/b/bibutils.rb
+++ b/Formula/b/bibutils.rb
@@ -10,8 +10,6 @@ class Bibutils < Formula
     regex(%r{url=.*?/bibutils[._-]v?(\d+(?:\.\d+)+)[._-]src\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "ac24439c4f2cf3ea608eb7b411d8094183796f81a3dee10e3ee550672e9ffae9"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "9cd55399d769cbc1cab21cfad48bb843a8c8a7c0a966445c6530c88ba8361b7d"

--- a/Formula/b/bioperl.rb
+++ b/Formula/b/bioperl.rb
@@ -16,8 +16,6 @@ class Bioperl < Formula
     regex(/href=["']?BioPerl[._-]v?(\d+\.\d+\.\d+)(?:\.?_\d+)?\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "17405e0b0b17e484a222e76279b4b9732b3d1010f0ef33a05552d8ee4cec1272"
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "61acb5dde612cf25bbc0f07789dc4275f0b630f09c3b264c36e1d015f8b9eb52"

--- a/Formula/b/bison.rb
+++ b/Formula/b/bison.rb
@@ -8,8 +8,6 @@ class Bison < Formula
   license "GPL-3.0-or-later"
   version_scheme 1
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "d47d87f1bead6f00956ea21f147d46ded1c5c2ac0c53193a1ed7b46105492228"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "d45a8c193646a25d281a6d3fd62d6f756d4e392cc2948e605a62f3d88ccbf188"

--- a/Formula/b/bitchx.rb
+++ b/Formula/b/bitchx.rb
@@ -23,8 +23,6 @@ class Bitchx < Formula
     patch :DATA
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 arm64_tahoe:    "a24e61a92b29742aed083f0630542dafa1b11daabbfbfe02ec73a1ba904789ff"

--- a/Formula/b/bitlbee.rb
+++ b/Formula/b/bitlbee.rb
@@ -11,8 +11,6 @@ class Bitlbee < Formula
     regex(/href=.*?bitlbee[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 arm64_tahoe:   "31ddec7ca433f3bcf5dc5f86206c99464e9586065bf0fbb54b327051ff751dff"

--- a/Formula/b/blastem.rb
+++ b/Formula/b/blastem.rb
@@ -39,8 +39,6 @@ class Blastem < Formula
     end
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 sonoma:       "06f0bb0d5d0e04267ab21bfa35f2146be7cf7c6acf85d8bd1a9141679c3741a1"

--- a/Formula/b/blaze.rb
+++ b/Formula/b/blaze.rb
@@ -6,8 +6,6 @@ class Blaze < Formula
   license "BSD-3-Clause"
   head "https://bitbucket.org/blaze-lib/blaze.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "1f564399ba9c93c4246e3cf3679b5b49661edb3ad9077afab40f94c220e6d49c"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "a80081c26f45e68615e6ef2dcde4f354ee8dc05cf2744d20d75efee48f7e7864"

--- a/Formula/b/bogofilter.rb
+++ b/Formula/b/bogofilter.rb
@@ -9,8 +9,6 @@ class Bogofilter < Formula
     url "https://sourceforge.net/projects/bogofilter/rss?path=/bogofilter-stable"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "52568286a8cb6ce65a146f26233362ec1df94e8d028d6c6d41dd889a31ab3e6c"

--- a/Formula/b/bombadillo.rb
+++ b/Formula/b/bombadillo.rb
@@ -6,8 +6,6 @@ class Bombadillo < Formula
   license "GPL-3.0-or-later"
   head "https://tildegit.org/sloum/bombadillo.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "31498bb84196e03bdbb936dc1528b02b3355832cc0a8ebd01dbdf176376caabc"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "704af144b953977108282ec76083d51d8d359b2f08402aa71da7822a79491591"

--- a/Formula/b/bonnie++.rb
+++ b/Formula/b/bonnie++.rb
@@ -10,7 +10,7 @@ class Bonniexx < Formula
     regex(/href=.*?bonnie\+\+[._-]v?(\d+(?:\.\d+)+[a-z]?)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
+  no_autobump! because: :incompatible_version_format
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "751104c5d03e4f91086a337c4ed4b12acd1464170f67b994cf20ec30f6456176"

--- a/Formula/b/bonnie++.rb
+++ b/Formula/b/bonnie++.rb
@@ -10,8 +10,6 @@ class Bonniexx < Formula
     regex(/href=.*?bonnie\+\+[._-]v?(\d+(?:\.\d+)+[a-z]?)\.t/i)
   end
 
-  no_autobump! because: :incompatible_version_format
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "751104c5d03e4f91086a337c4ed4b12acd1464170f67b994cf20ec30f6456176"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "2cdb858040bf6e8c19142a19932a6aa6294c863a4b3f7b2faebd5ebcb945ee29"

--- a/Formula/b/bootloadhid.rb
+++ b/Formula/b/bootloadhid.rb
@@ -10,8 +10,6 @@ class Bootloadhid < Formula
     regex(/href=.*?bootloadHID[._-]v?(\d{4}-\d{1,2}-\d{1,2})\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "5b761a6cb6b73fde389f5aee23438b696185418e0f9c77775b7f93b83ed686a6"
     sha256 cellar: :any,                 arm64_sequoia:  "0c8755c106cb46118e33efda3ce06c507bc13949530ee87f10b4807c8cbcc55a"

--- a/Formula/b/bozohttpd.rb
+++ b/Formula/b/bozohttpd.rb
@@ -10,8 +10,6 @@ class Bozohttpd < Formula
     regex(/href=.*?bozohttpd[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "f071d5d2e28bc3a4ccef5b81d780fbd3995a5cca9d508356ffa860ede9737bf6"
     sha256 cellar: :any,                 arm64_sequoia: "f91adb497f96847759c3427e7b14b81889547273bc078266abdcc0087e6f1c8f"

--- a/Formula/b/briss.rb
+++ b/Formula/b/briss.rb
@@ -5,8 +5,6 @@ class Briss < Formula
   sha256 "45dd668a9ceb9cd59529a9fefe422a002ee1554a61be07e6fc8b3baf33d733d9"
   license "GPL-3.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 3
     sha256 cellar: :any_skip_relocation, all: "7e198b253f493cc8b14159aa43e522d82a8ce999959f36a66ae0a1d86a173496"

--- a/Formula/b/bsdiff.rb
+++ b/Formula/b/bsdiff.rb
@@ -12,8 +12,6 @@ class Bsdiff < Formula
     regex(/href=.*?bsdiff[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "c1b39ac523c9bb26c5b194c20451b28be15bf1a8a5b59bab50a517f7619c472d"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "5aa138e7ada53aa574d2bf31f2cfa65cd53692001a1d7e5ad6240fc72975d6b3"

--- a/Formula/b/btparse.rb
+++ b/Formula/b/btparse.rb
@@ -5,8 +5,6 @@ class Btparse < Formula
   sha256 "631bf1b79dfd4c83377b416a12c349fe88ee37448dc82e41424b2f364a99477b"
   license "GPL-2.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "6bcfac3d46e83b1217a57419de338fbea65b77c71d9a4f6de49665990e93b746"
     sha256 cellar: :any,                 arm64_sequoia:  "7da3060367c602412a91935267f6f8eef48d2c15fc0e5fcfd7a8bc42423ba281"

--- a/Formula/b/build2.rb
+++ b/Formula/b/build2.rb
@@ -10,8 +10,6 @@ class Build2 < Formula
     regex(/^# (\d+\.\d+\.\d+)(?:\+\d+)?$/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:    "04b1c4088629832bebbfd1b82b8132b14ac4d623585dc9a3d2e3147be53025e6"
     sha256 arm64_sequoia:  "70ffd3523f4b4d74bd22b1374963bbefc8308140252481c2fd97972360757619"

--- a/Formula/b/bzip2.rb
+++ b/Formula/b/bzip2.rb
@@ -10,8 +10,6 @@ class Bzip2 < Formula
     regex(/href=.*?bzip2[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "e823d1ae6f9409cd524669dfe94dd9922e5661998be5ae416b237aa4713c8d54"


### PR DESCRIPTION
#267571

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI assisted with candidate discovery and one-commit-per-formula patching for `b*` formulas by removing `no_autobump! because: :requires_manual_review` where livecheck/status/source checks were compatible. I manually verified and reran `brew style` and `brew audit --strict` on the edited formula set.

Note: `bpm-tools` and `bsdsfv` were intentionally excluded from this batch due to strict audit findings unrelated to this change (missing `test do` blocks).

-----
