### PR TITLE
ejabberd: update license

### DIFF
--- a/Formula/e/ejabberd.rb
+++ b/Formula/e/ejabberd.rb
@@ -3,7 +3,7 @@ class Ejabberd < Formula
   homepage "https://www.ejabberd.im"
   url "https://github.com/processone/ejabberd/archive/refs/tags/26.03.tar.gz"
   sha256 "584b9d43a1f67e929fdb08fa7429f359fabc022923aca311666b1073ed709a52"
-  license "GPL-2.0-only"
+  license "GPL-2.0-or-later"
   head "https://github.com/processone/ejabberd.git", branch: "master"
 
   # There can be a notable gap between when a version is tagged and a


### PR DESCRIPTION
https://github.com/processone/ejabberd/blob/26.03/mix.exs#L190
```
      licenses: ["GPL-2.0-or-later"],
```