### PR TITLE
i*: remove no_autobump! manual review

### DIFF
--- a/Formula/i/i2c-tools.rb
+++ b/Formula/i/i2c-tools.rb
@@ -10,8 +10,6 @@ class I2cTools < Formula
     regex(/href=.*?i2c-tools[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_linux:  "8f6ac4fca0fb5e2bb8dd2cc1891c75021b6af50de8e3e66cef13131a67e4bfee"

--- a/Formula/i/i386-elf-gdb.rb
+++ b/Formula/i/i386-elf-gdb.rb
@@ -11,8 +11,6 @@ class I386ElfGdb < Formula
     formula "gdb"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 arm64_tahoe:   "a956c80bc7b8f5684e35879dbda8d3151fbeea1120aadfdabc87d32703807041"

--- a/Formula/i/i686-elf-grub.rb
+++ b/Formula/i/i686-elf-grub.rb
@@ -6,8 +6,6 @@ class I686ElfGrub < Formula
   sha256 "f3c97391f7c4eaa677a78e090c7e97e6dc47b16f655f04683ebd37bef7fe0faa"
   license "GPL-3.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 arm64_tahoe:   "e22e948d3c138afe51718fa03e908d0dafcc149ae3a027f76627e1482523523d"

--- a/Formula/i/iat.rb
+++ b/Formula/i/iat.rb
@@ -5,8 +5,6 @@ class Iat < Formula
   sha256 "fb72c42f4be18107ec1bff8448bd6fac2a3926a574d4950a4d5120f0012d62ca"
   license "GPL-2.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "4b7a2e6c46ce91c6a4eed38ff68cf506e7d37520266d57c222edb4ec5947b233"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "f6bc109730274136edd66490ce1029a7e48d083a418924684adbd72154a1ea84"

--- a/Formula/i/icon-naming-utils.rb
+++ b/Formula/i/icon-naming-utils.rb
@@ -13,8 +13,6 @@ class IconNamingUtils < Formula
     regex(/Version\s+v?(\d+(?:\.\d+)+)/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "0297c134b4aed0221b17224be3da86f54004e5d1ce7d12e4e9138b3335f65190"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "3caca3e4bf1e45408fdd966f46f860a0fd9002f471a1fa258e9c3c66ab28b204"

--- a/Formula/i/icoutils.rb
+++ b/Formula/i/icoutils.rb
@@ -10,8 +10,6 @@ class Icoutils < Formula
     regex(/href=.*?icoutils[._-](\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any, arm64_tahoe:    "5f28e12b6168d398c1b6a45fdd31fbe562734bf4e0bb9b92473326fe3652db3c"

--- a/Formula/i/id3v2.rb
+++ b/Formula/i/id3v2.rb
@@ -5,8 +5,6 @@ class Id3v2 < Formula
   sha256 "8105fad3189dbb0e4cb381862b4fa18744233c3bbe6def6f81ff64f5101722bf"
   license "GPL-2.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:   "33aafe768f00f1a37dcc4a02ea2ebca5a06fe9548ee98fdab3b3f598ba641512"

--- a/Formula/i/idsgrep.rb
+++ b/Formula/i/idsgrep.rb
@@ -10,8 +10,6 @@ class Idsgrep < Formula
     regex(/href=.*idsgrep[._-]v?(\d+(?:\.\d+)+)\.t*/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 arm64_tahoe:   "599f0677a847ef317bb1cf0a80501b84531bf0a3083f6cf31052bb5f70bab0fc"

--- a/Formula/i/idutils.rb
+++ b/Formula/i/idutils.rb
@@ -12,8 +12,6 @@ class Idutils < Formula
     regex(/href=.*?idutils[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 arm64_tahoe:    "e60e746f4261098cdd11898d89c236538d8232579351a5ebad27194c7f3f3784"

--- a/Formula/i/ifstat.rb
+++ b/Formula/i/ifstat.rb
@@ -12,8 +12,6 @@ class Ifstat < Formula
     regex(/href=["']?ifstat[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "6b215d7076e20b7465ac37f21c3141a87bb5801d17bbc238a9cf35ad5ebebd29"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "7929e573cc9e8172c16c8a9d4a5c3ff51fb02ba824a70c4e749cea56e9d33ed2"

--- a/Formula/i/iftop.rb
+++ b/Formula/i/iftop.rb
@@ -15,8 +15,6 @@ class Iftop < Formula
     regex(/href=.*?iftop[._-]v?(\d+(?:\.\d+)+(?:pre\d+)?)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "67c10b03293053b57eb788b632e71ecb2f4bb4eb56d5a2766b1838a654866413"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "6a3d6d2dbbb5f10a3cc0043846d9742314b1795d77f08dae5a2ce8abfe9696f3"

--- a/Formula/i/ii.rb
+++ b/Formula/i/ii.rb
@@ -11,8 +11,6 @@ class Ii < Formula
     regex(/href=.*?ii[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "894efd0eec847bf1e4490057f2ca140dacf7c5a26a251a56660101c78eb777a8"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "ab84f7b5884e3b926510c76631987ea2eb214d73c0595af30063c7b0131fe759"

--- a/Formula/i/imageworsener.rb
+++ b/Formula/i/imageworsener.rb
@@ -10,8 +10,6 @@ class Imageworsener < Formula
     regex(/href=.*?imageworsener[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:   "2ea02018611e3a89bd678dc6e1daa778ed958dc03d69bdc4a447cd6c43502ff7"

--- a/Formula/i/imake.rb
+++ b/Formula/i/imake.rb
@@ -10,8 +10,6 @@ class Imake < Formula
     regex(/href=.*?imake[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:   "e00d84afa586ef13b9a3839fb78191004c4bb76953057ccda30f602cc274565d"
     sha256 arm64_sequoia: "16145a844d8aaf431a839bc9d6c8ecc3ce22738e61536a1edfca0888ac8b9c20"

--- a/Formula/i/innoextract.rb
+++ b/Formula/i/innoextract.rb
@@ -21,8 +21,6 @@ class Innoextract < Formula
     regex(/href=.*?innoextract[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "1150222eb02fdb776418d3253e62ba75592481225b162026bf45ad687784d730"
     sha256 cellar: :any,                 arm64_sequoia: "9231e79c53ec988162f3173dad48d1e9a3d104af8b21e10f6837c922d4d12d99"

--- a/Formula/i/intercal.rb
+++ b/Formula/i/intercal.rb
@@ -17,8 +17,6 @@ class Intercal < Formula
     regex(/^v?(0(?:\.\d+)+)$/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 sonoma:       "d9b34181204263b17a9046ea236d9a2ef7eb49b9de6415349b7408f86aa21ead"
     sha256 arm64_linux:  "88da8548d1711605f7fd7f8047a53b9526f09b42951f4bed028d2a3bb177d8ce"

--- a/Formula/i/intltool.rb
+++ b/Formula/i/intltool.rb
@@ -6,8 +6,6 @@ class Intltool < Formula
   license "GPL-2.0-or-later"
   revision 2
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "a3b02903a82a77d89d14776957ba50c442e5bdf8948079c65ed927d80765f04a"

--- a/Formula/i/ip_relay.rb
+++ b/Formula/i/ip_relay.rb
@@ -10,8 +10,6 @@ class IpRelay < Formula
     regex(/href=.*?ip_relay[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "ea932a50ad3b1643e87dab5b41be2a75c2ac1f22392930e1cf3f05e85beef8ed"

--- a/Formula/i/ipbt.rb
+++ b/Formula/i/ipbt.rb
@@ -11,8 +11,6 @@ class Ipbt < Formula
     regex(/href=.*?ipbt[._-]v?(\d+(?:\.\d+)*)(?:[._-][\da-z]+)?\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "c859deb2c97e809a56ac2a8ec82da3fc411b398146bbae7012786fb8c9ff3cbe"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "92e01edfa69f113441a864b0a8f64ff02089a7f058da34d9a8a0d92c0cb9bdaa"

--- a/Formula/i/ipinfo.rb
+++ b/Formula/i/ipinfo.rb
@@ -12,8 +12,6 @@ class Ipinfo < Formula
     regex(/(?:new Array\(|\[)["']v?(\d+(?:\.\d+)+)["'],/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "97ebf675a6aa3fd914b342df26584eaded1d0d5b7b31ff4a8d2531ad61ab9152"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "ff62045518304b036f380fb7a14218208349858d1d1b5db7d39c3877e1361400"

--- a/Formula/i/ipsumdump.rb
+++ b/Formula/i/ipsumdump.rb
@@ -11,8 +11,6 @@ class Ipsumdump < Formula
     regex(/href=.*?ipsumdump[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:    "4b887c63e1aec769b9142c42cc8e5ddbb8020ab232604111f635c06e4a61ba6d"
     sha256 arm64_sequoia:  "df39ad78cb2e3dbca54558205978fc4c39ffee8b17f11027f51c62dab42b9da7"

--- a/Formula/i/irrlicht.rb
+++ b/Formula/i/irrlicht.rb
@@ -14,8 +14,6 @@ class Irrlicht < Formula
     regex(%r{url=.*?/irrlicht[._-]v?(\d+(?:\.\d+)+)\.(?:t|zip)}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:   "a8314699b2d76022efabbfc053bc1b50eb1d0e6c18a0e1744e7e45ecccab9f0f"

--- a/Formula/i/ispell.rb
+++ b/Formula/i/ispell.rb
@@ -11,8 +11,6 @@ class Ispell < Formula
     regex(/href=.*?ispell[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:    "46a439e8c57a40cc6102c1884e11c9e261286787efcd5b72fd3df42487216d17"
     sha256 arm64_sequoia:  "fc52b0f23b84dbe44eba8d0ef80ae93927f90591678155d6579af7e04819abb0"

--- a/Formula/i/itex2mml.rb
+++ b/Formula/i/itex2mml.rb
@@ -16,8 +16,6 @@ class Itex2mml < Formula
     regex(%r{<b>\s*Current itex2MML Version:\s*</b>\s*(\d+(?:\.\d+)+)[\s(<]}im)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "9927eb95f7d9d7dddfc7c684ca069bfa8b612c519461ef5233aa54098b9ea8d9"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "7218674b662a6415899e7eb4dc00ac2634c60837b7a4b9fa7a4019cf668d8890"

--- a/Formula/i/itpp.rb
+++ b/Formula/i/itpp.rb
@@ -11,8 +11,6 @@ class Itpp < Formula
     regex(%r{url=.*?/itpp[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:    "81d0b47a818e674b72ddec4f61ab65989c8ed629d9804d58afb01a1d615a8c09"

--- a/Formula/i/itstool.rb
+++ b/Formula/i/itstool.rb
@@ -11,8 +11,6 @@ class Itstool < Formula
     regex(/href=.*?itstool[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "716cb0efd44428ef62000438ff166627c117befbdd87b6d9c5580afac54c9dc2"
     sha256 cellar: :any,                 arm64_sequoia: "8659b398ae66d88d974879a6a4e4372f21b81f7d018b13d9dd10b459e84ddd95"


### PR DESCRIPTION
#269331

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI assisted with candidate discovery and one-commit-per-formula patching for `i*` formulas by removing `no_autobump! because: :requires_manual_review` where livecheck/status/source checks were compatible. I manually verified and reran `brew style` and `brew audit --strict` on the edited formula set.

Excluded from this batch: `id3lib` (strict-audit missing `test do`).

-----
