### PR TITLE
agent-browser: install shell completions

### DIFF
--- a/Formula/a/agent-browser.rb
+++ b/Formula/a/agent-browser.rb
@@ -36,6 +36,11 @@ class AgentBrowser < Formula
     node_modules.glob("node_modules/*/prebuilds/*").each do |prebuild_dir|
       rm_r(prebuild_dir) if prebuild_dir.basename.to_s != "#{os}-#{arch}"
     end
+
+    # Install shell completions
+    bash_completion.install node_modules/"completions/agent-browser.bash" => "agent-browser"
+    zsh_completion.install node_modules/"completions/agent-browser.zsh" => "_agent-browser"
+    fish_completion.install node_modules/"completions/agent-browser.fish"
   end
 
   def caveats


### PR DESCRIPTION
## Summary

- Install bash, zsh, and fish shell completions from the upstream `completions/` directory

The completion scripts are being added upstream in https://github.com/vercel-labs/agent-browser/pull/1140. This PR should **not be merged** until that PR is merged and included in a published npm release.