### PR TITLE
powershell 7.5.4 (new formula)

### DIFF
--- a/Formula/p/powershell.rb
+++ b/Formula/p/powershell.rb
@@ -6,6 +6,14 @@ class Powershell < Formula
       revision: "7c8d9e7e0ed2fc1f2caf50746fe9fef720ca2a0a"
   license "MIT"
 
+  bottle do
+    sha256 cellar: :any,                 arm64_tahoe:   "0f9e423fb1fee82f58b712cbd2a6fe119bf389aaec6936594579d07f566c3a80"
+    sha256 cellar: :any,                 arm64_sequoia: "9c83abf90d133412278bc76f6842bf064ddd425acb14069b91df623fe9356d3a"
+    sha256 cellar: :any,                 arm64_sonoma:  "8569cf80986498d035648ddb081436e08f83dafe40e31833e9acdf1838cf2eb1"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "0b9d273567b506ac8362df6a91f9d2012299c3e5f32cc8266299b104aceaf111"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "711a84538375f0a0746a206aa1c5f54d8affeabed704e06519f432a6ec611002"
+  end
+
   depends_on "dotnet@9"
 
   on_linux do

--- a/Formula/p/powershell.rb
+++ b/Formula/p/powershell.rb
@@ -1,0 +1,183 @@
+class Powershell < Formula
+  desc "Command-line shell and scripting language"
+  homepage "https://github.com/PowerShell/PowerShell"
+  url "https://github.com/PowerShell/PowerShell.git",
+      tag:      "v7.5.4",
+      revision: "7c8d9e7e0ed2fc1f2caf50746fe9fef720ca2a0a"
+  license "MIT"
+
+  depends_on "dotnet@9"
+
+  on_linux do
+    depends_on "openssl@3"
+  end
+
+  def install
+    dotnet = Formula["dotnet@9"]
+    ENV["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1"
+    ENV["DOTNET_CLI_HOME"] = buildpath
+    ENV["NUGET_PACKAGES"] = buildpath/".nuget/packages"
+    ENV["DOTNET_ROOT"] = dotnet.opt_libexec
+    inreplace "global.json", /"version": "\d.*"/, "\"version\": \"#{dotnet.version}\""
+
+    target_framework = "net#{dotnet.version.major_minor}"
+    dotnet_sources = [
+      "--source", "https://api.nuget.org/v3/index.json"
+    ]
+
+    dotnet_restore_flags = %w[
+      --disable-build-servers
+      --use-current-runtime
+      --nologo
+    ]
+    dotnet_publish_flags = %W[
+      --disable-build-servers
+      --nologo
+      -c Release
+      --no-self-contained
+      --use-current-runtime
+      -f #{target_framework}
+      --property:PublishReadyToRun=false
+      --property:GenerateFullPaths=true
+      --property:ErrorOnDuplicatePublishOutputFiles=false
+      --property:IsWindows=false
+    ]
+    dotnet_run_flags = %W[
+      --framework #{target_framework}
+      -c Release
+    ]
+    system "dotnet", "restore", "PowerShell.sln", *dotnet_restore_flags, *dotnet_sources
+
+    cd "src/ResGen" do
+      # Adding framework option to force out version
+      system "dotnet", "run", *dotnet_run_flags
+    end
+
+    # Build the dummy project https://github.com/PowerShell/PowerShell/blob/v7.5.4/build.psm1#L2572-L2589
+    inc_file = "powershell.inc"
+    dotnet_msbuild_flags = %W[
+      -t:_GetDependencies
+      -property:DesignTimeBuild=true;_DependencyFile=#{buildpath}/src/TypeCatalogGen/#{inc_file}
+      -nologo
+    ]
+    target_file = buildpath/"src/Microsoft.PowerShell.SDK/obj/Microsoft.PowerShell.SDK.csproj.TypeCatalog.targets"
+    target_file.dirname.mkpath
+    target_file.write <<~XML
+      <Project>
+          <Target Name="_GetDependencies"
+                  DependsOnTargets="ResolveAssemblyReferencesDesignTime">
+              <ItemGroup>
+                  <_RefAssemblyPath Include="%(_ReferencesFromRAR.OriginalItemSpec)%3B" Condition=" '%(_ReferencesFromRAR.NuGetPackageId)' != 'Microsoft.Management.Infrastructure' "/>
+              </ItemGroup>
+              <WriteLinesToFile File="$(_DependencyFile)" Lines="@(_RefAssemblyPath)" Overwrite="true" />
+          </Target>
+      </Project>
+    XML
+
+    system "dotnet", "msbuild",
+           "src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj", *dotnet_msbuild_flags
+
+    cd "src/TypeCatalogGen" do
+      system "dotnet", "run", *dotnet_run_flags,
+             "../System.Management.Automation/CoreCLR/CorePsTypeCatalog.cs", inc_file
+    end
+
+    system "dotnet", "publish", "src/powershell-unix/powershell-unix.csproj", *dotnet_publish_flags
+
+    # Dotnet RIDs use "x64" for Intel.
+    os = OS.mac? ? "osx" : "linux"
+    arch = Hardware::CPU.intel? ? "x64" : "arm64"
+    runtime = "#{os}-#{arch}"
+    publish_path = buildpath/"src/powershell-unix/bin/Release/#{target_framework}/#{runtime}/publish"
+
+    module_copy_script = buildpath/"homebrew-copy-psgallery-modules.ps1"
+    module_copy_script.write <<~PS1
+      $ErrorActionPreference = 'Stop'
+      Import-Module '#{buildpath/"build.psm1"}' -Force
+      Copy-PSGalleryModules -CsProjPath '#{buildpath/"src/Modules/PSGalleryModules.csproj"}' -Destination '#{publish_path/"Modules"}' -Force
+    PS1
+
+    # Hardcode the environment object as we dont have brew command. See https://github.com/PowerShell/PowerShell/blob/v7.5.4/build.psm1#L124-L224
+    mock_environment = <<~PS1
+      $environment = [PSCustomObject]@{
+        IsWindows = $false
+        IsLinux = "$#{OS.linux?}"
+        IsMacOS = "$#{OS.mac?}"
+      }
+    PS1
+
+    inreplace "build.psm1", /^\$environment = Get-EnvironmentInformation$/, mock_environment.chomp
+    system publish_path/"pwsh", "-NoLogo", "-NoProfile", "-File", module_copy_script
+
+    clear_native_dependencies(publish_path, runtime, dotnet)
+
+    libexec.install publish_path.glob("*")
+    (bin/"pwsh").write_env_script libexec/"pwsh",
+                                  DOTNET_ROOT: "${DOTNET_ROOT:-#{dotnet.opt_libexec}}"
+
+    man1.install buildpath/"assets/manpage/pwsh.1"
+    deuniversalize_machos libexec/"libpsl-native.dylib" if OS.mac?
+  end
+
+  # See https://github.com/PowerShell/PowerShell/blob/v7.5.4/build.psm1#L3804
+  def clear_native_dependencies(publish_path, runtime, dotnet)
+    diasym_suffix = runtime.end_with?("-x64") ? "amd64" : "arm64"
+    diasym_file = "microsoft.diasymreader.native.#{diasym_suffix}.dll"
+    deps_path = publish_path/"pwsh.deps.json"
+    deps = JSON.parse(deps_path.read)
+    target = ".NETCoreApp,Version=v#{dotnet.version.major_minor}/#{runtime}"
+
+    # Find the runtime pack for the specified target framework
+    pack = deps.dig("targets", target)&.keys&.find { |k| k.start_with?("runtimepack.Microsoft.NETCore.App.Runtime") }
+    deps.dig("targets", target, pack, "native")&.delete(diasym_file)
+
+    # Replace place the dependency file with the clean one
+    rm deps_path
+    deps_path.write(JSON.pretty_generate(deps))
+    rm publish_path/diasym_file, force: true
+  end
+
+  def caveats
+    <<~EOS
+      CurrentUser configs are at:
+        ~/.local/share/powershell/
+      CurrentUserAllHosts configs are at:
+        ~/.config/powershell/
+
+      To use Homebrew in PowerShell, run:
+        New-Item -Path (Split-Path -Parent -Path $PROFILE.CurrentUserAllHosts) -ItemType Directory -Force
+        Add-Content -Path $PROFILE.CurrentUserAllHosts -Value '$(#{HOMEBREW_PREFIX}/bin/brew shellenv) | Invoke-Expression'
+
+      To add Homebrew pwsh completions see: https://docs.brew.sh/Shell-Completion#configuring-completions-in-pwsh
+    EOS
+  end
+
+  test do
+    version_output = shell_output("#{bin}/pwsh -NoLogo -NoProfile -c '$PSVersionTable.PSVersion.ToString()'").chomp
+    pwsh_version_output = shell_output("#{bin}/pwsh -Version")
+    assert_equal version.to_s, version_output
+    assert_match version_output, pwsh_version_output
+
+    pipeline_output = shell_output("#{bin}/pwsh -NoLogo -NoProfile -c '(6..7 | Measure-Object -Sum).Sum'").chomp
+    assert_equal "13", pipeline_output
+
+    local_module = testpath/"HomebrewDemo.psm1"
+
+    local_module.write <<~PS1
+      function Get-HomebrewDemo {
+        $PSHOME
+      }
+      Export-ModuleMember -Function Get-HomebrewDemo
+    PS1
+
+    local_module_output = shell_output(
+      "#{bin}/pwsh -NoLogo -NoProfile -c 'Import-Module \"#{local_module}\"; Get-HomebrewDemo'",
+    ).chomp
+
+    assert_equal libexec.to_s, local_module_output
+
+    module_cmd = "Import-Module PowerShellGet; [bool](Get-Command Install-Module )"
+    module_output = shell_output("#{bin}/pwsh -NoLogo -NoProfile -c '#{module_cmd}'").lines.last.chomp
+    assert_equal "True", module_output
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`? -- **No because there already exists a cask with the same name. See below**

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
Ok, this needs an explanation:

Yes, PowerShell is already present as a Cask, but there are a few issues with that:
1. Microsoft doesn't bother to fix their code signing, i.e. the Cask will soon be removed, which indeed is a bit embarrassing for such a company.... (https://github.com/PowerShell/PowerShell/issues/26061)
2. Programs that require PowerShell to build, or just depend on it, can’t be published as a formula because formulae can’t depend on casks. 
3. Linux users can’t install PowerShell as casks are macOS only.

Also not to mention that powershell cask has the 2nd most install events in the past 90 days, which is huge.

I fully understand that this requires more work than creating the formula itself, like coordinating the removal of the PowerShell Cask once this gets approved. 


