### PR TITLE
jpeg-xl: add resource livecheck

### DIFF
--- a/Formula/j/jpeg-xl.rb
+++ b/Formula/j/jpeg-xl.rb
@@ -42,7 +42,13 @@ class JpegXl < Formula
   # https://github.com/libjxl/libjxl/tree/v#{version}/third_party
   resource "sjpeg" do
     url "https://github.com/webmproject/sjpeg/archive/94e0df6d0f8b44228de5be0ff35efb9f946a13c9.tar.gz"
+    version "94e0df6d0f8b44228de5be0ff35efb9f946a13c9"
     sha256 "ac94917fe745a674eabf1e044f23ec55cd5a548c9869c06ec4b19da14ee0227d"
+
+    livecheck do
+      url "https://raw.githubusercontent.com/libjxl/libjxl/refs/tags/v#{LATEST_VERSION}/deps.sh"
+      regex(/THIRD_PARTY_SJPEG="(\h+)"/i)
+    end
   end
 
   def install


### PR DESCRIPTION
```
❯ brew lc jpeg-xl --autobump -r
jpeg-xl: 0.11.2 ==> 0.11.2
  sjpeg: 94e0df6d0f8b44228de5be0ff35efb9f946a13c9 ==> 94e0df6d0f8b44228de5be0ff35efb9f946a13c9
```