### PR TITLE
rpiboot 20250908-162618 (new formula)

### DIFF
--- a/Formula/r/rpiboot.rb
+++ b/Formula/r/rpiboot.rb
@@ -1,0 +1,36 @@
+class Rpiboot < Formula
+  desc "Raspberry Pi USB boot tool for Compute Modules"
+  homepage "https://github.com/raspberrypi/usbboot"
+  url "https://github.com/raspberrypi/usbboot.git",
+      tag:      "20250908-162618",
+      revision: "d90eab5130c4fe4a6d92699e5268c1956f46939c"
+  license "Apache-2.0"
+  head "https://github.com/raspberrypi/usbboot.git", branch: "master"
+
+  livecheck do
+    url :stable
+    regex(/^(\d{8}-\d{6})$/i)
+  end
+
+  depends_on "pkgconf" => :build
+  depends_on "libusb"
+
+  uses_from_macos "vim" => :build # for xxd
+
+  def install
+    bin.mkpath
+    system "make", "install", "INSTALL_PREFIX=#{prefix}"
+  end
+
+  def caveats
+    <<~EOS
+      To boot a Compute Module with the default mass storage gadget:
+        sudo rpiboot -d "$(brew --prefix rpiboot)"/share/rpiboot/mass-storage-gadget64
+    EOS
+  end
+
+  test do
+    assert_match "RPIBOOT: build-date", shell_output("#{bin}/rpiboot --version")
+    assert_match "Usage: rpiboot", shell_output("#{bin}/rpiboot --help")
+  end
+end

--- a/Formula/r/rpiboot.rb
+++ b/Formula/r/rpiboot.rb
@@ -12,6 +12,15 @@ class Rpiboot < Formula
     regex(/^(\d{8}-\d{6})$/i)
   end
 
+  bottle do
+    sha256 arm64_tahoe:   "31cb9beee0a7ec2286049723c054e8db04f54adbad073b51566ec967bda97149"
+    sha256 arm64_sequoia: "f7a90ea74346f3e711f948d047edf2e2cd824f85e8ca0b4c7a7097d863942779"
+    sha256 arm64_sonoma:  "c66e0d7c224d8a185dbec4b96b2a54971d9c4d3acc5ccfce9d7e057bae0463c0"
+    sha256 sonoma:        "beca79fd2907f5c3a5a220d19d729d501c8ebaf3e61d4ad3939ebe903399d481"
+    sha256 arm64_linux:   "d46d84f2dca76f09f8a12511e76625f8c8a20e27301300b0432b7c1dd90b68d2"
+    sha256 x86_64_linux:  "2523c3dbff24ee0d324180c581a9b57ba8d718da4cbcc385fe536d898bc06a86"
+  end
+
   depends_on "pkgconf" => :build
   depends_on "libusb"
 

--- a/audit_exceptions/mismatched_binary_allowlist.json
+++ b/audit_exceptions/mismatched_binary_allowlist.json
@@ -11,5 +11,6 @@
   "preevy": "libexec/lib/node_modules/preevy/node_modules/@preevy/compose-tunnel-agent/out/*.node",
   "prestodb": "libexec/bin/procname/Linux-*/libprocname.so",
   "qemu": "share/qemu/*",
+  "rpiboot": "share/rpiboot/msd/start.elf",
   "x86_64-elf-grub": "lib/x86_64-elf/grub/i386-pc/*"
 }


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

> The `rpiboot` tool provides a file server for loading software into memory on a Raspberry Pi for provisioning. By default, it boots the device with firmware that makes it appear to the host as a USB mass-storage device. The host operating system then treats it as a standard USB drive, allowing the filesystem to be accessed. An operating system image can be written to the device using the [Raspberry Pi Imager](https://www.raspberrypi.com/software/).

> On Compute Module 4 and newer devices, rpiboot is also used to update the bootloader SPI flash EEPROM.

I successfully flashed a Compute Module from macOS with the built tool.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

I instructed Claude Code (Opus 4.6) to produce the formula given the `rpiboot` repository and the Formula Cookbook. I also gave it access to a container runtime in order to test the tool under Linuxbrew.

I reviewed the formula and iterated on it to simplify it. (The agent overly complicated things like copying specific files when `make install` would do it automatically, and struggled with building the `bin2c` utility that is a fallback for not having `xxd` on the host.) I also added the `caveat` myself, in order to hint to the user that the firmware they want to install is found under the formula's install prefix. 