### PR TITLE
nuitka: migrate to `python@3.14`

### DIFF
--- a/Formula/n/nuitka.rb
+++ b/Formula/n/nuitka.rb
@@ -9,12 +9,13 @@ class Nuitka < Formula
   head "https://github.com/Nuitka/Nuitka.git", branch: "develop"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "446a6c056e9ee1dbe150a3baecebb7f56710424006a6e45d8ddec6430ae6ea4e"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "f8cb422d3ac4735a57b129e3e2ffd9d0d5e48da629f866b327e1b6cb377717f0"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "1f9b2e79a92e4fffb9f1d36f6b7af766ad8c9863249dc285b7448db9845111db"
-    sha256 cellar: :any_skip_relocation, sonoma:        "6e7a727c8d2d516df1d443b6bc3c29b0f988edc2131e58a1e1ffd277ae67198d"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "8821e787630c9f5d2eb241712640f09b3191ccdb7662daeaee2f32ec64f5766f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "26b28b3abf449981e79bafe755d6dbe63ae24574ec255f88c37957c240597f80"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "96bfcc3de90d3485afb92ebbfb6896e1721f2935ad1b0e29b242247e82b9140c"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "065857cc5116eb682af9321275ebe8567609782bc4e14e471dd426e8f477650a"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "b0d061d1a02c582b52767a40e2a80eac30e16dff3fe887b9ece03a69acd691cb"
+    sha256 cellar: :any_skip_relocation, sonoma:        "ddf715eafcebf140aacb2db1ff403be4d9d39c93860fa0b44c1c3bec05dc5bcb"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "22b5886a56dff76aa00355af9b04801352092570c0884bda0f4872c524399988"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "75c898bedfde1072f1a0bacef64b831828a700fdd19b5fe79a33a40d77d69d1c"
   end
 
   depends_on "ccache"

--- a/Formula/n/nuitka.rb
+++ b/Formula/n/nuitka.rb
@@ -5,7 +5,8 @@ class Nuitka < Formula
   homepage "https://nuitka.net"
   url "https://files.pythonhosted.org/packages/ed/0e/2537066db2458843e4a1edfc524409069ad58a456fc4b312b18b1d327431/nuitka-4.0.7.tar.gz"
   sha256 "26543bfed6009a466ae8608bdc643add81a497e8662e4aaf157cd00aa7fd5b9f"
-  license "Apache-2.0"
+  license "AGPL-3.0-only"
+  head "https://github.com/Nuitka/Nuitka.git", branch: "develop"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "446a6c056e9ee1dbe150a3baecebb7f56710424006a6e45d8ddec6430ae6ea4e"
@@ -17,7 +18,7 @@ class Nuitka < Formula
   end
 
   depends_on "ccache"
-  depends_on "python@3.13" # planning to support Python 3.14, https://github.com/Nuitka/Nuitka/issues/3630
+  depends_on "python@3.14"
 
   on_linux do
     depends_on "patchelf"
@@ -25,11 +26,11 @@ class Nuitka < Formula
 
   def install
     virtualenv_install_with_resources
-    man1.install Dir["doc/*.1"]
+    man1.install buildpath.glob("doc/*.1")
   end
 
   test do
-    (testpath/"test.py").write <<~EOS
+    (testpath/"test.py").write <<~PYTHON
       def talk(message):
           return "Talk " + message
 
@@ -38,7 +39,7 @@ class Nuitka < Formula
 
       if __name__ == "__main__":
           main()
-    EOS
+    PYTHON
     assert_match "Talk Hello World", shell_output("#{libexec}/bin/python test.py")
     system bin/"nuitka", "--onefile", "-o", "test", "test.py"
     assert_match "Talk Hello World", shell_output("./test")


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

3.14 has been officially supported since 4.0: https://github.com/Nuitka/Nuitka/commit/5f4927621fab588b9d464ddf2ab21317fe8b82ab

And license changed in https://github.com/Nuitka/Nuitka/commit/25d9589c92abbe2b420e2808419addabb1aa9938