### PR TITLE
parallel-disk-usage: simplify completion installation

### DIFF
--- a/Formula/p/parallel-disk-usage.rb
+++ b/Formula/p/parallel-disk-usage.rb
@@ -18,17 +18,11 @@ class ParallelDiskUsage < Formula
   depends_on "rust" => :build
 
   def install
-    features = ["cli", "cli-completions"]
-    system "cargo", "install", *std_cargo_args(features:)
+    system "cargo", "install", *std_cargo_args(features: ["cli"])
 
-    system bin/"pdu-completions", "--name", "pdu", "--shell", "bash", "--output", "pdu.bash"
-    system bin/"pdu-completions", "--name", "pdu", "--shell", "fish", "--output", "pdu.fish"
-    system bin/"pdu-completions", "--name", "pdu", "--shell", "zsh", "--output", "_pdu"
-    bash_completion.install "pdu.bash" => "pdu"
-    fish_completion.install "pdu.fish"
-    zsh_completion.install "_pdu"
-
-    rm bin/"pdu-completions"
+    bash_completion.install "exports/completion.bash" => "pdu"
+    fish_completion.install "exports/completion.fish" => "pdu.fish"
+    zsh_completion.install "exports/completion.zsh" => "_pdu"
   end
 
   test do


### PR DESCRIPTION
## Description

Simplifies the completion file installation process for `parallel-disk-usage` by:

1. Removing the `cli-completions` feature flag from the build, keeping only the `cli` feature
2. Replacing the dynamic completion generation (via `pdu-completions` binary) with direct installation of pre-built completion files from the `exports/` directory
3. Removing the temporary `pdu-completions` binary after completion generation

This change assumes that the upstream project now provides pre-built completion files in the `exports/` directory, eliminating the need for runtime generation and the associated build complexity.

## Checklist

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source parallel-disk-usage`?
- [ ] Is your test running fine `brew test parallel-disk-usage`?
- [ ] Does your build pass `brew audit --strict parallel-disk-usage`?

- [x] AI was used to generate or assist with generating this PR.

https://claude.ai/code/session_01RVposY5P7i7rVxu25UZQ2D