### PR TITLE
itstool: add resource livecheck

### DIFF
--- a/Formula/i/itstool.rb
+++ b/Formula/i/itstool.rb
@@ -38,6 +38,14 @@ class Itstool < Formula
   resource "libxml2" do
     url "https://download.gnome.org/sources/libxml2/2.15/libxml2-2.15.1.tar.xz"
     sha256 "c008bac08fd5c7b4a87f7b8a71f283fa581d80d80ff8d2efd3b26224c39bc54c"
+
+    # Track the version of libxml2 formula. This is not the same as `formula "libxml2"`.
+    livecheck do
+      url "https://formulae.brew.sh/api/formula/libxml2.json"
+      strategy :json do |json|
+        json.dig("versions", "stable")
+      end
+    end
   end
 
   def python3


### PR DESCRIPTION
Output:
```console
❯ brew lc itstool --autobump -r
itstool: 2.0.7 ==> 2.0.7
  libxml2: 2.15.1 ==> 2.15.2
```

As note, `formula "libxml2"` will give the wrong version as it runs the default regex when used in resource.
```console
❯ brew lc itstool --autobump -r
itstool: 2.0.7 ==> 2.0.7
  libxml2: 2.15.1 ==> 2.14.6
```

Even at formula-level rather than resource-level, `formula "..."` doesn't give "the version of formula" but instead "the version of livecheck from formula" which is not what we want here (i.e. the version output needs to be ABI compatible with existing formula).

---

Though it is possible we will replace resource with `lxml` in a future release (assuming PR is merged) given status of libxml2 Python bindings.