### PR TITLE
powershell: remove non-Homebrew caveats

### DIFF
--- a/Formula/p/powershell.rb
+++ b/Formula/p/powershell.rb
@@ -150,21 +150,6 @@ class Powershell < Formula
     rm publish_path/diasym_file, force: true
   end
 
-  def caveats
-    <<~EOS
-      CurrentUser configs are at:
-        ~/.local/share/powershell/
-      CurrentUserAllHosts configs are at:
-        ~/.config/powershell/
-
-      To use Homebrew in PowerShell, run:
-        New-Item -Path (Split-Path -Parent -Path $PROFILE.CurrentUserAllHosts) -ItemType Directory -Force
-        Add-Content -Path $PROFILE.CurrentUserAllHosts -Value '$(#{HOMEBREW_PREFIX}/bin/brew shellenv) | Invoke-Expression'
-
-      To add Homebrew pwsh completions see: https://docs.brew.sh/Shell-Completion#configuring-completions-in-pwsh
-    EOS
-  end
-
   test do
     version_output = shell_output("#{bin}/pwsh -NoLogo -NoProfile -c '$PSVersionTable.PSVersion.ToString()'").chomp
     pwsh_version_output = shell_output("#{bin}/pwsh -Version")


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
Remove the non-homebrew caveats as discussed in https://github.com/Homebrew/homebrew-core/pull/268901#discussion_r2910119454