### PR TITLE
aria2: Remove AppleTLS

### DIFF
--- a/Formula/a/aria2.rb
+++ b/Formula/a/aria2.rb
@@ -7,13 +7,12 @@ class Aria2 < Formula
   revision 2
 
   bottle do
-    rebuild 2
-    sha256 arm64_tahoe:   "95bdbd84198eb00cac090ecedad387eabcfb5815ced97467a24c518020cf48dd"
-    sha256 arm64_sequoia: "8595dd94303e84f0d359fcdfcb507d1d5bf72254e73f10126b46b3bf1f04e13a"
-    sha256 arm64_sonoma:  "7038fdbb6d201ee9b7ffe0b21e350783c42168d3651f0c8259a2023282c782f5"
-    sha256 sonoma:        "237e81120aa836dac06a16342cad1eda81fd155ae731a683b2a819e27a43c2fb"
-    sha256 arm64_linux:   "ea893dc5171591d4aec0142c384d8b91cbb0766d9bf0b194a9837cee7ae65f1a"
-    sha256 x86_64_linux:  "f23aa8887c144680a5bf5429151d57a2cb8890cfd3e7989daf55ba631e565777"
+    sha256 arm64_tahoe:   "e02198308a07cc13589297bd682c0f63fe2e4ce09ff61d373696f4157eab89e5"
+    sha256 arm64_sequoia: "b8312eb29cb3a058600a38b560efcb7e2b4ae951de0010e64abfd9194f07392c"
+    sha256 arm64_sonoma:  "8815b6b79395235863349628dc0d753bbee9069e99d94257b7646ffd85615623"
+    sha256 sonoma:        "b88e53b1c54d82af91dea90551fc114b7c02149972d536b9d55a33b12f9a9fd5"
+    sha256 arm64_linux:   "151095fbbfe8819535eb1f3dc63642103f793b79ead0ab8282381baebaad0485"
+    sha256 x86_64_linux:  "f2a416d17d88fdbc5a4dabd1a6520eb736964c6d21cd7a9e2b2591330d74bdf5"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/a/aria2.rb
+++ b/Formula/a/aria2.rb
@@ -4,7 +4,7 @@ class Aria2 < Formula
   url "https://github.com/aria2/aria2/releases/download/release-1.37.0/aria2-1.37.0.tar.xz"
   sha256 "60a420ad7085eb616cb6e2bdf0a7206d68ff3d37fb5a956dc44242eb2f79b66b"
   license "GPL-2.0-or-later"
-  revision 1
+  revision 2
 
   bottle do
     rebuild 2
@@ -34,6 +34,7 @@ class Aria2 < Formula
 
   def install
     ENV.cxx11
+    ENV.append "LIBS", "-framework Security" if OS.mac?
 
     args = %w[
       --disable-silent-rules
@@ -42,14 +43,9 @@ class Aria2 < Formula
       --without-libgmp
       --without-libnettle
       --without-libgcrypt
+      --without-appletls
+      --with-openssl
     ]
-    if OS.mac?
-      args << "--with-appletls"
-      args << "--without-openssl"
-    else
-      args << "--without-appletls"
-      args << "--with-openssl"
-    end
 
     system "./configure", *args, *std_configure_args
     system "make", "install"


### PR DESCRIPTION
AppleTLS doesn't support TLS1.3 and throws errors when encountering TLS1.3.
Use openSSL instead.
aria2 isn't really maintained at the moment so this probably wont be fixed upstream for a long time if ever. [1]
Especially because Apple is deprecating SecureTransport and suggesting people migrate to Network.framework if they want TLS 1.3.

Curl has done similarly. [2]

[1] https://github.com/aria2/aria2/issues/2277
[2] https://daniel.haxx.se/blog/2025/01/14/secure-transport-support-in-curl-is-on-its-way-out/

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
