### PR TITLE
aptos: remove old workaround, add inreplace for correct bottle arch

### DIFF
--- a/Formula/a/aptos.rb
+++ b/Formula/a/aptos.rb
@@ -28,18 +28,20 @@ class Aptos < Formula
   uses_from_macos "llvm" => :build
 
   on_linux do
-    depends_on "lld" => :build
     depends_on "pkgconf" => :build
     depends_on "zip" => :build
     depends_on "elfutils"
     depends_on "openssl@3"
     depends_on "systemd"
+
+    on_intel do
+      depends_on "lld" => :build
+    end
   end
 
   def install
-    # Use correct compiler to prevent blst from enabling AVX support on macOS
-    # upstream issue report, https://github.com/supranational/blst/issues/253
-    ENV["CC"] = Formula["llvm"].opt_bin/"clang" if OS.mac?
+    # Remove optimization to allow bottles to be run on our minimum supported CPUs
+    inreplace ".cargo/config.toml", /,\s*"-C",\s*"target-cpu=x86-64-v3"/, ""
 
     system "cargo", "install", *std_cargo_args(path: "crates/aptos"), "--profile=cli"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
