### PR TITLE
j*: change/remove no_autobump!

### DIFF
--- a/Formula/j/jags.rb
+++ b/Formula/j/jags.rb
@@ -10,8 +10,6 @@ class Jags < Formula
     regex(%r{url=.*?/JAGS[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:   "cac7a756275255627578b03f0e89c7df5955b516b9b57b0475aaaf30ca5fe932"

--- a/Formula/j/jasmin.rb
+++ b/Formula/j/jasmin.rb
@@ -6,8 +6,6 @@ class Jasmin < Formula
   license "BSD-4-Clause"
   revision 2
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, all: "5ca0d0e4caaf51963cbbc63ffa2b3b2506737c8c0cc8a2773acb76f185221b11"

--- a/Formula/j/jbigkit.rb
+++ b/Formula/j/jbigkit.rb
@@ -12,8 +12,6 @@ class Jbigkit < Formula
     regex(/href=.*?jbigkit[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "a7cc930c8a3652caa237eb15f5528d6a9384ba2e14b7414de8946fe0fedf6816"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "589c8a946d59e05dc1d23a0225efc605234fe4095bed2f5bce170c90b346ab96"

--- a/Formula/j/jboss-forge.rb
+++ b/Formula/j/jboss-forge.rb
@@ -15,7 +15,7 @@ class JbossForge < Formula
     end
   end
 
-  no_autobump! because: :requires_manual_review
+  no_autobump! because: :incompatible_version_format
 
   bottle do
     rebuild 2

--- a/Formula/j/jcal.rb
+++ b/Formula/j/jcal.rb
@@ -10,8 +10,6 @@ class Jcal < Formula
     regex(/href=.*?jcal[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "aba60dbce990bacb3f58d4a08e1a5251e74d2d3f57965eb206f2bc15a7bd2390"
     sha256 cellar: :any,                 arm64_sequoia:  "31377fb6a087e5e70e9ae8a1bc7ac390db8efa860f7a956a759b27e710fe21e2"

--- a/Formula/j/jed.rb
+++ b/Formula/j/jed.rb
@@ -11,8 +11,6 @@ class Jed < Formula
     regex(/href=.*?jed.?v?(\d+(?:\.\d+)+(?:-\d+)?)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 arm64_tahoe:    "6551a5b3bdfe80b3b1446fbf84950d6c14a9b08c511c08af2424b4722821cf78"

--- a/Formula/j/jhiccup.rb
+++ b/Formula/j/jhiccup.rb
@@ -10,8 +10,6 @@ class Jhiccup < Formula
     regex(/href=.*?jHiccup[._-]v?(\d+(?:\.\d+)+)-dist(?:-\d+)?\.zip/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "010529211ca43ed531a37e60a1c33ee7a38b823038d204992713461c4ef4b56c"

--- a/Formula/j/jigdo.rb
+++ b/Formula/j/jigdo.rb
@@ -11,8 +11,6 @@ class Jigdo < Formula
     regex(/href=.*?jigdo[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 arm64_tahoe:   "e8dc3605b3abe08d1608a08a2c30309226c58b6497848e43ba3332ecc2d463f7"

--- a/Formula/j/jnettop.rb
+++ b/Formula/j/jnettop.rb
@@ -11,8 +11,6 @@ class Jnettop < Formula
     regex(%r{url=.*?/jnettop[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any,                 arm64_tahoe:    "94be630d1e700e5da48e52eb85019003f81295f9afd49c846296943881962a17"

--- a/Formula/j/joe.rb
+++ b/Formula/j/joe.rb
@@ -10,8 +10,6 @@ class Joe < Formula
     regex(%r{url=.*?/joe[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 arm64_tahoe:    "d75751dfb61cb1bdfee67fddef1a388620fcd01b46e17c1bbca7efd0dfd00159"

--- a/Formula/j/john-jumbo.rb
+++ b/Formula/j/john-jumbo.rb
@@ -12,8 +12,6 @@ class JohnJumbo < Formula
     regex(/^v?(\d+(?:\.\d+)+)-jumbo-\d$/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 3
     sha256 arm64_tahoe:   "448e0b52a33cd8611647ecc701949472f5ef720c473a63664b28ffa481e9beb0"

--- a/Formula/j/john.rb
+++ b/Formula/j/john.rb
@@ -11,8 +11,6 @@ class John < Formula
     regex(/href=.*?john[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 arm64_tahoe:   "de355d8210ec0ecde0806a9934c6f14600943b18ae9e98b67571e7b1f7f215f1"

--- a/Formula/j/jpdfbookmarks.rb
+++ b/Formula/j/jpdfbookmarks.rb
@@ -5,8 +5,6 @@ class Jpdfbookmarks < Formula
   sha256 "8ab51c20414591632e48ad3817e6c97e9c029db8aaeff23d74c219718cfe19f9"
   license "GPL-3.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "bbac7244d29ddb86bb5342e4752fa87479247a239a57663c5a701d2687aafc46"

--- a/Formula/j/jpeginfo.rb
+++ b/Formula/j/jpeginfo.rb
@@ -11,8 +11,6 @@ class Jpeginfo < Formula
     regex(/href=.*?jpeginfo[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "64d7d1095c95f1ea0e1c0a44b8921e4bfb3696dd47e842c4d403ba4ce8fda097"
     sha256 cellar: :any,                 arm64_sequoia:  "4f5080a068fc3c4e0dbd1f4a1797a633ed8c28e50ab57eecf33b2ee70eb464ae"

--- a/Formula/j/jthread.rb
+++ b/Formula/j/jthread.rb
@@ -10,8 +10,6 @@ class Jthread < Formula
     regex(/href=.*?jthread[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "6afeed9e7aae5a7268e9361ab770bc8b477a4e3752043ab2ece66a38eb589be6"
     sha256 cellar: :any,                 arm64_sequoia:  "0b2a1b4160a03bae62a73f61bd3e2bbedd3a4080f4e2650060a05bb445301c4b"

--- a/Formula/j/judy.rb
+++ b/Formula/j/judy.rb
@@ -5,8 +5,6 @@ class Judy < Formula
   sha256 "d2704089f85fdb6f2cd7e77be21170ced4b4375c03ef1ad4cf1075bd414a63eb"
   license "LGPL-2.1-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "55191515c4d8f62b225ce9fdf49be0742d708fc8615382c77e19b1a21dee6878"
     sha256 cellar: :any,                 arm64_sequoia:  "9c845c66e4c08af1feb840119e2013109cbfba280a96022e15aa1fe703fa8c61"

--- a/Formula/j/jumanpp.rb
+++ b/Formula/j/jumanpp.rb
@@ -10,8 +10,6 @@ class Jumanpp < Formula
     regex(/href=.*?jumanpp[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:    "22a0785a78be8dea8fb69e016c0ca887fc2f1e236734594bb350ba86a44f0d71"
     sha256 arm64_sequoia:  "6ea43f4832aa25047b071cc99cb91995b249db44017818191fd106b0c50f901d"

--- a/Formula/j/jupp.rb
+++ b/Formula/j/jupp.rb
@@ -12,8 +12,6 @@ class Jupp < Formula
     regex(/href=.*?joe[._-]v?(\d+(?:\.\d+)+jupp\d+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:    "851ad092f5d0183d4c1d09bba60a6f8a00cc4056ecc37bd44b70a8c29e27d7ae"
     sha256 arm64_sequoia:  "69af220c327528966dd893daab6d625a5b5241b9273f7b53decb37c5f1e33efe"

--- a/Formula/j/jxrlib.rb
+++ b/Formula/j/jxrlib.rb
@@ -17,7 +17,7 @@ class Jxrlib < Formula
     end
   end
 
-  no_autobump! because: :requires_manual_review
+  no_autobump! because: :incompatible_version_format
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "c4b636123bafc19b44451cfc90eecbf7ab7488527508c40a102594517d60c889"


### PR DESCRIPTION
#269331

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI assisted with candidate discovery and one-commit-per-formula patching for `j*` formulas. I removed `no_autobump! because: :requires_manual_review` where livecheck/status/source checks were compatible, and changed clear nonstandard version cases to `:incompatible_version_format`. I manually verified and reran `brew style` and `brew audit --strict` on the edited formula set.

Changes in this batch:
- Removed `no_autobump!` for 17 formulas.
- Updated `jboss-forge` and `jxrlib` to `no_autobump! because: :incompatible_version_format`.

Left unchanged:
- `jslint4java` (`livecheck` skipped)
- `juman` (manual review still appropriate)

-----
