### PR TITLE
erlang erlang@27: add ex_doc livecheck

### DIFF
--- a/Formula/e/erlang.rb
+++ b/Formula/e/erlang.rb
@@ -53,7 +53,13 @@ class Erlang < Formula
   # https://github.com/erlang/otp/blob/OTP-#{version}/make/ex_doc_link
   resource "ex_doc" do
     url "https://github.com/elixir-lang/ex_doc/releases/download/v0.39.3/ex_doc_otp_27"
+    version "0.39.3/ex_doc_otp_27"
     sha256 "bc16c8eaae26886f15a2d2cff490f3c873d425106e949eb5fe0e8377e778c93d"
+
+    livecheck do
+      url "https://raw.githubusercontent.com/erlang/otp/refs/tags/OTP-#{LATEST_VERSION}/make/ex_doc_link"
+      regex(%r{/v?(\d+(?:\.\d+)+/ex_doc_otp_\d+)$}i)
+    end
   end
 
   def install

--- a/Formula/e/erlang@27.rb
+++ b/Formula/e/erlang@27.rb
@@ -48,7 +48,13 @@ class ErlangAT27 < Formula
   # https://github.com/erlang/otp/blob/OTP-#{version}/make/ex_doc_link
   resource "ex_doc" do
     url "https://github.com/elixir-lang/ex_doc/releases/download/v0.37.3/ex_doc_otp_26"
+    version "0.37.3/ex_doc_otp_26"
     sha256 "b127190c72fe456ee4c291d4ca94eb955d0b3c0ca2d061481f65cbf0975e13dc"
+
+    livecheck do
+      url "https://raw.githubusercontent.com/erlang/otp/refs/tags/OTP-#{LATEST_VERSION}/make/ex_doc_link"
+      regex(%r{/v?(\d+(?:\.\d+)+/ex_doc_otp_\d+)$}i)
+    end
   end
 
   def install


### PR DESCRIPTION
Not sure about best way to handle the OTP version in ex_doc_link.

For now, went with including the entire filename which seemed to work (will need to wait for next version to verify):
```console
❯ brew lc -r --autobump erlang
erlang: 28.4.1 ==> 28.4.1
  html: 28.4.1 ==> 28.4.1
  ex_doc: 0.39.3/ex_doc_otp_27 ==> 0.39.3/ex_doc_otp_27
```

Alternatively, could ignore OTP version, but this would require manual update on major releases. Automatically bumping it would reduce maintenance.