### PR TITLE
blueprint-compiler 0.20.0

### DIFF
--- a/Formula/b/blueprint-compiler.rb
+++ b/Formula/b/blueprint-compiler.rb
@@ -4,8 +4,8 @@ class BlueprintCompiler < Formula
 
   desc "Markup language and compiler for GTK 4 user interfaces"
   homepage "https://gnome.pages.gitlab.gnome.org/blueprint-compiler/"
-  url "https://gitlab.gnome.org/GNOME/blueprint-compiler/-/archive/0.19.0/blueprint-compiler-0.19.0.tar.gz"
-  sha256 "f5aaf95d8a0ba4c8ad104465dd3df3eeb2e72b67785d969d7fd8bc7cf4127ee9"
+  url "https://download.gnome.org/sources/blueprint-compiler/0.20/blueprint-compiler-0.20.0.tar.xz"
+  sha256 "ec786d66f583e8296c845f1f82834d27b369f39d55a6380b34880493e22db382"
   license "LGPL-3.0-or-later"
   head "https://gitlab.gnome.org/GNOME/blueprint-compiler.git", branch: "main"
 

--- a/Formula/b/blueprint-compiler.rb
+++ b/Formula/b/blueprint-compiler.rb
@@ -10,7 +10,7 @@ class BlueprintCompiler < Formula
   head "https://gitlab.gnome.org/GNOME/blueprint-compiler.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "b78efc382e4cc768ec177a1c5495d31ca74063b9be63f2b69f3b507ea8a1d183"
+    sha256 cellar: :any_skip_relocation, all: "deb86cf728441594bf863fa9bf2c46285ca9819242020e8721b9a327e988a683"
   end
 
   depends_on "meson" => :build


### PR DESCRIPTION
Also switch to official tarballs which allows autobump to avoid unstable versions.

For example, 0.19.0 was unstable https://gitlab.gnome.org/GNOME/blueprint-compiler/-/tags/0.19.0
> Blueprint-compiler 0.19.0
>
> This is an unstable release.