### PR TITLE
quantum++: avoid fetching googletest

### DIFF
--- a/Formula/q/quantum++.rb
+++ b/Formula/q/quantum++.rb
@@ -12,7 +12,6 @@ class Quantumxx < Formula
   end
 
   depends_on "cmake" => [:build, :test]
-  depends_on "googletest" => :build
   depends_on "eigen"
   depends_on "pybind11"
 
@@ -24,8 +23,10 @@ class Quantumxx < Formula
   end
 
   def install
+    # Skip fetching googletest since we don't build/run tests
+    (buildpath/"build/_deps/googletest-src").mkpath
     args = %w[
-      -DFETCHCONTENT_FULLY_DISCONNECTED=OFF
+      -DFETCHCONTENT_FULLY_DISCONNECTED=ON
       -DHOMEBREW_ALLOW_FETCHCONTENT=ON
     ]
     system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
