### PR TITLE
hister 0.12.0 (new formula)

### DIFF
--- a/Formula/h/hister.rb
+++ b/Formula/h/hister.rb
@@ -1,0 +1,51 @@
+class Hister < Formula
+  desc "Your own search engine"
+  homepage "https://hister.org/"
+  url "https://github.com/asciimoo/hister/archive/refs/tags/v0.12.0.tar.gz"
+  sha256 "3b1b16854ee88ca461a1a943fb9b831e0bfc2cc8a5b8e08394140f0f7fb9c393"
+  license "AGPL-3.0-or-later"
+  head "https://github.com/asciimoo/hister.git", branch: "master"
+
+  depends_on "go" => :build
+  depends_on "node" => :build
+
+  def install
+    ENV["CGO_ENABLED"] = "1"
+    system "go", "generate", "./..."
+    system "go", "build", *std_go_args(ldflags: "-s -w")
+
+    generate_completions_from_executable(bin/"hister", shell_parameter_format: :cobra)
+
+    (var/"hister").mkpath
+  end
+
+  service do
+    run [opt_bin/"hister", "listen"]
+    keep_alive true
+    log_path var/"log/hister.log"
+    error_log_path var/"log/hister.log"
+    working_dir var/"hister"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/hister --version")
+
+    # Generate a default config; exercises the config package and embedded defaults.
+    config = testpath/"hister.yml"
+    system bin/"hister", "create-config", config
+    assert_match "app:", config.read
+
+    # Keep the data directory inside the test sandbox.
+    inreplace config, /^(\s*directory:).*$/, "\\1 #{testpath}"
+
+    # Spawn the server and confirm the embedded web UI responds.
+    port = free_port
+    pid = spawn bin/"hister", "--config", config, "listen", "--address", "127.0.0.1:#{port}"
+    begin
+      sleep 5
+      assert_match(/<html|<!doctype/i, shell_output("curl -fsS http://127.0.0.1:#{port}/"))
+    ensure
+      Process.kill("TERM", pid)
+    end
+  end
+end

--- a/Formula/h/hister.rb
+++ b/Formula/h/hister.rb
@@ -46,6 +46,7 @@ class Hister < Formula
       assert_match(/<html|<!doctype/i, shell_output("curl -fsS http://127.0.0.1:#{port}/"))
     ensure
       Process.kill("TERM", pid)
+      Process.wait(pid)
     end
   end
 end


### PR DESCRIPTION
New formula for [hister](https://github.com/asciimoo/hister) (v0.12.0). Upstream issue requesting Homebrew distribution: asciimoo/hister#161.

Repo stats: 767 stars, 42 forks, 13 tagged releases (v0.1.0–v0.12.0). License: AGPL-3.0-or-later.

The build runs `go generate ./...` (which invokes `webui/build.sh` to produce the Svelte web UI bundle embedded via `//go:embed`) and then `go build`. Node is a build-only dep; the runtime is a single static Go binary.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. The formula was drafted with Claude (Anthropic) and then verified by me locally: `brew audit --new --strict --online hister` passes clean, `brew install --build-from-source hister` succeeds (~1 min), `brew test hister` passes, and `hister --version` reports `v0.12.0`. I reviewed the formula against sibling Go+Node formulas (autobrr, anubis) for convention match and read the relevant upstream source (`generate.go`, `webui/build.sh`, `server/static/static.go`) before deciding on the build shape.
