### PR TITLE
code-server: revert to 4.112.0

### DIFF
--- a/Formula/c/code-server.rb
+++ b/Formula/c/code-server.rb
@@ -1,9 +1,14 @@
 class CodeServer < Formula
   desc "Access VS Code through the browser"
   homepage "https://github.com/coder/code-server"
-  url "https://registry.npmjs.org/code-server/-/code-server-4.114.0.tgz"
-  sha256 "0b7b14a267db634b7c3611ee7869998370f88cd668ef0877eef58a7e3d66e401"
+  url "https://registry.npmjs.org/code-server/-/code-server-4.112.0.tgz"
+  sha256 "adca4415d5553e9a70ef755f36f6de944aa2d9180540ff42d899eb9ebe28d8c8"
   license "MIT"
+  revision 1
+
+  livecheck do
+    skip "Newer versions use non-FOSS @github/copilot"
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "8c942206b830ef64dc0513e0b589fdd1d676daf7430121c73d0530c998d54990"
@@ -13,6 +18,12 @@ class CodeServer < Formula
     sha256 cellar: :any_skip_relocation, arm64_linux:   "12b48c262215a178bc461781fc18d385ba906a6fd8cd58b0d7e30319ef8cad97"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "49514e85f16edef9f5af5820ffc1896edc5dade9c2405b19d9fa0c5da4271426"
   end
+
+  # https://github.com/microsoft/vscode/commit/98f15b55eaa9ec24b60cad2905d53f721ad67357
+  # https://github.com/github/copilot-cli/blob/main/LICENSE.md
+  # https://github.com/github/copilot-cli/issues/19#issuecomment-3335871033
+  deprecate! date: "2026-04-11", because: "uses non-FOSS @github/copilot since 4.113.0"
+  disable! date: "2027-04-11", because: "uses non-FOSS @github/copilot since 4.113.0"
 
   depends_on "pkgconf" => :build
   depends_on "node@22"
@@ -26,6 +37,8 @@ class CodeServer < Formula
   end
 
   def install
+    odie "Do not upgrade to 4.113.0 or newer!" if version >= "4.113.0"
+
     # Fix broken node-addon-api: https://github.com/nodejs/node/issues/52229
     ENV.append "CXXFLAGS", "-DNODE_API_EXPERIMENTAL_NOGC_ENV_OPT_OUT"
 
@@ -45,9 +58,6 @@ class CodeServer < Formula
     rm_r(vscode_node_modules.glob("@anthropic-ai/sandbox-runtime/vendor/seccomp/#{arch}"))
     rm_r(anthropic_node_modules.glob("@parcel/watcher-{darwin,linux}*"))
     rm_r(vscode_node_modules.glob("@parcel/watcher-{darwin,linux}*"))
-    rm_r(vscode_node_modules.glob("@github/copilot/prebuilds/{darwin,linux}*"))
-    rm_r(vscode_node_modules.glob("@github/copilot/ripgrep/bin/*/rg"))
-    rm_r(vscode_node_modules.glob("@github/copilot/clipboard/node_modules/@teddyzhu/clipboard-*/clipboard.*"))
 
     # Remove pre-built binaries where source in not available to allow compilation
     # https://www.npmjs.com/package/@azure/msal-node-runtime

--- a/Formula/c/code-server.rb
+++ b/Formula/c/code-server.rb
@@ -11,12 +11,12 @@ class CodeServer < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "8c942206b830ef64dc0513e0b589fdd1d676daf7430121c73d0530c998d54990"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "ec49f8dfc8ca8a7e2546b66058e99e341491100cc9fad0c9d1f03880e50b5bc7"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "ad61fd8260520cdca936fceff2180d0c542d79ba4f4d2a5e670da929a95dcac2"
-    sha256 cellar: :any_skip_relocation, sonoma:        "ce638cfe849542bb6700f1ee9d69f23e9da5344114685de1966d4f28cd64823b"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "12b48c262215a178bc461781fc18d385ba906a6fd8cd58b0d7e30319ef8cad97"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "49514e85f16edef9f5af5820ffc1896edc5dade9c2405b19d9fa0c5da4271426"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "5f7ac4b3e3fe166cc6d861b4135796fdb9d2d30fb1b29987b50418b4a4b34ff8"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e8487c2ddc85086993dca155ec5b946c8289592351ca6cc66ef607bc7be99c62"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "2d90eca0664540b5eea48c3034340b25bb540865d2d15a2f21d4b6ec9d391867"
+    sha256 cellar: :any_skip_relocation, sonoma:        "9fd87893ceaa9ce6ab62becec31584422c66922ae417b4ec7abc422d03260220"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "8f3577f8080904eb450dbeb2f677e7bce9c85ea2e926475b91d9c6dcf49de112"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "dfa73f90f44342fd3e122986d843ae4d3de1e735ae5590e292ed18516b240cb4"
   end
 
   # https://github.com/microsoft/vscode/commit/98f15b55eaa9ec24b60cad2905d53f721ad67357


### PR DESCRIPTION
Closes #276736

---

`code-server` has started including `@github/copilot` due to https://github.com/microsoft/vscode/commit/98f15b55eaa9ec24b60cad2905d53f721ad67357

This is considered non-FOSS and unacceptable in Homebrew/core as it does not meet https://docs.brew.sh/License-Guidelines
- https://github.com/github/copilot-cli/blob/main/LICENSE.md
- https://github.com/github/copilot-cli/issues/19#issuecomment-3335871033

---

Our policy requires us to directly remove any formula that ships non-FOSS software - https://docs.brew.sh/Deprecating-Disabling-and-Removing#when-to-remove-formulae
>  A formula should be removed if it does not meet the criteria for [acceptable formulae](https://docs.brew.sh/Acceptable-Formulae) or [versioned formulae](https://docs.brew.sh/Versions), has a non-open-source license

Downgrading version to avoid direct removal and allows a deprecation period.

---

I did try looking into a Cask - https://github.com/Homebrew/homebrew-cask/pull/258776 - but there is problems with codesigning of `*.node` binaries. These do not trigger `brew audit` but will cause possible malicious software popup which may not meet our acceptable cask policy.

Seems to only be an issue on arm64 macOS as Intel macOS binaries look okay based on `gktool`. And Linux doesn't need this requirement. However, the largest portion of Homebrew's user base is on arm64 macOS so will lead to user issues if we tap migrate.

Also, some binaries are built with minimum macOS of 15.0. Not sure how many of these are actually used.