### PR TITLE
proj: add livecheck and mirror

### DIFF
--- a/Formula/p/proj.rb
+++ b/Formula/p/proj.rb
@@ -2,9 +2,15 @@ class Proj < Formula
   desc "Cartographic Projections Library"
   homepage "https://proj.org/"
   url "https://github.com/OSGeo/PROJ/releases/download/9.8.0/proj-9.8.0.tar.gz"
+  mirror "https://download.osgeo.org/proj/proj-9.8.0.tar.gz"
   sha256 "a8b493b00cf4d08b712b9e063ed5e53e2be90fcde46770e9dbd773341f378f43"
   license "MIT"
   head "https://github.com/OSGeo/proj.git", branch: "master"
+
+  livecheck do
+    url "https://download.osgeo.org/proj/"
+    regex(/href=.*?proj[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 arm64_tahoe:   "defaf305951c06d26473ea55fa96451d530e82a74d0dd11911e6ad53e3acf50f"


### PR DESCRIPTION
Same as resource `proj-data`

https://github.com/Homebrew/homebrew-core/blob/cec81f2e8907d69fd253b15eeb00ab2ba5390615/Formula/p/proj.rb#L33-L39

This avoids detecting extra tags:
```console
❯ git checkout main

❯ brew lc proj --autobump -r
proj: 9.8.0 ==> 9.8.0-1
  proj-data: 1.24 ==> 1.24

❯ git checkout proj-livecheck

❯ brew lc proj --autobump -r
proj: 9.8.0 ==> 9.8.0
  proj-data: 1.24 ==> 1.24
```

Mirror is for same tarball and is the officially documented URL at https://proj.org/en/stable/download.html
```console
❯ curl -sL "https://download.osgeo.org/proj/proj-9.8.0.tar.gz" | sha256
a8b493b00cf4d08b712b9e063ed5e53e2be90fcde46770e9dbd773341f378f43
```