### PR TITLE
wireplumber 0.5.13 (new formula)

### DIFF
--- a/Formula/p/pipewire.rb
+++ b/Formula/p/pipewire.rb
@@ -30,7 +30,6 @@ class Pipewire < Formula
   depends_on "gstreamer"
   depends_on "libsndfile"
   depends_on :linux
-  depends_on "lua"
   depends_on "ncurses"
   depends_on "openssl@3"
   depends_on "opus"
@@ -41,9 +40,10 @@ class Pipewire < Formula
   def install
     args = %W[
       -Dexamples=disabled
+      -Dsession-managers=[]
+      -Dsysconfdir=#{etc}
       -Dtests=disabled
       -Dudevrulesdir=#{lib}/udev/rules.d
-      -Dwireplumber:system-lua=true
     ]
 
     system "meson", "setup", "build", *args, *std_meson_args

--- a/Formula/p/pipewire.rb
+++ b/Formula/p/pipewire.rb
@@ -15,9 +15,9 @@ class Pipewire < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 arm64_linux:  "b95f6d975e3b592509118a9d80764e7f0a423ecca22349ca33019f1f0a1cda17"
-    sha256 x86_64_linux: "bfe9e2897ff11be6884c59ad00a1f7cd3a13099dd6f94776c1ecbf32e89ecae8"
+    rebuild 2
+    sha256 arm64_linux:  "4a0a676f56fbad5390b6b1c64223702fff09ef776b1ff02b6c9e819c672f6941"
+    sha256 x86_64_linux: "c7db79b782d57497febeeb84c7a8c3e733a17cda3312ccab4bba09ff879ffd67"
   end
 
   depends_on "meson" => :build

--- a/Formula/w/wireplumber.rb
+++ b/Formula/w/wireplumber.rb
@@ -1,0 +1,48 @@
+class Wireplumber < Formula
+  desc "Session / policy manager implementation for PipeWire"
+  homepage "https://pipewire.pages.freedesktop.org/wireplumber/"
+  url "https://gitlab.freedesktop.org/pipewire/wireplumber/-/archive/0.5.13/wireplumber-0.5.13.tar.bz2"
+  sha256 "056033cd4fa551b947eebd697bbf78fa9e6baf8f7f12cb5395656aa619de4946"
+  license "MIT"
+
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+  depends_on "pkgconf" => :build
+  depends_on "dbus" => :test
+
+  depends_on "glib"
+  depends_on :linux
+  depends_on "lua"
+  depends_on "pipewire"
+  depends_on "systemd"
+
+  def install
+    args = %W[
+      -Ddoc=disabled
+      -Dsysconfdir=#{etc}
+      -Dsystem-lua=true
+      -Dtests=false
+    ]
+    system "meson", "setup", "build", *args, *std_meson_args
+    system "meson", "compile", "-C", "build", "--verbose"
+    system "meson", "install", "-C", "build"
+  end
+
+  test do
+    ENV["XDG_DATA_DIRS"] = testpath # avoid loading system dbus services
+    ENV["XDG_RUNTIME_DIR"] = testpath
+    ENV["DBUS_SESSION_BUS_ADDRESS"] = address = "unix:path=#{testpath}/bus"
+    dbus_pid = spawn(Formula["dbus"].bin/"dbus-daemon", "--session", "--nofork", "--address=#{address}")
+    sleep 5
+    pipewire_pid = spawn(Formula["pipewire"].bin/"pipewire")
+    sleep 5
+    assert_match "PipeWire 'pipewire-0'", shell_output("#{bin}/wpctl status")
+  ensure
+    [pipewire_pid, dbus_pid].each do |pid|
+      next unless pid
+
+      Process.kill "TERM", pid
+      Process.wait pid
+    end
+  end
+end

--- a/Formula/w/wireplumber.rb
+++ b/Formula/w/wireplumber.rb
@@ -5,6 +5,11 @@ class Wireplumber < Formula
   sha256 "056033cd4fa551b947eebd697bbf78fa9e6baf8f7f12cb5395656aa619de4946"
   license "MIT"
 
+  bottle do
+    sha256 arm64_linux:  "865827696fad49a5efaa7d323ae681c07e8a55aaad8afaac2870a9a41139b707"
+    sha256 x86_64_linux: "9f51222ae212186d054843dd2e7f3557fe56c80f10bb8c8b234d85b9a088a24d"
+  end
+
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkgconf" => :build


### PR DESCRIPTION
Will be splitting out parts of `pipewire` to make it possible to use as dependency. Currently too heavyweight to work as a replacement for (pulseaudio, alsa, jack, etc.)

Starting with easy part (`wireplumber`) which is a subproject.