### PR TITLE
kimi-cli: update no_autobump reason

### DIFF
--- a/Formula/k/kimi-cli.rb
+++ b/Formula/k/kimi-cli.rb
@@ -8,7 +8,7 @@ class KimiCli < Formula
   license "Apache-2.0"
   head "https://github.com/MoonshotAI/kimi-cli.git", branch: "main"
 
-  no_autobump! because: "has non-PyPI resources"
+  no_autobump! because: "macOS resources cannot be updated on linux CI"
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "84397866890ec39e8085a96a7b25980d48a44f13eaedb0c619da9a35b4bc10d5"


### PR DESCRIPTION
New reason after https://github.com/Homebrew/brew/pull/21873 is `pyobjc-framework-cocoa` resource cannot be resolved on Linux

---

Ideally PyObjC upstream will replace setup.py with pyproject.toml which may help avoid some OS-specific code running.

May need to consider other ideas if this doesn't happen. Easiest may be to use a GitHub-hosted macOS runner to autobump a small subset of formulae.