### PR TITLE
libunistring, gettext, moc: add libiconv dependency

### DIFF
--- a/Formula/g/gettext.rb
+++ b/Formula/g/gettext.rb
@@ -25,6 +25,10 @@ class Gettext < Formula
   uses_from_macos "libxml2"
   uses_from_macos "ncurses"
 
+  on_macos do
+    depends_on "libiconv"
+  end
+
   on_linux do
     depends_on "acl"
   end
@@ -32,10 +36,6 @@ class Gettext < Formula
   def install
     # Workaround for newer Clang
     ENV.append_to_cflags "-Wno-incompatible-function-pointer-types" if DevelopmentTools.clang_build_version >= 1500
-
-    # macOS iconv implementation is slightly broken since Sonoma.
-    # upstream bug report, https://savannah.gnu.org/bugs/index.php?66541
-    ENV["am_cv_func_iconv_works"] = "yes" if OS.mac? && MacOS.version >= :sequoia
 
     args = [
       "--with-libunistring-prefix=#{Formula["libunistring"].opt_prefix}",

--- a/Formula/lib/libunistring.rb
+++ b/Formula/lib/libunistring.rb
@@ -17,16 +17,14 @@ class Libunistring < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "2491acf49407cf75d5f95a6296f2a1c0294646834022fdcad7e22471c0c9a6d4"
   end
 
+  on_macos do
+    depends_on "libiconv"
+  end
+
   def install
-    # macOS iconv implementation is slightly broken since Sonoma.
-    # This is also why we skip `make check`.
-    # https://github.com/coreutils/gnulib/commit/bab130878fe57086921fa7024d328341758ed453
-    # https://savannah.gnu.org/bugs/?65686
-    use_iconv_workaround = OS.mac? && MacOS.version >= :sonoma
-    ENV["am_cv_func_iconv_works"] = "yes" if use_iconv_workaround
     system "./configure", "--disable-silent-rules", *std_configure_args
     system "make"
-    system "make", "check" unless use_iconv_workaround
+    system "make", "check"
     system "make", "install"
   end
 

--- a/Formula/m/moc.rb
+++ b/Formula/m/moc.rb
@@ -77,15 +77,15 @@ class Moc < Formula
   depends_on "ncurses"
   depends_on "speex"
 
+  on_macos do
+    depends_on "libiconv"
+  end
+
   on_linux do
     depends_on "alsa-lib"
   end
 
   def install
-    # macOS iconv implementation is slightly broken since Sonoma.
-    # upstream bug report: https://savannah.gnu.org/bugs/index.php?66541
-    ENV["am_cv_func_iconv_works"] = "yes" if OS.mac? && MacOS.version >= :sequoia
-
     ENV.append_path "ACLOCAL_PATH", Formula["gettext"].pkgshare/"m4"
 
     # Not needed for > 2.5.2


### PR DESCRIPTION
<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Git is linked with the Homebrew-provided libiconv to avoid issues with the system libiconv [1]. However, the libunistring, gettext, and moc formulae intentionally bypass libiconv tests, effectively forcing them to use the system libiconv [2,3]. To ensure consistent behavior, add a libiconv dependency to these formulae.

[1] https://github.com/Homebrew/homebrew-core/pull/258461
[2] https://github.com/Homebrew/homebrew-core/pull/258461#discussion_r2901981144
[3] https://github.com/Homebrew/homebrew-core/pull/258461#discussion_r2902729110
