### PR TITLE
qi 0.5.0

### DIFF
--- a/Formula/q/qi.rb
+++ b/Formula/q/qi.rb
@@ -1,0 +1,21 @@
+class Qi < Formula
+  desc "Local-first knowledge search CLI"
+  homepage "https://github.com/itsmostafa/qi"
+  url "https://github.com/itsmostafa/qi/archive/refs/tags/v0.3.0.tar.gz"
+  sha256 "faacbdbfbca7683363bda0d390b6408fcb46b40e70b0613a7b7be942a44873e3"
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = %W[
+      -s -w
+      -X github.com/itsmostafa/qi/internal/version.Version=v#{version}
+    ]
+    system "go", "build", *std_go_args(ldflags:)
+  end
+
+  test do
+    assert_match "v#{version}", shell_output("#{bin}/qi version")
+  end
+end

--- a/Formula/q/qi.rb
+++ b/Formula/q/qi.rb
@@ -1,8 +1,8 @@
 class Qi < Formula
   desc "Local-first knowledge search CLI"
   homepage "https://github.com/itsmostafa/qi"
-  url "https://github.com/itsmostafa/qi/archive/refs/tags/v0.3.0.tar.gz"
-  sha256 "faacbdbfbca7683363bda0d390b6408fcb46b40e70b0613a7b7be942a44873e3"
+  url "https://github.com/itsmostafa/qi/archive/refs/tags/v0.5.0.tar.gz"
+  sha256 "a682c42265cfcdcb9f89bb136f913f2a26112970913e28816d4fd8db4b0fb4ad"
   license "MIT"
 
   depends_on "go" => :build


### PR DESCRIPTION
## Summary

- Bump `qi` from 0.3.0 to 0.5.0
- Updated URL and SHA256 for source tarball

## Changes in 0.5.0

- Auto-named collections and configuration reference
- `SlugFromPath` for auto-generating collection names
- Fix: rename existing collection when `--name` targets same path
- Fix: eliminate data-loss window in collection rename flow
- Fix: preserve collection settings on `--name` rename

## Test plan

- [ ] `brew install qi` installs successfully
- [ ] `qi version` outputs `v0.5.0`