### PR TITLE
Fix: pulseaudio apple silicon realtime setup

### DIFF
--- a/Formula/p/pulseaudio.rb
+++ b/Formula/p/pulseaudio.rb
@@ -14,6 +14,12 @@ class Pulseaudio < Formula
       url "https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/commit/c1990dd02647405b0c13aab59f75d05cbb202336.diff"
       sha256 "46505b7f915a96a4e5f4c46cd8a2cfb5a74586bfd585d69f31b7b2e27e17a4c8"
     end
+
+    # Fix real-time scheduling on Apple Silicon (hw.cpufrequency absent)
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/homebrew-core/5ccecc0040477611cff63d9b0fe2c05260e4616f/Patches/pulseaudio/apple-silicon-realtime.patch"
+      sha256 "d762fbf1a3ca8fcc53bd8e67b0998e051766b676898c8cf7a6a6bd4ef20de5eb"
+    end
   end
 
   # The regex here avoids x.99 releases, as they're pre-release versions.
@@ -23,7 +29,7 @@ class Pulseaudio < Formula
   end
 
   bottle do
-    rebuild 2
+    rebuild 3
     sha256 arm64_tahoe:   "73c349f7d337ebb0bdd1169325685e79f4cb4c253dd920339a7bc52c833ea4c7"
     sha256 arm64_sequoia: "3b0c4054a598015af0838395bfb6b96b40ff9297d4d382b80e06c6df7b76b9ab"
     sha256 arm64_sonoma:  "bf612fdd30e917faf4c6627a1324f1ffaf509f5dfa92748199ff57c6ce1efcfb"

--- a/Patches/pulseaudio/apple-silicon-realtime.patch
+++ b/Patches/pulseaudio/apple-silicon-realtime.patch
@@ -1,0 +1,73 @@
+From e7a37f96e840c548a50f029c853d7490866faf85 Mon Sep 17 00:00:00 2001
+From: Charles Strahan <charles@cstrahan.com>
+Date: Wed, 8 Apr 2026 16:05:06 -0500
+Subject: [PATCH] Fix real-time scheduling on Apple Silicon
+
+On Apple Silicon, the sysctl key hw.cpufrequency is absent because ARM
+SoCs have heterogeneous core frequencies. PulseAudio's Darwin real-time
+scheduling path used this to compute Mach THREAD_TIME_CONSTRAINT_POLICY
+parameters in CPU cycle units, so it silently fails on all M-series Macs.
+
+Replace the CPU-frequency approach with mach_timebase_info(), which
+converts nanoseconds to Mach absolute time units regardless of
+architecture. The time constraint values are chosen to match the original
+intent (~6.25ms period, ~0.3ms computation, ~0.45ms constraint).
+---
+ src/pulse/util.c | 29 ++++++++++++++++++-----------
+ 1 file changed, 18 insertions(+), 11 deletions(-)
+
+diff --git a/src/pulse/util.c b/src/pulse/util.c
+index c7b828cc2..147f68c7a 100644
+--- a/src/pulse/util.c
++++ b/src/pulse/util.c
+@@ -86,6 +86,7 @@ static int _main() PA_GCC_WEAKREF(main);
+ 
+ #ifdef __APPLE__
+ #include <mach/mach_init.h>
++#include <mach/mach_time.h>
+ #include <mach/thread_act.h>
+ #include <mach/thread_policy.h>
+ #include <sys/sysctl.h>
+@@ -464,22 +465,28 @@ int pa_thread_make_realtime(int rtprio) {
+ 
+ #if defined(OS_IS_DARWIN)
+     struct thread_time_constraint_policy ttcpolicy;
+-    uint64_t freq = 0;
+-    size_t size = sizeof(freq);
++    mach_timebase_info_data_t tbi;
+     int ret;
+ 
+-    ret = sysctlbyname("hw.cpufrequency", &freq, &size, NULL, 0);
+-    if (ret < 0) {
+-        pa_log_info("Unable to read CPU frequency, acquisition of real-time scheduling failed.");
++    ret = mach_timebase_info(&tbi);
++    if (ret != KERN_SUCCESS || tbi.numer == 0) {
++        pa_log_info("mach_timebase_info() failed, acquisition of real-time scheduling failed.");
+         return -1;
+     }
+ 
+-    pa_log_debug("sysctl for hw.cpufrequency: %llu", freq);
+-
+-    /* See http://developer.apple.com/library/mac/#documentation/Darwin/Conceptual/KernelProgramming/scheduler/scheduler.html */
+-    ttcpolicy.period = freq / 160;
+-    ttcpolicy.computation = freq / 3300;
+-    ttcpolicy.constraint = freq / 2200;
++    pa_log_debug("mach_timebase_info: numer=%u denom=%u", tbi.numer, tbi.denom);
++
++    /* Convert desired durations from nanoseconds to Mach absolute time units.
++     * On Apple Silicon hw.cpufrequency is absent (heterogeneous cores), so we
++     * use mach_timebase_info instead, which works on both Intel and ARM.
++     * Values match the original intent: period ~6.25ms, computation ~0.3ms,
++     * constraint ~0.45ms.
++     * See Apple TN2169 and the Mach scheduler documentation. */
++#define NS_TO_ABS(ns) ((uint32_t)((uint64_t)(ns) * tbi.denom / tbi.numer))
++    ttcpolicy.period = NS_TO_ABS(6250000);
++    ttcpolicy.computation = NS_TO_ABS(303030);
++    ttcpolicy.constraint = NS_TO_ABS(454545);
++#undef NS_TO_ABS
+     ttcpolicy.preemptible = 1;
+ 
+     ret = thread_policy_set(mach_thread_self(),
+-- 
+2.50.1 (Apple Git-155)
+


### PR DESCRIPTION
This fixes crackling/popping sounds when running pulseaudio on macOS on Apple silicon by fixing realtime configuration.

arm64 builds of macOS no longer support `hw.cpufrequency`, as any given value wouldn't make much sense: the cores are heterogeneous. This cause the realtime thread setup to fail, as it depended on that.

What the code should have done from the start: pick a target `period`/`computation`/`constraint` and multiply by the the factor provided by `mach_timebase_info` to express that in Mach absolute time units.

The patch included with this PR does just that, deriving the `period`/`computation`/`constraint` from the old code under the assumption of a 3 GHz clock.

You can see where the chromium source uses the same pattern: https://chromium.googlesource.com/chromium/chromium/+/master/base/threading/platform_thread_mac.mm#157

```c++
  // Define constants determining how much time the audio thread can
  // use in a given time quantum.  All times are in milliseconds.
  // About 128 frames @44.1KHz
  const double kTimeQuantum = 2.9;
  // Time guaranteed each quantum.
  const double kAudioTimeNeeded = kGuaranteedAudioDutyCycle * kTimeQuantum;
  // Maximum time each quantum.
  const double kMaxTimeAllowed = kMaxAudioDutyCycle * kTimeQuantum;
  // Get the conversion factor from milliseconds to absolute time
  // which is what the time-constraints call needs.
  mach_timebase_info_data_t tb_info;
  mach_timebase_info(&tb_info);
  double ms_to_abs_time =
      ((double)tb_info.denom / (double)tb_info.numer) * 1000000;
  thread_time_constraint_policy_data_t time_constraints;
  time_constraints.period = kTimeQuantum * ms_to_abs_time;
  time_constraints.computation = kAudioTimeNeeded * ms_to_abs_time;
  time_constraints.constraint = kMaxTimeAllowed * ms_to_abs_time;
  time_constraints.preemptible = 0;
```

This completely resolves the popping/crackling on arm64 macOS, and the logs are free of:

```
 D: [MacBook Pro Speakers] protocol-native.c: Requesting rewind due to end of underrun. 
```

This resolves the issue reported here: https://github.com/orgs/Homebrew/discussions/3166

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Claude Code discovered the `hw.cpufrequency` sysctl, which is no longer supported on M series macs. I've read the docs on `mach_timebase_info_data_t` and `mach_timebase_info` to check the implementation, and I've confirmed that _after_ this patch:

- The `Unable to read CPU frequency, acquisition of real-time scheduling failed.` message is no longer printed.
- The horrendous crackling/popping sounds when playing audio from my OrbStack VM goes away.

-----
