### PR TITLE
arf 0.3.0 (new formula)

### DIFF
--- a/Formula/a/arf.rb
+++ b/Formula/a/arf.rb
@@ -5,6 +5,15 @@ class Arf < Formula
   sha256 "5b44176ebd75523ff26f932ea1fd8a1a75e51007f5d156473fbaa503ff5af94e"
   license "MIT"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "0ec10e5e212aa6624d8bb06a0b2e84bc3f2977e4c2ea9da8f170a0aaa517a729"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "55dda9c780b0a7e48404c592625e5262886c16a05e5680d6b14239562c1047b6"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "6314dbd565192f62debac33789231a4f686ea1033e07416ed49168d3c5da6aef"
+    sha256 cellar: :any_skip_relocation, sonoma:        "64e7766f728d7ee486802355aa57878102db2ac27caa601e8b4cad3dd173786d"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "c3fa0da846afebd297e43382891a9ff325ec027003e0cb71a13889a7d8d2301c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e3d88919ca6899fb45dab2812b71704676e088df0341771fa7ebb5286ed76351"
+  end
+
   depends_on "rust" => :build
 
   def install

--- a/Formula/a/arf.rb
+++ b/Formula/a/arf.rb
@@ -1,0 +1,30 @@
+class Arf < Formula
+  desc "Modern R console with syntax highlighting and fuzzy search"
+  homepage "https://github.com/eitsupi/arf"
+  url "https://github.com/eitsupi/arf/archive/refs/tags/v0.3.0.tar.gz"
+  sha256 "5b44176ebd75523ff26f932ea1fd8a1a75e51007f5d156473fbaa503ff5af94e"
+  license "MIT"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args(path: "crates/arf-console")
+
+    generate_completions_from_executable(bin/"arf", "completions")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/arf --version")
+
+    system bin/"arf", "config", "init"
+    if OS.mac?
+      assert_path_exists testpath/"Library/Application Support/arf/arf.toml"
+    else
+      assert_path_exists testpath/".config/arf/arf.toml"
+    end
+    system bin/"arf", "config", "check"
+
+    assert_match "history", shell_output("#{bin}/arf history schema")
+    assert_match "sessions", shell_output("#{bin}/arf ipc list")
+  end
+end


### PR DESCRIPTION
## Description

[arf](https://github.com/eitsupi/arf) is an alternative R frontend — a modern, cross-platform R console written in Rust. It serves as a replacement for the default R terminal and an alternative to [radian](https://github.com/randy3k/radian).

### Key features

- Single binary with zero runtime dependencies (besides R itself)
- Tree-sitter-based syntax highlighting for R code
- Fuzzy history search (fzf-style via Ctrl+R)
- Interactive fuzzy help browser for R documentation
- Vi and Emacs editing modes, multiline editing, tab completion
- rig integration for switching R versions on the fly
- Headless mode and IPC server for AI agents and editor extensions
- TOML-based configuration

## Testing

```
brew install --build-from-source arf
arf --version
```

## Checklist

- [x] `brew audit --new --formula arf` passes
- [x] `brew style arf` passes
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?