### PR TITLE
triage(long-build): add `influxdb`

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -292,6 +292,7 @@ jobs:
                 graph-tool|\
                 gstreamer|\
                 haskell-language-server|\
+                influxdb|\
                 libtensorflow|\
                 llvm@19|\
                 llvm|\


### PR DESCRIPTION
based on the recent runs, https://github.com/Homebrew/homebrew-core/pulls?q=is%3Apr+influxdb+label%3A%22long+build%22, I think it makes sense to add influxdb into the `long build` list

- https://github.com/Homebrew/homebrew-core/pull/277338