### PR TITLE
animdl: deprecate

### DIFF
--- a/Formula/a/animdl.rb
+++ b/Formula/a/animdl.rb
@@ -19,6 +19,9 @@ class Animdl < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "8ebb633e0f672d698a29678b8dde3f7e0119195e410528f163eff55232f6bb0e"
   end
 
+  deprecate! date: "2026-04-27", because: :unmaintained
+  disable! date: "2027-04-27", because: :unmaintained
+
   depends_on "certifi"
   depends_on "libyaml"
   depends_on "python@3.14"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
The last commit was 3 years ago and depends on old vulnerable PyPI packages

Closes #279232