### PR TITLE
lib*: remove no_autobump! manual review (part 2)

### DIFF
--- a/Formula/lib/libfreehand.rb
+++ b/Formula/lib/libfreehand.rb
@@ -11,8 +11,6 @@ class Libfreehand < Formula
     regex(/href=["']?libfreehand[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:   "b70e47c7931caefe4bc6b042a589ace7ab5030effc050d9497cb18402aea3283"

--- a/Formula/lib/libftdi.rb
+++ b/Formula/lib/libftdi.rb
@@ -11,8 +11,6 @@ class Libftdi < Formula
     regex(/href=.*?libftdi1[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "09132f1d347fe01a17da39c406e4311ad5af9609c5306afdfe912132df89f74f"
     sha256 cellar: :any,                 arm64_sequoia:  "c53870c2c84cf0918cbf27dfa0f62b3dc331072846980ef86243f506e1752f7a"

--- a/Formula/lib/libgda.rb
+++ b/Formula/lib/libgda.rb
@@ -8,8 +8,6 @@ class Libgda < Formula
   license "LGPL-2.0-or-later"
   revision 5
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:   "3b88a622a31068287a6ffb6cbc65f564087bf4075f9b7d12e1558a271dfa4098"
     sha256 arm64_sequoia: "8f4076b1d7e3f9d4638d740248e2b2e2533e078c559701115c5a75fcea611a91"

--- a/Formula/lib/libgnt.rb
+++ b/Formula/lib/libgnt.rb
@@ -10,8 +10,6 @@ class Libgnt < Formula
     url "https://sourceforge.net/projects/pidgin/rss?path=/libgnt"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any, arm64_tahoe:   "8e41afafab8780d6c9415e0be6819934f2256539126ac13ca992f20a735a4dec"
     sha256 cellar: :any, arm64_sequoia: "54589732aa242fcd90ecc861024846b94b55280206e11300614a5b537fad3809"

--- a/Formula/lib/libgtop.rb
+++ b/Formula/lib/libgtop.rb
@@ -6,8 +6,6 @@ class Libgtop < Formula
   license "GPL-2.0-or-later"
   revision 1
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 arm64_tahoe:    "382e8b7e104d1ce90d94d855cf90d2fc04526ed66699aff6225088850d8ca8a5"

--- a/Formula/lib/libgxps.rb
+++ b/Formula/lib/libgxps.rb
@@ -12,8 +12,6 @@ class Libgxps < Formula
     regex(/libgxps[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any, arm64_tahoe:   "edf7249cfe2f25f697df299831a0cfbd6d4fcf3803b1fcd3cfd7a9767e13e69a"

--- a/Formula/lib/libhdhomerun.rb
+++ b/Formula/lib/libhdhomerun.rb
@@ -11,8 +11,6 @@ class Libhdhomerun < Formula
     strategy :header_match
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "0863843dfe760dd0454dae929a74f5230819eb2261ca61604ba41ce4044a9a1d"
     sha256 cellar: :any,                 arm64_sequoia: "b5e3c2ecfd8f80433a08d6cb12b312cc7ba251a0ddf1ca97580a10f4c598e69c"

--- a/Formula/lib/libicns.rb
+++ b/Formula/lib/libicns.rb
@@ -7,8 +7,6 @@ class Libicns < Formula
   license any_of: ["LGPL-2.0-or-later", "LGPL-2.1-or-later"]
   revision 5
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "1392fb2947748ea7d1156f9d66e18f28614106d0e25f0977ee14502e57a1201f"
     sha256 cellar: :any,                 arm64_sequoia:  "4f513b025e1f28cadb969f9546d4b9c0b77021310a3b634c0f6edf2ddcbb8c93"

--- a/Formula/lib/libidl.rb
+++ b/Formula/lib/libidl.rb
@@ -6,8 +6,6 @@ class Libidl < Formula
   license "LGPL-2.0-or-later"
   revision 1
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "a0e91391470fe336c418566901c022fbd51387a87581ac820e72592c561001d7"
     sha256 cellar: :any,                 arm64_sequoia:  "dc9090a7f3672741f6edaa0564cc8c5cb28cb24e4bc43108d8953e05f3fb1eaf"

--- a/Formula/lib/libkate.rb
+++ b/Formula/lib/libkate.rb
@@ -5,8 +5,6 @@ class Libkate < Formula
   sha256 "96827ca136ad496b4e34ff3ed2434a8e76ad83b1e6962b5df06ad24cbbfeebaf"
   license "BSD-3-Clause"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "a920e83dd38ef5cd401c635c08f65dfe0cd6c4b5b79e5edfb4761a76ca729028"
     sha256 cellar: :any,                 arm64_sequoia: "1cc9e076187d3fe58ab436f4729c43fc596c181cf9e5a12125836b676373f0cc"

--- a/Formula/lib/liblockfile.rb
+++ b/Formula/lib/liblockfile.rb
@@ -10,8 +10,6 @@ class Liblockfile < Formula
     regex(/href=.*?liblockfile[._-]v?(\d+(?:\.\d+)+)\.orig\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256                               arm64_tahoe:    "c382cf8fcf1c7952704c86d38b8fe15ee916870f977df1a92200a8fdaeb77648"
     sha256                               arm64_sequoia:  "22df0fabe8a8f4a92ab8f9d8f7c3add9dc1ca2f6233f0336d6059064dd8cc539"

--- a/Formula/lib/liblzf.rb
+++ b/Formula/lib/liblzf.rb
@@ -14,8 +14,6 @@ class Liblzf < Formula
     regex(/href=.*?liblzf[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "37954669600f0312c44a03a73a69df9467bba75628f0bc56747b7df6734f58e4"

--- a/Formula/lib/libmagic.rb
+++ b/Formula/lib/libmagic.rb
@@ -9,8 +9,6 @@ class Libmagic < Formula
     formula "file-formula"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:   "f7aa29830da3062c82a1573bcadb35df0951de214d908543db23f89d55fdb831"
     sha256 arm64_sequoia: "6f52d18caa98d2f3aee461cff07e20ee353476e5612bad6ab0865f5d0b90921b"

--- a/Formula/lib/libmatroska.rb
+++ b/Formula/lib/libmatroska.rb
@@ -11,8 +11,6 @@ class Libmatroska < Formula
     regex(/href=.*?libmatroska[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "bf1a6c41880272d8a17b3c0b66bcafa1f2e250ca16f1cef4230e58cdd8ff3b01"
     sha256 cellar: :any,                 arm64_sequoia:  "59abce74d2eef80b0ec6751dd6d9357c2c130d9d8d11dce0ef9d0f47fbe7007a"

--- a/Formula/lib/libmemcached.rb
+++ b/Formula/lib/libmemcached.rb
@@ -6,8 +6,6 @@ class Libmemcached < Formula
   license "BSD-3-Clause"
   revision 2
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any,                 arm64_tahoe:    "60a5db19afb5f8ea31dd1917cdf6e962cd54efe7fd012ab0e0c6c44497a6e2ad"

--- a/Formula/lib/libmng.rb
+++ b/Formula/lib/libmng.rb
@@ -6,8 +6,6 @@ class Libmng < Formula
   license "Zlib"
   revision 1
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any,                 arm64_tahoe:   "c1e187e0cbf4b730d8116e16edab09cc0b774101d4af55605239de0afe858d8f"

--- a/Formula/lib/libmnl.rb
+++ b/Formula/lib/libmnl.rb
@@ -10,8 +10,6 @@ class Libmnl < Formula
     regex(/href=.*?libmnl[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_linux:  "a2f88b9fc807bcdbc77da6579b9937d9c993a637187f1b98c85b82ef6d2f5c98"

--- a/Formula/lib/libmodplug.rb
+++ b/Formula/lib/libmodplug.rb
@@ -10,8 +10,6 @@ class Libmodplug < Formula
     regex(%r{url=.*?/libmodplug[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any,                 arm64_tahoe:    "1143c79498400dd323ef1a5e5c5e6ee7b6e1d6efc8cb742c63fa46b8cf7505b9"

--- a/Formula/lib/libmpc.rb
+++ b/Formula/lib/libmpc.rb
@@ -6,8 +6,6 @@ class Libmpc < Formula
   sha256 "ab642492f5cf882b74aa0cb730cd410a81edcdbec895183ce930e706c1c759b8"
   license "LGPL-3.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "92a98d2c43dbf1f520d71d7b497fd263ee76665149227bc4b1efe171918c2676"
     sha256 cellar: :any,                 arm64_sequoia:  "5c8cdc4d460525025f69157ea5187c4119da8bffab33e7923dc374c011c9cdac"

--- a/Formula/lib/libmpd.rb
+++ b/Formula/lib/libmpd.rb
@@ -11,8 +11,6 @@ class Libmpd < Formula
     regex(%r{href=["']?v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "f636f9c6f31941eacaeb91c4a0dd733fd109071bd66df027cd2cb177b387523f"
     sha256 cellar: :any,                 arm64_sequoia:  "18186d5954681b7a246a5349ec9ba4a236266e8532850b8e5a6f06692981669e"

--- a/Formula/lib/libmpeg2.rb
+++ b/Formula/lib/libmpeg2.rb
@@ -12,8 +12,6 @@ class Libmpeg2 < Formula
     regex(/href=.*?libmpeg2[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "774f58a1e39f846fdcb40c1b05446f9867836cc95e66fe25d2d829f8e98c88a4"
     sha256 cellar: :any,                 arm64_sequoia:  "2db4b583e04a71b456045c2bf9f7d08f1ee332e8305c0944d4b101c83ab71990"

--- a/Formula/lib/libmspub.rb
+++ b/Formula/lib/libmspub.rb
@@ -11,8 +11,6 @@ class Libmspub < Formula
     regex(/href=["']?libmspub[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:   "5cecb8db1dca13e86f7b8a41e9270f34e37485235327f3cca023975fb2ce630c"

--- a/Formula/lib/libmwaw.rb
+++ b/Formula/lib/libmwaw.rb
@@ -5,8 +5,6 @@ class Libmwaw < Formula
   sha256 "a1a39ffcea3ff2a7a7aae0c23877ddf4918b554bf82b0de5d7ce8e7f61ea8e32"
   license any_of: ["LGPL-2.1-or-later", "MPL-2.0"]
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:   "fa0e72719088f76b8996124a739c41c4b34547cf9c4f260e58afd6ddcc870cd4"

--- a/Formula/lib/libnatpmp.rb
+++ b/Formula/lib/libnatpmp.rb
@@ -10,8 +10,6 @@ class Libnatpmp < Formula
     regex(/href=.*?libnatpmp[._-]v?(\d{6,8})\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:    "abc3665366422cecdf87ae0ec5fc1242771bc30ffd0119466efee183805ff49e"

--- a/Formula/lib/libnetfilter-queue.rb
+++ b/Formula/lib/libnetfilter-queue.rb
@@ -10,8 +10,6 @@ class LibnetfilterQueue < Formula
     regex(/href=.*?libnetfilter_queue[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_linux:  "0d88b35944420ead47b296ddc1e8a374591138b640c4aeede86e02b0104de7c4"

--- a/Formula/lib/libnfnetlink.rb
+++ b/Formula/lib/libnfnetlink.rb
@@ -10,8 +10,6 @@ class Libnfnetlink < Formula
     regex(/href=.*?libnfnetlink[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_linux:  "29a3d3fc305c9252a22b3bce85447d2f895924c959185c00889cedc2d23fc78b"

--- a/Formula/lib/libnsbmp.rb
+++ b/Formula/lib/libnsbmp.rb
@@ -10,8 +10,6 @@ class Libnsbmp < Formula
     regex(/href=.*?libnsbmp[._-]v?(\d+(?:\.\d+)+)[._-]src\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "d75c82e5602bfb3c49ca8de06f9bb16002f10f1eb09b6c025d3a4e160f4b8aef"
     sha256 cellar: :any,                 arm64_sequoia:  "334b42b3b30917e7cb0850b079cced2c020a9ffe8389d1a703ffcd2896f64a22"

--- a/Formula/lib/libodfgen.rb
+++ b/Formula/lib/libodfgen.rb
@@ -12,8 +12,6 @@ class Libodfgen < Formula
     regex(/href=["']?libodfgen[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "f322394dcaf548a6c82e55f4d39ddc2c35aced9c316a07c8ddf491f2735be66f"
     sha256 cellar: :any,                 arm64_sequoia: "c1c268be3d7429eef8c2dee45c01e2879270b04c85380ee2c7bd7f64283ccfd2"

--- a/Formula/lib/libogg.rb
+++ b/Formula/lib/libogg.rb
@@ -12,8 +12,6 @@ class Libogg < Formula
     regex(%r{href=(?:["']?|.*?/)libogg[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "4d9d14f8e36ed913c02201bfc01682ba3f550de412e9a24e3ef9aed4f1b8a23d"
     sha256 cellar: :any,                 arm64_sequoia: "2423ff6b931f0393cd314052a7328a61fdd6f1d8519b65c4dff5ab560f82c52d"

--- a/Formula/lib/liboil.rb
+++ b/Formula/lib/liboil.rb
@@ -12,8 +12,6 @@ class Liboil < Formula
     regex(/href=.*?liboil[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:    "2952ae2a44d572b8bda832e965e061747b5ed1213ccd0bf0d7a41675f7498156"


### PR DESCRIPTION
#269331

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI assisted with candidate discovery and one-commit-per-formula patching for `lib*` formulas by removing `no_autobump! because: :requires_manual_review` where livecheck/status/source checks were compatible. This batch is intentionally capped at 30 formulas. I manually verified and reran `brew style` and `HOMEBREW_EVAL_ALL=1 brew audit --strict` on the edited formula set.

Excluded from this batch: `libgccjit`, `libgfshare` (livecheck errors), `libgdata` (deprecated), `libident`, `libmetalink`, `libmms`, `libmp3splt` (strict-audit blockers), and the remaining `lib*` formulas after this second 30-formula slice.

-----
