### PR TITLE
asccli 0.1.3 (new formula)

### DIFF
--- a/Formula/a/asccli.rb
+++ b/Formula/a/asccli.rb
@@ -1,0 +1,26 @@
+# typed: false
+# frozen_string_literal: true
+
+class Asccli < Formula
+  desc "App Store Connect CLI to manage apps, versions, and screenshots"
+  homepage "https://github.com/tddworks/asc-cli"
+  url "https://github.com/tddworks/asc-cli/archive/refs/tags/v0.1.3.tar.gz"
+  sha256 "37b73ccda07ddf0d81842e5ec75f6c83c025aa0f6a0b04cdf1c27fc144b54c81"
+  license "MIT"
+
+  depends_on xcode: ["26.0", :build]
+  depends_on macos: :sequoia
+
+  uses_from_macos "swift" => :build
+
+  def install
+    inreplace "Sources/ASCCommand/ASC.swift", '"0.1.0"', %Q("#{version}")
+    inreplace "Sources/ASCCommand/Commands/Version/VersionCommand.swift", '"asc 0.1.0"', %Q("asc #{version}")
+    system "swift", "build", "--disable-sandbox", "-c", "release"
+    bin.install ".build/release/asc" => "asccli"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/asccli --version")
+  end
+end


### PR DESCRIPTION
## Description

`asccli` is an App Store Connect CLI tool that manages apps, versions, localizations, screenshots, and TestFlight from the terminal. It is designed agent-first — every response includes affordances (ready-to-run commands) so AI agents can navigate the App Store Connect API without knowing the full command tree.

- **Homepage**: https://github.com/tddworks/asc-cli
- **License**: MIT
- **Language**: Swift (builds with `swift build`)

## Checklist

- [x] `brew install --build-from-source asccli` works
- [x] `brew test asccli` passes
- [x] `brew audit --strict asccli` passes with 0 errors
- [x] Formula is in `Formula/a/asccli.rb` with class `Asccli`
- [x] No conflict with existing `asc` formula (different project, different binary name)

## Notes

- The binary is installed as `asccli` (renamed from `asc`) to avoid conflicts with the existing `asc` formula in homebrew-core
- Requires Xcode 16.3+ for Swift 6.2 tools version
- Uses `inreplace` to inject the correct version string at build time (the upstream project hardcodes the version; a fix has been submitted upstream)

🤖 Generated with [Claude Code](https://claude.com/claude-code)