### PR TITLE
cgrep 9.1.0

### DIFF
--- a/Formula/c/cgrep.rb
+++ b/Formula/c/cgrep.rb
@@ -7,13 +7,12 @@ class Cgrep < Formula
   head "https://github.com/awgn/cgrep.git", branch: "master"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_tahoe:   "37bd0ff627442bba40b99ec4ece6957d02008f611dfc534a76100b7f9a8caf3e"
-    sha256 cellar: :any,                 arm64_sequoia: "ae4697fe71f6e15c595da258cea8289c32ef234d99b91580090d9edd48a738e8"
-    sha256 cellar: :any,                 arm64_sonoma:  "caddb9e8b415c6ea98cb60a47c6b5037507186833e8db354bbb8913fe50bd1f5"
-    sha256 cellar: :any,                 sonoma:        "43a71f50530e480907517a299f1001c590049529f4b89ea198551c5cb6f20cc5"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "44050fc6cbd4cedae9941e3182684c12acfef6ecd08ce71e80fe6c0d1a80756e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e8d9852362ac5b03d08e1c3fcb6679e02962f1f8e8874c5ae6f3644b3fd38304"
+    sha256 cellar: :any,                 arm64_tahoe:   "b42f9383d5a41f744a18add208aafc128c66e2c92350b23d09eaab77ea5db7fb"
+    sha256 cellar: :any,                 arm64_sequoia: "6fc1f842532ccc160c04bc2eab3b9adad196b4ef96e6eb611b7ab79203dfdda3"
+    sha256 cellar: :any,                 arm64_sonoma:  "7d85747ed757e85ab4dae3aa4c75abef1fdebdf4a667c0ee5ac5fd5550b41128"
+    sha256 cellar: :any,                 sonoma:        "8753927f7c4b5d1319579cf37128e000e5b126ef2ff37b407f52b59290650b8f"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "e01e5f966e2a0f4a7bf75801e7de78663703e5b6c816553d6a038ea69f408718"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0ca071d935a0beb72a598f0beef64be30482c475d5d373c025b0ca2bac3ec639"
   end
 
   depends_on "cabal-install" => :build

--- a/Formula/c/cgrep.rb
+++ b/Formula/c/cgrep.rb
@@ -1,8 +1,8 @@
 class Cgrep < Formula
   desc "Context-aware grep for source code"
-  homepage "https://github.com/awgn/cgrep"
-  url "https://github.com/awgn/cgrep/archive/refs/tags/v9.0.0.tar.gz"
-  sha256 "6f7be7a24446289421fabe98393d00a46a1751ce1f605d84135e83d0ddf1d49e"
+  homepage "https://awgn.github.io/cgrep/"
+  url "https://hackage.haskell.org/package/cgrep-9.1.0/cgrep-9.1.0.tar.gz"
+  sha256 "0bcdc712fcf21422a51338a7a152e3d3095343f595fd600f0e6e530b6565ecff"
   license "GPL-2.0-or-later"
   head "https://github.com/awgn/cgrep.git", branch: "master"
 
@@ -25,17 +25,7 @@ class Cgrep < Formula
 
   conflicts_with "aerleon", because: "both install `cgrep` binaries"
 
-  # Fix CPP directives alignment
-  # https://github.com/awgn/cgrep/pull/50
-  patch do
-    url "https://github.com/awgn/cgrep/commit/72748d85dbc2bb8059c4a4782be52347fc071eaa.patch?full_index=1"
-    sha256 "04ecc69ec482f0c07edcc07823c284e93e9822128f0398bf00918a81b08227ca"
-  end
-
   def install
-    # `base <4.16.0.0` is not available in the most recent GHC
-    inreplace "cgrep.cabal", "base ^>=4.15.0.0", "base >=4.15.0.0"
-
     # Workaround to build aeson with GHC 9.14, https://github.com/haskell/aeson/issues/1155
     args = ["--allow-newer=base,containers,template-haskell"]
 


### PR DESCRIPTION
Although missing tag on GitHub, this was released on Hackage which is official installation method:
- https://github.com/awgn/cgrep?tab=readme-ov-file#installation
- https://hackage.haskell.org/package/cgrep

Unless there a specific reason to use GitHub source (e.g. installing documention/man pages, handling metadata bumps like pandoc-crossref), Hackage is likely the better url to use similar to how we prioritize PyPI.

Also update homepage to match Hackage metadata