### PR TITLE
zeroclaw: add node build dep

### DIFF
--- a/Formula/z/zeroclaw.rb
+++ b/Formula/z/zeroclaw.rb
@@ -16,6 +16,7 @@ class Zeroclaw < Formula
   end
 
   depends_on "rust" => :build
+  depends_on "node" => :build
 
   def install
     system "cargo", "install", *std_cargo_args


### PR DESCRIPTION
Automated formula bump from ZeroClaw release workflow.

- Release tag: v0.6.9
- Source tarball: https://github.com/zeroclaw-labs/zeroclaw/archive/refs/tags/v0.6.9.tar.gz
- Source sha256: 08e3d503f6e6903ac2c52f46424ae03b279c17875a7f5dc0a06093890bd7fe7b