### PR TITLE
opencolorio: can use Apple expat since Sequoia

### DIFF
--- a/Formula/o/opencolorio.rb
+++ b/Formula/o/opencolorio.rb
@@ -8,13 +8,13 @@ class Opencolorio < Formula
   head "https://github.com/AcademySoftwareFoundation/OpenColorIO.git", branch: "main"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_tahoe:   "f96d8659cb4d97651e4b3f8e5e3adc624092a5c859e95d025bbd24bdf5ec41ad"
-    sha256 cellar: :any,                 arm64_sequoia: "a20e9815ceace0fb0c920a41a67559f8bc7c8a153c5bab6e826e5d4ba9f99701"
-    sha256 cellar: :any,                 arm64_sonoma:  "1bab9ea155f94659264e5b94791f74952ecdf9e7320974cb6cf8cb5686fa6b0c"
-    sha256 cellar: :any,                 sonoma:        "705119ea11a5f5d0c67f73c762c6bda3808238a32be0438f8d4503ff42f2bea9"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "7ded7252eabd0991f0f02740033554ca7c08dd77b97adf6971987317f2d744ca"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "44df1e47cada73f84b80225d7d3d6f4420c4c25b33d9d558519c4643c2e172e1"
+    rebuild 2
+    sha256 cellar: :any,                 arm64_tahoe:   "0ca624f3788e11cefd2b246e8154b85a819c2a40ed83e618abdb93c00dbedc16"
+    sha256 cellar: :any,                 arm64_sequoia: "a253b7d210772a5f07acdae83b8707e2c27da64f5dd883f5428e6b5e72afd456"
+    sha256 cellar: :any,                 arm64_sonoma:  "24f7868c7417b93233c10265dc9f594e07331d9a00c515a63d27c3baffb339ab"
+    sha256 cellar: :any,                 sonoma:        "c1b9c2d7eda1ec4613cd573a4c16414f286155f91f25715f7e0c204053e85fa3"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "9169481ded19f10e1b7c82e7c694d34c30dd78e0ab44107149b303208d869fd1"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5d91f280ab35dd2bfb6c30bf2480f9370fb33fd44aec3b542d2fd28ccd4680f2"
   end
 
   depends_on "cmake" => :build

--- a/Formula/o/opencolorio.rb
+++ b/Formula/o/opencolorio.rb
@@ -19,8 +19,7 @@ class Opencolorio < Formula
 
   depends_on "cmake" => :build
   depends_on "pybind11" => :build
-  depends_on "python@3.14" => [:build, :test] # for bindings, avoid runtime dependency due to `expat`
-  depends_on "expat"
+  depends_on "python@3.14" => [:build, :test]
   depends_on "imath"
   depends_on "little-cms2"
   depends_on "minizip-ng"
@@ -28,6 +27,8 @@ class Opencolorio < Formula
   depends_on "pystring"
   depends_on "yaml-cpp"
   depends_on "zlib-ng-compat"
+
+  uses_from_macos "expat", since: :sequoia # expat 2.6.0+ (Apple expat-37)
 
   on_arm do
     depends_on "sse2neon" => :build


### PR DESCRIPTION
- expat-35 == 2.5.0 - https://github.com/apple-oss-distributions/expat/blob/expat-35/expat/lib/expat.h
- expat-37 == 2.6.1 - https://github.com/apple-oss-distributions/expat/blob/expat-37/expat/lib/expat.h

From https://opensource.apple.com/releases/
- Sonoma 14.6 uses expat-35
- Sequoia 15.0 uses expat-37