### PR TITLE
mmtui 0.1.4 (new formula)

### DIFF
--- a/Formula/m/mmtui.rb
+++ b/Formula/m/mmtui.rb
@@ -1,8 +1,8 @@
 class Mmtui < Formula
   desc "Terminal user interface for NCAA March Madness brackets"
   homepage "https://github.com/holynakamoto/mmtui"
-  url "https://github.com/holynakamoto/mmtui/archive/refs/tags/v0.1.1.tar.gz"
-  sha256 "ea401fb0adc4ca4ceec55eecbc27f711896b515c8a1d9d140ad8f88c1f90fe98"
+  url "https://github.com/holynakamoto/mmtui/archive/refs/tags/v0.1.2.tar.gz"
+  sha256 "acb68435bc5ed32150976e9ad93c4100379421b10a9c883d0c717aa51079174c"
   license "MIT"
 
   depends_on "rust" => :build

--- a/Formula/m/mmtui.rb
+++ b/Formula/m/mmtui.rb
@@ -1,0 +1,17 @@
+class Mmtui < Formula
+  desc "Terminal user interface for NCAA March Madness brackets"
+  homepage "https://github.com/holynakamoto/mmtui"
+  url "https://github.com/holynakamoto/mmtui/archive/refs/tags/v0.1.0.tar.gz"
+  sha256 "9a67c83133f86d036cc7e98c0f961aa3a490bc8cc72ae8964087a3259adcd9d7"
+  license "MIT"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args(path: ".")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/mmtui --version")
+  end
+end

--- a/Formula/m/mmtui.rb
+++ b/Formula/m/mmtui.rb
@@ -1,8 +1,8 @@
 class Mmtui < Formula
   desc "Terminal user interface for NCAA March Madness brackets"
   homepage "https://github.com/holynakamoto/mmtui"
-  url "https://github.com/holynakamoto/mmtui/archive/refs/tags/v0.1.2.tar.gz"
-  sha256 "acb68435bc5ed32150976e9ad93c4100379421b10a9c883d0c717aa51079174c"
+  url "https://github.com/holynakamoto/mmtui/archive/refs/tags/v0.1.3.tar.gz"
+  sha256 "b318b8979ea29183408dc3aed93377db9c7121d8f34e71f31fbfbaf2b0f028fc"
   license "MIT"
 
   depends_on "rust" => :build

--- a/Formula/m/mmtui.rb
+++ b/Formula/m/mmtui.rb
@@ -1,8 +1,8 @@
 class Mmtui < Formula
   desc "Terminal user interface for NCAA March Madness brackets"
   homepage "https://github.com/holynakamoto/mmtui"
-  url "https://github.com/holynakamoto/mmtui/archive/refs/tags/v0.1.0.tar.gz"
-  sha256 "9a67c83133f86d036cc7e98c0f961aa3a490bc8cc72ae8964087a3259adcd9d7"
+  url "https://github.com/holynakamoto/mmtui/archive/refs/tags/v0.1.1.tar.gz"
+  sha256 "ea401fb0adc4ca4ceec55eecbc27f711896b515c8a1d9d140ad8f88c1f90fe98"
   license "MIT"
 
   depends_on "rust" => :build

--- a/Formula/m/mmtui.rb
+++ b/Formula/m/mmtui.rb
@@ -1,8 +1,8 @@
 class Mmtui < Formula
   desc "Terminal user interface for NCAA March Madness brackets"
   homepage "https://github.com/holynakamoto/mmtui"
-  url "https://github.com/holynakamoto/mmtui/archive/refs/tags/v0.1.3.tar.gz"
-  sha256 "b318b8979ea29183408dc3aed93377db9c7121d8f34e71f31fbfbaf2b0f028fc"
+  url "https://github.com/holynakamoto/mmtui/archive/refs/tags/v0.1.4.tar.gz"
+  sha256 "cb2966ae8ad79d28d390ae0fc9ed9dc45bc0aa34889d783cd3b099e2a76bf6ae"
   license "MIT"
 
   depends_on "rust" => :build


### PR DESCRIPTION
Adds a new formula for `mmtui` (v0.1.4), a terminal UI for NCAA March Madness brackets.

- Source tarball: https://github.com/holynakamoto/mmtui/archive/refs/tags/v0.1.4.tar.gz
- SHA256: cb2966ae8ad79d28d390ae0fc9ed9dc45bc0aa34889d783cd3b099e2a76bf6ae
- License: MIT

`cargo install` is used in `install`, and the test verifies `mmtui --version` matches the formula version.