### PR TITLE
libheif: remove postinstall to avoid `shared-mime-info` dependency

### DIFF
--- a/Formula/lib/libheif.rb
+++ b/Formula/lib/libheif.rb
@@ -23,7 +23,6 @@ class Libheif < Formula
   depends_on "libde265"
   depends_on "libpng"
   depends_on "libtiff"
-  depends_on "shared-mime-info"
   depends_on "webp"
   depends_on "x265"
 
@@ -48,10 +47,6 @@ class Libheif < Formula
 
     # Avoid rebuilding dependents that hard-code the prefix.
     inreplace lib/"pkgconfig/libheif.pc", prefix, opt_prefix
-  end
-
-  def post_install
-    system Formula["shared-mime-info"].opt_bin/"update-mime-database", "#{HOMEBREW_PREFIX}/share/mime"
   end
 
   test do


### PR DESCRIPTION
The update-mime-database is not run by upstream build scripts and major Linux distro packaging (e.g. Arch Linux, Debian) doesn't run it.

Instead, upstream documentation expects users to manually handle this: https://github.com/strukturag/libheif/blob/master/README.md#heifavif-thumbnails-for-the-gnome-desktop

Removing `shared-mime-info` aligns with our approach to reduce dependency trees and helps our goal of minifying `imagemagick`:
* Total macOS dependencies: 22 -> 17
* Total Linux dependencies: 38 -> 22
