### PR TITLE
autoconf: add HTTP mirror URL

### DIFF
--- a/Formula/a/autoconf.rb
+++ b/Formula/a/autoconf.rb
@@ -3,6 +3,7 @@ class Autoconf < Formula
   homepage "https://www.gnu.org/software/autoconf/"
   url "https://ftpmirror.gnu.org/gnu/autoconf/autoconf-2.73.tar.gz"
   mirror "https://ftp.gnu.org/gnu/autoconf/autoconf-2.73.tar.gz"
+  mirror "http://ftp.gnu.org/gnu/autoconf/autoconf-2.73.tar.gz"
   sha256 "259ddfa3bddc799cfb81489cc0f17dfdf1bd6d1505dda53c0f45ff60d6a4f9a7"
   license all_of: [
     "GPL-3.0-or-later",


### PR DESCRIPTION
The ResourceAuditor audit rule that requires at least one http:// URL for curl dependency formulas. This can cause cascading, seemingly unrelated failures when a formula change expands curl's dependency tree.

This issue was found when adding the libiconv dependency to gettext [1] and libunistring [2]. This formula is one of dependencies that cause failures.

[1] https://github.com/Homebrew/homebrew-core/pull/273710
[2] https://github.com/Homebrew/homebrew-core/pull/273716

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
