### PR TITLE
rustnet 1.3.0 (new formula)

### DIFF
--- a/Formula/r/rustnet.rb
+++ b/Formula/r/rustnet.rb
@@ -6,6 +6,15 @@ class Rustnet < Formula
   license "Apache-2.0"
   head "https://github.com/domcyrus/rustnet.git", branch: "main"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "ed765cd6481ccc2cd24c4e902272ae075a8d8092dd5fe0a6e58632c764f99504"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "8aa8187cff84d15ac84c43c59abca16b85523eff33f3f92ed3164f64fc7f271d"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "ed5fd8a6a29c0f519808468560084f3b9c57eb86a2c79e1886840c50f906f4db"
+    sha256 cellar: :any_skip_relocation, sonoma:        "e8299a8b442a7049a44a6772d1a376aaf4b67f0a43e72a78b860f9cfd419f44a"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "01a2c4e7669e19cdb979d1e8872c31758b429d74ffc7556e2cdf42e319b6aa8f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "96fae2119f9b26d5700219f58fe4b1829552aa4390be08169725d5ee19ea1bd2"
+  end
+
   depends_on "rust" => :build
 
   uses_from_macos "libpcap"

--- a/Formula/r/rustnet.rb
+++ b/Formula/r/rustnet.rb
@@ -1,0 +1,59 @@
+class Rustnet < Formula
+  desc "Cross-platform network monitoring terminal UI with deep packet inspection"
+  homepage "https://github.com/domcyrus/rustnet"
+  url "https://github.com/domcyrus/rustnet/archive/refs/tags/v1.3.0.tar.gz"
+  sha256 "258ea142f3ca04e45c33761eb28868a8d8afc62a3f9556a1d5b312e805905ce5"
+  license "Apache-2.0"
+  head "https://github.com/domcyrus/rustnet.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  uses_from_macos "libpcap"
+  uses_from_macos "zlib"
+
+  on_linux do
+    depends_on "llvm" => :build
+    depends_on "pkgconf" => :build
+    depends_on "elfutils"
+  end
+
+  # Skip cross-rs-specific lib search paths on native Linux builds.
+  # Already merged upstream; will no longer apply on the next release.
+  # https://github.com/domcyrus/rustnet/pull/259
+  patch do
+    url "https://github.com/domcyrus/rustnet/commit/9a5208d95904253dbae19fd548f44a91cafbd34f.patch?full_index=1"
+    sha256 "bc677735d7ae9924214df0d4cfc261346eab429bc11f182c09c93fbde474673b"
+  end
+
+  def install
+    ENV["RUSTNET_ASSET_DIR"] = buildpath/"assets-generated"
+    (buildpath/"assets-generated").mkpath
+
+    if OS.linux?
+      # Homebrew's compiler shim rewrites `clang` invocations to `gcc`, which
+      # breaks libbpf-cargo's BPF compile step (it runs `clang -target bpf`,
+      # an option gcc rejects). Surface the real clang from llvm in a shim
+      # dir that we place first on PATH; regular C compiles still go through
+      # Homebrew's gcc as intended.
+      (buildpath/"bpf-clang").mkpath
+      (buildpath/"bpf-clang"/"clang").make_symlink Formula["llvm"].opt_bin/"clang"
+      ENV.prepend_path "PATH", buildpath/"bpf-clang"
+    end
+
+    system "cargo", "install", *std_cargo_args
+
+    asset_dir = buildpath/"assets-generated"
+    bash_completion.install asset_dir/"rustnet.bash" => "rustnet"
+    zsh_completion.install asset_dir/"_rustnet"
+    fish_completion.install asset_dir/"rustnet.fish"
+    man1.install asset_dir/"rustnet.1"
+  end
+
+  test do
+    assert_match "rustnet #{version}", shell_output("#{bin}/rustnet --version")
+    assert_match "network monitoring", shell_output("#{bin}/rustnet --help").downcase
+
+    output = shell_output("#{bin}/rustnet --log-level not-a-level 2>&1", 1)
+    assert_match "Invalid log level", output
+  end
+end


### PR DESCRIPTION
-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source rustnet`?
- [x] Is your test running fine `brew test rustnet`?
- [x] Does your build pass `brew audit --strict rustnet` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source rustnet`)? If this is a new formula, does it pass `brew audit --new rustnet`?

-----

rustnet is a cross-platform network monitoring terminal UI written in Rust, with deep packet inspection for HTTP/HTTPS/DNS/SSH/QUIC and per-connection process attribution. Upstream: https://github.com/domcyrus/rustnet (Apache-2.0, 2k+ stars).

Notes on the formula:
- Completions and the manpage are generated by rustnet's `build.rs` into a path controlled by `RUSTNET_ASSET_DIR`.
- On Linux, the `ebpf` default feature is kept on. The formula prepends a small shim directory to `PATH` that surfaces the real `clang` from the `llvm` formula, because libbpf-cargo invokes `clang -target bpf` and Homebrew's compiler shim otherwise rewrites `clang` to `gcc`, which rejects `-target`. Regular C compiles are unaffected and still go through the Homebrew shim.
- Validated locally on macOS arm64 (Apple Silicon) and on Linux arm64 via the `homebrew/brew` Docker image; `brew audit --new --strict --online` is clean on both.

-----

- [x] AI was used to generate or assist with generating this PR. An AI assistant helped draft the formula and ran the local audit/build/test steps on macOS and Linux. I reviewed each line of the formula and verified the validation results before submitting.

-----