### PR TITLE
llvm: fix finding config files with `-no-canonical-prefixes`

### DIFF
--- a/Formula/f/flang.rb
+++ b/Formula/f/flang.rb
@@ -99,6 +99,8 @@ class Flang < Formula
     configs = ["-resource-dir=#{llvm.opt_prefix/relative_resource_dir}"]
     configs << "-Wl,-lto_library,#{llvm.opt_lib}/libLTO.dylib" if OS.mac?
     (libexec/"flang.cfg").atomic_write "#{configs.join("\n")}\n"
+
+    (prefix/"etc").install_symlink etc/"clang"
   end
 
   test do
@@ -166,7 +168,7 @@ class Flang < Formula
     return if OS.linux?
     return unless (etc/"clang").exist? # https://github.com/Homebrew/homebrew-test-bot/issues/805
 
-    assert_match %r{^Configuration file: #{Regexp.escape(etc)}/clang/.*\.cfg$}i,
+    assert_match %r{^Configuration file: .*/etc/clang/.*\.cfg$}i,
                  shell_output("#{bin}/flang --version")
   end
 end

--- a/Formula/f/flang.rb
+++ b/Formula/f/flang.rb
@@ -12,12 +12,13 @@ class Flang < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "f2db3d117ae0dff996faac0369f91cde670416dbb4d05a0e51ac80aa0e9ed158"
-    sha256 cellar: :any,                 arm64_sequoia: "9f3394c65540a5c725bb620cc3b0282986fc4510e52ccb3687f78ed1f53ff489"
-    sha256 cellar: :any,                 arm64_sonoma:  "6b9268d80ecc7806dc3435f1eed514ad7a1f03dbd747065c0eac39feef312461"
-    sha256 cellar: :any,                 sonoma:        "350a234bf10be21e18a016a8c6dd54f65d9a7072fdc491ae0192697e6b9d074f"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "c1b4a1dd76fbb498663ee6c8fe0d94df37c5b4eaa22cc86417ea9cd76b994914"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "16629e08e42dfdc136305e160f7482990cc68c9d38ee6f48e305f8efe2f1c4cc"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "123962c5ce9986392d4b16db2a5f84e8e1ba052073275bae029d5e536abfb83f"
+    sha256 cellar: :any,                 arm64_sequoia: "435179300904ed8f63c3cd308e4eef41d2de36c86349fe24cabb872714a03316"
+    sha256 cellar: :any,                 arm64_sonoma:  "f800e73bc3b94466b6a46c561c7d8840753a43bc31c5f6734c5450aa52105090"
+    sha256 cellar: :any,                 sonoma:        "b2709f3acbedce9ab7b713111c0c1f43e3ca2de5b404c5cf996ac6f6bb654dd1"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "2694276366cc208701eaa0d80b52c65552e62821003f5d0d0c7341a74dbd9618"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0ffe757e4ab4fb71a4673cf261b1dfe5c36d25d4c7d1b2e50293a0e72b81666d"
   end
 
   depends_on "cmake" => :build

--- a/Formula/l/llvm.rb
+++ b/Formula/l/llvm.rb
@@ -132,7 +132,7 @@ class Llvm < Formula
       -DCLANG_PYTHON_BINDINGS_VERSIONS=#{python_versions.join(";")}
       -DLLVM_CREATE_XCODE_TOOLCHAIN=OFF
       -DCLANG_FORCE_MATCHING_LIBCLANG_SOVERSION=OFF
-      -DCLANG_CONFIG_FILE_SYSTEM_DIR=#{clang_config_file_dir.relative_path_from(bin)}
+      -DCLANG_CONFIG_FILE_SYSTEM_DIR=../etc/clang
       -DCLANG_CONFIG_FILE_USER_DIR=~/.config/clang
     ]
 
@@ -395,6 +395,10 @@ class Llvm < Formula
       system "cmake", "--build", "."
       system "cmake", "--build", ".", "--target", "install"
     end
+
+    clang_config_file_dir.mkpath
+    touch clang_config_file_dir/".keepme"
+    (prefix/"etc").install_symlink clang_config_file_dir
 
     if OS.mac?
       # Get the version from `llvm-config` to get the correct HEAD or RC version too.
@@ -833,5 +837,11 @@ class Llvm < Formula
         end
       end
     end
+
+    return if OS.linux?
+    return unless clang_config_file_dir.exist? # https://github.com/Homebrew/homebrew-test-bot/issues/805
+
+    assert_match("Configuration file: #{opt_prefix}/etc/clang/",
+                 shell_output("#{opt_bin}/clang --version -no-canonical-prefixes"))
   end
 end

--- a/Formula/l/llvm.rb
+++ b/Formula/l/llvm.rb
@@ -24,12 +24,13 @@ class Llvm < Formula
   end
 
   bottle do
-    sha256                               arm64_tahoe:   "2e9357a9dc0143d1f9f71b0f84b2085c3266f5d510e7045574bc6128453ea5f2"
-    sha256                               arm64_sequoia: "75b1748d3ec6ccc427aec259b680bc73781504c152e612033d3ae04bcc335aac"
-    sha256                               arm64_sonoma:  "abf74a45f7b5ce253725b75315c8694c07ddce124a546f5ec5396de5e993381a"
-    sha256 cellar: :any,                 sonoma:        "aebac4aacc590fb33de2d3b665dda8397c8f0a301f262a91df55582fe3a4a4a6"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "ef1cdaf4ae35e7880cefde57b059a2c58babf6bcb7e136d7e560f1b91fec3674"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "7d18a9a91d52c0ba8eec085fe3aa832644d963775793d0f31f75cb9f25ded1df"
+    rebuild 1
+    sha256                               arm64_tahoe:   "4fb519b216308fa5ec95d91514159ae879e392a14176ba15088dc190daa38d02"
+    sha256                               arm64_sequoia: "f0dc9fd75dbaa423912c379f7d843710443ee3c30a54e29107b82c9889a74c9f"
+    sha256                               arm64_sonoma:  "17a3d9fae29ab75ea4497cd1bd78297f38da0c86d5a53b349f7ae7b2d949f638"
+    sha256 cellar: :any,                 sonoma:        "22c5be28e47c1e60b7917e7e891eec8a000d6500c6316182ee06ff32e905865f"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "46949c7b4eac0568064a5c742c58a9575927d5687227dc98ceba00c4c775757f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "03e0a8e736177979fadf63db623303c5526b90e147e8ebaf65e532206ba32640"
   end
 
   keg_only :provided_by_macos


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Fixes #220757.
