### PR TITLE
pgloader 3.6.10

### DIFF
--- a/Formula/p/pgloader.rb
+++ b/Formula/p/pgloader.rb
@@ -1,11 +1,36 @@
 class Pgloader < Formula
   desc "Data loading tool for PostgreSQL"
   homepage "https://github.com/dimitri/pgloader"
-  url "https://github.com/dimitri/pgloader/releases/download/v3.6.9/pgloader-bundle-3.6.9.tgz"
-  sha256 "a5d09c466a099eb7d59e485b4f45aa2eb45b0ad38499180646c5cafb7b81c9e0"
   license "PostgreSQL"
-  revision 1
   head "https://github.com/dimitri/pgloader.git", branch: "master"
+
+  stable do
+    # Using git checkout as Makefile runs `git archive` to create bundle
+    url "https://github.com/dimitri/pgloader.git",
+        tag:      "v3.6.10",
+        revision: "af8c3c147297654967a0744052ab2eb8682b1466"
+
+    # Resources to avoid `git clone`-ing them in Makefile
+    resource "qmynd" do
+      url "https://github.com/qitab/qmynd/archive/42664f5fd15a2f308c958c1062edebec30125308.tar.gz"
+      sha256 "f81c0511be76678649da1e7df2d0bf0c370ed190c11405b914378b55958ab97f"
+    end
+
+    resource "cl-ixf" do
+      url "https://github.com/dimitri/cl-ixf/archive/ed26f87e4127e4a9e3aac4ff1e60d1f39cca5183.tar.gz"
+      sha256 "22e3ad4595ff845bd610f472267a14070b3297058c597d753ac257c930094e10"
+    end
+
+    resource "cl-db3" do
+      url "https://github.com/dimitri/cl-db3/archive/38e5ad35f025769fb7f8dcdc6e56df3e8efd8e6d.tar.gz"
+      sha256 "6b7aeaa632799eb7b9ac474fbd196f4623f1093b957e6517c34c0d891cd2a21c"
+    end
+
+    resource "cl-csv" do
+      url "https://github.com/AccelerationNet/cl-csv/archive/2d64d4183bfc91824068cd4cf3414238d3c00fe5.tar.gz"
+      sha256 "c018cf1143a5542a6d263b23318628a17645c60b6c2bd1c6263907bcdeae9d55"
+    end
+  end
 
   livecheck do
     url :stable
@@ -36,8 +61,22 @@ class Pgloader < Formula
   end
 
   def install
-    system "make"
-    bin.install "bin/pgloader"
+    bundlename = "pgloader-bundle"
+    if build.stable?
+      # Improve reproducibility by avoiding master branch and git clones usage
+      inreplace "Makefile", /(git archive .*) master /, "\\1 v#{version} "
+      resources.each do |r|
+        r.stage("build/bundle/#{bundlename}/local-projects/#{r.name}")
+      end
+    end
+
+    # Creating bundle to use fixed date for reproducibly fetching dependencies. Increasing date to get
+    # https://github.com/melisgl/named-readtables/commit/6eea56674442b884a4fee6ede4c8aad63541aa5b
+    system "make", "build/#{bundlename}.tgz", "BUNDLENAME=#{bundlename}", "BUNDLEDIST=2026-01-01"
+
+    bin.mkpath
+    system "tar", "-xf", "build/#{bundlename}.tgz"
+    system "make", "-C", bundlename, "BUILDAPP=#{Formula["buildapp"].bin}/buildapp", "PGLOADER=#{bin}/pgloader"
 
     # Work around patchelf corrupting the SBCL core which is appended to binary
     # TODO: Find a better way to handle this in brew, either automatically or via DSL

--- a/Formula/p/pgloader.rb
+++ b/Formula/p/pgloader.rb
@@ -38,13 +38,12 @@ class Pgloader < Formula
   end
 
   bottle do
-    rebuild 2
-    sha256 cellar: :any,                 arm64_tahoe:   "f5baa53cabbdcdba97c61a8734543b06ffecf1edfb6a072fffe33673b6adda14"
-    sha256 cellar: :any,                 arm64_sequoia: "0b51ea7384a8623316882a7e4ca9fd5a67fd290fc2cea4f37e1b202b565a33cf"
-    sha256 cellar: :any,                 arm64_sonoma:  "02643e311b7153fc874298fc931b1a685a2cacee774b094807ca907938d1d778"
-    sha256 cellar: :any,                 sonoma:        "b3e66db5bd5d27ebb26eb4afad56169753c690f85606abcd28855f15eafbf5b2"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "9dad60ccd17c70c50388e58642587f660497c819d964544cb59ef9a80f942133"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3383d6eb3b97d354416fa7257bf7beafbbaa14d671dc285e44cf6b2c0116356b"
+    sha256 cellar: :any,                 arm64_tahoe:   "12b8c22a69da1b380adc072b1f8ea9b9d2bdc69d03530a566251e163c7cfbe2b"
+    sha256 cellar: :any,                 arm64_sequoia: "65977622649cc618a60bd5acaaedcce4ea0b5de39ef9a0ee3a77a5ba0819ffad"
+    sha256 cellar: :any,                 arm64_sonoma:  "69167a059b6cf21e05fba0680ca9e0184dc269b556940ce0e304d1bd731c30ef"
+    sha256 cellar: :any,                 sonoma:        "826b9b6529e101637416205667f78a0d0830f6f54c50b0b21f3ed8ef0d750758"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "f5640cc4d253febe88e8531a1767f7f3e3be20521192def77bac8bbeb1b10225"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "9f23ab10e44dba2d37a2581cf3ded0f0cfceb731e49af0f4565c98d60278a8a7"
   end
 
   depends_on "buildapp" => :build


### PR DESCRIPTION
Move to last tag. Although not made a release, Debian is using it and the Debian maintainers are the upstream developers.

Recreating bundle also allows fixing some issues with newer SBCL.