### PR TITLE
virtualpg: update license

### DIFF
--- a/Formula/v/virtualpg.rb
+++ b/Formula/v/virtualpg.rb
@@ -3,7 +3,7 @@ class Virtualpg < Formula
   homepage "https://www.gaia-gis.it/fossil/virtualpg/index"
   url "https://www.gaia-gis.it/gaia-sins/virtualpg-2.0.1.tar.gz"
   sha256 "be2aebeb8c9ff274382085f51d422e823858bca4f6bc2fa909816464c6a1e08b"
-  license "MPL-1.1"
+  license any_of: ["MPL-1.1", "GPL-2.0-or-later", "LGPL-2.1-or-later"]
 
   livecheck do
     url :homepage


### PR DESCRIPTION
https://www.gaia-gis.it/fossil/virtualpg/index

> VirtualPG is licensed under the [MPL tri-license](http://www.mozilla.org/MPL/boilerplate-1.1/mpl-tri-license-html) terms; you are free to choose the best-fit license between:
> * the [MPL 1.1](http://www.mozilla.org/MPL/MPL-1.1.html)
> * the [GPL v2.0](http://www.gnu.org/licenses/gpl-2.0.html#TOC1) or any subsequent version
> * the [LGPL v2.1](http://www.gnu.org/licenses/lgpl-2.1.html) or any subsequent version