### PR TITLE
scala-cli 1.12.4 (new formula) & scala: use native scala-cli

### DIFF
--- a/Formula/p/pwntools.rb
+++ b/Formula/p/pwntools.rb
@@ -31,7 +31,6 @@ class Pwntools < Formula
   conflicts_with "moreutils", because: "both install an `errno` executable"
   conflicts_with "cspice", because: "both install `version` binaries"
   conflicts_with "jena", because: "both install `update` binaries"
-  conflicts_with "scala", because: "both install `common` binaries"
 
   pypi_packages exclude_packages: %w[capstone certifi cryptography]
 

--- a/Formula/p/pwntools.rb
+++ b/Formula/p/pwntools.rb
@@ -10,12 +10,13 @@ class Pwntools < Formula
   head "https://github.com/Gallopsled/pwntools.git", branch: "dev"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "620dd787f93c98a5dc4506f69d7764f4af36444ada3fea4d5cdb4bad08a51476"
-    sha256 cellar: :any,                 arm64_sequoia: "80e8346facb2431dcd22596781b22731d19af7a7db93e09bc8540605ddf6620c"
-    sha256 cellar: :any,                 arm64_sonoma:  "daeeca7e82acf679cb15f9817cfff08f627297aab05e94d83a39e593583650cf"
-    sha256 cellar: :any,                 sonoma:        "2fbb55f6d41dc830d10a8e2b2f36a6736a1da3c89fa312017ef46aa70471b9b8"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "97cf9ed3f6aeeecbf2c81c2186ec5904fde522b1f545de991eb4d521ffd7e3a9"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "fe19848767ab22b74cadddf97eba47f2185f6ea8d3beef5b92615cd4277bbeb4"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "173963053778f57f1cb1061a1b0eb425f32d4a986135dcb909cd79f56c3ba2bc"
+    sha256 cellar: :any,                 arm64_sequoia: "4d4e3fd121e820cad7d7110885aefb82a3553b4030adb487224021e7876bffe5"
+    sha256 cellar: :any,                 arm64_sonoma:  "fce7e058b56ea4ac74b9ec1a9bba9493e1a1c3d51c219b63127d87001d234c1a"
+    sha256 cellar: :any,                 sonoma:        "187722c690ddc9cf14c0384c6072c3af594ff72c548959a25c865bcc325a7a4b"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "2cd3a8f47cfb0a966cfd17139469f38f3e79becd201b61cc20beea0a25d34bb3"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "7cf87eb86532b4347492b3ab03a52cced0e21b7ecc0471c4f92f217fb96d6deb"
   end
 
   depends_on "rust" => :build # for bcrypt

--- a/Formula/s/scala-cli.rb
+++ b/Formula/s/scala-cli.rb
@@ -6,6 +6,15 @@ class ScalaCli < Formula
       revision: "ca3f6e8f59562e1adcf798cd868b0233500f94f1"
   license "Apache-2.0"
 
+  bottle do
+    sha256                               arm64_tahoe:   "bbe4de04e1a58fb60cf7f6abd8d9839ebb0a89a48f3f003659a9f553cdae5708"
+    sha256                               arm64_sequoia: "92cb26714138cd1eab785157659477e0883fd0ca4e51ff7820cb54332e6b83c5"
+    sha256                               arm64_sonoma:  "e3667e5d7edec1eeb3f53d00d0be9ac16821f83d5c23d3b6c6fa9049ba375518"
+    sha256 cellar: :any_skip_relocation, sonoma:        "954a05d9404aa9ee9fe9d595995a64aa28e89274ad840414144795ffb825ca01"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "d22f74419d8c1558e0844a50d2cb82711d93412faa9f04c393a77bef3bb9549f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "eef9116b580721ac705d3b0ccc9a10b78411087163e80b1fa1f22153c107e4de"
+  end
+
   depends_on "openjdk@17" => [:build, :test]
 
   on_linux do

--- a/Formula/s/scala-cli.rb
+++ b/Formula/s/scala-cli.rb
@@ -1,0 +1,57 @@
+class ScalaCli < Formula
+  desc "Scala language runner and build tool"
+  homepage "https://scala-cli.virtuslab.org/"
+  url "https://github.com/VirtusLab/scala-cli.git",
+      tag:      "v1.12.4",
+      revision: "ca3f6e8f59562e1adcf798cd868b0233500f94f1"
+  license "Apache-2.0"
+
+  depends_on "openjdk@17" => [:build, :test]
+
+  on_linux do
+    depends_on "zlib-ng-compat"
+  end
+
+  def install
+    ENV["JAVA_HOME"] = Formula["openjdk@17"].opt_prefix
+    ENV["USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM"] = "false"
+    ENV["COURSIER_CACHE"] = "#{HOMEBREW_CACHE}/coursier/v1"
+    ENV["COURSIER_ARCHIVE_CACHE"] = "#{HOMEBREW_CACHE}/coursier/arc"
+    ENV["COURSIER_JVM_CACHE"] = "#{HOMEBREW_CACHE}/coursier/jvm"
+
+    system "./mill", "-i", "cli[].base-image.writeDefaultNativeImageScript",
+           "--scriptDest", "generate-native-image.sh"
+
+    # Without removing shims, native-image fails with:
+    #   Error: Unable to detect supported DARWIN native software development toolchain.
+    #   Querying with command '.../shims/mac/super/cc -v' prints:
+    #   cc: The build tool has reset ENV; --env=std required.
+    # The native-image binary does not propagate HOMEBREW_RUBY_PATH to child
+    # processes, so the superenv cc shim aborts. Remove shims so it uses the real C compiler.
+    ENV.remove "PATH", Superenv.shims_path
+    if OS.linux?
+      # native-image doesn't propagate env vars to the gcc subprocess it spawns,
+      # so LIBRARY_PATH won't reach the linker. Inject the path directly via
+      # -H:CLibraryPath so native-image passes -L to the linker command.
+      zlib_lib = Formula["zlib-ng-compat"].opt_lib
+      extra = "'-H:CLibraryPath=#{zlib_lib}' '-H:NativeLinkerOption=-Wl,-rpath,#{zlib_lib}'"
+      inreplace "generate-native-image.sh", "'--no-fallback'", "'--no-fallback' #{extra}"
+    end
+    system "bash", "./generate-native-image.sh"
+
+    bin.install Dir["out/cli/*/base-image/nativeImage.dest/scala-cli"].first
+  end
+
+  test do
+    ENV["SCALA_CLI_HOME"] = testpath
+    ENV["COURSIER_CACHE"] = ENV["COURSIER_ARCHIVE_CACHE"] = testpath/".coursier_cache"
+    ENV["COURSIER_JVM_CACHE"] = testpath/".coursier_jvm_cache"
+    ENV["JAVA_HOME"] = Formula["openjdk@17"].opt_prefix
+
+    (testpath/"Hello.scala").write <<~SCALA
+      @main def hello() = println("Hello from Scala CLI")
+    SCALA
+    assert_match "Hello from Scala CLI", shell_output("#{bin}/scala-cli run --server=false Hello.scala")
+    assert_match version.to_s, shell_output("#{bin}/scala-cli version")
+  end
+end

--- a/Formula/s/scala.rb
+++ b/Formula/s/scala.rb
@@ -1,6 +1,6 @@
 class Scala < Formula
   desc "JVM-based programming language"
-  homepage "https://dotty.epfl.ch/"
+  homepage "https://scala-lang.org/"
   url "https://github.com/scala/scala3/releases/download/3.8.2/scala3-3.8.2.tar.gz"
   sha256 "827356a78a70d3d792f1a77e109cc3fa3ea946b8d26848bb245f275be52fd78e"
   license "Apache-2.0"
@@ -15,16 +15,22 @@ class Scala < Formula
   end
 
   # JDK Compatibility: https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
-  depends_on "openjdk"
-
-  conflicts_with "pwntools", because: "both install `common` binaries"
+  depends_on "openjdk@17"
+  depends_on "scala-cli"
 
   def install
     rm Dir["bin/*.bat"]
+    rm Dir["libexec/*.bat"]
 
-    libexec.install "lib", "maven2", "VERSION", "libexec"
-    prefix.install "bin"
-    bin.env_script_all_files libexec/"bin", Language::Java.overridable_java_home_env
+    libexec.install "lib", "maven2", "VERSION"
+    (libexec/"libexec").install "libexec/common", "libexec/common-shared", "libexec/cli-common-platform"
+
+    inreplace libexec/"libexec/cli-common-platform",
+              /SCALA_CLI_CMD_BASH=.*/,
+              "SCALA_CLI_CMD_BASH=(\"#{Formula["scala-cli"].opt_bin}/scala-cli\")"
+
+    bin.install "bin/scala", "bin/scalac", "bin/scaladoc"
+    bin.env_script_all_files libexec/"bin", Language::Java.overridable_java_home_env("17")
 
     # Set up an IntelliJ compatible symlink farm in 'idea'
     idea = prefix/"idea"
@@ -39,6 +45,13 @@ class Scala < Formula
   end
 
   test do
+    ENV["SCALA_CLI_HOME"] = testpath
+    ENV["COURSIER_CACHE"] = ENV["COURSIER_ARCHIVE_CACHE"] = testpath/".coursier_cache"
+
+    %w[scala scalac scaladoc].each do |cmd|
+      assert_match version.to_s, shell_output("#{bin}/#{cmd} --version")
+    end
+
     file = testpath/"Test.scala"
     file.write <<~SCALA
       object Test {
@@ -48,8 +61,7 @@ class Scala < Formula
       }
     SCALA
 
-    out = shell_output("#{bin}/scala --server=false #{file}").strip
-
+    out = shell_output("#{bin}/scala --server=false #{file}").chomp
     assert_equal "4", out
   end
 end

--- a/Formula/s/scala.rb
+++ b/Formula/s/scala.rb
@@ -11,7 +11,8 @@ class Scala < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "d2d8ad6f10164bd6fc0b6e7077bd508a652d5723289ee1b14b8ee78faa91e0fe"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "c0e0c4e6c31c063f563984245f7d0e32ff33f3bd1b0d969192f497aa3ad4d0b9"
   end
 
   # JDK Compatibility: https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html


### PR DESCRIPTION
Fixes https://github.com/VirtusLab/scala-cli/issues/4139

Changes the `scala` (Scala 3 language installation) formula as follows (or the what and why of this PR)
- switch from the generic JVM-launcher tarball (`scala3-3.8.2.tar.gz`) to platform-specific tarballs that bundle a native image of `scala-cli` (`scala3-3.8.2-{arch}-{os}.tar.gz`)
- this is considerably better, as the native launchers for individual platforms are generally faster than their JVM equivalents, and also don't require a JVM to be installed in the first place; they're also the recommended and default way to use Scala CLI
  - this perhaps matters more, as Scala 3 requires JDK17 since Scala 3.8.0
  - what's more, while Scala CLI is built with Scala 3.3 LTS (will likely switch to 3.9 LTS when that's out), it uses an old implementation of lazy vals which warns on JDK 25 (and will outright error on JDK26+), as per  JEP-471
      - this has been mitigated in Scala 3.8 with https://github.com/scala/scala3/issues/9013 (the price being the required JVM is higher)
- I added sanity checks for all of the commands installed here (`scala`, `scalac`, `scaladoc`, `scala-cli`)
  - `scala-cli` gets installed under-the-hood anyway, so why not give it a symlink 🤷  
  - ~the tests involve various JVMs (8, 17, 25), which are managed by Coursier, Coursier's formula being a dependency for the tests (and only the tests)~

cc @tgodzik @WojciechMazur @SolalPirelli @hamzaremmal

### Checks
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
### AI/LLM stuff

(as one can see below, Claude was rather helpful here; big thanks for providing `AGENTS.md` in the repo, this sped me up considerably)

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Cursor (Claude) was used interactively to:
- Download and inspect the platform-specific tarball layout to understand the bin/, libexec/, lib/, maven2/, VERSION structure
- Compute SHA256 checksums for all 4 platform-specific tarballs
- Write the formula: platform-specific on_macos/on_linux + on_arm/on_intel URL blocks, the install method with libexec + symlink approach, and the test block
- Identify that conflicts_with "pwntools" could be removed (common moved from bin/ to libexec/)
- Debug the PROG_HOME resolution issue (scripts reference ../libexec/, ../VERSION, ../maven2/ relative to bin/)
- Fix component ordering (livecheck before on_macos, depends_on before on_macos) and livecheck style (url :stable)
- Add scala to not_a_binary_url_prefix_allowlist.json for the binary URL audit
- Expose scala-cli as a bin/ command via symlink from libexec/libexec/scala-cli

### Manual checks
```bash
HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source scala # installed successfully
scala version # works with empty JAVA_HOME
JAVA_HOME=<jdk8> scala version # native launcher starts with JDK 8
JAVA_HOME=<jdk8> scala --server=false --jvm 17 -e 'println(42)' # compiles and runs
JAVA_HOME=<jdk25> scala --server=false -e 'println(42)' # no sun.misc.Unsafe warnings (see https://github.com/VirtusLab/scala-cli/issues/4139 and https://github.com/scala/scala3/issues/9013)
scalac -version # 3.8.2, as it should be
scaladoc -version # likewise
scala-cli version # tested the launcher with JDK 8, 17, and 25
brew test scala # all assertions pass
brew audit scala # passes
brew audit --strict scala # 2 binary URL warnings (expected? allowlist added)
brew style Formula/s/scala.rb # no offenses
```
-----
