### PR TITLE
ngspice: disable macOS memory check

### DIFF
--- a/Formula/n/ngspice.rb
+++ b/Formula/n/ngspice.rb
@@ -13,12 +13,12 @@ class Ngspice < Formula
   end
 
   bottle do
-    sha256 arm64_tahoe:   "707746ba4112da19e618bfc475485bf703895fbeecd2819587f27be9e074bba4"
-    sha256 arm64_sequoia: "1800d5805217fe5a7f04ce961b5be89bb413be572acbe0955efcc88747fa8229"
-    sha256 arm64_sonoma:  "1f5af70b57c07daae7439916dc0499152f43bc91ad473c68e6908f1f0c1d9572"
-    sha256 sonoma:        "45be55251673886c652749ac40e255aa0dc2f68b89fce315c498bc1b8f3c48dc"
-    sha256 arm64_linux:   "083957b2e65f6f74958d43b681799ffecc64ec126f0f0b3bb30fd588dce53642"
-    sha256 x86_64_linux:  "c2ea7875c0bf0cc40082aa91dd348fd110b759d292eda53215b741c6882c2c5c"
+    sha256 arm64_tahoe:   "8343461583c56ca951d0508e8459462ea98f6af3f1783e2e491874828a1a5ad9"
+    sha256 arm64_sequoia: "3cffddf9fe4c94c3b706847ba461d60ca89dff9379839d72cc1c2f75e060983d"
+    sha256 arm64_sonoma:  "3ce129ec06cd1db6ead129a5f36a645fa196920df68b2b3870d4e3f8a840c7ee"
+    sha256 sonoma:        "93543c940da1f0d3d9f413ea0e49e1e7b274ea57d8bfde30ef8d6e1386b4782c"
+    sha256 arm64_linux:   "8f25521726c656b9866cb1ebb30bdd3c23ce6da724536a4de01b0597ccc7f3b1"
+    sha256 x86_64_linux:  "f42643fd6446de764738e5a58b68a01136f8ae8c6e89f8bbadae66b8db0bb1e7"
   end
 
   depends_on "fftw"

--- a/Formula/n/ngspice.rb
+++ b/Formula/n/ngspice.rb
@@ -4,6 +4,7 @@ class Ngspice < Formula
   url "https://downloads.sourceforge.net/project/ngspice/ng-spice-rework/46/ngspice-46.tar.gz"
   sha256 "a0d1699af1940b06649276dcd6ff5a566c8c0cad01b2f7b5e99dedbb4d64c19b"
   license :cannot_represent
+  revision 1
   head "https://git.code.sf.net/p/ngspice/ngspice.git", branch: "master"
 
   livecheck do
@@ -37,6 +38,9 @@ class Ngspice < Formula
     depends_on "libxext"
     depends_on "libxmu"
   end
+
+  # Disable the broken macOS memory check. upstream commit ref, https://sourceforge.net/p/ngspice/ngspice/ci/96404e993984065f9104d724672bcdcafd7f356f/
+  patch :DATA
 
   def install
     # Xft #includes <ft2build.h>, not <freetype2/ft2build.h>, hence freetype2
@@ -84,3 +88,24 @@ class Ngspice < Formula
     system bin/"ngspice", "test.cir"
   end
 end
+
+__END__
+diff --git a/src/frontend/outitf.c b/src/frontend/outitf.c
+index a9e47df..56883b0 100644
+--- a/src/frontend/outitf.c
++++ b/src/frontend/outitf.c
+@@ -556,6 +556,7 @@ OUTpD_memory(runDesc *run, IFvalue *refValue, IFvalue *valuePtr)
+ {
+     int i, n = run->numData;
+ 
++#ifndef __APPLE__
+     if (!cp_getvar("no_mem_check", CP_BOOL, NULL, 0)) {
+         /* Estimate the required memory */
+         size_t memrequ = (size_t)n * vlength2delta(0) * sizeof(double);
+@@ -569,6 +570,7 @@ OUTpD_memory(runDesc *run, IFvalue *refValue, IFvalue *valuePtr)
+             controlled_exit(1);
+         }
+     }
++#endif
+ 
+     for (i = 0; i < n; i++) {


### PR DESCRIPTION

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

