### PR TITLE
termusic 0.12.1 (new formula)

### DIFF
--- a/Formula/t/termusic.rb
+++ b/Formula/t/termusic.rb
@@ -5,6 +5,15 @@ class Termusic < Formula
   sha256 "686f66856d755f2d2056a9548f074b11ba9568ac8075fafd8903e332bf166227"
   license all_of: ["MIT", "GPL-3.0-or-later"]
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "1c2f883e043839db16ac4f8de8add8b972de0e008463f714e7a19c89cb76be45"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "87d7b2e39b0809ee26208e482ee7f85dea70d69b70a62833c526b4be18d76e42"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "9438afa2b260b4345bc0bde7c106fb3c2d5cb698cd4df6503d4bed74453c518c"
+    sha256 cellar: :any_skip_relocation, sonoma:        "06be1c021c63e361e292860592fb21b6abe48f044e8fcba7dc74740ce29d9069"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "c32e8c19f96b03217bdca10746787eaf5d000fea12be63e769c6985385604bd0"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4723e83582af2d07546b8af198ee691299a3bfb4e10dd55003391556ecc6f508"
+  end
+
   depends_on "pkgconf" => :build
   depends_on "protobuf" => :build
   depends_on "rust" => :build

--- a/Formula/t/termusic.rb
+++ b/Formula/t/termusic.rb
@@ -1,0 +1,41 @@
+class Termusic < Formula
+  desc "Music Player TUI written in Rust"
+  homepage "https://github.com/tramhao/termusic"
+  url "https://github.com/tramhao/termusic/archive/refs/tags/v0.12.1.tar.gz"
+  sha256 "686f66856d755f2d2056a9548f074b11ba9568ac8075fafd8903e332bf166227"
+  license all_of: ["MIT", "GPL-3.0-or-later"]
+
+  depends_on "pkgconf" => :build
+  depends_on "protobuf" => :build
+  depends_on "rust" => :build
+  depends_on "sound-touch" => :build
+  depends_on "openssl@3"
+
+  on_linux do
+    depends_on "alsa-lib"
+  end
+
+  def install
+    system "cargo", "install", *std_cargo_args(path: "tui", features: "cover-viuer-iterm")
+    system "cargo", "install", *std_cargo_args(path: "server")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/termusic --version")
+    assert_match version.to_s, shell_output("#{bin}/termusic-server --version")
+
+    output_log = testpath/"output.log"
+    pid = if OS.mac?
+      spawn bin/"termusic", [:out, :err] => output_log.to_s
+    else
+      require "pty"
+      PTY.spawn(bin/"termusic", [:out, :err] => output_log.to_s).last
+    end
+    sleep 1
+    assert_match "Server process ID", output_log.read
+  ensure
+    # Use KILL to ensure the process terminates, as TERM request to confirm exiting program.
+    Process.kill("KILL", pid)
+    Process.wait(pid)
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Several caveats, especially about some audit failures I'm aware of but have deliberately kept that way to talk about here
- I don't remember how the granularity have to be regarding licenses and how one license specific to some parts needs to be set (and as far as I can tell, https://docs.brew.sh/License-Guidelines doesn't answer this)
- ``  * line 14, col 5: Use `"cargo", "install", *std_cargo_args` `` I've seen it (and tested it before, it does work with this:
```
system "cargo", "install", *std_cargo_args(path: "server")
system "cargo", "install", *std_cargo_args(path: "tui")
```
Taken from https://github.com/Homebrew/homebrew-core/blob/94d546433f9bd93d75063890f3bcdfc26ce3c39e/Formula/y/yazi.rb#L31-L32
Using the default Homebrew Cargo command was leaving me with this: 
```error: found a virtual manifest at `/private/tmp/termusic-20260221-16706-7zjdoq/termusic-0.12.1/Cargo.toml` instead of a package manifest```

Using `fetch` and `build` seems like the standard way to do, usually, allows to compile all at once and specify features once. This seemed like the preferred way to build Rust applications to me, and I'm not sure why Homebrew recommends to use instead `cargo install` (where a `--all` flag doesn't exist, see https://github.com/rust-lang/cargo/issues/4101)

On top of it I wanted to use `cargo test`, which is used to test the produced binaries following the build, but either this ends in the `install` block, where it does not belong or we can't use it in the `test` block because with the context change we don't have what's required to do this. I don't know how is this handled and if some formula use the `cargo test` or not? It doesn't seems to be the case.

Places used to grab information and how to build it in the context of a package manager:
https://gitlab.archlinux.org/archlinux/packaging/packages/termusic/-/blob/0.12.0-1/PKGBUILD
https://github.com/tramhao/termusic/blob/master/.github/workflows/build.yml#L67-L100
https://github.com/tramhao/termusic/blob/master/.github/workflows/release.yml

Also, it might be to consider to support more features; currently it's only supporting the `iterm` protocol for the covers. This means it doesn't work on several terminals, and I can look to add the kitty and sixel protocols features, when I'll have answers for the other questions (if `install`, I'll have to look for the features this way)

Some last questions: 
- For GitHub releases is the `livecheck` block still mandatory?
- I had some pain to find how to do use in ruby the result of a command as argument to another command (`$()` in a bash command), `` ` ` `` ended up working, but maybe there are better ways to do so?
- I ended up copying the style of the commit of another new formula, I think the documentation might deserve a "new formula" case as here I wasn't sure what was accepted or not. Especially i don't think providing formula's version for the introduction in the repo makes sense?

EDIT: Also, is it required for now to add the `head` statement or is it inferred automatically?