### PR TITLE
squid: update livecheck

### DIFF
--- a/Formula/s/squid.rb
+++ b/Formula/s/squid.rb
@@ -5,11 +5,15 @@ class Squid < Formula
   sha256 "821f875575b042537a72ab4f0260496f447ccaf2c55dfd40a995f3ad238f616d"
   license "GPL-2.0-or-later"
 
-  # The Git repository contains tags for a higher major version that isn't the
-  # current release series yet, so we check the latest GitHub release instead.
+  # Upstream sometimes creates releases that use a stable tag (e.g., `v1.2.3`)
+  # but are labeled as "pre-release" on GitHub, so it's necessary to use the
+  # `GithubLatest` strategy.
   livecheck do
     url :stable
-    strategy :github_latest
+    regex(/^SQUID[._-]v?(\d+(?:[._]\d+)+)$/i)
+    strategy :github_latest do |json, regex|
+      json["tag_name"]&.[](regex, 1)&.tr("_", ".")
+    end
   end
 
   no_autobump! because: :incompatible_version_format


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

The `livecheck` block for `squid` uses the `GithubLatest` strategy and this works but it relies on matching the release `name`, as the default strategy regex doesn't match the version from tags like `SQUID_7_4` due to the underscore delimiter. This adds a regex to match the tag format and also adds a `strategy` block to replace the underscore delimiter with a dot.

Besides that, the previous comment about the Git tags no longer applies but we still need to use the `GithubLatest` strategy because upstream sometimes marks versions using a stable version format as "pre-release" on GitHub. I've updated the comment to reflect the current situation.