### PR TITLE
libcaca 0.99.beta20

### DIFF
--- a/Formula/lib/libcaca.rb
+++ b/Formula/lib/libcaca.rb
@@ -3,19 +3,14 @@ class Libcaca < Formula
   homepage "http://caca.zoy.org/wiki/libcaca"
   url "https://github.com/cacalabs/libcaca/releases/download/v0.99.beta20/libcaca-0.99.beta20.tar.bz2"
   mirror "https://fossies.org/linux/privat/libcaca-0.99.beta20.tar.bz2"
-  version "0.99b20"
   sha256 "ff9aa641af180a59acedc7fc9e663543fb397ff758b5122093158fd628125ac1"
   license "WTFPL"
   compatibility_version 1
 
+  # Need an explicit livecheck as only beta versions are available
   livecheck do
     url :stable
-    strategy :git do |tags, regex|
-      tags.map { |tag| tag[regex, 1]&.gsub(/\.?beta/, "b") }
-    end
   end
-
-  no_autobump! because: :incompatible_version_format
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "d84c3e4996866fd306f6ee465d2b26248af532f726187327b08fbc2c1fbae48d"
@@ -43,6 +38,10 @@ class Libcaca < Formula
 
   depends_on "pkgconf" => :build
   depends_on "imlib2"
+
+  on_linux do
+    depends_on "zlib-ng-compat"
+  end
 
   def install
     system "./bootstrap" if build.head?

--- a/Formula/lib/libcaca.rb
+++ b/Formula/lib/libcaca.rb
@@ -13,19 +13,13 @@ class Libcaca < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:    "d84c3e4996866fd306f6ee465d2b26248af532f726187327b08fbc2c1fbae48d"
-    sha256 cellar: :any,                 arm64_sequoia:  "5352a2e3f1f3e752955b499071b1b38521b7dcce378f51c8c20d5a6a3c9a57b7"
-    sha256 cellar: :any,                 arm64_sonoma:   "b61b6d0e7c9d1d7faf96997ce20a046aa71915c3a1132fb5a8f32cbdccd5e6ce"
-    sha256 cellar: :any,                 arm64_ventura:  "27d36a5457f9d98cf925cb402e9abb784c0d3453c8036fe74ebdeae04b7a9063"
-    sha256 cellar: :any,                 arm64_monterey: "b29bc6f1dd407411eab8689bfe190574b9fdc487d00dbdc7636e9483de867e56"
-    sha256 cellar: :any,                 arm64_big_sur:  "afa31ed628299e9d3fb4109b8f05b5b00fc2820c22804f85993eebda9a3097c0"
-    sha256 cellar: :any,                 sonoma:         "40a0eb8832b801282057e1260110740d38a911f9011ee1d88ab7575a4d6eab7f"
-    sha256 cellar: :any,                 ventura:        "a0fcaf753907e6dabf7d1a2038cdc95444fddf00f7dafd2b6ca88b7f552336ad"
-    sha256 cellar: :any,                 monterey:       "c7f6b2b19aaaa1417feac203e5c3676b6c0e70fb72816e16e1b85343e8cf55fb"
-    sha256 cellar: :any,                 big_sur:        "efe390bae78561024c804ac37bb5c0cf9f3397229bd91732cb59f9f4e32ecc8c"
-    sha256 cellar: :any,                 catalina:       "f0f86157174d749eedaec913f4d8d1b6d00824b6e580498847ac9e00c9c53d9e"
-    sha256 cellar: :any_skip_relocation, arm64_linux:    "c591f85155b4b4bc5efa7b98f5e43a638c2a6b9b5a771d26fe56ce31adb7285d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "7dab49e0d6bf0ed46dcc831c783da0124e5329f7e0e69f7d8cf847f9b825ebe2"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "1bf1cbd0c20bfcec98baa3baf5c7fbef225c45b96b016a7fe0c4b0aba329ba3f"
+    sha256 cellar: :any,                 arm64_sequoia: "73a575ae24fd5a0ef1868a5cbaba6c0e535f3c2b85fbe6763cf9641109a20757"
+    sha256 cellar: :any,                 arm64_sonoma:  "dcce30fad2e3096cb10d6c2d74200c51e9637bc5801bc53ae53e0b8359d6db16"
+    sha256 cellar: :any,                 sonoma:        "f2a90505005634192a9e683ee0b58072370ffd24147c528662252d511e54cd61"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "3bdbc127aecafd8e35ad5559205e2c0d9ba82b5c1c864e311a881367d46cdf01"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "14c988337fcd86dc31b0db8009e934c356c795ddf62aea1d1987549bb2f53f6c"
   end
 
   head do

--- a/audit_exceptions/unstable_allowlist.json
+++ b/audit_exceptions/unstable_allowlist.json
@@ -4,7 +4,7 @@
   "avahi": "0.9-rc",
   "aview": "1.3.0rc",
   "ftgl": "2.1.3-rc",
-  "libcaca": "0.99b",
+  "libcaca": "0.99.beta",
   "librasterlite2": "1.1.0-beta",
   "premake": "5.0.0-beta",
   "pwnat": "0.3-beta",


### PR DESCRIPTION
This only adjusts the version scheme to match official tags and to work with autobump.

Version stanza is no longer needed:
```console
❯ brew lc libcaca
libcaca: 0.99.beta20 ==> 0.99.beta20
```

Need to upload new bottles.

---

Based on `brew bump`, the version scheme change should be seen as an equivalent version number. Tested by adding `version "0.99b20"` in formula
```console
❯ brew bump libcaca
==> libcaca is up to date!
Current formula version:  0.99b20
Latest livecheck version: 0.99.beta20
```

And with `version "0.99b19"` in formula which is shown as upgrade:
```console
❯ brew bump libcaca
==> libcaca
Current formula version:  0.99b19
Latest livecheck version: 0.99.beta20

❯ brew lc libcaca --newer-only
libcaca: 0.99b19 ==> 0.99.beta20
```