### PR TITLE
far2l 2.8.0 (new formula)

### DIFF
--- a/Formula/f/far2l.rb
+++ b/Formula/f/far2l.rb
@@ -1,0 +1,47 @@
+class Far2l < Formula
+  desc "Linux port of FAR Manager v2, TTY version (includes base NetRocks support)"
+  homepage "https://github.com/elfmz/far2l"
+  url "https://github.com/elfmz/far2l/archive/refs/tags/v_2.8.0.tar.gz"
+  sha256 "b0fddad2e3985f245f9e691e23b90fb97f7d29d9a0b131fe686aa3cbb2e4ea01"
+  license "GPL-2.0-only"
+
+  livecheck do
+    url :stable
+    regex(/^v?_?(\d+(?:\.\d+)+)$/i)
+  end
+
+  depends_on "cmake" => :build
+  depends_on "gperf" => :build
+  depends_on "m4" => :build
+  depends_on "ninja" => :build
+  depends_on "pkg-config" => :build
+  depends_on "libarchive"
+  depends_on "libnfs"
+  depends_on "libssh"
+  depends_on "libxml2"
+  depends_on "neon"
+  depends_on "openssl@3"
+  depends_on "uchardet"
+
+  def install
+    args = %w[
+      -DUSEWX=OFF
+      -DUSESDL=OFF
+      -DTTYX=OFF
+      -DNETROCKS=ON
+      -DNR_AWS=OFF
+      -DNR_SMB=OFF
+      -DMULTIARC=ON
+      -DPYTHON=OFF
+      -DCOLORER=ON
+    ]
+
+    system "cmake", "-S", ".", "-B", "build", "-GNinja", *args, *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    assert_match "FAR2L Version:", shell_output("#{bin}/far2l --version")
+  end
+end

--- a/Formula/f/far2l.rb
+++ b/Formula/f/far2l.rb
@@ -1,5 +1,5 @@
 class Far2l < Formula
-  desc "Linux port of FAR Manager v2, TTY version (includes base NetRocks support)"
+  desc "Unix TTY port of FAR Manager v2 (with NetRocks support)"
   homepage "https://github.com/elfmz/far2l"
   url "https://github.com/elfmz/far2l/archive/refs/tags/v_2.8.0.tar.gz"
   sha256 "b0fddad2e3985f245f9e691e23b90fb97f7d29d9a0b131fe686aa3cbb2e4ea01"
@@ -12,16 +12,17 @@ class Far2l < Formula
 
   depends_on "cmake" => :build
   depends_on "gperf" => :build
-  depends_on "m4" => :build
   depends_on "ninja" => :build
-  depends_on "pkg-config" => :build
+  depends_on "pkgconf" => :build
   depends_on "libarchive"
   depends_on "libnfs"
   depends_on "libssh"
-  depends_on "libxml2"
   depends_on "neon"
   depends_on "openssl@3"
   depends_on "uchardet"
+
+  uses_from_macos "m4" => :build
+  uses_from_macos "libxml2"
 
   def install
     args = %w[


### PR DESCRIPTION
                                                                  
  ### Summary
  Add `far2l`, the popular Linux/Unix port of the classic FAR Manager v2.
                                                                                        
  ### Rationale
  far2l is widely used as the primary orthodox file manager for Linux/Unix              
  systems. While most distributions provide a heavy GUI build, this formula             
  focuses on a **lean, TTY-only version** suitable for servers and remote
  devices.                                                                              
                                                                  
  It is intentionally optimized for:                                                    
   
  - **Minimal footprint** — removes heavy dependencies like `aws-sdk-cpp`               
    (AWS/S3) and `samba` (SMB).                                   
  - **Environment versatility** — excludes X11 and wxWidgets, making it                 
    ideal for remote SSH sessions and headless servers.           
  - **Performance** — provides SFTP (via libssh), NFS, and WebDAV support               
    in a ~30 MB package.
                                                                                        
  ---                 
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. 
 
Claude (Anthropic) helped me to create the formula and iterated on it against `brew audit --new` and `brew audit --strict` until both passed cleanly.  I manually verified each change, ran `brew install --build-from-source`,  `brew test`, and `brew style` locally — all pass.
