### PR TITLE
postgresql@14: comment out disable

### DIFF
--- a/Formula/p/postgresql@14.rb
+++ b/Formula/p/postgresql@14.rb
@@ -22,7 +22,8 @@ class PostgresqlAT14 < Formula
   # deprecating one year before the last release,
   # see: https://www.postgresql.org/support/versioning/
   deprecate! date: "2025-11-12", because: :unsupported
-  disable! date: "2026-11-12", because: :unsupported
+  # FIXME: brew currently cannot handle `disable!` on future deprecation
+  # disable! date: "2026-11-12", because: :unsupported
 
   depends_on "pkgconf" => :build
   depends_on "icu4c@78"


### PR DESCRIPTION
currently cannot be autobumped, so comment out disable. same deal as 
- https://github.com/Homebrew/homebrew-core/pull/269576

relates to 
- https://github.com/Homebrew/homebrew-core/pull/269616