### PR TITLE
kubectx 0.10.0

### DIFF
--- a/Formula/k/kubectx.rb
+++ b/Formula/k/kubectx.rb
@@ -6,6 +6,15 @@ class Kubectx < Formula
   license "Apache-2.0"
   head "https://github.com/ahmetb/kubectx.git", branch: "master"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "95ff800339b3b2676da1f161d3b16152d2a42ff53e8f326386d48ecee2d60f0a"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "95ff800339b3b2676da1f161d3b16152d2a42ff53e8f326386d48ecee2d60f0a"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "95ff800339b3b2676da1f161d3b16152d2a42ff53e8f326386d48ecee2d60f0a"
+    sha256 cellar: :any_skip_relocation, sonoma:        "0a0c0b9585eb033f00a2cc66e83103c04a98f78d75b1ed59c3e7700360e80c38"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "5247260e65b79f83ca8e0c99eb957b941429d352229bf1cfc016f39d0631456f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e140d415df2320fb2c039d52e234a53355574b26e0e4dd4c1fa195321c4d9009"
+  end
+
   depends_on "go" => :build
 
   def install

--- a/Formula/k/kubectx.rb
+++ b/Formula/k/kubectx.rb
@@ -1,20 +1,17 @@
 class Kubectx < Formula
   desc "Tool that can switch between kubectl contexts easily and create aliases"
   homepage "https://github.com/ahmetb/kubectx"
-  url "https://github.com/ahmetb/kubectx/archive/refs/tags/v0.9.5.tar.gz"
-  sha256 "c94392fba8dfc5c8075161246749ef71c18f45da82759084664eb96027970004"
+  url "https://github.com/ahmetb/kubectx/archive/refs/tags/v0.10.0.tar.gz"
+  sha256 "efcedc14a1cb7e4d0c9b0e8b50fbecf5a24b337f8df7b018fb70a50420fcd27a"
   license "Apache-2.0"
   head "https://github.com/ahmetb/kubectx.git", branch: "master"
 
-  bottle do
-    rebuild 2
-    sha256 cellar: :any_skip_relocation, all: "6552e91e68ff8abda73be837c80539b47e3aadc73e5f8bab57cbb3bf0356c682"
-  end
-
-  depends_on "kubernetes-cli"
+  depends_on "go" => :build
 
   def install
-    bin.install "kubectx", "kubens"
+    ldflags = "-s -w -X main.version=v#{version}"
+    system "go", "build", *std_go_args(ldflags:, output: bin/"kubectx"), "./cmd/kubectx"
+    system "go", "build", *std_go_args(ldflags:, output: bin/"kubens"), "./cmd/kubens"
 
     ln_s bin/"kubectx", bin/"kubectl-ctx"
     ln_s bin/"kubens", bin/"kubectl-ns"
@@ -29,5 +26,7 @@ class Kubectx < Formula
   test do
     assert_match "USAGE:", shell_output("#{bin}/kubectx -h 2>&1")
     assert_match "USAGE:", shell_output("#{bin}/kubens -h 2>&1")
+    assert_match version.to_s, shell_output("#{bin}/kubectx -V")
+    assert_match version.to_s, shell_output("#{bin}/kubens -V")
   end
 end


### PR DESCRIPTION
## Summary

- Upgrade kubectx from 0.9.5 to 0.10.0
- Switch from shipping bash scripts (`kubectx`/`kubens`) to compiled Go binaries built from `cmd/kubectx` and `cmd/kubens`
- Remove `kubernetes-cli` runtime dependency (Go binary reads kubeconfig directly via `client-go`)
- Add `go` as a build dependency
- Add version assertions to tests

> [!IMPORTANT]
> **This version switches kubectx/kubens CLI tools from their bash script-based implementations to Go binary implementations** that have been in development for several years.
> If you see any issues, please report them at [ahmetb/kubectx](https://github.com/ahmetb/kubectx) repository and we'll get to it!

## Test plan

- [x] `brew style kubectx` — no offenses
- [x] `brew audit --strict kubectx` — clean
- [x] `brew install --build-from-source kubectx` — builds successfully
- [x] `brew test kubectx` — all assertions pass
- [x] Verified installed binaries are Mach-O arm64 executables (not scripts)
- [x] Verified `kubectx -V` / `kubens -V` output correct version
- [x] Verified `kubectl-ctx` and `kubectl-ns` symlinks are created