### PR TITLE
glibc: Include HOMEBREW_LANG envvar

### DIFF
--- a/Formula/g/glibc.rb
+++ b/Formula/g/glibc.rb
@@ -311,7 +311,7 @@ class Glibc < Formula
 
     # Get all extra installed locales from the system, except C locales
     locales = ENV.filter_map do |k, v|
-      v if k[/^LANG$|^LC_/] && v != "C" && !v.start_with?("C.")
+      v if k[/^HOMEBREW_LANG$|^LANG$|^LC_/] && v != "C" && !v.start_with?("C.")
     end
 
     # en_US.UTF-8 is required by gawk make check

--- a/Formula/g/glibc.rb
+++ b/Formula/g/glibc.rb
@@ -53,8 +53,9 @@ class Glibc < Formula
   end
 
   bottle do
-    sha256 arm64_linux:  "cde6809e25a013784fc921bac3217758655a49c72c7290a75649a98f9e0b2b4a"
-    sha256 x86_64_linux: "d36660b7cd74c76ad3770aa9817c48ea4cfcb0d226095e38f9cc9b414730bef0"
+    rebuild 1
+    sha256 arm64_linux:  "3afe478fb0d3f60b4817e3bc6a4055c6c18c986c9a6f6610be255bafcaa74afe"
+    sha256 x86_64_linux: "6a959a32fcfdcadcb1e27720f567c4921a289a2ccf0223abea7c271834780124"
   end
 
   keg_only "it can shadow system glibc if linked"


### PR DESCRIPTION
As per https://github.com/orgs/Homebrew/discussions/6785; this PR will add HOMEBREW_LANG to the environment variables that the post_install checks/scans for additional locale values.

HOMEBREW_LANG will be automatically defined by 'brew' by https://github.com/Homebrew/brew/pull/21945.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
