### PR TITLE
flow-cli: build with go 1.26

### DIFF
--- a/Formula/f/flow-cli.rb
+++ b/Formula/f/flow-cli.rb
@@ -20,7 +20,7 @@ class FlowCli < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "6c81c31f08d4d45834be1a873db8b17488bacdf7dd41340ba165964a72a00e8d"
   end
 
-  depends_on "go@1.25" => :build
+  depends_on "go" => :build
 
   conflicts_with "flow", because: "both install `flow` binaries"
 


### PR DESCRIPTION
Timeline Ref:
* https://github.com/Homebrew/homebrew-core/pull/258912
* https://github.com/onflow/flow-cli/pull/2239 
* https://github.com/onflow/flow-cli/commit/8f2311529a6778007732ae8f60696f807c5923b4
* https://github.com/onflow/flow-cli/releases/tag/v2.13.4
* https://github.com/Homebrew/homebrew-core/pull/262106
* https://github.com/onflow/flow-cli/releases/tag/v2.14.3
* https://github.com/Homebrew/homebrew-core/pull/269690
* https://github.com/Homebrew/homebrew-core/pull/271321

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
