### PR TITLE
node@18: use proper compiler selection

### DIFF
--- a/Formula/n/node@18.rb
+++ b/Formula/n/node@18.rb
@@ -53,8 +53,6 @@ class NodeAT18 < Formula
   end
 
   def install
-    ENV.llvm_clang if OS.mac? && (DevelopmentTools.clang_build_version <= 1100)
-
     # Fix to avoid fdopen() redefinition for vendored `zlib`
     # Too many commits to backport, so apply a workaround
     if OS.mac? && DevelopmentTools.clang_build_version >= 1700


### PR DESCRIPTION
Disabled formula, but getting rid of usage to avoid unwanted usage of ENV.llvm_clang on macOS