### PR TITLE
p*: remove no_autobump! manual review (part 2)

### DIFF
--- a/Formula/p/pioneers.rb
+++ b/Formula/p/pioneers.rb
@@ -6,8 +6,6 @@ class Pioneers < Formula
   license "GPL-2.0-or-later"
   revision 1
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 arm64_tahoe:    "adf66c9f80045db5ecfe7557d06d1e6aa95dc4a8e07c6d144106b350f5826c7c"
     sha256 arm64_sequoia:  "f8818813a32e582cfe48b07fea5acb1f9796fb529586e2b1d73eded630f64eb4"

--- a/Formula/p/pipemeter.rb
+++ b/Formula/p/pipemeter.rb
@@ -5,8 +5,6 @@ class Pipemeter < Formula
   sha256 "e470ac5f3e71b5eee1a925d7174a6fa8f0753f2107e067fbca3f383fab2e87d8"
   license "GPL-2.0-or-later"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "f87dfabadf8edc8e63b7032810808c7b126c8ade8712687113170ae531796760"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "0653426bc1f7a2f36bc886279953ec40660d867797f4623162cc749c2f48ba0e"

--- a/Formula/p/plplot.rb
+++ b/Formula/p/plplot.rb
@@ -9,8 +9,6 @@ class Plplot < Formula
   license all_of: ["LGPL-2.0-or-later", "BSD-3-Clause", "HPND", :cannot_represent]
   revision 4
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 arm64_tahoe:   "8299e82b21073d81694f33383bc0dd37931cfc8f468be9107b8c7b8fcd1cf501"

--- a/Formula/p/pmccabe.rb
+++ b/Formula/p/pmccabe.rb
@@ -13,8 +13,6 @@ class Pmccabe < Formula
     end
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "d6009f8f139c0e42442a816ca33c1bfdfc37139431948350fdc107d35d24c7cf"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "0e638bf96079e2650e33e91114ab8b2559fbc1d9b998e6afa5eae06a6e1d4eca"

--- a/Formula/p/pms.rb
+++ b/Formula/p/pms.rb
@@ -6,8 +6,6 @@ class Pms < Formula
   license "MIT"
   revision 1
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "9ea144b1cf1481050e378149ef8731963f537878c38d74faa182a687e85d64a0"
     sha256 cellar: :any,                 arm64_sequoia:  "24de40d237ca53721190a990da548b37b777fa60e7599c9c0c0dcf289333bbeb"

--- a/Formula/p/png++.rb
+++ b/Formula/p/png++.rb
@@ -10,8 +10,6 @@ class Pngxx < Formula
     regex(/href=.*?png\+\+[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "691981245534fb80ef1d86b9d7c2fff6f57ece7b50d7def13d5930be8dbf00f7"

--- a/Formula/p/pngcrush.rb
+++ b/Formula/p/pngcrush.rb
@@ -12,8 +12,6 @@ class Pngcrush < Formula
     regex(%r{url=.*?/pngcrush[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any,                 arm64_tahoe:   "d480e8fcafb2cce34d273a2142d1db3513fb094e2e1c6b638b67d2114b75a91f"

--- a/Formula/p/pngnq.rb
+++ b/Formula/p/pngnq.rb
@@ -6,8 +6,6 @@ class Pngnq < Formula
   license "BSD-3-Clause"
   revision 1
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 2
     sha256 cellar: :any,                 arm64_tahoe:   "2620068d9fc38a44ae6f531bf96c375f66ada13346305f21ca928ef23746c2c7"

--- a/Formula/p/podiff.rb
+++ b/Formula/p/podiff.rb
@@ -10,8 +10,6 @@ class Podiff < Formula
     regex(/href=.*?podiff[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "625ab776965963465a17dd8c25d5457d8e032218e5a2e329d0ae5d07e46d6350"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "f182567ba8a6a7b58d52d49833b794b0347a7e35d32dc0fb786ded005b36f407"

--- a/Formula/p/popt.rb
+++ b/Formula/p/popt.rb
@@ -15,8 +15,6 @@ class Popt < Formula
     regex(/^(?:popt[._-])?v?(\d+(?:[._]\d+)+)(?:[._-]release)?$/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "365d143d0d38003c60c1d6fb6d399ab4361690a64467d46a8f27c2f50d2dcfb6"
     sha256 cellar: :any,                 arm64_sequoia:  "4ff5f0c8c34f510a7336b16f42a6e058d028ff2025e9b01093b294be84d90bb2"

--- a/Formula/p/potrace.rb
+++ b/Formula/p/potrace.rb
@@ -10,8 +10,6 @@ class Potrace < Formula
     regex(/href=.*?potrace[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:   "f60557ba39e1e0bb436b79900bec393061141e8e73aa8b20cec3f3b95db69166"

--- a/Formula/p/prefixsuffix.rb
+++ b/Formula/p/prefixsuffix.rb
@@ -6,8 +6,6 @@ class Prefixsuffix < Formula
   license "GPL-2.0-or-later"
   revision 10
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256                               arm64_tahoe:    "9685f6462cb7c8c464ba24562d8d79038c4982fa6e173765570d11d7d2fef6bb"
     sha256                               arm64_sequoia:  "30ef0ba35485343f36734f212295160cedd798991dfa2abd35a6b60f7f95405e"

--- a/Formula/p/psftools.rb
+++ b/Formula/p/psftools.rb
@@ -17,8 +17,6 @@ class Psftools < Formula
     regex(/Stable Release.+?href=.*?psftools[._-]v?(\d+(?:\.\d+)+)\.t/im)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "06f275a8b9d1fe1537d8456c91ee2e58b90d514bfc721f2d89a4ef1f56f6f17d"
     sha256 cellar: :any,                 arm64_sequoia:  "12640a4b3994e97fca6c888cdd660d554598bf8bcbb308ceeb9b84215e7d8fb3"

--- a/Formula/p/ptunnel.rb
+++ b/Formula/p/ptunnel.rb
@@ -10,8 +10,6 @@ class Ptunnel < Formula
     regex(/href=.*?PingTunnel[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "0049b270a67c200fc498f50bfa732e2812106e758b2ee1eac0e43ca41e48c241"

--- a/Formula/p/puf.rb
+++ b/Formula/p/puf.rb
@@ -5,8 +5,6 @@ class Puf < Formula
   sha256 "3f1602057dc47debeb54effc2db9eadcffae266834389bdbf5ab14fc611eeaf0"
   license "GPL-2.0-only"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "ec01e1392c1d20a55a38aa3f02102a9687184966b760254a2fb280c37f48da73"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "148adff9f4f307fc6b8a94bf5a5baa2c66dd8f3aee810c349a4cc3a356517d90"

--- a/Formula/p/pwgen.rb
+++ b/Formula/p/pwgen.rb
@@ -5,8 +5,6 @@ class Pwgen < Formula
   sha256 "dab03dd30ad5a58e578c5581241a6e87e184a18eb2c3b2e0fffa8a9cf105c97b"
   license "GPL-2.0-only"
 
-  no_autobump! because: :requires_manual_review
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "7b3297c6e36caa295415af3c677a5ef056f824ae8280d7eb5023a693848a0dd5"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "78e78f3269e5a571f309e859d1765104c3a85a227bc12292efe437ca838696bb"


### PR DESCRIPTION
#269331


<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI assisted with alphabetical candidate discovery and one-commit-per-formula patching for `p*` formulas by removing `no_autobump! because: :requires_manual_review` where livecheck/status/source checks were compatible. I manually verified and reran `brew style` and `brew audit --strict` on the edited formula set.

Edited formulas in this batch:
- `pioneers`
- `pipemeter`
- `plplot`
- `pmccabe`
- `pms`
- `png++`
- `pngcrush`
- `pngnq`
- `podiff`
- `popt`
- `potrace`
- `prefixsuffix`
- `psftools`
- `ptunnel`
- `puf`
- `pwgen`

Excluded from this batch:
- `pgdbf`, `proctools` (strict-audit blockers: missing `test do`)
- `plotutils`, `pth` (livecheck non-`ok` in current run)
- `python-tk@3.9` (deprecated/disabled track)
- `portaudio` (manual bump mapping needed for version/url)
- `pipebench`, `ppl`, `pktanon`, `png2ico`, `prover9`, `pulseaudio`, `pwsafe` (left for further manual review)

-----

