### PR TITLE
gnupg: update livecheck

### DIFF
--- a/Formula/g/gnupg.rb
+++ b/Formula/g/gnupg.rb
@@ -5,11 +5,15 @@ class Gnupg < Formula
   sha256 "dd17ab2e9a04fd79d39d853f599cbc852062ddb9ab52a4ddeb4176fd8b302964"
   license "GPL-3.0-or-later"
 
-  # GnuPG appears to indicate stable releases with an even-numbered minor
-  # (https://gnupg.org/download/#end-of-life).
+  # GnuPG usually indicates stable releases with an even-numbered minor but
+  # can declare an odd-numbered minor stable. e.g. 2.5 was stable since 2.5.16,
+  # see https://lists.gnupg.org/pipermail/gnupg-announce/2025q4/000500.html.
+  # The livecheck scrapes the version from the templated homepage which is
+  # manually updated by upstream when a new release series is stable, e.g.
+  # https://dev.gnupg.org/rD18a889b403c7a5934d5080be140a4d79e1c83332
   livecheck do
-    url "https://gnupg.org/ftp/gcrypt/gnupg/"
-    regex(/href=.*?gnupg[._-]v?(\d+\.\d*[02468](?:\.\d+)*)\.t/i)
+    url :homepage
+    regex(/The current version of GnuPG is v?(\d+(?:\.\d+)+)\. /i)
   end
 
   bottle do


### PR DESCRIPTION
A bit fragile but not many great options here. Couldn't find a machine readable designation of stable release series.

Download server and git (https://dev.gnupg.org/source/gnupg/) lack information on which version is stable.

The template fill https://versions.gnupg.org/swdb.lst / https://dev.gnupg.org/source/gnupg-doc/browse/master/web/swdb.mac will include versions from the start of a release series, not when it is stable, e.g. 2.5.0 (public testing) shows up as gnupg26_ver
- https://dev.gnupg.org/source/gnupg-doc/browse/master/web/swdb.mac;d809526f3f411b42b665a8c2c59e293bebc70883$28
- https://lists.gnupg.org/pipermail/gnupg-announce/2024q3/000484.html