### PR TITLE
v*: remove `no_autobump!`

### DIFF
--- a/Formula/v/vamp-plugin-sdk.rb
+++ b/Formula/v/vamp-plugin-sdk.rb
@@ -18,8 +18,6 @@ class VampPluginSdk < Formula
     regex(/href=.*?vamp-plugin-sdk[._-]v?(\d+(?:\.\d+)+)\.orig\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "9bb7224a25dadc8224c09bee6594dcd2003a0d8a9f43f3bc392d889923ffb539"
     sha256 cellar: :any,                 arm64_sequoia: "0fd18a6d81ea391818744555984ec3b2f8052f801a097be6511dc4589d9810fc"

--- a/Formula/v/vbindiff.rb
+++ b/Formula/v/vbindiff.rb
@@ -10,8 +10,6 @@ class Vbindiff < Formula
     regex(/href=.*?vbindiff[._-]v?(\d+(?:\.\d+)+(?:.?beta\d+)?)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "e2e6e0b5616b035911aed46c5ab5fe7649886d86dbc880ea42e8c64cb70816c7"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "4a3b8297335705d8d6c97b391d707bd8c19d30b84d36e8f045065490230a1298"

--- a/Formula/v/vcdimager.rb
+++ b/Formula/v/vcdimager.rb
@@ -7,8 +7,6 @@ class Vcdimager < Formula
   license "GPL-2.0-or-later"
   revision 2
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "4fc5cf3e045233757dcf29a78fb731148d3c5ce9692df7825024b0b3ae66619e"
     sha256 cellar: :any,                 arm64_sequoia: "2dbaab4b58479eca7337c3648f97c5f77bb8fb2ee40fd065b931215a16d52330"

--- a/Formula/v/viennacl.rb
+++ b/Formula/v/viennacl.rb
@@ -7,8 +7,6 @@ class Viennacl < Formula
   revision 1
   head "https://github.com/viennacl/viennacl-dev.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "ef65ab6738404defb457637aa1d644b54db8bd55b9c0ddcc99dfb005e2653441"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "dd97554d6b9c07ca2fcf625dec5198ef86dffba1b1723e9e83796ccba63c2d7a"

--- a/Formula/v/vilistextum.rb
+++ b/Formula/v/vilistextum.rb
@@ -16,8 +16,6 @@ class Vilistextum < Formula
     end
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "49595a548ac3b8e7818c1467db59e825ee7d0ca03d38311b3494451bc40687e8"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "518d8afa3e88d75bb45459300aa06568ebdb4b712495fac4d0edbe3dcfa17fb5"

--- a/Formula/v/vip.rb
+++ b/Formula/v/vip.rb
@@ -28,7 +28,7 @@ class Vip < Formula
     end
   end
 
-  no_autobump! because: :requires_manual_review
+  no_autobump! because: :incompatible_version_format
 
   bottle do
     rebuild 2

--- a/Formula/v/virtualpg.rb
+++ b/Formula/v/virtualpg.rb
@@ -10,8 +10,6 @@ class Virtualpg < Formula
     regex(/href=.*?virtualpg[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:   "96423b815a0781a3635f54f02bac58f5b6f97ad735184005b812b7bbe2bda8c6"

--- a/Formula/v/vmdktool.rb
+++ b/Formula/v/vmdktool.rb
@@ -10,8 +10,6 @@ class Vmdktool < Formula
     regex(/href=.*?vmdktool[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "9c80ae2a1f31f2ce299e628833d1e506ac03b5a0a27ba6ad7cae14455a62eec1"

--- a/Formula/v/vncsnapshot.rb
+++ b/Formula/v/vncsnapshot.rb
@@ -11,8 +11,6 @@ class Vncsnapshot < Formula
     regex(%r{url=.*?/vncsnapshot[._-]v?(\d+(?:\.\d+)+[a-z]?)-src\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:   "cdc55184ba7f8d8bf9c418d2f76e64a0a58e53e99d6bc9cf0e1859c671e7879d"

--- a/Formula/v/vo-amrwbenc.rb
+++ b/Formula/v/vo-amrwbenc.rb
@@ -10,8 +10,6 @@ class VoAmrwbenc < Formula
     regex(%r{url=.*?/vo-amrwbenc[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "654ba6332b443125e46a211f00ed4f16b219d6de0068d8a4ea863200e97694cc"
     sha256 cellar: :any,                 arm64_sequoia: "fec91381e714f851e4215e99f160daeeb8844fe28ac28bb86f4de6076eb7db1e"

--- a/Formula/v/vorbisgain.rb
+++ b/Formula/v/vorbisgain.rb
@@ -10,8 +10,6 @@ class Vorbisgain < Formula
     regex(/href=.*?vorbisgain[._-]v?(\d+(?:\.\d+)+)\.(?:t|zip)/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "2184e1fd2ac1887c416d3aef7c8596ff7b4b5bb34e5f1d2e47f9b4ef54e69094"
     sha256 cellar: :any,                 arm64_sequoia:  "1e173fbe7ad9eff215301e6c55c6b8e30a8299c5f946a4102ef15cbbc5080b1f"

--- a/Formula/v/voro++.rb
+++ b/Formula/v/voro++.rb
@@ -11,8 +11,6 @@ class Voroxx < Formula
     regex(/href=.*?voro\+\+[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "e92608286d7f5525760a291095fffa5174353cd4360288b3b370734e266e332a"
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "5c76ccd2f7c88492a312735928f7b629188da9bac80b579effbf140eaff73cb7"

--- a/Formula/v/vroom.rb
+++ b/Formula/v/vroom.rb
@@ -6,8 +6,6 @@ class Vroom < Formula
       revision: "1fd711bc8c20326dd8e9538e2c7e4cb1ebd67bdb"
   license "BSD-2-Clause"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "603f9db571c5a11951f2d2f7a07e4a1108c07798cd1f347dbf4736e6baf6d7b3"
     sha256 cellar: :any,                 arm64_sequoia: "e6cb0a6729f091b1d219c0ba4bfb995dfd3e2e2a445091550743ed273e1c5812"

--- a/Formula/v/vsftpd.rb
+++ b/Formula/v/vsftpd.rb
@@ -11,8 +11,6 @@ class Vsftpd < Formula
     regex(/href=.*?vsftpd[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 arm64_tahoe:   "01dbfae43456eddf9dda1082d584faffbc1375610626a5b2c6229ae3fdbd13f2"

--- a/Formula/v/vstr.rb
+++ b/Formula/v/vstr.rb
@@ -11,8 +11,6 @@ class Vstr < Formula
     regex(/href=.*?vstr[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "2725b8c09c36af9b495587022630130f5561972343fa3d91bba4de2773f7c76e"
     sha256 cellar: :any,                 arm64_sequoia:  "578ee5248bf780a885cfc3dc8a806949ded7af743c3be7e7c839fe4d190a43cd"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

`vip` has incompatible version format and other formula are file to remove `no_autobump!`.

- https://github.com/Homebrew/homebrew-core/issues/269331