### PR TITLE
k*: remove no_autobump! manual review

### DIFF
--- a/Formula/k/kanif.rb
+++ b/Formula/k/kanif.rb
@@ -10,8 +10,6 @@ class Kanif < Formula
     regex(/href=.*?kanif[._-]v?(\d+(?:\.\d+)+)\.orig\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "f8e0c833384c4479f288c31b55223157190f271ca6489bbcc47cfb8c9c2042e8"

--- a/Formula/k/keyutils.rb
+++ b/Formula/k/keyutils.rb
@@ -5,8 +5,6 @@ class Keyutils < Formula
   sha256 "a61d5706136ae4c05bd48f86186bcfdbd88dd8bd5107e3e195c924cfc1b39bb4"
   license all_of: ["GPL-2.0-or-later", "LGPL-2.0-or-later"]
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_linux:  "569fc190618bdad81896e66145fe832b1d858644d19c87a59ce417158e0cea7e"
     sha256 cellar: :any_skip_relocation, x86_64_linux: "d5b06c4e38d2c4b7decb5b7bc0431b3416993231e5fa688950e4df83686a298d"

--- a/Formula/k/kimwitu++.rb
+++ b/Formula/k/kimwitu++.rb
@@ -10,8 +10,6 @@ class Kimwituxx < Formula
     regex(/href=.*?kimwitu\+\+[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "4f61b0ab3ba1cb98d66955c552211df3a280a78c0d922641ef9388803b1d7c55"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "3861ff2b9ae3eacfcb277bc50b6a3b1e16c608c807ff082ea2b2fe6d739f6608"

--- a/Formula/k/klavaro.rb
+++ b/Formula/k/klavaro.rb
@@ -11,8 +11,6 @@ class Klavaro < Formula
     regex(%r{url=.*?/klavaro[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:    "1953be5367f25a7ff30e60797c10c98d1c7a5cf28911c512e4904faf5f9f9519"
     sha256 arm64_sequoia:  "f51c0783c7004a02723e01896663c837923fe3ef5efc576821e68deb3383387c"

--- a/Formula/k/kore.rb
+++ b/Formula/k/kore.rb
@@ -11,8 +11,6 @@ class Kore < Formula
     regex(/href=.*?kore[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 arm64_tahoe:    "059c350956eced72b4ef7d31a358fac3e5df1b7132fabad051c2fef4a9f55c34"

--- a/Formula/k/kstart.rb
+++ b/Formula/k/kstart.rb
@@ -10,8 +10,6 @@ class Kstart < Formula
     regex(/href=.*?kstart[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "041e2a23f9396a6d7497e6931652dd9d2991aac192f93dda036ff923269fcadd"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "e4406b6bbb8c07dce6d556cafddb099811130501c3c377dd057f4c997ba2033c"

--- a/Formula/k/kumo.rb
+++ b/Formula/k/kumo.rb
@@ -10,8 +10,6 @@ class Kumo < Formula
     regex(%r{<version>v?(\d+(?:\.\d+)+)</version>}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, all: "964493ca566d7dc73ab4519fa820e7360981acd9d8d343920f843b83642cc008"

--- a/Formula/k/kyoto-cabinet.rb
+++ b/Formula/k/kyoto-cabinet.rb
@@ -10,8 +10,6 @@ class KyotoCabinet < Formula
     regex(/href=.*?kyotocabinet[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 arm64_tahoe:   "8c03d0a70b2156784bf4db81491d582b8dd5791125a5621a00d9cdbd5d34da4e"

--- a/Formula/k/kyoto-tycoon.rb
+++ b/Formula/k/kyoto-tycoon.rb
@@ -11,8 +11,6 @@ class KyotoTycoon < Formula
     regex(/href=.*?kyototycoon[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 arm64_tahoe:   "409039aba15f91854558024a2b4b4e7238164950a0f9aaecd576c0414c9b225b"


### PR DESCRIPTION
#269331

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI assisted with candidate discovery and one-commit-per-formula patching for `k*` formulas by removing `no_autobump! because: :requires_manual_review` where livecheck/status/source checks were compatible. I manually verified and reran `brew style` and `brew audit --strict` on the edited formula set.

Excluded from this batch: `kawa` (current livecheck returns a 502 from the GNU mirror) and `kettle` (deprecated formula).

-----
