### PR TITLE
freeswitch: livecheck all resources

### DIFF
--- a/Formula/f/freeswitch.rb
+++ b/Formula/f/freeswitch.rb
@@ -120,10 +120,9 @@ class Freeswitch < Formula
   #---------------
   # music on hold
   #---------------
-  moh_version = "1.0.52" # from build/moh_version.txt
   resource "sounds-music-8000" do
-    url "#{sounds_url_base}/freeswitch-sounds-music-8000-#{moh_version}.tar.gz"
-    version moh_version
+    url "#{sounds_url_base}/freeswitch-sounds-music-8000-1.0.52.tar.gz"
+    version "1.0.52"
     sha256 "2491dcb92a69c629b03ea070d2483908a52e2c530dd77791f49a45a4d70aaa07"
 
     livecheck do
@@ -132,28 +131,42 @@ class Freeswitch < Formula
     end
   end
   resource "sounds-music-16000" do
-    url "#{sounds_url_base}/freeswitch-sounds-music-16000-#{moh_version}.tar.gz"
-    version moh_version
+    url "#{sounds_url_base}/freeswitch-sounds-music-16000-1.0.52.tar.gz"
+    version "1.0.52"
     sha256 "93e0bf31797f4847dc19a94605c039ad4f0763616b6d819f5bddbfb6dd09718a"
+
+    livecheck do
+      url "https://raw.githubusercontent.com/signalwire/freeswitch/refs/tags/v#{LATEST_VERSION}/build/moh_version.txt"
+      regex(/^v?(\d+(?:\.\d+)+)$/i)
+    end
   end
   resource "sounds-music-32000" do
-    url "#{sounds_url_base}/freeswitch-sounds-music-32000-#{moh_version}.tar.gz"
-    version moh_version
+    url "#{sounds_url_base}/freeswitch-sounds-music-32000-1.0.52.tar.gz"
+    version "1.0.52"
     sha256 "4129788a638b77c5f85ff35abfcd69793d8aeb9d7833a75c74ec77355b2657a9"
+
+    livecheck do
+      url "https://raw.githubusercontent.com/signalwire/freeswitch/refs/tags/v#{LATEST_VERSION}/build/moh_version.txt"
+      regex(/^v?(\d+(?:\.\d+)+)$/i)
+    end
   end
   resource "sounds-music-48000" do
-    url "#{sounds_url_base}/freeswitch-sounds-music-48000-#{moh_version}.tar.gz"
-    version moh_version
+    url "#{sounds_url_base}/freeswitch-sounds-music-48000-1.0.52.tar.gz"
+    version "1.0.52"
     sha256 "cc31cdb5b1bd653850bf6e054d963314bcf7c1706a9bf05f5a69bcbd00858d2a"
+
+    livecheck do
+      url "https://raw.githubusercontent.com/signalwire/freeswitch/refs/tags/v#{LATEST_VERSION}/build/moh_version.txt"
+      regex(/^v?(\d+(?:\.\d+)+)$/i)
+    end
   end
 
   #-----------
   # sounds-en
   #-----------
-  sounds_en_version = "1.0.53" # from build/sounds_version.txt
   resource "sounds-en-us-callie-8000" do
-    url "#{sounds_url_base}/freeswitch-sounds-en-us-callie-8000-#{sounds_en_version}.tar.gz"
-    version sounds_en_version
+    url "#{sounds_url_base}/freeswitch-sounds-en-us-callie-8000-1.0.53.tar.gz"
+    version "1.0.53"
     sha256 "24a2baad88696169950c84cafc236124b2bfa63114c7c8ac7d330fd980c8db05"
 
     livecheck do
@@ -162,19 +175,34 @@ class Freeswitch < Formula
     end
   end
   resource "sounds-en-us-callie-16000" do
-    url "#{sounds_url_base}/freeswitch-sounds-en-us-callie-16000-#{sounds_en_version}.tar.gz"
-    version sounds_en_version
+    url "#{sounds_url_base}/freeswitch-sounds-en-us-callie-16000-1.0.53.tar.gz"
+    version "1.0.53"
     sha256 "3540235ed8ed86a3ec97d98225940f4c6bc665f917da4b3f2e1ddf99fc41cdea"
+
+    livecheck do
+      url "https://raw.githubusercontent.com/signalwire/freeswitch/refs/tags/v#{LATEST_VERSION}/build/sounds_version.txt"
+      regex(/^en-us-callie v?(\d+(?:\.\d+)+)$/i)
+    end
   end
   resource "sounds-en-us-callie-32000" do
-    url "#{sounds_url_base}/freeswitch-sounds-en-us-callie-32000-#{sounds_en_version}.tar.gz"
-    version sounds_en_version
+    url "#{sounds_url_base}/freeswitch-sounds-en-us-callie-32000-1.0.53.tar.gz"
+    version "1.0.53"
     sha256 "6f5a572f9c3ee1a035b9b72673ffd9db57a345ce0d4fb9f85167f63ac7ec386a"
+
+    livecheck do
+      url "https://raw.githubusercontent.com/signalwire/freeswitch/refs/tags/v#{LATEST_VERSION}/build/sounds_version.txt"
+      regex(/^en-us-callie v?(\d+(?:\.\d+)+)$/i)
+    end
   end
   resource "sounds-en-us-callie-48000" do
-    url "#{sounds_url_base}/freeswitch-sounds-en-us-callie-48000-#{sounds_en_version}.tar.gz"
-    version sounds_en_version
+    url "#{sounds_url_base}/freeswitch-sounds-en-us-callie-48000-1.0.53.tar.gz"
+    version "1.0.53"
     sha256 "980591a853fbf763818eb77132ea7e3ed876f8c4701e85070d612e1ebba09ae9"
+
+    livecheck do
+      url "https://raw.githubusercontent.com/signalwire/freeswitch/refs/tags/v#{LATEST_VERSION}/build/sounds_version.txt"
+      regex(/^en-us-callie v?(\d+(?:\.\d+)+)$/i)
+    end
   end
 
   #------------------------ End sound file resources --------------------------


### PR DESCRIPTION
Get all resources to livecheck. May allow them to be autobumped (need to see on next bump if URL can work with string interpolation):
```console
❯ git checkout freeswitch-resources-livecheck

❯ brew lc freeswitch --autobump -r
freeswitch: 1.10.12 ==> 1.10.12
  sounds-music-8000: 1.0.52 ==> 1.0.52
  sounds-music-16000: 1.0.52 ==> 1.0.52
  sounds-music-32000: 1.0.52 ==> 1.0.52
  sounds-music-48000: 1.0.52 ==> 1.0.52
  sounds-en-us-callie-8000: 1.0.53 ==> 1.0.53
  sounds-en-us-callie-16000: 1.0.53 ==> 1.0.53
  sounds-en-us-callie-32000: 1.0.53 ==> 1.0.53
  sounds-en-us-callie-48000: 1.0.53 ==> 1.0.53
  spandsp: 3.0.0-0d2e6ac65e ==> 3.0.0-0d2e6ac65e

❯ git checkout main

❯ brew lc freeswitch --autobump -r
freeswitch: 1.10.12 ==> 1.10.12
  sounds-music-8000: 1.0.52 ==> 1.0.52
  sounds-music-16000: Unable to get versions
  sounds-music-32000: Unable to get versions
  sounds-music-48000: Unable to get versions
  sounds-en-us-callie-8000: 1.0.53 ==> 1.0.53
  sounds-en-us-callie-16000: Unable to get versions
  sounds-en-us-callie-32000: Unable to get versions
  sounds-en-us-callie-48000: Unable to get versions
  spandsp: 3.0.0-0d2e6ac65e ==> 3.0.0-0d2e6ac65e
```