### PR TITLE
perl: remove unused expat

### DIFF
--- a/Formula/p/perl.rb
+++ b/Formula/p/perl.rb
@@ -24,7 +24,6 @@ class Perl < Formula
   depends_on "berkeley-db@5" # keep berkeley-db < 6 to avoid AGPL-3.0 restrictions
   depends_on "gdbm"
 
-  uses_from_macos "expat"
   uses_from_macos "libxcrypt"
 
   # Prevent site_perl directories from being removed


### PR DESCRIPTION
Doesn't seem to be used based on linkage:
```console
$ brew linkage perl
System libraries:
  /lib/aarch64-linux-gnu/ld-linux-aarch64.so.1
  /lib/aarch64-linux-gnu/libc.so.6
  /lib/aarch64-linux-gnu/libm.so.6
Homebrew libraries:
  /home/linuxbrew/.linuxbrew/opt/berkeley-db@5/lib/libdb-5.3.so (berkeley-db@5)
  /home/linuxbrew/.linuxbrew/opt/gdbm/lib/libgdbm.so.6 (gdbm)
  /home/linuxbrew/.linuxbrew/opt/gdbm/lib/libgdbm_compat.so.4 (gdbm)
  /home/linuxbrew/.linuxbrew/opt/libxcrypt/lib/libcrypt.so.2 (libxcrypt)
  /home/linuxbrew/.linuxbrew/opt/perl/lib/perl5/5.42/aarch64-linux-thread-multi/CORE/libperl.so (perl)
```

```console
$ brew linkage perl
System libraries:
  /usr/lib/libSystem.B.dylib
Homebrew libraries:
  /opt/homebrew/opt/berkeley-db@5/lib/libdb-5.3.dylib (berkeley-db@5)
  /opt/homebrew/opt/gdbm/lib/libgdbm.6.dylib (gdbm)
  /opt/homebrew/opt/perl/lib/perl5/5.42/darwin-thread-multi-2level/CORE/libperl.dylib (perl)
```