### PR TITLE
mesa: Enable KosmicKrisp on Sequoia

### DIFF
--- a/Formula/m/mesa.rb
+++ b/Formula/m/mesa.rb
@@ -147,7 +147,7 @@ class Mesa < Formula
       # Work around .../rusticl_system_bindings.h:1:10: fatal error: 'stdio.h' file not found
       ENV["SDKROOT"] = MacOS.sdk_for_formula(self).path
 
-      vulkan_drivers = (MacOS.version >= :tahoe) ? "kosmickrisp,swrast" : "swrast"
+      vulkan_drivers = (MacOS.version >= :sequoia) ? "kosmickrisp,swrast" : "swrast"
 
       %W[
         -Dgallium-drivers=llvmpipe,zink

--- a/Formula/m/mesa.rb
+++ b/Formula/m/mesa.rb
@@ -24,12 +24,13 @@ class Mesa < Formula
   head "https://gitlab.freedesktop.org/mesa/mesa.git", branch: "main"
 
   bottle do
-    sha256 arm64_tahoe:   "4eab1c854a97820840cdd11ef60522b15dcf2edf3acc64a8b40545607131bc87"
-    sha256 arm64_sequoia: "487eec9596e1dbd9ae8e65159bc0760894198dae8c71cf9d999287d03d74856a"
-    sha256 arm64_sonoma:  "f2b606ed629d054b113fc52b5162afe444c2e57ede9270c3fb80d69a73faf0d6"
-    sha256 sonoma:        "9bf88bff4f5ab94d5ec388eff97384f635d2200ea2e2682441d8314f98f44518"
-    sha256 arm64_linux:   "064ba76531c7ac86d5907bbe8e339c7457b5e6d7979471218674927d8ff5ea7d"
-    sha256 x86_64_linux:  "c1adac3c86df08b7239011b6eeccfad47f43a272af9620586bb68bf2b26de19a"
+    rebuild 1
+    sha256 arm64_tahoe:   "2b05b7ced44e18a006010b51a6e47ad57f8949d11e45cab7918928b99a6f8f85"
+    sha256 arm64_sequoia: "59c5838911d78e636432bdb621c48645e5e2151e38d01876e6b587acddde093e"
+    sha256 arm64_sonoma:  "ba04c52223da71b18ae1ab201bcea875f9d9089aa14a8819af190a3570eb320c"
+    sha256 sonoma:        "4fbbd4b0c94bf21ef0e68ebff19f9357af0ab1a9737deaecbba3d62a4c33a642"
+    sha256 arm64_linux:   "087333d0e60aac638f9d1b2bcd90ff586a0fedad6be4cd633239b4c00c43b322"
+    sha256 x86_64_linux:  "9322ab452c1c1d2279929e6448b06a0bfb42409c287e0787bd7d959ffee493b9"
   end
 
   depends_on "bindgen" => :build


### PR DESCRIPTION
KosmicKrisp "officially" only supports Tahoe but does compile and work on Sequoia, for now. (tested with vkcube, and some Switch emulators). Sonoma and below are no longer supported per Aitor of LunarG.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ x Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
