### PR TITLE
lpeg: add support for Lua 5.5

### DIFF
--- a/Formula/l/lpeg.rb
+++ b/Formula/l/lpeg.rb
@@ -13,12 +13,12 @@ class Lpeg < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "eac4a8e81fe8fe1855702941aa034eb8ea81f681b8db009d9e36a2aaf7bcbf1e"
-    sha256 cellar: :any,                 arm64_sequoia: "8941c78e5300722a52c3a62e6471122a0e4efa4508ec8117ae137616ed8a7abe"
-    sha256 cellar: :any,                 arm64_sonoma:  "5c1eae57e7209af8cd6188b560cd9a9850bb8424418439c48cfd091b70845942"
-    sha256 cellar: :any,                 sonoma:        "d31eb5abcd32e4730e9b26afc41221db254e0042187940a0676d5ba01253c7fd"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "fd2e06b940f418826f890869f7cd6d5512365bffd99d50fa78f0c3f13c061c98"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d940ee7049f656e7920ec081adb0b3a7237a65801addfebacfe71d5c2bf2f08c"
+    sha256 cellar: :any,                 arm64_tahoe:   "f3ef5600e2a654aea26c48469ab8ffee9fe117c71fe4d617646939b0f74059bd"
+    sha256 cellar: :any,                 arm64_sequoia: "afeb8aa90c0d61871094edc33f8992b478791bb24bbe07ddfe45b3e0da38e118"
+    sha256 cellar: :any,                 arm64_sonoma:  "2465c478129b2ccf00900021b54204d79145e8124d75c55ee3dea9d0a56f41f1"
+    sha256 cellar: :any,                 sonoma:        "973868eaace571f6f1c7764cf02a41f7fdd20b59b01d380f2905e76de06e439e"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "658195428657fbe6cbf45c95ab2e69dd416767ddbe6c02593a03984d1efcffdc"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "9087115cb278f1b318ca5334804948f0a44c7983d36acb0b5b171b12bd97df3f"
   end
 
   depends_on "lua" => [:build, :test]

--- a/Formula/l/lpeg.rb
+++ b/Formula/l/lpeg.rb
@@ -5,7 +5,7 @@ class Lpeg < Formula
   mirror "https://github.com/neovim/deps/raw/master/opt/lpeg-1.1.0.tar.gz"
   sha256 "4b155d67d2246c1ffa7ad7bc466c1ea899bbc40fef0257cc9c03cecbaed4352a"
   license "MIT"
-  revision 1
+  revision 2
 
   livecheck do
     url :homepage
@@ -21,7 +21,8 @@ class Lpeg < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "d940ee7049f656e7920ec081adb0b3a7237a65801addfebacfe71d5c2bf2f08c"
   end
 
-  depends_on "lua@5.4" => [:build, :test]
+  depends_on "lua" => [:build, :test]
+  depends_on "lua@5.4" => [:build, :test] # TODO: remove once no dependents need Lua 5.4
   depends_on "luajit" => [:build, :test]
 
   def make_install_lpeg_so(luadir, dllflags, abi_version)
@@ -31,18 +32,20 @@ class Lpeg < Formula
     system "make", "clean"
   end
 
-  def lua
-    Formula["lua@5.4"]
+  def luas
+    deps.map(&:to_formula).select { |f| f.name.match?(/^lua(@\d+(\.\d+)*)?$/) }
   end
+
+  def luajit = Formula["luajit"]
 
   def install
     dllflags = %w[-shared -fPIC]
     dllflags << "-Wl,-undefined,dynamic_lookup" if OS.mac?
 
-    luajit = Formula["luajit"]
-
     make_install_lpeg_so(luajit.opt_include/"luajit-2.1", dllflags, "5.1")
-    make_install_lpeg_so(lua.opt_include/"lua", dllflags, lua.version.major_minor)
+    luas.each do |lua|
+      make_install_lpeg_so(lua.opt_include/"lua", dllflags, lua.version.major_minor)
+    end
 
     doc.install "lpeg.html", "re.html"
     pkgshare.install "test.lua", "re.lua"
@@ -51,7 +54,9 @@ class Lpeg < Formula
   end
 
   test do
-    system lua.bin/"lua", pkgshare/"test.lua"
-    system "luajit", pkgshare/"test.lua"
+    luas.each do |lua|
+      system lua.bin/"lua", pkgshare/"test.lua"
+    end
+    system luajit.bin/"luajit", pkgshare/"test.lua"
   end
 end


### PR DESCRIPTION
Should allow migrating dependents to Lua 5.5 when support is available. Currently both dependents (corsixth and vis) have support in HEAD but not in a release.