### PR TITLE
cava: use most common Linux audio backends

### DIFF
--- a/Formula/c/cava.rb
+++ b/Formula/c/cava.rb
@@ -22,14 +22,18 @@ class Cava < Formula
 
   depends_on "fftw"
   depends_on "iniparser"
-  depends_on "portaudio"
 
   uses_from_macos "vim" => :build # needed for xxd
   uses_from_macos "ncurses"
 
+  on_macos do
+    depends_on "portaudio"
+  end
+
   on_linux do
     depends_on "alsa-lib"
-    depends_on "jack"
+    depends_on "pipewire"
+    depends_on "pulseaudio"
   end
 
   def install

--- a/Formula/c/cava.rb
+++ b/Formula/c/cava.rb
@@ -7,12 +7,13 @@ class Cava < Formula
   head "https://github.com/karlstav/cava.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any, arm64_tahoe:   "40bfbe3b8229358b42a646fad6d31616cf84ecc6f758d0cdf17b32f88b2e2430"
-    sha256 cellar: :any, arm64_sequoia: "1016458731ecffadbafeb4a10ad4aacc307b67a11568cfb8842344012893938b"
-    sha256 cellar: :any, arm64_sonoma:  "48381551d630ab4220cc39267c036c552f0ddea37afcfdfdb62f7d234009bacc"
-    sha256 cellar: :any, sonoma:        "e012cc6ab3a2bbf0f76244641e809882eea9190d94f34668d2dabfe83d6401d2"
-    sha256               arm64_linux:   "1e38d63792ba6bbbb12c1a1fe5d700e676f403bcce6c21681f000be9402d44e5"
-    sha256               x86_64_linux:  "43eda213bfc5d7e6f33894e04be08f1a32fcea5c230a65de659d73967ee6bf6e"
+    rebuild 1
+    sha256 cellar: :any, arm64_tahoe:   "ce734b6cad4e09a28b71bc21f861a2181f1d45254e2f27d1f2b6fd705484a7bd"
+    sha256 cellar: :any, arm64_sequoia: "7795fd596a4671c4d2ef6c8cda1e1f6eab3b7a28bab20c9be7da4ea476207e5d"
+    sha256 cellar: :any, arm64_sonoma:  "78f2072bcaa832eb5ada0a584169cc5f4f9c1aeee3e5998328dd7baf0e830227"
+    sha256 cellar: :any, sonoma:        "5849239202007b3d4738a803c006224c0c6d627bacd75d615e5bee22159e69e8"
+    sha256               arm64_linux:   "df962ffaf8f270bb6e60df98fa09edb6810a380ae0b52fd00e4722b30eae3003"
+    sha256               x86_64_linux:  "4fbdd158121e515e5ed7bfa4f9b4645178fb65d50c9171feedba2cde7fe89a47"
   end
 
   depends_on "autoconf" => :build


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

`portaudio` is usually uncommon on Linux. It is required on macOS - https://github.com/karlstav/cava#macos-1

`pipewire` and `pulseaudio` are most common on Linux, which should run on top of `alsa-lib`. So can prioritize those 3 backends.