### PR TITLE
cairo: do not require X11 deps on macOS

### DIFF
--- a/Formula/c/cairo.rb
+++ b/Formula/c/cairo.rb
@@ -4,6 +4,7 @@ class Cairo < Formula
   url "https://cairographics.org/releases/cairo-1.18.4.tar.xz"
   sha256 "445ed8208a6e4823de1226a74ca319d3600e83f6369f99b14265006599c32ccb"
   license any_of: ["LGPL-2.1-only", "MPL-1.1"]
+  revision 1
   head "https://gitlab.freedesktop.org/cairo/cairo.git", branch: "master"
 
   livecheck do
@@ -29,10 +30,6 @@ class Cairo < Formula
   depends_on "freetype"
   depends_on "glib"
   depends_on "libpng"
-  depends_on "libx11"
-  depends_on "libxcb"
-  depends_on "libxext"
-  depends_on "libxrender"
   depends_on "lzo"
   depends_on "pixman"
 
@@ -41,6 +38,10 @@ class Cairo < Formula
   end
 
   on_linux do
+    depends_on "libx11"
+    depends_on "libxcb"
+    depends_on "libxext"
+    depends_on "libxrender"
     depends_on "zlib-ng-compat"
   end
 
@@ -51,12 +52,14 @@ class Cairo < Formula
       -Dfreetype=enabled
       -Dpng=enabled
       -Dglib=enabled
-      -Dxcb=enabled
-      -Dxlib=enabled
       -Dzlib=enabled
       -Dglib=enabled
     ]
     args << "-Dquartz=enabled" if OS.mac?
+    if OS.linux?
+      args << "-Dxcb=enabled"
+      args << "-Dxlib=enabled"
+    end
 
     system "meson", "setup", "build", *args, *std_meson_args
     system "meson", "compile", "-C", "build", "--verbose"


### PR DESCRIPTION
As we already do with the gtk3 formulae, let's
not require these non-native deps on macOS, since
they are not strictly needed there and waste time on CI.

This is needed for #277057 since many GNOME dependencies depend indirectly on cairo

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
