### PR TITLE
dbhash lemon sqldiff sqlite sqlite-analyzer sqlite-rsync 3.51.3

### DIFF
--- a/Formula/d/dbhash.rb
+++ b/Formula/d/dbhash.rb
@@ -1,9 +1,9 @@
 class Dbhash < Formula
   desc "Computes the SHA1 hash of schema and content of a SQLite database"
   homepage "https://www.sqlite.org/dbhash.html"
-  url "https://sqlite.org/2026/sqlite-src-3520000.zip"
-  version "3.52.0"
-  sha256 "652a98ca833ed638809a52bec225a7f37799f71a995778f9ccb68ad03bd1fc11"
+  url "https://sqlite.org/2026/sqlite-src-3510300.zip"
+  version "3.51.3"
+  sha256 "f8a67a1f5b5cae7c6d42f0994ca7bf1a4a5858868c82adc9fc1340bed5eb8cd2"
   license "blessing"
 
   livecheck do

--- a/Formula/d/dbhash.rb
+++ b/Formula/d/dbhash.rb
@@ -13,14 +13,14 @@ class Dbhash < Formula
   no_autobump! because: :incompatible_version_format
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "0de93f1ecdde2adcf2af78e05cfab4ccbc82469fa3ec64b7e5d07519d2b92e5f"
-    sha256 cellar: :any,                 arm64_sequoia: "10684dbaa01d6d6c481d68aa27c57016317c87150ec70933b0973e7c2085d9cb"
-    sha256 cellar: :any,                 arm64_sonoma:  "178ba5d7ced18e754866264f69ff6dbafa24a79d5bda726fb453f4debb051b9b"
-    sha256 cellar: :any,                 tahoe:         "3e7f028dd3ade448847cf0d66966f83bcdf1cd7cb0d632ce92c3fa0145804bda"
-    sha256 cellar: :any,                 sequoia:       "bfdf04e4a24ae16e1c5aeefd69e366958a562caadc4f6459f1312a52674d6a8c"
-    sha256 cellar: :any,                 sonoma:        "b058bd2f041a5c702a4c9a90e0c560f1b9455508021c61e093c671e8e0262276"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "29ed628a2e5dc9ffa5a17fc221b49aaf21744431f1aca79be059fe8c42666f3f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "7afdce2bcd88757a7704ac25cbc53e8b882308af49cb071aed54e0c459fc7847"
+    sha256 cellar: :any,                 arm64_tahoe:   "2150ccd67f5a29b7a030e2d8d484fdeb97485d4849ac204204d5efbd0ca13bc1"
+    sha256 cellar: :any,                 arm64_sequoia: "ffb9131e77844bebb5c1a0daf2de80a0403eca839421f58ecf1239d60d8f47ba"
+    sha256 cellar: :any,                 arm64_sonoma:  "43d46d9459aacc82f1dc3b0771e4c058840354f918704bcdae72be8726cc8c57"
+    sha256 cellar: :any,                 tahoe:         "dd84508af10810f3dfa67331478a4645b8b1a326134993070f8c010542229606"
+    sha256 cellar: :any,                 sequoia:       "7bd5cd638c06d4e61998d6ccf744e0f180b8c3bc22411daebf1fcfb77c203273"
+    sha256 cellar: :any,                 sonoma:        "61286f274f9a4feb9f468073bdf709df1c46f1786b43f60dceb25422726edde7"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "22de2a1351c5935a9889f7d6a1a88fa769c64a01641854a47cca745305da049c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "6d55ac3b98be9e1db5d85b9d0a89c2db9b58f4cad2a702a1766d7247dde330eb"
   end
 
   uses_from_macos "tcl-tk" => :build

--- a/Formula/l/lemon.rb
+++ b/Formula/l/lemon.rb
@@ -1,9 +1,9 @@
 class Lemon < Formula
   desc "LALR(1) parser generator like yacc or bison"
   homepage "https://www.hwaci.com/sw/lemon/"
-  url "https://sqlite.org/2026/sqlite-src-3520000.zip"
-  version "3.52.0"
-  sha256 "652a98ca833ed638809a52bec225a7f37799f71a995778f9ccb68ad03bd1fc11"
+  url "https://sqlite.org/2026/sqlite-src-3510300.zip"
+  version "3.51.3"
+  sha256 "f8a67a1f5b5cae7c6d42f0994ca7bf1a4a5858868c82adc9fc1340bed5eb8cd2"
   license "blessing"
 
   livecheck do

--- a/Formula/l/lemon.rb
+++ b/Formula/l/lemon.rb
@@ -13,14 +13,14 @@ class Lemon < Formula
   no_autobump! because: :incompatible_version_format
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "a4a374712075d4afc63f969bb0caeb810d27d57a209415220ff08ace9e233289"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "0e8ac61ac4ace1d34d4c875ff59e60ea6de66109795e69471390f8eeedfb1614"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "29126702c069c921b051bda4057b8aba1e6c1f0b1e33e88f0cdbf3f1d40ce8f2"
-    sha256 cellar: :any_skip_relocation, tahoe:         "fc620ddd515c2ce47d1e2ad89cea246200f5d83f4d1503f274d2fce5260f7b52"
-    sha256 cellar: :any_skip_relocation, sequoia:       "f617a098f72ef7ddf5c554b129a7ec8e52249a1bdb5cc89af4b5c74891182cbe"
-    sha256 cellar: :any_skip_relocation, sonoma:        "54a5d8aa8fd22d02fa8ba36754205fd96d9c20194c14843cae2fec3815664c15"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "1f5de7cfb10c1e59aa7c55da1192ef0c9fbc86c128a7cc2d4357de7366c4db81"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "604eb0a04c87eb88628c630abcf7130190191a21a84cc6bf808f1f7017e3c002"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "4c7bb26090126cbea0b2fefa4f9bbb2fc4fdf623ee23a9d8f95a543e33886bdc"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "d3e870ef6d0be4833709f7cc3f7ca404f87fc3dba7e93f3dab7987a574109e6c"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "bfd956f08549a5315c8a94cbc0356ebb9de6e0eaf19511576407f2e7be2d36f0"
+    sha256 cellar: :any_skip_relocation, tahoe:         "e2c95f602211d6e8811c8cd4434bcd037426277645edbe09d5be6c1c9ff29f18"
+    sha256 cellar: :any_skip_relocation, sequoia:       "8935f6d67e500ebaa036812e4a5721ca8051530513bc3135e1b8bbf117bbe502"
+    sha256 cellar: :any_skip_relocation, sonoma:        "a34354e6ebe1d55a772cec79dfbb8ee6cd3d9ec76a3423230656e6b2f16e0d75"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "04b0bdbef3b291b742f45d219201013a353ef6b6c206da304b2fa3f1fb1af9cc"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c97987d8f30e5090e9b18f92e7d1a9ffc9750c345e8e09812096875cb649267f"
   end
 
   # Submitted the patch via email to the upstream

--- a/Formula/s/sqldiff.rb
+++ b/Formula/s/sqldiff.rb
@@ -1,9 +1,9 @@
 class Sqldiff < Formula
   desc "Displays the differences between SQLite databases"
   homepage "https://www.sqlite.org/sqldiff.html"
-  url "https://sqlite.org/2026/sqlite-src-3520000.zip"
-  version "3.52.0"
-  sha256 "652a98ca833ed638809a52bec225a7f37799f71a995778f9ccb68ad03bd1fc11"
+  url "https://sqlite.org/2026/sqlite-src-3510300.zip"
+  version "3.51.3"
+  sha256 "f8a67a1f5b5cae7c6d42f0994ca7bf1a4a5858868c82adc9fc1340bed5eb8cd2"
   license "blessing"
 
   livecheck do

--- a/Formula/s/sqldiff.rb
+++ b/Formula/s/sqldiff.rb
@@ -13,14 +13,14 @@ class Sqldiff < Formula
   no_autobump! because: :incompatible_version_format
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "20810d26d7d0f5ac4c89fd36c1f53d5b80482f546ca40c519d06d6a4fa0390e1"
-    sha256 cellar: :any,                 arm64_sequoia: "eea40ae84ace01a1baf895d01e20223dae5310a38ce2ce945bad79da7ae15951"
-    sha256 cellar: :any,                 arm64_sonoma:  "e9b3bc0597a4195b5e5706d8d893908d571ec4a08ea8b1f55e8fcbe1bf4149da"
-    sha256 cellar: :any,                 tahoe:         "24f59ea5d1c601940f7648873d3e0ef26545926d6d3cda9d7ca35a144b17e5d1"
-    sha256 cellar: :any,                 sequoia:       "e316ba7cbdf4ea6c4cd4256517a3efbdd568006f4809f649d3f2598de4f02171"
-    sha256 cellar: :any,                 sonoma:        "159014e1a6efa2253d140e1f230c597cf82fcce918cd44d671fb0f64aad7e50f"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "0faea85fb68459201ff0b39eaab5a6acd9b8068887cb6b755d1e4baf3a79fa23"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e2181db98ea7fbd1ae022e04190084bc6b168daab6212c29070ccd6561092f64"
+    sha256 cellar: :any,                 arm64_tahoe:   "6011d195cd289485a143042109707c3e06e495a83ec3b47a2a5919f4f3bfa9d3"
+    sha256 cellar: :any,                 arm64_sequoia: "1b8881e73d629473fb12d8d71ebd6438e7189e845dfa46b62efe1f5b2c725b29"
+    sha256 cellar: :any,                 arm64_sonoma:  "13650850b5303a6d9db47e24cb3e3dc9afb84648fb1ecd299ae2e80a8bf6c090"
+    sha256 cellar: :any,                 tahoe:         "d23b3975efbe1ff1c2b26c9bf7c89f33337c733f332ca640f90b73b90f8db154"
+    sha256 cellar: :any,                 sequoia:       "29916a1618cf2af91bc6bf40824a50f70ace1a42fefe5ccca7113811d5566433"
+    sha256 cellar: :any,                 sonoma:        "1d1f3688ae4ed5c9320ecc5b3d78484497077ee8e4765109c031958c750dd699"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "6c1e27d4fc8084d6a04af117e81e867895462c0f85ee794127fcefef75d546ce"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "add8d08c4a3f7ad6995d2e615f95609d1fdfdb88c6a343931bf78828fc799408"
   end
 
   uses_from_macos "tcl-tk" => :build

--- a/Formula/s/sqlite-analyzer.rb
+++ b/Formula/s/sqlite-analyzer.rb
@@ -1,9 +1,9 @@
 class SqliteAnalyzer < Formula
   desc "Analyze how space is allocated inside an SQLite file"
   homepage "https://www.sqlite.org/"
-  url "https://sqlite.org/2026/sqlite-src-3520000.zip"
-  version "3.52.0"
-  sha256 "652a98ca833ed638809a52bec225a7f37799f71a995778f9ccb68ad03bd1fc11"
+  url "https://sqlite.org/2026/sqlite-src-3510300.zip"
+  version "3.51.3"
+  sha256 "f8a67a1f5b5cae7c6d42f0994ca7bf1a4a5858868c82adc9fc1340bed5eb8cd2"
   license "blessing"
 
   livecheck do

--- a/Formula/s/sqlite-analyzer.rb
+++ b/Formula/s/sqlite-analyzer.rb
@@ -13,12 +13,12 @@ class SqliteAnalyzer < Formula
   no_autobump! because: :incompatible_version_format
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "5f9b23c4c345065c6ad7a2aef6b29814c7b426bbc268a6923d9be1a28c7170e7"
-    sha256 cellar: :any,                 arm64_sequoia: "756edebe091a2bab2a10e1bbd2c83e5f378340b5d653ddef5ea70494b4c10baf"
-    sha256 cellar: :any,                 arm64_sonoma:  "53ffa2bfcb22d677c2e2ecba8e6f21a87c43e777b6269235752d11a605dcf5dd"
-    sha256 cellar: :any,                 sonoma:        "4ca9aec3a0c29a973f9bb6e195f49bb7d2a9bbf0a597f12c5a0a8a50796af3cd"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "a058c75804d067e43ff6d932b8da98c759e935f04f371583ab38b74b2f221242"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5b36902a5502cd5792de9ce1f01be2b3613c7aefdc76cc6e9d19a39b54795e3c"
+    sha256 cellar: :any,                 arm64_tahoe:   "47ba7ae3b965af371df60ca1983ec977eea991ca623d286e0e35bad6195e67d8"
+    sha256 cellar: :any,                 arm64_sequoia: "8a3b2ad75ac91a99d07afac6e6223b515dae73efa16e70c8720ff1c3e5ae3b79"
+    sha256 cellar: :any,                 arm64_sonoma:  "9f95fe480a57131dcf127ded6a718c8e79a257a80348131875c6388b14a03742"
+    sha256 cellar: :any,                 sonoma:        "fa3fd0e9f8c5abbdf1542723d1e1520b89b7cd9b5584330269ae639fbb9fc1df"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "66eb695dced8b9b31a6387b3e2ea9b5768b54869510d499c0bb2e2bafae51ce9"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d1f3a46ecba766cd5db581e97ad9623617e54209fc97700212e596bcaf8eeea7"
   end
 
   depends_on "tcl-tk"

--- a/Formula/s/sqlite-rsync.rb
+++ b/Formula/s/sqlite-rsync.rb
@@ -13,14 +13,14 @@ class SqliteRsync < Formula
   no_autobump! because: :incompatible_version_format
 
   bottle do
-    sha256                               arm64_tahoe:   "a511d8e412735b283d706ac97ef7d15c3ad06f4f92ab1698373bbaf485f5c454"
-    sha256                               arm64_sequoia: "820d4b82a0133e99be511f88d0da614ad6b4106abcc7b83e87e9be6953d69b1f"
-    sha256                               arm64_sonoma:  "d8531af3531c7d8ea663026a6a68e8f9cf102abc086944a38d3932f081a3eded"
-    sha256 cellar: :any,                 tahoe:         "bc2f18e29f38c03a259817b01f9be406fd7ca441bb79321aafaddd446de14a38"
-    sha256 cellar: :any,                 sequoia:       "cb583387017aefca0e043f798b6dab1d402f1faa39e51000e18e9a1f123f283f"
-    sha256 cellar: :any,                 sonoma:        "f8d0d961aefccb86cc9672d711680db3f5cab79fc4ec40bf45dc9ef74b25b7f7"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "f3652fde83ffe2a650518e193961ca16f8ad99452826f522a2d634f2f20a8a8d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8f3850881eb522af939b269efb86aa83ef03219debc120e3b6a83f29ab5c9b4e"
+    sha256                               arm64_tahoe:   "c57a2ca27f068f2250eba95765cd85d9900c24f39b2d013a7b0e2b36f079d602"
+    sha256                               arm64_sequoia: "3fa2b08eb9020585cfc5bb0a3ccd049b59760aa9837fcc1b4cdab8e49c22c512"
+    sha256                               arm64_sonoma:  "814f07f546dce89b23700d2bb15ca22ab79bb9084d65657fdcba78970909afc3"
+    sha256 cellar: :any,                 tahoe:         "22659b2584507871de33c5461b44bc73a9e12a719584e00aacc8ca9c7a097b3e"
+    sha256 cellar: :any,                 sequoia:       "0a2737259d95f6522392e2435cc624995693d31b33a7be302addc0047b5986cc"
+    sha256 cellar: :any,                 sonoma:        "ea1998cd7270b65ccadfebdef673658937b2a660eb0b54af6aa3b07d1b40fd76"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "7da897e4351e8f463f4e989c0e77c104bd7b18ebc31cdf524e355fb2e6709cdd"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "98cd63f64373ad7a0df564bbd9b09ccbf9ba1abf718afff959eda9975833ea66"
   end
 
   uses_from_macos "tcl-tk" => :build

--- a/Formula/s/sqlite-rsync.rb
+++ b/Formula/s/sqlite-rsync.rb
@@ -1,9 +1,9 @@
 class SqliteRsync < Formula
   desc "SQLite remote copy tool"
   homepage "https://www.sqlite.org/"
-  url "https://sqlite.org/2026/sqlite-src-3520000.zip"
-  version "3.52.0"
-  sha256 "652a98ca833ed638809a52bec225a7f37799f71a995778f9ccb68ad03bd1fc11"
+  url "https://sqlite.org/2026/sqlite-src-3510300.zip"
+  version "3.51.3"
+  sha256 "f8a67a1f5b5cae7c6d42f0994ca7bf1a4a5858868c82adc9fc1340bed5eb8cd2"
   license "blessing"
 
   livecheck do

--- a/Formula/s/sqlite.rb
+++ b/Formula/s/sqlite.rb
@@ -1,9 +1,9 @@
 class Sqlite < Formula
   desc "Command-line interface for SQLite"
   homepage "https://sqlite.org/index.html"
-  url "https://sqlite.org/2026/sqlite-autoconf-3520000.tar.gz"
-  version "3.52.0"
-  sha256 "f6b50b0c103392af32a8be15b2b9d25959de9a00a70c3979128aafeaa5338b3f"
+  url "https://sqlite.org/2026/sqlite-autoconf-3510300.tar.gz"
+  version "3.51.3"
+  sha256 "81f5be397049b0cae1b167f2225af7646fc0f82e4a9b3c48c9ea3a533e21d77a"
   license "blessing"
 
   livecheck do

--- a/Formula/s/sqlite.rb
+++ b/Formula/s/sqlite.rb
@@ -17,14 +17,14 @@ class Sqlite < Formula
   no_autobump! because: :incompatible_version_format
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "6f216497d6123e4142e3ef9e813a62cfe3caa671b23181dd561634c7caaa0588"
-    sha256 cellar: :any,                 arm64_sequoia: "b369d834fb16f482aab47157153f60fb0b2e79473a5bf773dee8d2b459d37feb"
-    sha256 cellar: :any,                 arm64_sonoma:  "7f973aa2a36472cf48531368704517a488654664c14319f781e265c64d663077"
-    sha256 cellar: :any,                 tahoe:         "43f9b450624df90aec515b3d8ae86d98627136eeedbb2f9eb7d1dc192ebd2d99"
-    sha256 cellar: :any,                 sequoia:       "d4e3408cad162c8e3de3edc8d730d906b6b8c6ad18a15c590463dc96e284b8f9"
-    sha256 cellar: :any,                 sonoma:        "40aa845b3d21266f211fa751d9c9a721806064c1f6400953b78782dc388a9377"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "b610005e770ea11d6a035de8abd9c497bcb8d038279916c560c97fc48a8c7b37"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a218b752fa9462ba6b22002f55b4c76c0df2554e5e0b8b951d085dcb9feed7cf"
+    sha256 cellar: :any,                 arm64_tahoe:   "61b8c41bd50692618317c15cf49df150c43dc1171a0eb22e34398320675428f5"
+    sha256 cellar: :any,                 arm64_sequoia: "76cc45e2468ed978994cebd09c86f5c88308f80a57f7744813b699b786451b3e"
+    sha256 cellar: :any,                 arm64_sonoma:  "58cc3efa81a9415e21991191bed05e9af0ed07d836a4d1288eefb36fcbf6234f"
+    sha256 cellar: :any,                 tahoe:         "bbb00a1972755629db38439a8f36592ae1282ae76cf7adc665d5923c99fa8d43"
+    sha256 cellar: :any,                 sequoia:       "da75d72b08d32851919e68df4c0d772abc84dd7157a742759b04aaddee4d63b2"
+    sha256 cellar: :any,                 sonoma:        "1804a10be21353ffdcab30daf39602df232a5ed73c50fced8d6904892edd8857"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "4a052cecdfab5101384518ea53bbe20287f00e18e280abb11fb79e63365a31d0"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1699f0f7d4bd0a724140bb1e46709c93e9882d60ebc630bc83cdb21f3fb47e69"
   end
 
   keg_only :provided_by_macos


### PR DESCRIPTION
See: https://github.com/Homebrew/homebrew-core/issues/272250

---

Downgraded due to recalled release from compatibility issues in features: https://sqlite.org/releaselog/3_52_0.html
> Due to backwards-compatibility issues associated with some new features, the 3.52.0 release has been withdrawn.

Most users can stay on 3.52.0 if upgraded to that version.

If you want to hide brew warning on downgrade, can run `brew reinstall sqlite`.