### PR TITLE
apache-arrow: revision bump to use `llvm@21`

### DIFF
--- a/Formula/a/apache-arrow.rb
+++ b/Formula/a/apache-arrow.rb
@@ -9,12 +9,12 @@ class ApacheArrow < Formula
   head "https://github.com/apache/arrow.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any, arm64_tahoe:   "06690602b06dae05b84feb5bf35cb6697cbde007650a31d094641c0fdd663525"
-    sha256 cellar: :any, arm64_sequoia: "c50dea4c901425c183cf9ed123d6ed8a4ed494cd36a97899ae639f633254cefd"
-    sha256 cellar: :any, arm64_sonoma:  "301baba08481b8802f23d06c583e9acec3505b51ba2f6467d38b856fdae04a1a"
-    sha256 cellar: :any, sonoma:        "d488dd1183d6011ccd01bcbdc420a7d6e3cf8d9be659fabafa92de049ce53eeb"
-    sha256               arm64_linux:   "c9fa9dc9798ac1fb6b1f9e8dbf2ffe65a681f1eb4fb8d6c5e06d7216e6352bf2"
-    sha256               x86_64_linux:  "3da8ad666d51d5f8918471b540cddf8f434e002f06c82cbf8d5a42a5aa669edf"
+    sha256 cellar: :any, arm64_tahoe:   "c22fe0f6233b8249ad8d2ac9e6f792c11715a2b8f700dc32e814becc3a744179"
+    sha256 cellar: :any, arm64_sequoia: "3b53a0644996494587816b18e02a2ac271cf4fc87a970d4f2311278cf2aab500"
+    sha256 cellar: :any, arm64_sonoma:  "d8c6e62c238cfa860c5aad35fba9bf54ed52f8e78b1626956d75e3e67831811c"
+    sha256 cellar: :any, sonoma:        "00cc969a7b4d564589ced87afeda6b5dd2372ed6690eeb9c33dd29105a22b7ec"
+    sha256               arm64_linux:   "086fcd6489fbdb87210c0f839eedab7b14626f8987aa3db36e6f65360b2c24fb"
+    sha256               x86_64_linux:  "8c3e2221229b0b4bcd178b8716beb753eca9dae02262859bf6dda846c83d920b"
   end
 
   depends_on "boost" => :build

--- a/Formula/a/apache-arrow.rb
+++ b/Formula/a/apache-arrow.rb
@@ -5,6 +5,7 @@ class ApacheArrow < Formula
   mirror "https://archive.apache.org/dist/arrow/arrow-23.0.1/apache-arrow-23.0.1.tar.gz"
   sha256 "bd09adb4feac11fe49d1604f296618866702be610c86e2d513b561d877de6b18"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/apache/arrow.git", branch: "main"
 
   bottle do
@@ -26,7 +27,7 @@ class ApacheArrow < Formula
   depends_on "aws-sdk-cpp"
   depends_on "brotli"
   depends_on "grpc"
-  depends_on "llvm"
+  depends_on "llvm@21"
   depends_on "lz4"
   depends_on "openssl@3"
   depends_on "protobuf"
@@ -47,7 +48,7 @@ class ApacheArrow < Formula
     # We set `ARROW_ORC=OFF` because it fails to build with Protobuf 27.0
     args = %W[
       -DCMAKE_INSTALL_RPATH=#{rpath}
-      -DLLVM_ROOT=#{Formula["llvm"].opt_prefix}
+      -DLLVM_ROOT=#{Formula["llvm@21"].opt_prefix}
       -DARROW_DEPENDENCY_SOURCE=SYSTEM
       -DARROW_ACERO=ON
       -DARROW_COMPUTE=ON

--- a/Formula/a/aws-sdk-cpp.rb
+++ b/Formula/a/aws-sdk-cpp.rb
@@ -20,12 +20,13 @@ class AwsSdkCpp < Formula
   end
 
   bottle do
-    sha256                               arm64_tahoe:   "849dd3096032b267a151db934f3364d52f0012cc030e58528718848770476996"
-    sha256                               arm64_sequoia: "dc0eb3f3284afeac68c2b1232086dc40f74341a37699ad16a9afa86871cfe5be"
-    sha256                               arm64_sonoma:  "392f755022f2f2c115b5e9735e80c5f3580b4f09c3847651a4bef3a3a51007cb"
-    sha256 cellar: :any,                 sonoma:        "a5a348a2b4dd2220f0a7770bc99204727db14e2f81a31c795eac4bee6e99081d"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "3012d980d9a14dec06a8cd8bbba281a0869b7954995d6c0e6b24e6f21986d535"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "dfd771f0434b98b50e2f4976c36e93d0bb0242e02947701360411a1485e4dca8"
+    rebuild 1
+    sha256                               arm64_tahoe:   "bf22d8e6396b6f3fb60be214207e84e0c5b80b11bd3525b600a5c62fe261785a"
+    sha256                               arm64_sequoia: "9bf737ddb7b2adc41765db96251589ef72284e56ef7008b5e986c64082b9db36"
+    sha256                               arm64_sonoma:  "66c2d06aec56ba3ea073212bdb1130bfa0bf1ec2e9b7815428a3b5f3c0331871"
+    sha256 cellar: :any,                 sonoma:        "b738f5bb473c0d2b4fde59d0f871337845b519563821715e86d7b698c934a3c0"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "43e1b495c8fead310585c3b44ddc25b890853034102c6987c86350a77061a4f0"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3bc3bacedc9060ade38b5d33dab97dfc38b4cbe15d8d3897971ee61c07e3b260"
   end
 
   depends_on "cmake" => :build

--- a/Formula/a/aws-sdk-cpp.rb
+++ b/Formula/a/aws-sdk-cpp.rb
@@ -1,10 +1,19 @@
 class AwsSdkCpp < Formula
   desc "AWS SDK for C++"
   homepage "https://github.com/aws/aws-sdk-cpp"
-  url "https://github.com/aws/aws-sdk-cpp/archive/refs/tags/1.11.750.tar.gz"
-  sha256 "053d1f9a166e1614bef2691d652c800e5a0546f6fdf7676047ae62fb2ee12b64"
   license "Apache-2.0"
   head "https://github.com/aws/aws-sdk-cpp.git", branch: "main"
+
+  stable do
+    url "https://github.com/aws/aws-sdk-cpp/archive/refs/tags/1.11.750.tar.gz"
+    sha256 "053d1f9a166e1614bef2691d652c800e5a0546f6fdf7676047ae62fb2ee12b64"
+
+    # Backport fix for missing headers
+    patch do
+      url "https://github.com/aws/aws-sdk-cpp/commit/175e80312cba3d2aa8d6ac0069d2a19161b1f273.patch?full_index=1"
+      sha256 "e30e650e724023a852b6f7169babb5d323c3de85e75394cfc02bd10650167df9"
+    end
+  end
 
   livecheck do
     throttle 15


### PR DESCRIPTION
Same downgrade as usual since Apache Arrow restricts LLVM versions.
- https://github.com/apache/arrow/blob/main/cpp/CMakeLists.txt#L179-L195

New LLVM support is usually introduced in major releases.

---

In future, may try splitting out Gandiva given that is only reason this has an LLVM dependency so may be better to make it "optional" by shipping in separate formula. 