### PR TITLE
lookinside 2.2.2 (new formula)

### DIFF
--- a/Formula/l/lookinside.rb
+++ b/Formula/l/lookinside.rb
@@ -1,0 +1,29 @@
+class Lookinside < Formula
+  desc "Inspect debuggable app targets from the command-line"
+  homepage "https://github.com/Lakr233/LookInside"
+  url "https://github.com/Lakr233/LookInside/archive/refs/tags/2.2.2.tar.gz"
+  sha256 "4b274672ae95da201a3f9ed9ad80a95557519f430076c103a9f4c6e2fc8b9800"
+  license "GPL-3.0-only"
+  head "https://github.com/Lakr233/LookInside.git", branch: "main"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
+  depends_on xcode: ["15.3", :build]
+  depends_on :macos
+
+  uses_from_macos "swift" => :build
+
+  def install
+    system "swift", "build", "--disable-sandbox", "-c", "release", "--product", "lookinside"
+    bin.install ".build/release/lookinside"
+    generate_completions_from_executable(bin/"lookinside", "--generate-completion-script")
+  end
+
+  test do
+    assert_match "OVERVIEW: Inspect debuggable app targets from the command line.",
+                 shell_output("#{bin}/lookinside --help")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Add [LookInside](https://github.com/Lakr233/LookInside) CLI tool to Homebrew. LookInside is a macOS UI inspector for debuggable macOS and iOS apps.

cc @Lakr233