### PR TITLE
workflows: migrate actions/attest-build-provenance

### DIFF
--- a/.github/workflows/create-replacement-pr.yml
+++ b/.github/workflows/create-replacement-pr.yml
@@ -58,8 +58,8 @@ jobs:
       contents: read
       pull-requests: write # for `post-comment`, `gh api`, `gh pr edit`
       repository-projects: write # for `gh pr edit`
-      attestations: write # for actions/attest-build-provenance
-      id-token: write # for actions/attest-build-provenance
+      attestations: write # for actions/attest
+      id-token: write # for actions/attest
     steps:
       - name: Post comment once started
         uses: Homebrew/actions/post-comment@main
@@ -181,7 +181,7 @@ jobs:
             "$PR"
 
       - name: Generate build provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-path: '${{ steps.pr-pull.outputs.bottle_path }}/*.tar.gz'
         if: inputs.upload

--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -195,8 +195,8 @@ jobs:
       contents: read
       issues: write # for Homebrew/actions/post-comment
       pull-requests: write # for `gh pr edit`
-      attestations: write # for actions/attest-build-provenance
-      id-token: write # for actions/attest-build-provenance
+      attestations: write # for actions/attest
+      id-token: write # for actions/attest
     runs-on: ubuntu-latest
     needs: bottle
     if: inputs.upload
@@ -236,7 +236,7 @@ jobs:
           signing_key: ${{ secrets.BREWTESTBOT_SSH_SIGNING_KEY }}
 
       - name: Generate build provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-path: ${{ env.BOTTLES_DIR }}/*.tar.gz
 

--- a/.github/workflows/dispatch-rebottle.yml
+++ b/.github/workflows/dispatch-rebottle.yml
@@ -130,8 +130,8 @@ jobs:
       contents: write # for Homebrew/actions/git-try-push
       packages: write # for brew pr-upload
       pull-requests: write # for gh pr
-      attestations: write # for actions/attest-build-provenance
-      id-token: write # for actions/attest-build-provenance
+      attestations: write # for actions/attest
+      id-token: write # for actions/attest
     runs-on: ubuntu-latest
     needs: bottle
     if: inputs.upload
@@ -171,7 +171,7 @@ jobs:
           signing_key: ${{ secrets.BREWTESTBOT_SSH_SIGNING_KEY }}
 
       - name: Generate build provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-path: ${{ env.BOTTLES_DIR }}/*.tar.gz
 

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -370,7 +370,7 @@ jobs:
             "$PR"
 
       - name: Generate build provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-path: '${{steps.pr-pull.outputs.bottle_path}}/*.tar.gz'
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

As of version 4, actions/attest-build-provenance is simply a wrapper on top of [actions/attest](https://github.com/actions/attest) per https://github.com/actions/attest-build-provenance#usage.