### PR TITLE
hg-fast-export: backport fix for mercurial 7.2

### DIFF
--- a/Formula/h/hg-fast-export.rb
+++ b/Formula/h/hg-fast-export.rb
@@ -19,12 +19,8 @@ class HgFastExport < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "26cbfd49c68c6f13eadcd0d6365eaa554aae4ea236b78780a87664f6795be7e5"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e452579006d0079f87d4d472b2932ce585a2730058996782cf0b6054cd8e422e"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "6aa8a9b701199c436905cfa33617ac33bf918e08fbc6c820defdded2dd83c9e8"
-    sha256 cellar: :any_skip_relocation, sonoma:        "22d6c095c84ff4fdee418459f3aa0e9ceeef33de364dda42d24bd90232a7cf65"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "03cc5550a9adbe61efadcf56051885cc423d933ecf75bf43d74914090d9d4c57"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f7799b942685a7fa60d59a8e9b77c2d8865a681c55ddcefa2d5b23c05fbb2360"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "608ef4e7b632bb7795fe1162ad7c351c7c50f25ddd684075f3d353cbda11a0e6"
   end
 
   depends_on "mercurial"

--- a/Formula/h/hg-fast-export.rb
+++ b/Formula/h/hg-fast-export.rb
@@ -1,14 +1,22 @@
 class HgFastExport < Formula
   include Language::Python::Shebang
-  include Language::Python::Virtualenv
 
   desc "Fast Mercurial to Git converter"
   homepage "https://repo.or.cz/fast-export.git"
-  url "https://github.com/frej/fast-export/archive/refs/tags/v250330.tar.gz"
-  sha256 "1c4785f1e9e63e0ada87e0be5a7236d6889eea98975800671e3c3805b54bf801"
   license "GPL-2.0-or-later"
   revision 2
   head "https://github.com/frej/fast-export.git", branch: "master"
+
+  stable do
+    url "https://github.com/frej/fast-export/archive/refs/tags/v250330.tar.gz"
+    sha256 "1c4785f1e9e63e0ada87e0be5a7236d6889eea98975800671e3c3805b54bf801"
+
+    # Backport fix for mercurial 7.2
+    patch do
+      url "https://github.com/frej/fast-export/commit/76db75d9631fc90a25f58afa39b72822e792e724.patch?full_index=1"
+      sha256 "68c61af1c95ce55e9f41c18cbf6f7858139d6153654d343a639b30712350540b"
+    end
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "26cbfd49c68c6f13eadcd0d6365eaa554aae4ea236b78780a87664f6795be7e5"
@@ -19,26 +27,16 @@ class HgFastExport < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "f7799b942685a7fa60d59a8e9b77c2d8865a681c55ddcefa2d5b23c05fbb2360"
   end
 
-  depends_on "mercurial" => :test
+  depends_on "mercurial"
   depends_on "python@3.14"
-
-  # TODO: Switch back to formula after https://github.com/frej/fast-export/issues/348
-  resource "mercurial" do
-    url "https://www.mercurial-scm.org/release/mercurial-7.1.2.tar.gz"
-    sha256 "ce27b9a4767cf2ea496b51468bae512fa6a6eaf0891e49f8961dc694b4dc81ca"
-  end
 
   def install
     python3 = which("python3.14")
     libexec.install "plugins", "pluginloader"
     bin.install buildpath.glob("hg*.{sh,py}")
 
-    venv = virtualenv_create(libexec, python3)
-    venv.pip_install resource("mercurial")
-    venv_python = venv.root/"bin/python"
-
-    rewrite_shebang python_shebang_rewrite_info(venv_python), *bin.children
-    bin.env_script_all_files libexec/"bin", PYTHON: venv_python, PYTHONPATH: libexec
+    rewrite_shebang detected_python_shebang, *bin.children
+    bin.env_script_all_files libexec/"bin", PYTHON: python3, PYTHONPATH: libexec
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
