### PR TITLE
zycore-c 1.5.2 (new formula)

### DIFF
--- a/Formula/z/zycore-c.rb
+++ b/Formula/z/zycore-c.rb
@@ -5,6 +5,15 @@ class ZycoreC < Formula
   sha256 "943f91eb9ab2a8cc01ab9f8b785e769a273502071e0ee8011cdfcaad93947cec"
   license "MIT"
 
+  bottle do
+    sha256 cellar: :any,                 arm64_tahoe:   "9bd66ff88f720bf9c47da552f6072331448fe84df5b7da0279f92c0b40987a97"
+    sha256 cellar: :any,                 arm64_sequoia: "80c639348dfe12bbcd9a604189ca4fa8efe291b8a75085a96bc93d6fbba1e74f"
+    sha256 cellar: :any,                 arm64_sonoma:  "65c26276d69063393eedac9a756af987a8a8aa7e3bd26fd8a90546382dae9278"
+    sha256 cellar: :any,                 sonoma:        "b94facc5565aa5091503172da72a453a990e22b01c096db5c5e475399390eee8"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "3473fe4aa08dfd152aa063dc3e9968c3e1850efe0d9b3218cc82ced2fa90e067"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3fb6c52be79607df63982e518a665f8bcaaf5d601f8d633ffe4646ce505e8787"
+  end
+
   depends_on "cmake" => :build
 
   def install

--- a/Formula/z/zycore-c.rb
+++ b/Formula/z/zycore-c.rb
@@ -1,0 +1,48 @@
+class ZycoreC < Formula
+  desc "Zyan Core Library for C"
+  homepage "https://github.com/zyantific/zycore-c"
+  url "https://github.com/zyantific/zycore-c/archive/refs/tags/v1.5.2.tar.gz"
+  sha256 "943f91eb9ab2a8cc01ab9f8b785e769a273502071e0ee8011cdfcaad93947cec"
+  license "MIT"
+
+  depends_on "cmake" => :build
+
+  def install
+    system "cmake", "-S", ".", "-B", "build", "-DZYCORE_BUILD_SHARED_LIB=ON", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    (testpath/"test.c").write <<~C
+      #include <stdio.h>
+      #include <stdlib.h>
+      #include <Zycore/Status.h>
+      #include <Zycore/String.h>
+
+      static ZyanStatus TestDynamic(void) {
+        ZyanString string;
+        ZYAN_CHECK(ZyanStringInit(&string, 10));
+
+        ZyanStringView view1 = ZYAN_DEFINE_STRING_VIEW("Hello World!");
+        ZYAN_CHECK(ZyanStringAppend(&string, &view1));
+
+        const char* cstring;
+        ZYAN_CHECK(ZyanStringGetData(&string, &cstring));
+        printf("%s", cstring);
+
+        return ZyanStringDestroy(&string);
+      }
+
+      int main(void) {
+        if (!ZYAN_SUCCESS(TestDynamic())) {
+          return EXIT_FAILURE;
+        }
+        return EXIT_SUCCESS;
+      }
+    C
+
+    system ENV.cc, "test.c", "-o", "test", "-L#{lib}", "-lZycore"
+    assert_equal "Hello World!", shell_output("./test")
+  end
+end

--- a/Formula/z/zydis.rb
+++ b/Formula/z/zydis.rb
@@ -7,14 +7,13 @@ class Zydis < Formula
   head "https://github.com/zyantific/zydis.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "79b00be9f9a41dc1ba17f76b0b7ad4017db140c44076666d210f1bbd50a6fcc1"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "f925b7d0345acb686c8e62409639b866e7a1123e1209508de02393d5e7af0bee"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "a59d5b51d0d85f0a7d4970e9e1f9c88a4e70d1f2edb032954ef841868ac3e4c3"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "ae399b5f60c5d4bda9a1423990471f8dd13f53dafedffcba423fa911d89265d9"
-    sha256 cellar: :any_skip_relocation, sonoma:        "0f1bd1d7a92035759a01a25a9c2e7657e5c7a6a0c64d121ca3821dd0d5bf6c26"
-    sha256 cellar: :any_skip_relocation, ventura:       "9cef22740cd31a9e97983504c80eddfb4201860fccbe6887dd9692577ea7897d"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "18b2f83673880c27fbbdf90ca73ca1d5cf2777727f188a0d18dd6b2d9849e1e6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "57fa80a8a5f5de2515de7c9e0ec1df9c29bed0035716ca4abd64fadbc1e868ce"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "3d64cf57d8e2eb55ac2457d12c35d227cca34db9c480d0c7fe6e41fd207bacd2"
+    sha256 cellar: :any,                 arm64_sequoia: "be71db07f686d7a09c8db9171418d0f8b0fbe3129f02b32b4d2fb956be023a6d"
+    sha256 cellar: :any,                 arm64_sonoma:  "3f74e22ca0befe90b33a8682e243c4ad4faad8e05ed730b5a320d5fd0426b27e"
+    sha256 cellar: :any,                 sonoma:        "01ec1f6ed5fb736d90dceded3f6ce60e79a97749441b1974d74038fec675ee62"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "bfcb9abc2e3e2787212e9f9d3f2325730a33405e07567d2d0b67a4b82657b797"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "eb5cf27e4ef3db8977e70c0f33f9aa71da5ca8140769cfdd13e65925ca86c4d9"
   end
 
   depends_on "cmake" => :build

--- a/Formula/z/zydis.rb
+++ b/Formula/z/zydis.rb
@@ -1,10 +1,8 @@
 class Zydis < Formula
   desc "Fast and lightweight x86/x86_64 disassembler library"
   homepage "https://zydis.re"
-  # pull from git tag to get submodules
-  url "https://github.com/zyantific/zydis.git",
-      tag:      "v4.1.1",
-      revision: "a2278f1d254e492f6a6b39f6cb5d1f5d515659dc"
+  url "https://github.com/zyantific/zydis/archive/refs/tags/v4.1.1.tar.gz"
+  sha256 "45c6d4d499a1cc80780f7834747c637509777c01dca1e98c5e7c0bfaccdb1514"
   license "MIT"
   head "https://github.com/zyantific/zydis.git", branch: "master"
 
@@ -20,15 +18,28 @@ class Zydis < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "ronn-ng" => :build
+  depends_on "zycore-c"
 
   def install
-    system "cmake", "-S", ".", "-B", "build", "-DZYDIS_BUILD_TESTS=OFF", *std_cmake_args
+    args = %W[
+      -DCMAKE_INSTALL_RPATH=#{rpath}
+      -DZYAN_SYSTEM_ZYCORE=ON
+      -DZYDIS_BUILD_MAN=ON
+      -DZYDIS_BUILD_SHARED_LIB=ON
+      -DZYDIS_BUILD_TESTS=OFF
+    ]
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
+    (pkgshare/"examples").install "examples/EncodeMov.c"
   end
 
   test do
     output = shell_output("#{bin}/ZydisInfo -64 66 3E 65 2E F0 F2 F3 48 01 A4 98 2C 01 00 00")
     assert_match "xrelease lock add qword ptr gs:[rax+rbx*4+0x12C], rsp", output
+
+    system ENV.cc, pkgshare/"examples/EncodeMov.c", "-o", "test", "-L#{lib}", "-lZydis"
+    assert_equal "48 C7 C0 37 13 00 00", shell_output("./test").strip
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Resolves #272742

Repology link: https://repology.org/project/zycore/versions

Although 1.5.2 tag isn't marked github release, I went with it as all major Linux distros (e.g. Arch, Debian, Fedora) ship it. Also went with `zycore-c` name rather than `zycore` for similar reason.
