### PR TITLE
alot: update resources, add workaround for autobump

### DIFF
--- a/Formula/a/alot.rb
+++ b/Formula/a/alot.rb
@@ -10,13 +10,13 @@ class Alot < Formula
   head "https://github.com/pazz/alot.git", branch: "master"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "3f75efaa2b8a673e7c156d2fe2f85351e16f96996ce3745aec793a3ab595601a"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "91861d611c164dce0fffacb4b2635184e2bdf99ec2d8c3facc3f1ec37fc99d91"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "e276e9f74c21c55d1eef6bd0c5e22d2d412b7a52a1553cbed0e9bb1ce43046b4"
-    sha256 cellar: :any_skip_relocation, sonoma:        "dec524cd4c1013942005765ec9478e8cbbc39ffe5ba909799414a97ecebc8111"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "e0e294acc48f6670c5d9bd420a95ba19b124c6da01f57c846e7f93c6e1ef32a4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5295e73a1b7fbe558a8ac1654654139f6f9b2dde2648bd16d58e1c80ec039925"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "4e86a0ce97d6cc8a8304488d2effccc54c982a8af7ec914166b63869b9c5f973"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "3eba4481b042e48b8ddb83af29f6b08acd482a32f56bebdb21ba9b7c8b4279c8"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "ec6a1dd495e088b77c06b1a15825c4f54b09f3af1362f570083ec45ceb9de2f1"
+    sha256 cellar: :any_skip_relocation, sonoma:        "0146d2771d5a6ba5bbe478f357bed586a45742432e1ac1cc76b6a5d3ea18ad62"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "3b7c69764ff639df46ddf9005590910f67f456da7a693de2d6b89052ff87838d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "840419a87627aa0cf71ddf62fc064883b133623a7b8a1eb0a5c8f1f368c7ba3f"
   end
 
   depends_on "sphinx-doc" => :build

--- a/Formula/a/alot.rb
+++ b/Formula/a/alot.rb
@@ -3,15 +3,11 @@ class Alot < Formula
 
   desc "Text mode MUA using notmuch mail"
   homepage "https://github.com/pazz/alot"
-  # TODO: check if we can remove `standard-mailcap` from `pypi_packages`
-  # https://github.com/pazz/alot/issues/1632
   url "https://github.com/pazz/alot.git",
       tag:      "v0.12",
       revision: "40a190f4c5f18c1283fdb3186393c4a778f865a5"
   license "GPL-3.0-only"
   head "https://github.com/pazz/alot.git", branch: "master"
-
-  no_autobump! because: "`update-python-resources` cannot determine dependencies"
 
   bottle do
     rebuild 1
@@ -30,12 +26,13 @@ class Alot < Formula
   depends_on "notmuch"
   depends_on "python@3.14"
 
-  pypi_packages exclude_packages: "notmuch2",
-                extra_packages:   "standard-mailcap"
+  # Dependencies include non-PyPI packages so cannot use Homebrew's default resolver
+  pypi_packages package_name:   "",
+                extra_packages: %w[configobj python-magic standard-mailcap twisted urwid urwidtrees]
 
   resource "attrs" do
-    url "https://files.pythonhosted.org/packages/6b/5c/685e6633917e101e5dcb62b9dd76946cbb57c26e133bae9e0cd36033c0a9/attrs-25.4.0.tar.gz"
-    sha256 "16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11"
+    url "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz"
+    sha256 "d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32"
   end
 
   resource "automat" do
@@ -68,24 +65,14 @@ class Alot < Formula
     sha256 "87d3480dbb083c1d736222511a8cf380012a8176c2456d01ef483242abbbcf8c"
   end
 
-  resource "mock" do
-    url "https://files.pythonhosted.org/packages/07/8c/14c2ae915e5f9dca5a22edd68b35be94400719ccfa068a03e0fb63d0f6f6/mock-5.2.0.tar.gz"
-    sha256 "4e460e818629b4b173f32d08bf30d3af8123afbb8e04bb5707a1fd4799e503f0"
+  resource "packaging" do
+    url "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz"
+    sha256 "00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4"
   end
 
   resource "python-magic" do
     url "https://files.pythonhosted.org/packages/da/db/0b3e28ac047452d079d375ec6798bf76a036a08182dbb39ed38116a49130/python-magic-0.4.27.tar.gz"
     sha256 "c1ba14b08e4a5f5c31a302b7721239695b2f0f058d125bd5ce1ee36b9d9d3c3b"
-  end
-
-  resource "setuptools" do
-    url "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz"
-    sha256 "f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c"
-  end
-
-  resource "six" do
-    url "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz"
-    sha256 "ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"
   end
 
   resource "standard-mailcap" do
@@ -115,26 +102,38 @@ class Alot < Formula
   end
 
   resource "urwid" do
-    url "https://files.pythonhosted.org/packages/bb/d3/09683323e2290732a39dc92ca5031d5e5ddda56f8d236f885a400535b29a/urwid-3.0.3.tar.gz"
-    sha256 "300804dd568cda5aa1c5b204227bd0cfe7a62cef2d00987c5eb2e4e64294ed9b"
+    url "https://files.pythonhosted.org/packages/b1/59/67cd42db7c549c0c106d2b56d2d2ec1915c459e0a92722029efc5359e871/urwid-3.0.5.tar.gz"
+    sha256 "24be27ffafdb68c09cd95dc21b60ccfd02843320b25ce5feee1708b34fad5a23"
   end
 
   resource "urwidtrees" do
-    url "https://files.pythonhosted.org/packages/43/e1/ca5cf122cf1121b55acb39a1fb7e9fb1283c2eb0dc75fca751eb8c16b2f9/urwidtrees-1.0.3.tar.gz"
-    sha256 "50b19c06b03a5a73e561757a26d449cfe0c08afabe5c0f3cd4435596bdddaae9"
+    url "https://files.pythonhosted.org/packages/9f/a9/d98891fd9c143fb42277cb9a396aad5db76ed64bf747cb32ac19baaf04fa/urwidtrees-1.0.4.tar.gz"
+    sha256 "e693a0292e03092ba00abcfa2fa2537233be3696c4313d285b1eff94a4a45d4d"
   end
 
   resource "wcwidth" do
-    url "https://files.pythonhosted.org/packages/24/30/6b0809f4510673dc723187aeaf24c7f5459922d01e2f794277a3dfb90345/wcwidth-0.2.14.tar.gz"
-    sha256 "4d478375d31bc5395a3c55c40ccdf3354688364cd61c4f6adacaa9215d0b3605"
+    url "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz"
+    sha256 "cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159"
   end
 
   resource "zope-interface" do
-    url "https://files.pythonhosted.org/packages/71/c9/5ec8679a04d37c797d343f650c51ad67d178f0001c363e44b6ac5f97a9da/zope_interface-8.1.1.tar.gz"
-    sha256 "51b10e6e8e238d719636a401f44f1e366146912407b58453936b781a19be19ec"
+    url "https://files.pythonhosted.org/packages/86/a4/77daa5ba398996d16bb43fc721599d27d03eae68fe3c799de1963c72e228/zope_interface-8.2.tar.gz"
+    sha256 "afb20c371a601d261b4f6edb53c3c418c249db1a9717b0baafc9a9bb39ba1224"
+  end
+
+  # Check for any changes needed in `extra_packages`
+  def check_pypi_extra_packages
+    pypi_deps = File.read("pyproject.toml")[/^dependencies\s*=\s*\[\s*"([^\]]*)"\s*,?\s*\]/, 1]
+    odie "Failed to parse PyPI dependencies from pyproject.toml!" if pypi_deps.nil?
+
+    pypi_deps = pypi_deps.split(/"\s*,\s*"/).map { |pypi_dep| pypi_dep[/^([a-z0-9._-]+)/i, 1] }
+    pypi_deps -= %w[gpg notmuch2]
+    pypi_deps.sort!
+    odie "Parsed extra_packages: #{pypi_deps.inspect}" if pypi_packages_info.extra_packages != pypi_deps
   end
 
   def install
+    check_pypi_extra_packages if build.stable?
     venv = virtualenv_install_with_resources
 
     pkgshare.install Pathname("extra").children - [Pathname("extra/completion")]


### PR DESCRIPTION
Not possible to use Homebrew's PyPI resolver, i.e.
`pip install -q --no-deps --dry-run --report <https-url>`

Pip is not able to handle non-PyPI dependencies like gpg and notmuch2 (latter does have an unofficial package but probably better to avoid).

Rough check to make sure manual dependencies are up-to-date. May require touching up in future but at least more accurate than manually modifying resources.