### PR TITLE
powershell: fix version output

### DIFF
--- a/Formula/p/powershell.rb
+++ b/Formula/p/powershell.rb
@@ -44,6 +44,12 @@ class Powershell < Formula
       --use-current-runtime
       --nologo
     ]
+    # Normalize PowerShellVersion to "v<tag>-0-g<sha>" so the props file regex extracts
+    # PSCoreAdditionalCommits=0, which causes PSVersionInfo to emit GitCommitId = "7.x.x"
+    # (the clean tag) instead of the full git-describe string "7.x.x-0-g<sha>".
+    git_sha = Utils.safe_popen_read("git", "-C", buildpath, "rev-parse", "HEAD").chomp
+    normalized_ps_version = "v#{version}-0-g#{git_sha}"
+
     dotnet_publish_flags = %W[
       --disable-build-servers
       --nologo
@@ -55,6 +61,8 @@ class Powershell < Formula
       --property:GenerateFullPaths=true
       --property:ErrorOnDuplicatePublishOutputFiles=false
       --property:IsWindows=false
+      --property:PowerShellVersion=#{normalized_ps_version}
+      --property:ReleaseTag=#{version}
     ]
     dotnet_run_flags = %W[
       --framework #{target_framework}


### PR DESCRIPTION
This fixes the output of `pwsh -v` so that instead of `7.6.0-0-g767990ba06f8579d69f99eec46057541374aa892`, the output is just `7.6.0`. This change makes the build conform to the way the version is reported with the macOS .pkg and .msi installers. Some tools like the VS Code PowerShell extension expect the major.minor.patch format.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

I used Claude to help determine where the PowerShell build process was getting its version string in the build process and the format of the property. I asked it to look at:
* https://github.com/Homebrew/homebrew-core/blob/main/Formula/p/powershell.rb
* https://github.com/PowerShell/PowerShell/blob/master/src/System.Management.Automation/SourceGenerators/PSVersionInfoGenerator/PSVersionInfoGenerator.cs
* https://github.com/PowerShell/PowerShell/blob/v7.5.4/build.psm1
-----
