### PR TITLE
aicommit2 2.5.12

### DIFF
--- a/Formula/a/aicommit2.rb
+++ b/Formula/a/aicommit2.rb
@@ -6,7 +6,7 @@ class Aicommit2 < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "5dd7d2863f45c2eaf354a4007dccc5e78c51dea3b6313a5ea55ae091748091c7"
+    sha256 cellar: :any_skip_relocation, all: "6f89b8f87f48afe090c34f06643d9339498f688fb16cb032764a0e07092f936e"
   end
 
   depends_on "node"

--- a/Formula/a/aicommit2.rb
+++ b/Formula/a/aicommit2.rb
@@ -1,8 +1,8 @@
 class Aicommit2 < Formula
   desc "Reactive CLI that generates commit messages for Git and Jujutsu with AI"
   homepage "https://github.com/tak-bro/aicommit2"
-  url "https://registry.npmjs.org/aicommit2/-/aicommit2-2.5.8.tgz"
-  sha256 "5eea02e5c26f25517b5bb69d6f136590d516b1965c20152d41bf6096543f388a"
+  url "https://registry.npmjs.org/aicommit2/-/aicommit2-2.5.12.tgz"
+  sha256 "c2b72ffb6819d04eea6508e0b648693a07f28d819b623de92e616705db31f888"
   license "MIT"
 
   bottle do
@@ -12,7 +12,16 @@ class Aicommit2 < Formula
   depends_on "node"
 
   def install
-    system "npm", "install", *std_npm_args
+    # Optional dependencies include `@github/copilot-sdk`
+    # which uses proprietary license
+    (libexec/"aicommit2").install buildpath.glob("*")
+    cd libexec/"aicommit2" do
+      system "npm", "install", "--omit=optional", *std_npm_args(prefix: false)
+      with_env(npm_config_prefix: libexec) do
+        system "npm", "link"
+      end
+    end
+
     bin.install_symlink libexec.glob("bin/*")
   end
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Used Claude Code to analyze CI failures in #275895. The `@github/copilot-sdk` (added in v2.5.9) bundles platform-specific native binaries via `@github/copilot` causing 3 failures: architecture audit (x86_64 on arm64), libsecret linkage, and test assertion mismatch. Fix: remove `@github` directory post-install. Verified locally with `brew install --build-from-source`, `brew test`, and `brew audit`.

-----
