### PR TITLE
bind: fix HEAD build

### DIFF
--- a/Formula/b/bind.rb
+++ b/Formula/b/bind.rb
@@ -6,11 +6,15 @@ class Bind < Formula
   # or buggy. They are not suitable for general deployment. We have to use
   # "version_scheme" because someone upgraded to 9.15.0, and required a
   # downgrade.
-  url "https://downloads.isc.org/isc/bind9/9.20.22/bind-9.20.22.tar.xz"
-  sha256 "cba92ff631b949655f475fe4b54290f6860fd0070d399f2279f6437c0d383ec6"
   license "MPL-2.0"
   version_scheme 1
-  head "https://gitlab.isc.org/isc-projects/bind9.git", branch: "main"
+
+  stable do
+    url "https://downloads.isc.org/isc/bind9/9.20.22/bind-9.20.22.tar.xz"
+    sha256 "cba92ff631b949655f475fe4b54290f6860fd0070d399f2279f6437c0d383ec6"
+
+    depends_on "readline" # TODO: Remove in 9.22
+  end
 
   # BIND indicates stable releases with an even-numbered minor (e.g., x.2.x)
   # and the regex below only matches these versions.
@@ -28,6 +32,16 @@ class Bind < Formula
     sha256 x86_64_linux:  "d016b1f6e728a085e613a7c14af6b4ffdaddc6c3cb7bb10cff4f0a4af3e45619"
   end
 
+  head do
+    url "https://gitlab.isc.org/isc-projects/bind9.git", branch: "main"
+
+    depends_on "meson" => :build
+    depends_on "ninja" => :build
+    depends_on "lmdb"
+
+    uses_from_macos "libedit"
+  end
+
   depends_on "pkgconf" => :build
 
   depends_on "jemalloc"
@@ -36,7 +50,6 @@ class Bind < Formula
   depends_on "libnghttp2"
   depends_on "libuv"
   depends_on "openssl@3"
-  depends_on "readline"
   depends_on "userspace-rcu"
 
   uses_from_macos "libxml2"
@@ -52,18 +65,29 @@ class Bind < Formula
     # and also cover the case where a user on macOS 14- updates to macOS 15+.
     ENV.append_to_cflags "-DLIBXML_HAS_DEPRECATED_MEMORY_ALLOCATION_FUNCTIONS" if OS.mac?
 
-    args = [
-      "--sysconfdir=#{pkgetc}",
-      "--localstatedir=#{var}",
-      "--with-json-c",
-      "--with-libidn2=#{Formula["libidn2"].opt_prefix}",
-      "--with-openssl=#{Formula["openssl@3"].opt_prefix}",
-      "--without-lmdb",
-    ]
+    if build.head?
+      args = %W[
+        -Dlocalstatedir=#{var}
+        -Dsysconfdir=#{pkgetc}
+      ]
 
-    system "./configure", *args, *std_configure_args
-    system "make"
-    system "make", "install"
+      system "meson", "setup", "build", *args, *std_meson_args
+      system "meson", "compile", "-C", "build", "--verbose"
+      system "meson", "install", "-C", "build"
+    else
+      args = [
+        "--sysconfdir=#{pkgetc}",
+        "--localstatedir=#{var}",
+        "--with-json-c",
+        "--with-libidn2=#{Formula["libidn2"].opt_prefix}",
+        "--with-openssl=#{Formula["openssl@3"].opt_prefix}",
+        "--without-lmdb",
+      ]
+
+      system "./configure", *args, *std_configure_args
+      system "make"
+      system "make", "install"
+    end
 
     (buildpath/"named.conf").write named_conf
     system sbin/"rndc-confgen", "-a", "-c", "#{buildpath}/rndc.key"


### PR DESCRIPTION
Upstream switched build system to Meson.

For dependencies:
* `lmdb` is now mandatory in HEAD
* `readline` support was dropped in favor of `libedit` due to license
