### PR TITLE
yubico-piv-tool: add libykcs11 caveat for `/usr/local/lib/libykcs11.dylib`

### DIFF
--- a/Formula/y/yubico-piv-tool.rb
+++ b/Formula/y/yubico-piv-tool.rb
@@ -41,6 +41,16 @@ class YubicoPivTool < Formula
     system "cmake", "--install", "build"
   end
 
+  def caveats
+    on_macos do
+      <<~EOS
+        Some software expects libykcs11 in /usr/local/lib. If you need it, create a hardlink:
+          sudo mkdir -p /usr/local/lib
+          sudo ln -f #{HOMEBREW_PREFIX}/lib/libykcs11.dylib /usr/local/lib/libykcs11.dylib
+      EOS
+    end
+  end
+
   test do
     assert_match "yubico-piv-tool #{version}", shell_output("#{bin}/yubico-piv-tool --version")
   end


### PR DESCRIPTION
fixes https://github.com/Homebrew/homebrew-core/issues/275577

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [X] Is your test running fine `brew test <formula>`?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [X] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

the research of how to add a message and how its done for other formulas AI was used. gpt-5.4-mini

-----

output of `brew install and brew info`

```sh
$ HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source yubico-piv-tool
==> Fetching downloads for: yubico-piv-tool
✔︎ Bottle Manifest check (0.15.2)                                                                                                                                 Downloaded   16.2KB/ 16.2KB
✔︎ Bottle Manifest cmake (4.3.1)                                                                                                                                  Downloaded   11.7KB/ 11.7KB
✔︎ Bottle Manifest gengetopt (2.23)                                                                                                                               Downloaded   16.1KB/ 16.1KB
✔︎ Bottle Manifest help2man (1.49.3_4)                                                                                                                            Downloaded   12.7KB/ 12.7KB
✔︎ Bottle check (0.15.2)                                                                                                                                          Downloaded  164.0KB/164.0KB
✔︎ Bottle gengetopt (2.23)                                                                                                                                        Downloaded  310.9KB/310.9KB
✔︎ Bottle help2man (1.49.3_4)                                                                                                                                     Downloaded  207.3KB/207.3KB
✔︎ Formula yubico-piv-tool (2.7.3)                                                                                                                                Verified      2.2MB/  2.2MB
✔︎ Bottle cmake (4.3.1)                                                                                                                                           Downloaded   19.2MB/ 19.2MB
...
==> Installing dependencies for yubico-piv-tool: check, cmake, gengetopt and help2man
==> Installing yubico-piv-tool dependency: check
==> Pouring check--0.15.2.arm64_tahoe.bottle.tar.gz
🍺  /opt/homebrew/Cellar/check/0.15.2: 44 files, 631.5KB
==> Installing yubico-piv-tool dependency: cmake
==> Pouring cmake--4.3.1.arm64_tahoe.bottle.tar.gz
🍺  /opt/homebrew/Cellar/cmake/4.3.1: 4,041 files, 65.4MB
==> Installing yubico-piv-tool dependency: gengetopt
==> Pouring gengetopt--2.23.arm64_tahoe.bottle.tar.gz
🍺  /opt/homebrew/Cellar/gengetopt/2.23: 39 files, 1.2MB
==> Installing yubico-piv-tool dependency: help2man
==> Pouring help2man--1.49.3_4.arm64_tahoe.bottle.1.tar.gz
🍺  /opt/homebrew/Cellar/help2man/1.49.3_4: 73 files, 837.8KB
==> Installing yubico-piv-tool
==> cmake -S . -B build
==> cmake --build build
==> cmake --install build
==> Caveats
Some software expects libykcs11 in /usr/local/lib. If you need it, create a hardlink:
  sudo mkdir -p /usr/local/lib
  sudo ln -f /opt/homebrew/lib/libykcs11.dylib /usr/local/lib/libykcs11.dylib
==> Summary
🍺  /opt/homebrew/Cellar/yubico-piv-tool/2.7.3: 19 files, 973.4KB, built in 15 seconds
==> Running `brew cleanup yubico-piv-tool`...
Disable this behaviour by setting `HOMEBREW_NO_INSTALL_CLEANUP=1`.
Hide these hints with `HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).
==> Caveats
==> yubico-piv-tool
Some software expects libykcs11 in /usr/local/lib. If you need it, create a hardlink:
  sudo mkdir -p /usr/local/lib
  sudo ln -f /opt/homebrew/lib/libykcs11.dylib /usr/local/lib/libykcs11.dylib
  
$ HOMEBREW_NO_INSTALL_FROM_API=1 brew info yubico-piv-tool
==> yubico-piv-tool ✔: stable 2.7.3 (bottled)
Command-line tool for the YubiKey PIV application
https://developers.yubico.com/yubico-piv-tool/
Installed
/opt/homebrew/Cellar/yubico-piv-tool/2.7.3 (19 files, 973.4KB) *
  Built from source on 2026-04-01 at 10:52:20
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/y/yubico-piv-tool.rb
License: BSD-2-Clause
==> Dependencies
Build: check ✔, cmake ✔, gengetopt ✔, help2man ✔, pkgconf ✔
Required: openssl@3 ✔
==> Caveats
Some software expects libykcs11 in /usr/local/lib. If you need it, create a hardlink:
  sudo mkdir -p /usr/local/lib
  sudo ln -f /opt/homebrew/lib/libykcs11.dylib /usr/local/lib/libykcs11.dylib
==> Analytics
install: 366 (30 days), 1,611 (90 days), 5,280 (365 days)
install-on-request: 366 (30 days), 1,610 (90 days), 5,279 (365 days)
build-error: 0 (30 days)
```