### PR TITLE
jnettop: remove support for BDB

### DIFF
--- a/Formula/j/jnettop.rb
+++ b/Formula/j/jnettop.rb
@@ -38,10 +38,6 @@ class Jnettop < Formula
     depends_on "gettext"
   end
 
-  on_linux do
-    depends_on "berkeley-db@5"
-  end
-
   def install
     # Fix compile with newer Clang
     ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1200
@@ -52,7 +48,7 @@ class Jnettop < Formula
                                "$(jnettop_OBJECTS) $(AM_LDFLAGS) $(LDFLAGS) $(jnettop_LDFLAGS)"
     end
 
-    system "./configure", "--man=#{man}", *std_configure_args
+    system "./configure", "--man=#{man}", "--without-db4", *std_configure_args
     system "make", "install"
   end
 

--- a/Formula/j/jnettop.rb
+++ b/Formula/j/jnettop.rb
@@ -12,20 +12,13 @@ class Jnettop < Formula
   end
 
   bottle do
-    rebuild 2
-    sha256 cellar: :any,                 arm64_tahoe:    "94be630d1e700e5da48e52eb85019003f81295f9afd49c846296943881962a17"
-    sha256 cellar: :any,                 arm64_sequoia:  "9660bd7bea038b091d0e0fdee7bbc5daf4c764ef2869282e6bf8e619f4a8d3f0"
-    sha256 cellar: :any,                 arm64_sonoma:   "a06b56e12cf6bb3d313090095bdcc0b3e899d23dcd122cc80af8c36e4ba6b474"
-    sha256 cellar: :any,                 arm64_ventura:  "d9309bcae09fec8961c974c65107b4d6cab9761d171c7d4d54cd0c8bc7842337"
-    sha256 cellar: :any,                 arm64_monterey: "f2c6e3fed7a82f036acdf944ac6f27d11946995d961be3a0e804b8a9099a946a"
-    sha256 cellar: :any,                 arm64_big_sur:  "1f1f3c5e26f7fc52b331300926a4aa93e1081b31cc20cb533f9b0791477cc101"
-    sha256 cellar: :any,                 sonoma:         "9cd2a14ec9e61fff8a91107b290aa603066f3f613cd3a95c9c7311eb3355e307"
-    sha256 cellar: :any,                 ventura:        "a37b6e72480a3c0945b6e13fb651e2797199aeae23fe73e85804e84c3b1db723"
-    sha256 cellar: :any,                 monterey:       "9e14b85dd45a7b23d5548948dff568bde0f0db0ec59c91baff292c896c804423"
-    sha256 cellar: :any,                 big_sur:        "1a077d39b05adcb4ba5a5e777e6ff054ad3b910876ff3d49172057f050e8b39c"
-    sha256 cellar: :any,                 catalina:       "13d9effd79e9b18faa659af615a7b68c7a940adf5eaee5e30806553e1a237f0f"
-    sha256 cellar: :any_skip_relocation, arm64_linux:    "a06d489b070670f237da6659aa5c1803bd5ec72b8b07540b00b14d392879402c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "2e3617c2641b35e01517e783554157ece0999367fccf494fc9824618277464eb"
+    rebuild 3
+    sha256 cellar: :any,                 arm64_tahoe:   "0718bfddbc7db4199af6d06c8410cb25e1c19fa8199e77399b8711bd4537a24c"
+    sha256 cellar: :any,                 arm64_sequoia: "cafcb2e1c6f02334c406bb7ff8b7d73e3caf1a728dd45f1c68dbf69bd4516252"
+    sha256 cellar: :any,                 arm64_sonoma:  "a4d177c35919b5b7f27097739b860e60834e1384a78082fd6e169afc0f0e2621"
+    sha256 cellar: :any,                 sonoma:        "4b1574c7eb8c5245d4f25a876361c6ddcd1784d9dd73dd65487fbaf212fc8103"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "bdc34f37d6af5d676d8aac29edd603b27eed4a4e2ed53417699c4b79e52b4828"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a8f2c08236725ce449e6fc09b1864113a87a9c5abd08450707e6007d8f178533"
   end
 
   depends_on "pkgconf" => :build


### PR DESCRIPTION
Reducing usage of Berkeley DB to help phase out usage. Major distros like Debian and Fedora are planning removal. RHEL 10 has removed it - https://access.redhat.com/articles/7099256

Once major distros stop using BDB 5, then may be higher risk to keep around. Even newer BDB (which often can't be used due to AGPL relicense) may be either unmaintained or heavily reduced support by Oracle given last release was in 2020.