### PR TITLE
c*: remove no_autobump! manual review

### DIFF
--- a/Formula/c/cabal-install.rb
+++ b/Formula/c/cabal-install.rb
@@ -18,8 +18,6 @@ class CabalInstall < Formula
     patch :DATA
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:   "7b5a61167c4730638dd45f0b665ff76c4534b0b6a8d62bc8b5d29627b0150e8d"

--- a/Formula/c/cabextract.rb
+++ b/Formula/c/cabextract.rb
@@ -10,8 +10,6 @@ class Cabextract < Formula
     regex(/href=.*?cabextract[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "dc0b66c1f358e20b4eac4f6c9d44c6bcc62143732eddb9bc998db15d892e37b3"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "8101eb79dccd718a2568420757be4c4f191ee6e11a8c8107a000f1691b081456"

--- a/Formula/c/cairomm.rb
+++ b/Formula/c/cairomm.rb
@@ -10,8 +10,6 @@ class Cairomm < Formula
     regex(/href=.*?cairomm[._-]v?(\d+\.\d*[02468](?:\.\d+)*)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any, arm64_tahoe:    "f0343ad4ea24ef24041422413d36b5a8aae65628dd5d756c94114d22e09709ad"
     sha256 cellar: :any, arm64_sequoia:  "0a9512445631806965c6983c9081ca3502d04ae9d2ca70760152a5ea5add5ce6"

--- a/Formula/c/cairomm@1.14.rb
+++ b/Formula/c/cairomm@1.14.rb
@@ -10,8 +10,6 @@ class CairommAT114 < Formula
     regex(/href=.*?cairomm[._-]v?(1\.14(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any, arm64_tahoe:    "3c84812ac04258b3fe766341479b99b1e28a9572b995e7bd33e3184fdb29055a"
     sha256 cellar: :any, arm64_sequoia:  "87bd872e7129feb2db9ca965fe5e065ebef30f6a196f0c80d8012b60cef66bf2"

--- a/Formula/c/camellia.rb
+++ b/Formula/c/camellia.rb
@@ -10,8 +10,6 @@ class Camellia < Formula
     regex(%r{url=.*?/CamelliaLib[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "c02cf24237f1d621d5b395cb126efba1128b422026385868a8bf42ba2444d0fd"
     sha256 cellar: :any,                 arm64_sequoia:  "0679b21bf4e69b52af575fc7c30370b2fe0e70d2639b6fa550f3b4b3a3dfa392"

--- a/Formula/c/cargo-binutils.rb
+++ b/Formula/c/cargo-binutils.rb
@@ -8,8 +8,6 @@ class CargoBinutils < Formula
   license any_of: ["Apache-2.0", "MIT"]
   head "https://github.com/rust-embedded/cargo-binutils.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "1462ea07e63a12bca4c626cb452706ea56780f777a580ba4080c87978b661af8"
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "1e345e71200c674756c1c5052eb06d5c5476ab91b0446b2f53fb4d21329e86f8"

--- a/Formula/c/carton.rb
+++ b/Formula/c/carton.rb
@@ -6,8 +6,6 @@ class Carton < Formula
   license any_of: ["Artistic-1.0-Perl", "GPL-1.0-or-later"]
   head "https://github.com/perl-carton/carton.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "7cf6c91209b768cb3e963c1eb14131efe738a851748d61d9adf402c274beeabf"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "228551b5317d850f5ba6cc3dcf31eced4f9df54d28a804ce0dbf24652ca30e75"

--- a/Formula/c/castget.rb
+++ b/Formula/c/castget.rb
@@ -11,8 +11,6 @@ class Castget < Formula
     regex(/href=.*?castget[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "6260cc2436ada19971dceea5edf959d05602b072b8c9e4fe4e3cd4ba2d1cd414"
     sha256 cellar: :any,                 arm64_sequoia: "0a168ca1b2f72f15dec7ccc87492f7687daa913751dc92f93e170847d725d415"

--- a/Formula/c/cattle.rb
+++ b/Formula/c/cattle.rb
@@ -19,8 +19,6 @@ class Cattle < Formula
     regex(/href=.*?cattle[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256                               arm64_tahoe:    "e0a80736a4afb81659a8e8eaa4dee70a320bc7c8f7c756d14891c333f65748e6"
     sha256                               arm64_sequoia:  "502399f17e0777926e50b1a067eff9ff5520bcbf5457fb73156376891726d411"

--- a/Formula/c/cbmbasic.rb
+++ b/Formula/c/cbmbasic.rb
@@ -6,8 +6,6 @@ class Cbmbasic < Formula
   license "BSD-2-Clause"
   head "https://github.com/mist64/cbmbasic.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "7a998e7b4ececefdb1441daedfc1d7e21499bf353d7d2b38f43ce9506eb7e876"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "12b112458c348c5267a9dd565cd6eb627e77e5f7601aa8262192ef0547f5c824"

--- a/Formula/c/ccd2iso.rb
+++ b/Formula/c/ccd2iso.rb
@@ -5,8 +5,6 @@ class Ccd2iso < Formula
   sha256 "f874b8fe26112db2cdb016d54a9f69cf286387fbd0c8a55882225f78e20700fc"
   license "GPL-2.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "b0fdfe74cdd573d4b411974eb51ff6d8dd0be85e2ca817a42517d7651f21f638"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "e7196c00e29751b4d90307dcc66d0d0f329dcce6bc4c9ce9ae88aceef81e55ee"

--- a/Formula/c/ccfits.rb
+++ b/Formula/c/ccfits.rb
@@ -10,8 +10,6 @@ class Ccfits < Formula
     regex(/href=.*v?(\d+(?:\.\d+)+)/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "e095d123708d4f5c4c57b26c82155a75405f6e19f29c955ac7b52f4121d2df1d"
     sha256 cellar: :any,                 arm64_sequoia: "da6f787ac55d5f93ad25617af795ac878443371ca2bab55bf9fd64736d592cfd"

--- a/Formula/c/ccrypt.rb
+++ b/Formula/c/ccrypt.rb
@@ -5,8 +5,6 @@ class Ccrypt < Formula
   sha256 "b19c47500a96ee5fbd820f704c912f6efcc42b638c0a6aa7a4e3dc0a6b51a44f"
   license "GPL-2.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:    "cebf96f7115ebb2be8b7f058e24de430aa06506c3dcfa5aaf9c0ff67d1bd780b"
     sha256 arm64_sequoia:  "030055fedb7e4f4136631b6cb57863d19dfbc34c422410ef246422471f6ee0b9"

--- a/Formula/c/cdlabelgen.rb
+++ b/Formula/c/cdlabelgen.rb
@@ -10,8 +10,6 @@ class Cdlabelgen < Formula
     regex(/href=.*?cdlabelgen[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "b59e22a5f1b438e89d6ae6cc662a70c09c9fd3aeee92538cf6a049296a0ca2be"

--- a/Formula/c/cdpr.rb
+++ b/Formula/c/cdpr.rb
@@ -5,8 +5,6 @@ class Cdpr < Formula
   sha256 "32d3b58d8be7e2f78834469bd5f48546450ccc2a86d513177311cce994dfbec5"
   license "GPL-2.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "82a48884ef52f0eac1769644d8efa9ee572031be613669d16b3b23c1e09f1393"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "dfd6f6ef21a6f1fbc38367d4000fdf6a6dd9910b5959bc7c418e2a89b94d1476"

--- a/Formula/c/cdrtools.rb
+++ b/Formula/c/cdrtools.rb
@@ -13,8 +13,6 @@ class Cdrtools < Formula
     regex(%r{url=.*?/cdrtools[._-]v?(\d+(?:\.\d+)+(a\d\d)?)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:    "f288c36da4a1fb214eea796214193de02c0193d7e1237829114fe5b978e5e0f4"
     sha256 arm64_sequoia:  "12e1334974f92d034d839c30e8d1c4ff5d8a5e7341ae9d2f4013cc6bd1b73859"

--- a/Formula/c/ceres-solver.rb
+++ b/Formula/c/ceres-solver.rb
@@ -25,8 +25,6 @@ class CeresSolver < Formula
     regex(/href=.*?ceres-solver[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "8bca5dac2f24d423391151bf8fb69c53b119eb94e5ba899f95fe961cac036ee7"
     sha256 cellar: :any,                 arm64_sequoia: "05cf5a6bb6673ae173ed0832fdd1fa8fcfe5a7fd4db1947510f0f61501d94984"

--- a/Formula/c/cgdb.rb
+++ b/Formula/c/cgdb.rb
@@ -10,8 +10,6 @@ class Cgdb < Formula
     regex(/href=.*?cgdb[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:    "960dae291afe8d9e0ce627ee8c4d0fd2a521fdc7f0b731f4c7c5d7830a60ae2f"
     sha256 arm64_sequoia:  "dac79a6089d98cfbe4c2b9083d34c0558227e6888546e76c0d425550cb808f30"

--- a/Formula/c/cgit.rb
+++ b/Formula/c/cgit.rb
@@ -11,8 +11,6 @@ class Cgit < Formula
     regex(/href=.*?cgit[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 arm64_tahoe:   "be548ed68df6c0f5be5a264f52cd1a5625e34b562ff27086b95b222339179b18"

--- a/Formula/c/cgoban.rb
+++ b/Formula/c/cgoban.rb
@@ -6,8 +6,6 @@ class Cgoban < Formula
   license "GPL-2.0-or-later"
   revision 1
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "bcd2fe4d496b2e85dec96463a19aef542173bb207e4529f47935cb679f4ed277"
     sha256 cellar: :any,                 arm64_sequoia:  "a775648cbc6f12427ef0a6b83a920bf6b565e3b70b60ce75974d926eba786595"

--- a/Formula/c/cgvg.rb
+++ b/Formula/c/cgvg.rb
@@ -10,8 +10,6 @@ class Cgvg < Formula
     regex(/href=.*?cgvg[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, all: "06ba6e4b8f27a86f39d20fa7d6b0b456d584d9973f15c5a7916145ae46c4d989"

--- a/Formula/c/cheapglk.rb
+++ b/Formula/c/cheapglk.rb
@@ -11,8 +11,6 @@ class Cheapglk < Formula
     regex(/href=.*?cheapglk[._-]v?(?:\d+(?:\.\d+)*)\.t[^>]+?>\s*?CheapGlk library v?(\d+(?:\.\d+)+)/im)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "22ed56d38b62431e69151ad10604e0e8831a5f4b88d2f0d7105bb71d00708cf3"
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "a5600c759374d421d057d4901d84f12c4a0526ef88c23d6d838b699eb409a6c9"

--- a/Formula/c/check_postgres.rb
+++ b/Formula/c/check_postgres.rb
@@ -11,8 +11,6 @@ class CheckPostgres < Formula
     regex(/latest version.*?v?(\d+(?:\.\d+)+)/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "20317c9b4534bb9bb63f3318637c8d3b65162a78c7201f9f24d3e5f62efe178e"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "357245d50daeb670b0e7acdf6ba808e045a3246a6a1666cded448100b78ffda5"

--- a/Formula/c/cheops.rb
+++ b/Formula/c/cheops.rb
@@ -11,8 +11,6 @@ class Cheops < Formula
     regex(/href=.*?cheops[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "e22eb2ee77f28f3738d572be8a83cee17e20ee6c0a23919defdcc601443f4e5b"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "a19ba4057d685a8f61ecc2d198d517ae6859cf4a0479a153f3959ef832d45e20"

--- a/Formula/c/chipmunk-physics.rb
+++ b/Formula/c/chipmunk-physics.rb
@@ -13,8 +13,6 @@ class ChipmunkPhysics < Formula
     regex(/>\s*Chipmunk2D\s+v?(\d+(?:\.\d+)+)\s*</i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "812f69a9a0065f99dd7c215c6de16629def031aff0bdb8e315e91113c9f45a7e"
     sha256 cellar: :any,                 arm64_sequoia: "be1319def436cdfea53765897ce02cb7a223df465dbac30190d605c0d8c20738"

--- a/Formula/c/chmlib.rb
+++ b/Formula/c/chmlib.rb
@@ -10,8 +10,6 @@ class Chmlib < Formula
     regex(/href=.*?chmlib[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any,                 arm64_tahoe:    "023b19e53523d58babcd983aba314c758781ecfdcde1b76881d4b7f99503b7dc"

--- a/Formula/c/cidrmerge.rb
+++ b/Formula/c/cidrmerge.rb
@@ -5,8 +5,6 @@ class Cidrmerge < Formula
   sha256 "21b36fc8004d4fc4edae71dfaf1209d3b7c8f8f282d1a582771c43522d84f088"
   license "GPL-2.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "a1557d597adadd169e8de642a61a2adcc610583022f4fbfc391a80c6bc7fe46e"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "37c60d84cb5235c7e6f49d9be574b422aad1c9bcd2767a1ac54f037d068a1635"

--- a/Formula/c/civl.rb
+++ b/Formula/c/civl.rb
@@ -14,8 +14,6 @@ class Civl < Formula
     end
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "71c991aa3a7b29a8c41578d2220e02bbaad9b42d000b3119a0f054bd57892f82"

--- a/Formula/c/cksfv.rb
+++ b/Formula/c/cksfv.rb
@@ -10,8 +10,6 @@ class Cksfv < Formula
     regex(/href=.*?cksfv[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "98f4a00c83288bac3479fcd9e301409f3445d816bad334c6bd7632f302f8b638"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "96608dc540a21f5e14b2a1731b0d6350c00063db4528a1bcb56186188a157c00"

--- a/Formula/c/clean.rb
+++ b/Formula/c/clean.rb
@@ -5,8 +5,6 @@ class Clean < Formula
   sha256 "761f3a9e1ed50747b6a62a8113fa362a7cc74d359ac6e8e30ba6b30d59115320"
   license :public_domain
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "bc6ccc5a72395c51b6aebf78f3301e538b0c8d4ee67f42943cd4d0e15354b842"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "a1e4fead81bdadea6bd617523d7628f215ae6ee6a440a761d9a8b93348471ed8"

--- a/Formula/c/clipsafe.rb
+++ b/Formula/c/clipsafe.rb
@@ -11,8 +11,6 @@ class Clipsafe < Formula
     regex(/href=.*?clipsafe[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "a1e669adb584521510edd954b4e9220d7a597fce06352bc30d992f2dad0b30e4"
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "b25081afcd8b418a0e5945f90d905f8a96313e9fc0fdc9ff2cab2969d7852cdf"

--- a/Formula/c/clisp.rb
+++ b/Formula/c/clisp.rb
@@ -22,8 +22,6 @@ class Clisp < Formula
     strategy :page_match
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any, arm64_tahoe:   "7c6012970cf0b4c270ea9144deb1aa018a820f333dd0a23c98116a6da81cdccd"

--- a/Formula/c/clpbar.rb
+++ b/Formula/c/clpbar.rb
@@ -5,8 +5,6 @@ class Clpbar < Formula
   sha256 "fa0f5ec5c8400316c2f4debdc6cdcb80e186e668c2e4471df4fec7bfcd626503"
   license "GPL-2.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "428cfe8bba0bbe5074e6ea1f27f05ead41dd9fd65007b4ae9a9490e1673911af"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "b0b9fe17e86d7a2f3af256a5a55343351fb8d8affe328a5293290ba83fc4d5ba"

--- a/Formula/c/cmuclmtk.rb
+++ b/Formula/c/cmuclmtk.rb
@@ -13,8 +13,6 @@ class Cmuclmtk < Formula
     strategy :page_match
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "e382dbebb03c49d129bb2eacd23102d828d9814296bb751f275e2bd5cd4ac8e4"
     sha256 cellar: :any,                 arm64_sequoia:  "17749777bf2cedd02ab511ce2bab36a69389ea9c1f0b03c8a92927e3e54a5fae"

--- a/Formula/c/cntlm.rb
+++ b/Formula/c/cntlm.rb
@@ -10,8 +10,6 @@ class Cntlm < Formula
     regex(%r{url=.*?/cntlm[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 arm64_tahoe:    "730084818967f10d47a8458853ebb7a56bce4c2280759bda2f3c31d1edae9da3"

--- a/Formula/c/collectd.rb
+++ b/Formula/c/collectd.rb
@@ -20,8 +20,6 @@ class Collectd < Formula
     regex(/href=.*?collectd[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:   "96b35082902fad36f2eebfadecfb13424f4f019cb051fb7cc8a80aa10369e618"
     sha256 arm64_sequoia: "bd6bbc019cd159129bf0ae691889eb75bdb223852a510b968ac1d9f80e2f0fbe"

--- a/Formula/c/color-code.rb
+++ b/Formula/c/color-code.rb
@@ -10,8 +10,6 @@ class ColorCode < Formula
     regex(/href=.*?ColorCode[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "ad3f82efc9695c34bf0108765bd03a823567321fb844bbd2dfed5ed7b679ba4d"
     sha256 cellar: :any,                 arm64_sequoia:  "eca15102195ecbf35b9b5db261ad63a1e7849f68048a9872757c99a300af2198"

--- a/Formula/c/corkscrew.rb
+++ b/Formula/c/corkscrew.rb
@@ -10,8 +10,6 @@ class Corkscrew < Formula
     regex(/href=.*?corkscrew[._-]v?(\d+(?:\.\d+)+)\.orig\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "ddf9f9bccfc3f8abdac5ab156b3adebb82d263eec75503ca53b657dba4e310f3"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "d17faa8d3e8eb0fe11107515daf53fd0f9d22caaaa0d32993ca6e961ee9559cf"

--- a/Formula/c/cpio.rb
+++ b/Formula/c/cpio.rb
@@ -6,8 +6,6 @@ class Cpio < Formula
   sha256 "937610b97c329a1ec9268553fb780037bcfff0dcffe9725ebc4fd9c1aa9075db"
   license "GPL-3.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "a1aa072a11ce1402aaf38319e6fc087b9bf4fa029f2b76cc748b0d122f0cdce0"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "fced3fb939f4c350d3ba4b81b2b071d9510728ea28135429cdc150d40f7a1477"

--- a/Formula/c/cpl.rb
+++ b/Formula/c/cpl.rb
@@ -11,8 +11,6 @@ class Cpl < Formula
     regex(/href=.*?cpl[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "c6ae6b7cb1a84a01d0cf02626e62fa069c69ce1ddd58da71a7dbc650f4c233b5"
     sha256 cellar: :any,                 arm64_sequoia:  "44e6e7500a5c7a392a2b4d6ec6aeb8572da5c72ed27650293780e481d3fd05bf"

--- a/Formula/c/cpmtools.rb
+++ b/Formula/c/cpmtools.rb
@@ -10,8 +10,6 @@ class Cpmtools < Formula
     regex(/href=.*?cpmtools[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:    "efe04ea8503804dc1106da71858d617f5daffe04adb89a312aa32116396af00d"
     sha256 arm64_sequoia:  "e689ad1b8bec7b7fb8b2f39ddccca66072998a172b7ef8788eeb6e54d06c4395"

--- a/Formula/c/cppp.rb
+++ b/Formula/c/cppp.rb
@@ -10,8 +10,6 @@ class Cppp < Formula
     regex(/href=.*?cppp[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "29bae12103813789942c21786cc253702a2d5eae6baeff11561afc12bbafde7f"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "4b14311322cdff7ec30e93ba573bf916eae962c7d2488e7f85a88a4b8bead0a6"

--- a/Formula/c/cpptest.rb
+++ b/Formula/c/cpptest.rb
@@ -6,8 +6,6 @@ class Cpptest < Formula
   sha256 "7c258936a407bcd1635a9b7719fbdcd6c6e044b5d32f53bbf6fbf6f205e5e429"
   license "LGPL-2.1-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "b7ba7a08b1659d230bf822ed02e72535423504b3b5fe659cac6b16f6aa64d3bd"
     sha256 cellar: :any,                 arm64_sequoia:  "2e9bd9882a2be0879ed9c30b86dda312e9fdaf6f0913d1e52960e0c057454857"

--- a/Formula/c/cppunit.rb
+++ b/Formula/c/cppunit.rb
@@ -10,8 +10,6 @@ class Cppunit < Formula
     regex(/href=["']?cppunit[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "106d4a437b3dae596bfb93cc8e04de0e28d97d3446a5ad900f926168c8773f45"
     sha256 cellar: :any,                 arm64_sequoia:  "081175312ba1bb288369cb84ff8a8e3bf11cf9c451b80dac6cedc211590d020a"

--- a/Formula/c/crf++.rb
+++ b/Formula/c/crf++.rb
@@ -16,8 +16,6 @@ class Crfxx < Formula
     regex(/CRF\+\+ v?(\d+(?:\.\d+)+)[\s<]/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 3
     sha256 cellar: :any,                 arm64_tahoe:    "6dc7eda56c3ad4d066a9f4a244ec02d9bdb4b1fe482abfd632fdace270c68936"

--- a/Formula/c/crunch.rb
+++ b/Formula/c/crunch.rb
@@ -5,8 +5,6 @@ class Crunch < Formula
   sha256 "6a8f6c3c7410cc1930e6854d1dadc6691bfef138760509b33722ff2de133fe55"
   license "GPL-2.0-only"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "d449463edb9406d92410104b8302202c4aebd190cc181d8fea3e4fea2e8ef0c3"

--- a/Formula/c/cryptopp.rb
+++ b/Formula/c/cryptopp.rb
@@ -16,8 +16,6 @@ class Cryptopp < Formula
     end
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any,                 arm64_tahoe:   "53bc84217451c7ae2716346f62519e9b100409180949df14259c0159c04166e5"

--- a/Formula/c/cscope.rb
+++ b/Formula/c/cscope.rb
@@ -10,8 +10,6 @@ class Cscope < Formula
     regex(%r{url=.*?/cscope[._-]v?(\d+(?:\.\d+)+[a-z]?)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "a0a30f47c29cb9473180bfe1c3670ceff999e1cd694babbe88d90e012cca0827"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "690ea8542348fc155da1a174f6e98cf08d81be181a222853a504124c9071c08b"

--- a/Formula/c/cspice.rb
+++ b/Formula/c/cspice.rb
@@ -13,8 +13,6 @@ class Cspice < Formula
     regex(/current SPICE Toolkit version is (?:<[^>]+?>)?N0*(\d+)/im)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "040bfcb0ac95b84d33600b31a20d6bb50a81f606a713077d86bc4fe47f115108"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "c978ab6a4a6d85e200924e49a41e2da477561637bbd46f49d150614777d8d1ec"

--- a/Formula/c/ctags.rb
+++ b/Formula/c/ctags.rb
@@ -29,8 +29,6 @@ class Ctags < Formula
     regex(%r{url=.*?/ctags[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "1b09e6e1c3e9649115863ee3cea2062958a73f832210c98061679f217f3ad98a"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "614a735ab93afb5ed2a2f12a66819e0b35a1c644021670057d0cac0fbe9910ae"

--- a/Formula/c/cuba.rb
+++ b/Formula/c/cuba.rb
@@ -10,8 +10,6 @@ class Cuba < Formula
     regex(/href=.*?Cuba[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "656aad080bcb7bc9dffcda4e7f23362e1c8799a8ca39ca9543605254b33fae82"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "5d9f2c34f9e6c4b4e8216db0ccaea18f75b925714037f9893da4aaf54de2b785"

--- a/Formula/c/cunit.rb
+++ b/Formula/c/cunit.rb
@@ -5,8 +5,6 @@ class Cunit < Formula
   sha256 "f5b29137f845bb08b77ec60584fdb728b4e58f1023e6f249a464efa49a40f214"
   license "LGPL-2.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "79ec3ecdcc6e1f8b253b5093c45c25a272005796cebb0ca2c7cfb6f8d21d0d90"
     sha256 cellar: :any,                 arm64_sequoia:  "ed2227559e5ab1d8239ee28d11b8728832ac2301041631b31702a12be8f0d3fe"

--- a/Formula/c/cvs.rb
+++ b/Formula/c/cvs.rb
@@ -16,8 +16,6 @@ class Cvs < Formula
     regex(%r{href=["']?v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:   "12f7b6ba364b0131ac464c51dac10844da7be696fa3ec85b2aaa5ab0ee10fbce"

--- a/Formula/c/cvsutils.rb
+++ b/Formula/c/cvsutils.rb
@@ -10,8 +10,6 @@ class Cvsutils < Formula
     regex(/href=.*?cvsutils[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "9efd138b85d862065f5a5d36e02a4ec04c40b6f669bfe7feb09a08f233991d50"

--- a/Formula/c/cvsync.rb
+++ b/Formula/c/cvsync.rb
@@ -10,8 +10,6 @@ class Cvsync < Formula
     regex(/href=.*?cvsync[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 4
     sha256 cellar: :any,                 arm64_tahoe:   "462780681001bc3d967095fe7299ea1a80d5c61a97445fa71906b9c313a3d524"

--- a/Formula/c/cwb3.rb
+++ b/Formula/c/cwb3.rb
@@ -21,8 +21,6 @@ class Cwb3 < Formula
     regex(%r{url=.*?/cwb[._-]v?(\d+(?:\.\d+)+)-src\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:   "29bea0c252b17882c4f5b6bd3dbc8f754ba28f49b65ea07b2635ee9b8f1d8723"


### PR DESCRIPTION
#267571

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI assisted with candidate discovery and one-commit-per-formula patching for `c*` formulas by removing `no_autobump! because: :requires_manual_review` where livecheck/status/source checks were compatible. I manually verified and reran `brew style` and `brew audit --strict` on the edited formula set.

Excluded from this batch due strict audit findings unrelated to this change: `classads`, `cln`, `cppi`, `curlftpfs`.

-----
