### PR TITLE
container-diff: mention diffoci as replacement

### DIFF
--- a/Formula/c/container-diff.rb
+++ b/Formula/c/container-diff.rb
@@ -18,7 +18,7 @@ class ContainerDiff < Formula
   end
 
   deprecate! date: "2024-04-05", because: :repo_archived
-  disable! date: "2025-04-08", because: :repo_archived
+  disable! date: "2025-04-08", because: :repo_archived, replacement_formula: "diffoci"
 
   depends_on "go" => :build
 


### PR DESCRIPTION
Officiall6 recommended alternative - https://github.com/GoogleContainerTools/container-diff/blob/master/README.md
> If you are looking for an alternative, try [diffoci](https://github.com/reproducible-containers/diffoci)