### PR TITLE
tdb: update license

### DIFF
--- a/Formula/t/tdb.rb
+++ b/Formula/t/tdb.rb
@@ -3,7 +3,10 @@ class Tdb < Formula
   homepage "https://tdb.samba.org/"
   url "https://www.samba.org/ftp/tdb/tdb-1.4.15.tar.gz"
   sha256 "fba09d8df1f1b9072aeae8e78b2bd43c5afef20b2f6deefa633aa14a377a8dd2"
-  license "GPL-3.0-or-later"
+  license all_of: [
+    "LGPL-3.0-or-later",
+    "GPL-3.0-or-later", # tools/
+  ]
 
   livecheck do
     url "https://www.samba.org/ftp/tdb/"


### PR DESCRIPTION
Main license is more permissive LGPL-3.0-or-later while only the extra tools like tdbdump are GPL-3.0-or-later.

- https://github.com/samba-team/samba/blob/master/lib/tdb/LICENSE
- https://github.com/samba-team/samba/blob/master/lib/tdb/common/tdb.c#L10-L17
- https://github.com/samba-team/samba/blob/master/lib/tdb/tools/tdbdump.c#L6-L9

---

There are still some incompatibilities, e.g. GPL-2.0-only is not compatible with LGPL-3.0, but generally LGPL can make it easier to use as dependency.

We can't audit these without a more detailed licensing approach, e.g. Debian's COPYRIGHT file or more widespread REUSE.toml