### PR TITLE
lib*: remove no_autobump! manual review (part 1)

### DIFF
--- a/Formula/lib/libaacs.rb
+++ b/Formula/lib/libaacs.rb
@@ -11,8 +11,6 @@ class Libaacs < Formula
     regex(/href=.*?libaacs[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "bb76e9a99df6cbd2ddafd00b7d2bfec36f1d2340573402d912e25f2602d2a9af"
     sha256 cellar: :any,                 arm64_sequoia:  "ff23fb9dd6dd26f6dde8ac12c298be21546d2e3696fe7b064af1647b3788156d"

--- a/Formula/lib/libabw.rb
+++ b/Formula/lib/libabw.rb
@@ -11,8 +11,6 @@ class Libabw < Formula
     regex(/href=.*?libabw[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:   "94f750ee7bbbf84e58e7673ab8c00d6f5ac7805e3866887ef3a598f10465d555"

--- a/Formula/lib/libaio.rb
+++ b/Formula/lib/libaio.rb
@@ -17,8 +17,6 @@ class Libaio < Formula
     end
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_linux:  "f4a891153d9b7a34ea5f63cf64361f78c81c3a56a9cb8af6c94f0911dda3d4ff"

--- a/Formula/lib/libao.rb
+++ b/Formula/lib/libao.rb
@@ -6,8 +6,6 @@ class Libao < Formula
   license "GPL-2.0-or-later"
   head "https://gitlab.xiph.org/xiph/libao.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 3
     sha256 arm64_tahoe:    "e5015eef806ec149f9ad6e502d1aed412e9746da6f5ba2fa23947a5e58641d0b"

--- a/Formula/lib/libapplewm.rb
+++ b/Formula/lib/libapplewm.rb
@@ -5,8 +5,6 @@ class Libapplewm < Formula
   sha256 "5e5c85bcd81152b7bd33083135bfe2287636e707bba25f43ea09e1422c121d65"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any, arm64_tahoe:    "4b8eba3bb855a350470232642c48f34eb601408e1b7a4650bed5934bf0e6c6bc"
     sha256 cellar: :any, arm64_sequoia:  "9aed87eee9abadbc7e94ee746f6b54588d3eacd9fb455b2d94a96c4b7a19425e"

--- a/Formula/lib/libart.rb
+++ b/Formula/lib/libart.rb
@@ -12,8 +12,6 @@ class Libart < Formula
     regex(/libart_lgpl[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "5ef5d23e77d46adf971b467cdba6493e2ffb2dc153042ebc994723c8f0fd0317"
     sha256 cellar: :any,                 arm64_sequoia:  "3a01d5d537487e82c16a96a58e50cbfc189c6e2312fc9b93ce3d0ae110585a00"

--- a/Formula/lib/libb64.rb
+++ b/Formula/lib/libb64.rb
@@ -6,8 +6,6 @@ class Libb64 < Formula
   license "CC-PDDC"
   revision 1
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "3b92d742579da7f5934e8b7d99144b42167ff17b40144299d86924f828148368"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "210e5acb036ffda3a85af650cdcbda27c8ca804cb099d556a1dfd4779ec17fb7"

--- a/Formula/lib/libbdplus.rb
+++ b/Formula/lib/libbdplus.rb
@@ -11,8 +11,6 @@ class Libbdplus < Formula
     regex(/href=.*?libbdplus[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "7b8a3164167b5bc2e357f954ae319df5c9d6d7f0fb7b63f4ef71b65cbec9e3a4"
     sha256 cellar: :any,                 arm64_sequoia:  "9cc87d2f97a8450b3757c16b409e1c13a562e2d0e52492ab9d9cb032c908d600"

--- a/Formula/lib/libbs2b.rb
+++ b/Formula/lib/libbs2b.rb
@@ -5,8 +5,6 @@ class Libbs2b < Formula
   sha256 "6aaafd81aae3898ee40148dd1349aab348db9bfae9767d0e66e0b07ddd4b2528"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:    "1ba28dd968f0cee9f5e12adef12978ac728db271ffe588218ccd59ac8e3a3afe"

--- a/Formula/lib/libcanberra.rb
+++ b/Formula/lib/libcanberra.rb
@@ -19,8 +19,6 @@ class Libcanberra < Formula
     regex(/href=.*?libcanberra[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:    "ec6a63b0eb4cea2f117b082fadb5acc4792206193e3a64f8a02dcfdd6abda217"

--- a/Formula/lib/libcddb.rb
+++ b/Formula/lib/libcddb.rb
@@ -6,8 +6,6 @@ class Libcddb < Formula
   license "LGPL-2.0-or-later"
   revision 4
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any,                 arm64_tahoe:    "6324ea57171157edaca9aa78bbc30d5bc2389a5b9357bd8929a71bbdb7800720"

--- a/Formula/lib/libcello.rb
+++ b/Formula/lib/libcello.rb
@@ -11,8 +11,6 @@ class Libcello < Formula
     regex(/href=.*?libCello[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "f29b04252a3f79f89b5ed93d519639c4cf6c6033036d42d8a60567f466a19a96"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "0e380cf6073b22792954d22559177ff5ff3cbaf11fbe00948c27b675338ff116"

--- a/Formula/lib/libcmph.rb
+++ b/Formula/lib/libcmph.rb
@@ -5,8 +5,6 @@ class Libcmph < Formula
   sha256 "365f1e8056400d460f1ee7bfafdbf37d5ee6c78e8f4723bf4b3c081c89733f1e"
   license any_of: ["LGPL-2.1-only", "MPL-1.1"]
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "795cbd543a01cc09b16b32cd349b2c41ecf49511ec8dd413c9c992e044a7d1a0"
     sha256 cellar: :any,                 arm64_sequoia:  "43f6a25f51d2e29fc992882901b8fae82353d80efe71305bc6acf5bd852ff6c7"

--- a/Formula/lib/libcsv.rb
+++ b/Formula/lib/libcsv.rb
@@ -5,8 +5,6 @@ class Libcsv < Formula
   sha256 "d9c0431cb803ceb9896ce74f683e6e5a0954e96ae1d9e4028d6e0f967bebd7e4"
   license "LGPL-2.1-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any,                 arm64_tahoe:    "7e68ec2e60c356c84b0e330ad076afc58f0eb71eecd953ab4075821d835eb84d"

--- a/Formula/lib/libcutl.rb
+++ b/Formula/lib/libcutl.rb
@@ -11,6 +11,8 @@ class Libcutl < Formula
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
+  no_autobump! because: :requires_manual_review
+
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "28208d61e906d8696553ebd1b65a0d5c2abb8e889c91bed188f8bb434a112977"
     sha256 cellar: :any,                 arm64_sequoia: "085cbb14470957513c5a48765d1f0f924cd6646b7cb6e5070863b3fe756f54d2"

--- a/Formula/lib/libcutl.rb
+++ b/Formula/lib/libcutl.rb
@@ -11,8 +11,6 @@ class Libcutl < Formula
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "28208d61e906d8696553ebd1b65a0d5c2abb8e889c91bed188f8bb434a112977"
     sha256 cellar: :any,                 arm64_sequoia: "085cbb14470957513c5a48765d1f0f924cd6646b7cb6e5070863b3fe756f54d2"

--- a/Formula/lib/libdazzle.rb
+++ b/Formula/lib/libdazzle.rb
@@ -6,8 +6,6 @@ class Libdazzle < Formula
   license "GPL-3.0-or-later"
   revision 1
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:    "c85ea978999366c90f0a82d06f658d48a09ed3e021cd7edaedc8d18140145b77"
     sha256 arm64_sequoia:  "87f5700425b73e8a64c2b6af4f2f1ee74028b1921d147ba239a298c10ea12b05"

--- a/Formula/lib/libdbi.rb
+++ b/Formula/lib/libdbi.rb
@@ -5,8 +5,6 @@ class Libdbi < Formula
   sha256 "dafb6cdca524c628df832b6dd0bf8fabceb103248edb21762c02d3068fca4503"
   license "LGPL-2.1-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:    "2a44b6636fdd1a1ec49d06a47fa0b3b82fb5de1db98f124ed6e3b6c5dc5ed7f0"

--- a/Formula/lib/libdca.rb
+++ b/Formula/lib/libdca.rb
@@ -10,8 +10,6 @@ class Libdca < Formula
     regex(%r{href=.*?v?(\d+(?:\.\d+)+)[/"'>]}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "d61a15b00846c5be3aac61ac0f853f1f86a3e8dff28aaf3df07f546cc8ca1c4b"
     sha256 cellar: :any,                 arm64_sequoia:  "0737b7bd914efce32ae323ecbb5fca30b14b39ef31d704a482883598303518b5"

--- a/Formula/lib/libdmx.rb
+++ b/Formula/lib/libdmx.rb
@@ -5,8 +5,6 @@ class Libdmx < Formula
   sha256 "35a4e26a8b0b2b4fe36441dca463645c3fa52d282ac3520501a38ea942cbf74f"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "14977e0ecc11da42c82528f3c0d13d68df037f55e615ca95af6434cf214c2471"
     sha256 cellar: :any,                 arm64_sequoia:  "e5034cca46b4ff523130888f6d8bf0d75937e0f1b490a0cf0c0c175f32d8be2d"

--- a/Formula/lib/libdshconfig.rb
+++ b/Formula/lib/libdshconfig.rb
@@ -10,8 +10,6 @@ class Libdshconfig < Formula
     regex(/href=.*?libdshconfig[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:    "7d835c92dc8a1d1ce812a79d4fbbe8a900a77711f9a959362a1d03db8b7bfe8c"

--- a/Formula/lib/libdsk.rb
+++ b/Formula/lib/libdsk.rb
@@ -10,8 +10,6 @@ class Libdsk < Formula
     regex(/Stable version.*?href=.*?libdsk[._-]v?(\d+(?:\.\d+)+)\.t/im)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:   "feb56e14f0d05e880c42e25c4780cba7eb930b9e1aa4a313045accd8abdf4e49"

--- a/Formula/lib/libdv.rb
+++ b/Formula/lib/libdv.rb
@@ -5,8 +5,6 @@ class Libdv < Formula
   sha256 "a305734033a9c25541a59e8dd1c254409953269ea7c710c39e540bd8853389ba"
   license "LGPL-2.1-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:    "c14359502e9d8c606b0424966181a93c26fec27eb9ca41f2313af62888716c4d"

--- a/Formula/lib/libdvbcsa.rb
+++ b/Formula/lib/libdvbcsa.rb
@@ -12,8 +12,6 @@ class Libdvbcsa < Formula
     regex(%r{href=["']?v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "7978cc5fa8ca42fed7145ad8b1a5e445d1028c0bd30199d306466945e517bb41"
     sha256 cellar: :any,                 arm64_sequoia:  "e5119a840b0c4c13677acc889fc03d4c035c47fd74d6e6913a11786d5826192a"

--- a/Formula/lib/libdvbpsi.rb
+++ b/Formula/lib/libdvbpsi.rb
@@ -11,8 +11,6 @@ class Libdvbpsi < Formula
     regex(%r{href=["']?v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:    "8ca5d9293581da05648c293b9d1e0b67b1f33263c3fc57023f76822c5e2c2d59"

--- a/Formula/lib/libebml.rb
+++ b/Formula/lib/libebml.rb
@@ -11,8 +11,6 @@ class Libebml < Formula
     regex(/href=.*?libebml[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "b0156cbf1955e582256e75bdc14616f47df280ae9aecdf8b0b8fa5f9b5124aaa"
     sha256 cellar: :any,                 arm64_sequoia:  "2d15f6ce6df5cab89843ca6a7512a601b90ade25bbf7bcae17286664d72e11d0"

--- a/Formula/lib/libestr.rb
+++ b/Formula/lib/libestr.rb
@@ -10,8 +10,6 @@ class Libestr < Formula
     regex(/href=.*?libestr[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "25ff0e46e019f6de30b6d9a0980bd1eaaaa6a007f5c815f2e48607c6bab91714"
     sha256 cellar: :any,                 arm64_sequoia:  "c4ee35e1e3e47e5009e3fdb7be52737edebddcdd812e8c1811fcf73648a656cb"

--- a/Formula/lib/libev.rb
+++ b/Formula/lib/libev.rb
@@ -11,8 +11,6 @@ class Libev < Formula
     regex(/href=.*?libev[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "6f3bcc66907452a0f795ad6532d69deacdb1059379ca5a94da3a3e286342f94c"
     sha256 cellar: :any,                 arm64_sequoia:  "67740e5ba01e82c140ceadc512aa26a3990bfadaef0f4b545ba7f9aaf24c50bf"

--- a/Formula/lib/libexosip.rb
+++ b/Formula/lib/libexosip.rb
@@ -11,8 +11,6 @@ class Libexosip < Formula
     regex(/href=.*?libexosip2[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:    "65ae132c14b0b6e7928dacd91669bf489bf089b1cdcee75612ab52a2c6dc5363"

--- a/Formula/lib/libfastjson.rb
+++ b/Formula/lib/libfastjson.rb
@@ -10,8 +10,6 @@ class Libfastjson < Formula
     regex(/href=.*?libfastjson[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "dbb23a3103fbad3b4ae1a7b4a25630af8b2ce307ddabdf7b158eb8f1cc7e0ecc"
     sha256 cellar: :any,                 arm64_sequoia:  "e9a8424dc257099992210434ed1b30517d31ea60793715f5b2878421144ffa9e"

--- a/Formula/lib/libforensic1394.rb
+++ b/Formula/lib/libforensic1394.rb
@@ -11,8 +11,6 @@ class Libforensic1394 < Formula
     regex(/href=.*?libforensic1394[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "b4a478a738e2f3bb22a8316561b54914bcf0e2e4f00d7b90005d27f0564413ec"
     sha256 cellar: :any,                 arm64_sequoia:  "a3ae5e839007a8f6cfa3ca2e176285a889085333678c2b5edc095d22326e8aa6"


### PR DESCRIPTION
#269331

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI assisted with candidate discovery and one-commit-per-formula patching for `lib*` formulas by removing `no_autobump! because: :requires_manual_review` where livecheck/status/source checks were compatible. This batch was capped at 30 candidates, and `libcutl` was restored to manual review after verifying its stable URL embeds a separate `xsd/4.2` path component that still needs human review. I manually verified and reran `brew style` and `brew audit --strict` on the edited formula set.

Excluded from this batch: `lib3ds` (livecheck skipped on Google Code Archive), `libcutl` (stable URL path includes separate `xsd/4.2` release train), `libcuefile`, `libdaemon`, `libdc1394` (strict-audit blockers), and the remaining `lib*` formulas after this first slice.

-----
