### PR TITLE
http_load: disable formula

### DIFF
--- a/Formula/h/http_load.rb
+++ b/Formula/h/http_load.rb
@@ -38,6 +38,9 @@ class HttpLoad < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "5172c491fea4e76a68983d8fe6563a97e2ed2bef73b6bb0c95f5290282343116"
   end
 
+  # Upstream repo url is only available via http.
+  disable! date: "2026-07-24", because: :repo_removed
+
   depends_on "openssl@3"
 
   def install


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

I disabled the formulae because I was trying to migrate to openssl@4, but could not use the current https url. It is only available via http (at least for me). (I would support openssl@4).

But because it is also not hugely used, only 5 last 30 day which could have been me, I decided to disable it. 

Of course the alternative would be to switch to http, but this seems to me (also audit fails).

