### PR TITLE
tmux: remove 3rd party completion which is archived

### DIFF
--- a/Formula/t/tmux.rb
+++ b/Formula/t/tmux.rb
@@ -35,11 +35,6 @@ class Tmux < Formula
 
   uses_from_macos "bison" => :build # for yacc
 
-  resource "completion" do
-    url "https://raw.githubusercontent.com/imomaliev/tmux-bash-completion/8da7f797245970659b259b85e5409f197b8afddd/completions/tmux"
-    sha256 "4e2179053376f4194b342249d75c243c1573c82c185bfbea008be1739048e709"
-  end
-
   def install
     system "sh", "autogen.sh" if build.head?
 
@@ -59,7 +54,6 @@ class Tmux < Formula
     system "make", "install"
 
     pkgshare.install "example_tmux.conf"
-    bash_completion.install resource("completion")
   end
 
   def caveats


### PR DESCRIPTION
Resource repo is archived and 3rd-party so shouldn't include in formula https://github.com/imomaliev/tmux-bash-completion/commit/cd965a8d5e6adaf829b8d10e74fb20db001dec86. Either should use maintained copy in bash-completions (requires newer Bash) or should manually install to user completions path.