### PR TITLE
rtl-wmbus 1.1.0 (new formula)

### DIFF
--- a/Formula/r/rtl-wmbus.rb
+++ b/Formula/r/rtl-wmbus.rb
@@ -1,0 +1,19 @@
+class RtlWmbus < Formula
+  desc "Software defined receiver for wireless M-Bus with RTL-SDR"
+  homepage "https://github.com/weetmuts/rtl-wmbus"
+  url "https://github.com/weetmuts/rtl-wmbus/archive/refs/tags/1.1.0.tar.gz"
+  sha256 "0da72c7f5b026a4c0d8dc9beabba021f147c950f52eb8e09f4e41884d4f32ebf"
+  license "BSD-2-Clause"
+
+  head "https://github.com/weetmuts/rtl-wmbus.git", branch: "master"
+
+  def install
+    system "make", "release"
+    bin.install "build/rtl_wmbus"
+  end
+
+  test do
+    # Feed random bytes as I/Q samples; the decoder should process and exit cleanly
+    assert_match "rtl_wmbus", shell_output("#{bin}/rtl_wmbus -h 2>&1", 1)
+  end
+end


### PR DESCRIPTION
-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

`GitHub fork (not canonical repository)` because https://github.com/weetmuts/rtl-wmbus is technically a fork, but the original https://github.com/xaelsouth/rtl-wmbus is defunct and the fork is the canonical version for https://github.com/wmbusmeters/wmbusmeters.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Claude helped to complete the formula bootstrapped with `brew create`

-----
