### PR TITLE
bacon: remove unused dep

### DIFF
--- a/Formula/b/bacon.rb
+++ b/Formula/b/bacon.rb
@@ -19,10 +19,6 @@ class Bacon < Formula
   depends_on "rust" => :build
   depends_on "rustup" => :test
 
-  on_linux do
-    depends_on "alsa-lib"
-  end
-
   def install
     system "cargo", "install", *std_cargo_args
   end


### PR DESCRIPTION
```
$ brew linkage bacon
System libraries:
  /lib/aarch64-linux-gnu/libc.so.6
Homebrew libraries:
  /home/linuxbrew/.linuxbrew/opt/gcc/lib/gcc/current/libgcc_s.so.1 (gcc)
```