### PR TITLE
keyring: build an `:all` bottle

### DIFF
--- a/Formula/k/keyring.rb
+++ b/Formula/k/keyring.rb
@@ -66,6 +66,10 @@ class Keyring < Formula
     without = %w[jeepney secretstorage] unless OS.linux?
     virtualenv_install_with_resources(without:)
 
+    # Ensure uniform bottles
+    site_packages = libexec/Language::Python.site_packages("python3")
+    inreplace site_packages.glob("keyring-*dist-info/METADATA"), "/opt/homebrew", HOMEBREW_PREFIX
+
     generate_completions_from_executable(bin/"keyring", "--print-completion", shells: [:bash, :zsh])
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source keyring`?
- [x] Does your build pass `brew test keyring` and `brew audit --strict keyring`?

---

Replace `/opt/homebrew` reference in `keyring-*dist-info/METADATA` with `HOMEBREW_PREFIX` to make bottles uniform across platforms.

**Diffoscope analysis:** The only difference between arm64 macOS and Intel macOS bottles is a documentation line in the dist-info METADATA referencing `/opt/homebrew/share` on ARM but `@@HOMEBREW_PREFIX@@/share` on Intel. This `inreplace` makes all platforms produce identical output.

Ref #191352