### PR TITLE
various: remove livecheck and `no_autobump!`

### DIFF
--- a/Formula/a/aoeui.rb
+++ b/Formula/a/aoeui.rb
@@ -5,11 +5,6 @@ class Aoeui < Formula
   sha256 "0655c3ca945b75b1204c5f25722ac0a07e89dd44bbf33aca068e918e9ef2a825"
   license "GPL-2.0-only"
 
-  livecheck do
-    url "https://storage.googleapis.com/google-code-archive/v2/code.google.com/aoeui/downloads-page-1.json"
-    regex(/aoeui[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "5db4e6bc86d61cb543bba6cfc8f46bb1db2dd51314701866c881c50b09e4aab8"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "d884318d049fd6851389c8c37f7c0eb1042fbeb00c7cf7d0829ce6ab3d45d81d"

--- a/Formula/b/blazeblogger.rb
+++ b/Formula/b/blazeblogger.rb
@@ -5,11 +5,6 @@ class Blazeblogger < Formula
   sha256 "39024b70708be6073e8aeb3943eb3b73d441fbb7b8113e145c0cf7540c4921aa"
   license "GPL-3.0-only"
 
-  livecheck do
-    url "https://storage.googleapis.com/google-code-archive/v2/code.google.com/blazeblogger/downloads-page-1.json"
-    regex(/blazeblogger[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     rebuild 3
     sha256 cellar: :any_skip_relocation, all: "4f76e3eb4cb3ab302fdf746ec68a54f42422913c10916429788affadad93209c"

--- a/Formula/c/cifer.rb
+++ b/Formula/c/cifer.rb
@@ -5,11 +5,6 @@ class Cifer < Formula
   sha256 "436816c1f9112b8b80cf974596095648d60ffd47eca8eb91fdeb19d3538ea793"
   license "GPL-3.0-or-later"
 
-  livecheck do
-    url "https://storage.googleapis.com/google-code-archive/v2/code.google.com/cifer/downloads-page-1.json"
-    regex(/cifer[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "0ddcaf5c7910b356424491a71c0b42587701427aba17e0fdc02a9c088c148590"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "8d9f5339ed8c92d74cc50214716df2c6082a559fdf26b004ff69e0468e3faf0e"

--- a/Formula/c/cityhash.rb
+++ b/Formula/c/cityhash.rb
@@ -5,11 +5,6 @@ class Cityhash < Formula
   sha256 "76a41e149f6de87156b9a9790c595ef7ad081c321f60780886b520aecb7e3db4"
   license "MIT"
 
-  livecheck do
-    url "https://storage.googleapis.com/google-code-archive/v2/code.google.com/cityhash/downloads-page-1.json"
-    regex(/cityhash[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "a48224df147a6510be1f81144df6c5060ec5c053121bed9ff26e3bc0344585ed"
     sha256 cellar: :any,                 arm64_sequoia:  "ce559172129f8c960379c6cfc4f513d8dce917f386f4471f1a1ab5766a0acffd"

--- a/Formula/c/clamz.rb
+++ b/Formula/c/clamz.rb
@@ -6,11 +6,6 @@ class Clamz < Formula
   license "GPL-3.0-or-later"
   revision 1
 
-  livecheck do
-    url "https://storage.googleapis.com/google-code-archive/v2/code.google.com/clamz/downloads-page-1.json"
-    regex(/clamz[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "0d263cb2b16259b06794b4470e155967eab994f538c670fdcb2db680c5c5f03f"
     sha256 cellar: :any,                 arm64_sequoia:  "60807a8f262d22bbae1e13db11d9a7d9765896cc3c0e08ab919194f94e114705"

--- a/Formula/c/cmigemo.rb
+++ b/Formula/c/cmigemo.rb
@@ -12,11 +12,6 @@ class Cmigemo < Formula
     patch :DATA
   end
 
-  livecheck do
-    url "https://storage.googleapis.com/google-code-archive/v2/code.google.com/cmigemo/downloads-page-1.json"
-    regex(/cmigemo[._-]default[._-]src[._-]v?(\d{8})\.z/i)
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "b8bf233fe044c8a2bd5bc24fc9bf11eed7aeb0464f67bd7d7ad48f6d9e8edbbf"
     sha256 cellar: :any,                 arm64_sequoia:  "68bc0630d1414e71d16c8a0f39add12897a7f874119a8eeae19e44f28df8706c"

--- a/Formula/c/csshx.rb
+++ b/Formula/c/csshx.rb
@@ -8,11 +8,6 @@ class Csshx < Formula
   license any_of: ["Artistic-1.0-Perl", "GPL-1.0-or-later"]
   head "https://github.com/brockgr/csshx.git", branch: "master"
 
-  livecheck do
-    url "https://storage.googleapis.com/google-code-archive/v2/code.google.com/csshx/downloads-page-1.json"
-    regex(/csshX[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "b8bdc972870bbf205b870ecd86251a2975d517f0da679aecdc0299b9472ef338"

--- a/Formula/d/dsocks.rb
+++ b/Formula/d/dsocks.rb
@@ -6,11 +6,6 @@ class Dsocks < Formula
   license "BSD-2-Clause"
   head "https://github.com/dugsong/dsocks.git", branch: "master"
 
-  livecheck do
-    url "https://storage.googleapis.com/google-code-archive/v2/code.google.com/dsocks/downloads-page-1.json"
-    regex(/dsocks[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "601324838005b2686e67ea99328ad71a5f59250b8c329bbc9a0861d1bbfe0dbe"
     sha256 cellar: :any,                 arm64_sequoia:  "9130e47d1bfae90594a9127a2aa63144b9101563558cf1fa704205c874bf23a5"

--- a/Formula/f/fex.rb
+++ b/Formula/f/fex.rb
@@ -5,11 +5,6 @@ class Fex < Formula
   sha256 "03043c8eac74f43173068a2e693b6f73d5b45f453a063e6da11f34455d0e374e"
   license "Apache-2.0"
 
-  livecheck do
-    url "https://storage.googleapis.com/google-code-archive/v2/code.google.com/semicomplete/downloads-page-1.json"
-    regex(/fex[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "176a130c8c8b14eee48303c89fcab8d8dd6534e43fb042d8fab5b30486e2641b"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "d0777ac160fda3d6860d6a7077e98e05e0a7a80f75c4c15e39c58699bd9c22ff"

--- a/Formula/f/flow-tools.rb
+++ b/Formula/f/flow-tools.rb
@@ -5,11 +5,6 @@ class FlowTools < Formula
   sha256 "80bbd3791b59198f0d20184761d96ba500386b0a71ea613c214a50aa017a1f67"
   license "BSD-2-Clause"
 
-  livecheck do
-    url "https://storage.googleapis.com/google-code-archive/v2/code.google.com/flow-tools/downloads-page-1.json"
-    regex(/flow-tools[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     rebuild 2
     sha256 arm64_tahoe:   "c6ac8dfec95def2a25acdf33db6ddd896f473f64c402e415753a316d0eef78b1"

--- a/Formula/g/garmintools.rb
+++ b/Formula/g/garmintools.rb
@@ -5,8 +5,6 @@ class Garmintools < Formula
   sha256 "ffd50b7f963fa9b8ded3223c4786b07906c887ed900de64581a24ff201444cee"
   license "GPL-2.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "47a336083bb5161af82770d5c472d2ce4f358914bce8e2263458e5a757d45433"
     sha256 cellar: :any,                 arm64_sequoia:  "20a6201dcffaf971164afa65223ba7eb6ef53dca3c1a092e303dda0654f109d8"

--- a/Formula/g/git-multipush.rb
+++ b/Formula/g/git-multipush.rb
@@ -6,8 +6,6 @@ class GitMultipush < Formula
   license "GPL-3.0-or-later"
   head "https://github.com/gavinbeatty/git-multipush.git", branch: "main"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, all: "74cbae277a623c4ffc3d8b597734d05741cc549a2021de8c25eef4fc9ac4aa25"

--- a/Formula/h/hostdb.rb
+++ b/Formula/h/hostdb.rb
@@ -5,8 +5,6 @@ class Hostdb < Formula
   sha256 "beea7cfcdc384eb40d0bc8b3ad2eb094ee81ca75e8eef7c07ea4a47e9f0da350"
   license "GPL-2.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "7f0c8bfe7fe1652daa4aa926d6287ae94e851bd979ca6b53b3c0bc54e85dc208"

--- a/Formula/h/htmlcompressor.rb
+++ b/Formula/h/htmlcompressor.rb
@@ -5,8 +5,6 @@ class Htmlcompressor < Formula
   sha256 "88894e330cdb0e418e805136d424f4c262236b1aa3683e51037cdb66310cb0f9"
   license "Apache-2.0"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, all: "a8323e2d6001cc0effb3c29900f977118d35fc4a0a86be9cd49d0fa133d04f23"

--- a/Formula/j/jslint4java.rb
+++ b/Formula/j/jslint4java.rb
@@ -5,8 +5,6 @@ class Jslint4java < Formula
   sha256 "078240b17256a0472f9981d68f11556238658ebaa67be49ea49958adafc96a81"
   license "BSD-2-Clause"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, all: "96eda9ffe32e9dae5f01ef6dbad6c26ae7deeff1ad79163c18c0331819d44e46"

--- a/Formula/lib/lib3ds.rb
+++ b/Formula/lib/lib3ds.rb
@@ -5,8 +5,6 @@ class Lib3ds < Formula
   sha256 "f5b00c302955a67fa5fb1f2d3f2583767cdc61fdbc6fd843c0c7c9d95c5629e3"
   license "LGPL-2.1-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:    "05c4539d63ece4173e11e64c12337fb23165bac92574603467512f73c770fb2b"

--- a/Formula/m/memcache-top.rb
+++ b/Formula/m/memcache-top.rb
@@ -5,8 +5,6 @@ class MemcacheTop < Formula
   sha256 "d5f896a9e46a92988b782e340416312cc480261ce8a5818db45ccd0da8a0f22a"
   license "BSD-3-Clause"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "087a748b42b751770abe12ce9529e0e55d96b9f69f28ee7b6951e099271b8f3e"

--- a/Formula/m/mfcuk.rb
+++ b/Formula/m/mfcuk.rb
@@ -6,8 +6,6 @@ class Mfcuk < Formula
   license "GPL-2.0-or-later"
   revision 1
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "d64c65224a51793f1dd148741d3750dfed188a452c99793321837ee4e6ff98e0"
     sha256 cellar: :any,                 arm64_sequoia:  "102426161778216f2bf11462bbaa8bb369a883cc818b560491d85bc5307ef9d9"

--- a/Formula/m/mp3check.rb
+++ b/Formula/m/mp3check.rb
@@ -5,8 +5,6 @@ class Mp3check < Formula
   sha256 "27d976ad8495671e9b9ce3c02e70cb834d962b6fdf1a7d437bb0e85454acdd0e"
   license "GPL-2.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "7b728bb5db4fb551bba2fe2ca58a59ae28df476caa8457d4b9ee5d04811d77ac"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "5cd5050fc0ece72900fdee9f06144599fd519f2f62fa3ec3f8ed0af1e4805301"

--- a/Formula/n/nfcutils.rb
+++ b/Formula/n/nfcutils.rb
@@ -6,8 +6,6 @@ class Nfcutils < Formula
   license "GPL-3.0-or-later"
   revision 1
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "cd0945f758948d322f434b25388ca838233019379db9edad5ef599278141c020"
     sha256 cellar: :any,                 arm64_sequoia:  "588fdde98a8a04e2641697c4b881cc1ec3ef7ad1cc2f57d83f93769d9e9331a0"

--- a/Formula/o/oscats.rb
+++ b/Formula/o/oscats.rb
@@ -6,8 +6,6 @@ class Oscats < Formula
   license "GPL-3.0-or-later"
   revision 7
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "35dc1e697fe94c6ceab3be777ef3aa53ec83df8451739125105a4fa5e24e5fd7"
     sha256 cellar: :any,                 arm64_sequoia:  "14bdf254ea5eb224c087cc3bdc7ba53b46d52b77e2c440f738871e747ad7e33a"

--- a/Formula/p/pdf2image.rb
+++ b/Formula/p/pdf2image.rb
@@ -6,8 +6,6 @@ class Pdf2image < Formula
   license "FSFUL"
   revision 1
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:    "3441323b63b2667e68a90b70633c40813b10f0597933aadd8a46ff7a36413f8a"
     sha256 arm64_sequoia:  "412c25b88af18ef42fc4c705a409449b38f3fab9a792b40067ce2c510e524903"

--- a/Formula/p/picoc.rb
+++ b/Formula/p/picoc.rb
@@ -18,8 +18,6 @@ class Picoc < Formula
     end
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "190a69c827d572ea5c16c28021907f6eb657eaa4b3381fc379ebeeda16e1c102"

--- a/Formula/p/ppss.rb
+++ b/Formula/p/ppss.rb
@@ -5,8 +5,6 @@ class Ppss < Formula
   sha256 "25d819a97d8ca04a27907be4bfcc3151712837ea12a671f1a3c9e58bc025360f"
   license "GPL-3.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "e341e42c45d8ab9d5251b5330405329c45f1342a2cd94a466764b894a2b9ac6c"

--- a/Formula/r/rats.rb
+++ b/Formula/r/rats.rb
@@ -5,8 +5,6 @@ class Rats < Formula
   sha256 "2163ad111070542d941c23b98d3da231f13cf065f50f2e4ca40673996570776a"
   license "GPL-2.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:    "b310ca257b3697a46004e64f9c06bce6ae79bb75c86d832bc74c28cbd1f99a7d"
     sha256 arm64_sequoia:  "0957ff0fe765a50f6ec8a12edc3119741fe39133b438ee114ace6d05288fb06c"

--- a/Formula/r/rlog.rb
+++ b/Formula/r/rlog.rb
@@ -5,8 +5,6 @@ class Rlog < Formula
   sha256 "a938eeedeb4d56f1343dc5561bc09ae70b24e8f70d07a6f8d4b6eed32e783f79"
   license "LGPL-2.1-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "abe2bf8a021e632b0e828b667b5e2e09be2cb2bf5356b40adc7787248c16b12e"
     sha256 cellar: :any,                 arm64_sequoia:  "17aeadbbb0c7138389b80f0cecf0c59b6a329176eda02d38a9566502110f72f4"

--- a/Formula/s/somagic-tools.rb
+++ b/Formula/s/somagic-tools.rb
@@ -5,8 +5,6 @@ class SomagicTools < Formula
   sha256 "b091723c55e6910cbf36c88f8d37a8d69856868691899683ec70c83b122a0715"
   license "GPL-2.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "6efbacaa2b232898e3149d4392e6a6575cc34835b34cbf268bf73ddce6aef79f"
     sha256 cellar: :any,                 arm64_sequoia:  "6df28d78f161dc5a7e4a53d329db5c191848fe0c50abf3d7b0d71019d0ccbdae"

--- a/Formula/s/somagic.rb
+++ b/Formula/s/somagic.rb
@@ -5,8 +5,6 @@ class Somagic < Formula
   sha256 "3a9dd78a47335a6d041cd5465d28124612dad97939c56d7c10e000484d78a320"
   license "GPL-2.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "f077c27f36c94d14196836cb4f397c6d720cf39a399d64da000c62d2d0faac16"
     sha256 cellar: :any,                 arm64_sequoia:  "f2c83c2ff15da271002454ee3f3b73863d3143954a5d761bcabd7a1412824fb9"

--- a/Formula/t/truecrack.rb
+++ b/Formula/t/truecrack.rb
@@ -6,8 +6,6 @@ class Truecrack < Formula
   sha256 "25bf270fa3bc3591c3d795e5a4b0842f6581f76c0b5d17c0aef260246fe726b3"
   license "GPL-3.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "fa006f2b40a1844949c625ee3ded3b0626420c1969b7595b5081ba471a8ce234"

--- a/Formula/w/wy60.rb
+++ b/Formula/w/wy60.rb
@@ -5,8 +5,6 @@ class Wy60 < Formula
   sha256 "f7379404f0baf38faba48af7b05f9e0df65266ab75071b2ca56195b63fc05ed0"
   license "GPL-2.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:    "27074202271ebad114a776e830498514e56da281471bdd05eed3d4eb00dbee09"
     sha256 arm64_sequoia:  "6e8b275623922f42137e8d90712e41890ac44f9218dc7ff8d8476068d7497f01"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Google code archive is just a snapshot, so the livecheck is useless (add by myself). In this PR, I remove again the livecheck and also remove `no_autobump!` because we already have a feature to prevent them to livecheck as follows: 

```
> brew lc aoeui
aoeui: skipped - Stable URL is from Google Code Archive
```

