### PR TITLE
node@22: Update `fails_with :clang` build version

### DIFF
--- a/Formula/n/node@22.rb
+++ b/Formula/n/node@22.rb
@@ -45,7 +45,7 @@ class NodeAT22 < Formula
   uses_from_macos "python"
 
   on_macos do
-    depends_on "llvm" => :build if DevelopmentTools.clang_build_version <= 1100
+    depends_on "llvm" => :build if DevelopmentTools.clang_build_version <= 1400
   end
 
   on_linux do
@@ -53,9 +53,14 @@ class NodeAT22 < Formula
   end
 
   fails_with :clang do
-    build 1100
+    build 1400
     cause <<~EOS
-      error: calling a private constructor of class 'v8::internal::(anonymous namespace)::RegExpParserImpl<uint8_t>'
+      In file included from ../src/inspector_profiler.h:
+      /usr/local/opt/simdjson/include/simdjson.h:
+
+      error: no member named 'input_range' in namespace 'std::ranges'
+
+      (since C++20) https://en.cppreference.com/w/cpp/ranges/input_range.html
     EOS
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

I noticed that this `fails_with` clause is outdated, by trying to build `node@22` on macOS Monterey (Xcode/CLT 14), which failed due to a header using C++20 stuff being #include'd.

(Officially, Node.js 22 LTS [aims to be buildable with Xcode >= 13](https://github.com/nodejs/node/blob/v22.x/BUILDING.md#macos-prerequisites), but obviously Homebrew is not obligated to build it in the same way, with the vendored older `simdjson`)
