### PR TITLE
smctemp 0.7.0 (new formula)

### DIFF
--- a/Formula/s/smctemp.rb
+++ b/Formula/s/smctemp.rb
@@ -1,0 +1,19 @@
+class Smctemp < Formula
+  desc "Print CPU and GPU temperatures on macOS"
+  homepage "https://github.com/narugit/smctemp"
+  url "https://github.com/narugit/smctemp/archive/refs/tags/0.7.0.tar.gz"
+  sha256 "4ca4eaade1964f2d4d39c5fc21ccb357a1966c5c2b8bb1480b08a28d47f8d4dd"
+  license "GPL-2.0-only"
+  head "https://github.com/narugit/smctemp.git", branch: "main"
+
+  depends_on :macos
+
+  def install
+    system "make"
+    bin.install "smctemp"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/smctemp -v")
+  end
+end


### PR DESCRIPTION
-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source smctemp`?
- [x] Is your test running fine `brew test smctemp`?
- [x] Does your build pass `brew audit --strict smctemp` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source smctemp`)? Does it pass `brew audit --new smctemp`?

-----

- [ ] AI was used to generate or assist with generating this PR.

-----

`smctemp` prints CPU and GPU temperatures on macOS. It works on both Intel and Apple Silicon Macs (M1–M5).

https://github.com/narugit/smctemp

### Context
A prior attempt (#138800, 2023) was declined because the repo did not meet notability requirements at the time. The project has since grown to 97 stars, clearing the `brew audit --new` notability check.
