### PR TITLE
periphery: ensure that CLT `libIndexStore` can be found

### DIFF
--- a/Formula/p/periphery.rb
+++ b/Formula/p/periphery.rb
@@ -8,11 +8,10 @@ class Periphery < Formula
   head "https://github.com/peripheryapp/periphery.git", branch: "master"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "3e1c491a5c1dc82e247ca241433a5e06e9102d5b990dd990041bf6a8bb14e0ea"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "a795a73bb0537e622e971e79eeeb1e15376961c726ef252a8a2315a51f697aad"
-    sha256                               arm64_linux:   "b987c8031b3d4fdb652cd846eff55a3c4414995b64f4a87afc9651ea44fc9f21"
-    sha256                               x86_64_linux:  "703779b1a182165b076a38704fc21045826d6f091f703c9681c9229275b33e35"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "1b8a3b74aa0c3f8c01aa5f9d479391017072d01f019c336d8e835b52dad47c68"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "0a1dc3ad761d6dd38204a9ca8cd513fd77f580dd47150c159691fbf842b71a97"
+    sha256                               arm64_linux:   "092a72a761a35ab7d3c14b7a08f673579695ef6c4e883b1c745dc4fe87e34919"
+    sha256                               x86_64_linux:  "24907907f0325d589e4ce5963553fc243b59a551d350c0deb994e100f36d34b6"
   end
 
   # We need the CLT installed for libIndexStore.dylib.

--- a/Formula/p/periphery.rb
+++ b/Formula/p/periphery.rb
@@ -4,6 +4,7 @@ class Periphery < Formula
   url "https://github.com/peripheryapp/periphery/archive/refs/tags/3.7.4.tar.gz"
   sha256 "6e3eb93904d4ea3ba346526b3e7dd90d0d258d4eff91977b859b91115f028711"
   license "MIT"
+  revision 1
   head "https://github.com/peripheryapp/periphery.git", branch: "master"
 
   bottle do
@@ -14,15 +15,24 @@ class Periphery < Formula
     sha256                               x86_64_linux:  "703779b1a182165b076a38704fc21045826d6f091f703c9681c9229275b33e35"
   end
 
+  # We need the CLT installed for libIndexStore.dylib.
+  pour_bottle? only_if: :clt_installed
+
   depends_on xcode: ["16.4", :build]
 
   uses_from_macos "curl"
   uses_from_macos "libxml2"
   uses_from_macos "swift"
 
+  def clt_lib_directory
+    on_macos do
+      "#{MacOS::CLT::PKG_PATH}/usr/lib"
+    end
+  end
+
   def install
     args = if OS.mac?
-      ["--disable-sandbox"]
+      ["--disable-sandbox", "-Xlinker", "-rpath", "-Xlinker", clt_lib_directory]
     else
       swift_cellar_libexec_lib = Formula["swift"].libexec/"lib"
 
@@ -41,5 +51,9 @@ class Periphery < Formula
     manifest = shell_output "swift package --disable-sandbox describe --type json"
     File.write "manifest.json", manifest
     system bin/"periphery", "scan", "--strict", "--skip-build", "--json-package-manifest-path", "manifest.json"
+
+    return unless OS.mac?
+
+    assert_includes (bin/"periphery").rpaths, clt_lib_directory
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Fixes #279809.
