### PR TITLE
macdevtools 1.3.0 (new formula)

### DIFF
--- a/Formula/m/macdevtools.rb
+++ b/Formula/m/macdevtools.rb
@@ -1,0 +1,20 @@
+# Homebrew Formula for MacDevTools
+# Save this file as: homebrew-tap/Formula/macdevtools.rb
+
+class Macdevtools < Formula
+  desc "macOS Terminal Toolkit - All-in-One System Maintenance & Development Tools"
+  homepage "https://github.com/khakhasshi/MacDevTools"
+  url "https://github.com/khakhasshi/MacDevTools/archive/refs/tags/v1.3.0.tar.gz"
+  sha256 "6b59d0c416f2fb2006f9b4fb9f19ea3d1207d583cdf565410b8db71e6200a8f4"
+  license "MIT"
+
+  def install
+    libexec.install Dir["*.sh"]
+    libexec.install "tool"
+    bin.install_symlink libexec/"tool"
+  end
+
+  test do
+    system "#{bin}/tool", "help"
+  end
+end


### PR DESCRIPTION
Adds new formula macdevtools (v1.3.0), a macOS terminal toolkit for cache cleanup, diagnostics, and developer utilities.\n\nVerification performed:\n- brew style macdevtools\n- brew audit --new --strict --online macdevtools\n\nAdditionally validated installation/test through maintained tap while iterating formula fixes:\n- brew reinstall khakhasshi/tap/macdevtools\n- brew test khakhasshi/tap/macdevtools\n