### PR TITLE
python: fix venv script permissions

### DIFF
--- a/Formula/p/python-freethreading.rb
+++ b/Formula/p/python-freethreading.rb
@@ -349,6 +349,13 @@ class PythonFreethreading < Formula
     INI
   end
 
+  def post_install
+    # Ensure the template venv activation scripts are writable
+    # to allow reinitializing an existing venv without throwing a permission error.
+    # See: https://github.com/python/cpython/issues/86079
+    chmod "u+w", lib_cellar.glob("venv/scripts/**/*").select(&:file?)
+  end
+
   def sitecustomize
     <<~PYTHON
       # This file is created by Homebrew and is executed on each python startup.

--- a/Formula/p/python-freethreading.rb
+++ b/Formula/p/python-freethreading.rb
@@ -10,15 +10,15 @@ class PythonFreethreading < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 arm64_tahoe:   "395e3f7a26b17c8e60454e1fa37b956440baa739b99c96b068056f567809e570"
-    sha256 arm64_sequoia: "a80d70195c17a26a25e28341d45d1aafdd5cb51501995ac731847515a3795e2f"
-    sha256 arm64_sonoma:  "1eae19ff2aef7f78bab7de5c9dfd81b197aa3bc6a82fa2915de3a1c73956e1bc"
-    sha256 tahoe:         "d36d74870b3e3127223ebc42bf9ee04d7b14d3fbec97f802949a6323c1207401"
-    sha256 sequoia:       "1ec3ebe918c4655f77abbee5cbb685073f2cd9449503692ff0f18ed359a1edfd"
-    sha256 sonoma:        "c0af64a381e7ce5b074d375122810130d108c2b66eb7e791cceb7887a135e7f3"
-    sha256 arm64_linux:   "25d73840fff01bb22647600294855e8f7f3c00829b5d809a75bf4d09fb7456d9"
-    sha256 x86_64_linux:  "c5727ed710d50d6a5ddf8dd3446dc532410018d2f81dc4ed4a5e357dd7e7b9d6"
+    rebuild 2
+    sha256 arm64_tahoe:   "c924f6c8771130e9916297698de94ed1dd83770f548c025d20a4ba7db6960b0c"
+    sha256 arm64_sequoia: "6090349997de23e29ba40ea80dafc65d694339cb9b30aa1a75768e2dfb2eabb8"
+    sha256 arm64_sonoma:  "61c7fcd1b25b5c59719813823ae1cf6d06e7ac0d3f32b19b2f2a19ee2657d0e1"
+    sha256 tahoe:         "55e0f17a503091bbe5b83202c01e9a5828e931f38d851aa1648d23539da75b34"
+    sha256 sequoia:       "702db0bb1164eadaa6b5d0c4cfc14f7a54940681146d11f0879922336b706ab7"
+    sha256 sonoma:        "594371d102740c4cfa5db38f55fd39a13c450c670af1e94e48b96c2b958074bb"
+    sha256 arm64_linux:   "e15a845d5898f2c28bdcffc857754635d757ea4765709257ea5914eb01b20ec8"
+    sha256 x86_64_linux:  "a2dddfb16ae4a60208260f3b1f76d2f281006900ebc9c83c4a92b7bd26e5bb63"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/p/python@3.11.rb
+++ b/Formula/p/python@3.11.rb
@@ -13,14 +13,15 @@ class PythonAT311 < Formula
   end
 
   bottle do
-    sha256 arm64_tahoe:   "c77e291a53232b4fb948e374f7b7b069ad2de37a4ae4d42be734a9420279ce4a"
-    sha256 arm64_sequoia: "3559acf035f02e4149ac96aead12ff34f3f750d42d0f2005269cf8ea425dbf73"
-    sha256 arm64_sonoma:  "080e0613100f7917a5f7cfa137fbb24b1a3b2fc22d0cb16bfdab1711a49b0ab3"
-    sha256 tahoe:         "65a1f9f1ebc638c1bf31e180be612c5344aad5e316aad91b619d768f5082e222"
-    sha256 sequoia:       "a241cb9c6042ff6b30ee9f615d514253fd8342dae357f3e220d783329fff4ca9"
-    sha256 sonoma:        "0c18c903451ed1801b36642d21fecfe678cbde6a60f3ffca11619a5d95e53a1b"
-    sha256 arm64_linux:   "49f48a0eb833406b3238a704e02e2d456d8d7a75a770c381925606ee35fb1660"
-    sha256 x86_64_linux:  "d090cc3c5cb3ce2c30556b9a72f91346735e4021d2c7340f4aab87d2533b6595"
+    rebuild 1
+    sha256 arm64_tahoe:   "759345b256879a090e62e33ef2e5680372904ba5540911c2c41c164e64a9eddb"
+    sha256 arm64_sequoia: "65867c46485e40c31b38b7a64bfa05fe532263bf2082427bd26942eda349ecd9"
+    sha256 arm64_sonoma:  "25329ac1011900cb629b13589741eab39dd65b71636776b4588b645efb643134"
+    sha256 tahoe:         "856378493ef877a8a97026fb7b8810c5a0da62b430718d8944ac28974b077e9e"
+    sha256 sequoia:       "cf2791d35b9c1761b9798a19353942e640efe6b53974554908c6c6fbe7f947da"
+    sha256 sonoma:        "5938ba78ee82eaa511cc18810ca5006e67cadbcbd0d8a58644932ff333e74b95"
+    sha256 arm64_linux:   "653cfc03db4d67a9bd48af48c3922fd24180951cfa8f077d5f2ca4466ef02ac3"
+    sha256 x86_64_linux:  "62d7f77ab59b1f180c8cc013d3fc115b7ee338de4c46a68b8f5a01ebd1dffd7e"
   end
 
   # setuptools remembers the build flags python is built with and uses them to

--- a/Formula/p/python@3.11.rb
+++ b/Formula/p/python@3.11.rb
@@ -404,6 +404,11 @@ class PythonAT311 < Formula
     %W[wheel#{version.major_minor} pip#{version.major_minor}].each do |e|
       (HOMEBREW_PREFIX/"bin").install_symlink bin/e
     end
+
+    # Ensure the template venv activation scripts are writable
+    # to allow reinitializing an existing venv without throwing a permission error.
+    # See: https://github.com/python/cpython/issues/86079
+    chmod "u+w", lib_cellar.glob("venv/scripts/**/*").select(&:file?)
   end
 
   def sitecustomize

--- a/Formula/p/python@3.12.rb
+++ b/Formula/p/python@3.12.rb
@@ -13,15 +13,15 @@ class PythonAT312 < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 arm64_tahoe:   "4b2cf1174957cdfb7f95dacb9135ef47c57a7cc52f2ac590a9f7284cdfea0e63"
-    sha256 arm64_sequoia: "4f06f0e4e2b57b84574e69acb259a999cea8973aab52dff12efd7362edf8fa23"
-    sha256 arm64_sonoma:  "d9028cedd1255cff9178ce3d999a32da15d56c297367c9f7c51d5f913bdfce1d"
-    sha256 tahoe:         "3c17a3059af9efd973bfa165ab137a6918df1e03de0bde427ef8d192064d5277"
-    sha256 sequoia:       "afc9e76b23fb712f8cec447fdf2d6e470e064cb0470d82a4b3eac6f367b84666"
-    sha256 sonoma:        "552d3ad743dbce80ef456f042c7d58297fa05a5e46e4cd2fe0bd2f3ef305cfb0"
-    sha256 arm64_linux:   "2f6ffdbeb1c72207efa2644c2ac26ac11f1ab8b514165cba67c9a89c48ba54cb"
-    sha256 x86_64_linux:  "6d8adc5a6ad3c7d0085c87892a2ffb571e71739d5199b87413bb4db046eed266"
+    rebuild 2
+    sha256 arm64_tahoe:   "659fe17ffa45737acf153b6baaf3fa735b346b8ee191610517d81bdd0b84ea48"
+    sha256 arm64_sequoia: "6891247b265604f1017acddf0d36a0a18ba8d22f94d152f87673a5a9d460ab62"
+    sha256 arm64_sonoma:  "be7efe29ac1d26f89c241a0161aefc145358cf9025076ad8536b07e310295631"
+    sha256 tahoe:         "ce0a418a6634e2754d1b2619b17e01cdd99b5396f5c3338350081b6ee2e98163"
+    sha256 sequoia:       "40f4b28fe9d1fb1da601046eade86ccd3eb6f59561f76d67dc19ac8c39e15057"
+    sha256 sonoma:        "431d539f4b4a6b5d16d115235cfde7cf6755e40cd0e7ea326630582983d88828"
+    sha256 arm64_linux:   "c510379d54acc30e2092c31ed1ba2bcd46ee037c1be182b2bdf512b22f31c2db"
+    sha256 x86_64_linux:  "8ec7b34517ec4c1210f6178cdbfa40e3f1e5d5780d7f26567593a07e425045ff"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/p/python@3.12.rb
+++ b/Formula/p/python@3.12.rb
@@ -386,6 +386,13 @@ class PythonAT312 < Formula
     INI
   end
 
+  def post_install
+    # Ensure the template venv activation scripts are writable
+    # to allow reinitializing an existing venv without throwing a permission error.
+    # See: https://github.com/python/cpython/issues/86079
+    chmod "u+w", lib_cellar.glob("venv/scripts/**/*").select(&:file?)
+  end
+
   def sitecustomize
     <<~PYTHON
       # This file is created by Homebrew and is executed on each python startup.

--- a/Formula/p/python@3.13.rb
+++ b/Formula/p/python@3.13.rb
@@ -372,6 +372,13 @@ class PythonAT313 < Formula
     INI
   end
 
+  def post_install
+    # Ensure the template venv activation scripts are writable
+    # to allow reinitializing an existing venv without throwing a permission error.
+    # See: https://github.com/python/cpython/issues/86079
+    chmod "u+w", lib_cellar.glob("venv/scripts/**/*").select(&:file?)
+  end
+
   def sitecustomize
     <<~PYTHON
       # This file is created by Homebrew and is executed on each python startup.

--- a/Formula/p/python@3.13.rb
+++ b/Formula/p/python@3.13.rb
@@ -13,14 +13,15 @@ class PythonAT313 < Formula
   end
 
   bottle do
-    sha256 arm64_tahoe:   "634ab0fde359d2cea955174c66bf0b0b32561ed4499fbfb74dd1cad1f19847b7"
-    sha256 arm64_sequoia: "6f56f878abb103a8c8ffcd074e3816ef17c270e1b2ef6250f2e6c8e5b0d491d4"
-    sha256 arm64_sonoma:  "a22858be64d0d0b674acde2ad23afb6f516642349fd19ec4d59ae8ae05296b86"
-    sha256 tahoe:         "83a4786a90e9e004133098753eeafbfb74cf84ca692c71030220ddb407e70cb7"
-    sha256 sequoia:       "9cec77b14a74df55c998750e9b51b9d9bd4ca4d6028cdf24c59b92d621c35b2a"
-    sha256 sonoma:        "daeddf034c0d0eacaf325d1c92cfb76cbeb10d9abf6e3ff76f01390286d3b2b1"
-    sha256 arm64_linux:   "f7ecaf8648f6a794c4c9ca8888390839d69c7f61d686712059851a8e9fec9cac"
-    sha256 x86_64_linux:  "b993e12ecc2a85c1251acb70f6f7d49ee132ca3d96374661503f1deabf385569"
+    rebuild 1
+    sha256 arm64_tahoe:   "a59256351f294c59ac6de0e1824a6039d79adf87c10540d513f0875c23f12f90"
+    sha256 arm64_sequoia: "4feda6a62aaf3e9000ba2aa159fbbe32b0d61a1a48d83a358073f163a4a25ed9"
+    sha256 arm64_sonoma:  "4e47c92010a9e7ba83b9fab769c2ab2492bc8227e5a030fb58aea8a82802fd43"
+    sha256 tahoe:         "c09048600cff8db6668cd5a35a93bee682b2b6106f54da3ebe6b867ff4e4b898"
+    sha256 sequoia:       "a3c2b5704ba0b7b71f635721bb5c9a5bb35e1ee3bfd5805153adf717c0ea695c"
+    sha256 sonoma:        "44ce8d044d47a66aa2bf08c6f7122b190ac85b9223658c8bc7aa8f2a034c9ffa"
+    sha256 arm64_linux:   "b42d053cf514d341c91c4baa1543196302f85e4d5b4dae301836bffe9b964fee"
+    sha256 x86_64_linux:  "b4861c2c34fd473c24ceb734862f5b1691b46dc866017ce0a9c5e431c03ead45"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/p/python@3.14.rb
+++ b/Formula/p/python@3.14.rb
@@ -389,6 +389,13 @@ class PythonAT314 < Formula
     INI
   end
 
+  def post_install
+    # Ensure the template venv activation scripts are writable
+    # to allow reinitializing an existing venv without throwing a permission error.
+    # See: https://github.com/python/cpython/issues/86079
+    chmod "u+w", lib_cellar.glob("venv/scripts/**/*").select(&:file?)
+  end
+
   def sitecustomize
     <<~PYTHON
       # This file is created by Homebrew and is executed on each python startup.

--- a/Formula/p/python@3.14.rb
+++ b/Formula/p/python@3.14.rb
@@ -12,14 +12,15 @@ class PythonAT314 < Formula
   end
 
   bottle do
-    sha256 arm64_tahoe:   "92810d5e3f7e47b9b49c1bca6fb4d9f3cefbb90c77669f4e6785d0babcc1c1b9"
-    sha256 arm64_sequoia: "76505a94aa16b62f002671c0a81c64b4704adcdf05411f3e0a386b3c8610c477"
-    sha256 arm64_sonoma:  "41f0fac6d489a149fd99687d96832a9b2b3948a1924140cec812a98752584109"
-    sha256 tahoe:         "82e86b7276eeaf4cf1f336d2732be2ab8915bb92b71ee63609b9cb3a022f9a93"
-    sha256 sequoia:       "7e04ab45b53a87720413627558e8c72ee44aa6991a300903b6b600a49b793c17"
-    sha256 sonoma:        "564b57b5759f74940b826353d37b9e0c0767ff0a663d321330a673e0138b136a"
-    sha256 arm64_linux:   "c7bc359fda22b9bd1083e2b23b2a0e5f235a7ee71aa02751d2d11287d423cd33"
-    sha256 x86_64_linux:  "4bdc2a2fda5f6c7c5307a3bb9d8d33d5fb79d5d1c72c79a7fb1b32a53e68bd1b"
+    rebuild 1
+    sha256 arm64_tahoe:   "c3246a28c51f4d6478ce24e908cf2c04c1460982f6a2b576b7173734fceb98eb"
+    sha256 arm64_sequoia: "40cd23ba68c55931f4acce01ccc78bf466fbe87ce34d7b0f15fcdad3782ea204"
+    sha256 arm64_sonoma:  "4b8fae8f32ecc41cf2432eda551e13f99f86aabe497bcda333a0848e0d00e782"
+    sha256 tahoe:         "f89646d22dce30d958bb6ce1deb107fab974b7b55d91fb23412766490dcd62b0"
+    sha256 sequoia:       "f019b78211cfbdbf5aa253934695f56859e751ab4d41299043ac3baef83d36ae"
+    sha256 sonoma:        "fd644cbb417a9475f8c1f4e9359d19361dc8c5df9ca960bb072b7f3825724c8e"
+    sha256 arm64_linux:   "0bea2cc8cca02a43fbdb830b5a40a7f764d89128de330c55072acf1dd146d5c3"
+    sha256 x86_64_linux:  "65459b177976d613314ccaa2ba4f16e9c119f901ed5cbd72172ffc1b6fef1745"
   end
 
   depends_on "pkgconf" => :build


### PR DESCRIPTION
Preserve write permissions in the [venv activation scripts](https://docs.python.org/3/library/venv.html#how-venvs-work) in the Python formulas (`python@3.14`, `python@3.13`, `python@3.12`, `python@3.11` and `python-freethreading`). This prevents errors when reinitializing an existing venv (e.g. running `python3 -m venv myenv` twice), as described in the upstream CPython issue: https://github.com/python/cpython/issues/86079.

In practice, the permissions of these template scripts are not actually changed in this PR; they are just excluded from automatic scrubbing of their writable bit, by adding a `skip_clean` annotation for their directory, which prevents Homebrew's [Cleaner::clean_dir](https://github.com/Homebrew/brew/blob/966384bd63031be492c30f4a2fa9c100101c65dc/Library/Homebrew/cleaner.rb#L132) method from setting them to be read-only — which is done to all non-executable files.

(These venv activation scripts are not executable because they're meant to be sourced, not executed, so they are treated as plain data files, lacking a shebang and the executable bit.)

See the first commit message (for `python@3.14`) for additional context and details.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

  AI (Claude Opus 4.6 via Kiro, GPT 5.4 via Copilot CLI) was used to research context, discuss the approach, and implement the first version of this change (which was based on `chmod`, similar to what was done in [PR #256454](https://github.com/Homebrew/homebrew-core/pull/256454)); later, I also used Opus 4.6 to troubleshoot a CI failure related to that first approach, and identify and implement the `skip_clean` approach instead.