### PR TITLE
highway: update license

### DIFF
--- a/Formula/h/highway.rb
+++ b/Formula/h/highway.rb
@@ -3,7 +3,7 @@ class Highway < Formula
   homepage "https://github.com/google/highway"
   url "https://github.com/google/highway/archive/refs/tags/1.3.0.tar.gz"
   sha256 "07b3c1ba2c1096878a85a31a5b9b3757427af963b1141ca904db2f9f4afe0bc2"
-  license "Apache-2.0"
+  license any_of: ["Apache-2.0", "BSD-3-Clause"]
   compatibility_version 1
   head "https://github.com/google/highway.git", branch: "master"
 


### PR DESCRIPTION
https://github.com/google/highway/commit/92a7139f88e534378fb2525abb919ac79d894f82

Upstream dual-licensed to allow compatibility with GPL-2.0-only projects.