### PR TITLE
lynx: install COPYHEADER for complete license terms

### DIFF
--- a/Formula/l/lynx.rb
+++ b/Formula/l/lynx.rb
@@ -12,13 +12,13 @@ class Lynx < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 arm64_tahoe:   "f018c40ffe24220383f1e020875f64a62552bedc10e4948321992a4ceac5e83e"
-    sha256 arm64_sequoia: "3a912438a909ec79166e61ea5b9dea7376b0d3e0bf566d5de723697c2427b807"
-    sha256 arm64_sonoma:  "174ecc0b2aebe7c14294bdc63f7052d93405ac48021c9b81eea4e4a668830fae"
-    sha256 sonoma:        "5a3157c1ed95544f85968690b9d51c36975d1cc52c75069328d9ea6de28c4ae5"
-    sha256 arm64_linux:   "fceb7120d16369c1cd5350ff34a39f3d8276061a5119a64eec00be26ffc6e5f5"
-    sha256 x86_64_linux:  "6267a025209071f6109d8b8cfcb81de136bac11ead8b19ae2aa644ab74fee8fb"
+    rebuild 2
+    sha256 arm64_tahoe:   "dbadf2d9dcbb3567e809071dc8d240fbb4d6c229d44fd4a9fed0c98e14fbb818"
+    sha256 arm64_sequoia: "f596d1b37e3bb877c1e6cf8435504f7ef39920ac09d26040c4bae18da07791d2"
+    sha256 arm64_sonoma:  "35f0588c3df08e80fb0a4fde74ac5f7c33a918d890a085791f557299b5617154"
+    sha256 sonoma:        "82690721857094cf83bc59cdbf0c4feedada05ea7b902c5abeb7771273c74476"
+    sha256 arm64_linux:   "837b50b6330b76cf666e0c6134a1e4f3fc79ea03197c59059bcf0f5db6244576"
+    sha256 x86_64_linux:  "090af405647a09276b97bf5e3f4ef22a216950563ae19749c57e16142f09749f"
   end
 
   # Move to brew ncurses to fix screen related bugs

--- a/Formula/l/lynx.rb
+++ b/Formula/l/lynx.rb
@@ -4,7 +4,7 @@ class Lynx < Formula
   url "https://invisible-mirror.net/archives/lynx/tarballs/lynx2.9.2.tar.bz2"
   mirror "https://fossies.org/linux/www/lynx2.9.2.tar.bz2"
   sha256 "7374b89936d991669e101f4e97f2c9592036e1e8cdaa7bafc259a77ab6fb07ce"
-  license "GPL-2.0-only"
+  license "GPL-2.0-only" # with non-SPDX exception in COPYHEADER to use OpenSSL and other libs
 
   livecheck do
     url "https://invisible-mirror.net/archives/lynx/tarballs/?C=M&O=D"
@@ -49,6 +49,7 @@ class Lynx < Formula
                           "--enable-externs",
                           "--disable-config-info"
     system "make", "install"
+    prefix.install "COPYHEADER"
   end
 
   test do


### PR DESCRIPTION
Using a comment in license to keep track of formulae that are permitted to use OpenSSL even if exception cannot be expressed in SPDX. May need to see if SPDX allows using a custom ref for exception in which case we could add something like `:openssl_exception` as a placeholder.

Specific part of COPYHEADER is:
```
The copyright owners and developers for Lynx grant their express
permission for using any version of these common libraries (which are
known to have problematic licensing issues) with any operating system or
platform, regardless of the manner in which the libraries are
connected to the Lynx program:

        GNUTLS

        libbsd               http://libbsd.freedesktop.org/releases/

        libidn

        OpenSSL              http://www.openssl.org
```