### PR TITLE
misc: remove unneeded `OPENSSL_NO_VENDOR`

### DIFF
--- a/Formula/a/azure-cli.rb
+++ b/Formula/a/azure-cli.rb
@@ -768,7 +768,6 @@ class AzureCli < Formula
   def install
     # Ensure that the `openssl` crate picks up the intended library.
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     venv = virtualenv_create(libexec, "python3.13", system_site_packages: false)
     venv.pip_install resources

--- a/Formula/b/boa.rb
+++ b/Formula/b/boa.rb
@@ -25,7 +25,6 @@ class Boa < Formula
   def install
     # Ensure that the `openssl` crate picks up the intended library.
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", *std_cargo_args(path: "cli")
   end

--- a/Formula/b/btcli.rb
+++ b/Formula/b/btcli.rb
@@ -257,7 +257,6 @@ class Btcli < Formula
   def install
     ENV.O0
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
     # required to declare scalecodec's version, issue opened at https://github.com/JAMdotTech/py-scale-codec/issues/130
     ENV["TRAVIS_TAG"] = resource("scalecodec").version.to_s
     virtualenv_install_with_resources

--- a/Formula/c/cargo-c.rb
+++ b/Formula/c/cargo-c.rb
@@ -39,7 +39,6 @@ class CargoC < Formula
     ENV["LIBSSH2_SYS_USE_PKG_CONFIG"] = "1"
     # Ensure the correct `openssl` will be picked up.
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", *std_cargo_args
   end

--- a/Formula/c/cargo-clone.rb
+++ b/Formula/c/cargo-clone.rb
@@ -31,7 +31,6 @@ class CargoClone < Formula
   def install
     # Ensure that the `openssl` crate picks up the intended library.
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", *std_cargo_args(path: "cargo-clone")
   end

--- a/Formula/c/cargo-crev.rb
+++ b/Formula/c/cargo-crev.rb
@@ -29,7 +29,6 @@ class CargoCrev < Formula
 
   def install
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
     system "cargo", "install", "--no-default-features", *std_cargo_args(path: "./cargo-crev")
   end
 

--- a/Formula/c/cargo-geiger.rb
+++ b/Formula/c/cargo-geiger.rb
@@ -28,7 +28,6 @@ class CargoGeiger < Formula
   def install
     # Ensure that the `openssl` crate picks up the intended library.
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", *std_cargo_args(path: "cargo-geiger")
   end

--- a/Formula/c/cargo-generate.rb
+++ b/Formula/c/cargo-generate.rb
@@ -26,7 +26,6 @@ class CargoGenerate < Formula
     ENV["LIBSSH2_SYS_USE_PKG_CONFIG"] = "1"
     # Ensure the correct `openssl` will be picked up.
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", "--no-default-features", *std_cargo_args
   end

--- a/Formula/c/cargo-outdated.rb
+++ b/Formula/c/cargo-outdated.rb
@@ -27,7 +27,6 @@ class CargoOutdated < Formula
 
   def install
     ENV["LIBGIT2_NO_VENDOR"] = "1"
-    ENV["OPENSSL_NO_VENDOR"] = "1"
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
 
     system "cargo", "install", *std_cargo_args

--- a/Formula/c/cargo-udeps.rb
+++ b/Formula/c/cargo-udeps.rb
@@ -30,7 +30,6 @@ class CargoUdeps < Formula
     ENV["LIBGIT2_NO_VENDOR"] = "1"
     ENV["LIBSSH2_SYS_USE_PKG_CONFIG"] = "1"
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", "--no-default-features", *std_cargo_args
   end

--- a/Formula/c/cargo-update.rb
+++ b/Formula/c/cargo-update.rb
@@ -34,7 +34,6 @@ class CargoUpdate < Formula
     ENV["LIBSSH2_SYS_USE_PKG_CONFIG"] = "1"
     # Ensure the correct `openssl` will be picked up.
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", *std_cargo_args
   end

--- a/Formula/c/code-cli.rb
+++ b/Formula/c/code-cli.rb
@@ -34,7 +34,6 @@ class CodeCli < Formula
     # Ensure that the `openssl` crate picks up the intended library.
     # https://crates.io/crates/openssl#manual-configuration
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     ENV["VSCODE_CLI_NAME_LONG"] = "Code OSS"
     ENV["VSCODE_CLI_VERSION"] = version

--- a/Formula/c/code2prompt.rb
+++ b/Formula/c/code2prompt.rb
@@ -27,7 +27,6 @@ class Code2prompt < Formula
   def install
     # Ensure the correct `openssl` will be picked up.
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", *std_cargo_args(path: "crates/code2prompt")
   end

--- a/Formula/c/cookcli.rb
+++ b/Formula/c/cookcli.rb
@@ -20,7 +20,6 @@ class Cookcli < Formula
   depends_on "openssl@3"
 
   def install
-    ENV["OPENSSL_NO_VENDOR"] = "1"
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
 
     # Install npm dependencies and build assets

--- a/Formula/f/fend.rb
+++ b/Formula/f/fend.rb
@@ -31,7 +31,6 @@ class Fend < Formula
   def install
     # Ensure that the `openssl` crate picks up the intended library.
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", *std_cargo_args(path: "cli")
     system "./documentation/build.sh"

--- a/Formula/f/feroxbuster.rb
+++ b/Formula/f/feroxbuster.rb
@@ -22,7 +22,6 @@ class Feroxbuster < Formula
   def install
     # Ensure that the `openssl` crate picks up the intended library.
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", *std_cargo_args
 

--- a/Formula/f/findomain.rb
+++ b/Formula/f/findomain.rb
@@ -23,7 +23,6 @@ class Findomain < Formula
   def install
     # Ensure that the `openssl` crate picks up the intended library.
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", *std_cargo_args
   end

--- a/Formula/f/fnox.rb
+++ b/Formula/f/fnox.rb
@@ -28,7 +28,6 @@ class Fnox < Formula
   def install
     # Ensure that the `openssl` crate picks up the intended library.
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", *std_cargo_args
 

--- a/Formula/f/fw.rb
+++ b/Formula/f/fw.rb
@@ -43,7 +43,6 @@ class Fw < Formula
   def install
     # Ensure that the `openssl` crate picks up the intended library.
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", *std_cargo_args
     man1.install resource("fw.1")

--- a/Formula/g/geph4.rb
+++ b/Formula/g/geph4.rb
@@ -32,7 +32,6 @@ class Geph4 < Formula
   def install
     # Ensure that the `openssl` crate picks up the intended library.
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     rm_r(buildpath/".cargo")
     system "cargo", "install", *std_cargo_args

--- a/Formula/g/gerust.rb
+++ b/Formula/g/gerust.rb
@@ -25,7 +25,6 @@ class Gerust < Formula
   end
 
   def install
-    ENV["OPENSSL_NO_VENDOR"] = "1"
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
 
     system "cargo", "install", *std_cargo_args

--- a/Formula/g/git-series.rb
+++ b/Formula/g/git-series.rb
@@ -33,7 +33,6 @@ class GitSeries < Formula
     # Ensure that the `openssl` crate picks up the intended library.
     # https://crates.io/crates/openssl#manual-configuration
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     ENV["LIBGIT2_SYS_USE_PKG_CONFIG"] = "1"
     ENV["LIBSSH2_SYS_USE_PKG_CONFIG"] = "1"

--- a/Formula/g/git-workspace.rb
+++ b/Formula/g/git-workspace.rb
@@ -28,7 +28,6 @@ class GitWorkspace < Formula
     ENV["LIBSSH2_SYS_USE_PKG_CONFIG"] = "1"
     # Ensure the correct `openssl` will be picked up.
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", *std_cargo_args
     ENV["GIT_WORKSPACE"] = buildpath

--- a/Formula/g/gitnr.rb
+++ b/Formula/g/gitnr.rb
@@ -21,7 +21,6 @@ class Gitnr < Formula
 
   def install
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
     system "cargo", "install", *std_cargo_args
   end
 

--- a/Formula/g/gitui.rb
+++ b/Formula/g/gitui.rb
@@ -29,7 +29,6 @@ class Gitui < Formula
   def install
     # Ensure that the `openssl` crate picks up the intended library.
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", *std_cargo_args
   end

--- a/Formula/g/gstreamer.rb
+++ b/Formula/g/gstreamer.rb
@@ -232,7 +232,6 @@ class Gstreamer < Formula
     ENV.append_to_rustflags "--codegen link-args=-Wl,#{rpath_args.join(",")}"
 
     # Make sure the `openssl-sys` crate uses our OpenSSL.
-    ENV["OPENSSL_NO_VENDOR"] = "1"
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
 
     system "meson", "setup", "build", *args, *std_meson_args

--- a/Formula/g/gurk.rb
+++ b/Formula/g/gurk.rb
@@ -22,7 +22,6 @@ class Gurk < Formula
   def install
     # Ensure that the `openssl` crate picks up the intended library.
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", *std_cargo_args
   end

--- a/Formula/h/hk.rb
+++ b/Formula/h/hk.rb
@@ -37,7 +37,6 @@ class Hk < Formula
   def install
     # Ensure the correct `openssl` will be picked up.
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", *std_cargo_args
 

--- a/Formula/h/hurl.rb
+++ b/Formula/h/hurl.rb
@@ -33,7 +33,6 @@ class Hurl < Formula
   def install
     # FIXME: This formula uses the `openssl-sys` crate on Linux but does not link with our OpenSSL.
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", *std_cargo_args(path: "packages/hurl")
     system "cargo", "install", *std_cargo_args(path: "packages/hurlfmt")

--- a/Formula/i/icp-cli.rb
+++ b/Formula/i/icp-cli.rb
@@ -27,7 +27,6 @@ class IcpCli < Formula
   def install
     ENV["ICP_CLI_BUILD_DIST"] = "homebrew-core"
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", *std_cargo_args(path: "crates/icp-cli")
   end

--- a/Formula/l/lakekeeper.rb
+++ b/Formula/l/lakekeeper.rb
@@ -25,7 +25,6 @@ class Lakekeeper < Formula
   def install
     # Ensure that the `openssl` crate picks up the intended library.
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", *std_cargo_args(path: "crates/lakekeeper-bin")
   end

--- a/Formula/l/leetcode-cli.rb
+++ b/Formula/l/leetcode-cli.rb
@@ -24,7 +24,6 @@ class LeetcodeCli < Formula
   def install
     # Ensure that the `openssl` crate picks up the intended library.
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", *std_cargo_args
 

--- a/Formula/l/legba.rb
+++ b/Formula/l/legba.rb
@@ -26,7 +26,6 @@ class Legba < Formula
   def install
     # Ensure that the `openssl` crate picks up the intended library.
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", *std_cargo_args
 

--- a/Formula/l/lighthouse.rb
+++ b/Formula/l/lighthouse.rb
@@ -35,7 +35,6 @@ class Lighthouse < Formula
     ENV["PROTOC_NO_VENDOR"] = "1"
     # Ensure that the `openssl` crate picks up the intended library.
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     # fixing LLVM 22 builds, which got handled in https://github.com/sigp/xdelta3-rs/commit/fe3906605c87b6c0515bd7c8fc671f47875e3ccc
     inreplace "Cargo.toml", <<~OLD, <<~NEW

--- a/Formula/m/magika.rb
+++ b/Formula/m/magika.rb
@@ -33,7 +33,6 @@ class Magika < Formula
   end
 
   def install
-    ENV["OPENSSL_NO_VENDOR"] = "1"
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
 
     system "cargo", "install", *std_cargo_args(path: "rust/cli")

--- a/Formula/m/mise.rb
+++ b/Formula/m/mise.rb
@@ -36,7 +36,6 @@ class Mise < Formula
   def install
     # Ensure that the `openssl` crate picks up the intended library.
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", *std_cargo_args
     man1.install "man/man1/mise.1"

--- a/Formula/m/mlc.rb
+++ b/Formula/m/mlc.rb
@@ -28,7 +28,6 @@ class Mlc < Formula
     ENV.append_to_rustflags "-C linker=#{ENV.cc}"
 
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", *std_cargo_args
   end

--- a/Formula/o/omnara.rb
+++ b/Formula/o/omnara.rb
@@ -474,10 +474,7 @@ class Omnara < Formula
     without += %w[jeepney secretstorage] unless OS.linux?
     virtualenv_install_with_resources(without:)
 
-    if OS.linux?
-      ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-      ENV["OPENSSL_NO_VENDOR"] = "1"
-    end
+    ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix if OS.linux?
     resource("codex").stage do
       system "cargo", "install", *std_cargo_args(path: "codex-rs/cli", root: libexec)
     end

--- a/Formula/o/ord.rb
+++ b/Formula/o/ord.rb
@@ -25,7 +25,6 @@ class Ord < Formula
   def install
     # Ensure that the `openssl` crate picks up the intended library.
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", *std_cargo_args
   end

--- a/Formula/o/orogene.rb
+++ b/Formula/o/orogene.rb
@@ -36,7 +36,6 @@ class Orogene < Formula
   def install
     # Ensure that the `openssl` crate picks up the intended library.
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", *std_cargo_args
   end

--- a/Formula/p/pkgx.rb
+++ b/Formula/p/pkgx.rb
@@ -21,7 +21,6 @@ class Pkgx < Formula
   def install
     # Ensure that the `openssl` crate picks up the intended library.
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", *std_cargo_args(path: "crates/cli")
   end

--- a/Formula/p/projectable.rb
+++ b/Formula/p/projectable.rb
@@ -32,7 +32,6 @@ class Projectable < Formula
     ENV["LIBSSH2_SYS_USE_PKG_CONFIG"] = "1"
     # Ensure that the `openssl` crate picks up the intended library.
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", *std_cargo_args
   end

--- a/Formula/p/prr.rb
+++ b/Formula/p/prr.rb
@@ -31,7 +31,6 @@ class Prr < Formula
     ENV["LIBSSH2_SYS_USE_PKG_CONFIG"] = "1"
     # Ensure the correct `openssl` will be picked up.
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     # Specify GEN_DIR for shell completions and manpage generation
     ENV["GEN_DIR"] = buildpath

--- a/Formula/r/river.rb
+++ b/Formula/r/river.rb
@@ -27,7 +27,6 @@ class River < Formula
   def install
     # Ensure that the `openssl` crate picks up the intended library.
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", *std_cargo_args(path: "source/river")
   end

--- a/Formula/r/rojo.rb
+++ b/Formula/r/rojo.rb
@@ -24,7 +24,6 @@ class Rojo < Formula
   def install
     # Ensure that the `openssl` crate picks up the intended library.
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", *std_cargo_args
   end

--- a/Formula/r/rover.rb
+++ b/Formula/r/rover.rb
@@ -30,7 +30,6 @@ class Rover < Formula
   def install
     # Ensure that the `openssl` crate picks up the intended library.
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", *std_cargo_args
 

--- a/Formula/r/rqbit.rb
+++ b/Formula/r/rqbit.rb
@@ -29,7 +29,6 @@ class Rqbit < Formula
     # Ensure the declared `openssl@3` dependency will be picked up.
     # https://docs.rs/openssl/latest/openssl/#manual
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", *std_cargo_args(path: "crates/rqbit")
 

--- a/Formula/s/scryer-prolog.rb
+++ b/Formula/s/scryer-prolog.rb
@@ -21,7 +21,6 @@ class ScryerProlog < Formula
 
   def install
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", *std_cargo_args
   end

--- a/Formula/s/sh4d0wup.rb
+++ b/Formula/s/sh4d0wup.rb
@@ -29,7 +29,6 @@ class Sh4d0wup < Formula
   def install
     # Ensure that the `openssl` crate picks up the intended library.
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", *std_cargo_args
 

--- a/Formula/s/sheldon.rb
+++ b/Formula/s/sheldon.rb
@@ -33,7 +33,6 @@ class Sheldon < Formula
     ENV["LIBSSH2_SYS_USE_PKG_CONFIG"] = "1"
     # Ensure the correct `openssl` will be picked up.
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", "--no-default-features", *std_cargo_args
 

--- a/Formula/s/spotify_player.rb
+++ b/Formula/s/spotify_player.rb
@@ -27,7 +27,6 @@ class SpotifyPlayer < Formula
   def install
     # Ensure that the `openssl` crate picks up the intended library.
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     features = ["image", "notify"]
     system "cargo", "install", *std_cargo_args(path: "spotify_player", features:)

--- a/Formula/t/termscp.rb
+++ b/Formula/t/termscp.rb
@@ -29,7 +29,6 @@ class Termscp < Formula
   def install
     # Ensure that the `openssl` crate picks up the intended library.
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", *std_cargo_args
   end

--- a/Formula/t/trunk.rb
+++ b/Formula/t/trunk.rb
@@ -26,7 +26,6 @@ class Trunk < Formula
   def install
     # Ensure that the `openssl` crate picks up the intended library.
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", *std_cargo_args
   end

--- a/Formula/u/urx.rb
+++ b/Formula/u/urx.rb
@@ -22,7 +22,6 @@ class Urx < Formula
 
   def install
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", *std_cargo_args
   end

--- a/Formula/v/vsd.rb
+++ b/Formula/v/vsd.rb
@@ -32,7 +32,6 @@ class Vsd < Formula
 
   def install
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     inreplace "vsd/Cargo.toml" do |s|
       s.gsub! ", path = \"../mp4decrypt\"", ""

--- a/Formula/w/wally.rb
+++ b/Formula/w/wally.rb
@@ -27,7 +27,6 @@ class Wally < Formula
   end
 
   def install
-    ENV["OPENSSL_NO_VENDOR"] = "1"
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
     system "cargo", "install", *std_cargo_args
   end

--- a/Formula/y/yek.rb
+++ b/Formula/y/yek.rb
@@ -32,7 +32,6 @@ class Yek < Formula
 
   def install
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", *std_cargo_args
   end

--- a/Formula/y/yozefu.rb
+++ b/Formula/y/yozefu.rb
@@ -25,7 +25,6 @@ class Yozefu < Formula
   def install
     # Ensure that the `openssl` crate picks up the intended library.
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", *std_cargo_args(path: "crates/bin")
   end

--- a/Formula/z/zellij.rb
+++ b/Formula/z/zellij.rb
@@ -25,7 +25,6 @@ class Zellij < Formula
   def install
     # Ensure that the `openssl` crate picks up the intended library.
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
 
     system "cargo", "install", *std_cargo_args
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

`OPENSSL_NO_VENDOR` was moved to superenv way back in https://github.com/Homebrew/brew/commit/c3be703e02ac812e7533801f1f6aaef60c9a572a