### PR TITLE
latexdiff: use macOS perl

### DIFF
--- a/Formula/l/latexdiff.rb
+++ b/Formula/l/latexdiff.rb
@@ -6,7 +6,8 @@ class Latexdiff < Formula
   license "GPL-3.0-or-later"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "746b7460cf8014f4097fe356f29c89316814db4f3bc3ce2a638dca6c6e9fd0bd"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "7d747cedc4241a804cc7280b7605d20853ddfdbad574b7ee90fabca194f23152"
   end
 
   uses_from_macos "perl"

--- a/Formula/l/latexdiff.rb
+++ b/Formula/l/latexdiff.rb
@@ -9,8 +9,7 @@ class Latexdiff < Formula
     sha256 cellar: :any_skip_relocation, all: "746b7460cf8014f4097fe356f29c89316814db4f3bc3ce2a638dca6c6e9fd0bd"
   end
 
-  # osx default perl cause compilation error
-  depends_on "perl"
+  uses_from_macos "perl"
 
   def install
     bin.install %w[latexdiff-fast latexdiff-so latexdiff-vc latexrevise]


### PR DESCRIPTION
Original error from 1.3.1 was fixed in https://github.com/ftilmann/latexdiff/releases/tag/1.3.1.1