### PR TITLE
cmd/determine-rebottle-runners: use LINUX_CI_ARM_RUNNER

### DIFF
--- a/cmd/determine-rebottle-runners.rb
+++ b/cmd/determine-rebottle-runners.rb
@@ -22,7 +22,7 @@ module Homebrew
       sig { params(arch: Symbol, timeout: Integer).returns(T::Hash[Symbol, T.any(String, T::Hash[Symbol, String])]) }
       def linux_runner_spec(arch, timeout)
         linux_runner = if arch == :arm64
-          "ubuntu-22.04-arm"
+          OS::LINUX_CI_ARM_RUNNER
         elsif timeout > 360
           "linux-self-hosted-1"
         else


### PR DESCRIPTION
Needs:
- https://github.com/Homebrew/brew/pull/21787

Although it doesn't really matter which Ubuntu runner we use (given we use a container), old versions usually get removed at end of standard support (e.g. GitHub is planning removal of `ubuntu-22.04` in Apr 2027).

Seems lower maintenance to just update this in a single location.