### PR TITLE
at-spi2-core: do not require X11 deps on macOS

### DIFF
--- a/Formula/a/at-spi2-core.rb
+++ b/Formula/a/at-spi2-core.rb
@@ -4,6 +4,7 @@ class AtSpi2Core < Formula
   url "https://download.gnome.org/sources/at-spi2-core/2.60/at-spi2-core-2.60.0.tar.xz"
   sha256 "80e50c1a97d8fd660a3fadb02ca35876df881c266d3d6108fc5b4c113614cb99"
   license "LGPL-2.1-or-later"
+  revision 1
   compatibility_version 1
 
   bottle do
@@ -20,18 +21,22 @@ class AtSpi2Core < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkgconf" => [:build, :test]
-  depends_on "xorgproto" => :build
 
   depends_on "dbus"
   depends_on "glib"
-  depends_on "libx11"
-  depends_on "libxi"
-  depends_on "libxtst"
 
   uses_from_macos "libxml2" => :build
 
   on_macos do
     depends_on "gettext"
+  end
+
+  on_linux do
+    depends_on "xorgproto" => :build
+
+    depends_on "libx11"
+    depends_on "libxi"
+    depends_on "libxtst"
   end
 
   def install
@@ -75,6 +80,6 @@ class AtSpi2Core < Formula
 
     pkg_config_cflags = shell_output("pkg-config --cflags --libs atspi-2").chomp.split
     system ENV.cc, "test.c", *pkg_config_cflags, "-lgobject-2.0", "-o", "test"
-    assert_match "AT-SPI", shell_output("#{testpath}/test 2>&1", 133)
+    assert_match "AT-SPI", shell_output("#{testpath}/test 2>&1", OS.mac? ? 133 : 134)
   end
 end


### PR DESCRIPTION
As we already do with the gtk3 formulae, let's
not require these non-native deps on macOS, since
they are not strictly needed there and waste time on CI.

Related to #177052 and #252552

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI was used for debugging the test failure:

```
  (process:12840): dbind-ERROR **: 10:38:14.297: AT-SPI: Couldn't connect to accessibility bus. Is at-spi-bus-launcher running?
  Aborted (core dumped)
  Error: at-spi2-core: failed
  An exception occurred within a child process:
    Minitest::Assertion: Expected: 133
    Actual: 134
```

-----
