### PR TITLE
qi 0.3.0 (new formula)

### DIFF
--- a/Formula/q/qi.rb
+++ b/Formula/q/qi.rb
@@ -1,0 +1,21 @@
+class Qi < Formula
+  desc "Local-first knowledge search CLI"
+  homepage "https://github.com/itsmostafa/qi"
+  url "https://github.com/itsmostafa/qi/archive/refs/tags/v0.3.0.tar.gz"
+  sha256 "faacbdbfbca7683363bda0d390b6408fcb46b40e70b0613a7b7be942a44873e3"
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = %W[
+      -s -w
+      -X github.com/itsmostafa/qi/internal/version.Version=v#{version}
+    ]
+    system "go", "build", *std_go_args(ldflags:)
+  end
+
+  test do
+    assert_match "v#{version}", shell_output("#{bin}/qi version")
+  end
+end


### PR DESCRIPTION
## Summary

- **qi** is a local-first knowledge search CLI for macOS
- Indexes Markdown, plaintext, and source code files into SQLite
- Provides BM25 full-text search, vector search, and LLM-powered Q&A with citations
- Homepage: https://github.com/itsmostafa/qi
- License: MIT

## Checklist

- [x] `brew audit --new qi` passes with no errors
- [x] `brew install --build-from-source qi` installs successfully  
- [x] `brew test qi` passes
- [x] No pre-built binaries — builds from source with Go
- [x] Formula placed in `Formula/q/qi.rb`