### PR TITLE
git-spice: upgrade to 0.24.2, account for rename

### DIFF
--- a/Formula/g/git-spice.rb
+++ b/Formula/g/git-spice.rb
@@ -1,8 +1,8 @@
 class GitSpice < Formula
   desc "Manage stacked Git branches"
   homepage "https://abhinav.github.io/git-spice/"
-  url "https://github.com/abhinav/git-spice/archive/refs/tags/v0.23.0.tar.gz"
-  sha256 "606f03bff29c6d6e78a74ff4380c5a1b0d6ccde6b8aae2725d8738adea6033d6"
+  url "https://github.com/abhinav/git-spice/archive/refs/tags/v0.24.2.tar.gz"
+  sha256 "6605166dc47b179af0d3e9714dba83254b633e78d6b0bc2189592c5067b0ccf2"
   license "GPL-3.0-or-later"
   head "https://github.com/abhinav/git-spice.git", branch: "main"
 
@@ -23,9 +23,22 @@ class GitSpice < Formula
 
   def install
     ldflags = "-s -w -X main._version=#{version}"
-    system "go", "build", *std_go_args(ldflags:, output: bin/"gs")
+    system "go", "build", *std_go_args(ldflags:, output: bin/"git-spice")
+    bin.install_symlink "git-spice" => "gs"
 
     generate_completions_from_executable(bin/"gs", "shell", "completion")
+    generate_completions_from_executable(bin/"git-spice", "shell", "completion")
+  end
+
+  def caveats
+    <<~EOS
+      The executable has been renamed to 'git-spice'.
+      To ease the transition, this release also symlinks 'gs' to 'git-spice'.
+      The symlink will be dropped in a future release.
+      If you prefer to use 'gs', add an alias to your shell configuration:
+
+        alias gs='git-spice'
+    EOS
   end
 
   test do
@@ -36,11 +49,11 @@ class GitSpice < Formula
     system "git", "add", "foo"
     system "git", "commit", "-m", "bar"
 
-    assert_match "main", shell_output("#{bin}/gs log long 2>&1")
+    assert_match "main", shell_output("#{bin}/git-spice log long 2>&1")
 
-    output = shell_output("#{bin}/gs branch create feat1 2>&1", 1)
+    output = shell_output("#{bin}/git-spice branch create feat1 2>&1", 1)
     assert_match "error: Terminal is dumb, but EDITOR unset", output
 
-    assert_match version.to_s, shell_output("#{bin}/gs --version")
+    assert_match version.to_s, shell_output("#{bin}/git-spice --version")
   end
 end

--- a/Formula/g/git-spice.rb
+++ b/Formula/g/git-spice.rb
@@ -9,12 +9,12 @@ class GitSpice < Formula
   no_autobump! because: :bumped_by_upstream
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "207df90982a246096dd229f68f90440106c068de5e23f880d1d6f650d17c1944"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "207df90982a246096dd229f68f90440106c068de5e23f880d1d6f650d17c1944"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "207df90982a246096dd229f68f90440106c068de5e23f880d1d6f650d17c1944"
-    sha256 cellar: :any_skip_relocation, sonoma:        "a9f3bbb181b1be833de8ef518fe731b12dfdab837a965187b36885a8e3df3843"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "1a4964013504d7e914bb45963f1e832173873a7512c62652b04e0473ffffd09a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c6775405c0ac27cb37f6da0fd7675412c09a9177e83a73a6e0290dfcbea9049e"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "377d48138de5d3a3d0957305cb1b52d83db9126d9d4ec3145e0fc883ba0cf96b"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "377d48138de5d3a3d0957305cb1b52d83db9126d9d4ec3145e0fc883ba0cf96b"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "377d48138de5d3a3d0957305cb1b52d83db9126d9d4ec3145e0fc883ba0cf96b"
+    sha256 cellar: :any_skip_relocation, sonoma:        "9d655c0b65bf4d3a061f7b55ae16530585eca0fc8b5d45f00255ce1355b41a07"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "de2dbe8a6bde74014878969036a97710c9f7ae34b3fcddbe0edd3bfa91c2beaf"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3a9ee526792a2ae72bf7d38728e2455d9843482481bfbe45a570ea2bb8b21c20"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
git-spice is renaming the 'gs' binary to 'git-spice'.
For backwards compatibility, the 0.24 release series
includes the binary under both names: 'git-spice' and 'gs'.
('gs' warns if used, but continues to work.)

This commit updates the formula to install both binaries
('gs' as a symlink to 'git-spice').

In a future release, we'll drop the symlink,
so this release gives users enough time to transition.

Related:

- https://github.com/abhinav/git-spice/issues/469
- https://github.com/abhinav/git-spice/releases/tag/v0.24.0
  (.1 and .2 were needed to fix packaging issues.)

---

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
