### PR TITLE
hol-registry 1.5.2 (new formula)

### DIFF
--- a/Formula/h/hol-registry.rb
+++ b/Formula/h/hol-registry.rb
@@ -13,7 +13,21 @@ class HolRegistry < Formula
   end
 
   test do
-    output = shell_output("#{bin}/hol-registry --help")
-    assert_match "HOL Registry CLI - Universal Agent Discovery & Chat", output
+    skill_dir = testpath/"demo-skill"
+    system bin/"hol-registry", "skills", "init",
+           "--dir", skill_dir,
+           "--name", "demo-skill",
+           "--version", "0.1.0",
+           "--description", "Demo skill"
+
+    assert_path_exists skill_dir/"skill.json"
+    assert_path_exists skill_dir/"SKILL.md"
+
+    manifest = (skill_dir/"skill.json").read
+    assert_match "\"name\": \"demo-skill\"", manifest
+    assert_match "\"version\": \"0.1.0\"", manifest
+
+    lint_output = shell_output("#{bin}/hol-registry skills lint --dir #{skill_dir} --json")
+    assert_match "\"ok\": true", lint_output
   end
 end

--- a/Formula/h/hol-registry.rb
+++ b/Formula/h/hol-registry.rb
@@ -1,0 +1,19 @@
+class HolRegistry < Formula
+  desc "CLI for searching, resolving, and chatting with HOL registry agents"
+  homepage "https://github.com/hashgraph-online/registry-broker-skills"
+  url "https://registry.npmjs.org/@hol-org/registry/-/registry-1.5.2.tgz"
+  sha256 "094751f72a00bf9460e913776c7cc3d1823a75a6de342cdc13548c14cfa76c87"
+  license "Apache-2.0"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink libexec.glob("bin/*")
+  end
+
+  test do
+    output = shell_output("#{bin}/hol-registry --help")
+    assert_match "HOL Registry CLI - Universal Agent Discovery & Chat", output
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [formula cookbook](https://docs.brew.sh/Formula-Cookbook)?
- [x] Have you run `brew audit --new --strict --online hol-registry` (where applicable)?
- [x] Have you run `brew style --fix` (where applicable)?

---

Adds a new formula for `hol-registry`, the Hashgraph Online Registry Broker CLI distributed on npm.

Source:
- https://github.com/hashgraph-online/registry-broker-skills
- https://registry.npmjs.org/@hol-org/registry/-/registry-1.5.2.tgz

Validation run locally:
- `brew style Formula/h/hol-registry.rb`
- `brew audit --new --strict --online hol-registry` (attempted; local formula lookup unavailable before submission)
