### PR TITLE
claude-agent-acp: respect ripgrep

### DIFF
--- a/Formula/c/claude-agent-acp.rb
+++ b/Formula/c/claude-agent-acp.rb
@@ -4,6 +4,7 @@ class ClaudeAgentAcp < Formula
   url "https://registry.npmjs.org/@zed-industries/claude-agent-acp/-/claude-agent-acp-0.20.1.tgz"
   sha256 "6468b59590663f6304fe3e145b20a98b3c309087d5ec944787efc42bb623056c"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/zed-industries/claude-agent-acp.git", branch: "main"
 
   bottle do
@@ -20,11 +21,15 @@ class ClaudeAgentAcp < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    ripgrep_path = libexec/"lib/node_modules/@zed-industries/claude-agent-acp" /
-                   "node_modules/@anthropic-ai/claude-agent-sdk/vendor/ripgrep"
-    rm_r ripgrep_path
-    (bin/"claude-agent-acp").write_env_script libexec/"bin/claude-agent-acp",
-                                              USE_BUILTIN_RIPGREP: "1"
+    ripgrep_vendor_dir = libexec/"lib/node_modules/@zed-industries/claude-agent-acp" /
+                         "node_modules/@anthropic-ai/claude-agent-sdk/vendor/ripgrep"
+    rm_r ripgrep_vendor_dir
+    arch = Hardware::CPU.intel? ? "x64" : Hardware::CPU.arch.to_s
+    ripgrep_platform = "#{arch}-#{OS.kernel_name.downcase}"
+    platform_dir = ripgrep_vendor_dir/ripgrep_platform
+    platform_dir.mkpath
+    ln_s Formula["ripgrep"].opt_bin/"rg", platform_dir/"rg"
+    bin.install_symlink libexec/"bin/claude-agent-acp"
   end
 
   test do

--- a/Formula/c/claude-agent-acp.rb
+++ b/Formula/c/claude-agent-acp.rb
@@ -8,12 +8,12 @@ class ClaudeAgentAcp < Formula
   head "https://github.com/zed-industries/claude-agent-acp.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "17a316942a6c25519b63ffe2dc6b8d61a20b0f1441c8e3155f2c87dde0b4c499"
-    sha256 cellar: :any,                 arm64_sequoia: "3c32db69037794edc3148cfe639e0575a01446a4c5066a9cc7f9d81d166dc72f"
-    sha256 cellar: :any,                 arm64_sonoma:  "3c32db69037794edc3148cfe639e0575a01446a4c5066a9cc7f9d81d166dc72f"
-    sha256 cellar: :any,                 sonoma:        "5c972364292dd86dcf88fb334d6141994d7e9ffb3eabf70d65aa40b8ebe15e49"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "6c76d7ca17b364742c9594050048bbd0f2a84672007cb64dd541e95c6ae235c9"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0e6661f414c5e3169dbe1fc43562db7c37f8b98dc819fcc6b0a4f147a72718c0"
+    sha256 cellar: :any,                 arm64_tahoe:   "663641be4525f1a479eb189be639481f95c2cfa5fe05cfea0a79930b8ba138bc"
+    sha256 cellar: :any,                 arm64_sequoia: "fd2994d57c2b87853f96aab018d69a665e2cf251b38b0aa263b2e42b2a89a56b"
+    sha256 cellar: :any,                 arm64_sonoma:  "fd2994d57c2b87853f96aab018d69a665e2cf251b38b0aa263b2e42b2a89a56b"
+    sha256 cellar: :any,                 sonoma:        "b9809fed5fb3cda6e9ea29fae23fbbc894a44e802bb3d185b80b58956443e08a"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "b1230f0147dead14172b75ada601bd4e28af514b25fa1166d0e7fda2ccb51936"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5d135fcab46f27b307cd8251d19fd77aeca504245cc2c4d1915beb9aab346fe9"
   end
 
   depends_on "node"


### PR DESCRIPTION
Built and tested locally on macOS 26.3.

- Keep the SDK vendor ripgrep path but point it to Homebrew's rg so the Grep tool no longer hits ENOENT on the missing vendored binary and falls back to slow shell grep (fixes https://github.com/zed-industries/claude-agent-acp/issues/367).
- Remove the `USE_BUILTIN_RIPGREP` wrapper so user settings can opt into system ripgrep when desired.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI assistance: Drafted the formula change and validation plan. Manually verified by running brew install --build-from-source (with HOMEBREW_NO_INSTALL_FROM_API=1), brew test, brew audit --strict, and an ACP ripgrep debug check.

-----
