### PR TITLE
ffmpeg: enable `libvmaf` due to dependent `ab-av1`

### DIFF
--- a/Formula/f/ffmpeg.rb
+++ b/Formula/f/ffmpeg.rb
@@ -15,13 +15,13 @@ class Ffmpeg < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 arm64_tahoe:   "7799f9b312c176157e897e87f07d23249b0da377573f93863f2a0934a8eb5da2"
-    sha256 arm64_sequoia: "fa65fab570180030fde32541493ba0c9ad81b2bd527f355e08942b89df6709e9"
-    sha256 arm64_sonoma:  "51b2f2fad949f77f845d5b3a597df20eac4433538c36034ff6a0f3756e8f99bc"
-    sha256 sonoma:        "da49bd1a0fb3cda65ccb444321a53f91e763051f41ac910e418187dd9ee6ccba"
-    sha256 arm64_linux:   "62b4efe1ea8f74a3f677a3a3aa7321476eb8f6baccaf7c466bc7467f20d7cf2f"
-    sha256 x86_64_linux:  "08a5335d86b762b5079a1ccb37496dd59c4064490f2aff40f21f107cb51ff5c6"
+    rebuild 2
+    sha256 arm64_tahoe:   "024e65624fd6c45be22c5584824a58f9d1574f011de2ab8663deb24859d7c270"
+    sha256 arm64_sequoia: "e1c8c446667b1b7cd74f4469171b6c5bcc2f8b83bae402fc015455c2bab03d2d"
+    sha256 arm64_sonoma:  "68360419ec69152abf9b43c9600a4204a5ae35fc5a3e1ca04c9aa2272d878177"
+    sha256 sonoma:        "a8436e19dbac435e356681824c94cd67d7382409241a0b748333568cbc85a972"
+    sha256 arm64_linux:   "b35368cffecc23ce31d656f0d1e27b594562de8398e7685e7dca3b293ffc2676"
+    sha256 x86_64_linux:  "f6e9a913d33d319cc4c47876c71d06b91ef6e37df94555052d2674b7fed159e2"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/f/ffmpeg.rb
+++ b/Formula/f/ffmpeg.rb
@@ -34,6 +34,7 @@ class Ffmpeg < Formula
   # negligible and has all moved to e.g. x265 instead.
   depends_on "dav1d"
   depends_on "lame"
+  depends_on "libvmaf" # dependent: ab-av1
   depends_on "libvpx"
   depends_on "openssl@3"
   depends_on "opus"
@@ -76,6 +77,7 @@ class Ffmpeg < Formula
       --enable-libx264
       --enable-libmp3lame
       --enable-libdav1d
+      --enable-libvmaf
       --enable-libvpx
       --enable-libx265
       --enable-openssl


### PR DESCRIPTION
Fixes #274849

Maintainer feedback to make sure we want to enable. At least no recursive dependencies. License is `BSD-2-Clause-Patent`

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
