### PR TITLE
tofrodos 1.9.0

### DIFF
--- a/Formula/t/tofrodos.rb
+++ b/Formula/t/tofrodos.rb
@@ -6,12 +6,12 @@ class Tofrodos < Formula
   license "GPL-2.0-only"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "a9b776268d2a16c1b90af8e737892c3d7d5cf7992e16d4c10f2577b6cd3ab2db"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "8f3e81b2b9f9416c6dacd3ac6726ab17a4a03e0f63e736297a5f62e4428ac2b5"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "d9e3f6b98f27b4dadc65ad1e6a1f35af9f9ce2d004119a1f7a49f43ae5cd5456"
-    sha256 cellar: :any_skip_relocation, sonoma:        "39d54b14e9575c2e21770604bf6a361d6fbb1943a0ac5e953164c84869f7c144"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "061d7400737cb1ea86aff7de4596a7d69631ceb533e163d40cfc6cb8e3a44b3a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3c0ba730bd91559c765b22ddbfae28ea95c00ed5d4f9e354dce511f149251323"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "07b62a45db3e96d8c124a399d4423631d0eb8161a1c60e90720049bc7b432b7c"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "cf5149e273342d3b3bf5fe9c23e13232c44242720373c1149329c89f8eb2e18c"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "fd90aabaafa310b004b5b21bb0cb0f4b25b2d276aad5a3495661112a6765c258"
+    sha256 cellar: :any_skip_relocation, sonoma:        "41949c0a585cd9cc996d4397f9373f616e36a60d1f17f4b5605482b2aa02788a"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "e00859f93c7110703d8bb47a72f3a833ee22a85d1440d89230396caeef0faa6e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b7fcfcc80b11daa6dbe5d4658ffd01534fc61c8705bd78411c9405c945954626"
   end
 
   def install

--- a/Formula/t/tofrodos.rb
+++ b/Formula/t/tofrodos.rb
@@ -1,14 +1,9 @@
 class Tofrodos < Formula
   desc "Converts DOS <-> UNIX text files, alias tofromdos"
-  homepage "https://www.thefreecountry.com/tofrodos/"
-  url "https://www.thefreecountry.com/tofrodos/tofrodos-1.8.4.zip"
-  sha256 "fd7b5b5b368a38104dd3c8845c1f24198d973d8b96d4765e24643266a0fa2034"
+  homepage "https://github.com/ChristopherHeng/tofrodos"
+  url "https://github.com/ChristopherHeng/tofrodos/archive/refs/tags/1.9.0.tar.gz"
+  sha256 "f4e16646a1eca631cb0ba62440b47cb8651ce1e6bd2982e8426d3a98ad8083ec"
   license "GPL-2.0-only"
-
-  livecheck do
-    url :homepage
-    regex(/href=.*?tofrodos[._-]v?(\d+(?:\.\d+)+)\.(?:t|zip)/i)
-  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "a9b776268d2a16c1b90af8e737892c3d7d5cf7992e16d4c10f2577b6cd3ab2db"
@@ -22,8 +17,8 @@ class Tofrodos < Formula
   def install
     mkdir_p [bin, man1]
 
-    system "make", "-C", "src", "all"
-    system "make", "-C", "src", "BINDIR=#{bin}", "MANDIR=#{man1}", "install"
+    system "make", "-f", "makefile.gcc", "all"
+    system "make", "-f", "makefile.gcc", "BINDIR=#{bin}", "MANDIR=#{man1}", "install"
   end
 
   test do


### PR DESCRIPTION
From previous homepage (https://www.thefreecountry.com/tofrodos/):

> Tofrodos has moved to GitHub
>
> The official website for Tofrodos has moved. You can now find it at the [Tofrodos repository](https://github.com/ChristopherHeng/tofrodos). The source code and binaries can be obtained from its [Releases page](https://github.com/ChristopherHeng/tofrodos/releases), or if you prefer, you can clone the repository in the usual way.
> 
> Please update your bookmarks and links. This page will go away soon.