### PR TITLE
creduce: remove workaround for Apple Clang 13.1.6

### DIFF
--- a/Formula/c/creduce.rb
+++ b/Formula/c/creduce.rb
@@ -139,14 +139,6 @@ class Creduce < Formula
       end
     end
 
-    # Work around build failure seen on Apple Clang 13.1.6 by using LLVM Clang
-    # Undefined symbols for architecture x86_64:
-    #   "std::__1::basic_stringbuf<char, std::__1::char_traits<char>, ...
-    if DevelopmentTools.clang_build_version == 1316
-      ENV["CC"] = llvm.opt_bin/"clang"
-      ENV["CXX"] = llvm.opt_bin/"clang++"
-    end
-
     system "./configure", "--disable-silent-rules",
                           "--bindir=#{libexec}",
                           *std_configure_args


### PR DESCRIPTION
Apple Clang 13.1.6 was part of Xcode 13.3 - 13.4.1. The latest Xcode on macOS 11 is 13.2.1 while the latest Xcode on macOS 12 is 14.2.
