### PR TITLE
qtwebengine: use vendored `ffmpeg`

### DIFF
--- a/Formula/q/qtwebengine.rb
+++ b/Formula/q/qtwebengine.rb
@@ -35,11 +35,12 @@ class Qtwebengine < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "99dfde734b22c0064d6ed5168ba788470f16e2e6b94a5e2294bd473caa2dfcc7"
-    sha256 cellar: :any,                 arm64_sequoia: "1af3fda80d8e22716a7d6ae3ac5a3b498437c038c3f456953087dd442da6540d"
-    sha256 cellar: :any,                 arm64_sonoma:  "b166219239385c92766d08f7f868f62fb72264fa5f50df77882afdfada493869"
-    sha256 cellar: :any,                 sonoma:        "172e03a367cd18d35540c936dae17d3256afea431a49814044f55eb0ea2c91b8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "00d2b22e3ac0de9ac41fe7dec21b0b51b4d2d1d81d0debd2c33686fef9c5c1e3"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "9c1a6ccbb044acd5d0a1eaebb09619cced4f9f31f3317577bf3f091ab814429f"
+    sha256 cellar: :any,                 arm64_sequoia: "cfab735161312e7e5ba9d9992478d9b1ba2d2df2c45d4d4037d421da86448888"
+    sha256 cellar: :any,                 arm64_sonoma:  "a3d6f4651b703f7f471742db0efe5e9fdffe3b0de401af021a319ded43bfa28f"
+    sha256 cellar: :any,                 sonoma:        "f3fc664cf1d088ceb2635028bdd6b6b4c2bd7fef2b5275f33cbe382073a14a9a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "49913ea9abac4bd1f175be2995ee6fe7b8c78cf1655e6298f9ae143d7fe04b1b"
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/q/qtwebengine.rb
+++ b/Formula/q/qtwebengine.rb
@@ -17,7 +17,7 @@ class Qtwebengine < Formula
     "Apache-2.0",        # Abseil; Crashpad; FlatBuffers; libgav1; ...
     "blessing",          # sqlite
     "BSD-2-Clause",      # aom; cpuinfo; dav1d; libavif
-    "LGPL-2.1-or-later", # ffmpeg (macOS); speech-dispatcher (Linux)
+    "LGPL-2.1-or-later", # ffmpeg; speech-dispatcher (Linux)
     "libpng-2.0",        # libpng (macOS)
     "MIT",               # Brotli; CityHash; FP16; fast_float; ...
     "MPL-1.1",           # hunspell
@@ -79,7 +79,6 @@ class Qtwebengine < Formula
     depends_on "alsa-lib"
     depends_on "dbus"
     depends_on "expat"
-    depends_on "ffmpeg"
     depends_on "fontconfig"
     depends_on "freetype"
     depends_on "harfbuzz"
@@ -191,10 +190,12 @@ class Qtwebengine < Formula
       #
       # The vendored copy of `re2` is used to avoid rebuilds with `re2` version
       # bumps and due to frequent API incompatibilities in Qt's copy of Chromium.
+      #
+      # The vendored copy of `ffmpeg` is used due to Chromium's usage of private API
+      # Issue ref: https://issues.chromium.org/issues/40218408
       %w[
         -DFEATURE_webengine_ozone_x11=ON
         -DFEATURE_webengine_system_alsa=ON
-        -DFEATURE_webengine_system_ffmpeg=ON
         -DFEATURE_webengine_system_freetype=ON
         -DFEATURE_webengine_system_gbm=ON
         -DFEATURE_webengine_system_harfbuzz=ON


### PR DESCRIPTION
~~Also checking on if we still exceed 6 hours on arm64 linux runner.~~

Continuation of discussion from #272629. We want to avoid carrying a permanent, non-upstreamable patch.