### PR TITLE
fairy-stockfish: update to latest version and enable largeboards support

### DIFF
--- a/Formula/f/fairy-stockfish.rb
+++ b/Formula/f/fairy-stockfish.rb
@@ -16,14 +16,12 @@ class FairyStockfish < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "4ee205839b2f569fc11c0b2d09502a866be0cda2195f04a73cbc9329f2642ac9"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "36c6b1790bc144c874f7a1f737814c391380c47439b304c5c8e0ef368e773bc6"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "cbf99586202d3f28f7bfdf09830f620631030ae85276caf38d2b0d3246b22f9c"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "8d1e77f421472a96ed0281cf542c4c8d6edd58c181ddce745fc1901659e68593"
-    sha256 cellar: :any_skip_relocation, sonoma:        "ba82fe79eb4b379870174e79a83b61136a519b94419a471bcb6b20754d015d86"
-    sha256 cellar: :any_skip_relocation, ventura:       "c5ed0d702fac374bebd45b8a2a9e8074c887bda62e980f2528c5b35f94296650"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "04a1cdcecf55712d376a05918b2ec1423f3ac0f56eae9b6c8fcfe3a8687f3312"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "aba797d91cba8f0b56caf85f3d55e4c2fdf4a83bb1be0c11255fa580c320ed53"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "44c93f2b4f6e3b7ff1daa96bce98e9bc64b34c343921b6e145a23bf153131b2c"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "8b70af3b59355821eaf2ee870e0f962159bf599b8964c1ba965cc848c0cd9708"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "3523a6ba3cf152a83e798aeb19298fc8b59df95194441f8dba655d56264867c1"
+    sha256 cellar: :any_skip_relocation, sonoma:        "1943dab5d7ebe253c43cde8c33d5683a08619be682dedc41f6b4c107f0718c71"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "f4ffe9bc9209dbe890aac368fe2c74f7d6793ea9ece4ff6f837148dfc3405f8b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8316c36ce185f713c34e19e6da7c5d5033b4d7ffd4d850d6fad6e65b5d187683"
   end
 
   def install

--- a/Formula/f/fairy-stockfish.rb
+++ b/Formula/f/fairy-stockfish.rb
@@ -1,14 +1,18 @@
 class FairyStockfish < Formula
-  desc "Strong open source chess variant engine"
+  desc "Strong open source chess variant engine (with largeboards support)"
   homepage "https://fairy-stockfish.github.io/"
-  url "https://github.com/fairy-stockfish/Fairy-Stockfish/archive/refs/tags/fairy_sf_14.tar.gz"
-  sha256 "db5e96cf47faf4bfd4a500f58ae86e46fee92c2f5544e78750fc01ad098cbad2"
+  url "https://github.com/fairy-stockfish/Fairy-Stockfish/archive/refs/tags/fairy_sf_14_0_1_xq.tar.gz"
+  version "14.0.1"
+  sha256 "53914fc89d89afca7cfcfd20660ccdda125f1751f59a68b1f3ed1d4eb6cfe805"
   license "GPL-3.0-or-later"
   head "https://github.com/fairy-stockfish/Fairy-Stockfish.git", branch: "master"
 
   livecheck do
     url :stable
-    regex(/^fairy_sf[._-]v?(\d+(?:[._-]\d+)*)$/i)
+    regex(/^fairy_sf[._-]v?(\d+(?:[._-]\d+)*)(?:_xq)?$/i)
+    strategy :git do |tags, regex|
+      tags.filter_map { |tag| tag.match(regex)&.[](1)&.tr("_", ".") }
+    end
   end
 
   bottle do
@@ -45,7 +49,7 @@ class FairyStockfish < Formula
       "x86-64"
     end
 
-    system "make", "-C", "src", "build", "ARCH=#{arch}"
+    system "make", "-C", "src", "build", "ARCH=#{arch}", "largeboards=yes"
     bin.install "src/stockfish" => "fairy-stockfish"
   end
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

The upstream has released a new version ( https://github.com/fairy-stockfish/Fairy-Stockfish/releases ).  So this PR updates the formula accordingly. 

The upstream instruction ( https://github.com/fairy-stockfish/Fairy-Stockfish/wiki/Compiling-Fairy-Stockfish ) says, 

Quote:  

```
In order to compile the version for large-board variants (>8x8 board) just add largeboards=yes to your normal make command, e.g., use make build ARCH=x86-64 largeboards=yes instead of make build ARCH=x86-64. It is required to do a make clean before compiling the large-board version in order to avoid mixing up object files of both versions.
```

So this PR updates the make command accordingly.