### PR TITLE
defuddle 0.18.1 (new formula)

### DIFF
--- a/Formula/d/defuddle.rb
+++ b/Formula/d/defuddle.rb
@@ -5,6 +5,10 @@ class Defuddle < Formula
   sha256 "29d634b3e633e7ca0bd56fcb6296611b1f85e1823cd9bc1fe3220f1112149aec"
   license "MIT"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, all: "f5ad5cfe3fae1be629c6a6fdfe83c038e4abad5690e477e0b1727b3db6acdaca"
+  end
+
   depends_on "node"
 
   def install

--- a/Formula/d/defuddle.rb
+++ b/Formula/d/defuddle.rb
@@ -1,0 +1,31 @@
+class Defuddle < Formula
+  desc "Extract article content and metadata from web pages"
+  homepage "https://github.com/kepano/defuddle"
+  url "https://registry.npmjs.org/defuddle/-/defuddle-0.18.1.tgz"
+  sha256 "29d634b3e633e7ca0bd56fcb6296611b1f85e1823cd9bc1fe3220f1112149aec"
+  license "MIT"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink libexec.glob("bin/*")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/defuddle --version")
+
+    (testpath/"test.html").write <<~HTML
+      <html>
+        <body>
+          <article>
+            <h1>Test Article</h1>
+            <p>Hello from Homebrew.</p>
+          </article>
+        </body>
+      </html>
+    HTML
+    assert_match "Hello from Homebrew.", shell_output("#{bin}/defuddle parse #{testpath}/test.html --md")
+    assert_match "Test Article", shell_output("#{bin}/defuddle parse #{testpath}/test.html -p title")
+  end
+end


### PR DESCRIPTION
CLI tool to extract article content and metadata from web pages as clean Markdown. Created by [@kepano](https://github.com/kepano).

- **Homepage:** https://github.com/kepano/defuddle
- **License:** MIT
- **npm:** https://www.npmjs.com/package/defuddle

Upstream issue requesting Homebrew support: https://github.com/kepano/defuddle/issues/262

---

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source defuddle`?
- [x] Is your test running fine `brew test defuddle`?
- [x] Does your build pass `brew audit --strict --new --online defuddle`?