### PR TITLE
vscode-eslint-language-server 3.0.20 (new formula)

### DIFF
--- a/Formula/v/vscode-eslint-language-server.rb
+++ b/Formula/v/vscode-eslint-language-server.rb
@@ -1,0 +1,43 @@
+class VscodeEslintLanguageServer < Formula
+  desc "ESLint language server from VSCode"
+  homepage "https://github.com/microsoft/vscode-eslint"
+  url "https://github.com/microsoft/vscode-eslint/archive/refs/tags/release/3.0.20.tar.gz"
+  sha256 "f002c40e8fbf3186abe65158a206e18970c572e38e1872354ba074e0e2d76ad6"
+  license "MIT"
+
+  depends_on "node"
+
+  def install
+    system "npm", "ci"
+    system "npm", "run", "compile:server"
+
+    libexec.install Dir["*"]
+
+    (bin/"vscode-eslint-language-server").write <<~EOS
+      #!/usr/bin/env node
+      require('#{libexec}/server/out/eslintServer.js');
+    EOS
+  end
+
+  test do
+    require "open3"
+
+    json = <<~JSON
+      {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+          "rootUri": null,
+          "capabilities": {}
+        }
+      }
+    JSON
+
+    Open3.popen3(bin/"vscode-eslint-language-server", "--stdio") do |stdin, stdout|
+      stdin.write "Content-Length: #{json.size}\r\n\r\n#{json}"
+      sleep 2
+      assert_match(/^Content-Length: \d+/i, stdout.readline)
+    end
+  end
+end


### PR DESCRIPTION
Adds a new formula for vscode-eslint-language-server, the ESLint language server extracted from the [vscode-eslint](https://github.com/microsoft/vscode-eslint) extension.

Reopens #259385 which was closed as stale.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source vscode-eslint-language-server`?
- [x] Is your test running fine `brew test vscode-eslint-language-server`?
- [x] Does your build pass `brew audit --strict vscode-eslint-language-server`?