### PR TITLE
wifi-loc-control 1.0.5 (new formula)

### DIFF
--- a/Formula/w/wifi-loc-control.rb
+++ b/Formula/w/wifi-loc-control.rb
@@ -1,0 +1,64 @@
+class WifiLocControl < Formula
+  desc "Change macOS network location based on the Wi-Fi network name (SSID)"
+  homepage "https://github.com/vborodulin/wifi-loc-control"
+  url "https://github.com/vborodulin/wifi-loc-control/archive/refs/tags/1.0.5.tar.gz"
+  sha256 "13ef3b7611d519a1c5772432b64355c35d45df03af43e9afd260430d309664b6"
+  license "MIT"
+
+  depends_on :macos
+
+  def install
+    bin.install "wifi-loc-control.sh" => "wifi-loc-control"
+
+    # Modify the Program Path to brew installed one
+    inreplace "WifiLocControl.plist", "/usr/local/bin/wifi-loc-control.sh", bin/"wifi-loc-control"
+
+    # Install the plist file
+    prefix.install "WifiLocControl.plist" => "application.com.wifi-loc-control.plist"
+  end
+
+  service do
+    name macos: "application.com.wifi-loc-control"
+  end
+
+  test do
+    ENV["HOME"] = testpath
+    (testpath/"Library/Logs").mkpath
+
+    (testpath/"bin").mkpath
+
+    (testpath/"bin/networksetup").write <<~EOS
+      #!/bin/sh
+      echo "Preferred networks on en0:"
+      echo "TestSSID"
+    EOS
+
+    (testpath/"bin/scselect").write <<~EOS
+      #!/bin/sh
+      echo "$*" >> "#{testpath}/scselect_calls"
+      if [ "$#" -eq 0 ]; then
+        echo " * Work (Work)"
+        echo " Automatic (Automatic)"
+      else
+        echo "$1" > "#{testpath}/switched_location"
+      fi
+    EOS
+
+    (testpath/"bin/sleep").write <<~EOS
+      #!/bin/sh
+      exit 0
+    EOS
+
+    %w[networksetup scselect sleep].each do |file|
+      chmod 0755, testpath/"bin/#{file}"
+    end
+    ENV.prepend_path "PATH", testpath/"bin"
+
+    system bin/"wifi-loc-control"
+
+    assert_path_exists testpath/"switched_location"
+    assert_equal "Automatic", (testpath/"switched_location").read.strip
+    assert_match "Automatic", (testpath/"scselect_calls").read
+    assert_match "location switched to 'Automatic'", (testpath/"Library/Logs/WiFiLocControl.log").read
+  end
+end


### PR DESCRIPTION
## Description

[WiFiLocControl](https://github.com/vborodulin/wifi-loc-control) allows you to change your macOS [network location](https://support.apple.com/en-us/105129) automatically based on the Wi-Fi network (SSID) you are connected to. It is particularly useful for users who use Wi-Fi at work and at home, but the network settings (for example, custom DNS configurations) you use at work don't allow your Mac to automatically connect to the same type of network at home.

### Features
- Automatically changes network locations based on current Wi-Fi name.
- Supports alias configurations for multiple Wi-Fi names.
- Executes location-specific **scripts.**

## Checklist
<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?


