### PR TITLE
ruby: add versioned alias.

### DIFF
--- a/Aliases/ruby@4.0
+++ b/Aliases/ruby@4.0
@@ -1,0 +1,1 @@
+../Formula/r/ruby.rb


### PR DESCRIPTION
`ruby@4` exists but this did not.

Ideally an audit would have nudged for this.