### PR TITLE
gradle: remove 300MB+ of docs

### DIFF
--- a/Formula/g/gradle.rb
+++ b/Formula/g/gradle.rb
@@ -20,7 +20,7 @@ class Gradle < Formula
 
   def install
     rm(Dir["bin/*.bat"])
-    libexec.install %w[bin docs lib src]
+    libexec.install %w[bin lib src] # excluding 300MB+ of docs
     env = Language::Java.overridable_java_home_env
     (bin/"gradle").write_env_script libexec/"bin/gradle", env
   end

--- a/Formula/g/gradle.rb
+++ b/Formula/g/gradle.rb
@@ -11,7 +11,8 @@ class Gradle < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "21af8e92a414771d90d20dcc60dede096b38f0566f01bb079fe8a891ba469be7"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "8ba56bbcec5fa9fe98f91e5e85a3baf0271e7129fb9710b6ba184526a1dda134"
   end
 
   depends_on "gradle-completion"


### PR DESCRIPTION
This was over 60% of install which slows download and pour:
```console
❯ du -sh $(brew --prefix gradle)/libexec/* | sort -h
 12K	/opt/homebrew/opt/gradle/libexec/bin
 59M	/opt/homebrew/opt/gradle/libexec/src
148M	/opt/homebrew/opt/gradle/libexec/lib
323M	/opt/homebrew/opt/gradle/libexec/docs
```
