### PR TITLE
sqlite-utils: build an `:all` bottle

### DIFF
--- a/Formula/s/sqlite-utils.rb
+++ b/Formula/s/sqlite-utils.rb
@@ -56,6 +56,15 @@ class SqliteUtils < Formula
   def install
     virtualenv_install_with_resources
 
+    # Ensure uniform bottles: upstream hardcodes both /opt/homebrew (ARM)
+    # and /usr/local (Intel) in SPATIALITE_PATHS; normalise to HOMEBREW_PREFIX
+    # so all platforms produce identical output after relocation.
+    site_packages = libexec/Language::Python.site_packages("python3")
+    inreplace site_packages/"sqlite_utils/utils.py" do |s|
+      s.gsub!("/opt/homebrew", HOMEBREW_PREFIX)
+      s.gsub!("/usr/local", HOMEBREW_PREFIX)
+    end
+
     generate_completions_from_executable(bin/"sqlite-utils", shell_parameter_format: :click)
   end
 

--- a/Formula/s/sqlite-utils.rb
+++ b/Formula/s/sqlite-utils.rb
@@ -8,12 +8,8 @@ class SqliteUtils < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "101286c6739f5cc0bfd502ad4a2c68767f917adfae4410b5fa7324ca8502ded4"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "101286c6739f5cc0bfd502ad4a2c68767f917adfae4410b5fa7324ca8502ded4"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "101286c6739f5cc0bfd502ad4a2c68767f917adfae4410b5fa7324ca8502ded4"
-    sha256 cellar: :any_skip_relocation, sonoma:        "90d9defe35dffeee6ef36ca08c0ce5b7f7de8042ffb0b14c9af6e0a8a1150e3a"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "90d9defe35dffeee6ef36ca08c0ce5b7f7de8042ffb0b14c9af6e0a8a1150e3a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "90d9defe35dffeee6ef36ca08c0ce5b7f7de8042ffb0b14c9af6e0a8a1150e3a"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "c0e99d36e603786d51605e4d9ff62d9ef8de3c71322e7635c4c4b50dda79d163"
   end
 
   depends_on "python@3.14"

--- a/disabled_new_usr_local_relocation_formulae.json
+++ b/disabled_new_usr_local_relocation_formulae.json
@@ -8,5 +8,6 @@
   "python-setuptools",
   "rabbitmq",
   "ruby-install",
+  "sqlite-utils",
   "zsh-completions"
 ]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source sqlite-utils`?
- [x] Does your build pass `brew test sqlite-utils` and `brew audit --strict sqlite-utils`?

---

~~Replace `/opt/homebrew` reference in `sqlite_utils/utils.py` (the `SPATIALITE_PATHS` tuple) with `HOMEBREW_PREFIX` to make bottles uniform across platforms.~~

~~**Diffoscope analysis:** The only difference between arm64 macOS and Intel macOS/Linux bottles is a single line in `utils.py` where `/opt/homebrew/lib/mod_spatialite.dylib` appears on ARM but `@@HOMEBREW_PREFIX@@/lib/mod_spatialite.dylib` on Intel (after relocation). This `inreplace` makes all platforms produce identical output.~~

**Updated:** Replace both `/opt/homebrew` (ARM) and `/usr/local` (Intel) references in `sqlite_utils/utils.py` SPATIALITE_PATHS with `HOMEBREW_PREFIX`. Added `sqlite-utils` to `disabled_new_usr_local_relocation_formulae.json` because the selective `/usr/local` relocation (`keg_relocate.rb`) skips `/usr/local/lib` paths, which would leave Intel bottles un-relocated.

Ref #191352