### PR TITLE
hwatch: Use `generate_completions_from_executable`

### DIFF
--- a/Formula/h/hwatch.rb
+++ b/Formula/h/hwatch.rb
@@ -20,9 +20,7 @@ class Hwatch < Formula
   def install
     system "cargo", "install", *std_cargo_args
     man1.install "man/hwatch.1"
-    bash_completion.install "completion/bash/hwatch-completion.bash" => "hwatch"
-    zsh_completion.install "completion/zsh/_hwatch"
-    fish_completion.install "completion/fish/hwatch.fish"
+    generate_completions_from_executable(bin/"hwatch", "--completion")
   end
 
   test do

--- a/Formula/h/hwatch.rb
+++ b/Formula/h/hwatch.rb
@@ -7,12 +7,13 @@ class Hwatch < Formula
   head "https://github.com/blacknon/hwatch.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "bbfcf242956b948038552b56ea6400100265e235ab5961d5d06abc96d9b109a0"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "f1e91241cbb57069402224ab0a37f6934e5db3a8c3d38f80bbbb248a7c8603bd"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "7d294454071d036940437420c8aa779013a423c18062862cbb113627444aad60"
-    sha256 cellar: :any_skip_relocation, sonoma:        "01bfdd869c1c23ee9b67aa411a275840583985a4395c66f59d2067ffe68bb752"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "a3384a30c4c0ec39aa79d0586d26146886412848ab1c72d8bba4ae8b07f454f9"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b3ff129434a9834347f980009224a9217af9bcc01500d7805472b95aad1be011"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "d077e8fec77e684c25528f6b016b1808a402fc1b54b3a5fb60cc5fe5ff2002a8"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "7116bbfd15368f6f0a329ab9f970b1373abdd9cbedc97c7f93729ac8cbcaa36c"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "74cf64b8f48cb1ecf305b8237ba00782a3faf31d1d70a1dafd4f2af5b68ce817"
+    sha256 cellar: :any_skip_relocation, sonoma:        "c69ece693c39c0de3bfe6e5e26d112ec66b1f655d6b58e6218831b04ac35a0f8"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "00dac9d3c0cec491f497f4e81c8ebe0f626d4889383f10fa3b3cf0ffeee329ea"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "266e148d4fbcd8c9c6ee3e379ee8b7c030c8d671f4a9dda2633459a1cac74c1b"
   end
 
   depends_on "rust" => :build


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

0.3.20 added the `completion` subcommand, so you can do this now.