### PR TITLE
ktfmt: add `--sun-misc-unsafe-memory-access=allow` flag for Java 23 or above

### DIFF
--- a/Formula/k/ktfmt.rb
+++ b/Formula/k/ktfmt.rb
@@ -17,7 +17,11 @@ class Ktfmt < Formula
 
     system "gradle", "shadowJar", "--no-daemon"
     libexec.install "core/build/libs/ktfmt-#{version}-with-dependencies.jar"
-    bin.write_jar_script libexec/"ktfmt-#{version}-with-dependencies.jar", "ktfmt", java_version: "17"
+    # TODO: add a flag for Java 23 or above, see https://github.com/facebook/ktfmt/issues/533.
+    java_opts = "$(\"${JAVA_HOME}/bin/java\" -version 2>&1 | " \
+                "grep -q -E -e 'version \"(2[3-9]|[3-9][0-9])' && " \
+                "echo '--sun-misc-unsafe-memory-access=allow')"
+    bin.write_jar_script libexec/"ktfmt-#{version}-with-dependencies.jar", "ktfmt", java_opts: java_opts, java_version: "17"
   end
 
   test do


### PR DESCRIPTION
- Closes #271307.
- Refs https://github.com/facebook/ktfmt/issues/533.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
