### PR TITLE
pipewire: unbundle `lua`

### DIFF
--- a/Formula/p/pipewire.rb
+++ b/Formula/p/pipewire.rb
@@ -15,8 +15,9 @@ class Pipewire < Formula
   end
 
   bottle do
-    sha256 arm64_linux:  "147b6a69957a3e72775e9bfed7c7c01b431393332b8ac87da976132bc8bdf914"
-    sha256 x86_64_linux: "9efc9a35bda5feb4c008f7f243c2a2309653e8724124227010892129d76fd4ef"
+    rebuild 1
+    sha256 arm64_linux:  "b95f6d975e3b592509118a9d80764e7f0a423ecca22349ca33019f1f0a1cda17"
+    sha256 x86_64_linux: "bfe9e2897ff11be6884c59ad00a1f7cd3a13099dd6f94776c1ecbf32e89ecae8"
   end
 
   depends_on "meson" => :build

--- a/Formula/p/pipewire.rb
+++ b/Formula/p/pipewire.rb
@@ -29,6 +29,7 @@ class Pipewire < Formula
   depends_on "gstreamer"
   depends_on "libsndfile"
   depends_on :linux
+  depends_on "lua"
   depends_on "ncurses"
   depends_on "openssl@3"
   depends_on "opus"
@@ -41,6 +42,7 @@ class Pipewire < Formula
       -Dexamples=disabled
       -Dtests=disabled
       -Dudevrulesdir=#{lib}/udev/rules.d
+      -Dwireplumber:system-lua=true
     ]
 
     system "meson", "setup", "build", *args, *std_meson_args


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Avoids installation of a conflicting liblua.a.

In future PR, will try splitting out `wireplumber` similar to Linux distros.

Also need to figure out how to split/pare-down formula, e.g.
- Perhaps we should go for minimal library and ship `libpipewire` separately
- Or only split out the heavyweight extras like `gstreamer` plugin (which I'm guessing doesn't actually work by default given our GStreamer only searches plugins within its prefix)

Decision will likely be based on how easy it is to hack up build system to support this. I think latter may be simpler (i.e. we can always disable GStreamer support and defer decision of adding plugin later on).
