### PR TITLE
rad: add radls LSP server binary and update homepage

### DIFF
--- a/Formula/r/rad.rb
+++ b/Formula/r/rad.rb
@@ -1,6 +1,6 @@
 class Rad < Formula
   desc "Modern CLI scripts made easy"
-  homepage "https://amterp.github.io/rad/"
+  homepage "https://amterp.dev/rad/"
   url "https://github.com/amterp/rad/archive/refs/tags/v0.9.2.tar.gz"
   sha256 "7d2215d596fdb6d380761411bf868b7cd451a436efa6dd2153265a7b981e14d2"
   license "Apache-2.0"
@@ -21,6 +21,7 @@ class Rad < Formula
     ENV["CGO_ENABLED"] = "1" if OS.linux? && Hardware::CPU.arm?
 
     system "go", "build", *std_go_args(ldflags: "-s -w")
+    system "go", "build", *std_go_args(ldflags: "-s -w", output: bin/"radls"), "./radls"
   end
 
   test do
@@ -38,5 +39,13 @@ class Rad < Formula
     chmod "+x", testpath/"test"
 
     assert_match "Hello, Homebrew!\nHello, Homebrew!", shell_output("#{testpath}/test 2")
+
+    output_log = testpath/"output.log"
+    pid = spawn bin/"radls", [:out, :err] => output_log.to_s
+    sleep 2
+    assert_match "Spinning up Rad LSP server", output_log.read
+  ensure
+    Process.kill("TERM", pid)
+    Process.wait(pid)
   end
 end

--- a/Formula/r/rad.rb
+++ b/Formula/r/rad.rb
@@ -7,12 +7,13 @@ class Rad < Formula
   head "https://github.com/amterp/rad.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "2dc9e35ceee7326e0362ff3ba57263616c34de43d0a03fec36de1a6ec49cbf97"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "01d550b426abceb361865185e7be008a67a9fb0fac141baa95960ecd1b2bfa92"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "077f3f9c45c5060d48fd7747531839b432d613d195e242a86fb46371423da232"
-    sha256 cellar: :any_skip_relocation, sonoma:        "9a9e5b35aeafaeafce5e53572c6bc38247af98520dc04f3c3402a9aa690e162a"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "107605a7cfd3a13e4defcd762386cb7aa5670e6c641b2b3149e1c27ec40843da"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "baa5659342010df7ab5f889e3c386f3571875f23be7097f8bf86b4cde2186523"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "d2ddfb5f50ca27fc4156adbb4f0471db7fc13e095c89fed1eedff83b73b9d00f"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "f2540fee7bd9a821e8d7517251bca660e70d45903e5b532006075a117895c529"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "aeabb7881604b0120ea14212ce0f59ed14d683d1eb34ed6e5c96f7c4c42e4916"
+    sha256 cellar: :any_skip_relocation, sonoma:        "d03526abced8126bef2552e41b96b53c94880b6bd98aa51d86cae03c2dc55f43"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "2d976118e06481472a02d25be38663c68952ea98bf91b17994e2656df0a1c177"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a6fc540a6569f8ff546413f349981c20655c466a5046af788472f5fde37679bf"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
## Description

This PR makes two changes to the `rad` formula:

1. **Adds the `radls` binary** - Rad ships with an LSP server (`radls`) for editor integration. The binary lives in the `radls/` directory of the source tree and has been present since v0.6.26. The current formula only builds the main `rad` (language interpreter) binary.

2. **Updates the homepage URL** - Updates from the old GitHub Pages URL (https://amterp.github.io/rad) to the current custom domain (https://amterp.dev/rad).

I'm the author/maintainer of Rad. Point one was reported as user friction in https://github.com/amterp/rad/issues/113 - users installing via homebrew-core were missing the LSP server that the tap formula (`amterp/rad`) provides. For context, I did not realize a homebrew-core version of the Rad formula existed; I will remain on top of helping maintain it now that I know it exists.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

I used Claude Code (Opus) to walk me through the process of raising this PR and to sanity check my changes, the commit message, and to do the initial draft of this PR message. I've gone through the above checklist myself and validated the above-mentioned test commands run successfully.

-----
