### PR TITLE
maven@4 4.0.0-rc-5 (new formula)

### DIFF
--- a/Aliases/maven@3
+++ b/Aliases/maven@3
@@ -1,0 +1,1 @@
+../Formula/m/maven.rb

--- a/Formula/m/maven@4.rb
+++ b/Formula/m/maven@4.rb
@@ -1,0 +1,86 @@
+class MavenAT4 < Formula
+  desc "Java-based project management"
+  homepage "https://maven.apache.org/"
+  url "https://www.apache.org/dyn/closer.lua?path=maven/maven-4/4.0.0-rc-5/binaries/apache-maven-4.0.0-rc-5-bin.tar.gz"
+  mirror "https://archive.apache.org/dist/maven/maven-4/4.0.0-rc-5/binaries/apache-maven-4.0.0-rc-5-bin.tar.gz"
+  version "4.0.0-rc-5"
+  sha256 "ece6a5c99d3d041c76e7fed1814eb9ea3a20a120bcb3c235a73d2c4e8db16ca1"
+  license "Apache-2.0"
+
+  livecheck do
+    url "https://maven.apache.org/download.cgi"
+    regex(/href=.*?apache-maven[._-]v?(\d+(?:\.\d+)+(?:-rc-\d+)?)-bin\.t/i)
+  end
+
+  keg_only :versioned_formula
+
+  depends_on "openjdk"
+
+  def install
+    # Remove windows files
+    rm(Dir["bin/*.cmd"])
+
+    # Fix the permissions on the global settings file.
+    chmod 0644, "conf/settings.xml"
+
+    libexec.install Dir["*"]
+    os = OS.mac? ? "Mac" : "Linux"
+    arch = Hardware::CPU.arch.to_s
+    # Remove native binaries for foreign OS/architectures
+    (libexec/"lib/jline-native").children.each do |os_dir|
+      next unless os_dir.directory?
+
+      if os_dir.basename.to_s.match?(/#{os}/i)
+        os_dir.children.each do |arch_dir|
+          rm_r(arch_dir) if arch_dir.basename.to_s != arch
+        end
+      else
+        rm_r(os_dir)
+      end
+    end
+
+    # Build an `:all` bottle by changing the path for `mavenrc`
+    file = libexec/"bin/mvn"
+    inreplace file, "/usr/local/etc/mavenrc", "#{HOMEBREW_PREFIX}/etc/mavenrc"
+
+    # Leave conf file in libexec. The mvn symlink will be resolved and the conf
+    # file will be found relative to it
+    Pathname.glob("#{libexec}/bin/*") do |file|
+      next if file.directory?
+
+      basename = file.basename
+      next if basename.to_s == "m2.conf"
+
+      (bin/basename).write_env_script file, Language::Java.overridable_java_home_env
+    end
+  end
+
+  test do
+    (testpath/"pom.xml").write <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+        <modelVersion>4.0.0</modelVersion>
+        <groupId>org.homebrew</groupId>
+        <artifactId>maven-test</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <properties>
+          <maven.compiler.source>1.8</maven.compiler.source>
+          <maven.compiler.target>1.8</maven.compiler.target>
+          <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        </properties>
+      </project>
+    XML
+
+    (testpath/"src/main/java/org/homebrew/MavenTest.java").write <<~JAVA
+      package org.homebrew;
+      public class MavenTest {
+        public static void main(String[] args) {
+          System.out.println("Testing Maven with Homebrew!");
+        }
+      }
+    JAVA
+
+    system bin/"mvn", "compile", "-Duser.home=#{testpath}"
+  end
+end


### PR DESCRIPTION
Allow installing maven 4.x next to maven 3.x to prepare for Maven 4 adoption as it might require migrating user projects, see: https://maven.apache.org/guides/mini/guide-migration-to-mvn4.html

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
