### PR TITLE
ocaml 5.4.1

### DIFF
--- a/Formula/c/camlp-streams.rb
+++ b/Formula/c/camlp-streams.rb
@@ -7,12 +7,12 @@ class CamlpStreams < Formula
   revision 6
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "e7fe4bfbf60135b74ed63cd5430c8aaa06afc4b6755562448b43061c33dc92bb"
-    sha256 cellar: :any,                 arm64_sequoia: "bb52bd02f32203ab2afd5ba95e31870d7a1434958b1c738a05d9b74d4d5d8117"
-    sha256 cellar: :any,                 arm64_sonoma:  "367be637dbd5fb4baadb86f92ca0c6758d896f78fae0ae48beb93be26004fcf3"
-    sha256 cellar: :any,                 sonoma:        "9b129d7d4072cf67c52b0ae723390101a5790799788d34d9a169111c52220325"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "8c6078a8ea7c69644008875bd7f8a77025cd725f0ad98038136fe39c27536533"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0fb3cdc0726e6a68db04b269e89f5e3e6754bbbbf2ac102628f19edb9f8dda3a"
+    sha256 cellar: :any,                 arm64_tahoe:   "76394abee9ae7ef19a15ab56903b9464bbfdb87b41190971771c4434dcc93e47"
+    sha256 cellar: :any,                 arm64_sequoia: "af06355d22d11b04eb464579829aa50b85f731966bc624e1518307e190259e16"
+    sha256 cellar: :any,                 arm64_sonoma:  "610058986c20012b42f12681aa6960f0ab73c91bb29a773ec671793eabf371c9"
+    sha256 cellar: :any,                 sonoma:        "c9d510f707c518f3722cdea9e5a94b3807adf87185cac0e4a522c5abcde6c949"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "488c452c708981035a8158417c2b451228f0d2cf5119a1d3a86ef918d8a65674"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "15081fcdb9677e8cd2f645899eed800d8e7ce5d0f379fd6e286b3026075b0175"
   end
 
   depends_on "dune" => :build

--- a/Formula/c/camlp-streams.rb
+++ b/Formula/c/camlp-streams.rb
@@ -4,7 +4,7 @@ class CamlpStreams < Formula
   url "https://github.com/ocaml/camlp-streams/archive/refs/tags/v5.0.1.tar.gz"
   sha256 "ad71f62406e9bb4e7fb5d4593ede2af6c68f8b0d96f25574446e142c3eb0d9a4"
   license "LGPL-2.1-only" => { with: "OCaml-LGPL-linking-exception" }
-  revision 5
+  revision 6
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "e7fe4bfbf60135b74ed63cd5430c8aaa06afc4b6755562448b43061c33dc92bb"

--- a/Formula/c/camlpdf.rb
+++ b/Formula/c/camlpdf.rb
@@ -7,12 +7,12 @@ class Camlpdf < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "8ea80573733f7a69935abe06422690752fce76edb6a27dac8bc1976b6fc3f0f0"
-    sha256 cellar: :any,                 arm64_sequoia: "00918247784d02e38897e119f5853059b59a80020203f852ce952ada2af11187"
-    sha256 cellar: :any,                 arm64_sonoma:  "f3b2796264a233801ddaec9906869105fda3aba8445c95414752803124c05554"
-    sha256 cellar: :any,                 sonoma:        "3f8747e524240ad6c3e6778e585a668dd1ac0f5f423ac033a8d39f861d83648b"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "b5d7a301e8215960741c3930db016f45dd3bceb130e7c7fe4b729d5aff760c39"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "7457d2eeec4b15bfb5815f51d4e3a707bbbc29837063f5bf97231b0a98bd845f"
+    sha256 cellar: :any,                 arm64_tahoe:   "2ae180c8730f1552db117b06df7f2abe50abd3eb2eb6d42e3136864c0dd92d31"
+    sha256 cellar: :any,                 arm64_sequoia: "f8411747409bcb8ccc1a65bdbe81f6e07d96d98aa4af4120a76ee8781d932720"
+    sha256 cellar: :any,                 arm64_sonoma:  "a74fbd0854dffb24c77f9e30bb61ae5513e1ea22f76b5f5e3d30b43fb21879e0"
+    sha256 cellar: :any,                 sonoma:        "2919f746cc7d16eb9603f1e84543f7097672acd73964cc008c1af1006b380cc7"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "fc2ddfc666ce2a4e7977c2936ffbc4a8f949a828863c1254c2c1669bf525d5e1"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "fd11b6341f7102de7f52997ae11557fd8c3e95ce86f4ab741c39d839d6cd9b46"
   end
 
   depends_on "ocaml-findlib" => :build

--- a/Formula/c/camlpdf.rb
+++ b/Formula/c/camlpdf.rb
@@ -4,6 +4,7 @@ class Camlpdf < Formula
   url "https://github.com/johnwhitington/camlpdf/archive/refs/tags/v2.9.tar.gz"
   sha256 "2bbc222eb6e1be4ef6ec2900a1bba1da652704ff1343e742726689e077d35a27"
   license "LGPL-2.1-only" => { with: "OCaml-LGPL-linking-exception" }
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "8ea80573733f7a69935abe06422690752fce76edb6a27dac8bc1976b6fc3f0f0"

--- a/Formula/h/hierarchy-builder.rb
+++ b/Formula/h/hierarchy-builder.rb
@@ -12,12 +12,12 @@ class HierarchyBuilder < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "b3b5f4d1d6606534febc49a70c6ef26b257adae38c2bbf2946f3400f383ee36a"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "df712866b2cbe4241decc4309c842da8b7b0e878e9845fa61ba5978b7f3d13e7"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "1742cd3a0e219fbfc6bd21822e848e90ba56ccec3a8efd4e5c379524086bedfe"
-    sha256 cellar: :any_skip_relocation, sonoma:        "8562c64ebfb06375a32b2d8d1f12e5bd1576ebe7b66fe906c924d450221a7f93"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "9e7aead24d4ff70f0c61a6dd4a4030c563a77dcf367437cb7ae00a11bf020081"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d2fdd21a3c460b741f966ee40d64756b5084b090cf85453ab7f35899289ddb42"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "63f91b9b0b9c51d2a3c09f51b90d2050d39e000afc197915f64e7adcec0d36df"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "c53e865547b235b1c40e219068637d575cf851482e496c655eb179a936bbc02f"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "55bbe600514b9a25d73c478a71e4859d4075c30cd99ab38b8796453e8cfafb03"
+    sha256 cellar: :any_skip_relocation, sonoma:        "e9b283e817570664490222fd61427bdc2a5135ccabf1863aa848f2ee890e0de7"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "d4b7b4222fceff15e9b120e2f003b6b72d1a2eeac2358c02f4ce87f2983d31df"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "701e62ae84c7ccfba1c751d3daab8fac91243e84ff064c9541d546225b5fa5b0"
   end
 
   depends_on "rocq"

--- a/Formula/h/hierarchy-builder.rb
+++ b/Formula/h/hierarchy-builder.rb
@@ -4,7 +4,7 @@ class HierarchyBuilder < Formula
   url "https://github.com/math-comp/hierarchy-builder/releases/download/v1.10.2/hierarchy-builder-1.10.2.tar.gz"
   sha256 "bdd7dccc5248e7500e02fd1745fd17faa41920f43a32ca2de2b2139212ee53b5"
   license "MIT"
-  revision 2
+  revision 3
 
   livecheck do
     url :stable

--- a/Formula/m/math-comp.rb
+++ b/Formula/m/math-comp.rb
@@ -4,7 +4,7 @@ class MathComp < Formula
   url "https://github.com/math-comp/math-comp/archive/refs/tags/mathcomp-2.5.0.tar.gz"
   sha256 "3db2f4b1b7f9f5a12d3d0c4ba4e325a26a77712074200319660c0e67e25679f1"
   license "CECILL-B"
-  revision 3
+  revision 4
   head "https://github.com/math-comp/math-comp.git", branch: "master"
 
   bottle do

--- a/Formula/m/math-comp.rb
+++ b/Formula/m/math-comp.rb
@@ -8,12 +8,12 @@ class MathComp < Formula
   head "https://github.com/math-comp/math-comp.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "5320ff41473750288cf0db83fad9d47d6f7abdf049e06c5c3d8b3e842cc78c4a"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "96651e338894cee2d72ac9e81ca04d197563aed19cf0db269fd54b3658f7e048"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "c73b30e611aa6128665e31bf5acdbb89f0dcae74ac9cd3d5c11b8180c2faec4d"
-    sha256 cellar: :any_skip_relocation, sonoma:        "71ef8662ce5d2bd912b828987b5dd0b0b9558f39664fd31ce2133d7a754f4002"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "a7800bbb07c16c85bab27349b72d65f05ea2a59adffbce0e959fa29c3652f7a1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "54480221ea4d58c13d3bc6a3fe133974f2bdf40183f7da0fd47c2da6c5631bda"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "03645172fd12fc8a419b3220cc5b868dbfd5ca1a8a36e9866b0a1479f37a4a18"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "094a1eb55c62fd05623d5277b9b427d6f1809e458e4fd064844c12cf9b977ec7"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "f361bef7077775dbe45ca087dd332aec5727bb1c577549b9e373321241bfbb23"
+    sha256 cellar: :any_skip_relocation, sonoma:        "f1b7e1c3a77f020fecae846ff27843f89fb7eb3f86a52cf9c3d74790219ba80e"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "562db5b63ed008ca669ffbadb7c3623ffa85a0857507302045f115222f1781d2"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "cdd53214167d5ec66265df1a429cf0d2914b01337d530147ef0cc0e5178b7613"
   end
 
   depends_on "ocaml" => :build

--- a/Formula/o/ocaml-findlib.rb
+++ b/Formula/o/ocaml-findlib.rb
@@ -12,13 +12,12 @@ class OcamlFindlib < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256               arm64_tahoe:   "6f6f7669b4187e082f14cb9c9f617bec4490a32d719caecad5b7f4d01dff2d91"
-    sha256               arm64_sequoia: "fca7c5a0a0cf78d4339970cee1d0a80605e4adce120ba9e75eaaaed96cd0055d"
-    sha256               arm64_sonoma:  "4cf42f610e5248913f7cf5b494ccb84384063c3a13470547fc573dc1a532e746"
-    sha256 cellar: :any, sonoma:        "4addf3b776fbe1b639f4c3f7412a04ba799125dbdc567b79879310401481bd54"
-    sha256               arm64_linux:   "06f20185aef240f8b740a0347c04e4ba2f912c912b8c36b3464cc54fafaa1f56"
-    sha256               x86_64_linux:  "26996e1d983d47ca18e8fef158d9254b94a2ea7e0399386f518e9935aaf032c4"
+    sha256               arm64_tahoe:   "b690ccd47c921760a3fd174d89de314aa63a417db08f3762af5931450b993703"
+    sha256               arm64_sequoia: "f8eab8fc29b9a4ad8c18baddaaa04b79af5baa4a8286d116fc575548045c045b"
+    sha256               arm64_sonoma:  "83c91809db7f64c9fecc52ba362bf77d204200a5465f8c1f8855e484fe4e9549"
+    sha256 cellar: :any, sonoma:        "0edf302c1fe0a1eb98dc206e8ecd200ba8427d7911de83fa07c75bca1ebc05f1"
+    sha256               arm64_linux:   "05a6b6652cbdaf56349e566a394c4b8d12af6e90fd9a0be3f8752026f385179f"
+    sha256               x86_64_linux:  "9749365e2bddc7e75a52a64f1405c56a78f7cbde07b630e93b89e640bbcabdb5"
   end
 
   depends_on "ocaml"

--- a/Formula/o/ocaml-findlib.rb
+++ b/Formula/o/ocaml-findlib.rb
@@ -4,7 +4,7 @@ class OcamlFindlib < Formula
   url "https://github.com/ocaml/ocamlfind/archive/refs/tags/findlib-1.9.8.tar.gz"
   sha256 "d6899935ccabf67f067a9af3f3f88d94e310075d13c648fa03ff498769ce039d"
   license "MIT"
-  revision 2
+  revision 3
 
   livecheck do
     url "https://opam.ocaml.org/packages/ocamlfind/"
@@ -52,5 +52,13 @@ class OcamlFindlib < Formula
   test do
     output = shell_output("#{bin}/ocamlfind query findlib")
     assert_equal "#{HOMEBREW_PREFIX}/lib/ocaml/findlib", output.chomp
+
+    # Check if we need to rebuild ocaml-findlib to be used as a library
+    (testpath/"test.ml").write <<~OCAML
+      open Findlib;;
+      Findlib.init();
+    OCAML
+    system Formula["ocaml"].opt_bin/"ocamlopt", "-I", lib/"ocaml/findlib", "-o", "test", "findlib.cmxa", "test.ml"
+    system "./test"
   end
 end

--- a/Formula/o/ocaml-num.rb
+++ b/Formula/o/ocaml-num.rb
@@ -4,6 +4,7 @@ class OcamlNum < Formula
   url "https://github.com/ocaml/num/archive/refs/tags/v1.6.tar.gz"
   sha256 "b5cce325449aac746d5ca963d84688a627cca5b38d41e636cf71c68b60495b3e"
   license "LGPL-2.1-only" => { with: "OCaml-LGPL-linking-exception" }
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "8ee79694c29aed327203abaa275dee7f5e041f318cd137c3a3eceaf487317cf6"

--- a/Formula/o/ocaml-num.rb
+++ b/Formula/o/ocaml-num.rb
@@ -7,12 +7,12 @@ class OcamlNum < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "8ee79694c29aed327203abaa275dee7f5e041f318cd137c3a3eceaf487317cf6"
-    sha256 cellar: :any,                 arm64_sequoia: "6ee1ee0d2051f4c239c9237132fa360040acd888fc3f1e22c7d09c8d848dfa23"
-    sha256 cellar: :any,                 arm64_sonoma:  "459cea86755ea336dfb81795e7b1bc2109129c4db64190bc1c06e2b90e644418"
-    sha256 cellar: :any,                 sonoma:        "10857c605731b1a3f944b1a3c6fcc03a2cca2857faa0ba46e0970413bb4a8b62"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "713ed3e565058a66c023563a55c0f53fd44d479b5cf0df611fd734913711837f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1558cfe67cec4a8ce6f51be96437ddcad3a4c0ebc017e8dac395b9aacb2afa70"
+    sha256 cellar: :any,                 arm64_tahoe:   "76c722dd8ad6f12ccdda09f952f5f6b0ac5d240c4bbb4ded7d78915cea582c3f"
+    sha256 cellar: :any,                 arm64_sequoia: "6e7f4d21c10922367590c1edce13ed4864b6aa7b75ed33d5533f0b08f9b3c101"
+    sha256 cellar: :any,                 arm64_sonoma:  "93da978a25ffe78f43852b07dd2dee9c06de67534ffaf389e96e8b5d3d152a2b"
+    sha256 cellar: :any,                 sonoma:        "b7eb0c9fbb0d0c9fc3234011c0954abea2c44774aeda331094897ed1363f37d8"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "1582f04ba6900e23021d99ef4450ae945935fde491e4fae1a24f05c22a690417"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "594ea85e889f5063ea86712ffc6930e71597c8b438b5d82663e925fdfdebd47b"
   end
 
   depends_on "ocaml-findlib" => :build

--- a/Formula/o/ocaml-zarith.rb
+++ b/Formula/o/ocaml-zarith.rb
@@ -4,7 +4,7 @@ class OcamlZarith < Formula
   url "https://github.com/ocaml/Zarith/archive/refs/tags/release-1.14.tar.gz"
   sha256 "5db9dcbd939153942a08581fabd846d0f3f2b8c67fe68b855127e0472d4d1859"
   license "LGPL-2.0-only"
-  revision 3
+  revision 4
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "f59725b44ef1aa8656404d833c812f2ff3d2a2bc539ef998fe5aa2baeb079f1c"

--- a/Formula/o/ocaml-zarith.rb
+++ b/Formula/o/ocaml-zarith.rb
@@ -7,12 +7,12 @@ class OcamlZarith < Formula
   revision 4
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "f59725b44ef1aa8656404d833c812f2ff3d2a2bc539ef998fe5aa2baeb079f1c"
-    sha256 cellar: :any,                 arm64_sequoia: "d023c1e616b868d7fb2a773eeb426aab87d0ad4cd102df7c4eccb5cd0c3e959e"
-    sha256 cellar: :any,                 arm64_sonoma:  "59b4a24ead8319c8837252ca0702265c46e3820aa5629b9a940412edd50ab144"
-    sha256 cellar: :any,                 sonoma:        "69a2fafdd5ad8ecdd81ba9e812289b760feeffd275df0aa5b2bfd346272ad87c"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "0fbd3299e51a580a8b64f03f0bf132f426a3d49d07c7cb03e4f3b2e7220520db"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "dee59068932c13b018ec393239f0d5c9691924998a76ea2d031da8eff1fb482e"
+    sha256 cellar: :any,                 arm64_tahoe:   "a5f328838a9fb4010132b59a63e5c0df644c9193377b500a0ff4e10bd83ee925"
+    sha256 cellar: :any,                 arm64_sequoia: "e3125a63143f1bf107f2760cab2e839500705fad697a9b98bdd566df97c97705"
+    sha256 cellar: :any,                 arm64_sonoma:  "06bdae53e7838821893c5cfd0a547fb4531732a2f84aceaf34537672cb3f20a7"
+    sha256 cellar: :any,                 sonoma:        "7eeba2fab635c73bae503c4f7188af67412ffd4f6a16b7eaa81e1bd206ef7839"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "43c9bf11d4fca48437a3f8a146be4bd517a79faa566d4fcf1b81d4afebf435d2"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "72e1e830a5e594e3bd966df2e426ff5c19c89aed7176cc5a277032017792a669"
   end
 
   depends_on "ocaml-findlib" => :build

--- a/Formula/o/ocaml.rb
+++ b/Formula/o/ocaml.rb
@@ -23,12 +23,12 @@ class Ocaml < Formula
   end
 
   bottle do
-    sha256               arm64_tahoe:   "9e52a52b1b531cb999c24f7f7d524f840b4630a376c3888c5e91875d15cda6ce"
-    sha256               arm64_sequoia: "0e269db9117ff10e44a62f85521a46f85da8c1dca79915795776f3a0f26ab5a5"
-    sha256               arm64_sonoma:  "f67dbb07c32a737b605e9d35e65efcf05af7e6e1618faa586dad50769d5f9ba4"
-    sha256 cellar: :any, sonoma:        "688925c23de05f913dd9ec435ae71281254892b7109e1feba690aba1567b764e"
-    sha256               arm64_linux:   "475f722bfa5f1f4bf2eabe93829a425bf7ad167a624ad3705ca5ab62b5436477"
-    sha256               x86_64_linux:  "9be36dc8f324cb8ef5267c9d80343860105a6f0d8c3e04394bb3f0233b3b40f1"
+    sha256               arm64_tahoe:   "67867c7587d4add83c1983325c2ffb7107760637fe817fd98bdbbc8ed374d00e"
+    sha256               arm64_sequoia: "8d8d03eebe087c0740b36890ec4d2446004a2f1ad848a5ee5f63bb0a79995aa5"
+    sha256               arm64_sonoma:  "a407be2f74a548097b732f4eeaf50a84bc73436b962eb27cb5e5b8d5e8fc33e9"
+    sha256 cellar: :any, sonoma:        "1dc2f870b89858601afc035baecb02c2aeaf3bcde60f7bf0e7c476812c28a998"
+    sha256               arm64_linux:   "9af91f4fb0c768a44e7747877f5b83c01cf24b323a40cfb9e1ec1e241a269079"
+    sha256               x86_64_linux:  "da0f6cc0e1b0cc66bfefc29d116b3fbffe482953574b8295764de313d40d1ae3"
   end
 
   # The ocaml compilers embed prefix information in weird ways that the default

--- a/Formula/o/ocaml.rb
+++ b/Formula/o/ocaml.rb
@@ -4,19 +4,17 @@
 #
 # Specific packages to pay attention to include:
 # - camlp5
-# - lablgtk
 #
 # Applications that really shouldn't break on a compiler update are:
-# - coq
 # - coccinelle
 # - unison
 class Ocaml < Formula
   desc "General purpose programming language in the ML family"
   homepage "https://ocaml.org/"
-  url "https://caml.inria.fr/pub/distrib/ocaml-5.4/ocaml-5.4.0.tar.xz"
-  sha256 "dfaa8a2e11c799bc1765d8bef44911406ee5f4803027190382a939f88c912266"
+  url "https://caml.inria.fr/pub/distrib/ocaml-5.4/ocaml-5.4.1.tar.xz"
+  sha256 "b1e297adc186635540758eb064c7fab025598ae4436f3b9767e5025188b4e0ab"
   license "LGPL-2.1-only" => { with: "OCaml-LGPL-linking-exception" }
-  compatibility_version 1
+  compatibility_version 2
   head "https://github.com/ocaml/ocaml.git", branch: "trunk"
 
   livecheck do

--- a/Formula/r/rocq-elpi.rb
+++ b/Formula/r/rocq-elpi.rb
@@ -14,12 +14,12 @@ class RocqElpi < Formula
   end
 
   bottle do
-    sha256 arm64_tahoe:   "66f5f79c9c0b247a4f4c257918e0060c8937d55356a9fa7ca899921be590fd2d"
-    sha256 arm64_sequoia: "4006e4d8afea43f2ba2f126cbecdc7b60cadd6d85d5d94546f48db09ba6b2e41"
-    sha256 arm64_sonoma:  "2f95a9e10ad415d91f6776009016092d7cb9ad6cd6cb6707be0b8246592c917a"
-    sha256 sonoma:        "f940e54ae99807217f998c0f3207d7716be6d3611fb78a3b3bf06c5efa0a6f3c"
-    sha256 arm64_linux:   "8ed9b4772fb83b3987a52021245e1bb9fff7da3aff1fe73bdd7b5df4f049ddfb"
-    sha256 x86_64_linux:  "7b8c260e31ca799133d58cc8db868b47be10961b1fc1f1c5e9f029ff685d38b7"
+    sha256 arm64_tahoe:   "bf16e11e81aed811ff3370122873ec135f0476d5330b19b23d7739e170bf6713"
+    sha256 arm64_sequoia: "5f85a3d033ed19eb30ccf6e830beafeebcb7e103c7499ba6286499f09e91250b"
+    sha256 arm64_sonoma:  "633a069ba51abb921442b4e1595ed42afe8b04457642fb8dbec23bc4538a8012"
+    sha256 sonoma:        "f97723ee6985064bae456a0ac66f9a1aa2a4c6bce468b9c7a9c8f2d43154a390"
+    sha256 arm64_linux:   "f41e452874613a8407aa014a926e1d5f9ff9bbfd602f915012f4e4cbf817dd00"
+    sha256 x86_64_linux:  "e43ac552f0e02fc52356122e1069a60266d814aff7082300e4869bbad7d64259"
   end
 
   depends_on "dune" => :build

--- a/Formula/r/rocq-elpi.rb
+++ b/Formula/r/rocq-elpi.rb
@@ -5,6 +5,7 @@ class RocqElpi < Formula
   url "https://github.com/LPCIC/coq-elpi/releases/download/v3.3.1/rocq-elpi-3.3.1.tar.gz"
   sha256 "97468eea82299c7276ea5e1047342e8897de5a437a357e595a5728183ea66721"
   license "LGPL-2.1-or-later"
+  revision 1
   compatibility_version 1
 
   livecheck do

--- a/Formula/r/rocq.rb
+++ b/Formula/r/rocq.rb
@@ -21,12 +21,12 @@ class Rocq < Formula
   end
 
   bottle do
-    sha256 arm64_tahoe:   "b8360a844ef669a0b3b08a9a5a3dfe296902688ce6fbad6a7e9a612954e8e47f"
-    sha256 arm64_sequoia: "1a8d48139fa5839cdc196c5d4f79823d0a47b6f68f15f367091f16b628fe1c11"
-    sha256 arm64_sonoma:  "e534440b771adc163d4ecc14f72ec5efffd6e2e2b4c0f880c47c0dab281a4ff2"
-    sha256 sonoma:        "ab3466cbae6cc0d9a150993ef372cb7116b0b8e2347fcb1f63603c1d5327f665"
-    sha256 arm64_linux:   "9c307986f20b14744bb1cf125096710f009d8c40a83834ca02b93ac198e730ce"
-    sha256 x86_64_linux:  "a537821e69bdddf8dfc88fdfa542adf4e1fcc05886d6056fc4e5bb3c11dee459"
+    sha256 arm64_tahoe:   "115c48fed35576b8543ee131ce2e7d76aacbaf41bf26ba748da6e91318ac47e6"
+    sha256 arm64_sequoia: "6189d339f699d4741e897e3dd72b5e1b3166882cb5f8daaa0ee1e51577a98c95"
+    sha256 arm64_sonoma:  "00d13e12440801af1ca6c5511d1d25ed42aced5b2bb42156ad115add4abfb76e"
+    sha256 sonoma:        "d8cc0cb44561d73766ce10cdc1bdf105d07f98d0ba1cc478ea97d199500e4da3"
+    sha256 arm64_linux:   "0444ebaece6e0db5bff8c49dccdff11aeda920b641f5bef478ee54a667f7f59b"
+    sha256 x86_64_linux:  "d260c686d4408133e018b5035683bd963f4b0844af66f9890307929965f908b1"
   end
 
   head do

--- a/Formula/r/rocq.rb
+++ b/Formula/r/rocq.rb
@@ -2,6 +2,7 @@ class Rocq < Formula
   desc "Proof assistant for higher-order logic"
   homepage "https://rocq-prover.org/"
   license "LGPL-2.1-only"
+  revision 1
   compatibility_version 1
 
   stable do


### PR DESCRIPTION
Officially released but looks like upstream didn't modify https://ocaml.org/releases

Shows up on https://ocaml.org/changelog with release date of 2026-02-17.

Can also see other release announcements:
- https://ocaml.org/changelog/2026-02-17-ocaml-541-and-4143
- https://discuss.ocaml.org/t/ocaml-5-4-1-and-4-14-3-released/17822
- https://github.com/ocaml/ocaml/releases/tag/5.4.1

Also default installed after running `opam init`:
```console
❯ opam list | grep compiler
ocaml                 5.4.1       The OCaml compiler (virtual package)
ocaml-base-compiler   5.4.1       Official release of OCaml 5.4.1
ocaml-compiler        5.4.1       Official release of OCaml 5.4.1
```

For now just leaving livecheck. Can consider changing if same issue in next release.