### PR TITLE
cargo-watch: mention bacon as replacement

### DIFF
--- a/Formula/c/cargo-watch.rb
+++ b/Formula/c/cargo-watch.rb
@@ -18,6 +18,7 @@ class CargoWatch < Formula
   end
 
   deprecate! date: "2025-04-27", because: :repo_archived
+  disable! date: "2026-04-27", because: :repo_archived, replacement_formula: "bacon"
 
   depends_on "rust" => :build
   depends_on "rustup" => :test


### PR DESCRIPTION
Upstream recommendation 

https://github.com/watchexec/cargo-watch/blob/8.x/README.md#-cargo-watch

> I recommend [Bacon](https://dystroy.org/bacon/) or [Watchexec](https://github.com/watchexec/watchexec) instead. (see below for more)

https://github.com/watchexec/cargo-watch/blob/8.x/README.md#maintenance

> It's time to let it go. Use [Bacon](https://dystroy.org/bacon/). Remember Cargo Watch.