### PR TITLE
triage: label no_autobump-only PRs

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -192,7 +192,7 @@ jobs:
 
             - label: CI-syntax-only
               path: Formula/.+
-              patch_content: '^(?:[+-]  no_autobump! because: [^\n]+(?:\n|$))+$'
+              patch_content: '^(?:(?:--- \S+|\+\+\+ \S+|[+-]  no_autobump! because: [^\n]+)\n?)+$'
 
             - label: boost
               path: Formula/.+

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -190,6 +190,10 @@ jobs:
               path: Formula/.+
               content: 'no_autobump! because: :requires_manual_review'
 
+            - label: CI-syntax-only
+              path: Formula/.+
+              patch_content: '^(?:[+-]  no_autobump! because: [^\n]+(?:\n|$))+$'
+
             - label: boost
               path: Formula/.+
               content: depends_on "boost(@[0-9.]+)?"

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -194,6 +194,11 @@ jobs:
               path: Formula/.+
               patch_content: '^(?:(?:--- \S+|\+\+\+ \S+|[+-]  no_autobump! because: [^\n]+)\n?)+$'
 
+            - label: autobump
+              path: Formula/.+
+              patch_content: '^(?:(?:--- \S+|\+\+\+ \S+|[+-]  no_autobump! because: [^\n]+)\n?)+$'
+              keep_if_no_match: true
+
             - label: boost
               path: Formula/.+
               content: depends_on "boost(@[0-9.]+)?"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? (N/A: workflow-only change, no formula modified)
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting? (N/A: workflow-only change, no formula modified)
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`? (N/A: workflow-only change, no formula modified)

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI usage: Drafted and applied the triage label rule change.
Manual verification: Reviewed the diff, ran `actionlint .github/workflows/triage.yml`, and confirmed PR checks including `triage`/`workflows-label` are passing.

-----

Built and tested locally on macOS 26.3.

Add a triage label rule to apply `CI-syntax-only` when a PR only changes `no_autobump! because: ...` stanzas in formula files.
