### PR TITLE
flowrs 0.11.0

### DIFF
--- a/Formula/f/flowrs.rb
+++ b/Formula/f/flowrs.rb
@@ -12,12 +12,12 @@ class Flowrs < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "128d27eb3466dd9162d3d0be6b575e3d5665509754e480f22ea3a5e14a7e3667"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "6e1aa89ef7de9d086e1ff3eb05e0e0072e4e81c76afc71e1df90c781450248ba"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "214e6e83a7fdefe80808515d70c6dc929f4afc091e2297f134713ecf6314a98d"
-    sha256 cellar: :any_skip_relocation, sonoma:        "c54c6c432d5e58ec984d02b6d5b4ec93158df6ee4c37e7c66a87f5cc11cb98d9"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "b597d7b137c044c41893955b612d69d5d68320f7251f5e7ff8892282207f628d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1d328c5362232dd3f352ba0494735d70694da7d5b2b88d8c3edeefd0a63fbb30"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "865a7e258c6753904f50f7c55af7a068e252ceb75aee9d67f8e55b76899a792e"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "f258107a62776c5a8f1c1099ca43b5484a2a57ed9b9a2ae8dbd87b6bf4c055d3"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "36d7f89604ac556ee61aee93d23860ce37b74d08fe23160466a04b1b3810f786"
+    sha256 cellar: :any_skip_relocation, sonoma:        "a5f9d26c85afd3af6c6e00d58ce2644c5112832b125c9cf3833c1722f00108b0"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "e5aaf6d1b72dd7abae431ff1b32fb5b5efc0fbf741e2d3c5a040495a73ce723e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5134ce0f5bc5e3c7f858465565e38a59a0394a546893b0e26fb92d9eca7d23a6"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/f/flowrs.rb
+++ b/Formula/f/flowrs.rb
@@ -1,10 +1,15 @@
 class Flowrs < Formula
   desc "TUI application for Apache Airflow"
   homepage "https://github.com/jvanbuel/flowrs"
-  url "https://github.com/jvanbuel/flowrs/archive/refs/tags/v0.10.1.tar.gz"
-  sha256 "2880165ff505c0e3be26827c49c1c07e5cfdd26565caeb287710d02375b8c728"
+  url "https://github.com/jvanbuel/flowrs/archive/refs/tags/flowrs-tui-v0.11.0.tar.gz"
+  sha256 "c5cb0690957d52a3fb0a0b6acd7003ff7f0ba895ef77c65f98a038959387ba38"
   license "MIT"
   head "https://github.com/jvanbuel/flowrs.git", branch: "main"
+
+  livecheck do
+    url :stable
+    regex(/^flowrs-tui-v?(\d+(?:\.\d+)+)$/i)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "128d27eb3466dd9162d3d0be6b575e3d5665509754e480f22ea3a5e14a7e3667"


### PR DESCRIPTION
Update flowrs to 0.11.0.

The project was reorganized into a Cargo workspace, changing the release tag format from `v{version}` to `flowrs-tui-v{version}`. Updated the URL accordingly and added a `livecheck` block to match the new tag pattern.