### PR TITLE
f*: remove no_autobump! manual review

### DIFF
--- a/Formula/f/fann.rb
+++ b/Formula/f/fann.rb
@@ -5,8 +5,6 @@ class Fann < Formula
   sha256 "3d6ee056dab91f3b34a3f233de6a15331737848a4cbdb4e0552123d95eed4485"
   license "LGPL-2.1-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "2ac389dc68554448627859dcea8a703c0d81adce8de6fd1c32a4f43ac467ec7a"
     sha256 cellar: :any,                 arm64_sequoia:  "1a57d8d2501d63d56451fb00bc9fed3e5596b0afd995638b1c290e6a7aa663f5"

--- a/Formula/f/fastjar.rb
+++ b/Formula/f/fastjar.rb
@@ -10,8 +10,6 @@ class Fastjar < Formula
     regex(/href=.*?fastjar[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "1cb7800d86e7f8733755399304f9ccc3ea3d44c7d7ca6fd81b2f6aeaf5cc6061"

--- a/Formula/f/fastme.rb
+++ b/Formula/f/fastme.rb
@@ -11,8 +11,6 @@ class Fastme < Formula
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:    "4e5a8fb8bcbb621a2b49132177b1d4672669a8994b6bc31e5fc654082689c50c"

--- a/Formula/f/fb-client.rb
+++ b/Formula/f/fb-client.rb
@@ -14,8 +14,6 @@ class FbClient < Formula
     regex(%r{Latest release:.*?href=.*?/fb[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 3
     sha256 cellar: :any,                 arm64_tahoe:   "d8e28f243d35b05f844423d91864d16f6a762c9f504f275b844dd6b9a30e7cae"

--- a/Formula/f/fdk-aac.rb
+++ b/Formula/f/fdk-aac.rb
@@ -5,8 +5,6 @@ class FdkAac < Formula
   sha256 "829b6b89eef382409cda6857fd82af84fabb63417b08ede9ea7a553f811cb79e"
   license "Apache-2.0"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "3219079b606e1be7284a0b184c6ccb57676190d199261a0bb67556d28da94c2d"
     sha256 cellar: :any,                 arm64_sequoia:  "d25f4bc81d87c69c9d26d29ae088caeae1778b87f6ca2e13e759ef9d5e723c9a"

--- a/Formula/f/fetch-crl.rb
+++ b/Formula/f/fetch-crl.rb
@@ -10,8 +10,6 @@ class FetchCrl < Formula
     regex(/href=.*?fetch-crl[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "9d7e1263bc12cd3fe2919e2179c5e53e0f11ed1d38d45e08d612ec870fca65c8"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "52ab61a76d3a769a87f1f61f0d4c22ff747180d99afb62ad4e91a0a1d8b957af"

--- a/Formula/f/ffmpeg2theora.rb
+++ b/Formula/f/ffmpeg2theora.rb
@@ -7,8 +7,6 @@ class Ffmpeg2theora < Formula
   revision 12
   head "https://gitlab.xiph.org/xiph/ffmpeg2theora.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "42c00e60ebc22a03002de781c194a5bb837e0528fa92c32f89dd65a60c375757"
     sha256 cellar: :any,                 arm64_sequoia: "f80e6c1cf50dee0a7bc77cd75c58c10814972804cad86dc8c9167e03d6f1fa0b"

--- a/Formula/f/ffmpeg@2.8.rb
+++ b/Formula/f/ffmpeg@2.8.rb
@@ -13,8 +13,6 @@ class FfmpegAT28 < Formula
     regex(/href=.*?ffmpeg[._-]v?(2\.8(?:\.\d+)*)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:   "bae260c1a31f316dd652f4303f8432c48fc204e24d4d43991dc87b05cc60499d"
     sha256 arm64_sequoia: "4c4d7e61422afc7d4124be058dd4d9eabbcbb8c0412eb4ad5fd7a4cbbf9bcdc0"

--- a/Formula/f/ficy.rb
+++ b/Formula/f/ficy.rb
@@ -11,8 +11,6 @@ class Ficy < Formula
     regex(%r{href=.*?releases/fIcy[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "a229e2cdd5d347698dba54b95b66a0a17db438be849e798ba7b2c82ca4db924d"

--- a/Formula/f/figlet.rb
+++ b/Formula/f/figlet.rb
@@ -12,8 +12,6 @@ class Figlet < Formula
     strategy :page_match
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:    "08cea07f0d5aa44680d79cf97dbae12da8f80e85deb70b36f0e701be0896efd5"
     sha256 arm64_sequoia:  "a157e5806797a85551f7773614157047dfa09fb38e76d6502cb93c79a207851c"

--- a/Formula/f/file-formula.rb
+++ b/Formula/f/file-formula.rb
@@ -12,8 +12,6 @@ class FileFormula < Formula
     regex(/href=.*?file[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "65b81cd6df1455e32335632e523b2dc5a8401714d3425dcb5c6d8661043a8b03"
     sha256 cellar: :any,                 arm64_sequoia: "5fe19d9d579de777487bbaa3722d672da01bcfae88f92af992918069bb5a0ac0"

--- a/Formula/f/fizmo.rb
+++ b/Formula/f/fizmo.rb
@@ -11,8 +11,6 @@ class Fizmo < Formula
     regex(%r{href=.*?/fizmo[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:   "84b3dabce41fa7fd0883ff4cc412d65b73d42da0b9f5968db0570df314ba20d7"
     sha256 arm64_sequoia: "25c9f7c41969ef25f4487be678d26f761384e6f13aed58856138c6c5cea6a3f1"

--- a/Formula/f/fizsh.rb
+++ b/Formula/f/fizsh.rb
@@ -11,8 +11,6 @@ class Fizsh < Formula
     regex(%r{url=.*?/fizsh[._-]v?(\d+(?:\.\d+)+(?:-\d+)?)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "f893871f51a8542bbc01321935e948a6753e4eb5865885307dbdeed9882e7192"

--- a/Formula/f/flactag.rb
+++ b/Formula/f/flactag.rb
@@ -6,8 +6,6 @@ class Flactag < Formula
   license "GPL-3.0-or-later"
   revision 4
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "a51e19be9701ccbe86b20cbe0444217655d0e0c0c02779a0784b4e5bc5830f4f"
     sha256 cellar: :any,                 arm64_sequoia: "8701c9513901987485c41ce6778104199cac3fabcdfcc1fc2c82717ededa93e8"

--- a/Formula/f/flake.rb
+++ b/Formula/f/flake.rb
@@ -5,8 +5,6 @@ class Flake < Formula
   sha256 "8dd249888005c2949cb4564f02b6badb34b2a0f408a7ec7ab01e11ceca1b7f19"
   license "LGPL-2.1-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "a74ce50f62b9fcfaad31673092ece8fb2abed1a710117f8ed0bd0e62d01bfe6a"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "9d0c8523afc14e96a58b6494cf494b13527d6ba7f11c125b779999b1ad088644"

--- a/Formula/f/flawfinder.rb
+++ b/Formula/f/flawfinder.rb
@@ -14,8 +14,6 @@ class Flawfinder < Formula
     regex(/href=.*?flawfinder[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 5
     sha256 cellar: :any_skip_relocation, all: "ef4160192048471cc1fdda78cbfbda11725e3a826118988878a286f08a71d9a0"

--- a/Formula/f/flickcurl.rb
+++ b/Formula/f/flickcurl.rb
@@ -11,8 +11,6 @@ class Flickcurl < Formula
     regex(/href=.*?flickcurl[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "5ad4303f2feb50ec3bcac620cb35ec60de39f7c2f40f5d20587daa161064ce2e"
     sha256 cellar: :any,                 arm64_sequoia: "f7d7fcaa4becaba9efd332bc528a22cc9a844caac877510efa8aea89906a98bb"

--- a/Formula/f/fmpp.rb
+++ b/Formula/f/fmpp.rb
@@ -6,8 +6,6 @@ class Fmpp < Formula
   license "Apache-2.0"
   revision 2
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, all: "fd2a84f1e4cb90f27ac04f99af1b5da3499c81e111e78370ebd71f448dd97d12"

--- a/Formula/f/font-util.rb
+++ b/Formula/f/font-util.rb
@@ -5,8 +5,6 @@ class FontUtil < Formula
   sha256 "5c9f64123c194b150fee89049991687386e6ff36ef2af7b80ba53efaf368cc95"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "1e81859b3665bc1d739ed7a6d7844fb00408b423a1a974dba3f4d53afcfdb15f"

--- a/Formula/f/foremost.rb
+++ b/Formula/f/foremost.rb
@@ -11,8 +11,6 @@ class Foremost < Formula
     regex(/href=.*?foremost[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "d52d6e93501d0378121aab45c81f3091eba21303e633ae7194670860e36a5740"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "2fc223a574f2cc52cd6a40d668429f11a7211a34a206f49f1af4329f14a537db"

--- a/Formula/f/fortune.rb
+++ b/Formula/f/fortune.rb
@@ -11,8 +11,6 @@ class Fortune < Formula
     regex(/href=.*?fortune-mod[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 4
     sha256 arm64_tahoe:    "547b04ec0f01dad4bd92dc49811686b2a6ff159d9040ca79a17f0ee1494cb39d"

--- a/Formula/f/fpc.rb
+++ b/Formula/f/fpc.rb
@@ -14,8 +14,6 @@ class Fpc < Formula
     strategy :page_match
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "2a9bc7750dd16814a483d10f1dfd4827c6f89569ccc1b46a6b0b0d60f1c1b792"
     sha256 cellar: :any,                 arm64_sequoia:  "075f0b14b19da5236d2bb421450d1b86fb816bc62a9bb0adaf97404662f9ab02"

--- a/Formula/f/fprobe.rb
+++ b/Formula/f/fprobe.rb
@@ -5,8 +5,6 @@ class Fprobe < Formula
   sha256 "3a1cedf5e7b0d36c648aa90914fa71a158c6743ecf74a38f4850afbac57d22a0"
   license "GPL-2.0-only"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "4cbf791e6fc38eca3bf5be7634eedee0a1b970783f0f1516227838541d708b47"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "edcd1f7fb0c159ed2363136b500af38948c8e4a9a1cb26b4b3c6e745f2ef67c4"

--- a/Formula/f/freedink.rb
+++ b/Formula/f/freedink.rb
@@ -6,8 +6,6 @@ class Freedink < Formula
   license "GPL-3.0-or-later"
   revision 1
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 arm64_tahoe:   "68cd1561bc7d6a477d2d3457a0c1867bf19cec00fd84c46f0fe74fd18d961cf1"

--- a/Formula/f/fsevents-tools.rb
+++ b/Formula/f/fsevents-tools.rb
@@ -10,8 +10,6 @@ class FseventsTools < Formula
     regex(/href=.*?fsevents-tools[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "e9c957de83e07813d6363e58bf6d8e1c9ade1592ce6a965817d57a0b824fd165"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "69d137adc9cbcce94aa7160b76705454f3f04fc0598f2146264887fc0a278c2e"

--- a/Formula/f/fstrm.rb
+++ b/Formula/f/fstrm.rb
@@ -20,8 +20,6 @@ class Fstrm < Formula
     strategy :github_latest
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "7b3467f8c2db26584cb092d8d9c4fe769f459d6a015c7f935d335a885c996697"
     sha256 cellar: :any,                 arm64_sequoia:  "d33b95ae03b379e72f20439898cb8c87f896d2994783778803c7701d92a57998"

--- a/Formula/f/funcoeszz.rb
+++ b/Formula/f/funcoeszz.rb
@@ -10,8 +10,6 @@ class Funcoeszz < Formula
     regex(/href=.*?funcoeszz[._-]v?(\d+(?:\.\d+)+)\.sh/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "b9d4a7633bfd39f84797948a471e9d231cdc7539e472dc982cc33c2f4b6d3e88"

--- a/Formula/f/fuse-zip.rb
+++ b/Formula/f/fuse-zip.rb
@@ -6,8 +6,6 @@ class FuseZip < Formula
   license "GPL-3.0-or-later"
   head "https://bitbucket.org/agalanin/fuse-zip.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_linux:  "b9ea1815940249c680e5f6524a9da80d600f3dc8a1d40d89dec4b49de64b4d66"

--- a/Formula/f/fwknop.rb
+++ b/Formula/f/fwknop.rb
@@ -13,8 +13,6 @@ class Fwknop < Formula
     regex(/href=.*?fwknop[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:   "7963f9f9f757720644a3df1cfaeb3307b43dfc3148ece268a48fca4ca47bf83b"
     sha256 arm64_sequoia: "227c8c6bcd86942a72b26ab69e096cefd01941331e82ef5bf8c3942070081edf"


### PR DESCRIPTION
#267571

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI assisted with candidate discovery and one-commit-per-formula patching for `f*` formulas by removing `no_autobump! because: :requires_manual_review` where livecheck/status/source checks were compatible. I manually verified and reran `brew style` and `brew audit --strict` on the edited formula set.

Excluded from this batch: `fceux`, `fcrackzip`, `fex`, `ffe`, `flow-tools`, `freeimage`, `ftgl`, `fuego` (filter exclusions) and `fragroute`, `freealut` (strict-audit missing `test do`).

-----
