### PR TITLE
periphery: revert cleanup

### DIFF
--- a/Formula/p/periphery.rb
+++ b/Formula/p/periphery.rb
@@ -16,21 +16,59 @@ class Periphery < Formula
 
   depends_on xcode: ["16.4", :build]
 
+  uses_from_macos "swift" => [:build, :test]
   uses_from_macos "curl"
   uses_from_macos "libxml2"
-  uses_from_macos "swift"
+
+  on_linux do
+    depends_on "zlib-ng-compat"
+    depends_on "zstd"
+  end
 
   def install
     args = if OS.mac?
       ["--disable-sandbox"]
     else
-      swift_cellar_libexec_lib = Formula["swift"].libexec/"lib"
-
-      ["--static-swift-stdlib", "-Xswiftc", "-use-ld=ld", "-Xlinker", "-L#{swift_cellar_libexec_lib}", "-Xlinker",
-       "-rpath", "-Xlinker", swift_cellar_libexec_lib.to_s]
+      ["--static-swift-stdlib", "-Xswiftc", "-use-ld=ld"]
     end
     system "swift", "build", *args, "--configuration", "release", "--product", "periphery"
     bin.install ".build/release/periphery"
+
+    if OS.mac?
+      toolchain_lib = Pathname(MacOS::CLT::PKG_PATH)/"usr/lib"
+      indexstore = toolchain_lib/"libIndexStore.dylib"
+      odie "Missing libIndexStore in #{toolchain_lib}" unless indexstore.exist?
+      lib.mkpath
+      cp indexstore, lib/"libIndexStore.dylib"
+
+      # The binary inherits an absolute Xcode toolchain rpath from the build environment.
+      # Replace it with a loader-relative path so the bundled lib is used instead.
+      MachO::Tools.add_rpath(bin/"periphery", "@loader_path/../lib")
+      MachO.open(bin/"periphery").rpaths.each do |path|
+        next if path != toolchain_lib.to_s && !path.start_with?("#{toolchain_lib}/")
+
+        MachO::Tools.delete_rpath(bin/"periphery", path)
+      end
+    else
+      swift_libexec_lib = Formula["swift"].opt_libexec/"lib"
+      indexstore = Dir[swift_libexec_lib/"libIndexStore.so*"].map { |path| Pathname(path) }
+      odie "Missing libIndexStore in #{swift_libexec_lib}" if indexstore.empty?
+      indexstore.each do |path|
+        lib.install path
+      end
+
+      # The binary inherits an absolute Swift toolchain rpath from the build environment.
+      # Replace it with a loader-relative path so the bundled lib is used instead.
+      swift_toolchain_rpaths = [swift_libexec_lib, Formula["swift"].libexec/"lib"].flat_map do |path|
+        [path.to_s, (path.realpath.to_s if path.exist?)]
+      end.compact
+      periphery = bin/"periphery"
+      rpaths = periphery.rpaths.reject do |path|
+        path == lib.to_s || swift_toolchain_rpaths.include?(path)
+      end
+      rpaths.unshift("$ORIGIN/../lib")
+      periphery.patch!(rpath: rpaths.uniq.join(":"))
+    end
 
     generate_completions_from_executable(bin/"periphery", "--generate-completion-script")
   end


### PR DESCRIPTION
This reverts commit 89665266a1f1f4ce19887182a6a0220ff32b76a1.

https://github.com/Homebrew/homebrew-core/pull/279506 should not have been allowed without my approval, how can we prevent this in the future? Periphery needs to bundle `libIndexStore.dylib` as we cannot rely upon the dylib being available in the expected path on the user's system.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
