### PR TITLE
tcl-tk: update resource livecheck blocks

### DIFF
--- a/Formula/t/tcl-tk.rb
+++ b/Formula/t/tcl-tk.rb
@@ -40,6 +40,7 @@ class TclTk < Formula
     sha256 "d970a06ae1cdee7854ca1bc571e8b5fe7189788dc5a806bce67e24bbadbe7ae2"
 
     livecheck do
+      url :url
       regex(/^v?(\d+(?:\.\d+)+)$/i)
     end
   end
@@ -47,6 +48,11 @@ class TclTk < Formula
   resource "tcllib" do
     url "https://downloads.sourceforge.net/project/tcllib/tcllib/2.0/tcllib-2.0.tar.xz"
     sha256 "642c2c679c9017ab6fded03324e4ce9b5f4292473b62520e82aacebb63c0ce20"
+
+    livecheck do
+      url "https://sourceforge.net/projects/tcllib/rss?path=/tcllib"
+      regex(%r{url=.*?/tcllib[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    end
   end
 
   # There is no tcltls release compatible with TCL 9 and upstream Fossil repo
@@ -57,6 +63,11 @@ class TclTk < Formula
   resource "tcltls" do
     url "https://deb.debian.org/debian/pool/main/t/tcltls/tcltls_1.8.0.orig.tar.gz"
     sha256 "720a9e0bed3ba41b1ad141443c8651b7d0dc8fc9087f2077accb1ba9a5736489"
+
+    livecheck do
+      url "https://deb.debian.org/debian/pool/main/t/tcltls/"
+      regex(/href=.*?tcltls[._-]v?(\d+(?:\.\d+)+)\.orig\.t/i)
+    end
   end
 
   resource "tk" do
@@ -77,6 +88,14 @@ class TclTk < Formula
     url "https://github.com/tcltk/itk/archive/refs/tags/itk-4-2-3.tar.gz"
     version "4.2.3"
     sha256 "bc5ed347212fce403e04d3161cd429319af98da47effd3e32e20d2f04293b036"
+
+    livecheck do
+      url :url
+      regex(/^itk[._-]v?(\d+(?:[._-]\d+)+)$/i)
+      strategy :git do |tags, regex|
+        tags.filter_map { |tag| tag[regex, 1]&.tr("_-", ".") }
+      end
+    end
   end
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

There are `livecheck` blocks for some of the `tcl-tk` resources but not everything that could be checked. This adds additional `livecheck` blocks and adds the missing `url` call to the `critcl` `livecheck` block (it technically works without it at the moment but the behavior can be unpredictable, so we treat `url` as a required part of `livecheck` blocks).

For context, I created these `livecheck` blocks as part of testing out Nanda's recent brew PR to add further support for resource-updating in `brew bump` (namely, allowing resources with a `livecheck` block to be updated). Support for resource `livecheck` blocks within livecheck and bump remains in a "best effort" state (i.e., some things aren't supported yet) but I believe Nanda intends to work on adding some more `livecheck` blocks to resources, so I figured I'd create a PR for these.