### PR TITLE
docker-engine 29.2.1 (new formula)

### DIFF
--- a/Formula/d/docker-engine.rb
+++ b/Formula/d/docker-engine.rb
@@ -1,0 +1,68 @@
+class DockerEngine < Formula
+  desc "Pack, ship and run any application as a lightweight container (Daemon)"
+  homepage "https://www.docker.com/"
+  url "https://github.com/moby/moby.git",
+      tag:      "docker-v29.2.1",
+      revision: "6bc6209b88a7a834c91f77d848e025c79e0227a1"
+  license "Apache-2.0"
+  head "https://github.com/moby/moby.git", branch: "master"
+
+  livecheck do
+    url :stable
+    regex(/^docker-v(\d+(?:\.\d+)+)$/i)
+  end
+
+  depends_on "go" => :build
+  depends_on "go-md2man" => :build
+  depends_on "pkgconf" => :build
+  depends_on "containerd"
+  depends_on :linux
+  depends_on "nftables"
+  depends_on "runc"
+
+  def install
+    ldflags = %W[
+      -s -w
+      -X github.com/moby/moby/v2/dockerversion.BuildTime=#{time.iso8601}
+      -X github.com/moby/moby/v2/dockerversion.GitCommit=#{Utils.git_short_head}
+      -X github.com/moby/moby/v2/dockerversion.Version=#{version}
+      -X "github.com/moby/moby/v2/dockerversion.PlatformName=Docker Engine - Community"
+    ]
+
+    system "go", "build", *std_go_args(output: bin/"dockerd", ldflags:),
+      "github.com/moby/moby/v2/cmd/dockerd"
+    system "go", "build", *std_go_args(output: bin/"docker-proxy", ldflags:),
+      "github.com/moby/moby/v2/cmd/docker-proxy"
+    bin.install "contrib/dockerd-rootless.sh"
+    bin.install "contrib/dockerd-rootless-setuptool.sh"
+
+    man8.mkpath
+    system "go-md2man", "-in=man/dockerd.8.md", "-out=#{man8}/dockerd.8"
+  end
+
+  def caveats
+    <<~EOS
+      To run dockerd as the current user, execute the following commands:
+        brew install rootlesskit slirp4netns
+        dockerd-rootless-setuptool.sh install
+
+      NOTE: As the lifecycle of containerd is managed by dockerd,
+            do NOT run `containerd-rootless-setuptool.sh install`
+            before `dockerd-rootless-setuptool.sh install`.
+
+      To run dockerd as the root user, use `brew services` with `sudo --preserve-env=HOME`.
+    EOS
+  end
+
+  service do
+    run opt_bin/"dockerd"
+    # See the caveats for rootless mode
+    require_root true
+  end
+
+  test do
+    assert_match "Docker version #{version}", shell_output("#{bin}/dockerd --version")
+    assert_match "dockerd needs to be started with root privileges",
+      shell_output("#{bin}/dockerd 2>&1", 1)
+  end
+end

--- a/Formula/d/docker-engine.rb
+++ b/Formula/d/docker-engine.rb
@@ -12,6 +12,11 @@ class DockerEngine < Formula
     regex(/^docker-v(\d+(?:\.\d+)+)$/i)
   end
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_linux:  "9bad62c3a0c513eb5d5f5c17456fe989bac3b4ebcce40d890f98ff9158ac7775"
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "8f72ddcdf973009d50cf9180c1293a84a5a6deb7646ff75e1903314c0f29f75e"
+  end
+
   depends_on "go" => :build
   depends_on "go-md2man" => :build
   depends_on "pkgconf" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.
  - Used Claude Code for the initial draft, but almost ended up rewriting it from scratch by myself. Manually tested as follows:

```console
$ brew install docker rootlesskit slirp4netns

$ dockerd-rootless-setuptool.sh

$ docker run --rm hello-world

Hello from Docker!
[...]
```

(Ubuntu 25.10, aarch64)

-----
