### PR TITLE
snip 0.12.0 (new formula)

### DIFF
--- a/Formula/s/snip.rb
+++ b/Formula/s/snip.rb
@@ -1,0 +1,20 @@
+class Snip < Formula
+  desc "CLI proxy that reduces LLM token consumption by filtering shell output"
+  homepage "https://github.com/edouard-claude/snip"
+  url "https://github.com/edouard-claude/snip/archive/refs/tags/v0.12.0.tar.gz"
+  sha256 "64726fede5d51d1f1a6705c2d4a6c83be27c8a4872623136898d631f64107928"
+  license "MIT"
+  head "https://github.com/edouard-claude/snip.git", branch: "master"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = "-s -w -X github.com/edouard-claude/snip/internal/cli.version=#{version}"
+    system "go", "build", *std_go_args(ldflags:), "./cmd/snip"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/snip --version")
+    assert_match "filter", shell_output("#{bin}/snip --help")
+  end
+end


### PR DESCRIPTION
## Description

Add formula for [snip](https://github.com/edouard-claude/snip), a CLI proxy that reduces LLM token consumption by 60-90% by filtering shell output before it reaches AI coding assistants.

snip sits between AI tools (Claude Code, Cursor, Codex, Windsurf, Cline) and the shell, filtering verbose output through **126 declarative YAML filters** with 19 composable pipeline actions. Filters are data files, not compiled code, so anyone can contribute a filter without knowing Go.

## Notable stats

- 149 GitHub stars
- 126 built-in YAML filters covering 90+ CLI tools
- 6 native AI tool integrations
- MIT license
- Pure Go, zero CGO, static binaries
- Active development: 20+ releases since Feb 2026

## Checklist

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/creation?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`?
- [x] Does your build pass `brew test <formula>`?
- [x] Does your build pass `brew audit --strict --new <formula>`?