### PR TITLE
git: install git-jump

### DIFF
--- a/Formula/g/git.rb
+++ b/Formula/g/git.rb
@@ -12,12 +12,13 @@ class Git < Formula
   end
 
   bottle do
-    sha256 arm64_tahoe:   "102fc7ec06e6faea530225cc57b9f7651de67449f1f918ec52d840e6edd48c08"
-    sha256 arm64_sequoia: "ba2abb22be25b4f6e4be4dfb2bfcd9c17e6e55a705f1e588fb16e2f536fa2ceb"
-    sha256 arm64_sonoma:  "3fea19d3dff9e81ab08a618d74fb255c83d2d3decd92db964bbd5ff045eb2abb"
-    sha256 sonoma:        "f9050c76ec1039103c2449a87580b81a249f80704b80c541206831fec6d33464"
-    sha256 arm64_linux:   "83e5dcc0bbd53bab6990b04994f168122a8c9f92c8970bdcd11eb84670db8bd5"
-    sha256 x86_64_linux:  "7a7b8d8b093036e342efb95b1792d393f60810fb6e0b40b03545f4ad87014c70"
+    rebuild 1
+    sha256 arm64_tahoe:   "822dc9a395af7f1977ae98bd584f76ccd7390381de71b5420a4b0d69b15665cf"
+    sha256 arm64_sequoia: "e54c3b8416ce766df9c6efa6f96f14c6fe43cd805e3da2706c258b5d9520c93b"
+    sha256 arm64_sonoma:  "90035e05c20b14efb12550b50431b53da8d857ccd5d29ac7fafe8ab0f959d16e"
+    sha256 sonoma:        "4831766b1d63c27c19f6c84e2f74a2c2b1131a69f818467fab6b84536ca26d90"
+    sha256 arm64_linux:   "f6946b453ca295f25ba4c855fe51e65c23b29983dc97e4f8b14c21a8b4854985"
+    sha256 x86_64_linux:  "d8c0fc6ac9824ad9c77d566018db78c252ac3c2ce0652c72d8b6d0b861867034"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/g/git.rb
+++ b/Formula/g/git.rb
@@ -157,6 +157,11 @@ class Git < Formula
       git_core.install "git-subtree"
     end
 
+    # Install git-jump
+    cd "contrib/git-jump" do
+      git_core.install "git-jump"
+    end
+
     # install the completion script first because it is inside "contrib"
     bash_completion.install "contrib/completion/git-completion.bash"
     bash_completion.install "contrib/completion/git-prompt.sh"


### PR DESCRIPTION
`git-jump` is a contrib script bundled with Git.

We're already installing several user-facing contrib tools such as `git-subtree` and `git-credential-netrc`. `git-jump` is also user-facing so we can install it too.

See: https://github.com/git/git/blob/master/contrib/git-jump/README

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
