### PR TITLE
checkpwn 0.5.6

### DIFF
--- a/Formula/c/checkpwn.rb
+++ b/Formula/c/checkpwn.rb
@@ -1,8 +1,8 @@
 class Checkpwn < Formula
   desc "Check Have I Been Pwned and see if it's time for you to change passwords"
   homepage "https://github.com/brycx/checkpwn"
-  url "https://github.com/brycx/checkpwn/archive/refs/tags/0.5.4.tar.gz"
-  sha256 "f7802910b93932587b8a73aec3b33db24fd8088615a0be89b7c0945500059aae"
+  url "https://static.crates.io/crates/checkpwn/checkpwn-0.5.6.crate"
+  sha256 "c7540e67a6d25bf68926084d76a09866a9fb9eb265a2b4c21802fcbf741b51d4"
   license "MIT"
   head "https://github.com/brycx/checkpwn.git", branch: "master"
 

--- a/Formula/c/checkpwn.rb
+++ b/Formula/c/checkpwn.rb
@@ -7,12 +7,12 @@ class Checkpwn < Formula
   head "https://github.com/brycx/checkpwn.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "f44949d541a5090722b28b7476c2e2ecd71dea26c57496e9f301478e1fee73b5"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "231523bcebdd1c6bae0fe105089e7e8de4200f3487e91c7858fa23c32851c4af"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "f7fce288f337d494af4d34d5c9125a222f05d2f5a35de1757870a8f5cfcea627"
-    sha256 cellar: :any_skip_relocation, sonoma:        "79e425de48f6f832a02233f0643995d7f1d4656788fb4a5c760599a4e447104b"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "cb39905fbf588058e688b7122d29ca7d029fc297808f1849e3d5fb4c127ba293"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8aec0949f0c719a7bd263984378f48bbf58a0b922a6b2bc3fc06cc5c1f9daedb"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "f60a7bc5c125f61b2cab9356ffb94c54655aa3703390fd3ff0d0b5e101685da3"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "1e2e9e8589e7d5308ff7a9f5cebf138f6626156619720537afd7f7c698d4ae1e"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "a3d99626488af00d24f67479269952d059c0f3463fc40acc15cf556a596cf312"
+    sha256 cellar: :any_skip_relocation, sonoma:        "272889e72f9c64d14c59701570c09ec879b94a96d7ad5c770b84769b91a04d31"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "9b2101b67785e0305f6d22d080ec36b31f9a816f266708d5af36d828792237d0"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "702e2b2968002c784aab3ab98eb71305ce82e36ac060844cb57d8acecfcfea6b"
   end
 
   depends_on "rust" => :build


### PR DESCRIPTION
Use crates.io to get the latest release for dependency updates (https://github.com/brycx/checkpwn/commit/45c9689752fd8f4281e4c9be15474937e4e0b5b2)

Official installation method is `cargo install checkpwn` - https://github.com/brycx/checkpwn?tab=readme-ov-file#install