### PR TITLE
influxdb: update livecheck

### DIFF
--- a/Formula/i/influxdb.rb
+++ b/Formula/i/influxdb.rb
@@ -11,7 +11,7 @@ class Influxdb < Formula
   # version in the install script instead.
   livecheck do
     url "https://www.influxdata.com/d/install_influxdb3.sh"
-    regex(/^INFLUXDB_VERSION=["']v?(\d+(?:\.\d+)+)["']$/i)
+    regex(/^INFLUXDB_OSS_VERSION=["']v?(\d+(?:\.\d+)+)["']$/i)
   end
 
   bottle do


### PR DESCRIPTION
```console
❯ curl -sL https://www.influxdata.com/d/install_influxdb3.sh | grep -E 'INFLUXDB_(OSS_)?VERSION'
INFLUXDB_VERSION_FLAG_SET="0"
INFLUXDB_OSS_VERSION="3.9.0"
INFLUXDB_VERSION="${INFLUXDB_OSS_VERSION}"
            INFLUXDB_VERSION="$2"
            INFLUXDB_VERSION_FLAG_SET=1
            if [ "${INFLUXDB_VERSION_FLAG_SET}" == "0" ]; then
                INFLUXDB_VERSION="${INFLUXDB_ENT_VERSION}"
            printf "  --version VERSION: Specify InfluxDB version (default: %s)\n" "$INFLUXDB_VERSION"
URL="https://dl.influxdata.com/influxdb/releases/influxdb3-${EDITION_TAG}-${INFLUXDB_VERSION}_${ARTIFACT}.tar.gz"
```
```console
❯ brew lc --autobump influxdb
influxdb: 3.8.3 ==> 3.9.0
```