### PR TITLE
elixir-ls: symlink debug adapter

### DIFF
--- a/Formula/e/elixir-ls.rb
+++ b/Formula/e/elixir-ls.rb
@@ -12,7 +12,7 @@ class ElixirLs < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "4b5a157f08e6591c3d7c969df7004590817eca3b7d2f01dde422c4bdc3af6ffb"
+    sha256 cellar: :any_skip_relocation, all: "8385ec761f10d3b55b6c046b6a10c91a9f24ea4333aba88e8f11eba294e0e24e"
   end
 
   depends_on "elixir"

--- a/Formula/e/elixir-ls.rb
+++ b/Formula/e/elixir-ls.rb
@@ -4,6 +4,7 @@ class ElixirLs < Formula
   url "https://github.com/elixir-lsp/elixir-ls/archive/refs/tags/v0.30.0.tar.gz"
   sha256 "d8e6c1b7ffc2a122c280ab9790de3cc22b2c12cf98caeabca66e222c8b6a8da1"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     url :stable
@@ -24,23 +25,44 @@ class ElixirLs < Formula
     system "mix", "deps.get"
     system "mix", "compile"
     system "mix", "elixir_ls.release2", "-o", libexec
-    libexec.glob("*.bat").map(&:unlink)
+    rm Dir[libexec/"*.bat"]
 
     bin.install_symlink libexec/"language_server.sh" => "elixir-ls"
+    bin.install_symlink libexec/"debug_adapter.sh" => "elixir-debug-adapter"
   end
 
   test do
-    assert_path_exists bin/"elixir-ls"
     system "mix", "local.hex", "--force"
 
-    input =
-      "Content-Length: 152\r\n" \
-      "\r\n" \
-      "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"" \
-      "processId\":88075,\"rootUri\":null,\"capabilities\":{},\"trace\":\"ver" \
-      "bose\",\"workspaceFolders\":null}}\r\n"
-
+    # Test language server
+    json = <<~JSON
+      {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+          "rootUri": null,
+          "capabilities": {}
+        }
+      }
+    JSON
+    input = "Content-Length: #{json.size}\r\n\r\n#{json}"
     output = pipe_output(bin/"elixir-ls", input, 0)
-    assert_match "Content-Length", output
+    assert_match(/^Content-Length: \d+/i, output)
+
+    # Test debug adapter
+    json = <<~JSON
+      {
+        "seq": 1,
+        "type": "request",
+        "command": "initialize",
+        "arguments": {
+          "threadId": 1
+        }
+      }
+    JSON
+    input = "Content-Length: #{json.size}\r\n\r\n#{json}"
+    output = pipe_output(bin/"elixir-debug-adapter", input, 0)
+    assert_match(/^Content-Length: \d+/i, output)
   end
 end


### PR DESCRIPTION
-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

ElixirLS also comes with a debug adapter binary (that implements the [debug adapter protocol](https://microsoft.github.io/debug-adapter-protocol//)). This symlinks it to `elixir-debug-adapter` (the same name used by [Nixpkgs](https://search.nixos.org/packages?query=elixir-ls)) so that it is also present in your `$PATH`.

Also updates the test block.