### PR TITLE
jpegrescan: mention mozjpeg as replacement

### DIFF
--- a/Formula/j/jpegrescan.rb
+++ b/Formula/j/jpegrescan.rb
@@ -23,7 +23,7 @@ class Jpegrescan < Formula
   end
 
   deprecate! date: "2024-04-05", because: :repo_archived
-  disable! date: "2025-04-08", because: :repo_archived
+  disable! date: "2025-04-08", because: :repo_archived, replacement_formula: "mozjpeg"
 
   depends_on "jpeg-turbo"
 


### PR DESCRIPTION
https://github.com/kud/jpegrescan
> NB: [MozJPEG](https://github.com/mozilla/mozjpeg) has the same optimisation built-in and is faster, so we recommend using MozJPEG when possible.