### PR TITLE
lazyworktree 1.40.0 (new formula)

### DIFF
--- a/Formula/l/lazyworktree.rb
+++ b/Formula/l/lazyworktree.rb
@@ -1,0 +1,27 @@
+class Lazyworktree < Formula
+  desc "Terminal UI for managing Git worktrees"
+  homepage "https://github.com/chmouel/lazyworktree"
+  url "https://github.com/chmouel/lazyworktree/archive/refs/tags/v1.40.0.tar.gz"
+  sha256 "34ebee924e5b337983eee6cecee47a78e32e0ea20481497ee9632b30a79b1264"
+  license "Apache-2.0"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = %W[
+      -s -w
+      -X main.version=#{version}
+      -X main.date=#{time.iso8601}
+      -X main.builtBy=homebrew
+    ]
+    system "go", "build", *std_go_args(ldflags:), "./cmd/lazyworktree"
+
+    man1.install "lazyworktree.1"
+
+    generate_completions_from_executable(bin/"lazyworktree", "completion")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/lazyworktree --version")
+  end
+end


### PR DESCRIPTION
## Summary
- New formula for lazyworktree, a terminal UI for managing Git worktrees
- Builds from source with Go, installs man page and shell completions
- Homepage: https://github.com/chmouel/lazyworktree

## Test plan
- [x] `brew install --build-from-source` succeeds
- [x] `lazyworktree --version` shows 1.40.0
- [x] `brew test` passes
- [x] `brew audit --strict --new` passes
- [x] Man page and shell completions installed correctly