### PR TITLE
cblite 4.0.0 (new formula)

### DIFF
--- a/Formula/c/cblite.rb
+++ b/Formula/c/cblite.rb
@@ -1,0 +1,21 @@
+class Cblite < Formula
+  desc "Couchbase cblite command-line tool"
+  homepage "https://github.com/couchbaselabs/couchbase-mobile-tools"
+  url "https://github.com/couchbaselabs/couchbase-mobile-tools.git",
+    tag:      "cblite-4.0.0EE",
+    revision: "4de36110572a27b27e066a14392ad9283d7cfd28"
+  version "4.0.0"
+  license "Apache-2.0"
+
+  depends_on "cmake" => :build
+
+  def install
+    system "cmake", "-S", "cblite", "-B", "build", *std_cmake_args
+    system "cmake", "--build", "build", "cblite"
+    bin.install "build/cblite"
+  end
+
+  test do
+    system bin/"cblite", "--version"
+  end
+end


### PR DESCRIPTION
Provides the cblite CLI tool. Building from source instead of using the EE release since that requires an enterprise license, and is only available for x86.
Note this pulls in libcblite etc as submodules and statically links them, hence no dep on the libcblite(-community) cask.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
