### PR TITLE
juju 4.0.3

### DIFF
--- a/Formula/j/juju.rb
+++ b/Formula/j/juju.rb
@@ -8,14 +8,12 @@ class Juju < Formula
   head "https://github.com/juju/juju.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "b98c9f297f29e76112887dfd4eb4d978f409d89ca46dbcd4b7e1802bb92f098f"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "9b567efd235b7b08295be11f2da98ccd539d962e15bba629203eb91f55f461f3"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "b1ee9eca10d09c293f9886689d122b152e953210218f305b40814ab6a15a9aed"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "b536102f62cc526b92e4c056d8e31310ec0dced2885c9f2a8652aa07210c53ff"
-    sha256 cellar: :any_skip_relocation, sonoma:        "d6409d90d7b3278931e81518243f72d669fcf30f0a2f41f555e0473e841da5bc"
-    sha256 cellar: :any_skip_relocation, ventura:       "516fcf50b842a869b5f616654618d47c5c7414ddad5aeae5edfbd46511470283"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "efcfb8010c34b2f3ab61b39a9ad193f3dc1f560a7da11ada08694c8b942d920a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0eae5af767a79d6aff0d4b76caafe13f87ea95375df93403d96ea611fc42a805"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "e17654374554f8d3a4307422f36313d7f6cc323cf07b278af215303ae4f6289c"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "4825fa59f2f7706e6824939d61a0a7f29470d451e242d72e86c5beac37486bbb"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "55b6cfa1facef0eebc805770d87b955af813b3a522f01b1f96fc776a6ba21dd4"
+    sha256 cellar: :any_skip_relocation, sonoma:        "f11993feae1d2bb105d62baca5356cc90fe943e430e567475cfa598ebe0dd4d5"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "574378dedc08077ef5f765002da32681f5cf66bb46f72ce856b415a14a5b0299"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "03aefe40f0362a13edf3417078d9846e524d451125c6640945f661148b7afceb"
   end
 
   depends_on "go" => :build

--- a/Formula/j/juju.rb
+++ b/Formula/j/juju.rb
@@ -1,19 +1,11 @@
 class Juju < Formula
   desc "DevOps management tool"
-  homepage "https://juju.is/"
-  url "https://launchpad.net/juju/3.6/3.6.8/+download/juju-core_3.6.8.tar.gz"
-  sha256 "c11bb17d5bde7823a63e6354c785274c42008cfaf0e6abeb203b7ec89c83f890"
+  homepage "https://canonical.com/juju"
+  url "https://github.com/juju/juju/archive/refs/tags/v4.0.3.tar.gz"
+  sha256 "a8ce3cceeada77fead61bc0db551e1c4ba1a3fb51865cd075df39df307ff8abc"
   license "AGPL-3.0-only"
   version_scheme 1
   head "https://github.com/juju/juju.git", branch: "main"
-
-  # We check the Launchpad download page for Juju because the latest version
-  # listed on the main project page isn't always a stable version.
-  livecheck do
-    url "https://launchpad.net/juju/+download"
-    regex(/href=.*?juju-core[._-]v?(\d+(?:\.\d+)+)\.t/i)
-    strategy :page_match
-  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "b98c9f297f29e76112887dfd4eb4d978f409d89ca46dbcd4b7e1802bb92f098f"
@@ -29,11 +21,9 @@ class Juju < Formula
   depends_on "go" => :build
 
   def install
-    cd "src/github.com/juju/juju" do
-      system "go", "build", *std_go_args(ldflags: "-s -w"), "./cmd/juju"
-      system "go", "build", *std_go_args(output: bin/"juju-metadata", ldflags: "-s -w"), "./cmd/plugins/juju-metadata"
-      bash_completion.install "etc/bash_completion.d/juju"
-    end
+    system "go", "build", *std_go_args(ldflags: "-s -w"), "./cmd/juju"
+    system "go", "build", *std_go_args(output: bin/"juju-metadata", ldflags: "-s -w"), "./cmd/plugins/juju-metadata"
+    bash_completion.install "etc/bash_completion.d/juju"
   end
 
   test do


### PR DESCRIPTION
Updating homepage due to redirect:
```console
❯ curl -sIL https://juju.is | grep location:
location: https://canonical.com/juju/
location: https://canonical.com/juju
```

And remove livecheck to use GitHub:
```console
❯ brew lc juju --autobump
juju: 4.0.3 ==> 4.0.3
```

---

New versions don't seem be uploaded to Launchpad anymore.

The officially documented installer is snap - https://documentation.ubuntu.com/juju/latest/howto/manage-juju/

So can confirm versions at https://snapcraft.io/juju which has multiple release trains
- Newest stable is 4.0.3 which is in latest "4/stable"
- LTS is "3.6/stable". Can skip versioned formula until there is actual user demand for it.