### PR TITLE
txikijs 26.3.0 (new formula)

### DIFF
--- a/Formula/t/txikijs.rb
+++ b/Formula/t/txikijs.rb
@@ -1,0 +1,53 @@
+class Txikijs < Formula
+  desc "Tiny JavaScript runtime"
+  homepage "https://txikijs.org"
+  # pull from git tag to get submodules
+  url "https://github.com/saghul/txiki.js.git",
+    tag:      "v26.3.0",
+    revision: "9419f742e0c0470af500a4513ad4f529937d4fe7"
+  license "MIT"
+  head "https://github.com/saghul/txiki.js.git", branch: "master"
+
+  depends_on "cmake" => :build
+  # txiki.js builds WAMR with SIMD support, which requires SIMDe via FetchContent
+  depends_on "simde" => :build
+
+  depends_on "ada-url"
+  depends_on "libuv"
+  depends_on "mimalloc"
+  depends_on "sqlite"
+
+  uses_from_macos "libffi"
+
+  def install
+    inreplace "CMakeLists.txt" do |s|
+      # mimalloc
+      s.gsub! "add_subdirectory(deps/mimalloc EXCLUDE_FROM_ALL)", "find_package(mimalloc REQUIRED)"
+
+      # libuv
+      s.gsub! "add_subdirectory(deps/libuv EXCLUDE_FROM_ALL)", "find_package(libuv REQUIRED)"
+      s.gsub! "target_link_libraries(tjs PUBLIC uv_a)", "target_link_libraries(tjs PUBLIC libuv::uv)"
+      s.gsub! 'set(LWS_LIBUV_LIBRARIES uv_a CACHE STRING "" FORCE)',
+              'set(LWS_LIBUV_LIBRARIES libuv::uv CACHE STRING "" FORCE)'
+      s.gsub! 'set(LWS_LIBUV_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/deps/libuv/include" CACHE STRING "" FORCE)',
+              "set(LWS_LIBUV_INCLUDE_DIRS \"#{Formula["libuv"].opt_include}\" CACHE STRING \"\" FORCE)"
+
+      # sqlite
+      s.gsub! "add_subdirectory(deps/sqlite3 EXCLUDE_FROM_ALL)", ""
+
+      # ada-url
+      s.gsub! "add_subdirectory(deps/ada EXCLUDE_FROM_ALL)", ""
+    end
+
+    system "cmake", "-S", ".", "-B", "build",
+           "-DFETCHCONTENT_SOURCE_DIR_SIMDE=#{Formula["simde"].opt_prefix}",
+           *std_cmake_args
+    system "cmake", "--build", "build"
+    bin.install "build/tjs"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/tjs --version")
+    assert_equal "hello", shell_output("#{bin}/tjs eval \"console.log('hello')\"").strip
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

I used `brew create` and AI to bootstrap the formula file, and performed refactoring and validation manually.

-----

As pointed out in the previously proposed #235688, I made an effort to exclude as many of txiki.js's bundled dependencies as possible and instead rely on formulae already provided by Homebrew.

However, there are some dependencies that could not rely on existing formulae. I described my reasons below, though it may not be perfect.

## Why does `brew audit --new txikijs` fail? (Why `depends_on "sqlite"` instead of `uses_from_macos "sqlite"`?)

Because macOS's built-in SQLite does not allow `sqlite3_load_extension`.

## Why not use the mbedtls formula?

It uses a custom configuration file ([mbedtls_config.h](https://github.com/saghul/txiki.js/blob/b88afe7bbd0c2a5d695c217f114d06195a77c9c1/CMakeLists.txt#L267)).

## Why not use the wasm-micro-runtime formula?

Unlike that formula, it has [specific build options](https://github.com/saghul/txiki.js/blob/b88afe7bbd0c2a5d695c217f114d06195a77c9c1/CMakeLists.txt#L233-L247). For example, [the formula's SIMD is disabled](https://github.com/Homebrew/homebrew-core/blob/4394d006e39fd26037ead3cabb8d234108112adc/Formula/w/wasm-micro-runtime.rb#L38), whereas txiki.js enables it.

## Why not use the libwebsockets formula?

It applies a custom patch ([`lws.patch`](https://github.com/saghul/txiki.js/blob/b88afe7bbd0c2a5d695c217f114d06195a77c9c1/CMakeLists.txt#L327-L347)).

## Why not use the quickjs formula?

Unlike the quickjs formula, it depends on [QuickJS-NG](https://quickjs-ng.github.io/quickjs/).

## Why is this formula named txikijs instead of txiki as proposed in #235688?

The [binary name for txiki.js is `tjs`](https://txikijs.org/docs/getting-started#installation), and its [standard library also uses `tjs:` as a prefix](https://txikijs.org/docs/features/standard-library). When the formula name is txikijs, it is easier to accept that it can be abbreviated to tjs.
