### PR TITLE
stgit: remove libiconv dependency

### DIFF
--- a/Formula/s/stgit.rb
+++ b/Formula/s/stgit.rb
@@ -8,13 +8,12 @@ class Stgit < Formula
   head "https://github.com/stacked-git/stgit.git", branch: "master"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_tahoe:   "2245c222ebdc50df69174e08fca409001fa02cc99834cac0a475c1a3394c3f18"
-    sha256 cellar: :any,                 arm64_sequoia: "0ef7c40a70e9e127f869c3dfc533655d59dc8269118af2b3aeea7f9bcd952333"
-    sha256 cellar: :any,                 arm64_sonoma:  "b10ad29537f513ca8610cfad69ae4edc674a8cb6c357cb9c1144153803baa125"
-    sha256 cellar: :any,                 sonoma:        "ab4711c2838f32cbe2a605b5475b67026db843aec069749f08e280716d68df26"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "292c59af8ad6eece0537482b16abaf7e65b8ba7c56cd251e2aa3bf98fde34619"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "429022ab9a5b49d42b49966aec2a1dfec8049e50abda14c6b790da3028cf4a7b"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "e9a2472fb50048b0b022f20a5a1043c986cccbb42e26ec119c6d854b6071ee0f"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "920ab2c4eb232fca926817eea3d50284eee59a6ca78009321ecae95c2b0a9225"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "b0a3793db5006b763851e80d888b830e13c3fd17cfaf0eef744a261894a0123b"
+    sha256 cellar: :any_skip_relocation, sonoma:        "08987529eab4d62f17063aa78837bdc9ad80486820289a3a24670b497394c92d"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "6a2149594fbddbd6b1a5edd5885301e5a231c2296a09039ce5bf36921be8db37"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d416973811f15765d0354ec0c3e22eb468c987bb0dddcd38e10de0a0cd789e61"
   end
 
   depends_on "asciidoc" => :build

--- a/Formula/s/stgit.rb
+++ b/Formula/s/stgit.rb
@@ -4,6 +4,7 @@ class Stgit < Formula
   url "https://github.com/stacked-git/stgit/releases/download/v2.5.5/stgit-2.5.5.tar.gz"
   sha256 "9d84329c84bbb3e84b97b57aa29a79aa69f13c896f05842cd3a0f46fff3afe57"
   license "GPL-2.0-only"
+  revision 1
   head "https://github.com/stacked-git/stgit.git", branch: "master"
 
   bottle do
@@ -23,10 +24,6 @@ class Stgit < Formula
   depends_on "git"
 
   uses_from_macos "curl"
-
-  on_macos do
-    depends_on "libiconv"
-  end
 
   on_linux do
     depends_on "zlib-ng-compat"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

This is needed for Homebrew/brew#21810.

See also #273753.
