### PR TITLE
triage: label no_autobump-only PRs

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -190,6 +190,15 @@ jobs:
               path: Formula/.+
               content: 'no_autobump! because: :requires_manual_review'
 
+            - label: CI-syntax-only
+              path: Formula/.+
+              patch_content: '^(?:(?:--- \S+|\+\+\+ \S+|[+-]  no_autobump! because: [^\n]+|[+-])\n?)+$'
+
+            - label: autobump
+              path: Formula/.+
+              patch_content: '^(?:(?:--- \S+|\+\+\+ \S+|[+-]  no_autobump! because: [^\n]+|[+-])\n?)+$'
+              keep_if_no_match: true
+
             - label: boost
               path: Formula/.+
               content: depends_on "boost(@[0-9.]+)?"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI usage: drafted and iterated the triage label rules and test setup.
Manual verification: ran `actionlint .github/workflows/triage.yml`, inspected PR file patches, and validated outcomes using fork test PRs.

-----

Update triage labeling so PRs that only modify `no_autobump! because: ...` lines in formula files get `CI-syntax-only` and `autobump`.

Validation PRs on fork:
- [GunniBusch/homebrew-core#2](https://github.com/GunniBusch/homebrew-core/pull/2) (invalid mixed test: workflow + formula)
- [GunniBusch/homebrew-core#3](https://github.com/GunniBusch/homebrew-core/pull/3) (single formula `no_autobump` line change)
- [GunniBusch/homebrew-core#4](https://github.com/GunniBusch/homebrew-core/pull/4) (multiple formulae, only `no_autobump` line changes)
- [GunniBusch/homebrew-core#5](https://github.com/GunniBusch/homebrew-core/pull/5) (multiple `no_autobump` changes plus one extra non-`no_autobump` formula change)
- [GunniBusch/homebrew-core#6](https://github.com/GunniBusch/homebrew-core/pull/6) (remove `no_autobump` stanza with adjacent blank-line deletion)



<details><summary>Close</summary>
<p>

closes https://github.com/GunniBusch/homebrew-core/pull/2 
closes https://github.com/GunniBusch/homebrew-core/pull/3 
closes https://github.com/GunniBusch/homebrew-core/pull/4 
closes https://github.com/GunniBusch/homebrew-core/pull/5 
closes https://github.com/GunniBusch/homebrew-core/pull/6


</p>
</details> 