### PR TITLE
ffc.h 26.03.03 (new formula)

### DIFF
--- a/Formula/f/ffc.h.rb
+++ b/Formula/f/ffc.h.rb
@@ -1,0 +1,61 @@
+class FfcH < Formula
+  desc "Single-header C99 accelerated float/double parsing"
+  homepage "https://github.com/kolemannix/ffc.h"
+  url "https://github.com/kolemannix/ffc.h/archive/refs/tags/v26.03.03.tar.gz"
+  sha256 "691a49fa2f8d19f6b02c8de23c3fffa62fefafd815948d68dbd25a91f96fb795"
+  license "Apache-2.0"
+  head "https://github.com/kolemannix/ffc.h.git", branch: "main"
+
+  depends_on "cmake" => [:build, :test]
+
+  def install
+    args = %w[-DFETCHCONTENT_SOURCE_DIR_SUPPLEMENTAL_TEST_FILES=/dev/null] # unused
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
+    # Header-only, so we don't need to do `cmake --build`.
+    system "cmake", "--install", "build"
+    # Ensure the CMake config file has a name that can be found by CMake.
+    (lib/"cmake/ffc").install_symlink "ffcTargets.cmake" => "ffcConfig.cmake"
+  end
+
+  test do
+    (testpath/"ffc-test.c").write <<~'C'
+      #include <stdio.h>
+      #include <string.h>
+
+      #define FFC_IMPL
+      #include "ffc.h"
+
+      int main(void) {
+         char *input = "-1234.0e10";
+         ffc_outcome outcome;
+         double d = ffc_parse_double_simple(strlen(input), input, &outcome);
+         printf("%s is %f\n", input, d);
+
+         char *int_input = "-42";
+         int64_t out;
+         ffc_parse_i64(strlen(int_input), int_input, 10, &out);
+         printf("%s is %lld\n", int_input, out);
+
+         return 0;
+      }
+    C
+
+    system ENV.cc, "-I#{include}", "ffc-test.c", "-o", "ffc-test"
+    system "./ffc-test"
+
+    (testpath/"CMakeLists.txt").write <<~CMAKE
+      cmake_minimum_required(VERSION 3.15)
+
+      project(ffc_install_test LANGUAGES C)
+
+      find_package(ffc REQUIRED)
+
+      add_executable(ffc_install_test ffc-test.c)
+      target_link_libraries(ffc_install_test PRIVATE ffc::ffc)
+    CMAKE
+    ENV.prepend_path "CMAKE_PREFIX_PATH", prefix
+    system "cmake", "."
+    system "cmake", "--build", "."
+    system "./ffc_install_test"
+  end
+end

--- a/Formula/f/ffc.h.rb
+++ b/Formula/f/ffc.h.rb
@@ -6,6 +6,10 @@ class FfcH < Formula
   license "Apache-2.0"
   head "https://github.com/kolemannix/ffc.h.git", branch: "main"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, all: "11fe58e687d959752240ac9fa289999d7de749375a3cf9f5a8dd81579867f381"
+  end
+
   depends_on "cmake" => [:build, :test]
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

`brew audit` fails with

```
ffc.h
  * GitHub repository too new (<30 days old)
```

but we can probably look past that since this is about to be used as a dependency for `valkey`. See valkey-io/valkey#3329.
