### PR TITLE
ggml 0.9.8 (new formula)

### DIFF
--- a/Formula/g/ggml.rb
+++ b/Formula/g/ggml.rb
@@ -6,6 +6,15 @@ class Ggml < Formula
   license "MIT"
   head "https://github.com/ggml-org/ggml.git", branch: "master"
 
+  bottle do
+    sha256 arm64_tahoe:   "69c486240fa80e4e1d0db4002ade1a6152425cca50869ef8cac3b995ab8f52de"
+    sha256 arm64_sequoia: "e31d4d11b621d5243b98764e8cfaa41b5e2daf4e469d52fb8bafdfb0f3b85fe3"
+    sha256 arm64_sonoma:  "fafe775086bf0c4f1bf58b7f64eef846df873054595236a7b3fbcafce06a64d2"
+    sha256 sonoma:        "9be7f6b68ecf34fd2c767055df6827684e14fae8ea0e57927ff106ca1cd7c276"
+    sha256 arm64_linux:   "aa6acaf0edbc16e2403fb5586af96ef7f01fa91a2186fa281003f45b92c4c621"
+    sha256 x86_64_linux:  "28a7ea4ae8b17ab73941aac60daa44be9aa8109ac7fc25a734adb84631905e1d"
+  end
+
   depends_on "cmake" => [:build, :test]
 
   on_macos do

--- a/Formula/g/ggml.rb
+++ b/Formula/g/ggml.rb
@@ -1,0 +1,89 @@
+class Ggml < Formula
+  desc "Tensor library for machine learning"
+  homepage "https://github.com/ggml-org/ggml"
+  url "https://github.com/ggml-org/ggml/archive/refs/tags/v0.9.8.tar.gz"
+  sha256 "9d8b38e473697e9014ea2275fadb4ed5c247b1ca82404875fe5ac336c0d0754c"
+  license "MIT"
+  head "https://github.com/ggml-org/ggml.git", branch: "master"
+
+  depends_on "cmake" => [:build, :test]
+
+  on_macos do
+    depends_on "libomp"
+  end
+
+  on_linux do
+    depends_on "pkgconf" => :build
+    depends_on "shaderc" => :build
+    depends_on "openblas"
+    depends_on "vulkan-loader"
+  end
+
+  # These were previously provided by `llama.cpp`
+  link_overwrite "include/ggml*", "include/gguf.h", "lib/cmake/ggml/", "lib/libggml*"
+
+  # Lengthy test so not worth installing. Shorter examples/tests haven't been ported to new DL backend
+  resource "test-backend-ops.cpp" do
+    url "https://raw.githubusercontent.com/ggml-org/ggml/refs/tags/v0.9.8/tests/test-backend-ops.cpp"
+    sha256 "9408a64c81a90bef3895cdd565bd8434f76a40b3b91077901282203fc397236e"
+
+    livecheck do
+      formula :parent
+    end
+  end
+
+  def install
+    # CPU detection is needed to build multiple backends, particularly on ARM (e.g. `-march=armv8.x-a+...`)
+    ENV.runtime_cpu_detection
+
+    # TODO: Workaround for GCC 12 as armv9.2-a was added in GCC 13. Remove after Ubuntu 24.04 migration
+    if Hardware::CPU.arm? && ENV.compiler.to_s.start_with?("gcc") && DevelopmentTools.gcc_version(ENV.compiler) < 13
+      inreplace "src/ggml-cpu/CMakeLists.txt", "if (GGML_INTERNAL_SME)", "if (OFF)"
+    end
+
+    args = %W[
+      -DBUILD_SHARED_LIBS=ON
+      -DCMAKE_INSTALL_RPATH=#{rpath}
+      -DGGML_ALL_WARNINGS=OFF
+      -DGGML_BACKEND_DIR=#{libexec}
+      -DGGML_BACKEND_DL=ON
+      -DGGML_BLAS=ON
+      -DGGML_BUILD_EXAMPLES=OFF
+      -DGGML_BUILD_TESTS=OFF
+      -DGGML_CCACHE=OFF
+      -DGGML_LTO=ON
+      -DGGML_NATIVE=#{build.bottle? ? "OFF" : "ON"}
+    ]
+
+    # Enabling OpenBLAS for BLAS support and Vulkan for GPU support on Linux
+    args += %w[-DGGML_BLAS_VENDOR=OpenBLAS -DGGML_VULKAN=ON] if OS.linux?
+
+    # Not building Metal backend and CPU variants on Intel macOS
+    if OS.mac? && Hardware::CPU.intel?
+      args += %w[-DGGML_METAL=OFF -DGGML_METAL_EMBED_LIBRARY=ON]
+    elsif build.bottle?
+      args << "-DGGML_CPU_ALL_VARIANTS=ON"
+    end
+
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    testpath.install resource("test-backend-ops.cpp")
+
+    (testpath/"CMakeLists.txt").write <<~CMAKE
+      cmake_minimum_required(VERSION 4.0)
+      project(test LANGUAGES CXX)
+      set(CMAKE_CXX_STANDARD 17)
+      find_package(ggml REQUIRED)
+      add_executable(test test-backend-ops.cpp)
+      target_link_libraries(test PRIVATE ggml::ggml)
+    CMAKE
+
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    system "cmake", "--build", "build"
+    assert_match(/[1-9] backends passed/, shell_output("./build/test -o ABS"))
+  end
+end

--- a/style_exceptions/runtime_cpu_detection_allowlist.json
+++ b/style_exceptions/runtime_cpu_detection_allowlist.json
@@ -13,6 +13,7 @@
   "cryptopp",
   "fftw",
   "fio",
+  "ggml",
   "groestlcoin",
   "handbrake",
   "highway",


### PR DESCRIPTION
Note that this will slow down some `llama.cpp` updates as ggml is often first updated in llama.cpp repo and then synced into ggml repo.

However, avoiding multiple copies of ggml help with runtime loading issues. This is the approach most distros will pick when they add a package for these (e.g. how Debian currently handles it).

---

Compared to copy in llama.cpp:
* Enabled more dynamic backend loading so that we can use more than baseline. Even on macOS, this enables M1-M4-specific backends
* Enabled Vulkan support on Linux to provide a GPU backend. On macOS, we have Metal already. Can't provide NVIDIA CUDA support and AMD HIP requires dependencies not available in Homebrew/core.