### PR TITLE
nerdctl: cherry-pick `CNI: add Homebrew's installation path`

### DIFF
--- a/Formula/n/nerdctl.rb
+++ b/Formula/n/nerdctl.rb
@@ -19,8 +19,8 @@ class Nerdctl < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_linux:  "f56a55ab70d05398e06c6c542b2a03e5d80424c3dcdb1c1263b5101d0c07f0aa"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "7c99ebeb05ea37c502feab10d6b1571e380e2f3adbcfe9403ef6b73913da7784"
+    sha256 cellar: :any_skip_relocation, arm64_linux:  "c81283953a5fc7c7241d99b615ddd6d5bc15ca9c38aa0b7c7f1aca3f9531a88f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "482ba7a0f51fec5cb4ad63f904eeee97bfaf1ceb76e26504321d449478a4cc06"
   end
 
   depends_on "go" => :build

--- a/Formula/n/nerdctl.rb
+++ b/Formula/n/nerdctl.rb
@@ -1,11 +1,22 @@
 class Nerdctl < Formula
   desc "ContaiNERD CTL - Docker-compatible CLI for containerd"
   homepage "https://github.com/containerd/nerdctl"
-  url "https://github.com/containerd/nerdctl/archive/refs/tags/v2.2.1.tar.gz"
-  sha256 "f39c34d3a285e087f2b2869f06fea343d8285ad9bfb9417b9c5b6dd4e78d6fad"
   license "Apache-2.0"
-  revision 1
+  revision 2
   head "https://github.com/containerd/nerdctl.git", branch: "main"
+
+  stable do
+    url "https://github.com/containerd/nerdctl/archive/refs/tags/v2.2.1.tar.gz"
+    sha256 "f39c34d3a285e087f2b2869f06fea343d8285ad9bfb9417b9c5b6dd4e78d6fad"
+
+    # CNI: add Homebrew's installation path
+    # https://github.com/containerd/nerdctl/pull/4761
+    # Merged into main, targeted for v2.3.0.
+    patch do
+      url "https://github.com/containerd/nerdctl/commit/a1cffd64ccc1ac6c261f10937e3b3fa57ccac90c.patch?full_index=1"
+      sha256 "667781729c9225e28fe9ddb2ad32e7b46f2bcfc62b5ef95e5e9b592e0c221414"
+    end
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_linux:  "f56a55ab70d05398e06c6c542b2a03e5d80424c3dcdb1c1263b5101d0c07f0aa"


### PR DESCRIPTION
Cherry-pick containerd/nerdctl#4761 so that nerdctl can detect the path of the cni-pluguins forluma.

Prior to this commit, `--cni-path` had to be specified manually.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.
  - Didn't use
-----
