### PR TITLE
tinyxml: drop disable! still needed for Gazebo Citadel builds

### DIFF
--- a/Formula/t/tinyxml.rb
+++ b/Formula/t/tinyxml.rb
@@ -20,9 +20,6 @@ class Tinyxml < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "ade5525899de7063ade79d1b0dec70ceef3d0acc08e1dc1b55e937cb539ad38d"
   end
 
-  # sourceforge recommends tinyxml2 as an alternative
-  disable! date: "2025-06-03", because: :deprecated_upstream
-
   depends_on "cmake" => :build
 
   # The first two patches are taken from the debian packaging of tinyxml.

--- a/Formula/t/tinyxml.rb
+++ b/Formula/t/tinyxml.rb
@@ -20,7 +20,6 @@ class Tinyxml < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "ade5525899de7063ade79d1b0dec70ceef3d0acc08e1dc1b55e937cb539ad38d"
   end
 
-
   depends_on "cmake" => :build
 
   # The first two patches are taken from the debian packaging of tinyxml.

--- a/Formula/t/tinyxml.rb
+++ b/Formula/t/tinyxml.rb
@@ -20,8 +20,6 @@ class Tinyxml < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "ade5525899de7063ade79d1b0dec70ceef3d0acc08e1dc1b55e937cb539ad38d"
   end
 
-  # sourceforge recommends tinyxml2 as an alternative
-  disable! date: "2025-06-03", because: :deprecated_upstream
 
   depends_on "cmake" => :build
 


### PR DESCRIPTION
Addition comment:

This tinyxml is needed for classic gazebo to run on mac. See here: https://github.com/Kakcalu13/mac-gazebodistro/issues/1

Even if it's unmaintained for a while, it's still needed for legacy and classic. Please reconsider to put it back on. 

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?

I don't want to uninstall tinyxml. It's disabled, apparently. I installed it pre-2025. It is disabled for others. 

- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
This is not related to remove `disabled`.

- [x ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
<img width="767" height="736" alt="image" src="https://github.com/user-attachments/assets/e63544f0-dffb-4d28-8d7e-339f08b1b45c" />

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----