### PR TITLE
e*: remove no_autobump! manual review

### DIFF
--- a/Formula/e/easy-tag.rb
+++ b/Formula/e/easy-tag.rb
@@ -6,8 +6,6 @@ class EasyTag < Formula
   license "GPL-2.0-or-later"
   revision 12
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 arm64_tahoe:   "8251a64714fcb33ae2d6952b837cc4441424c68d85194fe85fa1ffb840d8f1af"

--- a/Formula/e/ebook-tools.rb
+++ b/Formula/e/ebook-tools.rb
@@ -6,8 +6,6 @@ class EbookTools < Formula
   license "MIT"
   revision 4
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "9cac7c5b835702327a836ed085a05cf2e7198af37bbc0d1e5704b2c587e68d3c"
     sha256 cellar: :any,                 arm64_sequoia: "71206983efece5f146c2ec3e0df4f41afa0a3d9332fd52ca9050f1dfd998e48a"

--- a/Formula/e/ebook2cw.rb
+++ b/Formula/e/ebook2cw.rb
@@ -10,8 +10,6 @@ class Ebook2cw < Formula
     regex(/href=.*?ebook2cw[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:    "cd48218169f8f598c5bbba765d4f632fd51eb0472e2416856008b0dd79c1c83f"
     sha256 arm64_sequoia:  "8ee60330873ad88bbe4346269b4ce0f1c1598382e98ebfae5a264d8af4474148"

--- a/Formula/e/ecasound.rb
+++ b/Formula/e/ecasound.rb
@@ -10,8 +10,6 @@ class Ecasound < Formula
     regex(/href=.*?ecasound[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:    "12e39a10c26842235843e303cf99bb10db7666a1fcd812d88b418ed2eae540c0"
     sha256 arm64_sequoia:  "44c42355a7959b320035dc42229da1ea6996934e220820a8e51c8c9b45e882ed"

--- a/Formula/e/ekg2.rb
+++ b/Formula/e/ekg2.rb
@@ -28,8 +28,6 @@ class Ekg2 < Formula
     regex(/^ekg2[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 arm64_tahoe:    "a7cbb93dd8788ed190854be1563c1643bda0e79d4373f095ef76811c37f1fff7"

--- a/Formula/e/ems-flasher.rb
+++ b/Formula/e/ems-flasher.rb
@@ -10,8 +10,6 @@ class EmsFlasher < Formula
     regex(/href=.*?ems-flasher[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "a7f24072022ccf384517e60b21fe3d5c4f32290601710f0149362eb6bf9b9723"
     sha256 cellar: :any,                 arm64_sequoia:  "3234b5a7a065c25076109874fb9f7f4c4a43b87f758320145eed22b186be84d3"

--- a/Formula/e/enscript.rb
+++ b/Formula/e/enscript.rb
@@ -8,8 +8,6 @@ class Enscript < Formula
   revision 1
   head "https://git.savannah.gnu.org/git/enscript.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:    "8ec384c474020c7910824f10690c55502ceaa686c444c4989dd3785268dac77a"
     sha256 arm64_sequoia:  "2236c54447fc2e015995a2fa047dd406dbfefa9db547a10b305e5817482d8446"

--- a/Formula/e/enter-tex.rb
+++ b/Formula/e/enter-tex.rb
@@ -6,8 +6,6 @@ class EnterTex < Formula
   license "GPL-3.0-or-later"
   head "https://gitlab.gnome.org/swilmet/enter-tex.git", branch: "main"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:   "d4f3f78d741b6b74ee5d5614d371083d7170d3632831fbeba0bd4b0860c0e09a"
     sha256 arm64_sequoia: "54bc5763249a15db71b9bcd7c99130d1c9792bacee307649191830c1047fb3dd"

--- a/Formula/e/eot-utils.rb
+++ b/Formula/e/eot-utils.rb
@@ -10,8 +10,6 @@ class EotUtils < Formula
     regex(/href=.*?eot-utilities[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "64e5e47e5219e1d27e3683f4c4d174c5cb79117aa6cbf99e1a6939530a359143"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "dcf1a3953bd2c4baedc5f004a95be4704f19c554d064c27e613a2384edbffd82"

--- a/Formula/e/epsilon.rb
+++ b/Formula/e/epsilon.rb
@@ -13,8 +13,6 @@ class Epsilon < Formula
     regex(%r{url=.*?/epsilon[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "0620e9ab8265a63a2c80dd4dfe7cb5b0f548f12fa5c597b679dd4cfdd079e4f1"
     sha256 cellar: :any,                 arm64_sequoia:  "00006841c371ebcd51bc9f3105d16bc690fa54fa0a37ee9b0acfd33cfcee9b1e"

--- a/Formula/e/epstool.rb
+++ b/Formula/e/epstool.rb
@@ -10,8 +10,6 @@ class Epstool < Formula
     regex(/href=.*?epstool[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "29ea3ebb0169c4f25d1fae90b5abacf77cda82f3da47c9052d02427521a98535"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "f50774d3fb87855e6cb3819a97739d3f5e45806a51a79b69dbcb7d1f966738a2"

--- a/Formula/e/espeak.rb
+++ b/Formula/e/espeak.rb
@@ -11,8 +11,6 @@ class Espeak < Formula
     regex(%r{url=.*?/espeak[._-]v?(\d+(?:\.\d+)+)(?:-source)?\.(?:t|zip)}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 arm64_tahoe:    "b3714356a1701d170fc7c6eb121a3db31c25e43c3ebae3e91dd5a6438d060c60"

--- a/Formula/e/etsh.rb
+++ b/Formula/e/etsh.rb
@@ -11,8 +11,6 @@ class Etsh < Formula
     regex(/href=.*?etsh[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256                               arm64_tahoe:    "563a005afcf2e27e22f7be999febc8c5f2cb26659f6e12a8ef2081531f6ded4f"
     sha256                               arm64_sequoia:  "d67ffc1ce7bd60251ea6a60da6f2c4676d2ee3c32cdf22743398de0c2eb7cb05"

--- a/Formula/e/exact-image.rb
+++ b/Formula/e/exact-image.rb
@@ -10,8 +10,6 @@ class ExactImage < Formula
     regex(/href=.*?exact-image[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:   "3408ea3e3e84443be2c9f8c30c93f1968a623030872acda7cc6b8a3523e4b99b"

--- a/Formula/e/exiftags.rb
+++ b/Formula/e/exiftags.rb
@@ -10,8 +10,6 @@ class Exiftags < Formula
     regex(/href=.*?exiftags[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "b4c31682830f7f18a47fcaa2c2c61d28e1e36cca0ab480d41ffffde7731f7b06"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "43f7d6a7bd08e653cfde12d0f3cdcdb371b27bb4912a8f2bcda42120da960cb7"

--- a/Formula/e/exiftran.rb
+++ b/Formula/e/exiftran.rb
@@ -11,8 +11,6 @@ class Exiftran < Formula
     regex(/href=.*?fbida[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:    "47382320dca8114cb256770c2bca548abc28281ed6b90b309d62e6cfcd7cf2f5"

--- a/Formula/e/expect.rb
+++ b/Formula/e/expect.rb
@@ -11,8 +11,6 @@ class Expect < Formula
     regex(%r{url=.*?/expect-?v?(\d+(?:\.\d+)+)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:   "02453adc4b8102ccdea2eddf5bb2a282ad6a62ad373121bf6ee6d9273e3d6d4c"
     sha256 arm64_sequoia: "bc49887735929062d3e347a111a7b53a0de95813652d626f00d9b5663ecb0c1d"

--- a/Formula/e/ezstream.rb
+++ b/Formula/e/ezstream.rb
@@ -12,8 +12,6 @@ class Ezstream < Formula
     regex(%r{href=(?:["']?|.*?/)ezstream[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "985d55fee7a55d60c0d2cfa98a71f35e87b1e03272c9ecece67e267e14f53eae"
     sha256 cellar: :any,                 arm64_sequoia: "6d75b37759ae3b6c4345e1ed4a137e860919c432e918b68e706937f99c049b90"


### PR DESCRIPTION
#267571

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI assisted with candidate discovery and one-commit-per-formula patching for `e*` formulas by removing `no_autobump! because: :requires_manual_review` where livecheck/status/source checks were compatible. I manually verified and reran `brew style` and `brew audit --strict` on the edited formula set.

Excluded from this batch: `eiffelstudio` (livecheck error), `empty` (nonstandard version format), and strict-audit issues `ekhtml`, `esniper`, `ex-vi`.

-----
