### PR TITLE
ascelerate 0.8.0 (new formula)

### DIFF
--- a/Formula/a/ascelerate.rb
+++ b/Formula/a/ascelerate.rb
@@ -1,0 +1,19 @@
+class Ascelerate < Formula
+  desc "Swift CLI for App Store Connect"
+  homepage "https://github.com/keremerkan/ascelerate"
+  url "https://github.com/keremerkan/ascelerate/archive/refs/tags/v0.8.0.tar.gz"
+  sha256 "8adca67fa03ee79092182a761105729eab09ca2d22935b6e74438cca171bec5b"
+  license "MIT"
+
+  depends_on xcode: ["15.0", :build]
+  depends_on :macos
+
+  def install
+    system "swift", "build", "-c", "release", "--disable-sandbox"
+    bin.install ".build/release/ascelerate"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/ascelerate version")
+  end
+end


### PR DESCRIPTION
## Description

A Swift CLI for App Store Connect. Manages the full app release lifecycle from the terminal — archiving, uploading builds, managing versions and localizations, screenshots, review submission, provisioning (devices, certificates, bundle IDs, profiles), in-app purchases, and subscriptions.

- **Homepage:** https://github.com/keremerkan/ascelerate
- **License:** MIT
- **Stars:** 100+
- **Language:** Swift 6.0
- **Platform:** macOS 13+

### Build notes

The release build takes ~4 minutes due to the [asc-swift](https://github.com/aaronsky/asc-swift) dependency which includes ~2500 generated source files covering the entire App Store Connect API surface.

### Checks

- [x] `brew audit --new ascelerate` passes
- [x] `brew install --build-from-source ascelerate` succeeds (4m16s)
- [x] `brew test ascelerate` passes