### PR TITLE
ktfmt: add `--sun-misc-unsafe-memory-access=allow` JVM flag

### DIFF
--- a/Formula/k/ktfmt.rb
+++ b/Formula/k/ktfmt.rb
@@ -17,7 +17,10 @@ class Ktfmt < Formula
 
     system "gradle", "shadowJar", "--no-daemon"
     libexec.install "core/build/libs/ktfmt-#{version}-with-dependencies.jar"
-    bin.write_jar_script libexec/"ktfmt-#{version}-with-dependencies.jar", "ktfmt", java_version: "17"
+    bin.write_jar_script libexec/"ktfmt-#{version}-with-dependencies.jar", "ktfmt",
+                         # TODO: https://github.com/facebook/ktfmt/issues/533
+                         "--sun-misc-unsafe-memory-access=allow",
+                         java_version: "17"
   end
 
   test do

--- a/Formula/k/ktfmt.rb
+++ b/Formula/k/ktfmt.rb
@@ -10,17 +10,16 @@ class Ktfmt < Formula
   end
 
   depends_on "gradle" => :build
-  depends_on "openjdk@25"
+  depends_on "openjdk"
 
   def install
-    ENV["JAVA_HOME"] = Formula["openjdk@25"].opt_prefix
+    ENV["JAVA_HOME"] = Formula["openjdk"].opt_prefix
 
     system "gradle", "shadowJar", "--no-daemon"
     libexec.install "core/build/libs/ktfmt-#{version}-with-dependencies.jar"
     bin.write_jar_script libexec/"ktfmt-#{version}-with-dependencies.jar", "ktfmt",
                          # TODO: https://github.com/facebook/ktfmt/issues/533
-                         "--sun-misc-unsafe-memory-access=allow",
-                         java_version: "25"
+                         "--sun-misc-unsafe-memory-access=allow"
   end
 
   test do

--- a/Formula/k/ktfmt.rb
+++ b/Formula/k/ktfmt.rb
@@ -10,17 +10,17 @@ class Ktfmt < Formula
   end
 
   depends_on "gradle" => :build
-  depends_on "openjdk@17"
+  depends_on "openjdk@25"
 
   def install
-    ENV["JAVA_HOME"] = Formula["openjdk@17"].opt_prefix
+    ENV["JAVA_HOME"] = Formula["openjdk@25"].opt_prefix
 
     system "gradle", "shadowJar", "--no-daemon"
     libexec.install "core/build/libs/ktfmt-#{version}-with-dependencies.jar"
     bin.write_jar_script libexec/"ktfmt-#{version}-with-dependencies.jar", "ktfmt",
                          # TODO: https://github.com/facebook/ktfmt/issues/533
                          "--sun-misc-unsafe-memory-access=allow",
-                         java_version: "17"
+                         java_version: "25"
   end
 
   test do


### PR DESCRIPTION
Newer JDKs emit warnings about `sun.misc.Unsafe` memory access when
running ktfmt. Suppress these by passing
`--sun-misc-unsafe-memory-access=allow` to the JVM in the generated
wrapper script.

- **`Formula/k/ktfmt.rb`**: Add
`"--sun-misc-unsafe-memory-access=allow"` as the `java_opts` positional
argument to `write_jar_script`, which interpolates it directly into the
`exec java <opts> -jar ...` invocation

Refs https://github.com/facebook/ktfmt/issues/533.

---------

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

- https://github.com/Goooler/homebrew-core/pull/1
- https://github.com/Goooler/homebrew-core/pull/2

-----
