### PR TITLE
libheif: caveat to explain `libheif-plugins`

### DIFF
--- a/Formula/lib/libheif.rb
+++ b/Formula/lib/libheif.rb
@@ -55,6 +55,10 @@ class Libheif < Formula
     inreplace lib/"pkgconfig/libheif.pc", prefix, opt_prefix
   end
 
+  def caveats
+    "Additional codecs can be enabled by `brew install libheif-plugins`"
+  end
+
   test do
     output = "File contains 2 images"
     example = pkgshare/"example.heic"


### PR DESCRIPTION
Since we don't have something like Debian "suggests", it may be difficult for users to know `libheif-plugins` is related to `libheif`. So adding a caveat similar to how we handle split out formulae (e.g. `git`/`git-gui`)