### PR TITLE
solr: Update service command to use correct flag

### DIFF
--- a/Formula/s/solr.rb
+++ b/Formula/s/solr.rb
@@ -31,7 +31,7 @@ class Solr < Formula
   end
 
   service do
-    run [opt_bin/"solr", "start", "-f", "-s", HOMEBREW_PREFIX/"var/lib/solr"]
+    run [opt_bin/"solr", "start", "-f", "--solr-home", HOMEBREW_PREFIX/"var/lib/solr"]
     working_dir HOMEBREW_PREFIX
   end
 

--- a/Formula/s/solr.rb
+++ b/Formula/s/solr.rb
@@ -7,7 +7,8 @@ class Solr < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "297252ed50fda7a37fcb61cdd77431b7508fa338cc1c2ddf59d279251630729e"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "0325be6c048e10ef7a3dc6d7e782ad9b1d12cf7f53a87d9f68d84bf7de01bd2c"
   end
 
   # Can be updated after https://github.com/apache/solr/pull/3153


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The old `-s` flag was renamed to `--solr-home` in version 9.8: https://github.com/apache/solr/pull/2743
