### PR TITLE
cmd/aspell-dictionaries: fix for ftpmirror

### DIFF
--- a/cmd/aspell-dictionaries.rb
+++ b/cmd/aspell-dictionaries.rb
@@ -22,12 +22,14 @@ module Homebrew
         dictionary_mirror = "https://ftp.gnu.org/gnu/aspell/dict"
         languages = {}
 
-        index_output = Utils::Curl.curl_output("#{dictionary_url}/0index.html").stdout
+        index_output = Utils::Curl.curl_output("--location", "#{dictionary_url}/0index.html").stdout
         index_output.split("<tr><td>").each do |line|
           next unless line.start_with?("<a ")
 
           _, language, _, path, = line.split('"')
           language&.tr!("-", "_")
+          break if languages.key?(language)
+
           languages[language] = path if language && path
         end
 
@@ -43,11 +45,11 @@ module Homebrew
           resource.fetch(verify_download_integrity: false)
 
           <<-EOS
-            resource "#{resource.name}" do
-              url "#{resource.url}"
-              mirror "#{resource.mirrors.first}"
-              sha256 "#{resource.cached_download.sha256}"
-            end
+  resource "#{resource.name}" do
+    url "#{resource.url}"
+    mirror "#{resource.mirrors.first}"
+    sha256 "#{resource.cached_download.sha256}"
+  end
 
           EOS
         end


### PR DESCRIPTION
Not sure if anyone uses this, but seems to have been broken after ftpmirror switch as it doesn't follow redirect.

Also remove some extra indentation and ignore Aspell 0.50 languages. For latter, command used to print out an extra `pt` but newer version has `pt_PT`/`pt_BR` instead.
