### PR TITLE
nerdctl: add missing artifacts

### DIFF
--- a/Formula/n/nerdctl.rb
+++ b/Formula/n/nerdctl.rb
@@ -4,6 +4,7 @@ class Nerdctl < Formula
   url "https://github.com/containerd/nerdctl/archive/refs/tags/v2.2.1.tar.gz"
   sha256 "f39c34d3a285e087f2b2869f06fea343d8285ad9bfb9417b9c5b6dd4e78d6fad"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/containerd/nerdctl.git", branch: "main"
 
   bottle do
@@ -18,6 +19,8 @@ class Nerdctl < Formula
   def install
     ldflags = "-s -w -X github.com/containerd/nerdctl/v#{version.major}/pkg/version.Version=#{version}"
     system "go", "build", *std_go_args(ldflags:), "./cmd/nerdctl"
+    bin.install Dir["extras/rootless/*"]
+    doc.install Dir["docs/*"]
 
     generate_completions_from_executable(bin/"nerdctl", shell_parameter_format: :cobra)
   end

--- a/Formula/n/nerdctl.rb
+++ b/Formula/n/nerdctl.rb
@@ -8,9 +8,8 @@ class Nerdctl < Formula
   head "https://github.com/containerd/nerdctl.git", branch: "main"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_linux:  "988e4dc5097b4de4101f5cccd25de622b9d2871f4579b3ddb59863df5e640dff"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "e52decf20eb724537a3eb99dfebd44b23d07336ed86f67cd7d90430767fc5b9e"
+    sha256 cellar: :any_skip_relocation, arm64_linux:  "f56a55ab70d05398e06c6c542b2a03e5d80424c3dcdb1c1263b5101d0c07f0aa"
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "7c99ebeb05ea37c502feab10d6b1571e380e2f3adbcfe9403ef6b73913da7784"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
The following files were not installed:
- `bin/containerd-rootless.sh`
- `bin/containerd-rootless-setuptool.sh`
- `share/doc/nerdctl/*`

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.
  - Didn't use
-----
