### PR TITLE
mcs 2026.3.17 (new formula)

### DIFF
--- a/Formula/m/mcs.rb
+++ b/Formula/m/mcs.rb
@@ -1,0 +1,20 @@
+class Mcs < Formula
+  desc "Reproducible AI infrastructure for Claude Code"
+  homepage "https://github.com/bguidolim/mcs"
+  url "https://github.com/bguidolim/mcs/archive/refs/tags/2026.3.17.tar.gz"
+  sha256 "c9bb3ae4bf1a5e22f7875ff596541d7dd6338c626c26e7f3a326799fff6cc75d"
+  license "MIT"
+
+  depends_on :macos
+
+  uses_from_macos "swift" => :build
+
+  def install
+    system "swift", "build", "--disable-sandbox", "-c", "release"
+    bin.install ".build/release/mcs"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/mcs --version")
+  end
+end


### PR DESCRIPTION
New formula: **mcs** — Configure Claude Code with MCP servers, plugins, skills, and hooks.

- Homepage: https://github.com/bguidolim/mcs
- 76+ GitHub stars
- MIT license
- macOS-only (`depends_on :macos`)
- Swift CLI built from source via SPM

Previously distributed via personal tap (`bguidolim/tap/managed-claude-stack`).

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. Claude Code (claude-opus-4-6) assisted with researching homebrew-core requirements, designing the formula (modeled after SwiftLint's formula pattern), and drafting this PR description. The formula was manually reviewed, tested locally with `brew install --build-from-source`, `brew test`, and `brew audit --new --strict --online`. All review comments will be addressed manually.

-----