### PR TITLE
gssh: add head for monorepo

### DIFF
--- a/Formula/g/gssh.rb
+++ b/Formula/g/gssh.rb
@@ -4,6 +4,7 @@ class Gssh < Formula
   url "https://github.com/int128/groovy-ssh/archive/refs/tags/2.12.0.tar.gz"
   sha256 "b2ce4ddc0d208e90ab4e986a1b1d759955783bdf3fe046f770eba98e6e6a13a9"
   license "Apache-2.0"
+  head "https://github.com/int128/gradle-ssh-plugin.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "7a553584f7cf8db8128678eb9cfaa533d5ded948f46ebc7ca9ed4fc0a0f52731"
@@ -25,7 +26,7 @@ class Gssh < Formula
     ENV["CIRCLE_TAG"] = version
     ENV["GROOVY_SSH_VERSION"] = version
     system "gradle", "shadowJar", "--no-daemon"
-    libexec.install "cli/build/libs/gssh.jar"
+    libexec.install "#{"groovy-ssh/" if build.head?}cli/build/libs/gssh.jar"
     bin.write_jar_script libexec/"gssh.jar", "gssh", java_version: "21"
   end
 


### PR DESCRIPTION
Formula is deprecated but upstream moved code to monorepo. Sadly no new release so not able to build from new repo.

Adding HEAD to make it easier to find any new releases