### PR TITLE
python@3.14: move _dbm to `python-gdbm@3.14` on Linux

### DIFF
--- a/Formula/p/python-gdbm@3.14.rb
+++ b/Formula/p/python-gdbm@3.14.rb
@@ -4,6 +4,7 @@ class PythonGdbmAT314 < Formula
   url "https://www.python.org/ftp/python/3.14.4/Python-3.14.4.tgz"
   sha256 "b4c059d5895f030e7df9663894ce3732bfa1b32cd3ab2883980266a45ce3cb3b"
   license "Python-2.0"
+  revision 1
 
   livecheck do
     formula "python@3.14"
@@ -51,6 +52,16 @@ class PythonGdbmAT314 < Formula
       library-dirs = ["#{Formula["gdbm"].opt_lib}"]
     TOML
 
+    (buildpath/"Modules/pyproject.toml").append_lines <<~TOML if OS.linux?
+      [[tool.setuptools.ext-modules]]
+      name = "_dbm"
+      sources = ["_dbmmodule.c"]
+      include-dirs = ["#{Formula["gdbm"].opt_include}", "#{python_include}/internal"]
+      libraries = ["gdbm_compat"]
+      library-dirs = ["#{Formula["gdbm"].opt_lib}"]
+      extra-compile-args = ["-DUSE_GDBM_COMPAT", "-DHAVE_GDBM_DASH_NDBM_H"]
+    TOML
+
     system python3, "-m", "pip", "install", *std_pip_args(prefix: false, build_isolation: true),
                                             "--target=#{libexec}", "./Modules"
     rm_r libexec.glob("*.dist-info")
@@ -67,5 +78,19 @@ class PythonGdbmAT314 < Formula
       with dbm.gnu.open("#{testdb}", "r") as db:
         assert db["testkey"] == b"testvalue"
     PYTHON
+
+    return unless OS.linux?
+
+    (testpath/"dbm_test.py").write <<~PYTHON
+      import dbm
+
+      with dbm.ndbm.open("test", "c") as db:
+        db[b"foo \\xbd"] = b"bar \\xbd"
+      with dbm.ndbm.open("test", "r") as db:
+        assert list(db.keys()) == [b"foo \\xbd"]
+        assert b"foo \\xbd" in db
+        assert db[b"foo \\xbd"] == b"bar \\xbd"
+    PYTHON
+    system python3, "dbm_test.py"
   end
 end

--- a/Formula/p/python-gdbm@3.14.rb
+++ b/Formula/p/python-gdbm@3.14.rb
@@ -11,13 +11,13 @@ class PythonGdbmAT314 < Formula
   end
 
   bottle do
-    sha256 cellar: :any, arm64_tahoe:   "1bef27f3b0d3a83a41e0ff854052b560848f21c0ae08d19221fee8ceb7322511"
-    sha256 cellar: :any, arm64_sequoia: "606abcbb6f1a952481671850346ef38b64e33bc76cc2f587ef3da89eb206898a"
-    sha256 cellar: :any, arm64_sonoma:  "2f22db62ae2601143417c1ba4a575d4b3137bb03c49fea8f338d5e8ae083c0b8"
-    sha256 cellar: :any, sequoia:       "999aa26f8f53dba6ca07e765f7516dd5ef3b68d31c1c630508d6b30b176f564c"
-    sha256 cellar: :any, sonoma:        "203e25fa170e365fdb196a0cd7aee90d7a877d59ce49f0227e5808292a4fa108"
-    sha256               arm64_linux:   "3030dc120dee0c17373bdf8024cfdf17dba4e459443d03fb0addaf56a5c9bf49"
-    sha256               x86_64_linux:  "08f842f1f18d922ee49c49ddae728e9659b34fa5b3284a0f060375e7212496ca"
+    sha256 cellar: :any, arm64_tahoe:   "af951802d8bc5eaff5946695ad920e07bd63bf42cc3adb39c5982492b20dce02"
+    sha256 cellar: :any, arm64_sequoia: "ce335535fc843258897a9ff3b5437fe803223548e478940aff325c8ea8229b75"
+    sha256 cellar: :any, arm64_sonoma:  "179b4e15ef0bb92af5873b463c4c8cbf463a393ea798dbf089804bec6403e6a0"
+    sha256 cellar: :any, sequoia:       "d4ba21e50a4100e0ec29f9bc03ec3287cbe4c3307363087b18ae626fe5b6a2c3"
+    sha256 cellar: :any, sonoma:        "437dc8334c48f8cb6a72419558de2935232b97d5e3f807023605d6bc77f7c4a8"
+    sha256               arm64_linux:   "5a732c7318b12eb0400d31a7a21de9de5230da97a1c618ff5228c1d8cfcda1ff"
+    sha256               x86_64_linux:  "28c28d97cb5f8adcfd5e62f7a126e79bf5b46c4a55d49c272243a1561f32c630"
   end
 
   depends_on "gdbm"

--- a/Formula/p/python@3.14.rb
+++ b/Formula/p/python@3.14.rb
@@ -37,7 +37,6 @@ class PythonAT314 < Formula
   uses_from_macos "unzip"
 
   on_linux do
-    depends_on "berkeley-db@5"
     depends_on "zlib-ng-compat"
   end
 
@@ -163,7 +162,7 @@ class PythonAT314 < Formula
       args << "MACOSX_DEPLOYMENT_TARGET=#{MacOS.version}"
     else
       args << "--enable-shared"
-      args << "--with-dbmliborder=bdb"
+      args << "--with-dbmliborder="
     end
 
     # Allow python modules to use ctypes.find_library to find homebrew's stuff
@@ -492,7 +491,8 @@ class PythonAT314 < Formula
     assert_match "ModuleNotFoundError: No module named '_gdbm'",
                  shell_output("#{python3} -Sc 'import dbm.gnu' 2>&1", 1)
 
-    # Verify that the selected DBM interface works
+    # Verify that the selected DBM interface works on macOS.
+    # Linux requires installing python-gdbm formula
     (testpath/"dbm_test.py").write <<~PYTHON
       import dbm
 
@@ -503,7 +503,7 @@ class PythonAT314 < Formula
           assert b"foo \\xbd" in db
           assert db[b"foo \\xbd"] == b"bar \\xbd"
     PYTHON
-    system python3, "dbm_test.py"
+    system python3, "dbm_test.py" if OS.mac?
 
     system bin/"pip#{version.major_minor}", "list", "--format=columns"
 

--- a/Formula/p/python@3.14.rb
+++ b/Formula/p/python@3.14.rb
@@ -12,14 +12,15 @@ class PythonAT314 < Formula
   end
 
   bottle do
-    sha256 arm64_tahoe:   "a57709f67ff38ea12b02cad10719afd42de03f8fc0a25fca857786e3c45b52f1"
-    sha256 arm64_sequoia: "a662a7f23fc2eeb0106eab7196080a446cc9a9557db1f863f7f902fd3640dd21"
-    sha256 arm64_sonoma:  "12d5adefd8d0a3f818501d9d33f79f3af2866655e3ef8d1f54955247b7c48298"
-    sha256 tahoe:         "7c11c07a27ba1f4cba5b5799c202e670814d9da719841ec2661f29061653a072"
-    sha256 sequoia:       "7e929fa45eeb65b5740d97f9fdaf7a3def6d30ac3c82069ef5d778b1d55f3fd5"
-    sha256 sonoma:        "24065e90fbd5a9b19f8f17516f0f9fa53aca0849463f8f7cb66b606fd154d6a5"
-    sha256 arm64_linux:   "f40a490b9277e2dca9aae2a1b6524780a57719235ebadf1fe8ec617df5a46057"
-    sha256 x86_64_linux:  "963a5b405bb22f47c659f7258da9d55677474ac1c21916ba9197655186cf4c66"
+    rebuild 1
+    sha256 arm64_tahoe:   "e6aad7f3013cf39f3ba0de702d6ffdb934ec28549fcffb580f91ec8d8685ffde"
+    sha256 arm64_sequoia: "dcbf428d7f9e448ee88d51c867a29d60e4ee48c69cb537ffa43154c6054951e8"
+    sha256 arm64_sonoma:  "16f997d2727745edc4ac87df52de2517711ba0cb7c298a97f2b14e1150a926cb"
+    sha256 tahoe:         "7498a873e826498cd2302e00f2c4a2bed207b2e3c97b06272c794d3d47662e14"
+    sha256 sequoia:       "c3a2c539efcfaedaa4330fd7bb2abf436435f0320c9acb364bb73de970623750"
+    sha256 sonoma:        "33ecbabc155041ef656a9572d0223a4d3412d14d763a2fdb1a963a9aacfc29c3"
+    sha256 arm64_linux:   "b351cac4da326df26d1b72878493b2ce038e990d3770bec75db1cfd849e6c561"
+    sha256 x86_64_linux:  "115dbf56f954ad54380ccac97205956e50c32ecd8b1bf54dbd509fef07423a79"
   end
 
   depends_on "pkgconf" => :build


### PR DESCRIPTION
Seeing if we can reduce Berkeley DB usage.

For Python, most Linux distros just use `gdbm` rather than BDB, but Homebrew has a harder time directly linking to GPL dependencies as we cannot rely on GNU's "system library" exception.

Approach here would be making dependents that need `dbm.ndbm` support add:
```rb
on_linux do
  depends_on "python-gdbm@3.14"
end
```

Also, since Python 3.13, `dbm` provides `dbm.sqlite3` so there is at least some functionality available without `python-gdbm` installed. So I expect lifespan of `berkeley-db@5` to be aligned to deprecation date of either Python 3.12 (2028-10) or 3.13 (2029-10) depending on whether we backport to Python 3.13. 

-----

`python-gdbm@3.14` is revision bumped to avoid missing _dbm in case `python@3.14` is reinstalled but not `python-gdbm@3.14`.

`python@3.14` does not need a revision bump as modules are installed in non-conflicting directories. If both _dbm exist, original would be loaded first and should work as expected.