### PR TITLE
cmd/check-bottle-modification.rb: fix type errors

### DIFF
--- a/cmd/check-bottle-modification.rb
+++ b/cmd/check-bottle-modification.rb
@@ -21,6 +21,8 @@ module Homebrew
 
       def get_pull_request_commits(pull_request)
         owner, repo = ENV.fetch("GITHUB_REPOSITORY").split("/")
+        raise "Unable to fetch `GITHUB_REPOSITORY` environment variable" if !owner || !repo
+
         response = GitHub::API.open_rest(GitHub.url_to("repos", owner, repo, "pulls", pull_request, "commits"))
 
         response.reject! do |item|
@@ -34,6 +36,8 @@ module Homebrew
 
       def commit_modifies_bottle_block?(sha)
         owner, repo = ENV.fetch("GITHUB_REPOSITORY").split("/")
+        raise "Unable to fetch `GITHUB_REPOSITORY` environment variable" if !owner || !repo
+
         response = GitHub::API.open_rest(GitHub.url_to("repos", owner, repo, "commits", sha))
 
         files = response.fetch("files")


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

The `owner` and `repo` variables in the `get_pull_request_commits` and `commit_modifies_bottle_block?` methods in `cmd/check-bottle-modification.rb` can technically be nil but the type signature for `GitHub.url_to` arguments is `T.any(String, Integer)`, resulting in an `Expected T.any(String, Integer) but found T.nilable(String) for argument subroutes` error. This accounts for this scenario by raising an error when `owner` or `repo` are nil.