### PR TITLE
bazel@8: comment out disable

### DIFF
--- a/Formula/b/bazel@8.rb
+++ b/Formula/b/bazel@8.rb
@@ -23,7 +23,8 @@ class BazelAT8 < Formula
 
   # https://bazel.build/release#support-matrix
   deprecate! date: "2028-01-01", because: :unsupported
-  disable! date: "2029-01-01", because: :unsupported
+  # FIXME: brew currently cannot handle `disable!` on future deprecation
+  # disable! date: "2029-01-01", because: :unsupported
 
   depends_on "openjdk@21"
 


### PR DESCRIPTION
Avoid wrong message until handling for this is fixed in brew:
```console
❯ brew info bazel@8 | grep Deprecated
Deprecated because it is not supported upstream! It will be disabled on 2029-01-01.

❯ brew info bazel@8 --json=v2 | jq -r '.formulae.[].deprecation_date'
2028-01-01
```

This also enables autobump as deprecated formulae are always skipped