### PR TITLE
ppsspp: build with `nasm`

### DIFF
--- a/Formula/p/ppsspp.rb
+++ b/Formula/p/ppsspp.rb
@@ -16,8 +16,8 @@ class Ppsspp < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "nasm" => :build # for bundled ffmpeg
   depends_on "pkgconf" => :build
-  depends_on "yasm" => :build
 
   depends_on "libzip"
   depends_on "miniupnpc"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Switch to `nasm` as at least better maintained than `yasm` (last release 2019 with CVEs). This aligns with our own FFmpeg build.

yasm/nasm should only be needed on x86_64 so try restricting it.