### PR TITLE
aoe: add shell completions

### DIFF
--- a/Formula/a/aoe.rb
+++ b/Formula/a/aoe.rb
@@ -26,6 +26,7 @@ class Aoe < Formula
 
   def install
     system "cargo", "install", *std_cargo_args
+    generate_completions_from_executable(bin/"aoe", "completion")
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *This PR was generated with AI assistance (Claude) to research Homebrew best practices for shell completions and create the formula change. The change follows the established pattern used by ripgrep, fd, and starship formulas.*

-----

## Summary

Add shell completions (bash, zsh, fish) for the `aoe` CLI tool.

The binary already supports completion generation via `aoe completion <shell>`, this PR simply wires it up in the formula using `generate_completions_from_executable`.

## Changes

- Add `generate_completions_from_executable(bin/"aoe", "completion")` to the install method

This follows the same pattern used by other Rust CLI tools like ripgrep, fd, and starship.