### PR TITLE
git-spice, ghostscript: drop conflicts_with

### DIFF
--- a/Formula/g/ghostscript.rb
+++ b/Formula/g/ghostscript.rb
@@ -58,7 +58,6 @@ class Ghostscript < Formula
 
   conflicts_with "gambit-scheme", because: "both install `gsc` binary"
   conflicts_with "gerbil-scheme", because: "both install `gsc` binary"
-  conflicts_with "git-spice", because: "both install `gs` binary"
 
   # https://sourceforge.net/projects/gs-fonts/
   resource "fonts" do

--- a/Formula/g/git-spice.rb
+++ b/Formula/g/git-spice.rb
@@ -19,8 +19,6 @@ class GitSpice < Formula
 
   depends_on "go" => :build
 
-  conflicts_with "ghostscript", because: "both install `gs` binary"
-
   def install
     ldflags = "-s -w -X main._version=#{version}"
     system "go", "build", *std_go_args(ldflags:, output: bin/"git-spice")


### PR DESCRIPTION
Following #276222, ghostscript and git-spice no longer conflict
because git-spice does not install a 'gs' binary anymore.

Reverts #191679

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
