### PR TITLE
bozohttpd: cleanup unused args and deps

### DIFF
--- a/Formula/b/bozohttpd.rb
+++ b/Formula/b/bozohttpd.rb
@@ -21,22 +21,9 @@ class Bozohttpd < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "c8f662a5761fcd610221da12ac4476496fe39bb5254c0192a05e6170b495c988"
   end
 
-  depends_on "pkgconf" => :build
-  depends_on "lua"
   depends_on "openssl@3"
 
   def install
-    # Both `cflags` are explained at http://www.eterna.com.au/bozohttpd/bozohttpd.8.html
-    cflags = [
-      # Disable NetBSD blocklistd support, which is enabled by default (see section "BLOCKLIST SUPPORT")
-      "-DNO_BLOCKLIST_SUPPORT",
-      # Enable basic authentication, which is disabled by default (see section "HTTP BASIC AUTHORIZATION")
-      "-DDO_HTPASSWD",
-    ]
-    cflags << Utils.safe_popen_read("pkg-config", "--libs", "--cflags", "lua").chomp
-    cflags << Utils.safe_popen_read("pkg-config", "--libs", "--cflags", "libcrypto").chomp
-
-    ENV.append "CFLAGS", cflags.join(" ")
     system "make", "-f", "Makefile.boot", "CC=#{ENV.cc}"
     bin.install "bozohttpd"
   end
@@ -48,8 +35,6 @@ class Bozohttpd < Formula
     (testpath/"index.html").write expected_output
 
     spawn bin/"bozohttpd", "-b", "-f", "-I", port.to_s, testpath
-    sleep 3
-
-    assert_match expected_output, shell_output("curl -s 127.0.0.1:#{port}")
+    assert_match expected_output, shell_output("curl --silent --retry 5 --retry-connrefused 127.0.0.1:#{port}")
   end
 end


### PR DESCRIPTION
Makefile.boot has
```make
LARGE_CFLAGS=	-D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
LOCAL_CFLAGS=	-DNO_LUA_SUPPORT -DNO_BLOCKLIST_SUPPORT -D_GNU_SOURCE -D_DEFAULT_SOURCE
CFLAGS=	$(OPT) $(LARGE_CFLAGS) $(LOCAL_CFLAGS)
```

So CFLAGS environment variable had no impact.

Also Lua support wasn't enabled which is likely why it didn't fail on Lua 5.5.0