### PR TITLE
devlog 1.1.0 (new formula)

### DIFF
--- a/Formula/devlog.rb
+++ b/Formula/devlog.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class Devlog < Formula
+  desc "AI-powered development log generator for git repositories"
+  homepage "https://gitlab.com/aice/devlog"
+  url "https://gitlab.com/aice/devlog/-/archive/v1.1.0/devlog-v1.1.0.tar.gz"
+  sha256 "fd8979babdcc7624c94e7baeba52448846343cf659751d4546bd802147e572ca"
+  license "MIT"
+
+  depends_on "rust" => :build
+  depends_on "pkg-config" => :build
+  depends_on "libgit2"
+  depends_on "openssl@3"
+
+  def install
+    system "cargo", "install", "--locked", "--root", prefix, "--path", "."
+  end
+
+  test do
+    assert_equal version.to_s, `#{bin}/devlog --version`.chomp.split.last
+  end
+end


### PR DESCRIPTION
Devlog transforms Git commit history into intelligent changelogs while keeping your code and data completely private. Built for enterprise use with default local-only mode — no cloud access required.

## Why Devlog

**Privacy First**: Code diffs never leave your machine by default. All processing happens locally. Cloud LLMs are completely optional and explicit.

**Works Offline**: Generate changelogs with zero network access using:
- Local Ollama (self-hosted LLMs)
- llama.cpp (embedded inference)
- Plain text mode (no AI needed)

**Flexible**: When cloud integration is needed, Devlog supports:
- Claude (Anthropic)
- GPT (OpenAI)
- Ollama (self-hosted)
- All with sanitization controls

## Key Features

- **Local-First**: Works completely offline by default
- **Enterprise Ready**: No data exfiltration, privacy controls built-in
- **Multiple Formats**: Markdown and JSON output
- **Conventional Commits**: Smart parsing of commit messages
- **LLM Flexible**: Local LLMs (Ollama, llama.cpp) or cloud optional
- **Privacy Controls**: 3-level privacy settings (strict, moderate, relaxed)

## Usage Examples

### No AI Required (Plain Mode)
```bash
devlog --repo . --output CHANGELOG.md
```

### With Local Ollama (Completely Private)
```bash
# Start Ollama with a local model (one-time setup)
ollama run mistral

# Generate changelog with local LLM
devlog --repo . --llm ollama --llm-model mistral

# Additional models: neural-chat, dolphin-mixtral, etc.
```

### With Local llama.cpp
```bash
# Run llama.cpp server on port 8000
./server -m model.gguf -ngl 33 -p 8000

# Use with devlog (compatible via ollama interface)
devlog --repo . --llm ollama --llm-model local
```

### Cloud (When Needed - Explicit Opt-in)
```bash
# Only works with explicit --allow-cloud flag
devlog --repo . --llm anthropic --allow-cloud \
  --privacy-level strict

# OpenAI example
devlog --repo . --llm open-ai --allow-cloud \
  --llm-model gpt-4 --privacy-level moderate
```

## Quality Metrics

- ✅ 287 unit tests (all passing)
- ✅ 5 documentation tests (all passing)
- ✅ Security: cargo-audit passing
- ✅ MIT licensed
- ✅ Enterprise-ready codebase

## Installation & Quick Start

```bash
brew install devlog

# Immediate use - no setup required
devlog --repo . --output CHANGELOG.md

# Or with local Ollama (self-hosted, zero privacy concerns)
ollama run mistral  # One-time setup
devlog --repo . --llm ollama --llm-model mistral
```

## Project Details

- **Repository**: https://gitlab.com/aice/devlog
- **License**: MIT
- **Designed for**: Enterprise, privacy-conscious teams
- **Data handling**: Local-first, code never sent to cloud by default
- **Compliance**: GDPR-friendly, no vendor lock-in, full audit trail

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
