### PR TITLE
composer: apply pour_bottle limit to ARM

### DIFF
--- a/Formula/c/composer.rb
+++ b/Formula/c/composer.rb
@@ -11,12 +11,13 @@ class Composer < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "2a80f6f3a1c84e2595cd19eae297e3b7c9024f62cf618890b9ae1e7ac5c1b23a"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "2a80f6f3a1c84e2595cd19eae297e3b7c9024f62cf618890b9ae1e7ac5c1b23a"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "2a80f6f3a1c84e2595cd19eae297e3b7c9024f62cf618890b9ae1e7ac5c1b23a"
-    sha256 cellar: :any_skip_relocation, sonoma:        "df6be3d8b4c58f2bf96e0b57c51b67def1f6223978b289d7a7f33fe4bd3cfa55"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "df6be3d8b4c58f2bf96e0b57c51b67def1f6223978b289d7a7f33fe4bd3cfa55"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "df6be3d8b4c58f2bf96e0b57c51b67def1f6223978b289d7a7f33fe4bd3cfa55"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "a2ccf50a27ea0643772b63a056801047388f211c6a9238b4651c47e8e5d96717"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "a2ccf50a27ea0643772b63a056801047388f211c6a9238b4651c47e8e5d96717"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "a2ccf50a27ea0643772b63a056801047388f211c6a9238b4651c47e8e5d96717"
+    sha256 cellar: :any_skip_relocation, sonoma:        "8b05f880c3c5ee1171aa7859e3969ec4d314eda26fd27afc54d2f60421573b99"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "8b05f880c3c5ee1171aa7859e3969ec4d314eda26fd27afc54d2f60421573b99"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8b05f880c3c5ee1171aa7859e3969ec4d314eda26fd27afc54d2f60421573b99"
   end
 
   depends_on "php"

--- a/Formula/c/composer.rb
+++ b/Formula/c/composer.rb
@@ -21,11 +21,9 @@ class Composer < Formula
 
   depends_on "php"
 
-  # Keg-relocation breaks the formula when it replaces `/usr/local` with a non-default prefix
+  # Keg-relocation breaks the formula when it replaces the prefix with a non-default value
   on_macos do
-    on_intel do
-      pour_bottle? only_if: :default_prefix
-    end
+    pour_bottle? only_if: :default_prefix
   end
 
   def install


### PR DESCRIPTION
guard added for Intel in homebrew/homebrew-core#81408 must also apply to ARM as of composer/ca-bundle#87

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Claude Sonnet 4.6 was used to trace the source of a phar signature validation error and to find the history of the existing code and where the gap was introduced. Claude authored the following description and I have reviewed and edited it. Code was manually edited, tested, and committed.

-----

The `composer` formula guards bottle installation on Intel macOS only:

```ruby
# Keg-relocation breaks the formula when it replaces `/usr/local` with a non-default prefix
on_macos do
  on_intel do
    pour_bottle? only_if: :default_prefix
  end
end
```

When this guard was added in homebrew-core#81408 (July 2021), a reviewer confirmed that `/opt/homebrew` was not present in the phar, so ARM was safe to exempt. That changed in March 2024 when Composer 2.7.2 picked up `composer/ca-bundle` v1.4.1 (PR #87), which added `/opt/homebrew` paths to its fallback CA bundle list. ARM bottles have included the `@@HOMEBREW_PREFIX@@` placeholder ever since, breaking the phar signature on any non-default ARM prefix.

The `on_macos` scope should be kept — Linux is unaffected, as confirmed in the original review discussion (Homebrew/brew#11742). Only the `on_intel` restriction needs lifting.
