### PR TITLE
gtk4 libadwaita: remove `sassc` usage

### DIFF
--- a/Formula/g/gtk4.rb
+++ b/Formula/g/gtk4.rb
@@ -29,7 +29,6 @@ class Gtk4 < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkgconf" => [:build, :test]
-  depends_on "sassc" => :build
   depends_on "cairo"
   depends_on "fontconfig"
   depends_on "fribidi"

--- a/Formula/g/gtk4.rb
+++ b/Formula/g/gtk4.rb
@@ -13,12 +13,13 @@ class Gtk4 < Formula
   end
 
   bottle do
-    sha256 arm64_tahoe:   "629aad16613de3d3c52a7b319e2b3b523c1cc107484b6967f860e2140aeff6eb"
-    sha256 arm64_sequoia: "05ed86ffb535047afa7e3f178358ddcd0e8c411df5be5b6711f8cdfab0749209"
-    sha256 arm64_sonoma:  "c1ed38af4735867e2f71f58aa72b1931240159fc0f6fce94faee9489efa904e4"
-    sha256 sonoma:        "b4e793432f03c317c8adc9cd518dea27394a301c755f45cebcdda8e568acd3c2"
-    sha256 arm64_linux:   "9933655624b796b21e1f5f3dcf3da514877f72d9603a83a6ea415a3e2949cced"
-    sha256 x86_64_linux:  "4977c56351fea5ee4954229a0906a56cb249ad2055133877ace71056dd97c10e"
+    rebuild 1
+    sha256 arm64_tahoe:   "df9fccdfab031083ad3665e2611c20b8dd7ae9197cc3f27117b8d78fcdad6b9b"
+    sha256 arm64_sequoia: "46d06f694632df98a45eeea8f11683941e6a2e81e63e88a49dae6b8c19057b91"
+    sha256 arm64_sonoma:  "1822fa25451d8fc9b38118d0af2691882c41715c833adf83328a82cd95c23f4a"
+    sha256 sonoma:        "ff5108a4cc81b600710f5cf01fb3bb97b798f782a0f85fd02e847e145e747daa"
+    sha256 arm64_linux:   "85b73eb5727ad76f794ed01225587c2792a6338a60dccb61c75627a6143854c4"
+    sha256 x86_64_linux:  "446dc5d917d848b6398529a78bb602f375e8c5cbd7fc2d571b70afd04aa7ba04"
   end
 
   depends_on "docbook" => :build

--- a/Formula/lib/libadwaita.rb
+++ b/Formula/lib/libadwaita.rb
@@ -24,12 +24,12 @@ class Libadwaita < Formula
     sha256 x86_64_linux:  "a117edaf5c71c53a95ceafe9e025c4690ca7bbaa321210bf560d66121fc41dff"
   end
 
+  depends_on "dart-sass" => :build
   depends_on "gettext" => :build
   depends_on "gobject-introspection" => :build
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkgconf" => [:build, :test]
-  depends_on "sassc" => :build
   depends_on "vala" => :build
 
   depends_on "appstream"
@@ -37,7 +37,6 @@ class Libadwaita < Formula
   depends_on "glib"
   depends_on "graphene"
   depends_on "gtk4"
-  depends_on "libsass"
   depends_on "pango"
 
   uses_from_macos "python" => :build
@@ -46,7 +45,19 @@ class Libadwaita < Formula
     depends_on "gettext"
   end
 
+  # Fix style without closed parentheses
+  patch do
+    url "https://gitlab.gnome.org/GNOME/libadwaita/-/commit/ad0214cd1f6fb79d743b252d35f2657f875480e8.diff"
+    sha256 "b7d8c4920805bf62253738e4d2a7e56bd8c9f4468f082b7c7f8819132a333ea5"
+  end
+
   def install
+    # Replace deprecated `sassc` with `sass` in the meson build file
+    inreplace "src/stylesheet/meson.build" do |s|
+      s.gsub! "'sassc'", "'sass'"
+      s.gsub! "'-a', '-M', '-t', 'compact'", "'--style', 'compressed'"
+    end
+
     system "meson", "setup", "build", "-Dtests=false", *std_meson_args
     system "meson", "compile", "-C", "build", "--verbose"
     system "meson", "install", "-C", "build"

--- a/Formula/lib/libadwaita.rb
+++ b/Formula/lib/libadwaita.rb
@@ -16,12 +16,13 @@ class Libadwaita < Formula
   end
 
   bottle do
-    sha256 arm64_tahoe:   "3645d495faea2cceea3cd940960b46b1b3434baef1479c7b0da742200090dfbf"
-    sha256 arm64_sequoia: "d25dd8ba4179c910c19c30833b85bc1430424e58c49792c757976619e80c8b44"
-    sha256 arm64_sonoma:  "76d48cee7aa9ac7fdc568f62c5313bc799595975b022b75d465b6b75e06fa25f"
-    sha256 sonoma:        "4a95fd1f17a61d71bf5dd4903f1a5a231d7a52b3395cd979af7ceaf17891e3ea"
-    sha256 arm64_linux:   "2aec703ee231963bd077303d01830b39801b52aa450e5d5b4c84a34bc350ee41"
-    sha256 x86_64_linux:  "a117edaf5c71c53a95ceafe9e025c4690ca7bbaa321210bf560d66121fc41dff"
+    rebuild 1
+    sha256 arm64_tahoe:   "881a99482118b9c5d55e837dd18d30deb5437d72b324811a0640a8503c782308"
+    sha256 arm64_sequoia: "8dd8ff82c9cffee0d1fa58f4e6e8e545b663006dc28dd1978e33490cf26de70c"
+    sha256 arm64_sonoma:  "3a60b46ebe1d02f32d5c0ee9e470947b1483c6685d03af04f2dbfd7cc6a1707d"
+    sha256 sonoma:        "3551f415600001e6fa2c2a1817c5922c94bf9fb566ea8aeffe411d183845c4f5"
+    sha256 arm64_linux:   "180e9facf4cc6736ce704e76437ba47d6e060f99024739017d29ceaaeead8b85"
+    sha256 x86_64_linux:  "af35c9ad4b433af1531f9e9a8376a2a29295357f3a8f3aa50ebccdb7042c5d9d"
   end
 
   depends_on "dart-sass" => :build


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

- `gtk4` uses sassc but the tarball is already creates css files and so we don't need. 
- `libadwaita` needs to replace `sassc` to the other `sass` tool and I tried to use `dart-sass`.

