### PR TITLE
t2sz 1.2.1 (new formula)

### DIFF
--- a/Formula/t/t2sz.rb
+++ b/Formula/t/t2sz.rb
@@ -1,0 +1,25 @@
+class T2sz < Formula
+  desc "Compress a file into a seekable zstd with per-file seeking for tar archives"
+  homepage "https://github.com/martinellimarco/t2sz"
+  url "https://github.com/martinellimarco/t2sz/archive/refs/tags/v1.2.1.tar.gz"
+  sha256 "0a39a2644aa1bec84dd31491bdafc6f4b4f2d5c8187144ff3273ea7e69c382a7"
+  license "GPL-3.0-or-later"
+
+  depends_on "cmake" => :build
+  depends_on "zstd"
+
+  def install
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    (testpath/"hello.txt").write "Hello, Homebrew!"
+    system "tar", "cf", "test.tar", "-C", testpath, "hello.txt"
+    system bin/"t2sz", "-o", "test.tar.zst", "test.tar"
+    assert_path_exists testpath/"test.tar.zst"
+    system "zstd", "-d", "test.tar.zst", "-o", "test.restored.tar"
+    assert_equal (testpath/"test.tar").read, (testpath/"test.restored.tar").read
+  end
+end


### PR DESCRIPTION
## Description

[t2sz](https://github.com/martinellimarco/t2sz) compresses a file into a seekable zstd, splitting it into multiple frames. For tar archives, it keeps each file in a separate frame, enabling fast random access and single-file extraction without decompressing the entire archive.

The compressed output is fully compatible with standard `zstd` decompression tools.

There is no equivalent tool currently available in homebrew-core. The `zstd` formula does not provide seekable compression.

## Evidence of third-party usage

**Distribution packages (5):**
- [Alpine Linux](https://pkgs.alpinelinux.org/packages?name=t2sz) (edge/testing)
- [AUR](https://aur.archlinux.org/packages/t2sz) (Arch Linux)
- [Snap Store](https://snapcraft.io/t2sz) (cross-distro)
- [YACP / Cygwin](https://github.com/fd00/yacp/tree/master/t2sz) — packaged by a third party (fd00), not the author
- [T2 SDE](https://t2sde.org/packages/t2sz)

**Adoption in other projects:**
- [ratarmount](https://github.com/mxmlnkn/ratarmount) (1,200+ stars) recommends t2sz in its README as the primary tool for creating seekable zstd files. Its author contributed to t2sz design through [issue discussions](https://github.com/martinellimarco/t2sz/issues/3).
- [indexed_zstd](https://pypi.org/project/indexed-zstd/) — companion Python library for reading seekable zstd files, ~2,000 weekly PyPI downloads.
- [libzstd-seek](https://github.com/martinellimarco/libzstd-seek) — companion C library for seeking in zstd files.

**Community engagement:**
- 75 GitHub stars
- 7 issues from 6 distinct external users, including bug reports, feature requests, and code contributions
- Active development since December 2020

## Checks

- [x] `brew audit --new --strict --online t2sz` passes
- [x] `brew install --build-from-source t2sz` succeeds
- [x] `brew test t2sz` passes