### PR TITLE
pi-coding-agent 0.67.2

### DIFF
--- a/Formula/p/pi-coding-agent.rb
+++ b/Formula/p/pi-coding-agent.rb
@@ -1,8 +1,8 @@
 class PiCodingAgent < Formula
   desc "AI agent toolkit"
   homepage "https://pi.dev/"
-  url "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.67.1.tgz"
-  sha256 "f73791ddc97fd91c91982833f90c3c0f30d0d308c87f7c00fe47ea111762794c"
+  url "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.67.2.tgz"
+  sha256 "55d0a7281e090ee79d037ae490995214ea2ea395a586b0933a58fc30ba57a928"
   license "MIT"
 
   bottle do


### PR DESCRIPTION
Created manually following the same version-bump pattern used in Homebrew/homebrew-core#277628.

- updates the npm tarball URL to 0.67.2
- updates the source sha256
- leaves bottle hashes untouched for Homebrew automation

Published upstream on npm: https://www.npmjs.com/package/@mariozechner/pi-coding-agent/v/0.67.2