### PR TITLE
bkmr 7.5.0

### DIFF
--- a/Formula/b/bkmr.rb
+++ b/Formula/b/bkmr.rb
@@ -1,8 +1,8 @@
 class Bkmr < Formula
   desc "Unified CLI Tool for Bookmark, Snippet, and Knowledge Management"
   homepage "https://github.com/sysid/bkmr"
-  url "https://github.com/sysid/bkmr/archive/refs/tags/v6.7.0.tar.gz"
-  sha256 "155373f4eafa21cf7b4d02b9463b2ed105ca42b65983d426ebf417457f0ce085"
+  url "https://github.com/sysid/bkmr/archive/refs/tags/v7.5.0.tar.gz"
+  sha256 "1830546367001a5714ab8e068dc137932700b42cd1e6ea9c8c0e80f255edbe0d"
   license "BSD-3-Clause"
   head "https://github.com/sysid/bkmr.git", branch: "main"
 
@@ -21,6 +21,7 @@ class Bkmr < Formula
   end
 
   depends_on "rust" => :build
+  depends_on "onnxruntime"
   depends_on "openssl@3"
 
   uses_from_macos "python"
@@ -31,7 +32,8 @@ class Bkmr < Formula
       # https://docs.rs/openssl/latest/openssl/#manual
       ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
 
-      system "cargo", "install", *std_cargo_args
+      system "cargo", "install", *std_cargo_args(features: "system-ort"),
+             "--no-default-features"
     end
 
     generate_completions_from_executable(bin/"bkmr", "completion")

--- a/Formula/b/bkmr.rb
+++ b/Formula/b/bkmr.rb
@@ -12,12 +12,12 @@ class Bkmr < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "f7bc4f841a00fa9206e5c5fdfd366693f8e1d4819f29d5f9da9d1b73a4d2387e"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "fd31aaf74381b34128e92c99d22c6ebc9243a0444d2456f4ad0c9a4ce85083b0"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "3fb98b70b1a4a2c9e3cda2efabcb093508040847983c7cadb279dd9666022692"
-    sha256 cellar: :any_skip_relocation, sonoma:        "51be718a6d750fe0ba8c0b5dd9ed20110829649d5621a77ef7caa05dac4b5e91"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "5f819c07dc34205322f263d4f82dc895740233d8a12dbcb1621a29e695f43d65"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4b20feea761aac3a22527ff446b6421387d6bd78d15deec9c226810cc9bd3e15"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "455458134351a15cc58d6e306b81b32890cf221d0bcc44ac52cc3cabc7d86ae6"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "319bcccc90e457c551d4f9d35dc2393da56c4af1b42bd1a90bcce2a660094b4e"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "e8083eabdcbec3903dbb542936bfca399547cc07d7f7ac6de930cb479bfd071a"
+    sha256 cellar: :any_skip_relocation, sonoma:        "03aa96e05ba7a3a3aef2142df95858d839846a1ca96d0ca6e74bea7e1b65251d"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "c5c57be80461476e14a123cda25bb8b2873fdcb07b8161bec805e431493d1782"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "fad514b4a4dfb24bbd9e8668d7fe0a677ebcd01efa0826d72396eaff166b45fe"
   end
 
   depends_on "rust" => :build


### PR DESCRIPTION
Bump bkmr from 6.7.0 to 7.5.0. Switch from downloading prebuilt ONNX Runtime binaries to using Homebrew's `onnxruntime` formula via dynamic loading.

**What changed in bkmr:** Added a `system-ort` cargo feature flag that switches `fastembed` from `ort-download-binaries` (embeds prebuilt ONNX Runtime) to `ort-load-dynamic` (loads `libonnxruntime` at runtime via `dlopen`). The default build (`cargo install bkmr`) is unchanged.

**Formula changes:**
- Version bump: 6.7.0 → 7.5.0
- Added `depends_on "onnxruntime"` — uses Homebrew's source-built ONNX Runtime
- Builds with `--no-default-features --features system-ort`
- Removed `depends_on arch: :arm64` and `depends_on :macos` — all platforms supported again

**Verification:**
- `brew audit --strict --online bkmr` passes
- `cargo check --no-default-features --features system-ort` compiles cleanly
- Tests pass

Supersedes #276293.
Upstream issue: https://github.com/sysid/bkmr/issues/71