### PR TITLE
wandio: enable autobump

### DIFF
--- a/Formula/w/wandio.rb
+++ b/Formula/w/wandio.rb
@@ -14,8 +14,6 @@ class Wandio < Formula
     end
   end
 
-  no_autobump! because: :incompatible_version_format
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_tahoe:   "5673ce841d6d082afc1432971b3b2e28596c4f931aa409b22f86e74317039ec4"


### PR DESCRIPTION
Should be possible to autobump this if upstream keeps using same format which has been used since July 2019. Can adjust if upstream changes it.