### PR TITLE
itk: fix hardcoded macOS SDK paths in cmake config

### DIFF
--- a/Formula/i/itk.rb
+++ b/Formula/i/itk.rb
@@ -105,6 +105,18 @@ class Itk < Formula
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
 
+    # Replace versioned macOS SDK paths with the unversioned symlink so that
+    # bottles built on one SDK version work on systems with a different SDK.
+    if OS.mac?
+      sdk_path = MacOS.sdk_path.to_s
+      generic_sdk = "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
+      if sdk_path != generic_sdk
+        Dir.glob(lib/"cmake/ITK-#{version.major_minor}/*.cmake").each do |f|
+          inreplace f, sdk_path, generic_sdk, audit_result: false
+        end
+      end
+    end
+
     # Remove the bundled JRE installed by SCIFIO ImageIO plugin
     rm_r(lib/"jre") if OS.linux? || Hardware::CPU.intel?
   end


### PR DESCRIPTION
## Summary
- Replace versioned macOS SDK paths (e.g. `MacOSX14.sdk`) with the unversioned `MacOSX.sdk` symlink in installed cmake config files
- Prevents bottle portability failures when downstream packages link against ITK on a system with a different SDK version

## Problem
ITK's cmake install writes absolute SDK paths like `/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/usr/lib/libexpat.tbd` into `ITKTargets.cmake`. When the bottle is built on macOS 14 SDK but installed on a system with macOS 26 SDK (or vice versa), downstream packages like vmtk fail with:
```
No rule to make target `/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/usr/lib/libexpat.tbd'
```

## Fix
After `cmake --install`, replace the versioned SDK path with `/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk` (the unversioned symlink that always points to the active SDK).

## Test plan
- [x] Built and tested locally on macOS 26 (Tahoe) x86_64
- [x] `brew style Formula/i/itk.rb` passes
- [x] Verified downstream vmtk builds successfully against the fixed ITK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew test <formula>` locally?
- [x] Does your build pass `brew audit --strict <formula>` locally?
- [x] AI assisted with this PR — identified the root cause, wrote the fix, verified style compliance