### PR TITLE
yalantinglibs 0.5.8

### DIFF
--- a/Formula/y/yalantinglibs.rb
+++ b/Formula/y/yalantinglibs.rb
@@ -13,7 +13,7 @@ class Yalantinglibs < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "095764a799c28dd3757f34e889aac7605f919941dc32a3d14480f398826d86fa"
+    sha256 cellar: :any_skip_relocation, all: "568fa71f67ad66eec83342e688ef18c7b35dd6678d37343236fcafd497e61591"
   end
 
   depends_on "cmake" => :build

--- a/Formula/y/yalantinglibs.rb
+++ b/Formula/y/yalantinglibs.rb
@@ -1,10 +1,16 @@
 class Yalantinglibs < Formula
   desc "Collection of modern C++ libraries"
   homepage "https://alibaba.github.io/yalantinglibs/en/"
-  url "https://github.com/alibaba/yalantinglibs/archive/refs/tags/lts2.0.1.tar.gz"
-  sha256 "b87e557b031d6a80464a75c5d1b6b9ae56a417350329ac74d14fd14723129634"
+  url "https://github.com/alibaba/yalantinglibs/archive/refs/tags/0.5.8.tar.gz"
+  sha256 "49b631c191f139ff465b489663a620f3ae24af6baa236cc1e3d96f3ac7506d73"
   license "Apache-2.0"
+  version_scheme 1
   head "https://github.com/alibaba/yalantinglibs.git", branch: "main"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "095764a799c28dd3757f34e889aac7605f919941dc32a3d14480f398826d86fa"
@@ -31,8 +37,11 @@ class Yalantinglibs < Formula
 
   test do
     (testpath/"test.cpp").write <<~CPP
+      #include <iostream>
+      #include "ylt/version.hpp"
       #include "ylt/struct_json/json_reader.h"
       #include "ylt/struct_json/json_writer.h"
+
       struct person {
        std::string name;
        int age;
@@ -45,9 +54,11 @@ class Yalantinglibs < Formula
         struct_json::to_json(p, str); // {"name":"tom","age":20}
         person p1;
         struct_json::from_json(p1, str);
+        std::cout << YLT_VERSION / 100000 << "." << YLT_VERSION / 100 % 1000 << "." << YLT_VERSION % 100;
       }
     CPP
+
     system ENV.cxx, "test.cpp", "-std=c++20", "-o", "test"
-    system "./test"
+    assert_equal version.to_s, shell_output("./test")
   end
 end


### PR DESCRIPTION
Switch to latest version/release rather than LTS which matches how we distribute other formulae.

Also add a test to verify version as this now matches library versioning. 

---

On side note, upstream's LTS versioning approach seems non-standard (greater than latest versions) and the version number isn't used within the library.

For example, lts2.0.1 is actually based on 0.5.6 - https://github.com/alibaba/yalantinglibs/blob/lts2.0.1/include/ylt/version.hpp
```c
#define YLT_VERSION 506  // 0.5.6
```
