### PR TITLE
l*: remove no_autobump! manual review

### DIFF
--- a/Formula/l/ladspa-sdk.rb
+++ b/Formula/l/ladspa-sdk.rb
@@ -10,8 +10,6 @@ class LadspaSdk < Formula
     regex(/href=.*?ladspa[._-]sdk[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 arm64_linux:  "c040c53ca46e36809ad0b9729b4fc3381d9ffb665bf9deb81726d27bb847170c"

--- a/Formula/l/lame.rb
+++ b/Formula/l/lame.rb
@@ -10,8 +10,6 @@ class Lame < Formula
     regex(%r{url=.*?/lame[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "59dc524bd852c6f9d5183deaf76cff3c0f8e546d96b707b4e00597f8526c8a99"
     sha256 cellar: :any,                 arm64_sequoia:  "0ae0dcb09c908b80ffbdb1bb168674e5190d6b9ae006d5282b7ab4f06eac9f36"

--- a/Formula/l/launch.rb
+++ b/Formula/l/launch.rb
@@ -11,8 +11,6 @@ class Launch < Formula
     regex(/href=.*?launch[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "d2a2a782722ff22b6b83014e8d62aed20453c44ec04cbe797daa4e2cec79882e"

--- a/Formula/l/lcdf-typetools.rb
+++ b/Formula/l/lcdf-typetools.rb
@@ -11,8 +11,6 @@ class LcdfTypetools < Formula
     regex(/href=.*?lcdf-typetools[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:    "014a5797b27475c13f3b8511f5e5c76db375fdd5b1a7aabbca35a2d020918aec"
     sha256 arm64_sequoia:  "5e354428d6719b3944d45a3836a61964221ae31b65a35cdc04d92a89c72bcd10"

--- a/Formula/l/ldapvi.rb
+++ b/Formula/l/ldapvi.rb
@@ -12,8 +12,6 @@ class Ldapvi < Formula
     regex(/href=.*?ldapvi[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "74bc513ed1c36a4f5f71454e94d55bdf2386ec43c5d84106d54615f5c29d3b48"
     sha256 cellar: :any,                 arm64_sequoia:  "619197cac0a0f9f7c8df2d5ced5e42f95e421c645ae87b7ae0d44048cbec6359"

--- a/Formula/l/lgeneral.rb
+++ b/Formula/l/lgeneral.rb
@@ -5,8 +5,6 @@ class Lgeneral < Formula
   sha256 "0a26b495716cdcab63b49a294ba31649bc0abe74ce0df48276e52f4a6f323a95"
   license "GPL-2.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 3
     sha256 arm64_tahoe:   "a65fba44b56f1ae92c209b5542e45371b8566fd465a8eb1c39913a4bdf334793"

--- a/Formula/l/lifelines.rb
+++ b/Formula/l/lifelines.rb
@@ -5,8 +5,6 @@ class Lifelines < Formula
   sha256 "2f00441ac0ed64aab8f76834c055e2b95600ed4c6f5845b9f6e5284ac58a9a52"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:    "c5cb2ca42297800da646da5d0503df4968cfc6a5426b355a1adcde9d34f455a5"
     sha256 arm64_sequoia:  "1f6bdc9020d5710b880583b1282be16a381ccc06e507fa708bba260fd5a256a0"

--- a/Formula/l/lilypond.rb
+++ b/Formula/l/lilypond.rb
@@ -19,8 +19,6 @@ class Lilypond < Formula
     regex(/href=.*?lilypond[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 arm64_tahoe:   "08e195be137c3be99594e3277083e3a87a1ddb795770df30a2c87054b5a8994f"

--- a/Formula/l/locateme.rb
+++ b/Formula/l/locateme.rb
@@ -10,8 +10,6 @@ class Locateme < Formula
     regex(%r{url=.*?/LocateMe[._-]v?(\d+(?:\.\d+)+)\.(?:t|zip)}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "105cc7bd0d5ced058850ebdd18e3b57d0969f9ef9f185665e28e785194e5cf6f"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "fb9d44f815969d55f09881d36089f4a34a43f7d63ad665a5dec05d8c39c55d59"

--- a/Formula/l/log4c.rb
+++ b/Formula/l/log4c.rb
@@ -11,8 +11,6 @@ class Log4c < Formula
     regex(%r{url=.*?/log4c[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:    "ea35b2efc5487ef7bdc2fb3cfe79889d49df229641fe0df54ee2d97ba5da6da6"
     sha256 arm64_sequoia:  "83103a56bdf9b8b2105f679fbeb44dca1c36c46d7afcc542b080e59e6e205f51"

--- a/Formula/l/log4cpp.rb
+++ b/Formula/l/log4cpp.rb
@@ -10,8 +10,6 @@ class Log4cpp < Formula
     regex(%r{url=.*?/log4cpp[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "2d325eaadac7646b1f637bcd8277bc4bd8a29b57da84a40541064b8008b1fc21"
     sha256 cellar: :any,                 arm64_sequoia: "92bbf1c1329d4f149a42f2fb278e8ae25776b1f7cdddda05fb4e9194646606ef"

--- a/Formula/l/log4shib.rb
+++ b/Formula/l/log4shib.rb
@@ -10,8 +10,6 @@ class Log4shib < Formula
     regex(/href=.*?log4shib[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "904dcc273d28ad65713782b2a01ee3a25997236147ac2281f3193148f5b22d16"
     sha256 cellar: :any,                 arm64_sequoia:  "8f3ca9cfd6b2cdc5d7487bcba05d48704e32a91a976addec41677d45525522a6"

--- a/Formula/l/lolcat.rb
+++ b/Formula/l/lolcat.rb
@@ -6,8 +6,6 @@ class Lolcat < Formula
       revision: "27441adfb51bc16073d65dbef300c8d3d7e86dc7"
   license "BSD-3-Clause"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "f3bdc980020b7f82e1a1e00736a06fcafbb5b51603130a562fcc0edf563051d6"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "5fbed8371f5d94b68f747973aa5c5f2d5fa5a9d0fb7a389d0417af3eac6924e9"

--- a/Formula/l/lpeg.rb
+++ b/Formula/l/lpeg.rb
@@ -11,8 +11,6 @@ class Lpeg < Formula
     regex(/href=.*?lpeg[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:    "23fa0a2aba7c78631a3a0116d17f97998069884af257cd741e08da9097802d65"

--- a/Formula/l/lrzsz.rb
+++ b/Formula/l/lrzsz.rb
@@ -11,8 +11,6 @@ class Lrzsz < Formula
     regex(/href=.*?lrzsz[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "d775c475daffed711d6092a64ff59d2b70a4190d2a38a0d0546c745ab3f47be3"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "6009c2f7058febf2aff37e82a6b2c3fd7d553948facff288e10b7c9b681b75dd"

--- a/Formula/l/ltl2ba.rb
+++ b/Formula/l/ltl2ba.rb
@@ -13,8 +13,6 @@ class Ltl2ba < Formula
     regex(/href=.*?ltl2ba[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "44343a3a706997bce508f8376785fa1f113926565bc18a57b0409545e1dff44d"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "18b178bd47a42ca3c5ab755e80cb5ec5a087807c1bef4fc064aa97a3ff18d76a"

--- a/Formula/l/lunchy.rb
+++ b/Formula/l/lunchy.rb
@@ -6,8 +6,6 @@ class Lunchy < Formula
       revision: "c78e554b60e408449937893b3054338411af273f"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, all: "071a71f4b6716723c0c3de5ce2daa1521e2fb339e009ea0df5e8ba1763a6fd8c"

--- a/Formula/l/lv.rb
+++ b/Formula/l/lv.rb
@@ -7,8 +7,6 @@ class Lv < Formula
   license "GPL-2.0-or-later"
   head "https://salsa.debian.org/debian/lv.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256                               arm64_tahoe:   "104d96df6f6d0a2d7dea6682973d5b13e7c676e3e919f745dd1f7215b80980a0"
     sha256                               arm64_sequoia: "d8fff4f49ad72ed22fe3b335d3a780a6ecc7e97d14e49d9a0cfdb459ab40fc77"

--- a/Formula/l/lv2.rb
+++ b/Formula/l/lv2.rb
@@ -11,8 +11,6 @@ class Lv2 < Formula
     regex(/href=.*?lv2[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, all: "25dce655720f7e01dee8e5b7db09049d887a4a0633ffac40a5333eec39283ce8"

--- a/Formula/l/lynx.rb
+++ b/Formula/l/lynx.rb
@@ -11,8 +11,6 @@ class Lynx < Formula
     regex(/href=.*?lynx[._-]?v?(\d+(?:\.\d+)+(?:rel\.?\d+)?)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 arm64_tahoe:   "f018c40ffe24220383f1e020875f64a62552bedc10e4948321992a4ceac5e83e"

--- a/Formula/l/lzop.rb
+++ b/Formula/l/lzop.rb
@@ -10,8 +10,6 @@ class Lzop < Formula
     regex(/href=.*?lzop[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "20091ae058723e28c6d638439220471a1c3862add310adb16aa7cde1e3ad4f1c"
     sha256 cellar: :any,                 arm64_sequoia:  "e29c398855c02fe9980a6365c4285c941988a3baa6fae5357dde1ae2ffed178e"


### PR DESCRIPTION
#269331

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI assisted with candidate discovery and one-commit-per-formula patching for `l*` formulas by removing `no_autobump! because: :requires_manual_review` where livecheck/status/source checks were compatible. I manually verified and reran `brew style` and `brew audit --strict` on the edited formula set.

Excluded from this batch: `launch4j`, `ldid-procursus`, `ldid`, `leela-zero`, `linux-headers@4.4`, `lsdvd` (VCS/deprecated/versioned cases left on manual review) and `lasi`, `loudmouth`, `lpc21isp`, `lxsplit`, `lzo` (strict-audit blockers).

-----
