### PR TITLE
ctre: fix description, remove unneeded `cmake --build`, improve test

### DIFF
--- a/Formula/c/ctre.rb
+++ b/Formula/c/ctre.rb
@@ -1,5 +1,5 @@
 class Ctre < Formula
-  desc "Compile-time PCRE-compatible regular expression matcher for C++"
+  desc "Compile-time regular expression matcher for C++"
   homepage "https://compile-time-regular-expressions.readthedocs.io/"
   url "https://github.com/hanickadot/compile-time-regular-expressions/archive/refs/tags/v3.10.0.tar.gz"
   sha256 "b17e6c9a6cc0cea65132f62a6c699cefed952721063569d6339eb3ca471045e6"
@@ -18,24 +18,22 @@ class Ctre < Formula
 
   def install
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args
-    system "cmake", "--build", "build"
     system "cmake", "--install", "build"
   end
 
   test do
-    (testpath/"test.cxx").write <<~CPP
+    (testpath/"test.c++").write <<~'CXX'
       #include <ctre-unicode.hpp>
-      #include <cassert>
-      #include <iostream>
 
       int main()
       {
-        const auto m = ctre::match<"[a-z]+([0-9]+)">("test123");
-        assert(m);
-        std::cout << m.get<1>();
+        constexpr auto url = "https://github.com/org/repo/archive/refs/tags/v1.6.18.tar.gz";
+        constexpr auto regex = ctll::fixed_string{R"(\d+(?:\.\d+)+)"};
+        constexpr auto version = ctre::search<regex>(url);
+        static_assert(version && version.get<0>() == "1.6.18");
       }
-    CPP
-    system ENV.cxx, "test.cxx", "-o", "test", "-std=c++20", "-I#{include}"
-    assert_equal "123", shell_output("./test")
+    CXX
+    system ENV.cxx, "test.c++", "-o", "test", "-std=c++20", "-I#{include}"
+    system "./test"
   end
 end


### PR DESCRIPTION
<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

1. According to https://compile-time-regular-expressions.readthedocs.io/en/latest/regex_syntax.html it's not fully PCRE-compatible, and the GitHub repo's description doesn't mention PCRE either.

2. The `cmake --build` invocation is no-op since the package is a header-only library and doesn't build any library binaries.

3. The new test block makes the library's compile-time nature more apparent by evaluating every statement at compile time thanks to `constexpr` and `static_assert`.

I didn't bump the revision number as the PR won't break API or ABI compatibility:
* It's header-only), so it's not possible for dependents to link against it (it can only be a `:no_linkage` dependency).
* There are currently no dependent packages of this library anyway.