### PR TITLE
reef 0.3.0 (new formula)

### DIFF
--- a/Formula/r/reef.rb
+++ b/Formula/r/reef.rb
@@ -1,0 +1,38 @@
+class Reef < Formula
+  desc "Bash compatibility layer for fish shell"
+  homepage "https://github.com/ZStud/reef"
+  url "https://github.com/ZStud/reef/archive/refs/tags/v0.3.0.tar.gz"
+  sha256 "316607217c85ca173cf3e3ce8a8a64978421d1f813e922f243673d587530acdf"
+  license "MIT"
+  head "https://github.com/ZStud/reef.git", branch: "main"
+
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
+  depends_on "rust" => :build
+  depends_on "fish"
+
+  def install
+    system "cargo", "install", *std_cargo_args
+
+    # Fish functions
+    (share/"fish/vendor_functions.d").install "fish/functions/export.fish"
+    (share/"fish/vendor_functions.d").install "fish/functions/unset.fish"
+    (share/"fish/vendor_functions.d").install "fish/functions/declare.fish"
+    (share/"fish/vendor_functions.d").install "fish/functions/local.fish"
+    (share/"fish/vendor_functions.d").install "fish/functions/readonly.fish"
+    (share/"fish/vendor_functions.d").install "fish/functions/shopt.fish"
+    (share/"fish/vendor_functions.d").install "fish/functions/fish_command_not_found.fish"
+
+    # conf.d
+    (share/"fish/vendor_conf.d").install "fish/conf.d/reef.fish"
+  end
+
+  test do
+    assert_match "reef #{version}", shell_output("#{bin}/reef --version")
+    system bin/"reef", "detect", "--", "export FOO=bar"
+    assert_equal "set -gx FOO bar", shell_output("#{bin}/reef translate -- 'export FOO=bar'").strip
+  end
+end


### PR DESCRIPTION
## Description

Add [reef](https://github.com/ZStud/reef) — a bash compatibility layer for fish shell.

Reef makes bash syntax work seamlessly inside fish. No prefix commands, no mode switching, no learning curve. You type bash — fish runs it. It uses a custom zero-copy Rust parser for AST translation with bash passthrough fallback.

- **Binary:** ~490KB, zero dependencies, LTO + strip
- **Tests:** 498 unit tests + 5 doc tests
- **License:** MIT
- **Published on:** crates.io (`reef-shell`), AUR, Nix flake, Copr, PPA

### Features
- Tier 1: keyword wrappers (`export`, `unset`, `source`) — <0.1ms
- Tier 2: AST translation (loops, conditionals, arithmetic, parameter expansion) — ~0.4ms
- Tier 3: bash passthrough with env diffing — ~1.6ms
- Persistence modes for cross-command bash state
- Confirm mode for previewing translations

### Test
```
brew install --build-from-source reef
reef --version
reef detect -- "export FOO=bar"
reef translate -- "export FOO=bar"
```