### PR TITLE
gmp-ecm 7.0.6 (new formula)

### DIFF
--- a/Formula/g/gmp-ecm.rb
+++ b/Formula/g/gmp-ecm.rb
@@ -1,0 +1,79 @@
+class GmpEcm < Formula
+  desc "Elliptic Curve Method for integer factorization"
+  homepage "https://gitlab.inria.fr/zimmerma/ecm"
+  url "https://gitlab.inria.fr/zimmerma/ecm/-/archive/git-7.0.6/ecm-git-7.0.6.tar.gz"
+  sha256 "d7f7cbfe414ae019fa0cd610685b9ad4d04d333ee3d826a05e6e5affd95ca91a"
+  license all_of: ["GPL-3.0-or-later", "LGPL-3.0-or-later"]
+  head "https://gitlab.inria.fr/zimmerma/ecm.git", branch: "master"
+
+  livecheck do
+    url :stable
+    regex(/git[._-]v?(\d+(?:\.\d+)+)/i)
+  end
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "gmp"
+
+  uses_from_macos "m4" => :build
+
+  def install
+    system "autoreconf", "--force", "--install"
+
+    args = %W[
+      --with-gmp=#{Formula["gmp"].prefix}
+      --enable-shared
+    ]
+
+    if OS.mac?
+      # On macOS, global symbols require a leading underscore.
+      # The configure script sometimes fails to detect this, leading to linker errors.
+      # Ref: https://gitlab.inria.fr/zimmerma/ecm/-/issues/21880
+      args << "gmp_cv_asm_underscore=yes"
+    end
+
+    system "./configure", *args, *std_configure_args
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    # Test the ecm binary: factor 121 = 11 * 11
+    assert_match "Factor found", pipe_output("#{bin}/ecm 100", "121\n")
+
+    # Test linking against libecm using the P-1 method, which is
+    # deterministic: P-1 with B1=5 finds 31 from 3937 = 31 * 127
+    # because 31-1 = 30 = 2*3*5 is 5-smooth while
+    # 127-1 = 126 = 2*3^2*7 is not.
+    (testpath/"test.c").write <<~C
+      #include <stdlib.h>
+      #include <gmp.h>
+      #include <ecm.h>
+
+      int main(void) {
+        mpz_t n, f;
+        ecm_params q;
+
+        mpz_init_set_ui(n, 3937);
+        mpz_init(f);
+        ecm_init(q);
+
+        q->method = ECM_PM1;
+
+        int ret = ecm_factor(f, n, 5.0, q);
+        if (ret <= 0 || mpz_cmp_ui(f, 31) != 0)
+          return 1;
+
+        ecm_clear(q);
+        mpz_clear(f);
+        mpz_clear(n);
+        return 0;
+      }
+    C
+    system ENV.cc, "test.c", "-o", "test",
+           "-I#{include}", "-L#{lib}", "-L#{Formula["gmp"].lib}",
+           "-lecm", "-lgmp"
+    system "./test"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

LLMs assisted with updating the formula to GMP-ECM 7.0.7. 

-----

## About

[GMP-ECM](https://gitlab.inria.fr/zimmerma/ecm) is a free implementation of the Elliptic Curve Method (ECM) for integer factorization, as well as the P-1 and P+1 methods. It provides both a command-line tool (`ecm`) and a C library (`libecm`).

This revises the original new-formula PR (closed as stale) to track the new upstream patch release 7.0.7. Notably, 7.0.7 no longer needs a patch or special configure arguments.

The `url` is a git-archive snapshot from GitLab rather than a release tarball, so it does not ship a pre-generated `configure`; `autoreconf` is run in `install` (the `autoconf`/`automake`/`libtool` build dependencies cover this).

Built and tested locally on Linux (x86_64).