### PR TITLE
kanata: add service support

### DIFF
--- a/Formula/k/kanata.rb
+++ b/Formula/k/kanata.rb
@@ -21,6 +21,16 @@ class Kanata < Formula
     system "cargo", "install", *std_cargo_args
   end
 
+  service do
+    run [opt_bin/"kanata", "--no-wait", "--cfg", "#{Dir.home}/.config/kanata/kanata.kbd"]
+    keep_alive true
+    require_root true
+    working_dir Dir.home
+    environment_variables PATH: std_service_path_env
+    log_path var/"log/kanata.log"
+    error_log_path var/"log/kanata.log"
+  end
+
   test do
     (testpath/"kanata.kbd").write <<~LISP
       (defsrc


### PR DESCRIPTION
This Pr is a followup to #260237

This PR intends to provide a reasonable default launchctl service to run
kanata with. Kanata needs root privileges to intercept hid devices.
Solving for vhiddaemon and vhidmanager to be on the system is outside of
the scope of the kanata formula, users must follow the kanata
documentation on getting the prerequisites installed (usually it's just
installing karabiner elements, but not allowing it to launch at start).

Related discussions on how to run kanata as a service are also found
here: <https://github.com/jtroo/kanata/discussions/1537>

---

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

- [ ] AI was used to generate or assist with generating this PR. _Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes_.

---
