### PR TITLE
q*: remove no_autobump! manual review

### DIFF
--- a/Formula/q/qdbm.rb
+++ b/Formula/q/qdbm.rb
@@ -10,8 +10,6 @@ class Qdbm < Formula
     regex(/href=.*?qdbm[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 3
     sha256 cellar: :any,                 arm64_tahoe:   "8758b4bbc07fe322baf1aeb4815956e31dfe20720429254f6e78a2e6c500acbe"

--- a/Formula/q/qodem.rb
+++ b/Formula/q/qodem.rb
@@ -5,8 +5,6 @@ class Qodem < Formula
   sha256 "dedc73bfa73ced5c6193f1baf1ffe91f7accaad55a749240db326cebb9323359"
   license :public_domain
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "62259c018c435331adcb0c9d99b72f119e03d4cb549a100e758f96deae273b8f"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "82b1c05936cabb7c92111db07b6443f9dcf4313bb092321cdfb32b9b0866e675"

--- a/Formula/q/qprint.rb
+++ b/Formula/q/qprint.rb
@@ -10,8 +10,6 @@ class Qprint < Formula
     regex(/href=.*?qprint[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "a29390a05c5e5744170726101f054366cf8c2cf8d8112b861574a4f9327d9ae1"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "4ac2245e4a3f2c14009c6e9c3418374623e94b32f7f265ffe6cd30f0693299a5"

--- a/Formula/q/qscintilla2.rb
+++ b/Formula/q/qscintilla2.rb
@@ -16,8 +16,6 @@ class Qscintilla2 < Formula
     regex(%r{href=.*?QScintilla/v?\d+(?:\.\d+)+/QScintilla(?:[._-](?:gpl|src))?[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "a4ce4700e5e688b9b0b60890459a3793fc53e8cbaf27884f9ba88e94fa719515"
     sha256 cellar: :any,                 arm64_sequoia: "27499e5e9430c801ac7265f06845ccc56d6669f1626fab44a16f1b7aec80d61b"

--- a/Formula/q/quex.rb
+++ b/Formula/q/quex.rb
@@ -14,8 +14,6 @@ class Quex < Formula
     regex(%r{url=.*?/quex[._-]v?(\d+(?:\.\d+)+)\.[tz]}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 4
     sha256 cellar: :any_skip_relocation, all: "f2d44465311851dc3bf25c68adc4d5041315e089d91ba9fce5d34a47f8a26782"

--- a/Formula/q/qwt.rb
+++ b/Formula/q/qwt.rb
@@ -10,8 +10,6 @@ class Qwt < Formula
     regex(%r{url=.*?/qwt[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any,                 arm64_tahoe:   "b9997bee5756f9c2f27627b70b4af65e8e83cf742a69fbf190bb82b745ade6f2"


### PR DESCRIPTION
#269331

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI assisted with alphabetical candidate discovery and one-commit-per-formula patching for `q*` formulas by removing `no_autobump! because: :requires_manual_review` where livecheck/status/source checks were compatible. I manually verified URL/version compatibility (including bump-formula probes for non-trivial URL templates) and reran `brew style` and `brew audit --strict` on the edited formula set.

Edited formulas in this batch:
- `qdbm`
- `qodem`
- `qprint`
- `qscintilla2`
- `quex`
- `qwt`

Left on manual review due non-version/manual constraints:
- `qhull` (manual version-gate logic in formula for versions beyond current)
- `qsoas` (upstream TLS/certificate-chain livecheck constraints noted in formula)
- `qt@5`, `qwt-qt5` (deprecated Qt 5 track)
- `quartz-wm` (commit-hash archive URL with explicit version)
- `quran` (git tag/revision source)

-----
