### PR TITLE
libimobiledevice: declare readline dependency for linux build

### DIFF
--- a/Formula/lib/libimobiledevice.rb
+++ b/Formula/lib/libimobiledevice.rb
@@ -27,6 +27,10 @@ class Libimobiledevice < Formula
   depends_on "libusbmuxd"
   depends_on "openssl@3"
 
+  on_linux do
+    depends_on "readline"
+  end
+
   def install
     # As long as libplist builds without Cython bindings,
     # so should libimobiledevice as well.


### PR DESCRIPTION
```
Full linkage --test libimobiledevice output
  Indirect dependencies with linkage:
    readline
```

- https://github.com/Homebrew/homebrew-core/actions/runs/24098486225/job/70341653333#step:4:4445
- https://github.com/Homebrew/homebrew-core/pull/276489