### PR TITLE
ggml: fix x86 source build

### DIFF
--- a/Formula/g/ggml.rb
+++ b/Formula/g/ggml.rb
@@ -62,7 +62,7 @@ class Ggml < Formula
       -DGGML_BUILD_TESTS=OFF
       -DGGML_CCACHE=OFF
       -DGGML_LTO=ON
-      -DGGML_NATIVE=#{build.bottle? ? "OFF" : "ON"}
+      -DGGML_NATIVE=OFF
     ]
 
     # Enabling OpenBLAS for BLAS support and Vulkan for GPU support on Linux


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

`ggml` source build in x86 Mac will raise build error `GGML_NATIVE is not compatible with GGML_BACKEND_DL, consider using GGML_CPU_ALL_VARIANTS`, this [CMakeLists](https://github.com/ggml-org/ggml/blob/v0.9.8/src/ggml-cpu/CMakeLists.txt#L382) shows we can't set `GGML_NATIVE` and `GGML_BACKEND_DL` flags at the same time in x86 architecture, but `GGML_NATIVE` flag is enable when we build from source.
