### PR TITLE
git-svn: update license to match installed files

### DIFF
--- a/Formula/g/git-svn.rb
+++ b/Formula/g/git-svn.rb
@@ -3,7 +3,7 @@ class GitSvn < Formula
   homepage "https://git-scm.com"
   url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.53.0.tar.xz"
   sha256 "5818bd7d80b061bbbdfec8a433d609dc8818a05991f731ffc4a561e2ca18c653"
-  license "GPL-2.0-only"
+  license "GPL-2.0-or-later"
   head "https://github.com/git/git.git", branch: "master"
 
   livecheck do


### PR DESCRIPTION
The installation tree looks like:
```
.
├── bin
│   └── git-svn -> ../libexec/git-core/git-svn
├── COPYING
├── INSTALL_RECEIPT.json
├── libexec
│   └── git-core
│       └── git-svn
├── README.md
└── sbom.spdx.json
```

Ignoring metafiles, the only actual file is git-svn which is https://github.com/git/git/blob/v2.53.0/git-svn.perl#L3

```perl
#!/usr/bin/perl
# Copyright (C) 2006, Eric Wong <normalperson@yhbt.net>
# License: GPL v2 or later
```