### PR TITLE
ab-av1: update test

### DIFF
--- a/Formula/a/ab-av1.rb
+++ b/Formula/a/ab-av1.rb
@@ -26,7 +26,10 @@ class AbAv1 < Formula
   test do
     assert_match version.to_s, shell_output("#{bin}/ab-av1 --version")
 
-    system bin/"ab-av1", "encode", "-i", test_fixtures("test.mp4"), "--crf", "32", "-o", testpath/"test.av1.mp4"
+    # Create a 5 second test MP4 (same as ffmpeg test) as the test fixture is too minimal
+    system Formula["ffmpeg"].bin/"ffmpeg", "-filter_complex", "testsrc=rate=1:duration=5", "test.mp4"
+
+    system bin/"ab-av1", "auto-encode", "-i", "test.mp4", "-o", testpath/"test.av1.mp4"
     assert_path_exists testpath/"test.av1.mp4"
   end
 end


### PR DESCRIPTION
Testing `auto-encode` to see more common use case rather than just `encode`:

> ### Command: auto-encode
> Automatically determine the best crf to deliver the `--min-vmaf` and use it to encode a video or image.
> 
> Two phases:
> * [crf-search](#command-crf-search) to determine the best --crf value
> * ffmpeg to encode using the settings

> ### Command: encode
> Invoke ffmpeg to encode a video or image.

Should fail right now.

---

Modified to show alternative to 
- https://github.com/Homebrew/homebrew-core/pull/276062

When combined with
- https://github.com/Homebrew/brew/pull/21922