### PR TITLE
netspeed-cli 0.2.0 (new formula)

### DIFF
--- a/Formula/n/netspeed-cli.rb
+++ b/Formula/n/netspeed-cli.rb
@@ -4,7 +4,6 @@ class NetspeedCli < Formula
   url "https://github.com/mapleDevJS/netspeed-cli/archive/refs/tags/v0.2.2.tar.gz"
   sha256 "fce853bf828868f79f395d2be92ba1f00116520d363d7eec9bf9e8b8af5b4357"
   license "MIT"
-  head "https://github.com/mapleDevJS/netspeed-cli.git", branch: "master"
 
   depends_on "rust" => :build
 

--- a/Formula/n/netspeed-cli.rb
+++ b/Formula/n/netspeed-cli.rb
@@ -1,0 +1,18 @@
+class NetspeedCli < Formula
+  desc "Command-line interface for testing internet bandwidth using speedtest.net"
+  homepage "https://github.com/mapleDevJS/netspeed-cli"
+  url "https://github.com/mapleDevJS/netspeed-cli/archive/refs/tags/v0.2.2.tar.gz"
+  sha256 "fce853bf828868f79f395d2be92ba1f00116520d363d7eec9bf9e8b8af5b4357"
+  license "MIT"
+  head "https://github.com/mapleDevJS/netspeed-cli.git", branch: "master"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    assert_match "netspeed-cli", shell_output("#{bin}/netspeed-cli --version")
+  end
+end

--- a/Formula/n/netspeed-cli.rb
+++ b/Formula/n/netspeed-cli.rb
@@ -10,6 +10,14 @@ class NetspeedCli < Formula
 
   def install
     system "cargo", "install", *std_cargo_args
+
+    # Install shell completions
+    bash_completion.install "completions/netspeed-cli.bash" => "netspeed-cli"
+    zsh_completion.install "completions/_netspeed-cli" => "_netspeed-cli"
+    fish_completion.install "completions/netspeed-cli.fish"
+
+    # Install man page
+    man1.install "netspeed-cli.1"
   end
 
   test do


### PR DESCRIPTION
Add netspeed-cli, a command-line internet bandwidth testing tool using speedtest.net servers.

### Features
- Download, upload, and latency testing against speedtest.net servers
- Multiple output formats: simple, JSON, CSV
- Shell completions (bash, zsh, fish)
- Man page included

### Checklist
- [x] `brew audit --strict --online` passes
- [x] `brew test` passes
- [x] Source is from a tagged GitHub release
- [x] Licensed under MIT