### PR TITLE
cli-agent-lint 0.3.4 (new formula)

### DIFF
--- a/Formula/c/cli-agent-lint.rb
+++ b/Formula/c/cli-agent-lint.rb
@@ -1,0 +1,19 @@
+class CliAgentLint < Formula
+  desc "Audit CLI tools for AI agent-readiness"
+  homepage "https://github.com/Camil-H/cli-agent-lint"
+  url "https://github.com/Camil-H/cli-agent-lint/archive/refs/tags/v0.3.4.tar.gz"
+  sha256 "bbd84b5536afb99b4668a288747ee1b8083517e4f71e9700639c3a1376cb41ba"
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = "-s -w -X github.com/Camil-H/cli-agent-lint/cmd.Version=#{version}"
+    system "go", "build", *std_go_args(ldflags:)
+    generate_completions_from_executable(bin/"cli-agent-lint", "completion")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/cli-agent-lint --version")
+  end
+end


### PR DESCRIPTION
## Description

[cli-agent-lint](https://github.com/Camil-H/cli-agent-lint) audits CLI tools for AI agent-readiness. It runs 34 checks across 5 categories (flow safety, token efficiency, self-describing, automation safety, predictability) and produces a letter-grade scorecard.

As AI agents increasingly drive CLIs non-interactively, tools need to meet specific requirements: structured output, non-interactive auth, clean exit codes, quiet modes, etc. This linter catches gaps before agents hit them in production.

- **License**: MIT
- **Language**: Go (builds with `go build`, no CGO)
- **Stars**: 30+
- **Dependencies**: Only Go standard library + `spf13/cobra` for CLI framework
- **Completions**: bash, zsh, fish via `cli-agent-lint completion <shell>`