### PR TITLE
snyk-agent-scan 0.4.3 (renamed from mcp-scan)

### DIFF
--- a/Formula/s/snyk-agent-scan.rb
+++ b/Formula/s/snyk-agent-scan.rb
@@ -1,21 +1,11 @@
-class McpScan < Formula
+class SnykAgentScan < Formula
   include Language::Python::Virtualenv
 
   desc "Constrain, log and scan your MCP connections for security vulnerabilities"
-  homepage "https://github.com/invariantlabs-ai/mcp-scan"
-  url "https://files.pythonhosted.org/packages/9d/ff/1ab49f2b1e3b8bdf114d442f6b49a3f703b9e6d01b0083bd6f9389fc4f7d/mcp_scan-0.4.2.tar.gz"
-  sha256 "b7b71bcb5f8137e5c1176be9a5b176b5cd3ddf668718ab38e5261d3a325a0e17"
+  homepage "https://github.com/snyk/agent-scan"
+  url "https://files.pythonhosted.org/packages/dc/08/4ec1ed162dc4e4bbcc05274933002356d61518ad348b2e952915f8cc8a43/snyk_agent_scan-0.4.3.tar.gz"
+  sha256 "5a169ba9cb8c6cca94ecd7dbc69e5ae20e4db57196294019a3583a80ee5a9bb8"
   license "Apache-2.0"
-  head "https://github.com/invariantlabs-ai/mcp-scan.git", branch: "main"
-
-  bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "47c0c6112aaed4eeb2940eea3367994f8f64863e83b1345e701c98be85555dc3"
-    sha256 cellar: :any,                 arm64_sequoia: "53fdd65edf420cbf044f55a881ebc4c75deaf875197d8936e744970f5228851e"
-    sha256 cellar: :any,                 arm64_sonoma:  "47227fa86ffb2d394057b3d9e7569ab98906f1830b959d08ae3f29e7004f3b21"
-    sha256 cellar: :any,                 sonoma:        "872696384a0a25cb8ede46ad9a303ace04a0aa2d70f3a4dae83e6af9a977e383"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "8029c3cb040fae7f50bb646de8123528a5b5441adf269cd96c72536a6c60b72c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "86bdb17df51e99fd4416266279c6278433888e9a03e5916f45feed8bed78db05"
-  end
 
   depends_on "certifi" => :no_linkage
   depends_on "cryptography" => :no_linkage
@@ -25,11 +15,6 @@ class McpScan < Formula
   depends_on "rpds-py" => :no_linkage
 
   pypi_packages exclude_packages: %w[certifi cryptography pydantic rpds-py]
-
-  resource "aiofiles" do
-    url "https://files.pythonhosted.org/packages/41/c3/534eac40372d8ee36ef40df62ec129bee4fdb5ad9706e58a29be53b2c970/aiofiles-25.1.0.tar.gz"
-    sha256 "a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2"
-  end
 
   resource "aiohappyeyeballs" do
     url "https://files.pythonhosted.org/packages/26/30/f84a107a9c4331c14b2b586036f40965c128aa4fee4dda5d3d51cb14ad54/aiohappyeyeballs-2.6.1.tar.gz"
@@ -67,13 +52,13 @@ class McpScan < Formula
   end
 
   resource "fastapi" do
-    url "https://files.pythonhosted.org/packages/48/47/75f6bea02e797abff1bca968d5997793898032d9923c1935ae2efdece642/fastapi-0.129.0.tar.gz"
-    sha256 "61315cebd2e65df5f97ec298c888f9de30430dd0612d59d6480beafbc10655af"
+    url "https://files.pythonhosted.org/packages/e7/7b/f8e0211e9380f7195ba3f3d40c292594fd81ba8ec4629e3854c353aaca45/fastapi-0.135.1.tar.gz"
+    sha256 "d04115b508d936d254cea545b7312ecaa58a7b3a0f84952535b4c9afae7668cd"
   end
 
   resource "filelock" do
-    url "https://files.pythonhosted.org/packages/02/a8/dae62680be63cbb3ff87cfa2f51cf766269514ea5488479d42fec5aa6f3a/filelock-3.24.2.tar.gz"
-    sha256 "c22803117490f156e59fafce621f0550a7a853e2bbf4f87f112b11d469b6c81b"
+    url "https://files.pythonhosted.org/packages/77/18/a1fd2231c679dcb9726204645721b12498aeac28e1ad0601038f94b42556/filelock-3.25.0.tar.gz"
+    sha256 "8f00faf3abf9dc730a1ffe9c354ae5c04e079ab7d3a683b7c32da5dd05f26af3"
   end
 
   resource "frozenlist" do
@@ -152,8 +137,8 @@ class McpScan < Formula
   end
 
   resource "pydantic-settings" do
-    url "https://files.pythonhosted.org/packages/96/a1/ae859ffac5a3338a66b74c5e29e244fd3a3cc483c89feaf9f56c39898d75/pydantic_settings-2.13.0.tar.gz"
-    sha256 "95d875514610e8595672800a5c40b073e99e4aae467fa7c8f9c263061ea2e1fe"
+    url "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz"
+    sha256 "b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025"
   end
 
   resource "pygments" do
@@ -172,8 +157,8 @@ class McpScan < Formula
   end
 
   resource "python-dotenv" do
-    url "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz"
-    sha256 "42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6"
+    url "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz"
+    sha256 "2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3"
   end
 
   resource "python-multipart" do
@@ -197,8 +182,8 @@ class McpScan < Formula
   end
 
   resource "regex" do
-    url "https://files.pythonhosted.org/packages/0b/86/07d5056945f9ec4590b518171c4254a5925832eb727b56d3c38a7476f316/regex-2026.1.15.tar.gz"
-    sha256 "164759aa25575cbc0651bef59a0b18353e54300d79ace8084c818ad8ac72b7d5"
+    url "https://files.pythonhosted.org/packages/8b/71/41455aa99a5a5ac1eaf311f5d8efd9ce6433c03ac1e0962de163350d0d97/regex-2026.2.28.tar.gz"
+    sha256 "a729e47d418ea11d03469f321aaf67cdee8954cde3ff2cf8403ab87951ad10f2"
   end
 
   resource "rich" do
@@ -212,8 +197,8 @@ class McpScan < Formula
   end
 
   resource "sse-starlette" do
-    url "https://files.pythonhosted.org/packages/8b/8d/00d280c03ffd39aaee0e86ec81e2d3b9253036a0f93f51d10503adef0e65/sse_starlette-3.2.0.tar.gz"
-    sha256 "8127594edfb51abe44eac9c49e59b0b01f1039d0c7461c6fd91d4e03b70da422"
+    url "https://files.pythonhosted.org/packages/5a/9f/c3695c2d2d4ef70072c3a06992850498b01c6bc9be531950813716b426fa/sse_starlette-3.3.2.tar.gz"
+    sha256 "678fca55a1945c734d8472a6cad186a55ab02840b4f6786f5ee8770970579dcd"
   end
 
   resource "starlette" do
@@ -227,13 +212,8 @@ class McpScan < Formula
   end
 
   resource "typer" do
-    url "https://files.pythonhosted.org/packages/5a/b6/3e681d3b6bb22647509bdbfdd18055d5adc0dce5c5585359fa46ff805fdc/typer-0.24.0.tar.gz"
-    sha256 "f9373dc4eff901350694f519f783c29b6d7a110fc0dcc11b1d7e353b85ca6504"
-  end
-
-  resource "types-aiofiles" do
-    url "https://files.pythonhosted.org/packages/84/6c/6d23908a8217e36704aa9c79d99a620f2fdd388b66a4b7f72fbc6b6ff6c6/types_aiofiles-25.1.0.20251011.tar.gz"
-    sha256 "1c2b8ab260cb3cd40c15f9d10efdc05a6e1e6b02899304d80dfa0410e028d3ff"
+    url "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz"
+    sha256 "e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45"
   end
 
   resource "uvicorn" do
@@ -242,8 +222,8 @@ class McpScan < Formula
   end
 
   resource "yarl" do
-    url "https://files.pythonhosted.org/packages/57/63/0c6ebca57330cd313f6102b16dd57ffaf3ec4c83403dcb45dbd15c6f3ea1/yarl-1.22.0.tar.gz"
-    sha256 "bebf8557577d4401ba8bd9ff33906f1376c877aa78d1fe216ad01b4d6745af71"
+    url "https://files.pythonhosted.org/packages/23/6e/beb1beec874a72f23815c1434518bfc4ed2175065173fb138c3705f658d4/yarl-1.23.0.tar.gz"
+    sha256 "53b1ea6ca88ebd4420379c330aea57e258408dd0df9af0992e5de2078dc9f5d5"
   end
 
   def install
@@ -251,8 +231,8 @@ class McpScan < Formula
   end
 
   test do
-    assert_match version.to_s, shell_output("#{bin}/mcp-scan --opt-out")
+    assert_match version.to_s, shell_output("#{bin}/snyk-agent-scan --opt-out")
 
-    assert_match "file ~/.cursor/mcp.json does not exist", shell_output("#{bin}/mcp-scan scan --opt-out")
+    assert_match "file ~/.cursor/mcp.json does not exist", shell_output("#{bin}/snyk-agent-scan scan --opt-out")
   end
 end

--- a/Formula/s/snyk-agent-scan.rb
+++ b/Formula/s/snyk-agent-scan.rb
@@ -7,6 +7,15 @@ class SnykAgentScan < Formula
   sha256 "5a169ba9cb8c6cca94ecd7dbc69e5ae20e4db57196294019a3583a80ee5a9bb8"
   license "Apache-2.0"
 
+  bottle do
+    sha256 cellar: :any,                 arm64_tahoe:   "7d4567faee17fb0e296029a8a0beae9e1da1320a6200693d2cb6daecf9a902fb"
+    sha256 cellar: :any,                 arm64_sequoia: "048171e354a8617da89e18808cb3c9594aef98071befe8f828ed774a9bea84a6"
+    sha256 cellar: :any,                 arm64_sonoma:  "387296ff88f10ee2bf7497d6e7a7373847fe13b0ce7307895405db779a316c22"
+    sha256 cellar: :any,                 sonoma:        "e7b87cd022ef8d709c6ecae8d8e3d2028473076946d5baf01ed8ffd00dcd9913"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "f0e93a47ec23ae54ba4e362be45b124d37bad979571d1731833d005db436c163"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c8f41940365e5c28639b99b98be5f1d3859e4bbd8480d8b6eebb6fb4be634bef"
+  end
+
   depends_on "certifi" => :no_linkage
   depends_on "cryptography" => :no_linkage
   depends_on "libyaml"

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -110,6 +110,7 @@
   "limbo": "turso",
   "llama": "walk",
   "mat": "mat2",
+  "mcp-scan": "snyk-agent-scan",
   "minizip2": "minizip-ng",
   "mist": "mist-cli",
   "mkl-dnn": "onednn",


### PR DESCRIPTION
agent-scan: renamed from mcp-scan

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

This fixes #270149 

The issue was that mcp-scan was migrated to agent-scan, so this pr migrated the formula
