### PR TITLE
vapoursynth 75

### DIFF
--- a/Formula/a/av1an.rb
+++ b/Formula/a/av1an.rb
@@ -4,6 +4,7 @@ class Av1an < Formula
   url "https://github.com/rust-av/Av1an/archive/refs/tags/v0.5.2.tar.gz"
   sha256 "58eba4215ffaf07a58065e78fb4aec8df9ebda48e9d996621d559f3024b3538b"
   license "GPL-3.0-only"
+  revision 1
   head "https://github.com/rust-av/Av1an.git", branch: "master"
 
   # Differentiate v-prefixed tags from old version schemes
@@ -31,6 +32,11 @@ class Av1an < Formula
   def install
     ENV["VERGEN_GIT_COMMIT_DATE"] = time.iso8601
     ENV["VERGEN_GIT_SHA"] = tap.user
+
+    # TODO: remove on next release
+    # Add support for vapoursynth R75 see: https://github.com/rust-av/Av1an/commit/17298da4fa337960cdf14b7869f513f8ab906896
+    system "cargo", "update", "-p", "vapoursynth", "--precise", "0.5.6" unless head?
+
     system "cargo", "install", *std_cargo_args(path: "av1an")
 
     generate_completions_from_executable(bin/"av1an", "--completions", shells: [:bash, :zsh, :fish, :pwsh])

--- a/Formula/m/mpv.rb
+++ b/Formula/m/mpv.rb
@@ -1,12 +1,21 @@
 class Mpv < Formula
   desc "Media player based on MPlayer and mplayer2"
   homepage "https://mpv.io"
-  url "https://github.com/mpv-player/mpv/archive/refs/tags/v0.41.0.tar.gz"
-  sha256 "ee21092a5ee427353392360929dc64645c54479aefdb5babc5cfbb5fad626209"
   license all_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later"]
-  revision 4
+  revision 5
   compatibility_version 1
   head "https://github.com/mpv-player/mpv.git", branch: "master"
+
+  stable do
+    url "https://github.com/mpv-player/mpv/archive/refs/tags/v0.41.0.tar.gz"
+    sha256 "ee21092a5ee427353392360929dc64645c54479aefdb5babc5cfbb5fad626209"
+    # Add support for Vapoursynth R74+
+    # TODO: Remove when the next mpv release includes this patch
+    patch do
+      url "https://github.com/mpv-player/mpv/commit/75b2ccfeb1ce4ed5a40ac9860fa74f3d1265e13f.patch?full_index=1"
+      sha256 "3906b98b02071a0d5747a400406494ca69cef7afd8d3eee4a99fdbe40dc90c1f"
+    end
+  end
 
   bottle do
     sha256               arm64_tahoe:   "d82d7d7bd6619371bd9fb273c8387c7c7bb34e3e37bc8b6bb68e0622bde55bcd"
@@ -63,6 +72,13 @@ class Mpv < Formula
 
   conflicts_with cask: "stolendata-mpv", because: "both install `mpv` binaries"
 
+  def python3
+    Formula["vapoursynth"].deps
+                          .find { |d| d.name.match?(/^python@\d+\.\d+$/) }
+                          .to_formula
+                          .opt_libexec/"bin/python"
+  end
+
   def install
     # LANG is unset by default on macOS and causes issues when calling getlocale
     # or getdefaultlocale in docutils. Force the default c/posix locale since
@@ -71,6 +87,10 @@ class Mpv < Formula
 
     # force meson find ninja from homebrew
     ENV["NINJA"] = which("ninja")
+
+    vapoursynth = Formula["vapoursynth"]
+    vapoursynth_site_packages = vapoursynth.opt_libexec.realpath/Language::Python.site_packages(python3)/"vapoursynth"
+    ENV.append "LDFLAGS", "-Wl,-rpath,#{vapoursynth_site_packages}"
 
     # libarchive is keg-only
     ENV.prepend_path "PKG_CONFIG_PATH", Formula["libarchive"].opt_lib/"pkgconfig" if OS.mac?
@@ -116,7 +136,12 @@ class Mpv < Formula
   end
 
   test do
-    system bin/"mpv", "--ao=null", "--vo=null", test_fixtures("test.wav")
+    (testpath/"test.vpy").write <<~PY
+      import vapoursynth as vs
+      core = vs.core
+      core.std.FlipVertical(video_in).set_output()
+    PY
+    system bin/"mpv", "--ao=null", "--vo=null", "--vf=vapoursynth=file=./test.vpy", test_fixtures("test.gif")
     assert_match "vapoursynth", shell_output("#{bin}/mpv --vf=help")
 
     # Make sure `pkgconf` can parse `mpv.pc` after the `inreplace`.

--- a/Formula/v/vapoursynth-bestsource.rb
+++ b/Formula/v/vapoursynth-bestsource.rb
@@ -5,6 +5,7 @@ class VapoursynthBestsource < Formula
       tag:      "R17",
       revision: "b026135190bdee175417310fa783e8383077193f"
   license "MIT"
+  revision 1
   head "https://github.com/vapoursynth/bestsource.git", branch: "master"
 
   livecheck do
@@ -28,24 +29,29 @@ class VapoursynthBestsource < Formula
   depends_on "vapoursynth"
   depends_on "xxhash"
 
-  def install
-    # Upstream build system wants to install directly into vapoursynth's libdir and does not respect
-    # prefix, but we want it in a Cellar location instead.
-    inreplace "meson.build" do |s|
-      s.gsub!("py.get_install_dir() / 'vapoursynth/plugins'", "get_option('libdir') / 'vapoursynth'")
-      s.gsub!("-march=x86-64-v2", "-msse4.1")
-    end
+  def python3
+    Formula["vapoursynth"].deps
+                          .find { |d| d.name.match?(/^python@\d\.\d+$/) }
+                          .to_formula
+                          .opt_libexec/"bin/python"
+  end
 
-    system "meson", "setup", "build", *std_meson_args
+  def install
+    inreplace "meson.build", "-march=x86-64-v2", "-msse4.1" if Hardware::CPU.intel?
+
+    site_packages = Language::Python.site_packages(python3)
+
+    args = %W[
+      -Dpython.platlibdir=#{site_packages}
+      -Dpython.purelibdir=#{site_packages}
+    ]
+
+    system "meson", "setup", "build", *args, *std_meson_args
     system "meson", "compile", "-C", "build", "--verbose"
     system "meson", "install", "-C", "build"
   end
 
   test do
-    python = Formula["vapoursynth"].deps
-                                   .find { |d| d.name.match?(/^python@\d\.\d+$/) }
-                                   .to_formula
-                                   .opt_libexec/"bin/python"
-    system python, "-c", "from vapoursynth import core; core.bs"
+    system python3, "-c", "from vapoursynth import core; core.bs"
   end
 end

--- a/Formula/v/vapoursynth-bm3d.rb
+++ b/Formula/v/vapoursynth-bm3d.rb
@@ -4,6 +4,7 @@ class VapoursynthBm3d < Formula
   url "https://github.com/HomeOfVapourSynthEvolution/VapourSynth-BM3D/archive/refs/tags/r10.tar.gz"
   sha256 "3582f8c0aa00c710b4d4d484da2716207f2e1f305124a9c365fc7530461c25f3"
   license "MIT"
+  revision 1
   head "https://github.com/HomeOfVapourSynthEvolution/VapourSynth-BM3D.git", branch: "master"
 
   bottle do
@@ -21,25 +22,34 @@ class VapoursynthBm3d < Formula
   depends_on "fftw"
   depends_on "vapoursynth"
 
+  def python3
+    Formula["vapoursynth"].deps
+                          .find { |d| d.name.match?(/^python@\d\.\d+$/) }
+                          .to_formula
+                          .opt_libexec/"bin/python"
+  end
+
   def install
     # Upstream build system wants to install directly into vapoursynth's libdir and does not respect
     # prefix, but we want it in a Cellar location instead.
     inreplace "meson.build" do |s|
       s.gsub!(/^incdir = include_directories\(.*?^\)/m,
-              "incdir = include_directories('#{Formula["vapoursynth"].opt_include}/vapoursynth', 'include')")
-      s.gsub! "install_dir: py.get_install_dir() / 'vapoursynth/plugins'", "install_dir: '#{lib}/vapoursynth'"
+              "incdir = include_directories('#{Formula["vapoursynth"].opt_include}', 'include')")
     end
 
-    system "meson", "setup", "build", *std_meson_args
+    site_packages = Language::Python.site_packages(python3)
+
+    args = %W[
+      -Dpython.platlibdir=#{site_packages}
+      -Dpython.purelibdir=#{site_packages}
+    ]
+
+    system "meson", "setup", "build", *args, *std_meson_args
     system "meson", "compile", "-C", "build", "--verbose"
     system "meson", "install", "-C", "build"
   end
 
   test do
-    python = Formula["vapoursynth"].deps
-                                   .find { |d| d.name.match?(/^python@\d\.\d+$/) }
-                                   .to_formula
-                                   .opt_libexec/"bin/python"
-    system python, "-c", "from vapoursynth import core; core.bm3d"
+    system python3, "-c", "from vapoursynth import core; core.bm3d"
   end
 end

--- a/Formula/v/vapoursynth-descale.rb
+++ b/Formula/v/vapoursynth-descale.rb
@@ -4,6 +4,7 @@ class VapoursynthDescale < Formula
   url "https://github.com/Irrational-Encoding-Wizardry/descale/archive/refs/tags/r8.tar.gz"
   sha256 "317d955cc2dfbc3fd1aecef2ea2d56e4f1cd99434492d71c6a1d48213ff35972"
   license "MIT"
+  revision 1
   head "https://github.com/Irrational-Encoding-Wizardry/descale.git", branch: "master"
 
   bottle do
@@ -20,12 +21,22 @@ class VapoursynthDescale < Formula
   depends_on "pkgconf" => :build
   depends_on "vapoursynth"
 
+  def python3
+    Formula["vapoursynth"].deps
+                          .find { |d| d.name.match?(/^python@\d\.\d+$/) }
+                          .to_formula
+                          .opt_libexec/"bin/python"
+  end
+
   def install
     # Upstream build system wants to install directly into vapoursynth's libdir and does not respect
     # prefix, but we want it in a Cellar location instead.
     inreplace "meson.build",
               "installdir = join_paths(vs.get_pkgconfig_variable('libdir'), 'vapoursynth')",
-              "installdir = '#{lib}/vapoursynth'"
+              "installdir = '#{Language::Python.site_packages(python3)}/vapoursynth/plugins'"
+
+    # Newer versions of VapourSynth have a different include path
+    inreplace "src/vsplugin.c", "<vapoursynth/", "<"
 
     system "meson", "setup", "build", *std_meson_args
     system "meson", "compile", "-C", "build", "--verbose"
@@ -33,10 +44,6 @@ class VapoursynthDescale < Formula
   end
 
   test do
-    python = Formula["vapoursynth"].deps
-                                   .find { |d| d.name.match?(/^python@\d\.\d+$/) }
-                                   .to_formula
-                                   .opt_libexec/"bin/python"
-    system python, "-c", "from vapoursynth import core; core.descale"
+    system python3, "-c", "from vapoursynth import core; core.descale"
   end
 end

--- a/Formula/v/vapoursynth-imwri.rb
+++ b/Formula/v/vapoursynth-imwri.rb
@@ -18,6 +18,11 @@ class VapoursynthImwri < Formula
     sha256               x86_64_linux:  "21b4c595a5528b6d61eaba2d223e2f51bdf2b69ff50d623a915fc55a98263513"
   end
 
+  # repository was archived by the owner on Apr 9, 2026
+  # Partly replaced by vapoursynth-bestsource
+  deprecate! date: "2025-04-09", because: :repo_archived
+  disable! date: "2025-04-09", because: :repo_archived
+
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkgconf" => :build

--- a/Formula/v/vapoursynth-ocr.rb
+++ b/Formula/v/vapoursynth-ocr.rb
@@ -4,6 +4,7 @@ class VapoursynthOcr < Formula
   url "https://github.com/vapoursynth/vs-ocr/archive/refs/tags/R3.tar.gz"
   sha256 "e9da11b7f5f3e4acfee5890729769217aa5b385bb573cb303c2661d8d8a83712"
   license "MIT"
+  revision 1
   version_scheme 1
   head "https://github.com/vapoursynth/vs-ocr.git", branch: "master"
 
@@ -25,12 +26,19 @@ class VapoursynthOcr < Formula
   depends_on "tesseract"
   depends_on "vapoursynth"
 
+  def python3
+    Formula["vapoursynth"].deps
+                          .find { |d| d.name.match?(/^python@\d\.\d+$/) }
+                          .to_formula
+                          .opt_libexec/"bin/python"
+  end
+
   def install
     # Upstream build system wants to install directly into vapoursynth's libdir and does not respect
     # prefix, but we want it in a Cellar location instead.
     inreplace "meson.build",
               "install_dir : join_paths(vapoursynth_dep.get_pkgconfig_variable('libdir'), 'vapoursynth')",
-              "install_dir : '#{lib}/vapoursynth'"
+              "install_dir : '#{Language::Python.site_packages(python3)}/vapoursynth/plugins'"
 
     system "meson", "setup", "build", *std_meson_args
     system "meson", "compile", "-C", "build", "--verbose"
@@ -38,10 +46,6 @@ class VapoursynthOcr < Formula
   end
 
   test do
-    python = Formula["vapoursynth"].deps
-                                   .find { |d| d.name.match?(/^python@\d\.\d+$/) }
-                                   .to_formula
-                                   .opt_libexec/"bin/python"
-    system python, "-c", "from vapoursynth import core; core.ocr"
+    system python3, "-c", "from vapoursynth import core; core.ocr"
   end
 end

--- a/Formula/v/vapoursynth-sub.rb
+++ b/Formula/v/vapoursynth-sub.rb
@@ -4,6 +4,7 @@ class VapoursynthSub < Formula
   url "https://github.com/vapoursynth/subtext/archive/refs/tags/R6.tar.gz"
   sha256 "536e2f056c7b318b0104b8b9050bb17c00d8ca60b0e5fdecf1ee92879c5f9165"
   license "MIT"
+  revision 1
   version_scheme 1
   head "https://github.com/vapoursynth/subtext.git", branch: "master"
 
@@ -23,25 +24,27 @@ class VapoursynthSub < Formula
   depends_on "libass"
   depends_on "vapoursynth"
 
-  def install
-    # Upstream build system wants to install directly into vapoursynth's libdir and does not respect
-    # prefix, but we want it in a Cellar location instead.
-    inreplace "meson.build" do |s|
-      s.gsub!(/^incdir = include_directories\(.*?^\)/m,
-              "incdir = include_directories('#{Formula["vapoursynth"].opt_include}/vapoursynth')")
-      s.gsub! "install_dir: py.get_install_dir() / 'vapoursynth/plugins'", "install_dir: '#{lib}/vapoursynth'"
-    end
+  def python3
+    Formula["vapoursynth"].deps
+                          .find { |d| d.name.match?(/^python@\d\.\d+$/) }
+                          .to_formula
+                          .opt_libexec/"bin/python"
+  end
 
-    system "meson", "setup", "build", *std_meson_args
+  def install
+    site_packages = Language::Python.site_packages(python3)
+
+    args = %W[
+      -Dpython.platlibdir=#{site_packages}
+      -Dpython.purelibdir=#{site_packages}
+    ]
+
+    system "meson", "setup", "build", *args, *std_meson_args
     system "meson", "compile", "-C", "build", "--verbose"
     system "meson", "install", "-C", "build"
   end
 
   test do
-    python = Formula["vapoursynth"].deps
-                                   .find { |d| d.name.match?(/^python@\d\.\d+$/) }
-                                   .to_formula
-                                   .opt_libexec/"bin/python"
-    system python, "-c", "from vapoursynth import core; core.sub"
+    system python3, "-c", "from vapoursynth import core; core.sub"
   end
 end

--- a/Formula/v/vapoursynth.rb
+++ b/Formula/v/vapoursynth.rb
@@ -1,10 +1,12 @@
 class Vapoursynth < Formula
+  include Language::Python::Virtualenv
+
   desc "Video processing framework with simplicity in mind"
   homepage "https://www.vapoursynth.com"
-  url "https://github.com/vapoursynth/vapoursynth/archive/refs/tags/R73.tar.gz"
-  sha256 "1bb8ffe31348eaf46d8f541b138f0136d10edaef0c130c1e5a13aa4a4b057280"
+  url "https://github.com/vapoursynth/vapoursynth/archive/refs/tags/R75.tar.gz"
+  sha256 "a1f71019de7f5c252c309e134f245bf49d64038b1f4e1df7f4dfb1e1ed290526"
   license "LGPL-2.1-or-later"
-  compatibility_version 1
+  compatibility_version 2
   head "https://github.com/vapoursynth/vapoursynth.git", branch: "master"
 
   livecheck do
@@ -23,10 +25,15 @@ class Vapoursynth < Formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
+  depends_on "cmake" => :build
   depends_on "cython" => :build
   depends_on "libtool" => :build
+  depends_on "meson" => :build
   depends_on "nasm" => :build
+  depends_on "ninja" => :build
   depends_on "pkgconf" => :build
+  depends_on "python-build" => :build
+  depends_on "python-packaging" => :build
   depends_on "python@3.14"
   depends_on "zimg"
 
@@ -38,18 +45,40 @@ class Vapoursynth < Formula
     fails_with :clang
   end
 
-  def install
-    ENV.prepend "LDFLAGS", "-L#{Formula["llvm"].opt_lib}/c++" if OS.mac? && MacOS.version <= :ventura
+  def python3
+    Formula["python@3.14"].opt_bin/"python3.14"
+  end
 
-    system "./autogen.sh"
-    inreplace "Makefile.in", "pkglibdir = $(libdir)", "pkglibdir = $(exec_prefix)"
-    system "./configure", "--disable-silent-rules",
-                          "--with-cython=#{Formula["cython"].bin}/cython",
-                          "--with-plugindir=#{HOMEBREW_PREFIX}/lib/vapoursynth",
-                          "--with-python_prefix=#{prefix}",
-                          "--with-python_exec_prefix=#{prefix}",
-                          *std_configure_args
-    system "make", "install"
+  def install
+    inreplace "meson.build" do |s|
+      s.gsub! "static: true", "static: false"
+      s.gsub! "avx2_args = '-march=x86-64-v3'", "avx2_args = ['-mavx2', '-mfma']" if Hardware::CPU.intel?
+    end
+
+    venv = virtualenv_create(libexec, python3)
+
+    args = %W[
+      -Dpython.platlibdir=#{venv.site_packages}
+      -Dpython.purelibdir=#{venv.site_packages}
+    ]
+
+    system "meson", "setup", "build", *args, *std_meson_args
+    system "meson", "compile", "-C", "build", "--verbose"
+    system "meson", "install", "-C", "build"
+
+    venv.pip_install_and_link(buildpath)
+
+    vs = venv.site_packages/"vapoursynth"
+
+    vs.install_symlink Language::Python.homebrew_site_packages(python3)/"vapoursynth/plugins"
+
+    lib.install_symlink vs.glob(shared_library("*"))
+
+    include.install_symlink (vs/"include").children
+
+    (share/"pkgconfig").install_symlink (vs/"pkgconfig").children
+
+    (prefix/Language::Python.site_packages(python3)/"homebrew-vapoursynth.pth").write venv.site_packages
   end
 
   def caveats
@@ -59,11 +88,11 @@ class Vapoursynth < Formula
         brew install vapoursynth-sub
       To use vapoursynth.core.ocr, execute:
         brew install vapoursynth-ocr
-      To use vapoursynth.core.imwri, execute:
-        brew install vapoursynth-imwri
+      To use vapoursynth.core.bs, execute:
+        brew install vapoursynth-bestsource
       To use vapoursynth.core.ffms2, execute the following:
         brew install ffms2
-        ln -s "../libffms2.dylib" "#{HOMEBREW_PREFIX}/lib/vapoursynth/#{shared_library("libffms2")}"
+        ln -s "../../../../libffms2.dylib" "#{Language::Python.homebrew_site_packages(python3)/"vapoursynth/plugins"}/#{shared_library("libffms2")}"
       For more information regarding plugins, please visit:
         http://www.vapoursynth.com/doc/plugins.html
     EOS


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

## Planned commits
- `vapoursynth 75`
- `vapoursynth-bestsource: update formula`
- `vapoursynth-bm3d: update formula`
- `vapoursynth-descale: update formula`
- `vapoursynth-imwri: update formula`
- `vapoursynth-ocr: update formula`
- `vapoursynth-sub: update formula`
## Validation summary
- `vapoursynth`: style: pass, test: pass, audit: pass
- `vapoursynth-bestsource`: style: pass, test: pass, audit: pass
- `vapoursynth-bm3d`: style: pass, test: pass, audit: pass
- `vapoursynth-descale`: style: pass, test: pass, audit: pass
- `vapoursynth-imwri`: style: pass, test: fail, audit: pass
- `vapoursynth-ocr`: style: pass, test: pass, audit: pass
- `vapoursynth-sub`: style: pass, test: pass, audit: pass
Fixes #280329

vapoursynth 75 switched to meson, and removed the option to set a custom plugin dir.


my solution was to jsut install it in libexec and create a symlink from the libexec site-packages to homebrew_site_packages plugins dir.

This also makes some inreplace patching of vapoursynth-* redundant as we jsut set the `-Dpython.*` vars