### PR TITLE
trivy: downgrade to 0.69.3

### DIFF
--- a/Formula/t/trivy.rb
+++ b/Formula/t/trivy.rb
@@ -1,8 +1,8 @@
 class Trivy < Formula
   desc "Vulnerability scanner for container images, file systems, and Git repos"
   homepage "https://trivy.dev/"
-  url "https://github.com/aquasecurity/trivy/archive/refs/tags/v0.69.4.tar.gz"
-  sha256 "3350da5e45f99ec86eec5cb87efe84241d82a019822e4270facb818519778d12"
+  url "https://github.com/aquasecurity/trivy/archive/refs/tags/v0.69.3.tar.gz"
+  sha256 "3ca5fa62932273dd7eef3b6ec762625da42304ebb8f13e4be9fdd61545ca1773"
   license "Apache-2.0"
   head "https://github.com/aquasecurity/trivy.git", branch: "main"
 


### PR DESCRIPTION
# Note to users

This PR was a precautionary measure in response to the security incident at Trivy. 0.69.4 was also a pulled release.

Users who had installed 0.69.4 from homebrew-core were however not affected by the security incident. The security breach affected upstream binaries only but homebrew-core formulae never use upstream binaries and always build from source. End users use binaries built on our own CI infrastructure.

These findings were confirmed in upstream's security advisory which details which install sources were compromised: https://github.com/aquasecurity/trivy/security/advisories/GHSA-69fq-xp46-6x23.

---

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
