### PR TITLE
libunicode: remove conditional on GCC

### DIFF
--- a/Formula/lib/libunicode.rb
+++ b/Formula/lib/libunicode.rb
@@ -23,7 +23,7 @@ class Libunicode < Formula
   end
 
   on_linux do
-    depends_on "gcc" if DevelopmentTools.gcc_version < 13
+    depends_on "gcc" # TODO: remove and rebuild bottle on Ubuntu 24.04
   end
 
   fails_with :clang do


### PR DESCRIPTION
The conditional is problematic as it can cause selection of incorrect dependency:
* bottling will resolve it at build-time which will impact the minimum required GCC ABI for bottle.
* installing will resolve it based on user's local machine which could be on an older GCC than brew GCC.

---

Although there can be a similar issue on macOS, it rarely happens as our minimum bottling macOS/Xcode increases every year and we usually don't need to link to LLVM's libc++

When it happens, we should use `on_system` blocks for runtime dependency to make sure there are no broken dependencies after pouring bottle.