### PR TITLE
ex-vi 4.1.3

### DIFF
--- a/Formula/e/ex-vi.rb
+++ b/Formula/e/ex-vi.rb
@@ -1,14 +1,10 @@
 class ExVi < Formula
   desc "UTF8-friendly version of traditional vi"
-  homepage "https://ex-vi.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/ex-vi/ex-vi/050325/ex-050325.tar.bz2"
-  sha256 "da4be7cf67e94572463b19e56850aa36dc4e39eb0d933d3688fe8574bb632409"
+  homepage "https://github.com/n-t-roff/heirloom-ex-vi"
+  url         "https://github.com/n-t-roff/heirloom-ex-vi.git",
+    tag:      "4.1.3",
+    revision: "d47dc5ab1c66dc603b7de92ed17692e00d42d95f"
   license all_of: ["BSD-4-Clause", "BSD-4-Clause-UC"]
-
-  livecheck do
-    url :stable
-    regex(%r{url=.*?/ex[._-]v?(\d+(?:\.\d+)*)\.t}i)
-  end
 
   bottle do
     rebuild 1
@@ -33,6 +29,8 @@ class ExVi < Formula
     # Fix compile with newer Clang
     ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
     ENV.deparallelize
+    system "./configure"
+    system "make"
     system "make", "install", "INSTALL=/usr/bin/install",
                               "PREFIX=#{prefix}",
                               "PRESERVEDIR=/var/tmp/vi.recover",


### PR DESCRIPTION
Followup to https://github.com/orgs/Homebrew/discussions/6800

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Regarding the guidelines for contributing, it's apparently not possible to use `brew bump-formula-pr` to switch from HTTP to Git fetch.

I can't come up with a good test for `vi`, it refuses to run if there's no graphical (i.e. ANSI) terminal available. Running `ex` is doable, but wouldn't test the problem that this upgrade is intended to solve.

I _have_ built using `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source ex-vi` and tested the resulting binary.