### PR TITLE
libgfshare: update homepage and source location

### DIFF
--- a/Formula/lib/libgfshare.rb
+++ b/Formula/lib/libgfshare.rb
@@ -1,14 +1,9 @@
 class Libgfshare < Formula
   desc "Library for sharing secrets"
-  homepage "https://www.digital-scurf.org/software/libgfshare"
-  url "https://www.digital-scurf.org/files/libgfshare/libgfshare-2.0.0.tar.bz2"
-  sha256 "86f602860133c828356b7cf7b8c319ba9b27adf70a624fe32275ba1ed268331f"
+  homepage "https://github.com/kinnison/libgfshare"
+  url "https://github.com/kinnison/libgfshare/archive/refs/tags/2.0.0.tar.gz"
+  sha256 "91d7ea7f3e5ddb3854a38827a3f6ea7c597db03067735dc953bd31c5b90f9930"
   license "MIT"
-
-  livecheck do
-    url "https://www.digital-scurf.org/files/libgfshare/"
-    regex(/href=.*?libgfshare[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "03c3d5940533347a32f937380585a7d501783d97ff8161a3b8b72a41d4ec8ce7"
@@ -26,13 +21,12 @@ class Libgfshare < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "4439a61e14f81e80009ad0e85a4e2a8183c106161d29e232176faa061ba380ba"
   end
 
-  # Fix -flat_namespace being used on Big Sur and later.
-  patch do
-    url "https://raw.githubusercontent.com/Homebrew/homebrew-core/1cf441a0/Patches/libtool/configure-pre-0.4.2.418-big_sur.diff"
-    sha256 "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923"
-  end
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
 
   def install
+    system "autoreconf", "--force", "--install", "--verbose"
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--disable-silent-rules",

--- a/Formula/lib/libgfshare.rb
+++ b/Formula/lib/libgfshare.rb
@@ -6,19 +6,13 @@ class Libgfshare < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:    "03c3d5940533347a32f937380585a7d501783d97ff8161a3b8b72a41d4ec8ce7"
-    sha256 cellar: :any,                 arm64_sequoia:  "cb19a495ba9032a4bd0e0c5e52bf818c8283af8b29dcb25a0a2f9bb0338c2880"
-    sha256 cellar: :any,                 arm64_sonoma:   "661368852f131d75f48672074dd635d04c95f30f61f1adae25c26db2cdc45dcc"
-    sha256 cellar: :any,                 arm64_ventura:  "ff95631a45cf14842a1cb98a7496022a886360fad2d4a9bae3154ebd6113726a"
-    sha256 cellar: :any,                 arm64_monterey: "0890a2e8ac99ea0497d467e1ab82bb8fe7a34d0f5cd75c01897f15b12ac65211"
-    sha256 cellar: :any,                 arm64_big_sur:  "d8fc2d9c78a69fc3fe30913aeaa6f1dbeea7091d78d50bd6e6fafcf4dc6dc212"
-    sha256 cellar: :any,                 sonoma:         "a8a4279f842d2809488dc30fe2ba7509412d0304e2d6f32e125ac80bf683f5cc"
-    sha256 cellar: :any,                 ventura:        "72816d2d02cec8f669f242e020e7b2980d9f16f51d8e388b57d77c5257a2775d"
-    sha256 cellar: :any,                 monterey:       "72af5816492ac0696211008f72b896eee5485c0227964c7eae8caadba28212d4"
-    sha256 cellar: :any,                 big_sur:        "619b6bee51163d432b903899d6d86223824e055124ead1856bc6c4399fef4fca"
-    sha256 cellar: :any,                 catalina:       "59d6afbdff08b3b457ae3bf6284859eb200929dbcf38c7a2e4f6025a45fe02dc"
-    sha256 cellar: :any_skip_relocation, arm64_linux:    "681eacdb672caf8dd195c5bb9bf891e5bb7c1317eb84e0e81faf1b155dd474ce"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4439a61e14f81e80009ad0e85a4e2a8183c106161d29e232176faa061ba380ba"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "9e5e82d21f97532066ac859f09e1bfe2dc1fa551109f538d1e4cdc09a80d5c4a"
+    sha256 cellar: :any,                 arm64_sequoia: "0fc98f80ef06554dcb6ce8b327e2deb830f59cd6d81a6e871204f3148a3c791b"
+    sha256 cellar: :any,                 arm64_sonoma:  "4b5d0de0f021094a0ba3b3dde70293441e07023aed4ec5fc068991a802186a31"
+    sha256 cellar: :any,                 sonoma:        "434c525551f2e403cbe28226836a20c16715e283c7b4439e1efb20a4eff10625"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "dd1cf741c9efe62d6498373e84a9d29b29ba0e16985721fb17d967ec5d43161f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1428a9c8652080cf16a5189f6a47c4b1feb62c2f4dbca7e688d86d0770c08802"
   end
 
   depends_on "autoconf" => :build


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Upstream refactor the homepage and now there is no info about `libgfshare`. This will resolve
- https://github.com/Homebrew/homebrew-core/issues/139929#issuecomment-4003471663

and a reference for author contact.
- https://social.flarn.net/@kinnison/115910671674613944