### PR TITLE
icp-cli: add dist env-var

### DIFF
--- a/Formula/i/icp-cli.rb
+++ b/Formula/i/icp-cli.rb
@@ -6,12 +6,13 @@ class IcpCli < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "b758599c874159eadd8f4a4d6d265f6ee0ee7d3225db4ff4d919b907fa51bc38"
-    sha256 cellar: :any,                 arm64_sequoia: "14b570772217d85f4f89a3275d6f7e26632f235d693e8018adbf625b1702bed1"
-    sha256 cellar: :any,                 arm64_sonoma:  "1f64e4e225529925128fdc7887e1da79f29c47204b255ba8039e68b107e92b93"
-    sha256 cellar: :any,                 sonoma:        "77df5e697d326092b358842209a1e0e96520588b2c2be5b5520ff44e3af52898"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "48d63029edb04c0a82371f496c30ed770e2aec29b479449f05d94ad626ae42c1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "033b82653683fa2f534868e38413d8d1ea3d001cb1e72ad6281267d23db72076"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "2be5acb73fd19e41e6a6b32d9a21eab56f1f7b06f5e51819ac62f094efabe0f1"
+    sha256 cellar: :any,                 arm64_sequoia: "b6f4adee98cb8f31ffc7c1f36200ef766e08fd5dfe017718c960bd9165937e65"
+    sha256 cellar: :any,                 arm64_sonoma:  "89564774dfe7331d7151556336a88228add0f3c338b2a3047c286b7eb1666c19"
+    sha256 cellar: :any,                 sonoma:        "a3e2a6ca0e20e76f88e2b712d5ae258ffe83050ab46e7bf19f9cdbb13436cd23"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "86d2eae198577d82d13e891983736ff85344c0241af5fc4a629f742c01f26dc6"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f4c8aa8185b9721c0b61e568cc04936280becef8e4ca2c1a5efb313b3727f744"
   end
 
   depends_on "rust" => :build

--- a/Formula/i/icp-cli.rb
+++ b/Formula/i/icp-cli.rb
@@ -25,6 +25,7 @@ class IcpCli < Formula
   end
 
   def install
+    ENV["ICP_CLI_BUILD_DIST"] = "homebrew-core"
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
     ENV["OPENSSL_NO_VENDOR"] = "1"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Adds `ICP_CLI_BUILD_DIST=homebrew-core` to the build. The next version of icp-cli wants to know where it came from so it can present an update nag referencing `brew upgrade` specifically. This does not require rebuilding the present bottles because the current version does not use this var yet, but it is also harmless to build with it if someone builds from source.