### PR TITLE
visidata: add openpyxl resource for xlsx support

### DIFF
--- a/Formula/v/visidata.rb
+++ b/Formula/v/visidata.rb
@@ -8,8 +8,8 @@ class Visidata < Formula
   license "GPL-3.0-or-later"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, all: "8be7f319d1633fce26ef5706d96174cf42244bea0f88da6114f7e5cf0ac9c962"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, all: "3ccfa12cd45005b9f4b80b1df0a9f27a41b9f8a16e210605fdb0e6fd10d27d84"
   end
 
   depends_on "python@3.14"

--- a/Formula/v/visidata.rb
+++ b/Formula/v/visidata.rb
@@ -14,6 +14,18 @@ class Visidata < Formula
 
   depends_on "python@3.14"
 
+  pypi_packages extra_packages: "openpyxl"
+
+  resource "et-xmlfile" do
+    url "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz"
+    sha256 "dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54"
+  end
+
+  resource "openpyxl" do
+    url "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz"
+    sha256 "cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050"
+  end
+
   resource "python-dateutil" do
     url "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz"
     sha256 "37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"
@@ -47,5 +59,8 @@ class Visidata < Formula
     CSV
 
     assert_match "age", shell_output("#{bin}/vd -b -f csv test.csv")
+
+    # Verify xlsx support (openpyxl) is available
+    system libexec/"bin/python", "-c", "import openpyxl"
   end
 end


### PR DESCRIPTION
## Summary

- Add `openpyxl` 3.1.5 and its dependency `et-xmlfile` 2.0.0 as resources
- Add test to verify `openpyxl` import succeeds

## Context

visidata supports xlsx files via openpyxl, but the formula does not include it as a resource. Opening an xlsx file with `vd` currently fails with:

```
ModuleNotFoundError: No module named 'openpyxl'
```

This adds openpyxl and its sole dependency et-xmlfile so xlsx support works out of the box.