### PR TITLE
unsloth 2026.3.5

### DIFF
--- a/Formula/gdbgui.rb
+++ b/Formula/gdbgui.rb
@@ -91,5 +91,12 @@ class Gdbgui < Formula
 
   test do
     assert_equal "0.13.2.0", shell_output("#{bin}/gdbgui -v").strip
+
+    pid = fork do
+      exec bin/"gdbgui", "-n"
+    end
+    sleep 3
+
+    assert_match "gdbgui - gdb in a browser", shell_output("curl -s 127.0.0.1:5000")
   end
 end

--- a/Formula/gdbgui.rb
+++ b/Formula/gdbgui.rb
@@ -1,0 +1,95 @@
+class Gdbgui < Formula
+  include Language::Python::Virtualenv
+
+  desc "Modern, browser-based frontend to gdb (gnu debugger)"
+  homepage "https://www.gdbgui.com/"
+  url "https://github.com/cs01/gdbgui/archive/0.13.2.0.tar.gz"
+  sha256 "325e4c6dd417d59b95ceb123173eee69d754f6ff3f97110c0cb960670460f858"
+
+  depends_on "gdb"
+  depends_on "python"
+
+  resource "click" do
+    url "https://files.pythonhosted.org/packages/4e/ab/5d6bc3b697154018ef196f5b17d958fac3854e2efbc39ea07a284d4a6a9b/click-7.1.1.tar.gz"
+    sha256 "8a18b4ea89d8820c5d0c7da8a64b2c324b4dabb695804dbfea19b9be9d88c0cc"
+  end
+
+  resource "Flask" do
+    url "https://files.pythonhosted.org/packages/32/57/3c33fe153ea008e9e0202eb028972178337c55777686aac03f41ade671f8/Flask-0.12.5.tar.gz"
+    sha256 "fac2b9d443e49f7e7358a444a3db5950bdd0324674d92ba67f8f1f15f876b14f"
+  end
+
+  resource "Flask-Compress" do
+    url "https://files.pythonhosted.org/packages/0e/2a/378bd072928f6d92fd8c417d66b00c757dc361c0405a46a0134de6fd323d/Flask-Compress-1.4.0.tar.gz"
+    sha256 "468693f4ddd11ac6a41bca4eb5f94b071b763256d54136f77957cfee635badb3"
+  end
+
+  resource "Flask-SocketIO" do
+    url "https://files.pythonhosted.org/packages/5d/94/6f55de2fd72f1d7f7eb17cd6045a50581e7c66d53580fc93fd607a5cd630/Flask-SocketIO-2.9.6.tar.gz"
+    sha256 "f49edfd3a44458fbb9f7a04a57069ffc0c37f000495194f943a25d370436bb69"
+  end
+
+  resource "gevent" do
+    url "https://files.pythonhosted.org/packages/5a/79/2c63d385d017b5dd7d70983a463dfd25befae70c824fedb857df6e72eff2/gevent-1.5.0.tar.gz"
+    sha256 "b2814258e3b3fb32786bb73af271ad31f51e1ac01f33b37426b66cb8491b4c29"
+  end
+
+  resource "greenlet" do
+    url "https://files.pythonhosted.org/packages/f8/e8/b30ae23b45f69aa3f024b46064c0ac8e5fcb4f22ace0dca8d6f9c8bbe5e7/greenlet-0.4.15.tar.gz"
+    sha256 "9416443e219356e3c31f1f918a91badf2e37acf297e2fa13d24d1cc2380f8fbc"
+  end
+
+  resource "itsdangerous" do
+    url "https://files.pythonhosted.org/packages/68/1a/f27de07a8a304ad5fa817bbe383d1238ac4396da447fa11ed937039fa04b/itsdangerous-1.1.0.tar.gz"
+    sha256 "321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19"
+  end
+
+  resource "Jinja2" do
+    url "https://files.pythonhosted.org/packages/64/a7/45e11eebf2f15bf987c3bc11d37dcc838d9dc81250e67e4c5968f6008b6c/Jinja2-2.11.2.tar.gz"
+    sha256 "89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0"
+  end
+
+  resource "MarkupSafe" do
+    url "https://files.pythonhosted.org/packages/b9/2e/64db92e53b86efccfaea71321f597fa2e1b2bd3853d8ce658568f7a13094/MarkupSafe-1.1.1.tar.gz"
+    sha256 "29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"
+  end
+
+  resource "pygdbmi" do
+    url "https://files.pythonhosted.org/packages/b1/06/f60cce2f9acb5ac4278cb1eedb7bb1a7bb52777b7ae74cd222c0068302fd/pygdbmi-0.9.0.3.tar.gz"
+    sha256 "5bdf2f072e8f2f6471f19f8dcd87d6425c5d8069d47c0a5ffe8d0eff48cb171e"
+  end
+
+  resource "Pygments" do
+    url "https://files.pythonhosted.org/packages/6e/4d/4d2fe93a35dfba417311a4ff627489a947b01dc0cc377a3673c00cf7e4b2/Pygments-2.6.1.tar.gz"
+    sha256 "647344a061c249a3b74e230c739f434d7ea4d8b1d5f3721bc0f3558049b38f44"
+  end
+
+  resource "python-engineio" do
+    url "https://files.pythonhosted.org/packages/71/5d/620b75396ce993001cbccc80dd786ab09a16a8e3f6c4878ad05f051064d6/python-engineio-3.12.1.tar.gz"
+    sha256 "2481732d93646998f7372ef0ecf003af7817b82720b881db173c3d50b4887916"
+  end
+
+  resource "python-socketio" do
+    url "https://files.pythonhosted.org/packages/9b/dd/45c2eb8fc9b8208cdf5948b468934b47f92ecca031c449863d8128d5cc15/python-socketio-4.5.1.tar.gz"
+    sha256 "149b98c33f8c3d09273fb4ebeb83781e4dc9411b56b27d9f058bec1bd1ed74b7"
+  end
+
+  resource "six" do
+    url "https://files.pythonhosted.org/packages/21/9f/b251f7f8a76dec1d6651be194dfba8fb8d7781d10ab3987190de8391d08e/six-1.14.0.tar.gz"
+    sha256 "236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a"
+  end
+
+  resource "Werkzeug" do
+    url "https://files.pythonhosted.org/packages/c3/1d/1c0761d9365d166dc9d882a48c437111d22b0df564d6d5768045d9a51fd0/Werkzeug-0.16.1.tar.gz"
+    sha256 "b353856d37dec59d6511359f97f6a4b2468442e454bd1c98298ddce53cac1f04"
+  end
+
+  def install
+    virtualenv_create(libexec, "python3")
+    virtualenv_install_with_resources
+  end
+
+  test do
+    assert_equal "0.13.2.0", shell_output("#{bin}/gdbgui -v").strip
+  end
+end

--- a/Formula/gdbgui.rb
+++ b/Formula/gdbgui.rb
@@ -90,7 +90,7 @@ class Gdbgui < Formula
   end
 
   test do
-    assert_equal "0.13.2.0", shell_output("#{bin}/gdbgui -v").strip
+    assert_equal version.to_s, shell_output("#{bin}/gdbgui -v").strip
 
     fork do
       exec bin/"gdbgui", "-n"

--- a/Formula/gdbgui.rb
+++ b/Formula/gdbgui.rb
@@ -7,7 +7,7 @@ class Gdbgui < Formula
   sha256 "325e4c6dd417d59b95ceb123173eee69d754f6ff3f97110c0cb960670460f858"
 
   depends_on "gdb"
-  depends_on "python"
+  depends_on "python@3.8"
 
   resource "click" do
     url "https://files.pythonhosted.org/packages/4e/ab/5d6bc3b697154018ef196f5b17d958fac3854e2efbc39ea07a284d4a6a9b/click-7.1.1.tar.gz"

--- a/Formula/gdbgui.rb
+++ b/Formula/gdbgui.rb
@@ -92,7 +92,7 @@ class Gdbgui < Formula
   test do
     assert_equal "0.13.2.0", shell_output("#{bin}/gdbgui -v").strip
 
-    pid = fork do
+    fork do
       exec bin/"gdbgui", "-n"
     end
     sleep 3

--- a/Formula/unsloth.rb
+++ b/Formula/unsloth.rb
@@ -1,0 +1,109 @@
+class Unsloth < Formula
+  include Language::Python::Virtualenv
+
+  desc "Run and train AI models with a unified local interface"
+  homepage "https://github.com/unslothai/unsloth"
+  url "https://files.pythonhosted.org/packages/source/u/unsloth/unsloth-2026.3.5.tar.gz"
+  sha256 "f8830bb4ea91d3b9eee88b611a343f52838173bf67eb22b36ae95fe7a52633b3"
+  license all_of: ["Apache-2.0", "AGPL-3.0-only"]
+
+  depends_on "rust" => :build
+  depends_on "python@3.13"
+
+  resource "annotated-doc" do
+    url "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz"
+    sha256 "fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4"
+  end
+
+  resource "annotated-types" do
+    url "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz"
+    sha256 "aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"
+  end
+
+  resource "click" do
+    url "https://files.pythonhosted.org/packages/46/61/de6cd827efad202d7057d93e0fed9294b96952e188f7384832791c7b2254/click-8.3.0.tar.gz"
+    sha256 "e7b8232224eba16f4ebe410c25ced9f7875cb5f3263ffc93cc3e8da705e229c4"
+  end
+
+  resource "markdown-it-py" do
+    url "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz"
+    sha256 "cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3"
+  end
+
+  resource "mdurl" do
+    url "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz"
+    sha256 "bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"
+  end
+
+  resource "nest-asyncio" do
+    url "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz"
+    sha256 "6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe"
+  end
+
+  resource "pydantic" do
+    url "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz"
+    sha256 "4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49"
+  end
+
+  resource "pydantic-core" do
+    url "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz"
+    sha256 "08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e"
+  end
+
+  resource "pygments" do
+    url "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz"
+    sha256 "636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"
+  end
+
+  resource "pyyaml" do
+    url "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz"
+    sha256 "d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f"
+  end
+
+  resource "rich" do
+    url "https://files.pythonhosted.org/packages/fb/d2/8920e102050a0de7bfabeb4c4614a49248cf8d5d7a8d01885fbb24dc767a/rich-14.2.0.tar.gz"
+    sha256 "73ff50c7c0c1c77c8243079283f4edb376f0f6442433aecb8ce7e6d0b92d1fe4"
+  end
+
+  resource "shellingham" do
+    url "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz"
+    sha256 "8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"
+  end
+
+  resource "typer" do
+    url "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz"
+    sha256 "e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45"
+  end
+
+  resource "typing-extensions" do
+    url "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz"
+    sha256 "0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"
+  end
+
+  resource "typing-inspection" do
+    url "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz"
+    sha256 "ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464"
+  end
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  def caveats
+    <<~EOS
+      This formula installs Unsloth's CLI and lightweight Python runtime only.
+
+      Upstream GPU/training dependencies such as Torch, bitsandbytes, xformers,
+      Triton, and related ML packages are not vendored by Homebrew here.
+      For full training or model inference support, follow Unsloth's upstream
+      setup instructions or run:
+        unsloth studio setup
+    EOS
+  end
+
+  test do
+    ENV["HOME"] = testpath
+    output = shell_output("#{bin}/unsloth studio reset-password")
+    assert_match "No auth database found", output
+  end
+end


### PR DESCRIPTION
Adds a new `unsloth` formula.

See https://github.com/unslothai/unsloth and https://unsloth.ai/docs/new/studio/install

Notes:
- packages the CLI and lightweight Python runtime with explicit Python resources
- adds `rust` as a build dependency for `pydantic-core`
- uses a functional CLI test via `unsloth studio reset-password`
- includes caveats because upstream GPU/training dependencies are not vendored in this formula

Validation completed locally:
- Ruby syntax check on the formula file

Validation attempted but blocked by local Homebrew state:
- `brew audit --new` by name could not be run because Homebrew did not resolve the staged formula by name from the local core tap
- direct `brew install --build-from-source` from the formula path entered Homebrew bootstrap/update work without returning a useful build log in this environment