### PR TITLE
trufflehog: install man page

### DIFF
--- a/Formula/t/trufflehog.rb
+++ b/Formula/t/trufflehog.rb
@@ -21,6 +21,7 @@ class Trufflehog < Formula
   def install
     ldflags = "-s -w -X github.com/trufflesecurity/trufflehog/v3/pkg/version.BuildVersion=#{version}"
     system "go", "build", *std_go_args(ldflags:)
+    man1.install "docs/man/trufflehog.1"
   end
 
   test do

--- a/Formula/t/trufflehog.rb
+++ b/Formula/t/trufflehog.rb
@@ -8,12 +8,13 @@ class Trufflehog < Formula
   head "https://github.com/trufflesecurity/trufflehog.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "e829c1817b1a511ee3c9d6317ad09fbcdd92b85101d9694fdc9c975e85d89c9f"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "d65ccfc546fa866b1775432b36314d50bb07314bac698728a5e6f53a276abecd"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "daeb8b3d26f871fa9f29f3824959a4f75095cb1a915f7153e776c7a142e8c34b"
-    sha256 cellar: :any_skip_relocation, sonoma:        "b36c27f9e8b143e5a1d015daa42278a08bc3d55621ceede7ad675d1d72728f37"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "2b743d7893f319d0cf20220ed6931bead7074aa9e624057f1bf2448d3131fdc8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0db232ff9193c5358fff9af83f68e6cbd1f6b55b14d063e50189c7723c361223"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "a56360b8ce6cf004f7893de031f066ff1124ade7387722819e98932d7e09f777"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "1011dd5e87d8c828c44f7d73906d22069d26923c3035e841f5797672cf7aaca1"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "638f205af87dcc6b2752c403d01e82fc5a8dd8b3681439af4272824718eafaf9"
+    sha256 cellar: :any_skip_relocation, sonoma:        "7fbb6e6d1987c49b6fcad02a683a995bdb30af361c7871e5dd3c35bae70c592a"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "bfd6cf4f53b5c72da60a2ff032b9b98cf442347b533fabcefd808ddb6bb7f4b4"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "32f2af9f5987a4d3ce84b07a929be27d801b65727a848647f3c73a99034aa403"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
## Summary

Adds `man1.install "docs/man/trufflehog.1"` so `man trufflehog` works after installing with the `homebrew-core` formula (`brew install trufflehog`).

Trufflehog now generates and ships a man page in the release tarball (under `docs/man/trufflehog.1`) but the homebrew-core formula doesn't install it. 

Upstream PR adding the man page: trufflesecurity/trufflehog#4894 (merged, released in v3.95.0).