### PR TITLE
hyphy 2.5.98 (new formula)

### DIFF
--- a/Formula/h/hyphy.rb
+++ b/Formula/h/hyphy.rb
@@ -1,0 +1,33 @@
+class Hyphy < Formula
+  desc "Hypothesis testing using Phylogenies"
+  homepage "https://www.hyphy.org"
+  url "https://github.com/veg/hyphy/archive/refs/tags/2.5.98.tar.gz"
+  sha256 "a2910238d1c641bed66cce409cec3f0a0488038e9f8a61a86c665dc30244f41a"
+  license "MIT"
+
+  depends_on "cmake" => :build
+
+  uses_from_macos "curl"
+
+  on_macos do
+    depends_on "libomp"
+  end
+
+  on_linux do
+    depends_on "zlib-ng-compat"
+  end
+
+  def install
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/hyphy --version")
+
+    cp pkgshare/"data/p51.nex", testpath
+    system bin/"hyphy", "slac", "--alignment", "p51.nex"
+    assert_path_exists "p51.nex.SLAC.json"
+  end
+end

--- a/Formula/h/hyphy.rb
+++ b/Formula/h/hyphy.rb
@@ -5,6 +5,15 @@ class Hyphy < Formula
   sha256 "a2910238d1c641bed66cce409cec3f0a0488038e9f8a61a86c665dc30244f41a"
   license "MIT"
 
+  bottle do
+    sha256 arm64_tahoe:   "ea9c9802fd2f640ddccc49aaa8c34eb2e33c8943117b90a75124190ead4b5b68"
+    sha256 arm64_sequoia: "cd6d6993865411aefd931a0b272f2765533b4d78eecfb71477e0d5817c583e55"
+    sha256 arm64_sonoma:  "7aa8c2f1836df5431660e2226e9a56ff327b93dd72810b9d222af9fdd94404a7"
+    sha256 sonoma:        "4c361c282a335e34224a8d6518c89b33098513459f64b2ae49bb5354e6c113ea"
+    sha256 arm64_linux:   "ca96b6e6edf86efbd0feb77698639cdcc864a516c88a8621fa319a4b37382523"
+    sha256 x86_64_linux:  "13a6735d628c69591407d7ffacb6d3dae990ca5b6acdd2ac6e3e856dd0a87063"
+  end
+
   depends_on "cmake" => :build
 
   uses_from_macos "curl"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Notes

- I initially tried `uses_from_macos "zlib"`, but this causes `brew linkage hyphy` to fail on Linux (output below).

```text
System libraries:
  /lib/aarch64-linux-gnu/ld-linux-aarch64.so.1
  /lib/aarch64-linux-gnu/libc.so.6
  /lib/aarch64-linux-gnu/libgcc_s.so.1
  /lib/aarch64-linux-gnu/libgomp.so.1
  /lib/aarch64-linux-gnu/libm.so.6
  /lib/aarch64-linux-gnu/libstdc++.so.6
Homebrew libraries:
  /home/linuxbrew/.linuxbrew/opt/curl/lib/libcurl.so.4 (curl)
  /home/linuxbrew/.linuxbrew/opt/zlib-ng-compat/lib/libz.so.1 (zlib-ng-compat)
Indirect dependencies with linkage:
  zlib-ng-compat
Dependencies with no linkage:
  zlib
```