### PR TITLE
podofo: detailed license

### DIFF
--- a/Formula/p/podofo.rb
+++ b/Formula/p/podofo.rb
@@ -3,7 +3,19 @@ class Podofo < Formula
   homepage "https://github.com/podofo/podofo"
   url "https://github.com/podofo/podofo/archive/refs/tags/1.0.3.tar.gz"
   sha256 "02815b21a51632c2849d41b067597e9356bbc54bad0efcd84c902b555c203ce7"
-  license all_of: ["LGPL-2.0-only", "GPL-2.0-only"]
+  # TODO: in v1.1 check if LGPL-2.0-or-later can be removed by scanning SPDX-License-Identifier
+  # https://github.com/podofo/podofo/blob/eb75c9f6d1b7b164f868433493c6560935cf981b/TODO.md
+  # https://www.mail-archive.com/podofo-users@lists.sourceforge.net/msg05022.html
+  license all_of: [
+    "LGPL-2.0-or-later",
+    { any_of: ["LGPL-2.0-or-later", "MPL-2.0"] },
+    "GPL-2.0-or-later", # tools/
+
+    # Additional licenses used in specific files
+    "Apache-2.0", # src/podofo/private/FontUtils*
+    "MIT",        # src/podofo/private/SASLprep*
+    "OpenSSL",    # src/podofo/private/OpenSSLInternal_Ripped.cpp
+  ]
   head "https://github.com/podofo/podofo.git", branch: "master"
 
   livecheck do


### PR DESCRIPTION
Original license was incomplete. At minimum needed `-or-later` which makes them more compatible with other licenses.

Also add note on relicense. Some files have already been relicensed so include that too (e.g. https://github.com/podofo/podofo/blob/1.0.3/src/podofo/main/PdfCommon.cpp#L3-L4)

---

Order of license stanza:
1. library has highest impact as it will propagate to dependents. So using that first so that a naive programmatic check can use first license for compatibility check.
2. tool license impacts all commands distributed. This usually doesn't impact dependents' license but still represents the other half of package.
3. remaining extra licenses are alphabetized. These are provided for completeness (as usually required by license fine-print) but is usually subsumed by (L)GPL when determining overall license.