### PR TITLE
druid: use closer.lua url

### DIFF
--- a/Formula/d/druid.rb
+++ b/Formula/d/druid.rb
@@ -1,7 +1,7 @@
 class Druid < Formula
   desc "High-performance, column-oriented, distributed data store"
   homepage "https://druid.apache.org/"
-  url "https://dlcdn.apache.org/druid/36.0.0/apache-druid-36.0.0-bin.tar.gz"
+  url "https://www.apache.org/dyn/closer.lua?path=druid/36.0.0/apache-druid-36.0.0-bin.tar.gz"
   mirror "https://archive.apache.org/dist/druid/36.0.0/apache-druid-36.0.0-bin.tar.gz"
   sha256 "e4a61b1ada6aedba77b12a9819a03e452e167d9605fd71c12af8a59074b9b490"
   license "Apache-2.0"


### PR DESCRIPTION
Looks like our formula audit doesn't handle dlcdn.apache.org.

Currently, this seems to be main (only?) server; however, Apache has mentioned URL is sponsored hosting which can change in the future.

closer.lua script is still recommended to avoid having to manually update all URLs if Apache switches to a different host or introduces alternative mirrors.
