### PR TITLE
rustup: link completions

### DIFF
--- a/Formula/r/rustup.rb
+++ b/Formula/r/rustup.rb
@@ -37,10 +37,17 @@ class Rustup < Formula
       bin.install_symlink bin/"rustup-init" => name
     end
     generate_completions_from_executable(bin/"rustup", "completions")
+    generate_completions_from_executable(bin/"rustup", "completions", "bash", "cargo",
+                                         base_name: "cargo", shell_parameter_format: :none, shells: [:bash])
+    generate_completions_from_executable(bin/"rustup", "completions", "zsh", "cargo",
+                                         base_name: "cargo", shell_parameter_format: :none, shells: [:zsh])
   end
 
   def post_install
     (HOMEBREW_PREFIX/"bin").install_symlink bin/"rustup", bin/"rustup-init"
+    (HOMEBREW_PREFIX/"etc/bash_completion.d").install_symlink bash_completion/"rustup"
+    (HOMEBREW_PREFIX/"share/fish/vendor_completions.d").install_symlink fish_completion/"rustup.fish"
+    (HOMEBREW_PREFIX/"share/zsh/site-functions").install_symlink zsh_completion/"_rustup"
   end
 
   def caveats


### PR DESCRIPTION
The rustup formula is keg-only, so the proxy binaries aren't linked into Homebrew's prefix. But an exception is made for the `rustup` binary: `bin/"rustup"` is manually linked in the `post_install` (per #177582). We should make the same exception for `rustup`'s completions.

Additionally, since rustup can generate (stub) completions for `cargo` (per rust-lang/rustup#1646), install (but don't link) those completions, so that they're available if the user does `brew link --force rustup`.

Bump the revision so `post_install` is triggered (like #178322).

-----

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
