### PR TITLE
g*: remove no_autobump! manual review (part 1)

### DIFF
--- a/Formula/g/gabedit.rb
+++ b/Formula/g/gabedit.rb
@@ -14,8 +14,6 @@ class Gabedit < Formula
     regex(/current stable version of gabedit is v?(\d+(?:\.\d+)+)/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "d50f949dc32c409c6bc33b00840ceb7f85a31490b62155d6ea2a1788395e77bc"
     sha256 cellar: :any,                 arm64_sequoia:  "4218b43130e1be48172b6935ac53abd245973a5a30f46d700b3bb848fed1791a"

--- a/Formula/g/gaffitter.rb
+++ b/Formula/g/gaffitter.rb
@@ -5,8 +5,6 @@ class Gaffitter < Formula
   sha256 "c85d33bdc6c0875a7144b540a7cce3e78e7c23d2ead0489327625549c3ab23ee"
   license "GPL-3.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "4ec8f9b01a9b1fff4a2d4cdfb51df68589b7574dcd825f9f6895e0083fe3901f"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "99ba8c060b64df92ba624ecdf846c053658ff42c15d92221a79e705e664057bd"

--- a/Formula/g/gaul.rb
+++ b/Formula/g/gaul.rb
@@ -5,8 +5,6 @@ class Gaul < Formula
   sha256 "7aabb5c1c218911054164c3fca4f5c5f0b9c8d9bab8b2273f48a3ff573da6570"
   license "GPL-2.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "e6d6c2c5f3c790afcff2232f8d2dc371a425fdedc42aa52a33daf94b0816439e"
     sha256 cellar: :any,                 arm64_sequoia:  "f6ef6f6e6711082dd49cae45e516aa9f8fdf0f2942ff4224f6c30d9e75976dcc"

--- a/Formula/g/gcab.rb
+++ b/Formula/g/gcab.rb
@@ -12,8 +12,6 @@ class Gcab < Formula
     regex(/gcab[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 arm64_tahoe:   "c75545ed9d16ec696c778a2d77108ad14afbf285827ca9ddcfeeae4c484b5b37"

--- a/Formula/g/gcc.rb
+++ b/Formula/g/gcc.rb
@@ -34,8 +34,6 @@ class Gcc < Formula
     regex(%r{href=["']?gcc[._-]v?(\d+(?:\.\d+)+)(?:/?["' >]|\.t)}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256                               arm64_tahoe:   "e208fa3a5ea6887bb9a81cee5ca629230f1f24eff3970f0d69f7dcf5dd5b7b80"
     sha256                               arm64_sequoia: "49b6841a2b7af55b29db5d63ee47a433bd75f85e3c5620c6615e7528252ffd63"

--- a/Formula/g/gcc@12.rb
+++ b/Formula/g/gcc@12.rb
@@ -13,8 +13,6 @@ class GccAT12 < Formula
     regex(%r{href=["']?gcc[._-]v?(12(?:\.\d+)+)(?:/?["' >]|\.t)}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 3
     sha256                               arm64_tahoe:  "68b256e75d6c49bf3e9244c6bcfd00755d42094fab747d15611e4e21fedbafec"

--- a/Formula/g/gcc@13.rb
+++ b/Formula/g/gcc@13.rb
@@ -11,8 +11,6 @@ class GccAT13 < Formula
     regex(%r{href=["']?gcc[._-]v?(13(?:\.\d+)+)(?:/?["' >]|\.t)}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 3
     sha256                               arm64_tahoe:   "2ae26a4499ac71797f04f9683c7fb02516f29965e6ff7627598edbeca5e4b1a0"

--- a/Formula/g/gcc@14.rb
+++ b/Formula/g/gcc@14.rb
@@ -11,8 +11,6 @@ class GccAT14 < Formula
     regex(%r{href=["']?gcc[._-]v?(14(?:\.\d+)+)(?:/?["' >]|\.t)}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 3
     sha256                               arm64_tahoe:   "aa76442b499cc647f5fe254808431f5d657120ee57bf3b0a9657755b6d38815c"

--- a/Formula/g/gcviewer.rb
+++ b/Formula/g/gcviewer.rb
@@ -11,8 +11,6 @@ class Gcviewer < Formula
     regex(%r{url=.*?/gcviewer[._-]v?(\d+(?:\.\d+)+)\.jar}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "a328eede0efee60ae573264f46a858ad1719edd56e787e0ce9aadeac6ed017c9"

--- a/Formula/g/gdb.rb
+++ b/Formula/g/gdb.rb
@@ -7,8 +7,6 @@ class Gdb < Formula
   license "GPL-3.0-or-later"
   head "https://sourceware.org/git/binutils-gdb.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 arm64_tahoe:   "2295e7004a3c90fe6098270d09ca48a7889925dcf34a07c54e9a1a47e09db70e"

--- a/Formula/g/geckodriver.rb
+++ b/Formula/g/geckodriver.rb
@@ -34,8 +34,6 @@ class Geckodriver < Formula
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "ef35a96f86a562d2e4ce13a0bc898e5ae48512877091f31a1dc54b3c3da3d9e5"
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "83fdf6d88e97169dbd88d75a957b29e8cddcc943b0f414fe67317dec60cdcbb1"

--- a/Formula/g/gedit.rb
+++ b/Formula/g/gedit.rb
@@ -5,8 +5,6 @@ class Gedit < Formula
   sha256 "f3437a675790c8593d511355252d751ab94328357bc6846d1106bf288161a5ed"
   license "GPL-2.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:   "f16f039fa3d91301dbdffbb90fe7a7e516298ca030f1d599ab9869bea105987a"
     sha256 arm64_sequoia: "a455eb1e0da6e1c6b453e53e1643c3f31a080d60870216c8c4ad7d62d69c386c"

--- a/Formula/g/gemgen.rb
+++ b/Formula/g/gemgen.rb
@@ -6,8 +6,6 @@ class Gemgen < Formula
   license "GPL-3.0-or-later"
   head "https://git.sr.ht/~kota/gemgen", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "44ca844b4b9eac43de6f9b2f7b9611bfd1a29f48986e3564e510aac4f93b3b12"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "6230c57aec303ceb06a41f2d9d78a15c648ec1b65db9cf68a2b12ef0cf7b1fcc"

--- a/Formula/g/gengetopt.rb
+++ b/Formula/g/gengetopt.rb
@@ -6,8 +6,6 @@ class Gengetopt < Formula
   sha256 "b941aec9011864978dd7fdeb052b1943535824169d2aa2b0e7eae9ab807584ac"
   license "GPL-3.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "f37f85a3ddffa7c215b078fc05f2980490d18d0202e6a92bcffd5ab88b2c9121"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "91c1d9533d5738baeeff859785ad663d51bb280ba1744f78183efa442b4bc37c"

--- a/Formula/g/geocode-glib.rb
+++ b/Formula/g/geocode-glib.rb
@@ -6,8 +6,6 @@ class GeocodeGlib < Formula
   license "GPL-2.0-or-later"
   revision 1
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any, arm64_tahoe:    "cb308eeeb5e4c4dd85bee423f170436edced9bbb7501419fa1f7634813bd120d"
     sha256 cellar: :any, arm64_sequoia:  "1afc937edacc9e447525801a51fb59580cbee67a30f995999cd8a9be08a39eff"

--- a/Formula/g/geomview.rb
+++ b/Formula/g/geomview.rb
@@ -12,8 +12,6 @@ class Geomview < Formula
     regex(/href=.*?geomview[._-]v?(\d+(?:\.\d+)+)(?:\.orig)?\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 sonoma:       "4abe048bc7d51440a13c37b0909f86e3f31156e60c3b46d9bad15d89d443e963"

--- a/Formula/g/getdns.rb
+++ b/Formula/g/getdns.rb
@@ -24,8 +24,6 @@ class Getdns < Formula
     strategy :github_latest
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "a7c28530f90a7b7154bd2c84bcca93ab7615776eda9903282a5d2ac7889d8e72"
     sha256 cellar: :any,                 arm64_sequoia:  "4de6139ffb48649141f2de34aa4525625427e92f6c663a228457e0d66c0bb4d2"

--- a/Formula/g/getxbook.rb
+++ b/Formula/g/getxbook.rb
@@ -11,8 +11,6 @@ class Getxbook < Formula
     regex(/href=.*?getxbook[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:    "b96137ef10aade7270e91deec24e1487fc1626b19d45ce68755f982b4e85cc96"

--- a/Formula/g/gforth.rb
+++ b/Formula/g/gforth.rb
@@ -6,8 +6,6 @@ class Gforth < Formula
   license "GPL-3.0-or-later"
   revision 3
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 arm64_tahoe:    "ede972e5e6570b4811d3967dd77c8780142c5bc97884a392c523b4b91b913148"

--- a/Formula/g/ghc@9.8.rb
+++ b/Formula/g/ghc@9.8.rb
@@ -15,8 +15,6 @@ class GhcAT98 < Formula
     regex(/v?(9\.8(?:\.\d+)+)[._-]notes/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:   "9480b6b54cbcaf29cd4ad8cae23cdb03bad48485186926d66685c40c90771fcf"

--- a/Formula/g/giflib.rb
+++ b/Formula/g/giflib.rb
@@ -10,8 +10,6 @@ class Giflib < Formula
     regex(%r{url=.*?/giflib[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "aab2a621b970bab0baf55c4cd72cebd118a7e283a3a0ce4a85a91546707df2f1"
     sha256 cellar: :any,                 arm64_sequoia:  "bf188a3d3e386e0b100831ca92173118c74645b033b56b4a7c148a91c2cfecb5"

--- a/Formula/g/gifsicle.rb
+++ b/Formula/g/gifsicle.rb
@@ -10,8 +10,6 @@ class Gifsicle < Formula
     regex(/href=.*?gifsicle[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "33c1243bdc845aa74b15f5e89eb46be030360140687dca87a06eebb30b8d0308"
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "75b564ba2a3671f341b02b63b0a8429ea02db301a6ecf1ab346a31d158f44139"

--- a/Formula/g/git-if.rb
+++ b/Formula/g/git-if.rb
@@ -14,8 +14,6 @@ class GitIf < Formula
     regex(/href=.*?git[._-]v?\d+(?:\.\d+)*\.(?:t|zip).+?Git\s+v?(\d+(?:\.\d+)+)/im)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "c717015c51d1fa994f53bc40cd7d4e3b64b0287682c227f5364f7b2b24232bc7"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "2918859c7196c31d059c74c800d7207bb77aa90b6b1ee67f07348a8d9871151a"

--- a/Formula/g/gitg.rb
+++ b/Formula/g/gitg.rb
@@ -11,8 +11,6 @@ class Gitg < Formula
     regex(/gitg[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:   "7e0c120472cfb2223b7615d56e431e51a865850aa768160458f27c8b0e8ba30a"
     sha256 arm64_sequoia: "6d64e919f7a876eb31d1f3e21b5d2122a7848d85c7255c58cebc041c2ca0d76b"

--- a/Formula/g/gitslave.rb
+++ b/Formula/g/gitslave.rb
@@ -5,8 +5,6 @@ class Gitslave < Formula
   sha256 "8aa3dcb1b50418cc9cee9bee86bb4b279c1c5a34b7adc846697205057d4826f0"
   license "LGPL-2.1-only"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "99050ee225d4cff6c68927afffda8d113f9d2cedb1d809ae06d4d22a5adbda6b"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "85f25f52b43ce52b80c082c154dba23fda5ab3c98e58fdd40699158fa971f3f3"

--- a/Formula/g/gl2ps.rb
+++ b/Formula/g/gl2ps.rb
@@ -10,8 +10,6 @@ class Gl2ps < Formula
     regex(/href=.*?gl2ps[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:   "cfd40bfcb06fceef93e5b04ff17a59a5df05742997959ecd4be2c9f3badc2c70"

--- a/Formula/g/glkterm.rb
+++ b/Formula/g/glkterm.rb
@@ -11,8 +11,6 @@ class Glkterm < Formula
     regex(/href=.*?glkterm[._-]v?(?:\d+(?:\.\d+)*)\.t[^>]+?>\s*?GlkTerm library v?(\d+(?:\.\d+)+)/im)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "43e67c7a7245b3260330d9d23807520aff007e05341b510dbea4818cd387cb45"

--- a/Formula/g/glktermw.rb
+++ b/Formula/g/glktermw.rb
@@ -11,8 +11,6 @@ class Glktermw < Formula
     regex(/href=.*?glktermw[._-]v?(?:\d+(?:\.\d+)*)\.t[^>]+?>\s*?GlkTerm library v?(\d+(?:\.\d+)+)/im)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "4fa3de55e34832b4cd122d80784210b5d85389306182944ebc6e1a63b5b54262"

--- a/Formula/g/gloox.rb
+++ b/Formula/g/gloox.rb
@@ -10,8 +10,6 @@ class Gloox < Formula
     regex(/Latest stable version.*?href=.*?gloox[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:   "1818e6a640fd72abca657dee0f7dd846408f5f7854723c9a98d6c7c776f8a0f9"

--- a/Formula/g/glpk.rb
+++ b/Formula/g/glpk.rb
@@ -6,8 +6,6 @@ class Glpk < Formula
   sha256 "4a1013eebb50f728fc601bdd833b0b2870333c3b3e5a816eeba921d95bec6f15"
   license "GPL-3.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "c60115e0b7c9c13a5e6fc91ceab0aab253c1bd161dae6151e56713a6de6589d5"
     sha256 cellar: :any,                 arm64_sequoia:  "d1711f363503b065183cf833d4d58ecd91dd06ac2b168af7bb217727a46e8f7b"

--- a/Formula/g/glulxe.rb
+++ b/Formula/g/glulxe.rb
@@ -12,8 +12,6 @@ class Glulxe < Formula
     regex(/href=.*?glulxe[._-]v?\d+(?:\.\d+)*\.t[^>]+?>\s*Glulxe\s+v?(\d+(?:\.\d+)+)\s*</im)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "e50d971e530488c405300c86b204007beb91ded9fb87dc8936cfee6374075d24"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "bdc5dcc5eba9d4e5417b56c4cdee27958bd6ba76e5cecc60e46fff7aa4b754ef"

--- a/Formula/g/gmp.rb
+++ b/Formula/g/gmp.rb
@@ -13,8 +13,6 @@ class Gmp < Formula
     regex(/href=.*?gmp[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "db8075f389ca0a9f9aba54762c93760db66ef92ee989f4a32b5e13b4b987339c"
     sha256 cellar: :any,                 arm64_sequoia:  "6683d73d6677d28e1e8d1b92d6ebfbc068c1d33e19b79114a22a648a99ba5991"

--- a/Formula/g/gnome-recipes.rb
+++ b/Formula/g/gnome-recipes.rb
@@ -6,8 +6,6 @@ class GnomeRecipes < Formula
   license "GPL-3.0-or-later"
   revision 3
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 arm64_tahoe:   "aa4f377580d2f261bf6997d22203eab2ab4a41dd25ac493c31c156712ffeebb8"

--- a/Formula/g/gnu-barcode.rb
+++ b/Formula/g/gnu-barcode.rb
@@ -6,8 +6,6 @@ class GnuBarcode < Formula
   sha256 "7c031cf3eb811242f53664379aebbdd9fae0b7b26b5e5d584c31a9f338154b64"
   license "GPL-3.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "57fbf7e1c8368b3405d771acfaff14d5f41d970681575c4e45484a8760a37a02"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "30ba34d1c972ec24c6f5ccd484585cd114456d7a6523f16f31dcf58c81089663"


### PR DESCRIPTION
#267571

Part 1 of 2 for `g*` no_autobump cleanup. Companion PR will be linked after creation. (split up to make review easier)
Companion PR (part 2): https://github.com/Homebrew/homebrew-core/pull/268730

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI assisted with candidate discovery and one-commit-per-formula patching for a subset of `g*` formulas by removing `no_autobump! because: :requires_manual_review` where livecheck/status/source checks were compatible. I manually verified and reran `brew style` and `brew audit --strict` on this subset.

-----

