### PR TITLE
apktool: prevent build on arm64 linux

### DIFF
--- a/Formula/a/apktool.rb
+++ b/Formula/a/apktool.rb
@@ -11,6 +11,10 @@ class Apktool < Formula
 
   depends_on "openjdk"
 
+  on_linux do
+    depends_on arch: :x86_64 # aapt2 is not supported on arm64 linux
+  end
+
   def install
     libexec.install "apktool_#{version}.jar"
     bin.write_jar_script libexec/"apktool_#{version}.jar", "apktool"

--- a/Formula/a/apktool.rb
+++ b/Formula/a/apktool.rb
@@ -1,8 +1,8 @@
 class Apktool < Formula
   desc "Tool for reverse engineering 3rd party, closed, binary Android apps"
   homepage "https://github.com/iBotPeaches/Apktool"
-  url "https://github.com/iBotPeaches/Apktool/releases/download/v2.12.1/apktool_2.12.1.jar"
-  sha256 "66cf4524a4a45a7f56567d08b2c9b6ec237bcdd78cee69fd4a59c8a0243aeafa"
+  url "https://github.com/iBotPeaches/Apktool/releases/download/v3.0.1/apktool_3.0.1.jar"
+  sha256 "b947b945b4bc455609ba768d071b64d9e63834079898dbaae15b67bf03bcd362"
   license "Apache-2.0"
 
   bottle do
@@ -18,13 +18,14 @@ class Apktool < Formula
 
   test do
     resource "homebrew-test.apk" do
-      url "https://raw.githubusercontent.com/facebook/redex/fa32d542d4074dbd485584413d69ea0c9c3cbc98/test/instr/redex-test.apk"
-      sha256 "7851cf2a15230ea6ff076639c2273bc4ca4c3d81917d2e13c05edcc4d537cc04"
+      url "https://raw.githubusercontent.com/iBotPeaches/Apktool/v3.0.1/brut.apktool/apktool-lib/src/test/resources/issue1157/issue1157.apk"
+      sha256 "b3159fd172d39c6b73d1c0f18e31ceeaf1fe25c638e8946eb1a9af9432e1fd24"
     end
 
     resource("homebrew-test.apk").stage do
-      system bin/"apktool", "d", "redex-test.apk"
-      system bin/"apktool", "b", "redex-test"
+      system bin/"apktool", "d", "issue1157.apk"
+      system bin/"apktool", "b", "issue1157"
+      assert_path_exists "issue1157/dist/issue1157.apk"
     end
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

I believe this is right way to restrict a formula to a specific architecture.