### PR TITLE
kcptun: move disable date earlier due to repo purge

### DIFF
--- a/Formula/k/kcptun.rb
+++ b/Formula/k/kcptun.rb
@@ -6,15 +6,6 @@ class Kcptun < Formula
   license "MIT"
   head "https://github.com/xtaci/kcptun.git", branch: "master"
 
-  # Upstream appears to use GitHub releases to indicate that a version is
-  # released (and some tagged versions don't end up as a release), so it's
-  # necessary to check release versions instead of tags.
-  livecheck do
-    url :stable
-    regex(/^v?(\d+(?:\.\d+)*)$/i)
-    strategy :github_latest
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "966cf0596429206627bddde19064d5056c205f7bbaa2f4a8359d7b3e045ee433"
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "966cf0596429206627bddde19064d5056c205f7bbaa2f4a8359d7b3e045ee433"
@@ -24,8 +15,9 @@ class Kcptun < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "0c71cd11997ea6c9d0454a6ee452c619b178dfa34918e8f9c909998a138ab423"
   end
 
+  # Purged repository so unable to build on any support OS
   deprecate! date: "2026-02-11", because: :repo_archived
-  disable! date: "2027-02-11", because: :repo_archived
+  disable! date: "2026-05-11", because: :repo_archived
 
   depends_on "go" => :build
 


### PR DESCRIPTION
Reducing time frame to only 3 month deprecation since the formula no longer builds from source due to intentional purge of git repository by upstream. This disables the formula prior to next mass bottling so we don't track it.

Our official policy https://docs.brew.sh/Deprecating-Disabling-and-Removing-Formulae#disabling
> Unpopular formulae (e.g. have fewer than 1000 [analytics installs in the last 90 days](https://formulae.brew.sh/analytics/install/90d/)) can be disabled immediately for any of the reasons above, e.g. they cannot be built from source on any supported macOS version or Linux


#5689 | kcptun | 86 | 0%
-- | -- | -- | --

Could directly disable, but just giving 3 months.

---

Also our deprecation policy:
> Deprecated formulae should continue to be maintained by the Homebrew maintainers so they still build from source and their bottles continue to work (even if unmaintained upstream). If this is not possible, they should be disabled.