### PR TITLE
spirv-reflect 1.4.341.0 (new formula)

### DIFF
--- a/Formula/s/spirv-reflect.rb
+++ b/Formula/s/spirv-reflect.rb
@@ -1,0 +1,34 @@
+class SpirvReflect < Formula
+  desc "SPIR-V shader reflection C/C++ library"
+  homepage "https://github.com/KhronosGroup/SPIRV-Reflect"
+  url "https://github.com/KhronosGroup/SPIRV-Reflect/archive/refs/tags/vulkan-sdk-1.4.341.0.tar.gz"
+  sha256 "3f55d5ad7dc6f02214633c851d4ea3872abe3a1ecec6b5d80cfc3255012c4b6a"
+  license "Apache-2.0"
+
+  depends_on "cmake" => :build
+  depends_on "spirv-headers"
+
+  def install
+    system "cmake", "-S", ".", "-B", "build",
+           "-DSPIRV_REFLECT_STATIC_LIB=ON",
+           *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+
+    # Patch installed header to use system SPIR-V headers by default
+    inreplace "#{include}/spirv_reflect.h",
+              "#if defined(SPIRV_REFLECT_USE_SYSTEM_SPIRV_H)",
+              "#if 1 // Patched by Homebrew to use system headers"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <spirv_reflect.h>
+      int main() {
+        SpvReflectShaderModule module;
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lspirv-reflect-static"
+  end
+end


### PR DESCRIPTION
SPIR-V Reflect is a lightweight library for SPIR-V shader reflection. It provides C/C++ API to extract shader information from SPIR-V bytecode.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR.
-----
AI usage: Claude wrote the actual recipe - I don't speak ruby.