### PR TITLE
corsixth: use `luarocks make`

### DIFF
--- a/Formula/c/corsixth.rb
+++ b/Formula/c/corsixth.rb
@@ -28,7 +28,7 @@ class Corsixth < Formula
   depends_on "luarocks" => :build
   depends_on "ffmpeg"
   depends_on "freetype"
-  depends_on "lpeg"
+  depends_on "lpeg" => :no_linkage
   depends_on "lua@5.4"
   depends_on "sdl2"
   depends_on "sdl2_mixer"
@@ -63,7 +63,7 @@ class Corsixth < Formula
 
     resources.each do |r|
       r.stage do
-        system "luarocks", "build", r.name, "--tree=#{luapath}"
+        system "luarocks", "make", "--tree=#{luapath}", "--lua-dir=#{lua.opt_prefix}"
       end
     end
 


### PR DESCRIPTION
Aligns with our other usage of luarocks. `luarocks build` will fetch rocks when passed as arguments (defeating purpose of resource) while `luarocks make` only performs compilation.
```console
❯ luarocks build --help
Usage: luarocks build [-h] [--only-deps] [--branch <name>] [--pin]
       [--no-install] [--no-doc] [--pack-binary-rock] [--keep]
       [--force] [--force-fast] [--verify] [--sign]
       [--check-lua-versions] [--pin] [--no-manifest] [--only-deps]
       [--deps-mode <mode>] [<rock>] [<version>]

Build and install a rock, compiling its C parts if any.
If the sources contain a luarocks.lock file, uses it as an authoritative source
for exact version of dependencies.
If no arguments are given, behaves as luarocks make.

Arguments:
   rock                  A rockspec file, a source rock file, or the name of a
                         rock to be fetched from a repository.
...

❯ luarocks make --help
Usage: luarocks make [-h] [--no-install] [--no-doc]
       [--pack-binary-rock] [--keep] [--force] [--force-fast]
       [--verify] [--sign] [--check-lua-versions] [--pin]
       [--no-manifest] [--only-deps] [--deps-mode <mode>] [<rockspec>]

Builds sources in the current directory, but unlike "build", it does not fetch
sources, etc., assuming everything is available in the current directory. If no
argument is given, it looks for a rockspec in the current directory and in
"rockspec/" and "rockspecs/" subdirectories, picking the rockspec with newest
version or without version name. If rockspecs for different rocks are found or
there are several rockspecs without version, you must specify which to use,
through the command-line.
```