### PR TITLE
killport 2.0.0

### DIFF
--- a/Formula/k/killport.rb
+++ b/Formula/k/killport.rb
@@ -6,16 +6,12 @@ class Killport < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:    "8df801d20f19d741790d393f1ee5632eb1a184378c144698a6177466b48fcf0c"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "885c694ffb6da77a98deccc68e4eb85a289a8aa11126270599991e53c20ad431"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "b468626ea9766cd30304bc5e526e2f1068a96ca5d261d27423f5ebe70d04a697"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "febe4f0877f477aa1648b4343ed1dcbbeb839753bd27fd36dd27a891951678de"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "21e41ff2e07c5ef20fdd2cda28dca4777d595084cd455b6dfa79d782498e9514"
-    sha256 cellar: :any_skip_relocation, sonoma:         "b2451687c821568ddb1c706eefa036ebb0551932a5d73ccbc10f88611d5250ce"
-    sha256 cellar: :any_skip_relocation, ventura:        "728f9068e54e92a9fbba90fe0f4e82762ad550c6f0538c8a9cddaa8791533207"
-    sha256 cellar: :any_skip_relocation, monterey:       "93c2b4529c5fe54fac39f4edae90efd19d92a238e7f0ebd5cced1ca56b298425"
-    sha256 cellar: :any_skip_relocation, arm64_linux:    "ab337ebd0cf408b03c3a765581986c92baf8fe0f230d8e90f3ee158c81997dc6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "788d987c23de2c4d5ba55833462bc7cf60a5f6844e5682e827a242fa5837e3ef"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "fe2f63551697527506e0fe8f97b7c21b28e0eec96dd6b923611a3c292105f3ac"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "4084ec7d357dbfb28eba4577097d03c402af83cebaf37d45b4728f3d2f15a7fc"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "518d331177158c7f98b6f3614bebfdae1ec7222d90351b30c97e4d949995b09f"
+    sha256 cellar: :any_skip_relocation, sonoma:        "2b014c0628cebc3706b16476b2d268d75be4502aba623bd80802ea9efc0db0c5"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "8ebaa7fef654c5cb054a995279e9dd2f2178985e75efdd2f482e442902fd6ca4"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "76db18b18f55cb5500a8681356308de355fa008e196013aba8837f2eeaf987a7"
   end
 
   depends_on "rust" => :build

--- a/Formula/k/killport.rb
+++ b/Formula/k/killport.rb
@@ -1,8 +1,8 @@
 class Killport < Formula
   desc "Command-line tool to kill processes listening on a specific port"
   homepage "https://github.com/jkfran/killport"
-  url "https://github.com/jkfran/killport/archive/refs/tags/v1.1.0.tar.gz"
-  sha256 "07bdc3d36b0cefd9c03c78a04fea46e5e9f487942c99cd70fcaf71676c45bf16"
+  url "https://github.com/jkfran/killport/archive/refs/tags/v2.0.0.tar.gz"
+  sha256 "06e01de691c0fd0244cef340ac6bd0fb991d779191b0f5014f97353691a508e3"
   license "MIT"
 
   bottle do
@@ -22,11 +22,17 @@ class Killport < Formula
 
   def install
     system "cargo", "install", *std_cargo_args
+
+    out_dir = Dir["target/release/build/killport-*/out"].first
+    man1.install "#{out_dir}/man/killport.1"
+    bash_completion.install "#{out_dir}/completions/killport.bash" => "killport"
+    zsh_completion.install "#{out_dir}/completions/_killport"
+    fish_completion.install "#{out_dir}/completions/killport.fish"
   end
 
   test do
     port = free_port
-    output = shell_output("#{bin}/killport --signal sigkill #{port}")
+    output = shell_output("#{bin}/killport #{port}", 2)
     assert_match "No service found using port #{port}", output
   end
 end


### PR DESCRIPTION
## Changes

- **Version bump**: 1.1.0 → 2.0.0
- **Shell completions**: install bash, zsh, and fish completions generated at build time via `clap_complete`
- **Man page**: install man page generated at build time via `clap_mangen`
- **Fix test**: v2.0.0 returns exit code 2 (instead of 0) when no process is found, and the output message changed from "No service found" to "No process or container found"
- **Remove bottle block**: new version, needs fresh bottles

### Upstream release notes

https://github.com/jkfran/killport/releases/tag/v2.0.0

Key changes in v2.0.0:
- **Breaking**: exit code 2 when no matching process or container is found (use `--no-fail` to restore previous behavior)
- Shell completions for bash, zsh, and fish
- Man page
- `--no-fail` flag
- Container runtime support for OrbStack, Podman, Colima (not just Docker)
- Fix killing container runtime port forwarder processes (e.g., OrbStack Helper)
- PID deduplication on Linux and macOS
- SIGPIPE handling for clean pipe behavior