### PR TITLE
llama.cpp whisper-cpp: comment on `ggml`

### DIFF
--- a/Formula/l/llama.cpp.rb
+++ b/Formula/l/llama.cpp.rb
@@ -29,7 +29,7 @@ class LlamaCpp < Formula
   end
 
   depends_on "cmake" => [:build, :test]
-  depends_on "ggml"
+  depends_on "ggml" # NOTE: reject all PRs that try to bundle ggml
   depends_on "openssl@3"
 
   def install

--- a/Formula/w/whisper-cpp.rb
+++ b/Formula/w/whisper-cpp.rb
@@ -23,7 +23,7 @@ class WhisperCpp < Formula
 
   depends_on "cmake" => :build
   depends_on "pkgconf" => :test
-  depends_on "ggml"
+  depends_on "ggml" # NOTE: reject all PRs that try to bundle ggml
   depends_on "sdl2"
 
   def install


### PR DESCRIPTION
Since bundling was seen in another PR, adding an explicit comment.

The entire point of `ggml` formula is to avoid mixed usage and multiple copies of `ggml`. This was done with understanding that `llama.cpp` update can be delayed until `ggml` gets a new release.