### PR TITLE
h*: remove no_autobump! manual review

### DIFF
--- a/Formula/h/halibut.rb
+++ b/Formula/h/halibut.rb
@@ -11,8 +11,6 @@ class Halibut < Formula
     regex(/href=.*?halibut[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "f11db8dba2812df50997b9282d74a8b2d8c7a3e24ebc7aa51169d1f958e51506"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "f9fc41c88b7b3b7d2cc9ae9160316ea794a4316e1ed217c3dca842324cdbff54"

--- a/Formula/h/harbour.rb
+++ b/Formula/h/harbour.rb
@@ -20,8 +20,6 @@ class Harbour < Formula
     regex(%r{url=.*?/harbour[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any,                 arm64_tahoe:   "06c136368fdf19cd9b6a627930406bd96d06c82a60beef63d4f702000eda8e6c"

--- a/Formula/h/hashcash.rb
+++ b/Formula/h/hashcash.rb
@@ -12,8 +12,6 @@ class Hashcash < Formula
     regex(/href=.*?hashcash[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "4f0504fa7b4b3ae51ffb3163090b4b4309557b5327cac38f203fdf11dfb8e026"
     sha256 cellar: :any,                 arm64_sequoia:  "ff46dc55af54e0d3f0e20308536a4ebd0d08fa18c8ae1797fbc75bf2be97c79f"

--- a/Formula/h/healpix.rb
+++ b/Formula/h/healpix.rb
@@ -7,7 +7,7 @@ class Healpix < Formula
   license "GPL-2.0-or-later"
   revision 2
 
-  no_autobump! because: :requires_manual_review
+  no_autobump! because: :incompatible_version_format
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "2cd47768112373cf69d551358a450576de47148b04927854453825f6f4d7ea34"

--- a/Formula/h/hello.rb
+++ b/Formula/h/hello.rb
@@ -5,8 +5,6 @@ class Hello < Formula
   sha256 "5a9a996dc292cc24dcf411cee87e92f6aae5b8d13bd9c6819b4c7a9dce0818ab"
   license "GPL-3.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "d5eafb7348c3b7253714c061785a67f7878f36e953b454f04a80ec9c62482720"
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "e81841d7339d3d83c7fbc3ba2f0ba20d9719b2b6e4db7acd47b5ed3c1ca9448c"

--- a/Formula/h/help2man.rb
+++ b/Formula/h/help2man.rb
@@ -7,8 +7,6 @@ class Help2man < Formula
   license "GPL-3.0-or-later"
   revision 4
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "d2e8018036792d9b999b50c7230443eececc319f3e51b780f6f10f2228c4641e"
     sha256 cellar: :any,                 arm64_sequoia: "b4559a8766dc2105a09add4cdc05f1c2d80258adca8bdbbacddd48ae53366ffd"

--- a/Formula/h/hfsutils.rb
+++ b/Formula/h/hfsutils.rb
@@ -11,8 +11,6 @@ class Hfsutils < Formula
     regex(/href=.*?hfsutils[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "3d8d4be93e186cb4e5f1aee2e128bbe94f68341e463b3fa86ea5cf15c30d0603"

--- a/Formula/h/hicolor-icon-theme.rb
+++ b/Formula/h/hicolor-icon-theme.rb
@@ -13,8 +13,6 @@ class HicolorIconTheme < Formula
     regex(/href=.*?hicolor-icon-theme[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, all: "76779247990b538d304e98b042fde85677491e428d0381a59383264ce8ef199f"
   end

--- a/Formula/h/hilite.rb
+++ b/Formula/h/hilite.rb
@@ -5,8 +5,6 @@ class Hilite < Formula
   sha256 "e15bdff2605e8d23832d6828a62194ca26dedab691c9d75df2877468c2f6aaeb"
   license "GPL-2.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "d0e8bd163b7a96b2ef1a79a9d69861cd045c6ffa351dbbda07bf25ba31899d68"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "f3535152f7fa6b54957f00de4158dd790073c81737140ae90c16cbda8d37ba51"

--- a/Formula/h/hmmer.rb
+++ b/Formula/h/hmmer.rb
@@ -11,8 +11,6 @@ class Hmmer < Formula
     regex(/href=.*?hmmer[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "1f42eea650a3ca55ba74920ce46d7e9cc019f203881097a0ee7978516c867f44"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "3342dd2de2909df5053dea525398b3e3902b07a1d58dab35a940bb7bf77b877b"

--- a/Formula/h/hspell.rb
+++ b/Formula/h/hspell.rb
@@ -11,8 +11,6 @@ class Hspell < Formula
     strategy :page_match
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 arm64_tahoe:   "c2f0ea64af6987d36f42b5f53aa51e781ff98cee49ea71b3f19d4137a8c4191b"

--- a/Formula/h/ht.rb
+++ b/Formula/h/ht.rb
@@ -5,8 +5,6 @@ class Ht < Formula
   sha256 "31f5e8e2ca7f85d40bb18ef518bf1a105a6f602918a0755bc649f3f407b75d70"
   license "GPL-2.0-only"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 3
     sha256 cellar: :any,                 arm64_tahoe:    "24189de18e537de36a5368d5e5a9e1017f07b25e16147467763496ff865e4a1b"

--- a/Formula/h/html2text.rb
+++ b/Formula/h/html2text.rb
@@ -6,8 +6,6 @@ class Html2text < Formula
   license "GPL-2.0-or-later"
   head "https://gitlab.com/grobian/html2text.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "9e719fed3a98611bfe8ca70a7b301f6f1a304a56e4f2d4b4dbfecab8ee0bd29a"
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "bb724b272c288e009206280fe3371215d25cc67421a131b9dca6e7eafd01b28d"

--- a/Formula/h/htmlcleaner.rb
+++ b/Formula/h/htmlcleaner.rb
@@ -6,8 +6,6 @@ class Htmlcleaner < Formula
   license "BSD-3-Clause"
   revision 1
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "481e7ce48a7dc9bddaa359cd8b30412f993266133f606e0970031feb20a3e924"

--- a/Formula/h/htmlcxx.rb
+++ b/Formula/h/htmlcxx.rb
@@ -5,8 +5,6 @@ class Htmlcxx < Formula
   sha256 "5d38f938cf4df9a298a5346af27195fffabfef9f460fc2a02233cbcfa8fc75c8"
   license all_of: ["LGPL-2.0-only", "Apache-2.0"]
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:    "8d731c143f491da872ee21c1ea5b39b216113ceab22b26212e1b249edce7b0c1"
     sha256 arm64_sequoia:  "e1cb2639240425d10dcaea3639f09ae7b7795141d85b562d5df0fd79709c6edc"

--- a/Formula/h/httrack.rb
+++ b/Formula/h/httrack.rb
@@ -13,8 +13,6 @@ class Httrack < Formula
     regex(/href=.*?httrack[._-]v?(\d+(?:\.\d+)+)\./i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 arm64_tahoe:   "9b8bc548b4e0708efd7b6f777f8b6b846d8322c1ba96266f435ac88b376a858d"


### PR DESCRIPTION
#269331

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI assisted with candidate discovery and one-commit-per-formula patching for `h*` formulas by removing `no_autobump! because: :requires_manual_review` where livecheck/status/source checks were compatible. I manually verified and reran `brew style` and `brew audit --strict` on the edited formula set.

Excluded from this batch: `h2spec`, `heksa`, `hostdb`, `hqx`, `htmlcompressor`, `http_load` (filter exclusions) and `h264bitstream`, `hyperestraier` (strict-audit blockers).

-----
