### PR TITLE
p*: remove no_autobump! manual review

### DIFF
--- a/Formula/p/perl-xml-parser.rb
+++ b/Formula/p/perl-xml-parser.rb
@@ -7,8 +7,6 @@ class PerlXmlParser < Formula
   revision 1
   head "https://github.com/cpan-authors/XML-Parser.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "fee3b040b53302d6739156e3fe6ec3d20d4a68976db97596fbc69ae67ca6f478"
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "5aaad7520178860c8af99e458d36f34aad602ae20d27321cc87c9d5519ea5bd8"

--- a/Formula/p/pg_top.rb
+++ b/Formula/p/pg_top.rb
@@ -14,8 +14,6 @@ class PgTop < Formula
     regex(/^v?(3(?:\.\d+)+)$/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "9adc494d9d026662d8e072527c22e736fe60bf0153eecdc5d3d4b6271abfc8a9"
     sha256 cellar: :any,                 arm64_sequoia:  "b9d888449873a35c6f29b43698da65bda0e4136eb1f2d0176338fcbc617e4e5b"

--- a/Formula/p/phodav.rb
+++ b/Formula/p/phodav.rb
@@ -7,8 +7,6 @@ class Phodav < Formula
   revision 1
   head "https://gitlab.gnome.org/GNOME/phodav.git", branch: "master"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:   "f1192115b21287b4a91568fa9257b8db536bb3529471c9fcf09da51f43408206"
     sha256 arm64_sequoia: "275e604708cdfcd2d5468532bd3ae37c7fc914f913ae2923b5c10b05d9ccab89"

--- a/Formula/p/pigz.rb
+++ b/Formula/p/pigz.rb
@@ -12,8 +12,6 @@ class Pigz < Formula
     regex(/href=.*?pigz[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "042145d01637ec82b2da2e4c2ef05ff1391b39c5aaafdebbe46d43f2b595404a"


### PR DESCRIPTION
#269331

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI assisted with alphabetical candidate discovery and patching for the `p*` batch. I removed `no_autobump! because: :requires_manual_review` only where livecheck, URL/version compatibility review, and strict audit/style checks were compatible.

Edited formulas in this batch:
- `perl-xml-parser`
- `pg_top`
- `phodav`
- `pigz`

Excluded from this batch:
- `pgdbf` (strict-audit blocker: missing `test do`; kept on manual review path)

-----
