### PR TITLE
talosctl: autocomplete to use cobra format

### DIFF
--- a/Formula/t/talosctl.rb
+++ b/Formula/t/talosctl.rb
@@ -26,7 +26,7 @@ class Talosctl < Formula
     ]
     system "go", "build", *std_go_args(ldflags:), "./cmd/talosctl"
 
-    generate_completions_from_executable(bin/"talosctl", "completion")
+    generate_completions_from_executable(bin/"talosctl", shell_parameter_format: :cobra)
   end
 
   test do


### PR DESCRIPTION
The previous autocomplete did not work properly because talosctl was using it's own autocomplete script. I created a PR in talos repo to fix to use cobra completion. This has been merged in the new 1.13.0 version.

Previous failed PR: https://github.com/Homebrew/homebrew-core/pull/275965

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
