### PR TITLE
hyperestraier qdbm: deprecate

### DIFF
--- a/Formula/h/hyperestraier.rb
+++ b/Formula/h/hyperestraier.rb
@@ -26,6 +26,10 @@ class Hyperestraier < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "67da1265df5336838e42f563b8b90041d83d848739bf7972950de444cef78650"
   end
 
+  # Last release on 2007-12-24 and needs unmaintained `qdbm`
+  deprecate! date: "2026-04-18", because: :unmaintained
+  disable! date: "2027-04-18", because: :unmaintained
+
   depends_on "pkgconf" => :build
   depends_on "qdbm"
 

--- a/Formula/q/qdbm.rb
+++ b/Formula/q/qdbm.rb
@@ -20,6 +20,10 @@ class Qdbm < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "4f532caae96d2ab1726eb1fd9196db93dd0b4511f9b407b209c545a801449877"
   end
 
+  # Last release on 2007-12-22. Succeeded by tokyo-cabinet -> kyoto-cabinet -> tkrzw
+  deprecate! date: "2026-04-18", because: :unmaintained
+  disable! date: "2027-04-18", because: :unmaintained
+
   on_linux do
     depends_on "zlib-ng-compat"
   end


### PR DESCRIPTION
Plan to also deprecate `tokyo-cabinet` once new `duc` release is available so we can switch to `tkrzw` directly. Want to avoid doing a double replacement as only `tkrzw` is supported in 1.5.0+

- https://github.com/zevv/duc/blob/master/INSTALL#L100-L110