### PR TITLE
lib*: remove no_autobump! manual review (part 3)

### DIFF
--- a/Formula/lib/libextractor.rb
+++ b/Formula/lib/libextractor.rb
@@ -6,8 +6,6 @@ class Libextractor < Formula
   sha256 "bb8f312c51d202572243f113c6b62d8210301ab30cbaee604f9837d878cdf755"
   license "GPL-3.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 arm64_tahoe:   "c2fd159149aca1a534cbfefa4d19fc9247eeb7c1884ec184d02b51abc1a10104"

--- a/Formula/lib/libgccjit.rb
+++ b/Formula/lib/libgccjit.rb
@@ -23,8 +23,6 @@ class Libgccjit < Formula
     formula "gcc"
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 arm64_tahoe:   "e25a101a9c694e6414fd821fb92081c9eee03f23de41cc1ad691ac06369f6e70"

--- a/Formula/lib/libnova.rb
+++ b/Formula/lib/libnova.rb
@@ -7,8 +7,6 @@ class Libnova < Formula
   # libnova is LGPL but the libnovaconfig binary is GPL
   license all_of: ["LGPL-2.0-or-later", "GPL-2.0-or-later"]
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "fd79a01fd5a7306387bce5efbc22a21740446e9b8f6297bcd7c5dc2d9af64284"
     sha256 cellar: :any,                 arm64_sequoia: "ffa8ba8b5274d3a3860f9f3fdcd77ac6dde469714b22627b3cde37126b96b04a"

--- a/Formula/lib/liboping.rb
+++ b/Formula/lib/liboping.rb
@@ -10,8 +10,6 @@ class Liboping < Formula
     regex(/href=.*?liboping[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "b799d5c3ab5ca9ace10e0b8e9f338111ce0220b1df97d3d5c025a18e0c6d47a6"
     sha256 cellar: :any,                 arm64_sequoia:  "5395bb6ef912f023eb75a29a46eb614a0fb9dec8f65fe29f40af6173d0f8f809"

--- a/Formula/lib/libosip.rb
+++ b/Formula/lib/libosip.rb
@@ -11,8 +11,6 @@ class Libosip < Formula
     regex(/href=.*?libosip2[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "8c2b8a49121fa1e1975470aea9d13f5803bb8a9f68b23497b8c5d4fd25b8b90f"
     sha256 cellar: :any,                 arm64_sequoia:  "751eaf3b56ce1d3f5ad7e076909391f1cef386f430cd96719ff8a97bcc76bd03"

--- a/Formula/lib/libowfat.rb
+++ b/Formula/lib/libowfat.rb
@@ -12,8 +12,6 @@ class Libowfat < Formula
     regex(/href=.*?libowfat[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "bc30d254df3bcd360e4f3171d2afc99997cadfec8fd46a90f2c56991677ee87b"
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "c3846b7776a5350100cf8a734e0a45fcbe822f53128ab88bce24cfb259b3d27c"

--- a/Formula/lib/libpagemaker.rb
+++ b/Formula/lib/libpagemaker.rb
@@ -10,8 +10,6 @@ class Libpagemaker < Formula
     regex(/href=["']?libpagemaker[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "d9e3c687bbf276008a19981600851d145d6bf8f6ce17a689bb3aea7c3c3722ed"
     sha256 cellar: :any,                 arm64_sequoia:  "8b12308a14b296bf195cae2a64b4242efb1dfa589903d3312d1543a4e3891bfb"

--- a/Formula/lib/libpciaccess.rb
+++ b/Formula/lib/libpciaccess.rb
@@ -6,8 +6,6 @@ class Libpciaccess < Formula
   license "MIT"
   revision 1
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_linux:  "8dbbb641d72ca3d52c3e888e98ce1b4ebca20f5eca28a171b5ddc00b7a52bbf9"
     sha256 cellar: :any_skip_relocation, x86_64_linux: "a553839647c06387234321eb625545c4b1b3f757a9db3621127fff968a187a28"

--- a/Formula/lib/libpst.rb
+++ b/Formula/lib/libpst.rb
@@ -10,8 +10,6 @@ class Libpst < Formula
     regex(/href=.*?libpst[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:   "fd7349c417348d0e83213928612500c662ae584e15e66310898c9f49118d6a40"

--- a/Formula/lib/libpthread-stubs.rb
+++ b/Formula/lib/libpthread-stubs.rb
@@ -5,8 +5,6 @@ class LibpthreadStubs < Formula
   sha256 "59da566decceba7c2a7970a4a03b48d9905f1262ff94410a649224e33d2442bc"
   license "MIT"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "303b8c21fc1b9322b6bd8f24e75a4e53a1c331d09b4f6271f75eba743d119819"

--- a/Formula/lib/libquantum.rb
+++ b/Formula/lib/libquantum.rb
@@ -12,8 +12,6 @@ class Libquantum < Formula
     regex(/href=.*?libquantum[._-]v?(\d+\.[02468](?:\.\d+)*)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "f5e852b2b95f054f6b23ebe164e034efef63568d27c86743b49af217d2599ecf"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "1104c2f6a72d4e1576077b6bb549f7e579ccd5d0869ff4e7ea7753655dd5c370"

--- a/Formula/lib/libquicktime.rb
+++ b/Formula/lib/libquicktime.rb
@@ -6,8 +6,6 @@ class Libquicktime < Formula
   license "LGPL-2.1-or-later"
   revision 5
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 arm64_tahoe:   "5f0134430e06269fcef851532addb2e837cf60ef41c44ad3dd9155c1d5df6b50"

--- a/Formula/lib/libretls.rb
+++ b/Formula/lib/libretls.rb
@@ -10,8 +10,6 @@ class Libretls < Formula
     regex(/href=.*?libretls[._-]v?(\d+(?:\.\d+)+(?:p\d+)?)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "38becb1d91ff6265dd0127e0396ed3e4a67802772e2a389761c2415a51a146b8"
     sha256 cellar: :any,                 arm64_sequoia:  "19bba1bc2787f51fb0415c0af6cd57a2428318ce53c5abcf2076a5763a5e738b"

--- a/Formula/lib/librevenge.rb
+++ b/Formula/lib/librevenge.rb
@@ -10,8 +10,6 @@ class Librevenge < Formula
     regex(%r{url=.*?/librevenge[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:   "facf55a083cd1ced9b8d830f69bc324721fec9fd04ae71c39c8cb86bd0e2d6e1"

--- a/Formula/lib/librttopo.rb
+++ b/Formula/lib/librttopo.rb
@@ -11,8 +11,6 @@ class Librttopo < Formula
     regex(/^(?:librttopo[._-])?v?(\d+(?:\.\d+)+)$/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "96402f9ebcae6c7b387f95565523e927a702cee02b90253b8fa0c1e654e3a4a5"
     sha256 cellar: :any,                 arm64_sequoia:  "93fca6e17145fc8eacdc667787aa422507c03c5cc868907ef140892ac8be1394"

--- a/Formula/lib/libsass.rb
+++ b/Formula/lib/libsass.rb
@@ -12,8 +12,6 @@ class Libsass < Formula
     strategy :github_latest
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "ed01028a87ef04e5dd829f40013f3db3cff5317e1cb0ee3f7ac9de135281cb61"
     sha256 cellar: :any,                 arm64_sequoia:  "d5f0835bddfab893cf537c1cb10f42a6abbaa04100954223de905a7f3879a581"

--- a/Formula/lib/libsigrok.rb
+++ b/Formula/lib/libsigrok.rb
@@ -49,8 +49,6 @@ class Libsigrok < Formula
     regex(/href=.*?libsigrok[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 3
     sha256                               arm64_tahoe:   "95e9aaa190e987c353cccf6cc717b084bce946bc42e2c397a6f24700722a95be"

--- a/Formula/lib/libsigrokdecode.rb
+++ b/Formula/lib/libsigrokdecode.rb
@@ -15,8 +15,6 @@ class Libsigrokdecode < Formula
     regex(/href=.*?libsigrokdecode[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 4
     sha256 arm64_tahoe:   "23396e67a66de629ac081dc782c68f9fcd38617f0b6f9127f2f46dbd245f2d37"

--- a/Formula/lib/libsoxr.rb
+++ b/Formula/lib/libsoxr.rb
@@ -10,8 +10,6 @@ class Libsoxr < Formula
     regex(%r{url=.*?/soxr[._-]v?(\d+(?:\.\d+)+)(?:-Source)?\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:    "6fd815529e1078139d7965e7bb7e92b4fa5680e74ca671357aaf4c0e1ea1dc95"

--- a/Formula/lib/libspatialite.rb
+++ b/Formula/lib/libspatialite.rb
@@ -22,8 +22,6 @@ class Libspatialite < Formula
     regex(/href=.*?libspatialite[._-]v?(\d+(?:\.\d+)+[a-z]?)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "ec3bff2150de386d746181a90e8a9a706a5cd0abba9fff83b982f31cec916a93"
     sha256 cellar: :any,                 arm64_sequoia: "587bf2902aaa3908a1dcc76dda6fe5ab38ead02dad6e6bd8f4521c28c0174686"

--- a/Formula/lib/libspectre.rb
+++ b/Formula/lib/libspectre.rb
@@ -11,8 +11,6 @@ class Libspectre < Formula
     regex(/href=.*?libspectre[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "827462a01392f7b4ba24ec5b45ea4aeee0e7e0a674efe43d5b0e52ffeb150bf0"
     sha256 cellar: :any,                 arm64_sequoia: "d9e00969398b5ccd244aed543e3a6468f56e07dbc1939d7bde6b4b9d19701001"

--- a/Formula/lib/libsquish.rb
+++ b/Formula/lib/libsquish.rb
@@ -6,8 +6,6 @@ class Libsquish < Formula
   license "MIT"
   revision 1
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "c15bdf4ca7dde73653792c819df794092170e884ca1e7aeb006810955c3db6eb"
     sha256 cellar: :any,                 arm64_sequoia:  "e8c9dcc536fed98d8b68dc6187b2ccbd47dd3fc08d4590811ca605c4ff6c6a39"

--- a/Formula/lib/libsvg-cairo.rb
+++ b/Formula/lib/libsvg-cairo.rb
@@ -11,8 +11,6 @@ class LibsvgCairo < Formula
     regex(/href=.*?libsvg-cairo[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "081812b09f3aa7da3467f583323424b3cec95d2f371b0745f6e3569857c31d5d"
     sha256 cellar: :any,                 arm64_sequoia:  "fb922d8f987fcfbf1a37e34cb527ce24345328d188e2fc453a5c70de848dbd41"

--- a/Formula/lib/libsvg.rb
+++ b/Formula/lib/libsvg.rb
@@ -11,8 +11,6 @@ class Libsvg < Formula
     regex(/href=.*?libsvg[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "091152c66a1d15b4dd1fb58d23f484a24bc7e4e6f3f5d93d864400e30b2a14ad"
     sha256 cellar: :any,                 arm64_sequoia: "749dd33b051aa0a0f32dab2201dc1f34b47ca79bd40ba3c729c5a31f8ac97c59"

--- a/Formula/lib/libtar.rb
+++ b/Formula/lib/libtar.rb
@@ -6,8 +6,6 @@ class Libtar < Formula
       revision: "0907a9034eaf2a57e8e4a9439f793f3f05d446cd"
   license "NCSA"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 3
     sha256 cellar: :any,                 arm64_tahoe:   "23ceb454b2f6611082364f55c92c573111df507f73b3d19ca69555bc4ebac48a"

--- a/Formula/lib/libtecla.rb
+++ b/Formula/lib/libtecla.rb
@@ -10,8 +10,6 @@ class Libtecla < Formula
     regex(/href=.*?libtecla[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "3883edbec56c880a52d9805b5fa4688136ccdb26fe9fe8b4c8b302b3f3c79de4"
     sha256 cellar: :any,                 arm64_sequoia:  "389b4e8a32591e201b3c174ce301bfaeb27a38dd8398992eff9171678d1b4bfc"

--- a/Formula/lib/libtermkey.rb
+++ b/Formula/lib/libtermkey.rb
@@ -10,8 +10,6 @@ class Libtermkey < Formula
     regex(/href=.*?libtermkey[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:    "3f3b0155836ea23f051a5b94c6129d6ed1927f9daea716e1f72634470c7557b7"

--- a/Formula/lib/libuecc.rb
+++ b/Formula/lib/libuecc.rb
@@ -6,8 +6,6 @@ class Libuecc < Formula
   license "BSD-2-Clause"
   head "https://git.universe-factory.net/fastd/libuecc.git", branch: "main"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "d27a92b37c542bc9880f60bdf8dce4dec889c93b469e8cfc855d963ade17f9f8"
     sha256 cellar: :any,                 arm64_sequoia:  "a94e6f279789d442ddfce719d48af0c5a430e4d255f9c8dd16b7cb691062988f"

--- a/Formula/lib/libusb-compat.rb
+++ b/Formula/lib/libusb-compat.rb
@@ -13,8 +13,6 @@ class LibusbCompat < Formula
     regex(%r{url=.*?/libusb-compat[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:    "63dfe2cf30c69c8f654177fbd754d013e0b5d86636cf731f5e22fbf3071d228e"

--- a/Formula/lib/libvdpau.rb
+++ b/Formula/lib/libvdpau.rb
@@ -10,8 +10,6 @@ class Libvdpau < Formula
     regex(/^(?:libvdpau[._-])?v?(\d+(?:\.\d+)+)$/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:    "f9726bd90703d99de544a8ad2b2f4e043b547a82af7887ed0d220d8f011612e4"
     sha256 arm64_sequoia:  "8baf9479a1307dd3f6819d5953b200195a91d7c522f01b2b4930e9fc750b3615"

--- a/Formula/lib/libvirt-glib.rb
+++ b/Formula/lib/libvirt-glib.rb
@@ -11,8 +11,6 @@ class LibvirtGlib < Formula
     regex(/href=.*?libvirt-glib[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:   "ba34897f21e90fc3c2e580b4b3a736ac40dde9df609b5e8bb650ed65d528bd41"
     sha256 arm64_sequoia: "2215ee81bf32c6dfb3e1091165cfcd1fd6130d190a368221567d26ac93a2d5a0"

--- a/Formula/lib/libvo-aacenc.rb
+++ b/Formula/lib/libvo-aacenc.rb
@@ -10,8 +10,6 @@ class LibvoAacenc < Formula
     regex(%r{url=.*?/vo-aacenc[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "86707b69dbdb8c92aa266ebe65b67721e688fcf078e66106a578ddcf0ab6c3f0"
     sha256 cellar: :any,                 arm64_sequoia:  "364ec1b50f38e6b1b0dc5e1ea7b12b624e249aea41810491669c9356ff96feac"

--- a/Formula/lib/libvorbis.rb
+++ b/Formula/lib/libvorbis.rb
@@ -11,8 +11,6 @@ class Libvorbis < Formula
     regex(%r{href=(?:["']?|.*?/)libvorbis[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:    "99c0de7ff87f4648bb17acd0324a15563e975b7492dbd4f11fd656a8eb6b5622"


### PR DESCRIPTION
#269331

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI assisted with candidate discovery and one-commit-per-formula patching for `lib*` formulas by removing `no_autobump! because: :requires_manual_review` where livecheck/status/source checks were compatible. I manually verified and reran `brew style` and `HOMEBREW_EVAL_ALL=1 brew audit --strict` on the edited formula set.

Excluded from this batch: `libcuefile`, `libdaemon`, `libdc1394`, `libident`, `libmetalink`, `libmms`, `libmp3splt`, `libnids`, `liboauth`, `libopennet`, `libotr`, `libpcl`, `libpoker-eval`, `libreplaygain`, `libresample`, `libshout`, `libsmi`, `libstxxl` (strict-audit blockers), `libgdata`, `libsoup@2` (deprecated), `libgfshare` (livecheck 404), `libpeas@1` (versioned), and `librasterlite2` (nonstandard beta version format).

-----
