### PR TITLE
asciiquarium: fix gray/washed-out colors on modern terminals

### DIFF
--- a/Formula/a/asciiquarium.rb
+++ b/Formula/a/asciiquarium.rb
@@ -4,7 +4,7 @@ class Asciiquarium < Formula
   url "https://robobunny.com/projects/asciiquarium/asciiquarium_1.1.tar.gz"
   sha256 "1b08c6613525e75e87546f4e8984ab3b33f1e922080268c749f1777d56c9d361"
   license "GPL-2.0-or-later"
-  revision 6
+  revision 7
 
   livecheck do
     url "https://robobunny.com/projects/asciiquarium/"
@@ -34,6 +34,15 @@ class Asciiquarium < Formula
     sha256 "7d5c3c2d4f9b657a8b1dce7f5e2cbbe02ada2e97c72f3a0304bf3c99d084b045"
   end
 
+  # Fix washed-out/gray colors on terminals that customise their ANSI palette
+  # (e.g. many iTerm2 profiles desaturate colors 0-7 for readability).
+  # Term::Animation initialises Curses color pairs 1-8 from the terminal's
+  # ANSI palette colors 0-7. Re-initialising those pairs with xterm-256color
+  # slots 16-231 (standard RGB values, not overridable per profile) restores
+  # vivid colors. use_default_colors() + bg=-1 keeps character backgrounds
+  # transparent, matching the terminal background instead of forcing black.
+  patch :DATA
+
   def install
     ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
 
@@ -44,22 +53,25 @@ class Asciiquarium < Formula
       end
     end
 
+    # Fix two Term::Animation bugs that cause gray/washed-out colors on modern ncurses:
+    # 1. bkgdset() with a COLOR_PAIR is OR'd into every drawn character's attributes,
+    #    corrupting color pairs (e.g. COLOR_BLACK → uninitialised pair → terminal
+    #    default color, turning the castle and submarine gray).
+    # 2. Missing attrset(0) before the per-frame space-fill lets color attributes
+    #    from the previous frame bleed into the background.
+    inreplace libexec/"lib/perl5/Term/Animation.pm" do |s|
+      s.gsub! "$self->{WIN}->bkgdset($self->{COLORS}{'w'});",
+              "$self->{WIN}->bkgdset(0);"
+      s.sub!  "\t\t$self->{WIN}->addstr( 0, 0, ' 'x$self->size() );",
+              "\t\t$self->{WIN}->attrset(0);\n\t\t$self->{WIN}->addstr( 0, 0, ' 'x$self->size() );"
+    end
+
     chmod 0755, "asciiquarium"
     bin.install "asciiquarium"
     bin.env_script_all_files(libexec/"bin", PERL5LIB: ENV["PERL5LIB"])
   end
 
   test do
-    # This is difficult to test because:
-    # - There are no command line switches that make the process exit
-    # - The output is a constant stream of terminal control codes
-    # - Testing only if the binary exists can still result in failure
-
-    # The test process is as follows:
-    # - Spawn the process capturing stdout and the pid
-    # - Kill the process after there is some output
-    # - Ensure the start of the output matches what is expected
-
     require "pty"
     ENV["TERM"] = "xterm"
     PTY.spawn(bin/"asciiquarium") do |stdout, stdin, _pid|
@@ -75,3 +87,30 @@ class Asciiquarium < Formula
     end
   end
 end
+
+__END__
+--- a/asciiquarium
++++ b/asciiquarium
+@@ -87,6 +87,22 @@
+ 	#nodelay(1);
+
+ 	$anim->color(1);
++
++	# Override Curses color pairs with fixed xterm-256color palette entries.
++	# Slots 16-231 have standard RGB values independent of terminal profile,
++	# so colors stay vivid even when the ANSI palette (0-7) is customised.
++	# use_default_colors() + bg=-1 makes character backgrounds transparent.
++	if(COLORS() >= 232) {
++		use_default_colors();
++		init_pair(1, 231, -1);  # w = white   (#ffffff)
++		init_pair(2, 196, -1);  # r = red     (#ff0000)
++		init_pair(3,  46, -1);  # g = green   (#00ff00)
++		init_pair(4,  27, -1);  # b = blue    (#005fff)
++		init_pair(5,  51, -1);  # c = cyan    (#00ffff)
++		init_pair(6, 201, -1);  # m = magenta (#ff00ff)
++		init_pair(7, 226, -1);  # y = yellow  (#ffff00)
++		init_pair(8, 238, -1);  # k = dark    (#444444)
++	}
+
+ 	my $start_time = time;
+ 	my $paused = 0;


### PR DESCRIPTION
## Problem

On macOS with iTerm2 (and other terminals that customise their ANSI color palette), asciiquarium displays in washed-out gray instead of vivid colors. This is a well-known issue with no existing fix in the formula.

Root causes (three bugs, all fixed here):

### 1. Term::Animation `bkgdset()` corrupts color pairs

`Term::Animation` calls `bkgdset(COLOR_PAIR(1))` (white-on-black). Per the ncurses spec, this value is **OR'd into every drawn character's attributes**. COLOR_BLACK is pair 8 (value 2048); OR'd with the white background (pair 1, value 256) it becomes 2304 = COLOR_PAIR(9), which is uninitialised and renders as the terminal's default color (gray). This turns the castle and submarine — which use COLOR_BLACK to be nearly invisible — into a prominent gray block.

Fix: `bkgdset(0)` (no color pair, no corruption).

### 2. Term::Animation missing `attrset(0)` before frame clear

The per-frame `addstr(0, 0, ' ' x size)` call inherits the color attribute left by the last entity of the previous frame, tinting the background.

Fix: `attrset(0)` before `addstr`.

### 3. ANSI palette desaturation

`Term::Animation` initialises Curses color pairs 1–8 from ANSI palette slots 0–7. Many terminal profiles desaturate these for readability, so all colors appear muted/gray.

Fix: re-initialise those same pairs (the COLOR_PAIR handles already stored in Term::Animation's color hash remain valid) with xterm-256color slots 16–231, whose RGB values are defined by the standard and are not overridable per profile. `use_default_colors()` + `bg=-1` keeps character backgrounds transparent so they blend with the terminal's own background color.

## Testing

Tested on macOS Sequoia with iTerm2 using profiles with both vivid and desaturated ANSI palettes.