### PR TITLE
buildkitd 0.28.0 (new formula)

### DIFF
--- a/Formula/b/buildkit.rb
+++ b/Formula/b/buildkit.rb
@@ -16,12 +16,12 @@ class Buildkit < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "e3ca0f23931d989d241869ec59fd6590eda659c8626a02fa4c0fac1ee94c7c5e"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e3ca0f23931d989d241869ec59fd6590eda659c8626a02fa4c0fac1ee94c7c5e"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "e3ca0f23931d989d241869ec59fd6590eda659c8626a02fa4c0fac1ee94c7c5e"
-    sha256 cellar: :any_skip_relocation, sonoma:        "131202a351452d4e8e7dd4c3ea0384294bcbff874c405528c721be8cdc61b5e7"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "d040b515b5ab0bb86665aa0646cc8c4e4a16a2946218693c13f41c7283931f82"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f5492ed18cf1c0481df4c77620b7ed6eeca7fc69de85ad3fe6ed64360d88f98c"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "291782fc68044e422d0c4dc0e1bf7005c66297326ac90ac1fc508020afcec954"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "291782fc68044e422d0c4dc0e1bf7005c66297326ac90ac1fc508020afcec954"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "291782fc68044e422d0c4dc0e1bf7005c66297326ac90ac1fc508020afcec954"
+    sha256 cellar: :any_skip_relocation, sonoma:        "06f4e670c424cb24ad8e542c716c79e606bedf12eab1c14b7a63ac3a26d24cd7"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "fa8554e9920aac8c31e479041070e2a85d00be0befec14442d72d6fac62aa9ca"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "254f4519fce6bcff1fa1c08d8165c3d88140f1615ad4402076ebf10a568bffba"
   end
 
   depends_on "go" => :build

--- a/Formula/b/buildkit.rb
+++ b/Formula/b/buildkit.rb
@@ -1,10 +1,10 @@
 class Buildkit < Formula
   desc "Concurrent, cache-efficient, and Dockerfile-agnostic builder toolkit"
   homepage "https://github.com/moby/buildkit"
-  url "https://github.com/moby/buildkit.git",
-      tag:      "v0.28.0",
-      revision: "5245d869d85d9c98f986b600584c332a3b001986"
+  url "https://github.com/moby/buildkit/archive/refs/tags/v0.28.0.tar.gz"
+  sha256 "2307112b30593fb8fc4d479ce4547862fa101fa2ecd50a852330a1117a988bbc"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/moby/buildkit.git", branch: "master"
 
   # There can be a notable gap between when a version is tagged and a
@@ -27,7 +27,7 @@ class Buildkit < Formula
   depends_on "go" => :build
 
   def install
-    revision = Utils.git_head
+    revision = build.head? ? Utils.git_short_head : tap.user
     ldflags = %W[
       -s -w
       -X github.com/moby/buildkit/version.Version=#{version}
@@ -38,6 +38,15 @@ class Buildkit < Formula
     system "go", "build", "-mod=vendor", *std_go_args(ldflags:, output: bin/"buildctl"), "./cmd/buildctl"
 
     doc.install Dir["docs/*.md"]
+  end
+
+  def caveats
+    on_linux do
+      <<~EOS
+        The daemon component is provided in a separate formula:
+          brew install buildkitd
+      EOS
+    end
   end
 
   test do

--- a/Formula/b/buildkitd.rb
+++ b/Formula/b/buildkitd.rb
@@ -1,0 +1,60 @@
+class Buildkitd < Formula
+  desc "Concurrent, cache-efficient, and Dockerfile-agnostic builder toolkit (Daemon)"
+  homepage "https://github.com/moby/buildkit"
+  url "https://github.com/moby/buildkit/archive/refs/tags/v0.28.0.tar.gz"
+  sha256 "2307112b30593fb8fc4d479ce4547862fa101fa2ecd50a852330a1117a988bbc"
+  license "Apache-2.0"
+  head "https://github.com/moby/buildkit.git", branch: "master"
+
+  # There can be a notable gap between when a version is tagged and a
+  # corresponding release is created, so we check the "latest" release instead
+  # of the Git tags.
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
+  depends_on "go" => :build
+
+  depends_on :linux
+  depends_on "runc"
+
+  def install
+    revision = build.head? ? Utils.git_short_head : tap.user
+    ldflags = %W[
+      -s -w
+      -X github.com/moby/buildkit/version.Version=#{version}
+      -X github.com/moby/buildkit/version.Revision=#{revision}
+      -X github.com/moby/buildkit/version.Package=github.com/moby/buildkit
+    ]
+
+    system "go", "build", "-mod=vendor", *std_go_args(ldflags:, output: bin/"buildkitd"), "./cmd/buildkitd"
+    # Docs are not installed here, as they are already provided by the buildkit (client) formula.
+  end
+
+  def caveats
+    <<~EOS
+      To run buildkitd as the current user, see the following steps:
+        OCI worker mode:
+          brew install rootlesskit
+          rootlesskit buildkitd
+        containerd worker mode:
+          brew install nerdctl containerd rootlesskit slirp4netns
+          containerd-rootless-setuptool.sh install
+          CONTAINERD_NAMESPACE=default containerd-rootless-setuptool.sh install-buildkit-containerd
+
+      To run buildkitd as the root user, use `brew services` with `sudo --preserve-env=HOME`.
+    EOS
+  end
+
+  service do
+    run opt_bin/"buildkitd"
+    require_root true
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/buildkitd --version")
+    assert_match "buildkitd: rootless mode requires to be executed as the mapped root in a user namespace",
+      shell_output("#{bin}/buildkitd 2>&1", 1)
+  end
+end

--- a/Formula/b/buildkitd.rb
+++ b/Formula/b/buildkitd.rb
@@ -14,6 +14,11 @@ class Buildkitd < Formula
     strategy :github_latest
   end
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_linux:  "aeef826aa5ac6bba845296fd2aeb5fb7c8b32cf455ad85023e65e15b7354758e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "fb0f2ad2f794821947ac5c76d7cbd80aa7d9d965e0c3d52f53ba7c5f7df1a005"
+  end
+
   depends_on "go" => :build
 
   depends_on :linux


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.
  - Used Claude Code for the initial draft, then reviewed, modified, and tested the commit by myself as follows:


Daemon:
```console
$ brew install -q rootlesskit
==> Fetching downloads for: rootlesskit
✔︎ Bottle Manifest rootlesskit (2.3.6)                                                                                                                                                                                                                                 Downloaded    3.3KB/  3.3KB
✔︎ Bottle rootlesskit (2.3.6)                                                                                                                                                                                                                                          Downloaded    6.8MB/  6.8MB
==> Pouring rootlesskit--2.3.6.arm64_linux.bottle.tar.gz
🍺  /home/linuxbrew/.linuxbrew/Cellar/rootlesskit/2.3.6: 14 files, 17.3MB
==> Running `brew cleanup rootlesskit`...
Disable this behaviour by setting `HOMEBREW_NO_INSTALL_CLEANUP=1`.
Hide these hints with `HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).

$ rootlesskit buildkitd
INFO[2026-03-05T20:50:35+09:00] auto snapshotter: using overlayfs            
WARN[2026-03-05T20:50:35+09:00] CDI setup error /etc/buildkit/cdi: failed to monitor for changes: no such file or directory 
WARN[2026-03-05T20:50:35+09:00] CDI setup error /etc/cdi: failed to monitor for changes: no such file or directory 
WARN[2026-03-05T20:50:35+09:00] CDI setup error /var/run/cdi: failed to monitor for changes: no such file or directory 
INFO[2026-03-05T20:50:35+09:00] found worker "17fy19ri7i6601i3f3gmaoe31", labels=map[org.mobyproject.buildkit.worker.executor:oci org.mobyproject.buildkit.worker.hostname:lima-agent org.mobyproject.buildkit.worker.network:host org.mobyproject.buildkit.worker.oci.process-mode:sandbox org.mobyproject.buildkit.worker.selinux.enabled:false org.mobyproject.buildkit.worker.snapshotter:overlayfs], platforms=[linux/arm64] 
WARN[2026-03-05T20:50:35+09:00] skipping containerd worker, as "/run/containerd/containerd.sock" does not exist 
INFO[2026-03-05T20:50:35+09:00] found 1 workers, default="17fy19ri7i6601i3f3gmaoe31" 
WARN[2026-03-05T20:50:35+09:00] currently, only the default worker can be used. 
INFO[2026-03-05T20:50:35+09:00] running server on /run/user/501/buildkit/buildkitd.sock
```

Client:
```console
$ brew install -q buildkit
✔︎ Bottle Manifest buildkit (0.28.0)                                                                                                                                                                                                                                   Downloaded    7.5KB/  7.5KB
✔︎ Bottle buildkit (0.28.0)                                                                                                                                                                                                                                            Downloaded    7.7MB/  7.7MB
==> Pouring buildkit--0.28.0.arm64_linux.bottle.tar.gz
🍺  /home/linuxbrew/.linuxbrew/Cellar/buildkit/0.28.0: 23 files, 22.2MB
==> Running `brew cleanup buildkit`...
Disable this behaviour by setting `HOMEBREW_NO_INSTALL_CLEANUP=1`.
Hide these hints with `HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).

$ cat <<EOF >Dockerfile
FROM alpine
RUN apk add fastfetch
EOF

$ buildctl --addr "unix://$XDG_RUNTIME_DIR/buildkit/buildkitd.sock" build --frontend dockerfile.v0 --local dockerfile=. --local context=.
[+] Building 4.6s (5/5) FINISHED                                                                                                                                                                                                                                                                 
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                        0.0s
 => => transferring dockerfile: 71B                                                                                                                                                                                                                                                         0.0s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                                                                                                                                                            2.3s
 => [internal] load .dockerignore                                                                                                                                                                                                                                                           0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                                             0.0s
 => [1/2] FROM docker.io/library/alpine:latest@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659                                                                                                                                                                      0.8s
 => => resolve docker.io/library/alpine:latest@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659                                                                                                                                                                      0.0s
 => => sha256:d8ad8cd72600f46cc068e16c39046ebc76526e41051f43a8c249884b200936c0 4.20MB / 4.20MB                                                                                                                                                                                              0.7s
 => => extracting sha256:d8ad8cd72600f46cc068e16c39046ebc76526e41051f43a8c249884b200936c0                                                                                                                                                                                                   0.1s
 => [2/2] RUN apk add fastfetch

$ echo $?
0
```

-----
