### PR TITLE
graalvm: enable macOS x86_64 support

### DIFF
--- a/Formula/g/graalvm.rb
+++ b/Formula/g/graalvm.rb
@@ -37,10 +37,6 @@ class Graalvm < Formula
   uses_from_macos "unzip"
   uses_from_macos "zip"
 
-  on_macos do
-    depends_on arch: :arm64
-  end
-
   on_linux do
     depends_on "alsa-lib"
     depends_on "fontconfig"


### PR DESCRIPTION
The GraalVm formula is not working on intel as it has a requirement for arm only. It should work. This change will remove the precheck. I am building native image binaries for arm and intel as it needs architecture specific instructions

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
