### PR TITLE
jira-commands: add formula

### DIFF
--- a/Formula/j/jira-commands.rb
+++ b/Formula/j/jira-commands.rb
@@ -1,0 +1,20 @@
+class JiraCommands < Formula
+  desc "Fast terminal client for Atlassian Jira"
+  homepage "https://github.com/mulhamna/jira-commands"
+  url "https://github.com/mulhamna/jira-commands/archive/refs/tags/v0.27.1.tar.gz"
+  sha256 "f32ca1a21c21294f465d4dbca9e41df897d8ab3225e5c52c08f603e05b5ef5b9"
+  license any_of: ["MIT", "Apache-2.0"]
+  head "https://github.com/mulhamna/jira-commands.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", "--bin", "jirac", *std_cargo_args(path: "crates/jira")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/jirac --version")
+    output = shell_output("#{bin}/jirac tui --help")
+    assert_match "Jira", output
+  end
+end


### PR DESCRIPTION
## Summary
- add a new `jira-commands` formula for `jirac`, a Rust-based Jira CLI
- build from the upstream source release tarball with no runtime dependencies
- package the primary end-user CLI first and keep the initial formula scope small

## Why this is useful
`jirac` fills a real gap among Jira CLIs already used by terminal-heavy developers:
- interactive TUI for browsing and managing issues
- runtime custom-field discovery, so less brittle config across Jira instances
- support for Jira Cloud and Jira Data Center
- bulk operations, worklogs, attachments, and raw API access in one binary
- cross-platform single-binary distribution model

Even though the project is still earlier in adoption than some older Jira tools, the feature set and packaging quality are already strong, and this PR is intentionally scoped to the main CLI only to make review easier.

## Testing
- `cargo check --offline -p jira-commands`
- source tarball sha256 verified for `v0.27.1`
- Homebrew `brew audit` / `brew test` not run in this environment
