### PR TITLE
libzip: enable autobump

### DIFF
--- a/Formula/lib/libzip.rb
+++ b/Formula/lib/libzip.rb
@@ -12,8 +12,6 @@ class Libzip < Formula
     regex(/href=.*?libzip[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  no_autobump! because: "unable to get versions"
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "08417964bf803b08c703fa297f87ff23998f73c6cfe0b327103d02c9a41582af"
     sha256 cellar: :any,                 arm64_sequoia: "6a65f5a729a460ee8988e05e9af08880215a008692dffede96e51694d0a8b428"


### PR DESCRIPTION
CI is able to check version - https://github.com/Homebrew/homebrew-core/actions/runs/23713309326/job/69076379772#step:6:28

Usually "unable to get versions" is sporadic failure which can happen due to rate limiting and other network issues. If happens on next release, can switch to GitHub tarball - https://github.com/nih-at/libzip/releases/download/v1.11.4/libzip-1.11.4.tar.xz