### PR TITLE
neofetch: re-enable with maintained upstream (7.6.0)

### DIFF
--- a/Formula/n/neofetch.rb
+++ b/Formula/n/neofetch.rb
@@ -1,18 +1,15 @@
 class Neofetch < Formula
   desc "Fast, highly customisable system info script"
-  homepage "https://github.com/dylanaraps/neofetch"
-  url "https://github.com/dylanaraps/neofetch/archive/refs/tags/7.1.0.tar.gz"
-  sha256 "58a95e6b714e41efc804eca389a223309169b2def35e57fa934482a6b47c27e7"
+  homepage "https://github.com/suparious/neofetch"
+  url "https://github.com/suparious/neofetch/archive/refs/tags/7.6.0.tar.gz"
+  sha256 "71ffa7f22dbde250f3eeae89728cb70f65e8d1915e9afb1042d78980760e7625"
   license "MIT"
-  head "https://github.com/dylanaraps/neofetch.git", branch: "master"
+  head "https://github.com/suparious/neofetch.git", branch: "master"
 
   bottle do
     rebuild 4
     sha256 cellar: :any_skip_relocation, all: "1382d315f586920f24251b6cd7a79b1c940634d073b42c72007ed87a796d1efc"
   end
-
-  deprecate! date: "2024-05-04", because: :repo_archived
-  disable! date: "2025-05-05", because: :repo_archived
 
   on_macos do
     depends_on "screenresolution"


### PR DESCRIPTION
Switch homepage, url, and head to the actively maintained fork at suparious/neofetch (v7.6.0). Removes deprecate!/disable! since the upstream is no longer archived.

The fork integrates 160+ community PRs, adds 32 new distros, and continues active development. The original dylanaraps/neofetch was archived in April 2024.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
