### PR TITLE
g*: remove no_autobump! manual review (part 2)

### DIFF
--- a/Formula/g/gnu-complexity.rb
+++ b/Formula/g/gnu-complexity.rb
@@ -6,8 +6,6 @@ class GnuComplexity < Formula
   sha256 "80a625a87ee7c17fed02fb39482a7946fc757f10d8a4ffddc5372b4c4b739e67"
   license "GPL-3.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "edf8e7fe3a3c8d707ff63dbd5d5ef0226653cd76bf7c6d5faf077f09f1fb2b31"
     sha256 cellar: :any,                 arm64_sequoia:  "cd060b26ae921fe515fb597c86e07eb82c0cad595d8eab8547cd421db5a249e3"

--- a/Formula/g/gnu-go.rb
+++ b/Formula/g/gnu-go.rb
@@ -10,8 +10,6 @@ class GnuGo < Formula
   revision 1
   head "https://git.savannah.gnu.org/git/gnugo.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "65707404eb0034b25296dc8c9dfc0dd3ec1016b4ef97744500b702317c50b89c"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "b638af6216ed0bd736823bab2fe42ca902dd9768a69fee4009726808aeeea448"

--- a/Formula/g/gnu-prolog.rb
+++ b/Formula/g/gnu-prolog.rb
@@ -11,8 +11,6 @@ class GnuProlog < Formula
     regex(/href=.*?gprolog[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "47608f61774ab4abb61279ebad504f55aec87807f65c9399f63aeec15fae16d9"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "311488f7874b46d9e06c9499df180ab4008260935fbe5f6335eb4cb37d303f84"

--- a/Formula/g/gnu-sed.rb
+++ b/Formula/g/gnu-sed.rb
@@ -6,8 +6,6 @@ class GnuSed < Formula
   sha256 "6e226b732e1cd739464ad6862bd1a1aba42d7982922da7a53519631d24975181"
   license "GPL-3.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 3
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "48a39d1b81adb766f45db53a0f4f8e9ce8b942386c270cfcdad3fbd08cb653f9"

--- a/Formula/g/gnu-shogi.rb
+++ b/Formula/g/gnu-shogi.rb
@@ -6,8 +6,6 @@ class GnuShogi < Formula
   sha256 "1ecc48a866303c63652552b325d685e7ef5e9893244080291a61d96505d52b29"
   license "GPL-3.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "e07a2b34459c996910fb2cd8ad3302d978081ab6878330612895115f4b4dd2c2"
     sha256                               arm64_sequoia:  "af1b6d676a20358883f12095fc36af7379e69c8438cc1c3096116b0748952485"

--- a/Formula/g/gnu-smalltalk.rb
+++ b/Formula/g/gnu-smalltalk.rb
@@ -17,8 +17,6 @@ class GnuSmalltalk < Formula
     end
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 3
     sha256 arm64_tahoe:   "0b4242a4f666b10130804e15b8ac1cb06db8ca8c2dce4b3ff22809b27e3bed03"

--- a/Formula/g/gnu-tar.rb
+++ b/Formula/g/gnu-tar.rb
@@ -6,8 +6,6 @@ class GnuTar < Formula
   sha256 "14d55e32063ea9526e057fbf35fcabd53378e769787eff7919c3755b02d2b57e"
   license "GPL-3.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "4e3782b9393e2e53a1cccd9c1047c2fc43b81c34746b10755050d5d162b21269"

--- a/Formula/g/gnu-time.rb
+++ b/Formula/g/gnu-time.rb
@@ -6,8 +6,6 @@ class GnuTime < Formula
   sha256 "fbacf0c81e62429df3e33bda4cee38756604f18e01d977338e23306a3e3b521e"
   license "GPL-3.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "feac0744561e6ed40145815079575f4066bb3f8c363d1c9fc2302fde2f93b7bf"

--- a/Formula/g/gnucobol.rb
+++ b/Formula/g/gnucobol.rb
@@ -12,8 +12,6 @@ class Gnucobol < Formula
     regex(/href=.*?gnucobol[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:   "8d42fa5a5cf8b4b2a63826ffd2a4f12fa7508d7ceef895df62bfecfa306a49a1"
     sha256 arm64_sequoia: "959e8f74d52e0bdf664261059d8015cbffbed70a8c8582991a11cea5fb35fe0f"

--- a/Formula/g/gnupg@1.4.rb
+++ b/Formula/g/gnupg@1.4.rb
@@ -12,8 +12,6 @@ class GnupgAT14 < Formula
     regex(/href=.*?gnupg[._-]v?(1\.4(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 arm64_tahoe:   "4ca96fcb6e85fd587e3716a10c8aadc3117fd1055e368627efb8eb8ecbbd486f"

--- a/Formula/g/goyacc.rb
+++ b/Formula/g/goyacc.rb
@@ -6,8 +6,6 @@ class Goyacc < Formula
   license "BSD-3-Clause"
   head "https://gitlab.com/cznic/goyacc.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "c200a6f48e69a0a02aaa20cb0face2d581c44fdc868517beb5eed571074ebcc9"
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "b225608148f3a4a021cf2c97288a15a0896f98772c89f2908c8abb359ffb0138"

--- a/Formula/g/gplugin.rb
+++ b/Formula/g/gplugin.rb
@@ -12,8 +12,6 @@ class Gplugin < Formula
     url "https://sourceforge.net/projects/pidgin/rss?path=/gplugin"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 arm64_tahoe:   "1467d4fde4bc7c78346be7deb8b19f52e9156a61e8ea10b1a4fa039655b91b5d"

--- a/Formula/g/gptfdisk.rb
+++ b/Formula/g/gptfdisk.rb
@@ -5,8 +5,6 @@ class Gptfdisk < Formula
   sha256 "2abed61bc6d2b9ec498973c0440b8b804b7a72d7144069b5a9209b2ad693a282"
   license "GPL-2.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "54e5ae58037ac6fac2b63fd42b7f477699b2c42fb1b38d050950de551d670c76"
     sha256 cellar: :any,                 arm64_sequoia:  "ba4643273f140cbd13365868699724cf632eb57dd3e5557d416437f84462b0c1"

--- a/Formula/g/gputils.rb
+++ b/Formula/g/gputils.rb
@@ -10,8 +10,6 @@ class Gputils < Formula
     regex(%r{url=.*?/gputils[._-]v?(\d+(?:\.\d+)+(?:-\d+)?)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:    "2320be53fb17f6a272346de555bd3aa73422f990493a92c24e693346e334f5e8"
     sha256 arm64_sequoia:  "002f4b80984f18e0c836c7672e342110f8a1fa7f8d45572acf70610361047d61"

--- a/Formula/g/gqlplus.rb
+++ b/Formula/g/gqlplus.rb
@@ -6,8 +6,6 @@ class Gqlplus < Formula
   license "GPL-2.0-only"
   revision 2
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:   "9397a0096269caa5527b82304329ef4504f54978ed22d11dc37195f257fba161"

--- a/Formula/g/grace.rb
+++ b/Formula/g/grace.rb
@@ -11,8 +11,6 @@ class Grace < Formula
     regex(/href=.*?grace[._-]v?(\d+(?:\.\d+)+)\.orig\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:    "f930e961b7d6dd7d104e8f786247a044113ff0b7e58be16061d5a04ff4365188"
     sha256 arm64_sequoia:  "61fed352c42b6211971448d69512dd09726ef1daa1fab3f52d3ceeec048ad6d9"

--- a/Formula/g/grepcidr.rb
+++ b/Formula/g/grepcidr.rb
@@ -10,8 +10,6 @@ class Grepcidr < Formula
     regex(/href=.*?grepcidr[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "abdf37c44368707f096b0fe3d2b5bfab47418823ffc48cf5137e4efdd58670d3"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "a5eaf72370f021e79e6cc7d25139a7789fad25fdef67ce5ceaa0f69dbd655b97"

--- a/Formula/g/groff.rb
+++ b/Formula/g/groff.rb
@@ -7,8 +7,6 @@ class Groff < Formula
   license "GPL-3.0-or-later"
   revision 1
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:    "7684d4604e213bf74894799b38f98153e743c504c493d7cedff5c25109d46854"
     sha256 arm64_sequoia:  "46fa52805546514d174798f2a8723a84827c13c2c7c106e246c9ff77b43eb4cf"

--- a/Formula/g/grsync.rb
+++ b/Formula/g/grsync.rb
@@ -6,8 +6,6 @@ class Grsync < Formula
   license "GPL-2.0-only"
   revision 1
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:    "7986e7f825b1b6c2f31beadad835a38e018b215d50ec918a4c943c1449127127"
     sha256 arm64_sequoia:  "7acba4db4f6cd2ad09e1cffff1f7c0d24c46cbc611c8ed9c7e78a604b746b2cf"

--- a/Formula/g/gsar.rb
+++ b/Formula/g/gsar.rb
@@ -14,8 +14,6 @@ class Gsar < Formula
     regex(/gsar v?(\d+(?:\.\d+)+) released/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "dafb595928b7f06f2562e9dcd982cc3f4b30ed770eb6e34d56d1caf8745eda46"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "b42feea06c9d194323f2917165a2dd23e1100cd27e51194f379bbf3920c5d0ed"

--- a/Formula/g/gsasl.rb
+++ b/Formula/g/gsasl.rb
@@ -6,8 +6,6 @@ class Gsasl < Formula
   sha256 "41e8e442648eccaf6459d9ad93d4b18530b96c8eaf50e3f342532ef275eff3ba"
   license "GPL-3.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:   "1dd75fa56b2505c6edd733f8848a46dd624dba73d43df132deddc1a05c167d30"
     sha256 arm64_sequoia: "f7ec07e3b1add0e32af563452c3f8ebf2317b3acad6b6a48b029dd72491354ab"

--- a/Formula/g/gssdp.rb
+++ b/Formula/g/gssdp.rb
@@ -5,8 +5,6 @@ class Gssdp < Formula
   sha256 "ff97fdfb7f561d3e6813b4f6a2145259e7c2eff43cc0e63f3fd031d0b6266032"
   license "LGPL-2.1-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any, arm64_tahoe:   "757813a4572ec251ec2b0b5d08fac402448d7eb07e798f4ddae34beafb4dd786"
     sha256 cellar: :any, arm64_sequoia: "ebe88f533fe10a5c8bcd40124a1eba3be1fb2d7b1f519b8d52c8e5d72de9a252"

--- a/Formula/g/gtk-vnc.rb
+++ b/Formula/g/gtk-vnc.rb
@@ -13,8 +13,6 @@ class GtkVnc < Formula
     regex(/gtk-vnc[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 arm64_tahoe:   "83712dce18d0595c9f12c0a24ee58c518d944b7ac1d6fa1211dc1c73504cb351"

--- a/Formula/g/gtkdatabox.rb
+++ b/Formula/g/gtkdatabox.rb
@@ -6,8 +6,6 @@ class Gtkdatabox < Formula
   license "LGPL-2.1-or-later"
   revision 1
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "8f8e5772768a8b7e7530d36c8fb991ff76c361cdab7729e508a8e7e8c12dceec"
     sha256 cellar: :any,                 arm64_sequoia:  "5754a6b703bfc85c30adfe1f78b4f5e3416a4d9f04d9531d1c43fb584e136307"

--- a/Formula/g/gtkglext.rb
+++ b/Formula/g/gtkglext.rb
@@ -6,8 +6,6 @@ class Gtkglext < Formula
   license "LGPL-2.1-or-later"
   revision 4
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "764e97c887571389641f45ef171ca06af71ac4bc5fcaaff56e85c9d663cad92a"
     sha256 cellar: :any,                 arm64_sequoia:  "c7d1eb4cd50853e471d11db5256550eb6eea8d0b66424e66bf4662f54bbcfc64"

--- a/Formula/g/gtkmm.rb
+++ b/Formula/g/gtkmm.rb
@@ -11,8 +11,6 @@ class Gtkmm < Formula
     regex(/gtkmm[._-]v?(2\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "9dd2dd1231eb90fe70da1f8961d9bd08e3e4f471ecba0cab542e6e30afc3cdcb"
     sha256 cellar: :any,                 arm64_sequoia:  "f41c412495a1c1d336076a5fc85f4499ae4c0cb2ef25b67ec8f2474cdca0f8a0"

--- a/Formula/g/gtksourceview3.rb
+++ b/Formula/g/gtksourceview3.rb
@@ -11,8 +11,6 @@ class Gtksourceview3 < Formula
     regex(/gtksourceview[._-]v?(3\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:   "72ddfb15569484b9703111b8e49c012ef5b58ef5e13c528d7b69773e1033826e"
     sha256 arm64_sequoia: "8260f146baeaee7420598450f7c4929891722c45afd354a601c8ff1f9ee60b71"

--- a/Formula/g/gtksourceview4.rb
+++ b/Formula/g/gtksourceview4.rb
@@ -11,8 +11,6 @@ class Gtksourceview4 < Formula
     regex(/gtksourceview[._-]v?(4\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:   "cf116d257b9203f04a8c94b4a1f108d7cda39aa99204c2d676bd568e49a91d2b"
     sha256 arm64_sequoia: "140a902d39fda0c6b0d88f6999ff0f00ed82871520bc680b4e1158bcb50d26ea"

--- a/Formula/g/gtksourceviewmm3.rb
+++ b/Formula/g/gtksourceviewmm3.rb
@@ -11,8 +11,6 @@ class Gtksourceviewmm3 < Formula
     regex(/gtksourceviewmm[._-]v?(3\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "9b6d8f50cc16f92feecf432734adc4837246ba8f3fdb933b126393f6137dadc1"
     sha256 cellar: :any,                 arm64_sequoia:  "8de9f30c9a139c912211e4766370c1b2a3b4f78150a4342f6242f56581ebf3bb"

--- a/Formula/g/gtkspell3.rb
+++ b/Formula/g/gtkspell3.rb
@@ -6,8 +6,6 @@ class Gtkspell3 < Formula
   license "GPL-2.0-or-later"
   revision 4
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:    "b64eeabbec9be14150c26d9213d525edb028af2546a0a1d85ea26e55d26d3b9d"
     sha256 arm64_sequoia:  "f182f8a623b04c25479cfedab38fcc1bc4c6df7f548b7c3b1ceab211fbe16115"

--- a/Formula/g/gtmess.rb
+++ b/Formula/g/gtmess.rb
@@ -6,8 +6,6 @@ class Gtmess < Formula
   license "GPL-2.0-or-later"
   revision 2
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256                               arm64_tahoe:    "032661770161ac72df852e094fc8e45548d91740ff5f462563941972e31d374f"

--- a/Formula/g/gts.rb
+++ b/Formula/g/gts.rb
@@ -6,8 +6,6 @@ class Gts < Formula
   license "LGPL-2.0-or-later"
   revision 3
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "1a940ea785d016728373922b4b02ed3d40f3abf4da34cc29c671446eada28d59"
     sha256 cellar: :any,                 arm64_sequoia:  "b93bb9f091fbf2d25c99437f8ef0dc0e40f680fe445b968cf952d2d067417ebb"

--- a/Formula/g/gzrt.rb
+++ b/Formula/g/gzrt.rb
@@ -10,8 +10,6 @@ class Gzrt < Formula
     regex(/href=.*?gzrt[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "670cc86444773ca0a6a1b37c47b02eedb11a330d9ee4a002be567f4721dce63b"


### PR DESCRIPTION
#267571

Part 2 of 2 for `g*` no_autobump cleanup.
Companion PR (part 1): https://github.com/Homebrew/homebrew-core/pull/268729

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI assisted with candidate discovery and one-commit-per-formula patching for a subset of `g*` formulas by removing `no_autobump! because: :requires_manual_review` where livecheck/status/source checks were compatible. I manually verified and reran `brew style` and `brew audit --strict` on this subset.

-----
