### PR TITLE
formulae: make `gettext` runtime dep on macOS-only

### DIFF
--- a/Formula/l/lgeneral.rb
+++ b/Formula/l/lgeneral.rb
@@ -15,9 +15,12 @@ class Lgeneral < Formula
     sha256 x86_64_linux:  "feadf3058a4c903237b6cf8d09b61f97ba5fb5656a6ff3819f96660dd0d4400b"
   end
 
-  depends_on "gettext"
   depends_on "sdl12-compat"
   depends_on "sdl2"
+
+  on_macos do
+    depends_on "gettext"
+  end
 
   def install
     # Applied in community , to remove in next release
@@ -25,7 +28,7 @@ class Lgeneral < Formula
 
     args = ["--disable-silent-rules", "--disable-sdltest"]
     # Help old config scripts identify arm64 linux
-    args << "--build=aarch64-unknown-linux-gnu" if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+    args << "--build=aarch64-unknown-linux-gnu" if OS.linux? && Hardware::CPU.arm64?
 
     system "./configure", *args, *std_configure_args
     system "make", "install"

--- a/Formula/lib/libgtop.rb
+++ b/Formula/lib/libgtop.rb
@@ -26,9 +26,12 @@ class Libgtop < Formula
   depends_on "gobject-introspection" => :build
   depends_on "intltool" => :build
   depends_on "pkgconf" => [:build, :test]
-  depends_on "gettext"
   depends_on "glib"
   depends_on "libxau"
+
+  on_macos do
+    depends_on "gettext"
+  end
 
   def install
     # workaround for newer clang

--- a/Formula/n/neomutt.rb
+++ b/Formula/n/neomutt.rb
@@ -18,10 +18,10 @@ class Neomutt < Formula
   end
 
   depends_on "docbook-xsl" => :build
+  depends_on "gettext" => :build
   depends_on "pkgconf" => :build
   # The build breaks when it tries to use system `tclsh`.
   depends_on "tcl-tk" => :build
-  depends_on "gettext"
   depends_on "gpgme"
   depends_on "libidn2"
   depends_on "lmdb"
@@ -32,11 +32,13 @@ class Neomutt < Formula
   depends_on "pcre2"
   depends_on "sqlite"
 
+  uses_from_macos "libxml2" => :build
   uses_from_macos "libxslt" => :build # for xsltproc
   uses_from_macos "cyrus-sasl"
   uses_from_macos "krb5"
 
   on_macos do
+    depends_on "gettext"
     depends_on "libgpg-error"
     # Build again libiconv for now on,
     # but reconsider when macOS 14.2 is released

--- a/Formula/o/open-sp.rb
+++ b/Formula/o/open-sp.rb
@@ -28,7 +28,10 @@ class OpenSp < Formula
   depends_on "ghostscript" => :build
   depends_on "libtool" => :build
   depends_on "xmlto" => :build
-  depends_on "gettext"
+
+  on_macos do
+    depends_on "gettext"
+  end
 
   # Apply Gentoo patch to fix build error: ISO C++11 does not allow access declarations
   patch do

--- a/Formula/o/osinfo-db-tools.rb
+++ b/Formula/o/osinfo-db-tools.rb
@@ -21,10 +21,10 @@ class OsinfoDbTools < Formula
     sha256 x86_64_linux:  "5432275a5e7c855af96a4eee2c464566ed2b46c379ad81fe86feb1f9f940fd49"
   end
 
+  depends_on "gettext" => :build
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkgconf" => :build
-  depends_on "gettext"
   depends_on "glib"
   depends_on "json-glib"
   depends_on "libarchive"
@@ -32,6 +32,10 @@ class OsinfoDbTools < Formula
 
   uses_from_macos "pod2man" => :build
   uses_from_macos "libxml2"
+
+  on_macos do
+    depends_on "gettext"
+  end
 
   skip_clean "share/osinfo"
 

--- a/Formula/p/pinfo.rb
+++ b/Formula/p/pinfo.rb
@@ -24,10 +24,14 @@ class Pinfo < Formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
+  depends_on "gettext" => :build
   depends_on "libtool" => :build
-  depends_on "gettext"
 
   uses_from_macos "ncurses"
+
+  on_macos do
+    depends_on "gettext"
+  end
 
   on_system :linux, macos: :ventura_or_newer do
     depends_on "texinfo" => :build

--- a/Formula/r/redshift.rb
+++ b/Formula/r/redshift.rb
@@ -31,10 +31,14 @@ class Redshift < Formula
     depends_on "libtool" => :build
   end
 
+  depends_on "gettext" => :build
   depends_on "intltool" => :build
   depends_on "pkgconf" => :build
-  depends_on "gettext"
   depends_on "glib"
+
+  on_macos do
+    depends_on "gettext"
+  end
 
   def install
     args = %w[

--- a/Formula/s/synfig.rb
+++ b/Formula/s/synfig.rb
@@ -23,6 +23,7 @@ class Synfig < Formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
+  depends_on "gettext" => :build
   depends_on "intltool" => :build
   depends_on "libtool" => :build
   depends_on "pkgconf" => [:build, :test]
@@ -34,7 +35,6 @@ class Synfig < Formula
   depends_on "fontconfig"
   depends_on "freetype"
   depends_on "fribidi"
-  depends_on "gettext"
   depends_on "glib"
   depends_on "glibmm@2.66"
   depends_on "harfbuzz"
@@ -53,6 +53,7 @@ class Synfig < Formula
   uses_from_macos "perl" => :build
 
   on_macos do
+    depends_on "gettext"
     depends_on "liblqr"
     depends_on "libomp"
     depends_on "little-cms2"

--- a/Formula/v/vips.rb
+++ b/Formula/v/vips.rb
@@ -21,6 +21,7 @@ class Vips < Formula
     sha256 x86_64_linux:  "75dfe5c6c9191ddeb732f47b6f8f15eb9d38cdf0aaa2b2e1f772e94c70270fee"
   end
 
+  depends_on "gettext" => :build
   depends_on "gobject-introspection" => :build
   depends_on "meson" => :build
   depends_on "ninja" => :build
@@ -30,7 +31,6 @@ class Vips < Formula
   depends_on "cgif"
   depends_on "fftw"
   depends_on "fontconfig"
-  depends_on "gettext"
   depends_on "glib"
   depends_on "highway"
   depends_on "imagemagick"
@@ -56,6 +56,10 @@ class Vips < Formula
 
   uses_from_macos "python" => :build
   uses_from_macos "expat"
+
+  on_macos do
+    depends_on "gettext"
+  end
 
   on_linux do
     depends_on "zlib-ng-compat"

--- a/Formula/z/zvbi.rb
+++ b/Formula/z/zvbi.rb
@@ -17,10 +17,14 @@ class Zvbi < Formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
+  depends_on "gettext" => :build
   depends_on "libtool" => :build
   depends_on "pkgconf" => :build
-  depends_on "gettext"
   depends_on "libpng"
+
+  on_macos do
+    depends_on "gettext"
+  end
 
   def install
     system "./autogen.sh"
@@ -29,7 +33,7 @@ class Zvbi < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libzvbi.h>
       #include <stdio.h>
 
@@ -46,7 +50,7 @@ class Zvbi < Formula
         vbi_decoder_delete(dec);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lzvbi", "-I#{include}", "-o", "test"
     assert_match version.to_s, shell_output("./test")
   end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
