### PR TITLE
neovide: fix false positive in test

### DIFF
--- a/Formula/n/neovide.rb
+++ b/Formula/n/neovide.rb
@@ -27,6 +27,7 @@ class Neovide < Formula
   end
 
   on_linux do
+    depends_on "xorg-server" => :test
     depends_on "expat"
     depends_on "fontconfig"
     depends_on "freetype"
@@ -71,11 +72,11 @@ class Neovide < Formula
     bin.write_exec_script prefix/"Neovide.app/Contents/MacOS/neovide"
   end
 
-  def nvim_connected_clients_count(socket)
+  def nvim_ui_count(socket)
     Utils.safe_popen_read(
       "nvim", "--headless",
               "--server", socket,
-              "--remote-expr", 'luaeval("vim.tbl_count(vim.api.nvim_list_chans()) - 1")'
+              "--remote-expr", 'luaeval("vim.tbl_count(vim.api.nvim_list_uis())")'
     ).chomp.to_i
   end
 
@@ -88,10 +89,11 @@ class Neovide < Formula
     sleep 1 until socket.exist? && socket.socket?
 
     neovide_cmd = [bin/"neovide", "--no-fork", "--server=#{socket}"]
+    neovide_cmd.unshift(Formula["xorg-server"].bin/"xvfb-run") if OS.linux? && ENV.exclude?("DISPLAY")
     ohai neovide_cmd.join(" ")
     neovide_pid = spawn(*neovide_cmd)
 
-    sleep 1 until nvim_connected_clients_count(socket).positive?
+    sleep 1 until nvim_ui_count(socket).positive?
     system "nvim", "--server", socket, "--remote-send", ":q<CR>"
 
     Process.wait nvim_pid


### PR DESCRIPTION
see https://github.com/Homebrew/homebrew-core/pull/276077

we should wait for UI attachment instead of generic channels

previously it used `nvim_list_chans()` to decide when Neovide had connected to the headless neovim instance.

that means the test could report success before Neovide had actually finished attaching. Once that happened, the test would send `:q` too early, shut down the neovim server and race Neovide during startup.

Neovide `0.16.1` made this easier to see because startup attach failures now keep the process living longer by showing an error window. So an existing timing bug in the formula test started showing up as a timeout.

we simply fix it by waiting for an actual UI attachment with `nvim_list_uis()` instead of trying to infer readiness from channels.

it was reproduced locally with `brew test-bot` and the updated test passes.


```shell
HOMEBREW_DEVELOPER=1 \
  HOMEBREW_NO_AUTO_UPDATE=1 \
  HOMEBREW_NO_INSTALL_FROM_API=1 \
  brew test-bot \
    --only-formulae \
    --junit \
    --only-json-tab \
    --skip-dependents \
    --testing-formulae=neovide
==> Using Homebrew/brew 5.1.3-68-gd19cb650eef4 (Merge pull request #21920 from Homebrew/npm-pip-cooldown-defaults)
==> Using Homebrew/homebrew-core f5557ad6ace6 (neovide 0.16.1)

==> Running Formulae#run!

==> Running Formulae#formula!(neovide)
==> brew deps --tree --prune --annotate --include-build --include-test neovide
==> Determining dependencies...
==> brew fetch --formulae --retry cargo-bundle certifi llvm@21 lua lua@5.4 lzip rust sphinx-doc
==> brew install --only-dependencies --verbose --formula --build-bottle neovide
==> Starting tests for neovide
==> brew fetch --formula --retry neovide --build-bottle
==> brew install --verbose --formula --build-bottle neovide
==> brew style --formula neovide
==> brew audit --formula neovide --online --git --skip-style
==> brew bottle --verbose --json neovide --only-json-tab
==> brew bottle --merge --write --no-commit --no-all-checks ./neovide--0.16.1.arm64_sonoma.bottle.json
==> brew uninstall --formula --force --ignore-dependencies neovide
==> brew uninstall --formulae --force --ignore-dependencies cargo-bundle certifi llvm@21 lua lua@5.4 lzip rust sphinx-doc
==> brew install --only-dependencies ./neovide--0.16.1.arm64_sonoma.bottle.tar.gz
==> brew install ./neovide--0.16.1.arm64_sonoma.bottle.tar.gz
==> brew linkage --test neovide
==> brew linkage --cached --test --strict neovide
==> brew linkage --cached neovide
==> brew install --formula --only-dependencies --include-test neovide
==> brew test --verbose neovide

All steps passed!
```

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----