### PR TITLE
depsguard 0.1.0 (new formula)

### DIFF
--- a/Formula/d/depsguard.rb
+++ b/Formula/d/depsguard.rb
@@ -1,0 +1,18 @@
+class Depsguard < Formula
+  desc "Harden package manager configs against supply chain attacks, built by Arnica"
+  homepage "https://depsguard.com"
+  url "https://github.com/arnica/depsguard/archive/refs/tags/v0.1.0.tar.gz"
+  sha256 "05696ce205b78a9f936af418cb7ab95f7931ad8135115588b4f050f8eed57271"
+  license "MIT"
+  head "https://github.com/arnica/depsguard.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    assert_match "depsguard", shell_output("#{bin}/depsguard --help")
+  end
+end


### PR DESCRIPTION
## Summary
- add a new `depsguard` formula for the Rust CLI that hardens package manager configs against supply chain attacks
- build from source using `cargo install` with Homebrew standard Cargo args
- include a basic `--help` formula test

## Test plan
- [x] `brew style --fix Formula/d/depsguard.rb`
- [ ] `brew install --build-from-source ./Formula/d/depsguard.rb` (blocked in this environment due to local Homebrew cellar permissions)
- [ ] `brew audit --strict --new --online depsguard` (ready to run in a normal local Homebrew environment)
- [ ] `brew test depsguard`