### PR TITLE
dart-sdk: add resource livecheck

### DIFF
--- a/Formula/d/dart-sdk.rb
+++ b/Formula/d/dart-sdk.rb
@@ -25,6 +25,12 @@ class DartSdk < Formula
   resource "depot-tools" do
     url "https://chromium.googlesource.com/chromium/tools/depot_tools.git",
         revision: "4ce8ba39a3488397a2d1494f167020f21de502f3"
+    version "4ce8ba39a3488397a2d1494f167020f21de502f3"
+
+    livecheck do
+      url "https://chromium.googlesource.com/chromium/tools/depot_tools.git/+/refs/heads/main?format=JSON"
+      regex(/"commit":\s*"(\h+)"/i)
+    end
   end
 
   def install


### PR DESCRIPTION
```
❯ brew lc -r --autobump dart-sdk
dart-sdk: 3.11.2 ==> 3.11.2
  depot-tools: 4ce8ba39a3488397a2d1494f167020f21de502f3 ==> 6b62257bd9fc9ee0e00d10712a0f3db63132ba2f
```