### PR TITLE
mlx-c ollama: add mlx 0.31.2 support

### DIFF
--- a/Formula/m/mlx-c.rb
+++ b/Formula/m/mlx-c.rb
@@ -4,7 +4,7 @@ class MlxC < Formula
   url "https://github.com/ml-explore/mlx-c/archive/refs/tags/v0.6.0.tar.gz"
   sha256 "6ec2eab86ed3ce661c0d9b834027870651546138b7b4470fa8ef5533498c79aa"
   license "MIT"
-  revision 1
+  revision 2
   compatibility_version 1
 
   bottle do
@@ -27,10 +27,28 @@ class MlxC < Formula
     cause "Requires C++20 support"
   end
 
-  # pr ref: https://github.com/ml-explore/mlx-c/pull/114
+  # support for mlx_distributed_group_free() (#110)
   patch do
-    url "https://github.com/GunniBusch/mlx-c/commit/3fce35b0b1fa1160fdf767229bfb84d695ef1e5d.patch?full_index=1"
-    sha256 "0361169fe85cdaccfb9a25e3f8a9991951b263b33b7683867972c36dca05e97c"
+    url "https://github.com/ml-explore/mlx-c/commit/1e3c24ffebfdfbeecca054c51637fc4381d98aab.patch?full_index=1"
+    sha256 "24831d5bc44b72a0fd027572a4e4eaf754ed9805ffed86185bb8dbdfb6284818"
+  end
+
+  # support for gguf (#111)
+  patch do
+    url "https://github.com/ml-explore/mlx-c/commit/89d3454ac3f46ff68668dd9f7817c6d47650e47c.patch?full_index=1"
+    sha256 "411749fd1908fdee783c3b378471603606852ce3a0ee0011ca5b66f47187b9d3"
+  end
+
+  # support for graph export (#112)
+  patch do
+    url "https://github.com/ml-explore/mlx-c/commit/782d4712862b247a094086419ce130fd82cf3c53.patch?full_index=1"
+    sha256 "4469b3ec2836efeadce98a192ae26f423cdbbd182edcd2126f4a6ef36891ce58"
+  end
+
+  # regenerate bindings for MLX 0.31.2 (#114)
+  patch do
+    url "https://github.com/ml-explore/mlx-c/commit/fba4470b89073180056c9ea46c443051375f7399.patch?full_index=1"
+    sha256 "5102eafc68ea94cbe8cabb4acaa9905e17d1c92cb6a1b8c7f0f73dc863c09609"
   end
 
   def install

--- a/Formula/m/mlx-c.rb
+++ b/Formula/m/mlx-c.rb
@@ -8,9 +8,9 @@ class MlxC < Formula
   compatibility_version 1
 
   bottle do
-    sha256 cellar: :any, arm64_tahoe:   "83d092eb6a813c680997c13cafaff9cf6559be17f94eaa80f4aa503dd5e6b8f0"
-    sha256 cellar: :any, arm64_sequoia: "721c3c05e50cf23350c725d4b3855ab8fe2ff7265b9e2d61e951b730fe5b2b5b"
-    sha256 cellar: :any, arm64_sonoma:  "03127804f9796dfa15b14e4e4faaa19420a182377441a98275fd855ab32fe973"
+    sha256 cellar: :any, arm64_tahoe:   "b30c755158db3f9d9090b69a1a74f3e05ae8e7a3969695d9f0974f1bc1d3df1b"
+    sha256 cellar: :any, arm64_sequoia: "1c912954c1d7c888c99638fc58a541d364862c3acf3b279627e5221b9bd0afa7"
+    sha256 cellar: :any, arm64_sonoma:  "b09d19e06b33a10936b006a67202a091715bbedf9fe1620b1162eb140f8af0fd"
   end
 
   depends_on "cmake" => :build

--- a/Formula/o/ollama.rb
+++ b/Formula/o/ollama.rb
@@ -17,12 +17,12 @@ class Ollama < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "df6992f990e77de9672a6f74b2df31b525903f49723439e2adfe10aa460e66c4"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "9cb6c4c7b41202858d7ce67ec2e092d5df6e42550edf9583dc3f69bfb1da8e65"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "cc004195a39477101256c3207a6003d6b50ae77ee613798f5ecd0e7e4b52bea4"
-    sha256 cellar: :any_skip_relocation, sonoma:        "f27e8ab720bf03e686ba4ef4c4176757e0203d7e599906fe7d23abadfaba4307"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "05c99954b6c16078865d166e389588abb5c7fd2ac40e5003239c562604306164"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3d9f9271e950b21cbee95879e841d51b3c73409133044bcc33adba9dc79b7640"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "de7f24489b290528b2c910124794ba8b1c704cc7950e964785531c8a27d6200c"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "7aa2da3f6e13c63bb59dd84985455f17f30a0082a7811288d9de63e25a5b4466"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "fd2ba929a766e1daca960565af6e99529a7e599b5c08e77333e99a8c14bc6d80"
+    sha256 cellar: :any_skip_relocation, sonoma:        "f211d8baa6bb2bc69487b05e015509900e4a25af706424d0f15fd7addfabb08e"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "947791ec3f92bbaae1acfa8efee9786810bd80f51e60bfb2621e73e4595e3d58"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0d8be852f2ffb384b2f65cd89661f6219dae51c474240466160b821163c0517f"
   end
 
   depends_on "cmake" => :build

--- a/Formula/o/ollama.rb
+++ b/Formula/o/ollama.rb
@@ -5,6 +5,7 @@ class Ollama < Formula
       tag:      "v0.21.2",
       revision: "590109c8352e8d5a6206e8909b518a54a2b0a7b8"
   license "MIT"
+  revision 1
   head "https://github.com/ollama/ollama.git", branch: "main"
 
   # Upstream creates releases that use a stable tag (e.g., `v1.2.3`) but are
@@ -31,9 +32,16 @@ class Ollama < Formula
     on_arm do
       depends_on "mlx-c" => :no_linkage
 
-      # Fixes x/imagegen/mlx wrapper generation with system-installed mlx-c headers.
-      # upstream pr ref, https://github.com/ollama/ollama/pull/14201
       if build.stable?
+
+        # Support for mlx 0.31.2, pr ref https://github.com/ollama/ollama/pull/15793
+        patch do
+          url "https://github.com/ollama/ollama/commit/bdd7fdd171be290099d368aacb747f9a1241299a.patch?full_index=1"
+          sha256 "88de38e8e190f1f465288094778844146d4883aa86adaebf68efc27c46ef0127"
+        end
+
+        # Fixes x/imagegen/mlx wrapper generation with system-installed mlx-c headers.
+        # upstream pr ref, https://github.com/ollama/ollama/pull/14201
         patch do
           url "https://github.com/ollama/ollama/commit/c051122297824c223454b82f4af3afe94379e6dd.patch?full_index=1"
           sha256 "a22665cd1acec84f6bb53c84dd9a40f7001f2b1cbe2253aed3967b4401cde6a0"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

## Planned commits
- `mlx-c: mlx 0.31.2 patch`
- `ollama: mlx 0.31.2 support`
## Validation summary
- `mlx-c`: style: pass, test: pass, audit: pass
- `ollama`: style: pass, test: pass, audit: pass

fixes #279176  

Apparently Ollama, did not support mlx 0.31.2, but my quick tests earlier were passing. I also added remaining patches to mlx-c for all the remaining symbols introduced in mlx 0.31.2 