### PR TITLE
glibc@2.13, glibc@2.17: update `keg_only` reason to prevent auto-linking

### DIFF
--- a/Formula/g/glibc@2.13.rb
+++ b/Formula/g/glibc@2.13.rb
@@ -76,7 +76,7 @@ class GlibcAT213 < Formula
     sha256 x86_64_linux: "fcfd8511ae57b126f377789db1294e74bd48c2be941badd8e33a378dbdef9e16"
   end
 
-  keg_only :versioned_formula
+  keg_only "it can shadow system glibc if linked"
 
   depends_on GawkRequirement => :build
   depends_on "linux-headers@4.4" => :build

--- a/Formula/g/glibc@2.17.rb
+++ b/Formula/g/glibc@2.17.rb
@@ -77,7 +77,7 @@ class GlibcAT217 < Formula
     sha256 x86_64_linux: "23e8506f5365138f86d33a39c62dd543813acdc71d160c9de6bde623c6b2d1ef"
   end
 
-  keg_only :versioned_formula
+  keg_only "it can shadow system glibc if linked"
 
   depends_on GawkRequirement => :build
   depends_on "linux-headers@4.4" => :build

--- a/audit_exceptions/versioned_keg_only_allowlist.json
+++ b/audit_exceptions/versioned_keg_only_allowlist.json
@@ -9,6 +9,8 @@
   "gcc@12",
   "gcc@13",
   "gcc@14",
+  "glibc@2.13",
+  "glibc@2.17",
   "glibmm@2.66",
   "gnupg@1.4",
   "icu4c@78",


### PR DESCRIPTION
Needed to unblock: https://github.com/Homebrew/homebrew-core/pull/272691