### PR TITLE
git-mob: remove flaky test to access github

### DIFF
--- a/Formula/g/git-mob.rb
+++ b/Formula/g/git-mob.rb
@@ -33,10 +33,6 @@ class GitMob < Formula
     system bin/"git-add-coauthor", "bb", "Barry Butterworth", "barry@butterworth.org"
     assert_equal 3, JSON.parse((testpath/".git-coauthors").read)["coauthors"].size
 
-    system "git", "config", "--global", "git-mob-config.github-fetch", "true"
-    system bin/"git-mob", "BrewTestBot"
-    assert_equal 4, JSON.parse((testpath/".git-coauthors").read)["coauthors"].size
-
     system bin/"git-mob", "bb"
 
     script = testpath/".git/hooks/prepare-commit-msg"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

The test frequently failed to access github multiple times with other api, so let's remove.