### PR TITLE
termusic: add features, adjust dependencies

### DIFF
--- a/Formula/t/termusic.rb
+++ b/Formula/t/termusic.rb
@@ -7,12 +7,13 @@ class Termusic < Formula
   head "https://github.com/tramhao/termusic.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "1c2f883e043839db16ac4f8de8add8b972de0e008463f714e7a19c89cb76be45"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "87d7b2e39b0809ee26208e482ee7f85dea70d69b70a62833c526b4be18d76e42"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "9438afa2b260b4345bc0bde7c106fb3c2d5cb698cd4df6503d4bed74453c518c"
-    sha256 cellar: :any_skip_relocation, sonoma:        "06be1c021c63e361e292860592fb21b6abe48f044e8fcba7dc74740ce29d9069"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "c32e8c19f96b03217bdca10746787eaf5d000fea12be63e769c6985385604bd0"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4723e83582af2d07546b8af198ee691299a3bfb4e10dd55003391556ecc6f508"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "e3facb7042db6b4dd321d40077b8f19c1c4db1880fe2e1814555f573656cb44b"
+    sha256 cellar: :any,                 arm64_sequoia: "d83195d661adccb98aebbb151861fe34cd51fdefe46865ea1da642d4195f8b41"
+    sha256 cellar: :any,                 arm64_sonoma:  "ab04857bd9d272a05c41d7bad1cff3dda4926b96250c569452caf421012ea888"
+    sha256 cellar: :any,                 sonoma:        "a63a6ab065346edc1f230305318ba7ca301b2c065c3fe6414f6f4bcc8c5eb774"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "5bb1fb574dd37e881471ae1eb8e8b027ae83ab1626d3aed9c8fae06568f7ac6b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "53a444e5a34adb183b14326f05c0f5a251d4e17e6e59d7d6cd2e4e4a397b2d24"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/t/termusic.rb
+++ b/Formula/t/termusic.rb
@@ -4,6 +4,7 @@ class Termusic < Formula
   url "https://github.com/tramhao/termusic/archive/refs/tags/v0.12.1.tar.gz"
   sha256 "686f66856d755f2d2056a9548f074b11ba9568ac8075fafd8903e332bf166227"
   license all_of: ["MIT", "GPL-3.0-or-later"]
+  head "https://github.com/tramhao/termusic.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "1c2f883e043839db16ac4f8de8add8b972de0e008463f714e7a19c89cb76be45"
@@ -17,16 +18,20 @@ class Termusic < Formula
   depends_on "pkgconf" => :build
   depends_on "protobuf" => :build
   depends_on "rust" => :build
-  depends_on "sound-touch" => :build
   depends_on "openssl@3"
+  depends_on "opus"
+
+  uses_from_macos "llvm" => :build # for libclang
 
   on_linux do
     depends_on "alsa-lib"
+    depends_on "libgccjit"
   end
 
   def install
-    system "cargo", "install", *std_cargo_args(path: "tui", features: "cover-viuer-iterm")
-    system "cargo", "install", *std_cargo_args(path: "server")
+    server_features = %w[rusty-libopus rusty-simd rusty-soundtouch]
+    system "cargo", "install", *std_cargo_args(path: "tui")
+    system "cargo", "install", *std_cargo_args(path: "server", features: server_features)
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Following discussions with one of `termusic` maintainers in https://github.com/tramhao/termusic/pull/654 https://github.com/tramhao/termusic/pull/657 and https://github.com/tramhao/termusic/issues/121 for example, I bring here several improvements to the formula.

- It appears `sound-touch` dependency is not used anymore, as it's brought through Rust dependencies (cargo), notably the `rusty-soundtouch` feature.
- Add Opus codec support through `rusty-libopus`
- Remove a cover feature that's default (no need to declare it twice, this isn't overwritten)
- Add a head stanza (shouldn't this be inferred from repo? I encountered errors building head without the stanza)

Ideally, we'd like to bring Sixels support, currently behind the `cover-viuer-sixel` feature.
Homebrew already package `libsixel`, used in the `timg` formula and I'm not seeing anything special in it regarding linking.
It does work on Linux, but when testing against macOS, we end up with warnings and errors:

With Homebrew:
Build:
```
❯ HOMEBREW_NO_INSTALL_FROM_API=1 brew install --HEAD termusic
==> Fetching downloads for: termusic
✔︎ Formula termusic (HEAD-e8cdd60)
==> cargo install --path=tui --features=cover-viuer
==> cargo install --path=server --features=rusty-soundtouch, rusty-simd, rusty-l
Warning: Could not fix /private/tmp/termusic-20260303-42027-ksovie/target/release/build/sixel-sys-769cf930faf65c1b/out/lib/libsixel.1.dylib in /opt/homebrew/Cellar/termusic/HEAD-e8cdd60/bin/termusic
```

Crash on runtime:
```
❯ termusic
dyld[71896]: Library not loaded: /private/tmp/termusic-20260305-65890-sc67eh/target/release/build/sixel-sys-769cf930faf65c1b/out/lib/libsixel.1.dylib
  Referenced from: <3E092587-AF82-368C-9170-8801E92BBFCC> /opt/homebrew/Cellar/termusic/HEAD-80da861/bin/termusic
  Reason: tried: '/private/tmp/termusic-20260305-65890-sc67eh/target/release/build/sixel-sys-769cf930faf65c1b/out/lib/libsixel.1.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/private/tmp/termusic-20260305-65890-sc67eh/target/release/build/sixel-sys-769cf930faf65c1b/out/lib/libsixel.1.dylib' (no such file), '/private/tmp/termusic-20260305-65890-sc67eh/target/release/build/sixel-sys-769cf930faf65c1b/out/lib/libsixel.1.dylib' (no such file)
zsh: abort      termusic
```


Directly with Cargo, build fails so only compilation failure logs, no runtime crash. Can't tell why Homebrew is able to build with only a warning while Cargo fails earlier and refuse to build.

```
error: linking with `cc` failed: exit status: 1
  |
  = note:  "cc" "<1 object files omitted>" "/var/folders/vf/ptf858lx6mv_3hdbs1z6s85w0000gn/T/rustcxMnkAe/{libsoundtouch_ffi-dd84587000a5f537,liblibsqlite3_sys-411a915570a2d171,libring-29d341ebf59f7479}.rlib" "<sysroot>/lib/rustlib/aarch64-apple-darwin/lib/libcompiler_builtins-*.rlib" "-lc++" "-framework" "AudioToolbox" "-framework" "CoreAudio" "-framework" "CoreFoundation" "-lobjc" "-framework" "Foundation" "-framework" "MediaPlayer" "-lSystem" "-framework" "AppKit" "-framework" "QuartzCore" "-framework" "Foundation" "-lobjc" "-framework" "CoreGraphics" "-framework" "CoreGraphics" "-lSystem" "-lsixel" "-framework" "Security" "-framework" "SystemConfiguration" "-framework" "CoreFoundation" "-liconv" "-lSystem" "-lc" "-lm" "-arch" "arm64" "-mmacosx-version-min=11.0.0" "-L" "/private/tmp/termusic/target/release/build/ring-1c8894531431b14c/out" "-L" "/private/tmp/termusic/target/release/build/libsqlite3-sys-69fbb5d5af6d1bb3/out" "-L" "/private/tmp/termusic/target/release/build/sixel-sys-769cf930faf65c1b/out/lib" "-L" "/private/tmp/termusic/target/release/build/soundtouch-ffi-9b0cd805ec1a8cff/out" "-o" "/private/tmp/termusic/target/release/deps/termusic_server-e2f171ead366de0f" "-Wl,-dead_strip" "-nodefaultlibs"
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: ld: warning: ignoring duplicate libraries: '-lSystem', '-lobjc'
          ld: warning: search path '/private/tmp/termusic/target/release/build/sixel-sys-769cf930faf65c1b/out/lib' not found
          ld: library 'sixel' not found
          clang: error: linker command failed with exit code 1 (use -v to see invocation)


error: could not compile `termusic-server` (bin "termusic-server") due to 1 previous error
warning: build failed, waiting for other jobs to finish...
error: linking with `cc` failed: exit status: 1
  |
  = note:  "cc" "<1 object files omitted>" "/var/folders/vf/ptf858lx6mv_3hdbs1z6s85w0000gn/T/rustcxPDwPk/{liblibsqlite3_sys-411a915570a2d171,libring-29d341ebf59f7479}.rlib" "<sysroot>/lib/rustlib/aarch64-apple-darwin/lib/libcompiler_builtins-*.rlib" "-lsixel" "-framework" "Security" "-framework" "SystemConfiguration" "-framework" "IOKit" "-framework" "CoreFoundation" "-lobjc" "-framework" "Foundation" "-liconv" "-framework" "CoreFoundation" "-lSystem" "-lc" "-lm" "-arch" "arm64" "-mmacosx-version-min=11.0.0" "-L" "/private/tmp/termusic/target/release/build/ring-1c8894531431b14c/out" "-L" "/private/tmp/termusic/target/release/build/libsqlite3-sys-69fbb5d5af6d1bb3/out" "-L" "/private/tmp/termusic/target/release/build/sixel-sys-769cf930faf65c1b/out/lib" "-o" "/private/tmp/termusic/target/release/deps/termusic-85517e71d7928fc1" "-Wl,-dead_strip" "-nodefaultlibs"
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: ld: warning: search path '/private/tmp/termusic/target/release/build/sixel-sys-769cf930faf65c1b/out/lib' not found
          ld: library 'sixel' not found
          clang: error: linker command failed with exit code 1 (use -v to see invocation)


error: could not compile `termusic` (bin "termusic") due to 1 previous error
```

This looks like a macOS specific thing preventing linking, but maybe you already crossed the situation and have an easy answer to this?

It'd be nice to have for now, but the target in the future, as seen in the https://github.com/tramhao/termusic/pull/657/ PR is to replace the external dependency with a full-rust solution.

Ping @hasezoey who's upstream maintainer in case you got anything worthy I forgot to add here!

EDIT: To maintainers, can't we keep atomic commits? It's an obligation to either squash them in a single one, or open several PRs?