### PR TITLE
pipewire-gstreamer 1.6.2 (new formula)

### DIFF
--- a/Formula/p/pipewire-gstreamer.rb
+++ b/Formula/p/pipewire-gstreamer.rb
@@ -1,0 +1,48 @@
+class PipewireGstreamer < Formula
+  desc "GStreamer Plugin for PipeWire"
+  homepage "https://pipewire.org"
+  url "https://gitlab.freedesktop.org/pipewire/pipewire/-/archive/1.6.2/pipewire-1.6.2.tar.gz"
+  sha256 "2014c187fccdd6d245585be4eda7dabd781dcddd921604c40ab015bba6cb042d"
+  license "MIT"
+  head "https://gitlab.freedesktop.org/pipewire/pipewire.git", branch: "master"
+
+  livecheck do
+    formula "pipewire"
+  end
+
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+  depends_on "pkgconf" => [:build, :test]
+  depends_on "glib"
+  depends_on "gstreamer"
+  depends_on :linux
+  depends_on "pipewire"
+
+  def install
+    args = %W[
+      -Dexamples=disabled
+      -Dgstreamer=enabled
+      -Dgstreamer-device-provider=enabled
+      -Dsession-managers=[]
+      -Dsysconfdir=#{etc}
+      -Dtests=disabled
+      -Dudevrulesdir=#{lib}/udev/rules.d
+    ]
+
+    system "meson", "setup", "build", *args, *std_meson_args
+    system "meson", "compile", "-C", "build", "--verbose", "gstpipewire"
+    (lib/"gstreamer-1.0").install "build/src/gst/libgstpipewire.so"
+  end
+
+  def caveats
+    <<~EOS
+      For GStreamer to find the bundled plugin:
+        export GST_PLUGIN_PATH=#{opt_lib}/gstreamer-1.0
+    EOS
+  end
+
+  test do
+    ENV["GST_PLUGIN_PATH"] = opt_lib/"gstreamer-1.0"
+    assert_match "pipewiresink: PipeWire sink", shell_output("#{Formula["gstreamer"].bin}/gst-inspect-1.0 pipewire")
+  end
+end

--- a/Formula/p/pipewire-gstreamer.rb
+++ b/Formula/p/pipewire-gstreamer.rb
@@ -10,6 +10,11 @@ class PipewireGstreamer < Formula
     formula "pipewire"
   end
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_linux:  "ee4e435ed86521beb4b421b9e6781a00982dae23a6de7747fdb55ab1639a5530"
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "154f32dce5a913be0bfac715017398d15fe38f97db96bad129dbd6d941be280b"
+  end
+
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkgconf" => [:build, :test]

--- a/Formula/p/pipewire.rb
+++ b/Formula/p/pipewire.rb
@@ -3,7 +3,11 @@ class Pipewire < Formula
   homepage "https://pipewire.org"
   url "https://gitlab.freedesktop.org/pipewire/pipewire/-/archive/1.6.2/pipewire-1.6.2.tar.gz"
   sha256 "2014c187fccdd6d245585be4eda7dabd781dcddd921604c40ab015bba6cb042d"
-  license all_of: ["GPL-2.0-only", "LGPL-2.1-or-later", "MIT"]
+  license all_of: [
+    "MIT",
+    "GPL-2.0-only",      # libjackserver.so
+    "LGPL-2.1-or-later", # libspa-alsa.so
+  ]
   head "https://gitlab.freedesktop.org/pipewire/pipewire.git", branch: "master"
 
   # We restrict matching to versions with an even-numbered minor version number,
@@ -27,7 +31,6 @@ class Pipewire < Formula
   depends_on "dbus"
   depends_on "fftw"
   depends_on "glib"
-  depends_on "gstreamer"
   depends_on "libsndfile"
   depends_on :linux
   depends_on "ncurses"
@@ -40,6 +43,8 @@ class Pipewire < Formula
   def install
     args = %W[
       -Dexamples=disabled
+      -Dgstreamer=disabled
+      -Dgstreamer-device-provider=disabled
       -Dsession-managers=[]
       -Dsysconfdir=#{etc}
       -Dtests=disabled

--- a/Formula/p/pipewire.rb
+++ b/Formula/p/pipewire.rb
@@ -19,9 +19,9 @@ class Pipewire < Formula
   end
 
   bottle do
-    rebuild 2
-    sha256 arm64_linux:  "4a0a676f56fbad5390b6b1c64223702fff09ef776b1ff02b6c9e819c672f6941"
-    sha256 x86_64_linux: "c7db79b782d57497febeeb84c7a8c3e733a17cda3312ccab4bba09ff879ffd67"
+    rebuild 3
+    sha256 arm64_linux:  "572d431263ce7c0eabb028b14b223ede107c4b4cb0c57636211233cb2e9579e2"
+    sha256 x86_64_linux: "b720368f7ef595d040cd68d8ae3631933fcca03ea1b06e51ee791042c7202159"
   end
 
   depends_on "meson" => :build

--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -54,6 +54,7 @@
   ["notmuch", "notmuch-mutt"],
   ["openssh", "ssh-copy-id"],
   ["petsc", "petsc-complex"],
+  ["pipewire", "pipewire-gstreamer"],
   ["poppler", "poppler-qt5"],
   ["python-tk@3.10", "python@3.10"],
   ["python-gdbm@3.11", "python-tk@3.11", "python@3.11"],


### PR DESCRIPTION
This removes GStreamer from PipeWire which prunes out heavy dependencies like LLVM. Compared to PulseAudio formula (which it somewhat replaces), PipeWire formula has pretty much the same dependency tree with addition of:
- `fftw` (filter-chain convolver feature)
- `systemd` (manually disabled in PulseAudio)

Naming/description chosen based on existing `libnice-gstreamer`. Caveat copied from `aravis`.

---

Note that GStreamer plugin has same limitation of prior non-monolithic GStreamer installation where plugin is not detected by default.

For now, leaving as a separate formula as this is maintained by PipeWire rather than GStreamer monorepo. If there is strong enough demand, could merge as a resource of GStreamer formula. May be worth trying to get GStreamer upstream to allow adding custom directories, though I think all attempts have been rejected/ignored.

Could be worth exploring some other ideas:
1. a symlink approach instead where we install GStreamer's plugins into a separate directory, have a reverse symlink, and postinstall symlink plugins into HOMEBREW_PREFIX/lib. 
2. allow sharing Cellar for multiple related formulae. This is a bit more complicated but idea would help with formulae like LLVM, GStreamer, Rust, etc. where relocatable paths result in Cellar location.