### PR TITLE
workflows: add per-formula command-not-found DB entry update

### DIFF
--- a/.github/workflows/command-not-found-db-entry.yml
+++ b/.github/workflows/command-not-found-db-entry.yml
@@ -6,13 +6,7 @@ on:
       - main
     paths:
       - Formula/**/*.rb
-  workflow_dispatch:
-    inputs:
-      formula:
-        description: Formula name to update (leave empty to derive from last commit)
-        required: false
 
-# Queue updates — never cancel in progress, just wait
 concurrency:
   group: command-not-found-db-entry
   cancel-in-progress: false
@@ -33,7 +27,6 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       packages: write
-
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -49,181 +42,36 @@ jobs:
           workflow-key: command-not-found-db-entry
           uninstall: true
 
-      - name: Determine formula name(s)
-        id: formula-names
-        env:
-          MANUAL_FORMULA: ${{ inputs.formula }}
-        run: |
-          if [[ -n "$MANUAL_FORMULA" ]]; then
-            # workflow_dispatch with explicit formula name
-            echo "names=$MANUAL_FORMULA" >> "$GITHUB_OUTPUT"
-          else
-            # Derive from files changed in this push commit
-            names="$(
-              git -C "${{ steps.set-up-homebrew.outputs.repository-path }}" \
-                diff-tree --no-commit-id -r --name-only "${{ github.sha }}^..${{ github.sha }}" \
-              | grep '^Formula/.*\.rb$' \
-              | sed 's|^Formula/[a-z]/||; s|^Formula/||; s|\.rb$||'
-            )"
+      - name: Detect changed formulae
+        id: formulae-detect
+        run: brew test-bot --only-formulae-detect
 
-            if [[ -z "$names" ]]; then
-              echo "::notice ::No formula files changed in this commit — skipping."
-              echo "names=" >> "$GITHUB_OUTPUT"
-            else
-              echo "names=$names" >> "$GITHUB_OUTPUT"
-            fi
-          fi
-
-      - name: Pull executables.txt from GitHub Packages
-        if: steps.formula-names.outputs.names != ''
+      - name: Pull executables.txt
+        if: steps.formulae-detect.outputs.testing_formulae != '' || steps.formulae-detect.outputs.deleted_formulae != ''
         run: oras pull ghcr.io/homebrew/command-not-found/executables:latest
 
       - name: Update database entries
-        if: steps.formula-names.outputs.names != ''
+        if: steps.formulae-detect.outputs.testing_formulae != '' || steps.formulae-detect.outputs.deleted_formulae != ''
         env:
-          FORMULA_NAMES: ${{ steps.formula-names.outputs.names }}
-          HOMEBREW_REPOSITORY: ${{ steps.set-up-homebrew.outputs.repository-path }}
+          TESTING_FORMULAE: ${{ steps.formulae-detect.outputs.testing_formulae }}
+          DELETED_FORMULAE: ${{ steps.formulae-detect.outputs.deleted_formulae }}
         run: |
-          # Determine the Linux bottle tag for this runner
-          BOTTLE_TAG="x86_64_linux"
-
-          for formula_name in $FORMULA_NAMES; do
-            echo "::group::Processing $formula_name"
-
-            # ------ Check if formula is disabled or deprecated ------
-            formula_status="$(
-              brew ruby -e "
-                require 'formulary'
-                f = Formulary.factory('$formula_name')
-                if f.disabled?
-                  puts 'disabled'
-                elsif f.deprecated?
-                  puts 'deprecated'
-                else
-                  puts 'active'
-                end
-              " 2>/dev/null || echo "not_found"
-            )"
-
-            echo "Formula status: $formula_status"
-
-            if [[ "$formula_status" == "not_found" || \
-                  "$formula_status" == "disabled" || \
-                  "$formula_status" == "deprecated" ]]; then
-              # Remove the formula's line from executables.txt if present
-              if grep -q "^${formula_name}(" executables.txt 2>/dev/null; then
-                sed -i "/^${formula_name}(/d" executables.txt
-                echo "::notice ::Removed $formula_name from executables.txt (status: $formula_status)"
-              else
-                echo "::notice ::$formula_name not in executables.txt — nothing to remove."
-              fi
-              echo "::endgroup::"
-              continue
-            fi
-
-            # ------ Get version ------
-            formula_version="$(
-              brew ruby -e "
-                require 'formulary'
-                puts Formulary.factory('$formula_name').pkg_version
-              " 2>/dev/null || echo ""
-            )"
-
-            if [[ -z "$formula_version" ]]; then
-              echo "::warning ::Could not determine version for $formula_name — skipping."
-              echo "::endgroup::"
-              continue
-            fi
-
-            # ------ Try to get executables from bottle manifest ------
-            executables=""
-
-            manifest_file="$(
-              find "$HOME/.cache/Homebrew" -maxdepth 1 -name "${formula_name}_bottle_manifest--*" 2>/dev/null | head -1 || true
-            )"
-
-            # Fetch manifest if not cached
-            if [[ -z "$manifest_file" ]]; then
-              brew fetch --bottle-tag="$BOTTLE_TAG" "$formula_name" 2>/dev/null || true
-              manifest_file="$(
-                find "$HOME/.cache/Homebrew" -maxdepth 1 -name "${formula_name}_bottle_manifest--*" 2>/dev/null | head -1 || true
-              )"
-            fi
-
-            if [[ -n "$manifest_file" ]]; then
-              raw_exes="$(
-                jq --raw-output \
-                  '.manifests[0].annotations."sh.brew.path_exec_files" // empty' \
-                  "$manifest_file" 2>/dev/null || true
-              )"
-
-              if [[ -n "$raw_exes" ]]; then
-                # raw_exes is space-separated paths like "bin/rg bin/foo"
-                # extract just the basenames and sort them
-                executables="$(
-                  echo "$raw_exes" \
-                  | tr ' ' '\n' \
-                  | xargs -I{} basename {} \
-                  | sort \
-                  | tr '\n' ' ' \
-                  | sed 's/ $//'
-                )"
-              fi
-            fi
-
-            # ------ Build the new DB line ------
-            new_line="${formula_name}(${formula_version}):${executables}"
-
-            # ------ Check if anything actually changed ------
-            existing_line="$(grep "^${formula_name}(" executables.txt 2>/dev/null || true)"
-
-            if [[ "$existing_line" == "$new_line" ]]; then
-              echo "::notice ::$formula_name is already up to date — skipping."
-              echo "::endgroup::"
-              continue
-            fi
-
-            # ------ Update executables.txt (remove old line, add new, re-sort) ------
-            # Remove existing entry for this formula if present
-            sed -i "/^${formula_name}(/d" executables.txt
-
-            # Append new line
-            echo "$new_line" >> executables.txt
-
-            # Re-sort the file in-place
-            sort -o executables.txt executables.txt
-
-            if [[ -z "$existing_line" ]]; then
-              echo "::notice ::Added $formula_name to executables.txt"
-            else
-              echo "::notice ::Updated $formula_name in executables.txt"
-            fi
-
-            echo "::endgroup::"
+          for formula in ${TESTING_FORMULAE//,/ } ${DELETED_FORMULAE//,/ }; do
+            [[ -n "$formula" ]] && brew which-entry --output-db=executables.txt "$formula"
           done
 
       - name: Log in to GitHub Packages
-        if: >
-          github.ref == 'refs/heads/main' &&
-          steps.formula-names.outputs.names != ''
-        run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" \
-            | oras login ghcr.io --username brewtestbot --password-stdin
+        if: github.ref == 'refs/heads/main' && (steps.formulae-detect.outputs.testing_formulae != '' || steps.formulae-detect.outputs.deleted_formulae != '')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "$GITHUB_TOKEN" | oras login ghcr.io --username brewtestbot --password-stdin
 
-      - name: Push updated executables.txt to GitHub Packages
-        if: >
-          github.ref == 'refs/heads/main' &&
-          steps.formula-names.outputs.names != ''
-        run: |
-          oras push \
-            --artifact-type application/vnd.homebrew.command-not-found.executables \
-            ghcr.io/homebrew/command-not-found/executables:latest \
-            executables.txt:text/plain
+      - name: Push to GitHub Packages
+        if: github.ref == 'refs/heads/main' && (steps.formulae-detect.outputs.testing_formulae != '' || steps.formulae-detect.outputs.deleted_formulae != '')
+        run: oras push --artifact-type application/vnd.homebrew.command-not-found.executables ghcr.io/homebrew/command-not-found/executables:latest executables.txt:text/plain
 
       - name: Verify upload
-        if: >
-          github.ref == 'refs/heads/main' &&
-          steps.formula-names.outputs.names != ''
+        if: github.ref == 'refs/heads/main' && (steps.formulae-detect.outputs.testing_formulae != '' || steps.formulae-detect.outputs.deleted_formulae != '')
         run: |
           shasum --algorithm=256 executables.txt > executables.txt.sha256
           rm -f executables.txt

--- a/.github/workflows/command-not-found-db-entry.yml
+++ b/.github/workflows/command-not-found-db-entry.yml
@@ -139,14 +139,14 @@ jobs:
             executables=""
 
             manifest_file="$(
-              ls "$HOME/.cache/Homebrew/${formula_name}_bottle_manifest"--* 2>/dev/null | head -1 || true
+              find "$HOME/.cache/Homebrew" -maxdepth 1 -name "${formula_name}_bottle_manifest--*" 2>/dev/null | head -1 || true
             )"
 
             # Fetch manifest if not cached
             if [[ -z "$manifest_file" ]]; then
               brew fetch --bottle-tag="$BOTTLE_TAG" "$formula_name" 2>/dev/null || true
               manifest_file="$(
-                ls "$HOME/.cache/Homebrew/${formula_name}_bottle_manifest"--* 2>/dev/null | head -1 || true
+                find "$HOME/.cache/Homebrew" -maxdepth 1 -name "${formula_name}_bottle_manifest--*" 2>/dev/null | head -1 || true
               )"
             fi
 

--- a/.github/workflows/command-not-found-db-entry.yml
+++ b/.github/workflows/command-not-found-db-entry.yml
@@ -1,0 +1,231 @@
+name: Update command-not-found database entry
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - Formula/**/*.rb
+  workflow_dispatch:
+    inputs:
+      formula:
+        description: Formula name to update (leave empty to derive from last commit)
+        required: false
+
+# Queue updates — never cancel in progress, just wait
+concurrency:
+  group: command-not-found-db-entry
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash -xeuo pipefail {0}
+
+env:
+  HOMEBREW_DEVELOPER: 1
+  HOMEBREW_NO_AUTO_UPDATE: 1
+  HOMEBREW_NO_INSTALL_FROM_API: 1
+  GH_NO_UPDATE_NOTIFIER: 1
+
+jobs:
+  update-db-entry:
+    if: github.repository_owner == 'Homebrew'
+    runs-on: ubuntu-slim
+    permissions:
+      packages: write
+
+    steps:
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@main
+        with:
+          core: true
+          cask: false
+
+      - name: Install oras
+        uses: Homebrew/actions/cache-homebrew-prefix@main
+        with:
+          install: oras
+          workflow-key: command-not-found-db-entry
+          uninstall: true
+
+      - name: Determine formula name(s)
+        id: formula-names
+        env:
+          MANUAL_FORMULA: ${{ inputs.formula }}
+        run: |
+          if [[ -n "$MANUAL_FORMULA" ]]; then
+            # workflow_dispatch with explicit formula name
+            echo "names=$MANUAL_FORMULA" >> "$GITHUB_OUTPUT"
+          else
+            # Derive from files changed in this push commit
+            names="$(
+              git -C "${{ steps.set-up-homebrew.outputs.repository-path }}" \
+                diff-tree --no-commit-id -r --name-only "${{ github.sha }}^..${{ github.sha }}" \
+              | grep '^Formula/.*\.rb$' \
+              | sed 's|^Formula/[a-z]/||; s|^Formula/||; s|\.rb$||'
+            )"
+
+            if [[ -z "$names" ]]; then
+              echo "::notice ::No formula files changed in this commit — skipping."
+              echo "names=" >> "$GITHUB_OUTPUT"
+            else
+              echo "names=$names" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
+      - name: Pull executables.txt from GitHub Packages
+        if: steps.formula-names.outputs.names != ''
+        run: oras pull ghcr.io/homebrew/command-not-found/executables:latest
+
+      - name: Update database entries
+        if: steps.formula-names.outputs.names != ''
+        env:
+          FORMULA_NAMES: ${{ steps.formula-names.outputs.names }}
+          HOMEBREW_REPOSITORY: ${{ steps.set-up-homebrew.outputs.repository-path }}
+        run: |
+          # Determine the Linux bottle tag for this runner
+          BOTTLE_TAG="x86_64_linux"
+
+          for formula_name in $FORMULA_NAMES; do
+            echo "::group::Processing $formula_name"
+
+            # ------ Check if formula is disabled or deprecated ------
+            formula_status="$(
+              brew ruby -e "
+                require 'formulary'
+                f = Formulary.factory('$formula_name')
+                if f.disabled?
+                  puts 'disabled'
+                elsif f.deprecated?
+                  puts 'deprecated'
+                else
+                  puts 'active'
+                end
+              " 2>/dev/null || echo "not_found"
+            )"
+
+            echo "Formula status: $formula_status"
+
+            if [[ "$formula_status" == "not_found" || \
+                  "$formula_status" == "disabled" || \
+                  "$formula_status" == "deprecated" ]]; then
+              # Remove the formula's line from executables.txt if present
+              if grep -q "^${formula_name}(" executables.txt 2>/dev/null; then
+                sed -i "/^${formula_name}(/d" executables.txt
+                echo "::notice ::Removed $formula_name from executables.txt (status: $formula_status)"
+              else
+                echo "::notice ::$formula_name not in executables.txt — nothing to remove."
+              fi
+              echo "::endgroup::"
+              continue
+            fi
+
+            # ------ Get version ------
+            formula_version="$(
+              brew ruby -e "
+                require 'formulary'
+                puts Formulary.factory('$formula_name').pkg_version
+              " 2>/dev/null || echo ""
+            )"
+
+            if [[ -z "$formula_version" ]]; then
+              echo "::warning ::Could not determine version for $formula_name — skipping."
+              echo "::endgroup::"
+              continue
+            fi
+
+            # ------ Try to get executables from bottle manifest ------
+            executables=""
+
+            manifest_file="$(
+              ls "$HOME/.cache/Homebrew/${formula_name}_bottle_manifest"--* 2>/dev/null | head -1 || true
+            )"
+
+            # Fetch manifest if not cached
+            if [[ -z "$manifest_file" ]]; then
+              brew fetch --bottle-tag="$BOTTLE_TAG" "$formula_name" 2>/dev/null || true
+              manifest_file="$(
+                ls "$HOME/.cache/Homebrew/${formula_name}_bottle_manifest"--* 2>/dev/null | head -1 || true
+              )"
+            fi
+
+            if [[ -n "$manifest_file" ]]; then
+              raw_exes="$(
+                jq --raw-output \
+                  '.manifests[0].annotations."sh.brew.path_exec_files" // empty' \
+                  "$manifest_file" 2>/dev/null || true
+              )"
+
+              if [[ -n "$raw_exes" ]]; then
+                # raw_exes is space-separated paths like "bin/rg bin/foo"
+                # extract just the basenames and sort them
+                executables="$(
+                  echo "$raw_exes" \
+                  | tr ' ' '\n' \
+                  | xargs -I{} basename {} \
+                  | sort \
+                  | tr '\n' ' ' \
+                  | sed 's/ $//'
+                )"
+              fi
+            fi
+
+            # ------ Build the new DB line ------
+            new_line="${formula_name}(${formula_version}):${executables}"
+
+            # ------ Check if anything actually changed ------
+            existing_line="$(grep "^${formula_name}(" executables.txt 2>/dev/null || true)"
+
+            if [[ "$existing_line" == "$new_line" ]]; then
+              echo "::notice ::$formula_name is already up to date — skipping."
+              echo "::endgroup::"
+              continue
+            fi
+
+            # ------ Update executables.txt (remove old line, add new, re-sort) ------
+            # Remove existing entry for this formula if present
+            sed -i "/^${formula_name}(/d" executables.txt
+
+            # Append new line
+            echo "$new_line" >> executables.txt
+
+            # Re-sort the file in-place
+            sort -o executables.txt executables.txt
+
+            if [[ -z "$existing_line" ]]; then
+              echo "::notice ::Added $formula_name to executables.txt"
+            else
+              echo "::notice ::Updated $formula_name in executables.txt"
+            fi
+
+            echo "::endgroup::"
+          done
+
+      - name: Log in to GitHub Packages
+        if: >
+          github.ref == 'refs/heads/main' &&
+          steps.formula-names.outputs.names != ''
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" \
+            | oras login ghcr.io --username brewtestbot --password-stdin
+
+      - name: Push updated executables.txt to GitHub Packages
+        if: >
+          github.ref == 'refs/heads/main' &&
+          steps.formula-names.outputs.names != ''
+        run: |
+          oras push \
+            --artifact-type application/vnd.homebrew.command-not-found.executables \
+            ghcr.io/homebrew/command-not-found/executables:latest \
+            executables.txt:text/plain
+
+      - name: Verify upload
+        if: >
+          github.ref == 'refs/heads/main' &&
+          steps.formula-names.outputs.names != ''
+        run: |
+          shasum --algorithm=256 executables.txt > executables.txt.sha256
+          rm -f executables.txt
+          oras pull ghcr.io/homebrew/command-not-found/executables:latest
+          shasum --algorithm=256 --check executables.txt.sha256

--- a/.github/workflows/command-not-found-db-entry.yml
+++ b/.github/workflows/command-not-found-db-entry.yml
@@ -27,6 +27,8 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       packages: write
+    outputs:
+      has-changes: ${{ steps.has-changes.outputs.result }}
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -89,3 +91,17 @@ jobs:
           rm -f executables.txt
           oras pull ghcr.io/homebrew/command-not-found/executables:latest
           shasum --algorithm=256 --check executables.txt.sha256
+  delete-old-versions:
+    needs: update-db-entry
+    runs-on: ubuntu-slim
+    if: github.ref == 'refs/heads/main' && needs.update-db-entry.outputs.has-changes == 'true'
+    permissions:
+      packages: write
+    steps:
+      - name: Delete old versions from GitHub Packages
+        uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
+        with:
+          package-name: command-not-found/executables
+          package-type: container
+          min-versions-to-keep: 0
+          delete-only-untagged-versions: true

--- a/.github/workflows/command-not-found-db-entry.yml
+++ b/.github/workflows/command-not-found-db-entry.yml
@@ -46,12 +46,24 @@ jobs:
         id: formulae-detect
         run: brew test-bot --only-formulae-detect
 
+      - name: Check if formulae changed
+        id: has-changes
+        env:
+          TESTING_FORMULAE: ${{ steps.formulae-detect.outputs.testing_formulae }}
+          DELETED_FORMULAE: ${{ steps.formulae-detect.outputs.deleted_formulae }}
+        run: |
+          if [[ -n "$TESTING_FORMULAE" || -n "$DELETED_FORMULAE" ]]; then
+            echo "result=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "result=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Pull executables.txt
-        if: steps.formulae-detect.outputs.testing_formulae != '' || steps.formulae-detect.outputs.deleted_formulae != ''
+        if: steps.has-changes.outputs.result == 'true'
         run: oras pull ghcr.io/homebrew/command-not-found/executables:latest
 
       - name: Update database entries
-        if: steps.formulae-detect.outputs.testing_formulae != '' || steps.formulae-detect.outputs.deleted_formulae != ''
+        if: steps.has-changes.outputs.result == 'true'
         env:
           TESTING_FORMULAE: ${{ steps.formulae-detect.outputs.testing_formulae }}
           DELETED_FORMULAE: ${{ steps.formulae-detect.outputs.deleted_formulae }}
@@ -61,17 +73,17 @@ jobs:
           done
 
       - name: Log in to GitHub Packages
-        if: github.ref == 'refs/heads/main' && (steps.formulae-detect.outputs.testing_formulae != '' || steps.formulae-detect.outputs.deleted_formulae != '')
+        if: github.ref == 'refs/heads/main' && steps.has-changes.outputs.result == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: echo "$GITHUB_TOKEN" | oras login ghcr.io --username brewtestbot --password-stdin
 
       - name: Push to GitHub Packages
-        if: github.ref == 'refs/heads/main' && (steps.formulae-detect.outputs.testing_formulae != '' || steps.formulae-detect.outputs.deleted_formulae != '')
+        if: github.ref == 'refs/heads/main' && steps.has-changes.outputs.result == 'true'
         run: oras push --artifact-type application/vnd.homebrew.command-not-found.executables ghcr.io/homebrew/command-not-found/executables:latest executables.txt:text/plain
 
       - name: Verify upload
-        if: github.ref == 'refs/heads/main' && (steps.formulae-detect.outputs.testing_formulae != '' || steps.formulae-detect.outputs.deleted_formulae != '')
+        if: github.ref == 'refs/heads/main' && steps.has-changes.outputs.result == 'true'
         run: |
           shasum --algorithm=256 executables.txt > executables.txt.sha256
           rm -f executables.txt


### PR DESCRIPTION
Implements the approach discussed in homebrew/brew#20752.

Replaces the daily batch `brew which-update` job with a lightweight per-formula workflow that triggers on each push to `main` that touches a formula file.

For each changed formula it:
1. Reads `sh.brew.path_exec_files` from the bottle manifest
2. Pulls `executables.txt` via `oras`
3. Updates only that formula's single line or removes it if the formula is disabled, deprecated, or deleted
4. Pushes the updated file back via `oras`

Key design decisions:
- `cancel-in-progress: false` so rapid merges queue rather than clobber each other (per Rylan12's spec in homebrew/brew#20752)
- Uses `github.sha^..github.sha` diff-tree range to correctly handle merge commits
- No-ops if the formula's entry is already up to date

Partial implementation of homebrew/brew#20752 `brew which-update` removal in homebrew/brew is a separate follow-up.

@MikeMcQuaid can you please review it!!

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
