### PR TITLE
formanator 3.0.0 (new formula)

### DIFF
--- a/Formula/f/formanator.rb
+++ b/Formula/f/formanator.rb
@@ -1,0 +1,19 @@
+class Formanator < Formula
+  desc "Submit and manage Forma (https://joinforma.com) claims from the command-line and MCP clients"
+  homepage "https://github.com/timrogers/formanator"
+  url "https://github.com/timrogers/formanator/archive/refs/tags/v3.0.0.tar.gz"
+  sha256 "4bb7128d4f1d276138b3d182f5a1d55fdc428a9af9e8306d7d6ceba37cbf7155"
+  license "MIT"
+  head "https://github.com/timrogers/formanator.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/formanator --version")
+    assert_match "Usage: formanator <COMMAND>", shell_output("#{bin}/formanator help")
+  end
+end

--- a/Formula/f/formanator.rb
+++ b/Formula/f/formanator.rb
@@ -1,5 +1,5 @@
 class Formanator < Formula
-  desc "Submit and manage Forma (https://joinforma.com) claims from the command-line and MCP clients"
+  desc "Submit and manage claims from the command-line and MCP clients"
   homepage "https://github.com/timrogers/formanator"
   url "https://github.com/timrogers/formanator/archive/refs/tags/v3.0.0.tar.gz"
   sha256 "4bb7128d4f1d276138b3d182f5a1d55fdc428a9af9e8306d7d6ceba37cbf7155"


### PR DESCRIPTION
This adds a new formula for [Formanator](https://github.com/timrogers/formanator), a tool built in Rust for submitting and managing [Forma](https://joinforma.com) claims from the command line and Model Context Protocol (MCP) clients.

I've tested this by:

* installing locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source foo`
* making sure the CLI runs when installed with Homebrew
* auditing with `brew audit --new formanator` and `brew audit --strict formanator`
* testing with `brew test formanator`

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [X] Is your test running fine `brew test <formula>`?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
