### PR TITLE
sandkasten 0.2.0 (new formula)

### DIFF
--- a/Formula/s/sandkasten.rb
+++ b/Formula/s/sandkasten.rb
@@ -1,0 +1,35 @@
+# Homebrew formula for sandkasten.
+#
+# This file is the canonical template. The live copy lives in the tap at
+# https://github.com/DatanoiseTV/homebrew-sandkasten/blob/main/Formula/sandkasten.rb
+# and is structured so it can be submitted unchanged to homebrew-core
+# once the project meets the notability threshold (see SUBMISSION.md).
+#
+# To cut a release:
+#   1. tag a new version (e.g. `git tag v0.2.1 && git push --tags`)
+#   2. download the source tarball and compute `shasum -a 256`
+#   3. update `url` + `sha256` below
+#   4. copy this file to the tap repo
+
+class Sandkasten < Formula
+  desc     "Fast, kernel-enforced application sandbox for macOS and Linux"
+  homepage "https://github.com/DatanoiseTV/sandkasten"
+  url      "https://github.com/DatanoiseTV/sandkasten/archive/refs/tags/v0.2.0.tar.gz"
+  sha256   "4a1613465c7875c165a52308869983a7146512de5d35088064bd7f84d9f2346b"
+  license  any_of: ["MIT", "Apache-2.0"]
+  head     "https://github.com/DatanoiseTV/sandkasten.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+
+    # Shell completions shipped alongside the binary.
+    generate_completions_from_executable(bin/"sandkasten", "completions")
+  end
+
+  test do
+    assert_match "self", shell_output("#{bin/"sandkasten"} templates")
+    system bin/"sandkasten", "doctor"
+  end
+end


### PR DESCRIPTION
### Summary

Add `sandkasten`, a fast kernel-enforced application sandbox for macOS
and Linux. It uses native isolation primitives on each platform
(Seatbelt on macOS; user/mount/pid/net namespaces + Landlock +
seccomp-BPF on Linux), so there is no VM or container runtime
dependency.

- Upstream: https://github.com/DatanoiseTV/sandkasten
- License: `MIT OR Apache-2.0`
- Language: Rust (stable toolchain)

### Notability — disclosure

The [acceptable-formulae](https://docs.brew.sh/Acceptable-Formulae)
policy asks for 75+ stars / 30+ forks / 30+ watchers. As of submission
the repo is new and sits below every threshold:

- stars: 0
- forks: 0
- watchers: 0

I'm submitting anyway because the tool solves a concrete problem that
other open-source sandboxes on Homebrew don't (`firejail` is
Linux-only; Apple's `sandbox-exec` is macOS-only and undocumented; no
single formula offers a profile-as-TOML sandbox that works on both).
A pre-existing tap at `DatanoiseTV/homebrew-sandkasten` already serves
this formula unchanged.

**If the maintainers prefer to wait for notability, I understand.**
Please close without ceremony and I'll resubmit later — the tap will
keep users unblocked in the meantime.

### Checklist

- [x] Formula is minimal (4 keywords + `depends_on "rust" => :build`
      + `cargo install` + `generate_completions_from_executable`)
- [x] `test do` exercises both `sandkasten templates` and
      `sandkasten doctor`
- [x] `brew audit --strict --online` passes clean on the live tap
      (which uses the same formula verbatim)
- [x] License is MIT OR Apache-2.0, both SPDX-standard
- [x] Upstream has a stable, signed tag (v0.2.0) with a published
      release
- [x] Shell completions installed (bash, zsh, fish)
- [ ] `brew install --build-from-source sandkasten` verified by CI
      (I don't have the `homebrew/core` checkout locally to run
      `brew audit --new --strict --online --git sandkasten`; relying
      on Homebrew CI for that)