### PR TITLE
clipper: embed version via ldflags

### DIFF
--- a/Formula/c/clipper.rb
+++ b/Formula/c/clipper.rb
@@ -17,7 +17,14 @@ class Clipper < Formula
   depends_on :macos
 
   def install
-    system "go", "build", *std_go_args(ldflags: "-s -w"), "clipper.go"
+    clipper_version = if build.stable?
+      version.to_s
+    else
+      Utils.safe_popen_read("git", "describe", "--tags", "--dirty").chomp
+    end
+
+    ldflags = %W[-s -w -X main.version=#{clipper_version}]
+    system "go", "build", *std_go_args(ldflags:), "clipper.go"
   end
 
   service do
@@ -46,5 +53,8 @@ class Clipper < Formula
         Process.kill "TERM", clipper.pid
       end
     end
+
+    version_output = shell_output("#{bin}/clipper -v 2>&1")
+    assert_match version.to_s, version_output
   end
 end

--- a/Formula/c/clipper.rb
+++ b/Formula/c/clipper.rb
@@ -7,10 +7,11 @@ class Clipper < Formula
   head "https://github.com/wincent/clipper.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "44b24d4c30b5e9f0b830a3c4f9189bac8f62d4e84c1a268493b3a36eff3a1b7b"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "44b24d4c30b5e9f0b830a3c4f9189bac8f62d4e84c1a268493b3a36eff3a1b7b"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "44b24d4c30b5e9f0b830a3c4f9189bac8f62d4e84c1a268493b3a36eff3a1b7b"
-    sha256 cellar: :any_skip_relocation, sonoma:        "f1e008969ac9bb3e7978963fc1c43d22514338f9a255a57e99d45ad4581ae990"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "9a774abbbe9a959f39a478a85b38f06ee5991ffd4eeb2d6314d242da59ed5402"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "9a774abbbe9a959f39a478a85b38f06ee5991ffd4eeb2d6314d242da59ed5402"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "9a774abbbe9a959f39a478a85b38f06ee5991ffd4eeb2d6314d242da59ed5402"
+    sha256 cellar: :any_skip_relocation, sonoma:        "82e62e607c9831b635560f0783e52f3d3f1a98bda6a0fc8083f61629b9423b79"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
`clipper -v` was printing `clipper version: unknown (darwin)` from the bottle because the `install` block wasn't passing `-X main.version=...` in the ldflags. The upstream Makefile does this passing in a `VERSION` obtained from `git describe` as ldflags:

- https://github.com/wincent/clipper/blob/3.0.0/Makefile#L28

Stable builds (bottle builds, non-`HEAD` builds) will use a GitHub source tarball, which doesn't include a `.git` directory or tag. For these, we use `version.to_s`, which will get parsed out of the URL.

For `--HEAD` builds, we use `git describe` just like the upstream Makefile does.

This matches the pattern used in other formulae:

- https://github.com/Homebrew/homebrew-core/blob/main/Formula/g/gh.rb
- https://github.com/Homebrew/homebrew-core/blob/main/Formula/h/hugo.rb
- https://github.com/Homebrew/homebrew-core/blob/main/Formula/a/atlantis.rb

The `unless head?` guard on the strict version assertion in the test block follows the pattern from `bluez.rb`:

- https://github.com/Homebrew/homebrew-core/blob/main/Formula/b/bluez.rb

~~Bumped `revision` because this change does influence the built binary's behavior (ie. the output of `clipper -v`).~~

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

I used Claude to find links to prior art for this pattern, and also identify the validation steps:

    brew tap homebrew/core --force
    brew style clipper
    brew audit --strict --online clipper
    brew uninstall --force clipper
    HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source clipper
    clipper -v   # clipper version: 3.0.0 (darwin)
    HOMEBREW_NO_INSTALL_FROM_API=1 brew test clipper
    brew uninstall --force clipper
    HOMEBREW_NO_INSTALL_FROM_API=1 brew install --HEAD --build-from-source clipper
    clipper -v   # clipper version: 3.0.0-3-ga22b4f0 (darwin)
    HOMEBREW_NO_INSTALL_FROM_API=1 brew test clipper
