### PR TITLE
pay 0.5.0

### DIFF
--- a/Formula/p/pay.rb
+++ b/Formula/p/pay.rb
@@ -1,8 +1,8 @@
 class Pay < Formula
   desc "HTTP client that automatically handles 402 Payment Required"
   homepage "https://github.com/solana-foundation/pay"
-  url "https://github.com/solana-foundation/pay/archive/refs/tags/pay-v0.4.0.tar.gz"
-  sha256 "63f0cc9535214a16ab3fa3d546a1d83d01114e46677605d74c4e6a1f04264d96"
+  url "https://github.com/solana-foundation/pay/archive/refs/tags/pay-v0.5.0.tar.gz"
+  sha256 "a5f97c4d8a5c168e5e5ae3368c5a2c0ced74c668f562004cbf849cd16a136fcf"
   license "Apache-2.0"
   head "https://github.com/solana-foundation/pay.git", branch: "main"
 
@@ -29,6 +29,7 @@ class Pay < Formula
   end
 
   test do
-    assert_match "No wallet configured", shell_output("#{bin}/pay fetch https://httpbin.org/get 2>&1", 1)
+    assert_match "No wallet configured",
+                 shell_output("#{bin}/pay fetch https://payment-debugger.vercel.app/mpp/quote/AAPL 2>&1", 1)
   end
 end


### PR DESCRIPTION
Supersedes #277033 — same 0.5.0 bump plus a test URL update.

The previous test pointed at `httpbin.org/get` and asserted the binary exits 1 with `No wallet configured`. Since v0.5 `pay fetch` lazy-loads the wallet only when a 402 challenge actually comes back, so a 200 endpoint no longer triggers the wallet check and the test fails.

Updated to point at `payment-debugger.vercel.app/mpp/quote/AAPL`, which returns a 402 with an MPP challenge — exercising the same error path the original test was meant to cover.