### PR TITLE
wakadash 0.2.0 (new formula)

### DIFF
--- a/Formula/w/wakadash.rb
+++ b/Formula/w/wakadash.rb
@@ -1,0 +1,32 @@
+class Wakadash < Formula
+  desc "Live terminal dashboard for WakaTime coding stats"
+  homepage "https://github.com/b00y0h/wakadash"
+  url "https://github.com/b00y0h/wakadash/archive/refs/tags/v0.2.0.tar.gz"
+  sha256 "8cd2bfef0fc8399fb1b1e34557b0a83afecf53c2a907fa8e349f3ca3298988e4"
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def install
+    # Set ldflags for version injection (matches GoReleaser pattern)
+    ldflags = %W[
+      -s -w
+      -X main.version=#{version}
+      -X main.commit=#{tap.user}
+      -X main.date=#{time.iso8601}
+    ]
+
+    # Build from source using Go toolchain
+    system "go", "build", *std_go_args(ldflags:), "./cmd/wakadash"
+  end
+
+  test do
+    # Test version output
+    assert_match version.to_s, shell_output("#{bin}/wakadash --version")
+
+    # Test graceful failure when ~/.wakatime.cfg doesn't exist
+    # (Don't test actual dashboard since that requires WakaTime API key)
+    output = shell_output("#{bin}/wakadash 2>&1", 1)
+    assert_match(/wakatime|config|api/i, output)
+  end
+end


### PR DESCRIPTION
Live terminal dashboard for WakaTime coding stats.

## Description

wakadash provides a live-updating terminal UI for WakaTime coding statistics, similar to htop for coding activity. It displays:
- Real-time coding time summaries
- Language breakdown with color-coded bars
- Project time distribution
- Hourly activity sparklines
- Weekly activity heatmap

Built with the Bubble Tea TUI framework for a responsive terminal experience.

## Checklist

- [x] Built from source on macOS (Apple Silicon and x86_64)
- [x] Passes `brew test`
- [x] Passes `brew audit --strict --online`
- [x] Original work (not a fork of another project)
- [x] MIT license (DFSG-compatible)
- [ ] Meets popularity threshold (see note below)

## Acceptance Notes

This is an early submission. The project was created 2026-02-19 and does not yet meet the >=30 forks, >=30 watchers, or >=75 stars threshold for self-submitted software.

I'm submitting early to:
1. Get formula feedback and improvements while building community adoption
2. Establish the formula for when popularity thresholds are met
3. Demonstrate the tool's quality and usefulness

In the meantime, users can install via personal tap: `brew install b00y0h/wakadash/wakadash`

## Links

- GitHub: https://github.com/b00y0h/wakadash
- Personal tap (immediate availability): https://github.com/b00y0h/homebrew-wakadash