### PR TITLE
cloudfox: checksum update for release 2.0.0

### DIFF
--- a/Formula/c/cloudfox.rb
+++ b/Formula/c/cloudfox.rb
@@ -2,7 +2,7 @@ class Cloudfox < Formula
   desc "Automating situational awareness for cloud penetration tests"
   homepage "https://github.com/BishopFox/cloudfox"
   url "https://github.com/BishopFox/cloudfox/archive/refs/tags/v2.0.0.tar.gz"
-  sha256 "4a013f1bf8f79517f3dc660128520bb9a36a10c78a1b6f87cc1c2a797874a6e6"
+  sha256 "41b95f0d80c5e142f56f498eff94e109a5b6528184a18c0feaa0b6d394398bbb"
   license "MIT"
   head "https://github.com/BishopFox/cloudfox.git", branch: "main"
 

--- a/Formula/c/cloudfox.rb
+++ b/Formula/c/cloudfox.rb
@@ -7,12 +7,13 @@ class Cloudfox < Formula
   head "https://github.com/BishopFox/cloudfox.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "0ead04a919711474a7b3a9363df9340bc8bb85e2c3fd7a0e63f51a6a533b6235"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "0ead04a919711474a7b3a9363df9340bc8bb85e2c3fd7a0e63f51a6a533b6235"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "0ead04a919711474a7b3a9363df9340bc8bb85e2c3fd7a0e63f51a6a533b6235"
-    sha256 cellar: :any_skip_relocation, sonoma:        "8a81f06ab4851042af2af7d68a25746e4d2388c0e43cff304948ed9df03baa7d"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "637e800050a1864fa57739572aff43bde77e2ec29d1a75e27cce5c2e5c59f6a4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8f0207d3be754f77166cb0d3c34a5c778572e003c0a614a83148d11c592b4e09"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "78f58ed261a29e27825858cd4b99b200d68927589f1fc591c84e986d9286d91e"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "78f58ed261a29e27825858cd4b99b200d68927589f1fc591c84e986d9286d91e"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "78f58ed261a29e27825858cd4b99b200d68927589f1fc591c84e986d9286d91e"
+    sha256 cellar: :any_skip_relocation, sonoma:        "b44ac8a7e14b3c0bfa0f1be104220fd8e0cd965bcba200984892c7dc2a07e3c3"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "9220bf69db639a1c07eb534963b6ee780b56a7547ad182ed6bacda9487f90fd2"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "9b5ae1d70456eb61bca41051b6541a577e9834f76a57641b14f8f69c964ebda9"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Found in:
* https://github.com/Homebrew/homebrew-core/pull/270582

https://github.com/BishopFox/cloudfox/actions/workflows/autorelease.yml
<img width="1153" height="588" alt="image" src="https://github.com/user-attachments/assets/c4ee313e-e6ae-4692-b055-e0191a1557b6" />

indicates that the tag v2.0.0 was moved from https://github.com/BishopFox/cloudfox/commit/0ba9e2d37fd7f6cc831d19b62c2e1e6c40b8ef63 to https://github.com/BishopFox/cloudfox/commit/db8a6895c3d45368c1f536b5360354f492adbc39

Diff: https://github.com/BishopFox/cloudfox/compare/0ba9e2d37fd7f6cc831d19b62c2e1e6c40b8ef63...db8a6895c3d45368c1f536b5360354f492adbc39

includes upstream change:
* https://github.com/BishopFox/cloudfox/pull/118