### PR TITLE
hashnet-mcp 1.0.24 (new formula)

### DIFF
--- a/Formula/h/hashnet-mcp.rb
+++ b/Formula/h/hashnet-mcp.rb
@@ -1,0 +1,19 @@
+class HashnetMcp < Formula
+  desc "Hashgraph Online MCP server for agent discovery and chat"
+  homepage "https://github.com/hashgraph-online/hashnet-mcp-js"
+  url "https://registry.npmjs.org/@hol-org/hashnet-mcp/-/hashnet-mcp-1.0.24.tgz"
+  sha256 "1a10936dbbd9e715f0b5b3596b17a00d8cf74924cde5965f792b390c91aad9a1"
+  license "Apache-2.0"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink libexec.glob("bin/*")
+  end
+
+  test do
+    output = shell_output("#{bin}/hashnet-mcp up --help")
+    assert_match "Usage: npx @hol-org/hashnet-mcp up [options]", output
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [formula cookbook](https://docs.brew.sh/Formula-Cookbook)?
- [x] Have you run `brew audit --new --strict --online hashnet-mcp` (where applicable)?
- [x] Have you run `brew style --fix` (where applicable)?

---

Adds a new formula for `hashnet-mcp`, the Hashgraph Online MCP server CLI distributed on npm.

Source:
- https://github.com/hashgraph-online/hashnet-mcp-js
- https://registry.npmjs.org/@hol-org/hashnet-mcp/-/hashnet-mcp-1.0.24.tgz

Validation run locally:
- `brew style Formula/h/hashnet-mcp.rb`
- `brew audit --new --strict --online hashnet-mcp` (attempted; local tap resolution blocked before formula lookup)
