### PR TITLE
beads: update repository URLs

### DIFF
--- a/Formula/b/beads.rb
+++ b/Formula/b/beads.rb
@@ -1,11 +1,11 @@
 class Beads < Formula
   desc "Memory upgrade for your coding agent"
-  homepage "https://github.com/steveyegge/beads"
-  url "https://github.com/steveyegge/beads/archive/refs/tags/v1.0.2.tar.gz"
+  homepage "https://github.com/gastownhall/beads"
+  url "https://github.com/gastownhall/beads/archive/refs/tags/v1.0.2.tar.gz"
   sha256 "21f6170bd039ab0fefc7ee686f391a7b0c919690074d056bfb0636d3233b1914"
   license "MIT"
   compatibility_version 1
-  head "https://github.com/steveyegge/beads.git", branch: "main"
+  head "https://github.com/gastownhall/beads.git", branch: "main"
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "adad56fd7f1c4a793b273867b481d482511a9ad5b45176fcc70f6570d2fd6156"


### PR DESCRIPTION
-----

- [x] Have you followed the guidelines for contributing?
- [x] Have you ensured that your commits follow the commit style guide?
- [x] Have you checked that there aren't other open pull requests for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source beads`?
- [ ] Is your test running fine `brew test beads`?
- [ ] Does your build pass `brew audit --strict beads`?

-----

- [x] AI was used to generate or assist with generating this PR. OpenAI Codex applied the narrow URL update and verified the new source archive checksum.

-----

This updates the Beads formula to point at the official successor repository after the upstream repo moved from `steveyegge/beads` to `gastownhall/beads`. The old URLs still redirect, but the formula should reference the canonical upstream.

No version, bottle, dependency, build, or test behavior is changed.

Validation:
- `curl -LfsS https://github.com/gastownhall/beads/archive/refs/tags/v1.0.2.tar.gz | shasum -a 256` matches the existing formula SHA256: `21f6170bd039ab0fefc7ee686f391a7b0c919690074d056bfb0636d3233b1914`

Not run locally:
- `brew install --build-from-source beads`
- `brew test beads`
- `brew audit --strict beads`

Homebrew is not installed in this execution environment.