### PR TITLE
erlang_ls: mention erlang-language-platform as replacement

### DIFF
--- a/Formula/e/erlang_ls.rb
+++ b/Formula/e/erlang_ls.rb
@@ -17,7 +17,7 @@ class ErlangLs < Formula
   end
 
   deprecate! date: "2026-02-17", because: :repo_archived
-  disable! date: "2027-02-17", because: :repo_archived
+  disable! date: "2027-02-17", because: :repo_archived, replacement_formula: "erlang-language-platform"
 
   depends_on "erlang"
   depends_on "rebar3"


### PR DESCRIPTION
https://github.com/erlang-ls/erlang_ls/blob/main/README.md
> We recommend switching to the [Erlang Language Platform (ELP)](https://github.com/whatsapp/erlang-language-platform) language server.