### PR TITLE
nullclaw 2026.2.21 (new formula)

### DIFF
--- a/Formula/n/nullclaw.rb
+++ b/Formula/n/nullclaw.rb
@@ -1,0 +1,39 @@
+class Nullclaw < Formula
+  desc "Tiny autonomous AI assistant infrastructure written in Zig"
+  homepage "https://nullclaw.github.io"
+  url "https://github.com/nullclaw/nullclaw/archive/refs/tags/v2026.2.21.tar.gz"
+  sha256 "397a775676e28390175d31a96248595f4637ca36008e3b4dbb0e7c6cfd4cd581"
+  license "MIT"
+  head "https://github.com/nullclaw/nullclaw.git", branch: "main"
+
+  depends_on "zig" => :build
+
+  def install
+    # Fix illegal instruction errors when using bottles on older CPUs.
+    # https://github.com/Homebrew/homebrew-core/issues/92282
+    cpu = case ENV.effective_arch
+    when :arm_vortex_tempest then "apple_m1" # See `zig targets`.
+    when :armv8 then "xgene1" # Closest to `-march=armv8-a`
+    else ENV.effective_arch
+    end
+
+    args = ["-Dversion=#{version}"]
+    args << "-Dcpu=#{cpu}" if build.bottle?
+
+    system "zig", "build", *args, *std_zig_args
+  end
+
+  service do
+    run [opt_bin/"nullclaw", "daemon"]
+    keep_alive true
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/nullclaw --version")
+
+    ENV["HOME"] = testpath
+    output = shell_output("#{bin}/nullclaw status 2>&1")
+    assert_match "nullclaw Status", output
+    assert_match(/Version:\s+#{Regexp.escape(version.to_s)}/, output)
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. Claude Code was used to scaffold the formula based on existing Zig formula patterns (ncdu, fancy-cat, bold). The formula was manually verified: built from source, tested `--version` and `status` commands, confirmed `--prefix` and `-Dversion=` flags work correctly with the Zig build system.

-----

Built and tested locally on macOS 15.3 (arm64).

Supersedes #268586 which was closed pending `--version` support ([nullclaw/nullclaw#27](https://github.com/nullclaw/nullclaw/issues/27), now resolved).