### PR TITLE
dotnet 10.0.106

### DIFF
--- a/Formula/d/dotnet.rb
+++ b/Formula/d/dotnet.rb
@@ -3,16 +3,17 @@ class Dotnet < Formula
   homepage "https://dotnet.microsoft.com/"
   license "MIT"
   version_scheme 1
+  compatibility_version 1
   head "https://github.com/dotnet/dotnet.git", branch: "main"
 
   stable do
     # Source-build tag announced at https://github.com/dotnet/source-build/discussions
-    url "https://github.com/dotnet/dotnet/archive/refs/tags/v10.0.105.tar.gz"
-    sha256 "c634e849db52424b75c82c010116cb8290bc952431b7ccf6078ed7365d57b90e"
+    url "https://github.com/dotnet/dotnet/archive/refs/tags/v10.0.106.tar.gz"
+    sha256 "04a29699e8b5ead160a633c376d815280ccd7a78e03c80f257e329c0bfdfe771"
 
     resource "release.json" do
-      url "https://github.com/dotnet/dotnet/releases/download/v10.0.105/release.json"
-      sha256 "e8f1ccc6f7f1e2f5b2265bcab5a5351535288c9c5261ac7c677e865a6a547dcd"
+      url "https://github.com/dotnet/dotnet/releases/download/v10.0.106/release.json"
+      sha256 "f89b778619633f8bf075506495854651e52b205454b85cd01f622a50029688f6"
 
       livecheck do
         formula :parent

--- a/Formula/d/dotnet.rb
+++ b/Formula/d/dotnet.rb
@@ -31,12 +31,12 @@ class Dotnet < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "7a473a10c5f4b75cc5c4ded89263cfeb5c9d50e2520935cce75be400f5b14ffa"
-    sha256 cellar: :any,                 arm64_sequoia: "3dc28e3e729add4029a3b0b2b302c449a4321bdd1e189091d1d5cd2ee912420a"
-    sha256 cellar: :any,                 arm64_sonoma:  "410db18a7f83def7d657cd67f5e8e79e5d54d3f55226bf2ed44196d8fa55a710"
-    sha256 cellar: :any,                 sonoma:        "28ea46ab7b6fffced27292dc10790063a2d426c1792170a863fdc0704127044e"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "e72ff8fed4f6b10b62f78dd62fc996d3d5c3c1dde9b2c3f6eadf5b09f1c0a9a6"
-    sha256                               x86_64_linux:  "bdab4c1a8a2cd86ac784ba1d95d18ff9b9bc796c159f86655b6929e9befabee2"
+    sha256 cellar: :any,                 arm64_tahoe:   "1fdce799acbc95ba613c4273cdfcd269d11e07db8627ba1c8b6978e889bfbb64"
+    sha256 cellar: :any,                 arm64_sequoia: "b4ff8ca04bcea24ea98f95baf2f8e443bd48d094fd46d3e96ac794a50ab3bcfa"
+    sha256 cellar: :any,                 arm64_sonoma:  "4af5303d7788beca1097a5c1d4bd312b48fd6132084c93b2bc9deccef2d1d78a"
+    sha256 cellar: :any,                 sonoma:        "25c3b114fcfdd7a9b3a8e366469a87e19d1208e0da9f7e4c25ea1519b78690a5"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "28bd08eb004c41176a7061fafeb759d7e4cf4aea9a18d2193d5e962aead1efc9"
+    sha256                               x86_64_linux:  "2c40d67f0a88d8e7a572b78080c8ec508e06036c1ce841e7f8d32c78ec38ccb8"
   end
 
   depends_on "cmake" => :build

--- a/Formula/p/powershell.rb
+++ b/Formula/p/powershell.rb
@@ -5,7 +5,7 @@ class Powershell < Formula
       tag:      "v7.6.0",
       revision: "767990ba06f8579d69f99eec46057541374aa892"
   license "MIT"
-  revision 1
+  revision 2
 
   livecheck do
     url :stable
@@ -44,6 +44,7 @@ class Powershell < Formula
       --disable-build-servers
       --use-current-runtime
       --nologo
+      --property:WarningsNotAsErrors=NU1903
     ]
     dotnet_publish_flags = %W[
       --disable-build-servers
@@ -57,6 +58,7 @@ class Powershell < Formula
       --property:ErrorOnDuplicatePublishOutputFiles=false
       --property:IsWindows=false
       --property:ReleaseTag=#{version}
+      --property:WarningsNotAsErrors=NU1903
     ]
     dotnet_run_flags = %W[
       --framework #{target_framework}
@@ -75,6 +77,7 @@ class Powershell < Formula
       -t:_GetDependencies
       -property:DesignTimeBuild=true;_DependencyFile=#{buildpath}/src/TypeCatalogGen/#{inc_file}
       -nologo
+      -p:WarningsNotAsErrors=NU1903
     ]
     target_file = buildpath/"src/Microsoft.PowerShell.SDK/obj/Microsoft.PowerShell.SDK.csproj.TypeCatalog.targets"
     target_file.dirname.mkpath

--- a/Formula/p/powershell.rb
+++ b/Formula/p/powershell.rb
@@ -13,12 +13,12 @@ class Powershell < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "9e164ecea7a8319f50bdb63f940553c3225f5b4fdb721705451ff1c1c3e9ed54"
-    sha256 cellar: :any,                 arm64_sequoia: "4db31779851843df9958c3bd84b49ac5a8f92a9b90cee8f1739cf3acbb6d3f2f"
-    sha256 cellar: :any,                 arm64_sonoma:  "033c71c388fbbb54f390f70c89230930f3bb6bd2936286ffa2f37340776a2a2a"
-    sha256 cellar: :any,                 sonoma:        "57e179c0bd8c2565a279edca93152578e0aac3a3bd52673a8eb6de8cd6ef82e8"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "597e50330a560c00e8cae859e9b661d75ecf3d9b5b1dfb4129915f40ab094019"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e3ef9b43d72327b1d67625e1e83a7d59f26352d8321a9a84ab38e8f6f062cc4a"
+    sha256 cellar: :any,                 arm64_tahoe:   "23d4e1fd2b41069a252d34cd5d1edde61a99a0b63bbb8b797cd3d6796d62aae8"
+    sha256 cellar: :any,                 arm64_sequoia: "65d76038f7b950749d20d99411a432821d63b8eeaa953bdd46e90cff86551e67"
+    sha256 cellar: :any,                 arm64_sonoma:  "fb52383ff82208b155224dc20ebfe53bdcb095265f4c7722d157f348e68f80e2"
+    sha256 cellar: :any,                 sonoma:        "5d82cce6d2c432cc0a5b0157c2a8bb98eaa0469f9a27cf9ed3141040d38d2e9a"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "8cda2c3fcf51135800bbe4001c141051aeb79fca3358841110221788ac7988c3"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "dcc017990d60d72ab1b02c90855d289387b384801738d4a69d41d4a10e3ff7dd"
   end
 
   depends_on "dotnet"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

fixes #277579 

~Powershell needs to be always bumped for each new dotnet version. This is because of the symlink to dotnet.~

Edit:

So there were 2 issues:

1. Powershell reported a security vulnerability in one of its dependencies (a warning) as an error.
2. Powershell has a symlink to the fixed dotnet runtime that was used during build, only fixed via rebuild on new dotnet runtime version

