### PR TITLE
telegraf: fix building from head

### DIFF
--- a/Formula/t/telegraf.rb
+++ b/Formula/t/telegraf.rb
@@ -23,7 +23,8 @@ class Telegraf < Formula
   depends_on "go" => :build
 
   def install
-    ldflags = "-s -w -X github.com/influxdata/telegraf/internal.Version=#{version}"
+    build_version = build.head? ? "0.0.0-#{version}" : version
+    ldflags = "-s -w -X github.com/influxdata/telegraf/internal.Version=#{build_version}"
     system "go", "build", *std_go_args(ldflags:), "./cmd/telegraf"
 
     (buildpath/"telegraf.conf").write Utils.safe_popen_read(bin/"telegraf", "config")


### PR DESCRIPTION
Fixes `brew install telegraf --head` which was broken because the version number must be in dotted-tri format:

```
% go build -ldflags="-s -w -X github.com/influxdata/telegraf/internal.Version=HEAD-7d4a3b6" ./cmd/telegraf
ld: warning: ignoring duplicate libraries: '-lproc'

% ./telegraf config
panic: HEAD is not in dotted-tri format

goroutine 1 [running]:
github.com/coreos/go-semver/semver.Must(...)
        /Users/ingmar/Library/Caches/Homebrew/go_mod_cache/pkg/mod/github.com/coreos/go-semver@v0.3.1/semver/semver.go:65
github.com/coreos/go-semver/semver.New({0x109ccd280?, 0x1118e7400?})
        /Users/ingmar/Library/Caches/Homebrew/go_mod_cache/pkg/mod/github.com/coreos/go-semver@v0.3.1/semver/semver.go:49 +0x3c
github.com/influxdata/telegraf/config.NewConfig()
        /private/tmp/telegraf-20260219-36443-drrpb2/config/config.go:162 +0x220
main.main()
        /private/tmp/telegraf-20260219-36443-drrpb2/cmd/telegraf/main.go:453 +0x94
```

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
