### PR TITLE
libpathrs 0.2.4 (new formula)

### DIFF
--- a/Formula/lib/libpathrs.rb
+++ b/Formula/lib/libpathrs.rb
@@ -6,6 +6,11 @@ class Libpathrs < Formula
   license any_of: ["MPL-2.0", "LGPL-3.0-or-later"]
   head "https://github.com/cyphar/libpathrs.git", branch: "main"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_linux:  "54e2fb4e4f26b0e376cf5435f6b76c391e001fc3dcd4661614952e193d2600c0"
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "19d30702ac6daba0bd789f87a94d19ebc66152f1f8a8d7b550f9f5e3159a8935"
+  end
+
   depends_on "lld" => :build
   depends_on "pkgconf" => :build
   depends_on "rust" => :build

--- a/Formula/lib/libpathrs.rb
+++ b/Formula/lib/libpathrs.rb
@@ -1,0 +1,42 @@
+class Libpathrs < Formula
+  desc "C-friendly API to make path resolution safer on Linux"
+  homepage "https://github.com/cyphar/libpathrs"
+  url "https://github.com/cyphar/libpathrs/archive/refs/tags/v0.2.4.tar.gz"
+  sha256 "2bd56d6cfdc6b2394740a329efdaf9eeda315ae947c68adb1f673a3cb76f65a7"
+  license any_of: ["MPL-2.0", "LGPL-3.0-or-later"]
+  head "https://github.com/cyphar/libpathrs.git", branch: "main"
+
+  depends_on "lld" => :build
+  depends_on "pkgconf" => :build
+  depends_on "rust" => :build
+  depends_on :linux
+
+  def install
+    # Not parallelizable because hack/with-crate-type.sh modifies Cargo.toml in-place
+    ENV.deparallelize
+    system "make", "release"
+    # install.sh is the recommended installation method
+    # https://github.com/cyphar/libpathrs/blob/main/INSTALL.md#installing
+    system "./install.sh", "--prefix=#{prefix}", "--libdir=#{lib}"
+  end
+
+  test do
+    (testpath/"test.c").write <<~C
+      #include <pathrs.h>
+      #include <stdio.h>
+      #include <unistd.h>
+
+      int main(void) {
+        int fd = pathrs_open_root("/tmp");
+        if (fd < 0) return 1;
+        int resolved = pathrs_inroot_resolve(fd, ".");
+        close(fd);
+        if (resolved < 0) return 1;
+        close(resolved);
+        return 0;
+      }
+    C
+    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lpathrs", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.
  - Used Claude Code for the draft and modified it manually. Manually verified by installing and testing runc HEAD (1.5.0-rc.1+dev), which depends on this library.
-----

libpathrs is now required by the HEAD of runc.

<details>

<p>

```console
$ brew install --HEAD runc
==> Fetching downloads for: runc
✔︎ API Source runc.rb                                                                                                    Verified      1.2KB/  1.2KB
✔︎ Bottle Manifest go-md2man (2.0.7)                                                                                     Downloaded    9.5KB/  9.5KB
✔︎ Bottle Manifest pkgconf (2.5.1)                                                                                       Downloaded   12.2KB/ 12.2KB
✔︎ Bottle go-md2man (2.0.7)                                                                                              Downloaded  875.6KB/875.6KB
✔︎ Bottle pkgconf (2.5.1)                                                                                                Downloaded  152.6KB/152.6KB
✔︎ Formula runc (HEAD-62d4f14)
==> Installing dependencies for runc: go-md2man and pkgconf
==> Installing runc dependency: go-md2man
==> Pouring go-md2man--2.0.7.arm64_linux.bottle.tar.gz
🍺  /home/linuxbrew/.linuxbrew/Cellar/go-md2man/2.0.7: 7 files, 2.3MB
==> Installing runc dependency: pkgconf
==> Pouring pkgconf--2.5.1.arm64_linux.bottle.tar.gz
🍺  /home/linuxbrew/.linuxbrew/Cellar/pkgconf/2.5.1: 29 files, 773.2KB
==> Installing runc --HEAD
==> make
Last 15 lines from /home/suda.guest/.cache/Homebrew/Logs/runc/01.make.log:
2026-04-02 03:26:42 +0000

make

go build -trimpath "-buildmode=pie"  -tags "seccomp urfave_cli_no_docs libpathrs " -ldflags "-X main.gitCommit=v1.5.0-rc.1-34-g62d4f147  " -o runc .
# github.com/opencontainers/runc
/home/linuxbrew/.linuxbrew/Cellar/go/1.26.1/libexec/pkg/tool/linux_arm64/link: running gcc-15 failed: exit status 1
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/shims/linux/super/gcc-15 -Wl,-z,relro -pie -Wl,--build-id=0xcb7a6cbfe5103a374af55694b6f6828adfc8acfd -o $WORK/b001/exe/a.out -Wl,--export-dynamic-symbol=_cgo_panic -Wl,--export-dynamic-symbol=_cgo_topofstack -Wl,--export-dynamic-symbol=crosscall2 -Wl,--compress-debug-sections=zlib /var/tmp/go-link-4011693837/go.o /var/tmp/go-link-4011693837/000000.o /var/tmp/go-link-4011693837/000001.o /var/tmp/go-link-4011693837/000002.o /var/tmp/go-link-4011693837/000003.o /var/tmp/go-link-4011693837/000004.o /var/tmp/go-link-4011693837/000005.o /var/tmp/go-link-4011693837/000006.o /var/tmp/go-link-4011693837/000007.o /var/tmp/go-link-4011693837/000008.o /var/tmp/go-link-4011693837/000009.o /var/tmp/go-link-4011693837/000010.o /var/tmp/go-link-4011693837/000011.o /var/tmp/go-link-4011693837/000012.o /var/tmp/go-link-4011693837/000013.o /var/tmp/go-link-4011693837/000014.o /var/tmp/go-link-4011693837/000015.o /var/tmp/go-link-4011693837/000016.o /var/tmp/go-link-4011693837/000017.o /var/tmp/go-link-4011693837/000018.o /var/tmp/go-link-4011693837/000019.o /var/tmp/go-link-4011693837/000020.o /var/tmp/go-link-4011693837/000021.o /var/tmp/go-link-4011693837/000022.o /var/tmp/go-link-4011693837/000023.o /var/tmp/go-link-4011693837/000024.o /var/tmp/go-link-4011693837/000025.o /var/tmp/go-link-4011693837/000026.o /var/tmp/go-link-4011693837/000027.o /var/tmp/go-link-4011693837/000028.o /var/tmp/go-link-4011693837/000029.o /var/tmp/go-link-4011693837/000030.o /var/tmp/go-link-4011693837/000031.o /var/tmp/go-link-4011693837/000032.o /var/tmp/go-link-4011693837/000033.o /var/tmp/go-link-4011693837/000034.o /var/tmp/go-link-4011693837/000035.o /var/tmp/go-link-4011693837/000036.o /var/tmp/go-link-4011693837/000037.o /var/tmp/go-link-4011693837/000038.o /var/tmp/go-link-4011693837/000039.o -O2 -g -lresolv -O2 -g -O2 -g -O2 -g -lpthread -O2 -g -O2 -g -L/home/linuxbrew/.linuxbrew/Cellar/libseccomp/2.6.0/lib -lseccomp -O2 -g -L/home/linuxbrew/.linuxbrew/Cellar/libseccomp/2.6.0/lib -lseccomp -O2 -g -L/home/linuxbrew/.linuxbrew/Cellar/libpathrs/0.2.4/lib -lpathrs
/usr/bin/ld: cannot find -lpathrs: No such file or directory
collect2: error: ld returned 1 exit status

make: *** [Makefile:85: runc-bin] Error 1

READ THIS: https://docs.brew.sh/Troubleshooting

runc's formula was built from an unstable upstream --HEAD.
This build failure is expected behaviour.
```

</p>
</details>

Tested the functionality of the formula as follows:
```bash
brew install --HEAD runc
brew install docker docker-engine rootlesskit slirp4netns
dockerd-rootless-setuptool.sh install
docker run hello-world
```