### PR TITLE
gcc@*: use `zlib-ng-compat`

### DIFF
--- a/Formula/g/gcc@10.rb
+++ b/Formula/g/gcc@10.rb
@@ -29,8 +29,6 @@ class GccAT10 < Formula
   depends_on "libmpc"
   depends_on "mpfr"
 
-  uses_from_macos "zlib"
-
   on_macos do
     depends_on arch: :x86_64
     # Align dates to remove Intel macOS support with brew
@@ -41,10 +39,8 @@ class GccAT10 < Formula
 
   on_linux do
     depends_on "binutils"
-
-    on_arm do
-      depends_on "zstd"
-    end
+    depends_on "zlib-ng-compat"
+    depends_on "zstd"
   end
 
   def version_suffix

--- a/Formula/g/gcc@11.rb
+++ b/Formula/g/gcc@11.rb
@@ -34,10 +34,9 @@ class GccAT11 < Formula
   depends_on "mpfr"
   depends_on "zstd"
 
-  uses_from_macos "zlib"
-
   on_linux do
     depends_on "binutils"
+    depends_on "zlib-ng-compat"
   end
 
   # Branch from the Darwin maintainer of GCC, with a few generic fixes and

--- a/Formula/g/gcc@9.rb
+++ b/Formula/g/gcc@9.rb
@@ -29,8 +29,6 @@ class GccAT9 < Formula
   depends_on "libmpc"
   depends_on "mpfr"
 
-  uses_from_macos "zlib"
-
   on_macos do
     depends_on arch: :x86_64
     # Align dates to remove Intel macOS support with brew
@@ -41,6 +39,7 @@ class GccAT9 < Formula
 
   on_linux do
     depends_on "binutils"
+    depends_on "zlib-ng-compat"
   end
 
   def version_suffix


### PR DESCRIPTION
Cannot be rebottled due to 0 macOS runners but should be able to use existing bottle as Linux RPATH should pick up `HOMEBREW_PREFIX/lib`.

Minor issue is current bottle will prioritize `brew install zlib` in RPATH but should be ABI compatible either way and user can always uninstall `zlib`.