### PR TITLE
node: unbundle simdutf

### DIFF
--- a/Formula/n/node.rb
+++ b/Formula/n/node.rb
@@ -4,7 +4,7 @@ class Node < Formula
   url "https://nodejs.org/dist/v25.9.0/node-v25.9.0.tar.xz"
   sha256 "8f78af3ee55fb278668b5f801db58bd1a38ea161318eb5ce2128ddbc9cd813aa"
   license "MIT"
-  revision 2
+  revision 3
   compatibility_version 1
   head "https://github.com/nodejs/node.git", branch: "main"
 
@@ -38,6 +38,7 @@ class Node < Formula
   depends_on "nbytes"
   depends_on "openssl@3"
   depends_on "simdjson"
+  depends_on "simdutf"
   depends_on "sqlite" # Fails with macOS sqlite.
   depends_on "uvwasi"
   depends_on "zstd"
@@ -124,6 +125,7 @@ class Node < Formula
       "ngtcp2"        => ["ngtcp2",          "libngtcp2"],
       "openssl"       => ["openssl/openssl", "openssl@3"],
       "simdjson"      => ["simdjson",        "simdjson"],
+      "simdutf"       => ["simdutf",         "simdutf"],
       "sqlite"        => ["sqlite",          "sqlite"],
       "uvwasi"        => ["uvwasi",          "uvwasi"],
       "zlib"          => ["zlib",            ("zlib-ng-compat" unless OS.mac?)],
@@ -139,12 +141,10 @@ class Node < Formula
 
     # TODO: Try to devendor these libraries.
     # - `--shared-gtest` is only used for building the test suite, which we don't run here.
-    # - `--shared-simdutf` seems to result in build failures.
     # - `--shared-temporal_capi` is only used when building with `--v8-enable-temporal-support`
     # - `--shared-lief` is not available as dependency in Homebrew.
     ignored_shared_flags = %w[
       gtest
-      simdutf
       temporal_capi
       lief
     ].map { |library| "--shared-#{library}" }


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

We unbundled merve in 90df578579f50a31e2d6782e7ad9149589ed7b23. merve
depends on `simdutf`, and we don't want to load two different versions
of `simdutf` in-process. This means we should try to unbundle `simdutf`
too.
