### PR TITLE
iproute2: remove unused BDB

### DIFF
--- a/Formula/i/iproute2.rb
+++ b/Formula/i/iproute2.rb
@@ -20,7 +20,6 @@ class Iproute2 < Formula
   depends_on "flex" => :build
   depends_on "pkgconf" => :build
 
-  depends_on "berkeley-db@5" # keep berkeley-db < 6 to avoid AGPL incompatibility
   depends_on "elfutils"
   depends_on "libbpf"
   depends_on "libcap"


### PR DESCRIPTION
```console
$ brew linkage iproute2
System libraries:
  /lib/aarch64-linux-gnu/ld-linux-aarch64.so.1
  /lib/aarch64-linux-gnu/libc.so.6
  /lib/aarch64-linux-gnu/libm.so.6
Homebrew libraries:
  /home/linuxbrew/.linuxbrew/opt/elfutils/lib/libelf.so.1 (elfutils)
  /home/linuxbrew/.linuxbrew/opt/libbpf/lib/libbpf.so.1 (libbpf)
  /home/linuxbrew/.linuxbrew/opt/libcap/lib/libcap.so.2 (libcap)
  /home/linuxbrew/.linuxbrew/opt/libmnl/lib/libmnl.so.0 (libmnl)
  /home/linuxbrew/.linuxbrew/opt/libtirpc/lib/libtirpc.so.3 (libtirpc)
```