### PR TITLE
goenv 3.1.1, goenv@2 2.2.40 (new formula)

### DIFF
--- a/Aliases/goenv@3
+++ b/Aliases/goenv@3
@@ -1,0 +1,1 @@
+../Formula/g/goenv.rb

--- a/Formula/g/goenv.rb
+++ b/Formula/g/goenv.rb
@@ -1,11 +1,12 @@
 class Goenv < Formula
   desc "Go version management"
   homepage "https://github.com/go-nv/goenv"
-  url "https://github.com/go-nv/goenv/archive/refs/tags/2.2.39.tar.gz"
-  sha256 "9c5571e731c1bbf4f6cc1d3606da1960ba56cf0ce1206c58a74e52e6df430e35"
+  url "https://github.com/go-nv/goenv/archive/refs/tags/3.0.1.tar.gz"
+  sha256 "ecaefc6c98cb53c4dd53b86dc604e9e9c2fcafc281c8e3c24e9070365f61cc41"
   license "MIT"
   version_scheme 1
-  head "https://github.com/go-nv/goenv.git", branch: "master"
+  # TODO: Uncomment when default branch is changed from 'master' to 'main'
+  # head "https://github.com/go-nv/goenv.git", branch: "main"
 
   livecheck do
     url :stable
@@ -16,23 +17,19 @@ class Goenv < Formula
     sha256 cellar: :any_skip_relocation, all: "3cd517fd086597a2c1439187f5126ee613038ed5b84b291a100f10c1bcada012"
   end
 
-  def install
-    inreplace_files = [
-      "libexec/goenv",
-      "plugins/go-build/install.sh",
-      "test/goenv.bats",
-      "test/test_helper.bash",
-      "plugins/go-build/test/test_helper.bash",
-    ]
-    inreplace inreplace_files, "/usr/local", HOMEBREW_PREFIX
+  depends_on "go" => :build
 
-    prefix.install Dir["*"]
-    %w[goenv-install goenv-uninstall go-build].each do |cmd|
-      bin.install_symlink "#{prefix}/plugins/go-build/bin/#{cmd}"
-    end
+  def install
+    ldflags = %W[
+      -s -w
+      -X main.version=#{version}
+      -X main.commit=#{tap&.user || "homebrew"}
+      -X main.buildTime=#{time.iso8601}
+    ]
+    system "go", "build", *std_go_args(ldflags:, output: bin/"goenv")
   end
 
   test do
-    assert_match "Usage: goenv <command> [<args>]", shell_output("#{bin}/goenv help")
+    assert_match "no Go versions installed yet", shell_output("#{bin}/goenv list 2>&1", 1)
   end
 end

--- a/Formula/g/goenv.rb
+++ b/Formula/g/goenv.rb
@@ -1,11 +1,12 @@
 class Goenv < Formula
   desc "Go version management"
   homepage "https://github.com/go-nv/goenv"
-  url "https://github.com/go-nv/goenv/archive/refs/tags/2.2.39.tar.gz"
-  sha256 "9c5571e731c1bbf4f6cc1d3606da1960ba56cf0ce1206c58a74e52e6df430e35"
+  url "https://github.com/go-nv/goenv/archive/refs/tags/3.1.1.tar.gz"
+  sha256 "8c107c1ec31cd544bbf59dc822676ef1966811a13e006aa35ba09546a74c4d9b"
   license "MIT"
   version_scheme 1
-  head "https://github.com/go-nv/goenv.git", branch: "master"
+  # TODO: Uncomment when default branch is changed from 'master' to 'main'
+  # head "https://github.com/go-nv/goenv.git", branch: "main"
 
   livecheck do
     url :stable
@@ -13,26 +14,37 @@ class Goenv < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "3cd517fd086597a2c1439187f5126ee613038ed5b84b291a100f10c1bcada012"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "3cd517fd086597a2c1439187f5126ee613038ed5b84b291a100f10c1bcada012"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "3cd517fd086597a2c1439187f5126ee613038ed5b84b291a100f10c1bcada012"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "3cd517fd086597a2c1439187f5126ee613038ed5b84b291a100f10c1bcada012"
+    sha256 cellar: :any_skip_relocation, sonoma:        "3cd517fd086597a2c1439187f5126ee613038ed5b84b291a100f10c1bcada012"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "3cd517fd086597a2c1439187f5126ee613038ed5b84b291a100f10c1bcada012"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3cd517fd086597a2c1439187f5126ee613038ed5b84b291a100f10c1bcada012"
   end
 
-  def install
-    inreplace_files = [
-      "libexec/goenv",
-      "plugins/go-build/install.sh",
-      "test/goenv.bats",
-      "test/test_helper.bash",
-      "plugins/go-build/test/test_helper.bash",
-    ]
-    inreplace inreplace_files, "/usr/local", HOMEBREW_PREFIX
+  depends_on "go" => :build
 
-    prefix.install Dir["*"]
-    %w[goenv-install goenv-uninstall go-build].each do |cmd|
-      bin.install_symlink "#{prefix}/plugins/go-build/bin/#{cmd}"
-    end
+  def install
+    ldflags = %W[
+      -s -w
+      -X main.version=#{version}
+      -X main.commit=#{tap&.user || "homebrew"}
+      -X main.buildTime=#{time.iso8601}
+    ]
+    system "go", "build", *std_go_args(ldflags:, output: bin/"goenv")
+  end
+
+  def caveats
+    <<~EOS
+      If you are upgrading from goenv v2, you may need to remove the stale shim:
+        rm -f "${GOENV_ROOT:-$HOME/.goenv}/shims/goenv"
+    EOS
   end
 
   test do
-    assert_match "Usage: goenv <command> [<args>]", shell_output("#{bin}/goenv help")
+    ENV["GOENV_ROOT"] = testpath/".goenv"
+
+    output = shell_output("#{bin}/goenv root")
+    assert_equal testpath/".goenv", Pathname(output.chomp)
   end
 end

--- a/Formula/g/goenv.rb
+++ b/Formula/g/goenv.rb
@@ -14,12 +14,12 @@ class Goenv < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "3cd517fd086597a2c1439187f5126ee613038ed5b84b291a100f10c1bcada012"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "3cd517fd086597a2c1439187f5126ee613038ed5b84b291a100f10c1bcada012"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "3cd517fd086597a2c1439187f5126ee613038ed5b84b291a100f10c1bcada012"
-    sha256 cellar: :any_skip_relocation, sonoma:        "3cd517fd086597a2c1439187f5126ee613038ed5b84b291a100f10c1bcada012"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "3cd517fd086597a2c1439187f5126ee613038ed5b84b291a100f10c1bcada012"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3cd517fd086597a2c1439187f5126ee613038ed5b84b291a100f10c1bcada012"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "837b6e4bff590588c8aad04799de851220c19b95fe06167ddd6a9bcece81a82c"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "837b6e4bff590588c8aad04799de851220c19b95fe06167ddd6a9bcece81a82c"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "837b6e4bff590588c8aad04799de851220c19b95fe06167ddd6a9bcece81a82c"
+    sha256 cellar: :any_skip_relocation, sonoma:        "0f7a26d066ec80953a4036e8abd1625bbe169b4e97a2f10ef1264434ad0ef0f0"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "8088ae118a1dbdd36d3cb55aea571e139d78a9acc42dc2cb11ed670dc48a5c28"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2578892fc7eb443d45b0807eb977e96425ab6f0afc29cd5624e4c2abe5072def"
   end
 
   depends_on "go" => :build

--- a/Formula/g/goenv@2.rb
+++ b/Formula/g/goenv@2.rb
@@ -1,0 +1,37 @@
+class GoenvAT2 < Formula
+  desc "Go version management"
+  homepage "https://github.com/go-nv/goenv"
+  url "https://github.com/go-nv/goenv/archive/refs/tags/2.2.39.tar.gz"
+  sha256 "9c5571e731c1bbf4f6cc1d3606da1960ba56cf0ce1206c58a74e52e6df430e35"
+  license "MIT"
+
+  livecheck do
+    url :stable
+    regex(/^v?(2\.\d+\.\d+)$/i)
+  end
+
+  keg_only :versioned_formula
+
+  # End-of-support on 2028-12-31: https://github.com/go-nv/goenv/pull/525
+  disable! date: "2028-12-31", because: :versioned_formula
+
+  def install
+    inreplace_files = [
+      "libexec/goenv",
+      "plugins/go-build/install.sh",
+      "test/goenv.bats",
+      "test/test_helper.bash",
+      "plugins/go-build/test/test_helper.bash",
+    ]
+    inreplace inreplace_files, "/usr/local", HOMEBREW_PREFIX
+
+    prefix.install Dir["*"]
+    %w[goenv-install goenv-uninstall go-build].each do |cmd|
+      bin.install_symlink "#{prefix}/plugins/go-build/bin/#{cmd}"
+    end
+  end
+
+  test do
+    assert_match "Warning: no Go detected on the system", shell_output("#{bin}/goenv versions 2>&1", 1)
+  end
+end

--- a/Formula/g/goenv@2.rb
+++ b/Formula/g/goenv@2.rb
@@ -1,0 +1,40 @@
+class GoenvAT2 < Formula
+  desc "Go version management"
+  homepage "https://github.com/go-nv/goenv"
+  url "https://github.com/go-nv/goenv/archive/refs/tags/2.2.40.tar.gz"
+  sha256 "c539e4550cc0b66f3b11206e19d84ee2ac9426f7b31db1f22ff5c4b55ad27f6b"
+  license "MIT"
+
+  livecheck do
+    url :stable
+    regex(/^v?(2\.\d+\.\d+)$/i)
+  end
+
+  keg_only :versioned_formula
+
+  # Goenv version 3.0.0 was released 2026-05-04
+  deprecate! date: "2026-05-04", because: "superseded by v3.x; disables 2028-12-31", replacement_formula: "goenv"
+
+  # End-of-support on 2028-12-31: https://github.com/go-nv/goenv/pull/525
+  disable! date: "2028-12-31", because: :unmaintained
+
+  def install
+    inreplace_files = [
+      "libexec/goenv",
+      "plugins/go-build/install.sh",
+      "test/goenv.bats",
+      "test/test_helper.bash",
+      "plugins/go-build/test/test_helper.bash",
+    ]
+    inreplace inreplace_files, "/usr/local", HOMEBREW_PREFIX
+
+    prefix.install Dir["*"]
+    %w[goenv-install goenv-uninstall go-build].each do |cmd|
+      bin.install_symlink "#{prefix}/plugins/go-build/bin/#{cmd}"
+    end
+  end
+
+  test do
+    assert_match "Warning: no Go detected on the system", shell_output("#{bin}/goenv versions 2>&1", 1)
+  end
+end

--- a/Formula/g/goenv@2.rb
+++ b/Formula/g/goenv@2.rb
@@ -10,6 +10,10 @@ class GoenvAT2 < Formula
     regex(/^v?(2\.\d+\.\d+)$/i)
   end
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, all: "5369ded9060184d95823f3ed663c1bca51d4a1ce5128c9430c96eec7b703256a"
+  end
+
   keg_only :versioned_formula
 
   # Goenv version 3.0.0 was released 2026-05-04

--- a/disabled_new_usr_local_relocation_formulae.json
+++ b/disabled_new_usr_local_relocation_formulae.json
@@ -2,7 +2,7 @@
   "colordiff",
   "cpanminus",
   "davmail",
-  "goenv",
+  "goenv@2",
   "luarocks",
   "meson",
   "phpmyadmin",

--- a/disabled_new_usr_local_relocation_formulae.json
+++ b/disabled_new_usr_local_relocation_formulae.json
@@ -2,7 +2,7 @@
   "colordiff",
   "cpanminus",
   "davmail",
-  "goenv",
+  "goenv@2",
   "luarocks",
   "meson",
   "mockserver",


### PR DESCRIPTION
This Pull Request will add the goenv@2 formula for legacy support and update goenv to use v3.

While goenv v3.1.1 is officially stable and backward compatible, we're maintaining v2 as the legacy because:

1. **CI/Production dependencies**: AWS CodeBuild and other CI systems currently depend on v2 - we need to update their docker files
2. **Field validation**: v3 is newly released and needs more testing

Users can explicitly use legacy v2 with: `brew install goenv@2`

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [X] Is your test running fine `brew test <formula>`?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

It was used for mimicking the gogcli formula since we dont do prebuilt binaries.

-----
