### PR TITLE
r-rig: add menu bar app

### DIFF
--- a/Formula/r/r-rig.rb
+++ b/Formula/r/r-rig.rb
@@ -14,12 +14,39 @@ class RRig < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "f8f9fb4827b02f91ce993fc00131440b6344cbf27ed22e8cf2c3abfe4f107a05"
   end
 
+  depends_on "cbindgen" => :build
   depends_on "rust" => :build
+  depends_on xcode: :build
+  depends_on :macos
 
   conflicts_with "rig", because: "both install `rig` binary"
 
   def install
+    system "cargo", "build", "--lib", "--release"
+    system("cbindgen -l c > Rig.App/Rig/rig.h")
+    mkdir_p "Rig.app/lib"
+    cp "target/release/libriglib.a", "Rig.app/lib/libriglib.a"
+    Dir.chdir("Rig.app") do
+      xcodebuild "-arch", Hardware::CPU.arch,
+                 "MACOSX_DEPLOYMENT_TARGET=#{MacOS.version}",
+                 "CODE_SIGN_IDENTITY=",
+                 "CODE_SIGNING_REQUIRED=NO",
+                 "-configuration", "Release",
+                 "-scheme", "Rig",
+                 "-IDEPackageSupportDisableManifestSandbox=1",
+                 "-IDEPackageSupportDisablePluginExecutionSandbox=1",
+                 "-derivedDataPath", "build",
+                 "clean", "build"
+      deuniversalize_machos "build/Build/Products/Release/Rig.app/Contents/Library/" \
+                            "LoginItems/LaunchAtLoginHelper.app/Contents/MacOS/LaunchAtLoginHelper"
+      prefix.install "build/Build/Products/Release/Rig.app"
+    end
     system "cargo", "install", *std_cargo_args
+  end
+
+  service do
+    run "#{opt_bin}/../Rig.app/Contents/MacOS/Rig"
+    keep_alive false
   end
 
   test do


### PR DESCRIPTION
Build the rig menu bar app, written in Swift, and add a service for it.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
