### PR TITLE
`{ffmpeg,imagemagick}{,-full}`: bump revision, flip keg only

### DIFF
--- a/Formula/f/ffmpeg-full.rb
+++ b/Formula/f/ffmpeg-full.rb
@@ -6,7 +6,7 @@ class FfmpegFull < Formula
   # None of these parts are used by default, you have to explicitly pass `--enable-gpl`
   # to configure to activate them. In this case, FFmpeg's license changes to GPL v2+.
   license "GPL-2.0-or-later"
-  revision 3
+  revision 4
   head "https://github.com/FFmpeg/FFmpeg.git", branch: "master"
 
   livecheck do
@@ -21,8 +21,6 @@ class FfmpegFull < Formula
     sha256 arm64_linux:   "9e042fbe34bbff163693254a5b18da834e511629160faafd4a2986f2eddb0dfe"
     sha256 x86_64_linux:  "5802b976baabafeda60e5a3801d3a1acb2f3f94eab0b99082d977a7e46c5663d"
   end
-
-  keg_only :versioned_formula
 
   depends_on "pkgconf" => :build
   depends_on "aom"

--- a/Formula/f/ffmpeg.rb
+++ b/Formula/f/ffmpeg.rb
@@ -6,7 +6,7 @@ class Ffmpeg < Formula
   # None of these parts are used by default, you have to explicitly pass `--enable-gpl`
   # to configure to activate them. In this case, FFmpeg's license changes to GPL v2+.
   license "GPL-2.0-or-later"
-  revision 4
+  revision 5
   compatibility_version 1
   head "https://github.com/FFmpeg/FFmpeg.git", branch: "master"
 
@@ -23,6 +23,8 @@ class Ffmpeg < Formula
     sha256 arm64_linux:   "f5a701c93d3cb1c8c7f7d0f28c4aa44252604214b01b44654d74ae44c6baf0bd"
     sha256 x86_64_linux:  "7db34826b4b98eb9f3bb1f5e758ee953f6ab36dc4bb97922fb3d1673b7af7bfc"
   end
+
+  keg_only :versioned_formula
 
   depends_on "pkgconf" => :build
 

--- a/Formula/i/imagemagick-full.rb
+++ b/Formula/i/imagemagick-full.rb
@@ -4,6 +4,7 @@ class ImagemagickFull < Formula
   url "https://imagemagick.org/archive/releases/ImageMagick-7.1.2-16.tar.xz"
   sha256 "bb463666e99145b143de5f4168dc0a8a2d3033ce49ce6aba7915f75076376eaf"
   license "ImageMagick"
+  revision 1
   head "https://github.com/ImageMagick/ImageMagick.git", branch: "main"
 
   livecheck do
@@ -19,8 +20,6 @@ class ImagemagickFull < Formula
     sha256 arm64_linux:   "15bd56aeaa7103e77b18872e284f5ea9ad8ea2ef462c775cfde46a052d1ba204"
     sha256 x86_64_linux:  "05a62c408f6c7e757cb8550ea427b36503b51e9c652cfcef32342b17e2c10136"
   end
-
-  keg_only :versioned_formula
 
   depends_on "pkgconf" => :build
   depends_on "cairo"

--- a/Formula/i/imagemagick.rb
+++ b/Formula/i/imagemagick.rb
@@ -4,6 +4,7 @@ class Imagemagick < Formula
   url "https://imagemagick.org/archive/releases/ImageMagick-7.1.2-16.tar.xz"
   sha256 "bb463666e99145b143de5f4168dc0a8a2d3033ce49ce6aba7915f75076376eaf"
   license "ImageMagick"
+  revision 1
   head "https://github.com/ImageMagick/ImageMagick.git", branch: "main"
 
   livecheck do
@@ -19,6 +20,8 @@ class Imagemagick < Formula
     sha256 arm64_linux:   "25d7190f95584c964f1916c4c3b2ce7911826f744cfe32c3add7dfc0da4d5422"
     sha256 x86_64_linux:  "cd10a6157a359df60edd9d7130efc8f77a50dd4b9325dafda659f9b639ee4582"
   end
+
+  keg_only :versioned_formula
 
   depends_on "pkgconf" => :build
 


### PR DESCRIPTION
Let's make the `-full` versions not keg-only by default.

This will be a companion to https://github.com/Homebrew/brew/pull/21676 which will make this behaviour change less eventful for users.

Will try to get 🟢 before https://github.com/Homebrew/brew/pull/21676 has merged but will avoid merging until https://github.com/Homebrew/brew/pull/21676 is ready for a new release.