### PR TITLE
brew-no-quarantine (new formula): Homebrew wrapper to remove the quarantine attribute from casks

### DIFF
--- a/Formula/b/brew-no-quarantine.rb
+++ b/Formula/b/brew-no-quarantine.rb
@@ -1,0 +1,29 @@
+class BrewNoQuarantine < Formula
+  desc "Homebrew wrapper to remove the quarantine attribute from casks"
+  homepage "https://github.com/huangyxi/brew-no-quarantine"
+  url "https://github.com/huangyxi/brew-no-quarantine/archive/refs/tags/v0.1.0.tar.gz"
+  sha256 "5284b86112bfcf5f380b3d7e8b06c0bd41ecb6f033e68a6816dd82154aa3daac"
+  license "MIT"
+
+  depends_on "ruby" => :build
+  depends_on :macos
+
+  def install
+    ENV["BUNDLE_FORCE_RUBY_PLATFORM"] = "1"
+    ENV["BUNDLE_WITHOUT"] = "development test"
+    ENV["BUNDLE_VERSION"] = "system"
+    ENV["GEM_HOME"] = libexec
+    ENV["VERSION"] = version
+
+    system "bundle", "install"
+    system "gem", "build", "#{name}.gemspec"
+    system "gem", "install", "#{name}-#{version}.gem"
+
+    bin.install libexec/"bin/#{name}"
+    bin.env_script_all_files(libexec/"bin", GEM_HOME: ENV["GEM_HOME"])
+  end
+
+  test do
+    refute_empty shell_output("#{bin/name} --version")
+  end
+end


### PR DESCRIPTION
A new formula that allows further removal of the quarantine attribute from installed or upgraded casks. Link: https://github.com/huangyxi/brew-no-quarantine

This formula reintroduces the deprecated `--no-quarantine` argument from Homebrew/brew#20929 without modifying core Homebrew code, giving users additional flexibility when managing casks.
It also improves transparency around quarantine handling, as `postflight` scripts in third-party taps can remove `xattr` without the stricter auditing applied to the official cask repository. This may introduce security risks that are not always recognized by end users, potentially posing a more serious concern than the explicit `--no-quarantine` argument.
In addition, it reduces reliance on `postflight`, a powerful arbitrary script execution mechanism, by extracting this common usage pattern into a dedicated tool, which helps reviewers and automated scanners detect other potential security issues more easily.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`? **All checks passed except for notability.**

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
