### PR TITLE
Shaka-packager 3.5.0 (new formula)

### DIFF
--- a/Formula/s/shaka-packager.rb
+++ b/Formula/s/shaka-packager.rb
@@ -1,0 +1,37 @@
+class ShakaPackager < Formula
+  desc "Tool and media packaging SDK for DASH and HLS packaging and encryption"
+  homepage "https://shaka-project.github.io/shaka-packager/"
+  url "https://github.com/shaka-project/shaka-packager.git",
+    tag: "v3.5.0",
+    revision: "3fc16608677bfa40568601399ce19d9e22e0a205"
+  license "BSD-3-Clause"
+  head "https://github.com/shaka-project/shaka-packager.git", branch: "main"
+
+  depends_on "cmake" => :build
+  depends_on "ninja" => :build
+
+  def install
+    args = %w[
+      -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+      -DBUILD_SHARED_LIBS=OFF
+      -DFULLY_STATIC=OFF
+    ]
+    system "cmake", "-S", ".", "-B", "build", "-G", "Ninja", *args, *std_cmake_args
+    system "cmake", "--build", "build", "--config", "Release"
+    system "cmake", "--install", "build", "--strip", "--config", "Release"
+  end
+
+  test do
+    resource "testdata" do
+      url "https://github.com/mediaelement/mediaelement-files/raw/refs/heads/master/big_buck_bunny.mp4"
+      sha256 "543a4ad9fef4c9e0004ec9482cb7225c2574b0f889291e8270b1c4d61dbc1ab8"
+    end
+
+    resource("testdata").stage do
+      assert_match "Packaging completed successfully", shell_output("#{bin}/packager \
+        input=big_buck_bunny.mp4,stream=video,output=big_buck_bunny.mp4 \
+        --enable_raw_key_decryption \
+        --keys label=SD:key=6143b5373a51cb46209cfed0d747da66:key_id=2c7ed98f472124deafe1dfeba2b45a34")
+    end
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
The latter fails because of

```text
  * Non-executables were installed to "/opt/homebrew/opt/shaka-packager/bin".
    The offending files are:
      /opt/homebrew/opt/shaka-packager/bin/pssh-box-protos
  * Formulae should not require patches to build. Patches should be submitted and accepted upstream first.
```

However, the non-executable files inside `/opt/homebrew/opt/shaka-packager/bin/pssh-box-protos` are needed and used by the installed `pssh-box.py`. 

This is a new PR as discussed in #255606 since shaka-packager 3.5.0 has been released, which already includes the needed fixes for building from source on macOS.

