### PR TITLE
postgres*: add aliases.

### DIFF
--- a/Aliases/postgres
+++ b/Aliases/postgres
@@ -1,0 +1,1 @@
+../Formula/p/postgresql@18.rb

--- a/Aliases/postgresql
+++ b/Aliases/postgresql
@@ -1,0 +1,1 @@
+../Formula/p/postgresql@18.rb

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -140,7 +140,6 @@
   "poac": "cabin",
   "polarssl": "mbedtls",
   "pony-language-server": "ponyc",
-  "postgresql": "postgresql@14",
   "prefligit": "prek",
   "prest": "prestd",
   "presto": "prestodb",


### PR DESCRIPTION
Let's add these aliases now we've renamed things so `brew install postgresql` and `brew install postgres` no longer warn any more.

Could save this for Homebrew 5.1.0 if it's a "breaking change" or whatever.