### PR TITLE
phantom 6.0.0

### DIFF
--- a/Formula/p/phantom.rb
+++ b/Formula/p/phantom.rb
@@ -6,7 +6,7 @@ class Phantom < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "44195c9478ecbad4f9f87da365be5499a15861ae6940304c219adc8bc66b8d4f"
+    sha256 cellar: :any_skip_relocation, all: "cf8840cb0e590d744495851480d7a6468d6b528767dd1eb882a1fa2d2d863026"
   end
 
   depends_on "node"

--- a/Formula/p/phantom.rb
+++ b/Formula/p/phantom.rb
@@ -1,8 +1,8 @@
 class Phantom < Formula
   desc "CLI tool for seamless parallel development with Git worktrees"
-  homepage "https://github.com/aku11i/phantom"
-  url "https://registry.npmjs.org/@aku11i/phantom/-/phantom-5.1.0.tgz"
-  sha256 "92000a1e2b905b7ecfb3acb6e6a8a9c8f422ec1211b15a71eb68ced62e36f411"
+  homepage "https://github.com/phantompane/phantom"
+  url "https://registry.npmjs.org/@phantompane/cli/-/cli-6.0.0.tgz"
+  sha256 "5ceb6247f4b8ef507086927e3ebc9edbd1b62a3613e79c45d55a77b955ba679a"
   license "MIT"
 
   bottle do


### PR DESCRIPTION
Update phantom formula for GitHub/npm org migration and version bump.

- Homepage moved from `aku11i/phantom` to `phantompane/phantom`
- npm package renamed from `@aku11i/phantom` to `@phantompane/cli`
- Updated to version 6.0.0

Reference:
- https://github.com/phantompane/phantom/releases/tag/v6.0.0
- https://github.com/phantompane/phantom/pull/399
- https://github.com/phantompane/phantom/pull/404

---

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other [open](https://github.com/Homebrew/homebrew-core/pulls) or [closed](https://github.com/Homebrew/homebrew-core/pulls?q=is%3Apr+is%3Aclosed) pull requests for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Does your build pass `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>`?
- [x] AI disclosure: This PR was created with assistance from Claude Code. Changes were manually verified.