### PR TITLE
llvm@*: use `zlib-ng-compat`

### DIFF
--- a/Formula/l/llvm@14.rb
+++ b/Formula/l/llvm@14.rb
@@ -39,13 +39,13 @@ class LlvmAT14 < Formula
   uses_from_macos "libedit"
   uses_from_macos "libffi"
   uses_from_macos "ncurses"
-  uses_from_macos "zlib"
 
   on_linux do
     depends_on "pkgconf" => :build
     depends_on "python-setuptools" => :build
     depends_on "binutils" # needed for gold
     depends_on "elfutils" # openmp requires <gelf.h>
+    depends_on "zlib-ng-compat"
   end
 
   # Fix build with Xcode 15

--- a/Formula/l/llvm@15.rb
+++ b/Formula/l/llvm@15.rb
@@ -40,12 +40,12 @@ class LlvmAT15 < Formula
   uses_from_macos "libedit"
   uses_from_macos "libffi"
   uses_from_macos "ncurses"
-  uses_from_macos "zlib"
 
   on_linux do
     depends_on "pkgconf" => :build
     depends_on "binutils" # needed for gold
     depends_on "elfutils" # openmp requires <gelf.h>
+    depends_on "zlib-ng-compat"
   end
 
   def python3


### PR DESCRIPTION
Can't be rebottled as 0 macOS runners but existing bottles should work.

Can see linkage from existing bottles without `zlib` installed:
```
$ brew linkage llvm@14 | grep libz.so
  /home/linuxbrew/.linuxbrew/lib/libz.so.1 (zlib-ng-compat)

$ brew linkage llvm@15 | grep libz.so
  /home/linuxbrew/.linuxbrew/lib/libz.so.1 (zlib-ng-compat)
```