### PR TITLE
parallel-disk-usage: man page and simplification

### DIFF
--- a/Formula/p/parallel-disk-usage.rb
+++ b/Formula/p/parallel-disk-usage.rb
@@ -18,17 +18,12 @@ class ParallelDiskUsage < Formula
   depends_on "rust" => :build
 
   def install
-    features = ["cli", "cli-completions"]
-    system "cargo", "install", *std_cargo_args(features:)
+    system "cargo", "install", *std_cargo_args
 
-    system bin/"pdu-completions", "--name", "pdu", "--shell", "bash", "--output", "pdu.bash"
-    system bin/"pdu-completions", "--name", "pdu", "--shell", "fish", "--output", "pdu.fish"
-    system bin/"pdu-completions", "--name", "pdu", "--shell", "zsh", "--output", "_pdu"
-    bash_completion.install "pdu.bash" => "pdu"
-    fish_completion.install "pdu.fish"
-    zsh_completion.install "_pdu"
-
-    rm bin/"pdu-completions"
+    bash_completion.install "exports/completion.bash" => "pdu"
+    fish_completion.install "exports/completion.fish" => "pdu.fish"
+    zsh_completion.install "exports/completion.zsh" => "_pdu"
+    man1.install "exports/pdu.1"
   end
 
   test do


### PR DESCRIPTION
**DISCLAIMER:** I asked an AI to generate this code since I don't know Ruby.

## Description

Add a man page. Use bundled completions and man page from the upstream `exports/` directory instead of generating them at build time. This simplifies the build by dropping the `cli-completions` feature flag.

## Checklist

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source parallel-disk-usage`?
- [x] Is your test running fine `brew test parallel-disk-usage`?
- [x] Does your build pass `brew audit --strict parallel-disk-usage`?

- [x] AI was used to generate or assist with generating this PR.

https://claude.ai/code/session_01J6QaGQfqHD5rwt6tHfrp3Q