### PR TITLE
tkrzw: enable `zstd` support

### DIFF
--- a/Formula/t/tkrzw.rb
+++ b/Formula/t/tkrzw.rb
@@ -20,19 +20,30 @@ class Tkrzw < Formula
     sha256 x86_64_linux:  "a0bbd8fd655b6360e7cf7fab8fc05b19f58c9eb4aff8a91ac0d075b1afaeec12"
   end
 
+  depends_on "lz4"
+  depends_on "xz"
+  depends_on "zstd"
+
   on_linux do
     depends_on "zlib-ng-compat"
   end
 
   def install
-    if OS.linux?
-      ENV.append_to_cflags "-I#{Formula["zlib-ng-compat"].opt_include}"
-      ENV.append "LDFLAGS", "-L#{Formula["zlib-ng-compat"].opt_lib}"
-    end
     # Don't add -lstdc++ to tkrzw_build_util and tkrzw.pc
     ENV["ac_cv_lib_stdcpp_main"] = "no" if ENV.compiler == :clang
 
-    system "./configure", "--enable-zlib", *std_configure_args
+    # zstd support is needed by dependents. Other features are for indirect dependencies.
+    # Also force shim path for CC/CXX as configure seems to use a different PATH
+    args = %W[
+      --enable-lz4
+      --enable-lzma
+      --enable-zlib
+      --enable-zstd
+      CC=#{which(ENV.cc)}
+      CXX=#{which(ENV.cxx)}
+    ]
+
+    system "./configure", *args, *std_configure_args
     system "make"
     system "make", "install"
   end
@@ -52,7 +63,7 @@ class Tkrzw < Formula
 
     cflags = shell_output("#{bin}/tkrzw_build_util config -i").chomp.split
     ldflags = shell_output("#{bin}/tkrzw_build_util config -l").chomp.split
-    ldflags.unshift "-L#{Formula["zlib-ng-compat"].opt_lib}" if OS.linux?
+    ldflags.unshift "-L#{HOMEBREW_PREFIX}/lib"
     system ENV.cxx, "-std=c++17", "test.cpp", "-o", "test", *cflags, *ldflags
     assert_equal "world\n", shell_output("./test")
   end

--- a/Formula/t/tkrzw.rb
+++ b/Formula/t/tkrzw.rb
@@ -11,13 +11,13 @@ class Tkrzw < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 arm64_tahoe:   "4b7d88b7e147b4f11a63156fe098d9e2a3d725598291e8bb1626e500f8726e8e"
-    sha256 arm64_sequoia: "201f3d9038e118ffdad673c1207ec72f10e2c63d743520b35189385032ec3775"
-    sha256 arm64_sonoma:  "c556c2a940a0535b5eb78005b6612c108fc31987fb0a8ecec3bdde9f2ca4f83e"
-    sha256 sonoma:        "f6f4257aff9c7fccc0ff8c2bb6f6ae9723d0c85e406a4331ed27e900d22e1223"
-    sha256 arm64_linux:   "a7ef046fc7c1fbfe96ecf02e483fd60563372f83a6615daa227b8150be5a88ea"
-    sha256 x86_64_linux:  "a0bbd8fd655b6360e7cf7fab8fc05b19f58c9eb4aff8a91ac0d075b1afaeec12"
+    rebuild 2
+    sha256 arm64_tahoe:   "2a93d5a38b3e08c37d54d667daec5725390de6704e0ded01dae185d6fece38fa"
+    sha256 arm64_sequoia: "c0d04a3456293bd15f82e6a73841e89afa3667c703090ef5bbf8cc83f65a7ed3"
+    sha256 arm64_sonoma:  "4cdac837ea7a7725dfd53dd144ecf10bdd943ad16afb69a78fb157898902c159"
+    sha256 sonoma:        "f0a9dfb7aa1d28dc848b8ae5a67093fe8ba7d73576fbb49f6eaf31804a46f63c"
+    sha256 arm64_linux:   "2b2d2a3bc55190b7b8d86704fc5ca5920280277a238d55b20ae15c8ec00f1496"
+    sha256 x86_64_linux:  "b4afc2a954abf29f144c953048526c89d242af29652ac59d9ee05cd5d715ecd0"
   end
 
   depends_on "lz4"


### PR DESCRIPTION
This will be needed by future `duc` release

- https://github.com/zevv/duc/commit/91b2e34fcc222c4fa982334f78e7192aca8b4e45

---

Zstd pulls in other dependencies so can enable those features
```console
❯ brew deps --tree zstd
zstd
├── lz4
└── xz
```

Also found that `zlib-ng-compat` wasn't found due to not using our shim. Went with passing full `which` path to use shim.