### PR TITLE
expert: use recommended build method

### DIFF
--- a/Formula/e/expert.rb
+++ b/Formula/e/expert.rb
@@ -17,18 +17,24 @@ class Expert < Formula
   depends_on "elixir" => :build
   depends_on "erlang" => :build
   depends_on "just" => :build
-  depends_on "xz" => :build
-  depends_on "zig@0.15" => :build
+  depends_on "openssl@3"
+
+  uses_from_macos "ncurses"
+
+  on_linux do
+    depends_on "zlib-ng-compat"
+  end
 
   def install
-    os = OS.mac? ? "darwin" : "linux"
-    arch = Hardware::CPU.arm? ? "arm64" : "amd64"
-
     system "mix", "local.hex", "--force", "--if-missing"
     system "mix", "local.rebar", "--force", "--if-missing"
-    system "just", "burrito-local"
+    system "just", "release"
 
-    bin.install "apps/expert/burrito_out/expert_#{os}_#{arch}" => "expert"
+    # Remove Windows `.bat` files before install to avoid needlessly copying them
+    rm Dir[buildpath/"apps/expert/_build/prod/rel/plain/{bin,releases/**}/*.bat"]
+    libexec.install Dir[buildpath/"apps/expert/_build/prod/rel/plain/*"]
+    inreplace libexec/"bin/start_expert", '"$(dirname -- "$0")"/plain', "\"#{libexec}/bin/plain\""
+    bin.install_symlink libexec/"bin/start_expert" => "expert"
   end
 
   test do


### PR DESCRIPTION
-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This switches away from the burrito build method and moves towards the recommended plain one instead, which should address the points made in https://github.com/elixir-lang/expert/issues/556#issuecomment-4202515592 and https://github.com/elixir-lang/expert/issues/557#issuecomment-4206868525, and removes the `zig` and `xz` dependencies.