### PR TITLE
perl: remove support for BDB on Linux

### DIFF
--- a/Formula/b/bioperl.rb
+++ b/Formula/b/bioperl.rb
@@ -4,7 +4,7 @@ class Bioperl < Formula
   url "https://cpan.metacpan.org/authors/id/C/CJ/CJFIELDS/BioPerl-1.7.8.tar.gz"
   sha256 "c490a3be7715ea6e4305efd9710e5edab82dabc55fd786b6505b550a30d71738"
   license any_of: ["Artistic-1.0-Perl", "GPL-1.0-or-later"]
-  revision 5
+  revision 6
   head "https://github.com/bioperl/bioperl-live.git", branch: "master"
 
   # We specifically match versions with three numeric parts because upstream
@@ -98,6 +98,8 @@ class Bioperl < Formula
     # support for `brew update-perl-resources` or upstream reduces dependencies:
     # Issue ref: https://github.com/bioperl/bioperl-live/issues/314
     depends_on "cpanminus" => :build
+
+    depends_on "berkeley-db@5"
   end
 
   def install

--- a/Formula/b/bioperl.rb
+++ b/Formula/b/bioperl.rb
@@ -17,12 +17,12 @@ class Bioperl < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "293417ccf86c9a0c7cbba6ea6f3074ca6d54b0ae9b192a85e57c0500eaae8b74"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "17556c5bf70068e4e7bf489bc486076f76304648c7fdda955138f305c751420a"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "7095b993a428c044b7722b4c4b52b8bf9ed46804dfd0b4625175eb02d7b7a7c0"
-    sha256 cellar: :any_skip_relocation, sonoma:        "519a9359035523356d8bc712280715dc21337d4c987360f769f1d6255e2278a7"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "cbfce7db6b21fd7ef9139acb05f5c740aafe7cabde5e582a9b243eda8c66288a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3d791346056696397c1a244a097a2c1d3cfaa1be0a194c6c8e2d18fbc142a8e4"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "b4773adc73c8210df2cfafc04ed53803335c223cf4735eae2de99669cae89923"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "2ddd61103b91a51433dd23b4a5d725b515bcac6e8ec2527fdcbb06f22f24d916"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "928051ece9c757d4f4cea5dd03d9bb8a8aeff27e31b71589bfb0ced04a8db952"
+    sha256 cellar: :any_skip_relocation, sonoma:        "a31951bd44a73a07e65bcd8c6d512747796afe5b1cecd36c0a90d681dfac27ec"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "2272d3f403e0b53c003b38f1ad904bb104517f5ea0a7e197749a1aaf583b0c46"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "219b56a086c6913e72b9f9958eec9fb14a459bb28fdafc47ea33eea0463241df"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/l/latexml.rb
+++ b/Formula/l/latexml.rb
@@ -4,7 +4,7 @@ class Latexml < Formula
   url "https://dlmf.nist.gov/LaTeXML/releases/LaTeXML-0.8.8.tar.gz"
   sha256 "7d2bbe2ce252baf86ba3f388cd0dec3aa4838f49d612b9ec7cc4ff88105badcc"
   license :public_domain
-  revision 3
+  revision 4
   head "https://github.com/brucemiller/LaTeXML.git", branch: "master"
 
   livecheck do
@@ -199,6 +199,15 @@ class Latexml < Formula
     resource "Clone" do
       url "https://cpan.metacpan.org/authors/id/G/GA/GARU/Clone-0.46.tar.gz"
       sha256 "aadeed5e4c8bd6bbdf68c0dd0066cb513e16ab9e5b4382dc4a0aafd55890697b"
+    end
+  end
+
+  on_linux do
+    depends_on "berkeley-db@5"
+
+    resource "DB_File" do
+      url "https://cpan.metacpan.org/authors/id/P/PM/PMQS/DB_File-1.860.tar.gz"
+      sha256 "cbe5e90b0e40e0d566f505789b73196e93c56709f660ca316af50662260749a0"
     end
   end
 

--- a/Formula/l/latexml.rb
+++ b/Formula/l/latexml.rb
@@ -13,13 +13,12 @@ class Latexml < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "057d23d0e132bd293cc5bd6d7edfbd1948f217f78e10c6a165c80162d0062eac"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "057d23d0e132bd293cc5bd6d7edfbd1948f217f78e10c6a165c80162d0062eac"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "057d23d0e132bd293cc5bd6d7edfbd1948f217f78e10c6a165c80162d0062eac"
-    sha256 cellar: :any_skip_relocation, sonoma:        "346ae87bee5846e6061da231725ff8d36536f4f54573f35ee45fc2a9d550ab00"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "3edef95e5de01faea89df58067032b97f35a39167a0088b2e57b5b0f7d20cc3f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "66cf9a55bdf9f5a78849620c3a3e02d3c4a903b08d0a7bbd6b57c66768fe1716"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "0ee7b24cab9e984fcf31e129625112066fba70eec41af975edf335d6c4ada770"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "0ee7b24cab9e984fcf31e129625112066fba70eec41af975edf335d6c4ada770"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "0ee7b24cab9e984fcf31e129625112066fba70eec41af975edf335d6c4ada770"
+    sha256 cellar: :any_skip_relocation, sonoma:        "61d644697b4abd324431a973b3bcbd72d92fe4789322e34409871ea5780d0751"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "c1ef021340ab4c5b7a72caf1c78405ba076c9aaa16d6832927fa077d542bec17"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0548ea531d505fa3fff0489d9f0e05a281cfa52492127fba9cfa280bd18dcd80"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/p/perl.rb
+++ b/Formula/p/perl.rb
@@ -21,7 +21,6 @@ class Perl < Formula
     sha256 x86_64_linux:  "92d8ab5d61decdb5afde5e0abfeecb31a5adac7d8638e95d56daaf7248f0b6dd"
   end
 
-  depends_on "berkeley-db@5" # keep berkeley-db < 6 to avoid AGPL-3.0 restrictions
   depends_on "gdbm"
 
   uses_from_macos "libxcrypt"
@@ -50,13 +49,18 @@ class Perl < Formula
     ]
     args << "-Dusedevel" if build.head?
 
+    # On macOS, we can use Apple's system library to support DB_File module.
+    # On Linux, we explicitly exclude bundled DB_File to avoid opportunistic
+    # linkage to Berkeley DB. Dependents and users can install it from CPAN.
+    args << "-Ui_db" unless OS.mac?
+
     system "./Configure", *args
     system "make"
     system "make", "install"
   end
 
   def caveats
-    <<~EOS
+    s = <<~EOS
       By default non-brewed cpan modules are installed to the Cellar. If you wish
       for your modules to persist across updates we recommend using `local::lib`.
 
@@ -65,6 +69,13 @@ class Perl < Formula
       And add the following to your shell profile e.g. ~/.profile or ~/.zshrc
         eval "$(perl -I$HOME/perl5/lib/perl5 -Mlocal::lib=$HOME/perl5)"
     EOS
+    on_linux do
+      s += <<~EOS
+
+        Bundled DB_File module was not installed. If needed, you can install it from CPAN.
+      EOS
+    end
+    s
   end
 
   test do

--- a/Formula/p/perl.rb
+++ b/Formula/p/perl.rb
@@ -13,12 +13,13 @@ class Perl < Formula
   end
 
   bottle do
-    sha256 arm64_tahoe:   "c38c4726d8051ec62909766bf22f9adc4eb58cfb5986508e9db0ab4ac62c9e82"
-    sha256 arm64_sequoia: "be4f87d55038181b37d0575cc078df330c69fd02830c9f88594b1862386f49f3"
-    sha256 arm64_sonoma:  "da40f848051fa1c6e32325a6e3fa0f9fd75b14f7fdb328ae4b7ab822e3ba534c"
-    sha256 sonoma:        "06a30da13092e77fe0bd4d7c82a6e24061d6f94db99d57f78f9e24a276decb38"
-    sha256 arm64_linux:   "4e40892b92c139702ac188ebf39cf2700b88717bea16277fcc9adec42413a773"
-    sha256 x86_64_linux:  "92d8ab5d61decdb5afde5e0abfeecb31a5adac7d8638e95d56daaf7248f0b6dd"
+    rebuild 1
+    sha256 arm64_tahoe:   "11266b9a2528911df242d82ec041ee91a50c3374d03c9401b558e521b5569916"
+    sha256 arm64_sequoia: "055da0dbe11d31788f13154fb01f7b5596e8450705bd4a1e54e799977d7bddaa"
+    sha256 arm64_sonoma:  "e9270cae03ec248b9910b33924cd522773d4494ed1da07a4fbc8bc70c48eeddd"
+    sha256 sonoma:        "78ee0a26f6650a15d49bc1e6586b91f9716981207059d511704d15f30882c63a"
+    sha256 arm64_linux:   "a2adf29ff516a10c5851c1da904cb033cb92f89c5ea8efee5600065d06f3d989"
+    sha256 x86_64_linux:  "036d3e8899b33c3c4f7dd9b69057f5dd522184a72750b212376d8fd5fc7d120f"
   end
 
   depends_on "gdbm"


### PR DESCRIPTION
Part of effort to reduce Berkeley DB usage in formulae. Perl is low level dependency on Linux so BDB cascades across Homebrew/core.

`cpan -i DB_File` or alternatives can be used to install this on Linux. For dependent formulae, can add as resource if needed.

Was considering a separate formula, but decided against it since we want to avoid adding new formulae using BDB. Also goes against Homebrew's docs to avoid formulae for anything that can easily be installed from CPAN.

---

On side note, was seeing if possible to remove `gdbm` dependency; however, it is more complicated as GDBM_File is a core module (maintained in Perl repo) rather than bundled CPAN module (e.g. DB_File is maintained in external repo - https://github.com/pmqs/DB_File).

It is possible to build without `gdbm`, but trying to use CPAN module via `cpan -i GDBM_File` fails:
```
The most recent version "1.24" of the module "GDBM_File"
is part of the perl-5.42.2 distribution. To install that, you need to run
  force install GDBM_File   --or--
  install SHAY/perl-5.42.2.tar.gz
```

If we ever want to avoid dependency in `perl`, then likely need to create a separate formula similar to `python-gdbm` so that dependents/users can easily install it.