### PR TITLE
tree-sitter@0.22 (new formula)

### DIFF
--- a/Formula/t/tree-sitter@0.22.rb
+++ b/Formula/t/tree-sitter@0.22.rb
@@ -1,0 +1,50 @@
+class TreeSitterAT022 < Formula
+  desc "Incremental parsing library"
+  homepage "https://tree-sitter.github.io/"
+  url "https://github.com/tree-sitter/tree-sitter/archive/refs/tags/v0.22.6.tar.gz"
+  sha256 "e2b687f74358ab6404730b7fb1a1ced7ddb3780202d37595ecd7b20a8f41861f"
+  license "MIT"
+
+  livecheck do
+    url :stable
+    regex(/^v?(0\.22(?:\.\d+)+)$/i)
+  end
+
+  keg_only :versioned_formula
+
+  def install
+    system "make", "install", "AMALGAMATED=1", "PREFIX=#{prefix}"
+  end
+
+  test do
+    (testpath/"test_program.c").write <<~C
+      #include <stdio.h>
+      #include <string.h>
+      #include <tree_sitter/api.h>
+      int main(int argc, char* argv[]) {
+        TSParser *parser = ts_parser_new();
+        if (parser == NULL) {
+          return 1;
+        }
+        // Because we have no language libraries installed, we cannot
+        // actually parse a string successfully. But, we can verify
+        // that it can at least be attempted.
+        const char *source_code = "empty";
+        TSTree *tree = ts_parser_parse_string(
+          parser,
+          NULL,
+          source_code,
+          strlen(source_code)
+        );
+        if (tree == NULL) {
+          printf("tree creation failed");
+        }
+        ts_tree_delete(tree);
+        ts_parser_delete(parser);
+        return 0;
+      }
+    C
+    system ENV.cc, "-I#{include}", "test_program.c", "-L#{lib}", "-ltree-sitter", "-o", "test_program"
+    assert_equal "tree creation failed", shell_output("./test_program")
+  end
+end


### PR DESCRIPTION
The upstream build of `semgrep/semgrep` requires a fixed version of tree-sitter `0.22.x`; this PR introduces a new formula to build `tree-sitter` at `0.22` (similar to `tree-sitter@0.25`).

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
