### PR TITLE
vcflib 1.0.15 (new formula)

### DIFF
--- a/Formula/v/vcflib.rb
+++ b/Formula/v/vcflib.rb
@@ -1,0 +1,39 @@
+class Vcflib < Formula
+  desc "C++ library and cmdline tools for parsing and manipulating VCF files"
+  homepage "https://github.com/vcflib/vcflib"
+  url "https://github.com/vcflib/vcflib/releases/download/v1.0.15/vcflib-1.0.15-src.tar.gz"
+  sha256 "178e8c27fffc5324ac73f1c4b35f407184271b57f82aedc2efb9703df6ee3d49"
+  license "MIT"
+
+  depends_on "cmake" => :build
+  depends_on "pkgconf" => :build
+  depends_on "pybind11" => :build
+  depends_on "python@3.14" => [:build, :test]
+  depends_on "htslib"
+  depends_on "wfa2-lib"
+  depends_on "xz"
+
+  uses_from_macos "bzip2"
+  uses_from_macos "zlib"
+
+  on_macos do
+    depends_on "libomp"
+  end
+
+  def install
+    args = ["-DZIG=OFF"]
+    args << "-DCMAKE_INSTALL_RPATH=#{rpath}" if OS.mac?
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/vcfcheck --version")
+
+    assert_match "fileformat=VCF", shell_output("#{bin}/vcfrandom")
+
+    ENV["PYTHONPATH"] = lib
+    system "python3.14", "-c", "import pyvcflib"
+  end
+end

--- a/Formula/v/vcflib.rb
+++ b/Formula/v/vcflib.rb
@@ -5,6 +5,15 @@ class Vcflib < Formula
   sha256 "178e8c27fffc5324ac73f1c4b35f407184271b57f82aedc2efb9703df6ee3d49"
   license "MIT"
 
+  bottle do
+    sha256 cellar: :any,                 arm64_tahoe:   "dae474cbc0c7e6df472e8a8b7d903fcc326706e985391a533a92eecdcab56dc5"
+    sha256 cellar: :any,                 arm64_sequoia: "ef9292a2426c8dde700d72dbef0a8c90b64aca16e13408dcebff8153381563f7"
+    sha256 cellar: :any,                 arm64_sonoma:  "f20a7074ff10f55f5f61b7c1c7664c695716ab9e423580b0ec58c9b909c88408"
+    sha256 cellar: :any,                 sonoma:        "3e65b889529b3887e5ee65f67aca8cf7321bd151635af66767f0a1eb2a9ff009"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "593cc2e3478b480c04250f7396747e8d4a3e3dff01ac220a592b6cf3d4aaa03b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b270eec4b3a5cecdcef38f0f2fd32bf813d46753eeacbbb5471688b3855645e4"
+  end
+
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
   depends_on "pybind11" => :build


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Notes

- Uses `-DZIG=OFF`, but also works with `zig@0.15`. From what I can tell, it's only used in a single executable (`vcfcreatemulti`) and there's a C++ version of the function if it's disabled ([relevant code](https://github.com/search?q=repo%3Avcflib%2Fvcflib%20NO_ZIG&type=code)).
- `pybind11` is needed to build (otherwise, it fails with `Unknown CMake command "pybind11_add_module"`).