### PR TITLE
groonga: livecheck resource for latest tag

### DIFF
--- a/Formula/g/groonga.rb
+++ b/Formula/g/groonga.rb
@@ -44,6 +44,10 @@ class Groonga < Formula
   resource "groonga-normalizer-mysql" do
     url "https://github.com/groonga/groonga-normalizer-mysql/releases/download/v1.3.0/groonga-normalizer-mysql-1.3.0.tar.gz"
     sha256 "693c24eff9ba95cd498ba28f8d5826843caec347b5aa6976e565e69535b44147"
+
+    livecheck do
+      url :url
+    end
   end
 
   def install


### PR DESCRIPTION
```
❯ brew lc groonga --autobump -r
groonga: 16.0.0 ==> 16.0.0
  groonga-normalizer-mysql: 1.3.0 ==> 1.3.0
```

There doesn't seem to be a specific version requirement for now. May need to check on it in 2.0.0 but documentation mainly mentions installing from package managers, e.g.
- https://github.com/groonga/groonga/blob/main/doc/source/install/ubuntu.md#groonga-normalizer-mysql-package

And for bundled builds uses a "latest" tarball:
- https://github.com/groonga/groonga/blob/main/vendor/download_groonga_normalizer_mysql.rb#L65-L66