### PR TITLE
pdf-zusammenfugen 0.2.0 (new formula)

### DIFF
--- a/Formula/p/pdf-zusammenfugen.rb
+++ b/Formula/p/pdf-zusammenfugen.rb
@@ -1,0 +1,19 @@
+class PdfZusammenfugen < Formula
+  desc "Merge multiple PDF files into one from the command-line"
+  homepage "https://pdfzus.de/"
+  url "https://github.com/wsgtcyx/PDF-Zusammenfugen-cargo/archive/refs/tags/v0.2.0.tar.gz"
+  sha256 "e866659ec10df0e18f679906d6084a98b1420707f738a8933f14be69e839feaa"
+  license "MIT"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args(path: ".")
+  end
+
+  test do
+    assert_match "Usage", shell_output("#{bin}/pdf-zusammenfugen --help")
+    output = shell_output("#{bin}/pdf-zusammenfugen -o out.pdf 2>&1", 2)
+    assert_match "Bitte mindestens eine Eingabe-PDF", output
+  end
+end


### PR DESCRIPTION
## Summary
Add a new formula: `pdf-zusammenfugen` (v0.2.0), a Rust CLI that merges multiple PDF files into a single PDF.

## Formula
- Homepage: https://pdfzus.de/
- Source: https://github.com/wsgtcyx/PDF-Zusammenfugen-cargo
- Stable URL: https://github.com/wsgtcyx/PDF-Zusammenfugen-cargo/archive/refs/tags/v0.2.0.tar.gz
- License: MIT
- Build dependency: `rust`
- Binary: `pdf-zusammenfugen`

## Local checks
- `brew style Formula/p/pdf-zusammenfugen.rb`
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`
- `brew test <formula>`
- `brew audit --strict --new <formula>`

## Checklist
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI usage:
- AI assisted with drafting the formula and PR description.
- I manually verified the final formula and checks before submission.
