### PR TITLE
pipenv, tox: remove stale `post_install`

### DIFF
--- a/Formula/p/pipenv.rb
+++ b/Formula/p/pipenv.rb
@@ -73,18 +73,6 @@ class Pipenv < Formula
     inreplace file, "/opt/homebrew/bin/bash", "$HOMEBREW_PREFIX/bin/bash"
   end
 
-  # Avoid relative paths
-  def post_install
-    lib_python_path = Pathname.glob(libexec/"lib/python*").first
-    lib_python_path.each_child do |f|
-      next unless f.symlink?
-
-      realpath = f.realpath
-      rm f
-      ln_s realpath, f
-    end
-  end
-
   test do
     ENV["LC_ALL"] = "en_US.UTF-8"
     system bin/"pipenv", "--python", which(python3)

--- a/Formula/t/tox.rb
+++ b/Formula/t/tox.rb
@@ -72,18 +72,6 @@ class Tox < Formula
     virtualenv_install_with_resources
   end
 
-  # Avoid relative paths
-  def post_install
-    lib_python_path = Pathname.glob(libexec/"lib/python*").first
-    lib_python_path.each_child do |f|
-      next unless f.symlink?
-
-      realpath = f.realpath
-      rm f
-      ln_s realpath, f
-    end
-  end
-
   test do
     assert_match "usage", shell_output("#{bin}/tox --help")
     system bin/"tox"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

These were added almost a decade ago: https://github.com/Homebrew/homebrew-core/commit/39a6dd0dbe7497f05d5363d335cdbc5bda332371 to fix https://github.com/Homebrew/homebrew-core/pull/20902#issuecomment-346245819 and https://github.com/Homebrew/homebrew-core/commit/857ee194151b74efc0a987dfb71fdf1a4f7f01a6

Not clear why symlinks would have existed under `libexec/"lib/python3.X"`, but there's definitely none today:

```
$ brew ruby -e 'p :tox.f.libexec.glob("lib/python*").first.each_child.to_a'
[#<Pathname:/opt/homebrew/opt/tox/libexec/lib/python3.14/site-packages>]
```