### PR TITLE
quint: depend on node@24

### DIFF
--- a/Formula/q/quint.rb
+++ b/Formula/q/quint.rb
@@ -7,7 +7,7 @@ class Quint < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "19a69a901a152ac9fb9e83a48b521548376aaec6c59c4e466c59379d8bdc2870"
+    sha256 cellar: :any_skip_relocation, all: "e23549d53ff802e620b55539f16ce88eda7d81298c5ec39104c1ebcd242a692d"
   end
 
   # Remove when Node 25 is fixed upstream: https://github.com/nodejs/node/issues/61971

--- a/Formula/q/quint.rb
+++ b/Formula/q/quint.rb
@@ -4,12 +4,15 @@ class Quint < Formula
   url "https://registry.npmjs.org/@informalsystems/quint/-/quint-0.31.0.tgz"
   sha256 "f1ba3ac13f5fd5c1439cf6b6518a56b871ec6ac4c634b2044de23e7a3cc572a8"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "19a69a901a152ac9fb9e83a48b521548376aaec6c59c4e466c59379d8bdc2870"
   end
 
-  depends_on "node"
+  # Remove when Node 25 is fixed upstream: https://github.com/nodejs/node/issues/61971
+  # Formula-specific tracking: https://github.com/informalsystems/quint/issues/1926
+  depends_on "node@24"
 
   def install
     system "npm", "install", *std_npm_args


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI assistance: log triage and drafting the formula edit/PR text.
Manual verification: `HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_FROM_API=1 brew reinstall --build-from-source quint`, `HOMEBREW_NO_AUTO_UPDATE=1 brew test quint`, `HOMEBREW_NO_AUTO_UPDATE=1 brew audit --strict quint`, `HOMEBREW_NO_AUTO_UPDATE=1 brew style Formula/q/quint.rb`.

-----

Built and tested locally on macOS 26.2.

Temporarily depend on `node@24` (with `revision 1`) due the Node 25.7.0 runtime regression after #269249.

Refs:
- https://github.com/Homebrew/homebrew-core/pull/269249
- https://github.com/nodejs/node/issues/61971
- https://github.com/informalsystems/quint/issues/1926