### PR TITLE
solr: Use --user-managed flag to start the service

### DIFF
--- a/Formula/s/solr.rb
+++ b/Formula/s/solr.rb
@@ -7,8 +7,8 @@ class Solr < Formula
   license "Apache-2.0"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, all: "0325be6c048e10ef7a3dc6d7e782ad9b1d12cf7f53a87d9f68d84bf7de01bd2c"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, all: "5acd947f8767a29eebf0748639ab369d30c981170b8211082d987aab0c351180"
   end
 
   # Can be updated after https://github.com/apache/solr/pull/3153

--- a/Formula/s/solr.rb
+++ b/Formula/s/solr.rb
@@ -32,7 +32,7 @@ class Solr < Formula
   end
 
   service do
-    run [opt_bin/"solr", "start", "-f", "--solr-home", HOMEBREW_PREFIX/"var/lib/solr"]
+    run [opt_bin/"solr", "start", "-f", "--user-managed", "--solr-home", HOMEBREW_PREFIX/"var/lib/solr"]
     working_dir HOMEBREW_PREFIX
   end
 
@@ -43,11 +43,11 @@ class Solr < Formula
     assert_match "No Solr nodes are running", shell_output("#{bin}/solr status")
 
     # Start a Solr node => exit code 0
-    shell_output("#{bin}/solr start -p #{port} -Djava.io.tmpdir=/tmp")
+    shell_output("#{bin}/solr start --user-managed -p #{port} -Djava.io.tmpdir=/tmp")
     assert_match(/Solr process \d+ running on port #{port}/, shell_output("#{bin}/solr status"))
 
     # Impossible to start a second Solr node on the same port => exit code 1
-    shell_output("#{bin}/solr start -p #{port}", 1)
+    shell_output("#{bin}/solr start --user-managed -p #{port}", 1)
     # Stop a Solr node => exit code 0
     # Exit code is 1 without init process in a docker container
     shell_output("#{bin}/solr stop -p #{port}", (OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"]) ? 1 : 0)


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Since version 10.0.0 the default mode has changed from User Managed to Cloud, breaking existing setups - local Solr requires this flag to work.

ref: https://github.com/apache/solr/pull/2729

-----

Sorry for not catching that ealier in https://github.com/Homebrew/homebrew-core/pull/271757 !
