### PR TITLE
d*: remove no_autobump! manual review

### DIFF
--- a/Formula/d/daemonlogger.rb
+++ b/Formula/d/daemonlogger.rb
@@ -5,8 +5,6 @@ class Daemonlogger < Formula
   sha256 "79fcd34d815e9c671ffa1ea3c7d7d50f895bb7a79b4448c4fd1c37857cf44a0b"
   license "GPL-2.0-only"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:    "0ced73ca63e8d048dbc4692cbadf68f13d834fb8e5bf642be31d4573d58d17bb"

--- a/Formula/d/daemontools.rb
+++ b/Formula/d/daemontools.rb
@@ -11,8 +11,6 @@ class Daemontools < Formula
     regex(/href=.*?daemontools[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "4d2dc1ed742ae4b8ab911aef610c8315ea79b9dce79a4a9d21028f413352bd6c"

--- a/Formula/d/dbacl.rb
+++ b/Formula/d/dbacl.rb
@@ -5,8 +5,6 @@ class Dbacl < Formula
   sha256 "ff0dfb67682e863b1c3250acc441ce77c033b9b21d8e8793e55b622e42005abd"
   license "GPL-3.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "71b6ff99f31ad16b0e638be6e6c0470c61ccc8b9d51bfcabbe46ea7444976a77"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "9caea8b960e8ffc974ad321a472a70e46f5cb401dacfbef096309743c49e2c9d"

--- a/Formula/d/dc3dd.rb
+++ b/Formula/d/dc3dd.rb
@@ -5,8 +5,6 @@ class Dc3dd < Formula
   sha256 "bd1b66d20a4020ab94b512e56d76cb5f86470d0216081586d596366927cb8d8b"
   license "GPL-3.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:    "1319a1907495f80e22c8e4047ff2a3764821774313b674853ac89f0f95159c1d"
     sha256 arm64_sequoia:  "1cdfecc59688663ad056a3dc3db19a87d5e7c6356f9f88c33695126b0270639c"

--- a/Formula/d/dcled.rb
+++ b/Formula/d/dcled.rb
@@ -10,8 +10,6 @@ class Dcled < Formula
     regex(/href=.*?dcled[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "5369329587a6c3ec28976ebbd89fc4f8361b2472e38ee6518ebdf95dc04cddd1"
     sha256 cellar: :any,                 arm64_sequoia:  "1e3b757bcbd17baa0865903e7639f2bdeede51da0e38b5859047810ec34ae39b"

--- a/Formula/d/dcraw.rb
+++ b/Formula/d/dcraw.rb
@@ -12,8 +12,6 @@ class Dcraw < Formula
     regex(/href=.*?dcraw[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "06e4e4b56c7abf6a3401a398f2b0caca6851a348dc87215c53ccb1eef0b38e18"
     sha256 cellar: :any,                 arm64_sequoia:  "a083652ace0c260b03d51e3a34412dd5f9213cf146dca60f6d5d2a1ecbc8c191"

--- a/Formula/d/ddd.rb
+++ b/Formula/d/ddd.rb
@@ -12,8 +12,6 @@ class Ddd < Formula
     "MIT-open-group", # ddd/athena_ddd/PannerM.C
   ]
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:    "25083bd2eeac8896b1406a713d5ca294cacb800fee16e0368e434e6715b72644"
     sha256 arm64_sequoia:  "3c31137211b8185a0b8e3ceffce6474c803cf8790348211ad0690162697a1613"

--- a/Formula/d/deheader.rb
+++ b/Formula/d/deheader.rb
@@ -15,8 +15,6 @@ class Deheader < Formula
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, all: "2caa30192b0b43e4892d9742d759b65d3cee8109c87e7169fd371a896cfd424e"
   end

--- a/Formula/d/denominator.rb
+++ b/Formula/d/denominator.rb
@@ -10,8 +10,6 @@ class Denominator < Formula
     regex(%r{<version>v?(\d+(?:\.\d+)+)</version>}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, all: "3da7d5704460e94f75bd1241c7d285971b2c22f23633c2cea058cccefc6a65e5"

--- a/Formula/d/detach.rb
+++ b/Formula/d/detach.rb
@@ -10,8 +10,6 @@ class Detach < Formula
     regex(/href=.*?detach[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "26af0691540557a38f48cea373f6a0a9085bf2ba7a71bfcb7aa67e844ce3f466"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "f7d0f80127112fcf6691ce7b4b90aa1fc5ee9ddee51d755b1a895f47419f2455"

--- a/Formula/d/devil.rb
+++ b/Formula/d/devil.rb
@@ -32,8 +32,6 @@ class Devil < Formula
     end
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "b38672c3417c92fde8b5cca2a59f14c31201f9a5f043a1bb5d7d04c4983d5398"
     sha256 cellar: :any,                 arm64_sequoia:  "06f0d3689766e92e01e492d9abbceeac345df99fa96a018cf74963ff4b6c9cca"

--- a/Formula/d/dfu-util.rb
+++ b/Formula/d/dfu-util.rb
@@ -5,8 +5,6 @@ class DfuUtil < Formula
   sha256 "b4b53ba21a82ef7e3d4c47df2952adf5fa494f499b6b0b57c58c5d04ae8ff19e"
   license "GPL-2.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "53e343420fcab5133dd295cf75d8a74b5933fabfbb53c90c3ef798735b5f9445"
     sha256 cellar: :any,                 arm64_sequoia:  "5cfdae94eea7b66aae31b16dd689bd8078d7aa685786dcf45f9f9324db12727d"

--- a/Formula/d/dhcping.rb
+++ b/Formula/d/dhcping.rb
@@ -11,8 +11,6 @@ class Dhcping < Formula
     regex(/href=.*?dhcping[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "508383a636e12497a54b8c5ee9732aaa9e3128e988fead007b84a79e871ff040"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "57a8c433ed1c7da1d25968b298425ee8c4eb654cc2c3db24ef634eb98fe2c2f6"

--- a/Formula/d/dhex.rb
+++ b/Formula/d/dhex.rb
@@ -10,8 +10,6 @@ class Dhex < Formula
     regex(/href=.*?dhex[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "c43035367348acd1ea2109bfcae68108766e691eeaaf7b921f68e9306f7d9fec"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "6ce6ef0c4079748f07bbfb1f8f74f39caf377df59e244555fe508c63c63367a6"

--- a/Formula/d/diary.rb
+++ b/Formula/d/diary.rb
@@ -11,8 +11,6 @@ class Diary < Formula
     regex(/href=.*?diary[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "2cf6dc0be5b3beea462918ef2b58d2c94ecec01aba46b260a85772abbef73b94"
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "d4d8011263079585a4927de9a321597b04e522c33940059d1a97b9f31acf8763"

--- a/Formula/d/diction.rb
+++ b/Formula/d/diction.rb
@@ -6,8 +6,6 @@ class Diction < Formula
   sha256 "35c2f1bf8ddf0d5fa9f737ffc8e55230736e5d850ff40b57fdf5ef1d7aa024f6"
   license "GPL-3.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:    "abe65914558d009a92abe38d0c86b41936e724e53ec3d3045ff5b2f37be7cf4c"
     sha256 arm64_sequoia:  "6516cc7161c82d0f8db43cc8feb42dfac2f946e632c76432cb7ed00fde3fe078"

--- a/Formula/d/disktype.rb
+++ b/Formula/d/disktype.rb
@@ -11,8 +11,6 @@ class Disktype < Formula
     regex(%r{url=.*?/disktype[._-]v?(\d+(?:\.\d+)*)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "42c78cc38ea028f25b5c2122e72e66d49803b717c8994a45db84fda5b192f492"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "cc0c898196ec806c92c56cda1d1edce496eb6dea79d614ab746021f2e315ec4c"

--- a/Formula/d/djview4.rb
+++ b/Formula/d/djview4.rb
@@ -10,8 +10,6 @@ class Djview4 < Formula
     regex(%r{url=.*?/djview[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:   "97d3a20862eef89b5dff5f2792ee3f5b08adcbb5c4edfc50d350030a9c326c67"

--- a/Formula/d/djvu2pdf.rb
+++ b/Formula/d/djvu2pdf.rb
@@ -10,8 +10,6 @@ class Djvu2pdf < Formula
     regex(/href=.*?djvu2pdf[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "9fdbe69a5415de2630d2a2934f513f985db8d4917b5451ef0241fd125e1096fc"

--- a/Formula/d/dmagnetic.rb
+++ b/Formula/d/dmagnetic.rb
@@ -10,8 +10,6 @@ class Dmagnetic < Formula
     regex(/href=.*?dMagnetic[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:    "1d303cc3cb631d54618e5c0d4f0f84590d3396dd85ae4826f065f6a5ebd7a7e6"
     sha256 arm64_sequoia:  "9f840a9ccf56d119e074527daa5b430d0670bd1425a44efa2882459e279ba40c"

--- a/Formula/d/dmalloc.rb
+++ b/Formula/d/dmalloc.rb
@@ -10,8 +10,6 @@ class Dmalloc < Formula
     regex(/href=.*?dmalloc[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "5739c56456cf07b59f8c884ca56e499aa3e618c2712500819c0457af57018b96"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "2406c340e3935d9f228d695c270eb5fd74abef38bafa84f10bded7826c8e8c80"

--- a/Formula/d/dmg2img.rb
+++ b/Formula/d/dmg2img.rb
@@ -12,8 +12,6 @@ class Dmg2img < Formula
     regex(/href=.*?dmg2img[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any,                 arm64_tahoe:   "606ad411e551ca06e51b65e8e86db388a2f8d49a684fac4b803fc06adee95f1d"

--- a/Formula/d/dns2tcp.rb
+++ b/Formula/d/dns2tcp.rb
@@ -10,8 +10,6 @@ class Dns2tcp < Formula
     regex(/href=.*?dns2tcp[._-]v?(\d+(?:\.\d+)+)\.orig\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "2cefc14058fc1f4bff6d872e8b5ad5e5504891f7992857a5fa8b7f469617c4d5"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "0eb7cacef30472d6ca9cd59507d8fe3f078ad731b1e779ff8147bb2730547adb"

--- a/Formula/d/dnstop.rb
+++ b/Formula/d/dnstop.rb
@@ -11,8 +11,6 @@ class Dnstop < Formula
     regex(/href=.*?dnstop[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "46e3c705bd4c7649ab67f2712d623825f0006cb764e844131a654fe057de19ec"

--- a/Formula/d/dnstracer.rb
+++ b/Formula/d/dnstracer.rb
@@ -15,8 +15,6 @@ class Dnstracer < Formula
     regex(/href=.*?dnstracer[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "bf4002b2b3c7b6e94bfbd23130cae602e9e7c7d9e3145b7210cbc4fc574b5004"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "154b03978527a24ea93fa486de2f90f51bba19a873cd8fc7760027b7cf9e965d"

--- a/Formula/d/docbook2x.rb
+++ b/Formula/d/docbook2x.rb
@@ -10,8 +10,6 @@ class Docbook2x < Formula
     regex(%r{url=.*?/docbook2X[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "87b0d72f55d9ff922befd55d7e708a23804d99c0ae1fab7e57c7694a6f91e833"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "6515ef361ee9ad2b83b539b46bb8869a09e98819fdb23277340e0557be168635"

--- a/Formula/d/docx2txt.rb
+++ b/Formula/d/docx2txt.rb
@@ -5,8 +5,6 @@ class Docx2txt < Formula
   sha256 "b297752910a404c1435e703d5aedb4571222bd759fa316c86ad8c8bbe58c6d1b"
   license "GPL-3.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, all: "9c8866a49e04bb1b2a4797c4c911e5aee4df8c3a86701a6a792e55415ac10a7b"

--- a/Formula/d/dopewars.rb
+++ b/Formula/d/dopewars.rb
@@ -5,8 +5,6 @@ class Dopewars < Formula
   sha256 "623b9d1d4d576f8b1155150975308861c4ec23a78f9cc2b24913b022764eaae1"
   license "GPL-2.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:    "e8059b057bea2eb7a0c33542aebc0be5dfb26ba9f681594af77f6584accd328f"
     sha256 arm64_sequoia:  "5e19478fc233eac61d8c45e6b671f1853c0b4f95777a4a2d99ad1ed6eac6d38a"

--- a/Formula/d/doublecpp.rb
+++ b/Formula/d/doublecpp.rb
@@ -5,8 +5,6 @@ class Doublecpp < Formula
   sha256 "232f8bf0d73795558f746c2e77f6d7cb54e1066cbc3ea7698c4fba80983423af"
   license "GPL-2.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "d1c9462ef87c13b4a5c4affd18d0bc2ebf1f532bcde2a9eb44cf45ca2959f6ec"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "2e15c4d309ffb4ce79625a484249eabbcee9f337a7e79c7c36a332cd0e25ca06"

--- a/Formula/d/doxymacs.rb
+++ b/Formula/d/doxymacs.rb
@@ -6,8 +6,6 @@ class Doxymacs < Formula
   license "GPL-2.0-or-later"
   revision 1
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "fe13bd89660f57f1c74c95e0b0ae7def510c8a80d6a9ec1bb05799153d546496"
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "e22393964e0e2f3f1b841be5fcadcf4cacc9d6ac8597e4ba77cdd2a883e0417a"

--- a/Formula/d/dps8m.rb
+++ b/Formula/d/dps8m.rb
@@ -11,8 +11,6 @@ class Dps8m < Formula
     regex(/href=.*?dps8m[._-]r?(\d+(?:\.\d+)+)[._-]src\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any, arm64_tahoe:   "5d60fd88809f95e134a996e6f9d03f9b8b5f4d82d2da4ea0ea6861e44883a5f4"
     sha256 cellar: :any, arm64_sequoia: "2299a62a4694d96a06590dda48aec1b5bc7d4223a16027fc8d7e2815b89ef96b"

--- a/Formula/d/dtach.rb
+++ b/Formula/d/dtach.rb
@@ -5,8 +5,6 @@ class Dtach < Formula
   sha256 "32e9fd6923c553c443fab4ec9c1f95d83fa47b771e6e1dafb018c567291492f3"
   license "GPL-2.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "a3296ea100c480737f279e984c3e0cf25d0d5844aac527c09cf9cc1ff3bb4ada"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "df21c7a193afc665bc0d8e35b51990fa1c86a7d586acefc9248641e2fc93ac07"

--- a/Formula/d/duff.rb
+++ b/Formula/d/duff.rb
@@ -5,8 +5,6 @@ class Duff < Formula
   sha256 "15b721f7e0ea43eba3fd6afb41dbd1be63c678952bf3d80350130a0e710c542e"
   license "Zlib"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "643c694ade386db6a76b2da2cabedb1068774a1d4bb9f6ab48b86703e0a58935"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "c424b8c034bc699eee2d55c766aad34f4f7ea1f46a5c6f0a6a221159917fd396"

--- a/Formula/d/dvanalyzer.rb
+++ b/Formula/d/dvanalyzer.rb
@@ -10,8 +10,6 @@ class Dvanalyzer < Formula
     regex(/href=.*?dvanalyzer[._-]?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "e8bb414e0719a71fcc95ea8c1351f983fa7df1d0a3c350182c9be47b8064fefc"

--- a/Formula/d/dvd-vr.rb
+++ b/Formula/d/dvd-vr.rb
@@ -10,8 +10,6 @@ class DvdVr < Formula
     regex(/href=.*?dvd-vr[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "c866d88cd9c2d24675c6adb25ea1b78fc4139e15d46ce14e652e1302c99137f9"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "7ec179b825a5afc971de1205ec65943227d9c09257a16558a068bc47c024887d"

--- a/Formula/d/dvdauthor.rb
+++ b/Formula/d/dvdauthor.rb
@@ -11,8 +11,6 @@ class Dvdauthor < Formula
     regex(%r{url=.*?/dvdauthor[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "ed44deb629315e130b499c9e41a1cdfd789d62ed26e410c10d480a27ea93abec"
     sha256 cellar: :any,                 arm64_sequoia: "17b2f6a33354311992ca16d0f2455671df0f23b65cdb83088ff383b0fd78daff"

--- a/Formula/d/dvdbackup.rb
+++ b/Formula/d/dvdbackup.rb
@@ -6,8 +6,6 @@ class Dvdbackup < Formula
   license "GPL-3.0-or-later"
   revision 3
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any, arm64_tahoe:    "208d77cbe6a64a85548098e3fddf37053ad567406e1745b238fa40ca3a33915f"
     sha256 cellar: :any, arm64_sequoia:  "5689e478b50f13da8f0b4c4176281df944c3c8a095344e7f3fd6b2073cb7f937"

--- a/Formula/d/dwatch.rb
+++ b/Formula/d/dwatch.rb
@@ -10,8 +10,6 @@ class Dwatch < Formula
     regex(/href=.*?dwatch[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 arm64_tahoe:    "d8916e526f70eb17c0010715a61c5746c20214fe8210f544f50650358ab1bb0a"

--- a/Formula/d/dwdiff.rb
+++ b/Formula/d/dwdiff.rb
@@ -11,8 +11,6 @@ class Dwdiff < Formula
     regex(/href=.*?dwdiff[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:   "72db22b7bee1b3fbb618afb253f77a38a89d8f48dce43a05e4e43f00c33f49a1"
     sha256 arm64_sequoia: "a0c989ceab85b65e504e45d4ce9168d2536a523a0aeb32c5ce252227e9b9fa73"

--- a/Formula/d/dxflib.rb
+++ b/Formula/d/dxflib.rb
@@ -10,8 +10,6 @@ class Dxflib < Formula
     regex(/href=.*?dxflib[._-]v?(\d+(?:\.\d+)+)-src\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "3bbe74f4cb179ff9cd5df3e09b664f29033deb63211128b73bab5cf18c6b71a1"
     sha256 cellar: :any,                 arm64_sequoia:  "a4ba8424bf3cd50726d26445fa590fb069d6dff461324400938a3be82e98ef0c"


### PR DESCRIPTION
#267571

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI assisted with candidate discovery and one-commit-per-formula patching for `d*` formulas by removing `no_autobump! because: :requires_manual_review` where livecheck/status/source checks were compatible. I manually verified and reran `brew style` and `brew audit --strict` on the edited formula set.

Excluded from this batch due strict audit findings unrelated to this change: `deja-gnu`, `dirac`, `djbdns`, `dsh`, `dvdrtools`.

-----
