### PR TITLE
cargo-fuzz: update test

### DIFF
--- a/Formula/c/cargo-fuzz.rb
+++ b/Formula/c/cargo-fuzz.rb
@@ -35,8 +35,10 @@ class CargoFuzz < Formula
     system "rustup", "set", "profile", "minimal"
     system "rustup", "default", "beta"
 
-    system "cargo", "init"
-    system bin/"cargo-fuzz", "init"
-    assert_path_exists testpath/"fuzz/Cargo.toml"
+    system "cargo", "init", "homebrew"
+    cd "homebrew" do
+      system bin/"cargo-fuzz", "init"
+      assert_path_exists testpath/"homebrew/fuzz/Cargo.toml"
+    end
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Found in
- https://github.com/Homebrew/homebrew-core/actions/runs/22740579307/job/65962765879#step:3:3708

rustup `cargo init` is denied on the HOME path now, so add path to test. Need to check similar cases.