### PR TITLE
podman: macos service integration

### DIFF
--- a/Formula/p/podman.rb
+++ b/Formula/p/podman.rb
@@ -195,7 +195,8 @@ class Podman < Formula
   end
 
   service do
-    run linux: [opt_bin/"podman", "system", "service", "--time", "0"]
+    run linux: [opt_bin/"podman", "system", "service", "--time", "0"],
+        macos: [opt_bin/"podman", "machine", "start"]
     environment_variables PATH: std_service_path_env
     working_dir HOMEBREW_PREFIX
   end


### PR DESCRIPTION
https://github.com/containers/podman/issues/28547

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

```
❯ brew style podman
1 file inspected, no offenses detected

❯ brew test podman
==> Testing podman
==> /opt/homebrew/Cellar/podman/5.8.2/bin/podman-remote -v
==> /opt/homebrew/Cellar/podman/5.8.2/bin/podman-remote info 2>&1
==> /opt/homebrew/Cellar/podman/5.8.2/bin/podman-remote machine init homebrew-testvm
Getting image source signatures
Copying blob 2c0878ba6eaa done   |
Copying config 44136fa355 done   |
Writing manifest to image destination
==> /opt/homebrew/Cellar/podman/5.8.2/bin/podman-remote machine rm -f homebrew-testvm

❯ brew audit --strict podman
Fetching gem metadata from https://rubygems.org/.......
Fetching rexml 3.4.4
Installing rexml 3.4.4
Bundle complete! 44 Gemfile dependencies, 35 gems now installed.
Bundled gems are installed into `../../opt/homebrew/Library/Homebrew/vendor/bundle`
```
