### PR TITLE
portable-openssl: update `cacert` resource livecheck

### DIFF
--- a/Formula/p/portable-openssl.rb
+++ b/Formula/p/portable-openssl.rb
@@ -32,14 +32,8 @@ class PortableOpenssl < PortableFormula
     sha256 "b6e66569cc3d438dd5abe514d0df50005d570bfc96c14dca8f768d020cb96171"
 
     livecheck do
-      url "https://curl.se/ca/cadate.t"
-      regex(/^#define\s+CA_DATE\s+(.+)$/)
-      strategy :page_match do |page, regex|
-        match = page.match(regex)
-        next if match.blank?
-
-        Date.parse(match[1]).iso8601
-      end
+      url "https://curl.se/docs/caextract.html"
+      regex(/href=.*?cacert[._-](\d{4}-\d{2}-\d{2})\.pem/i)
     end
   end
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
Matches the livecheck we use in the `ca-certificates` formula. The previous livecheck was returning an outdated version.