### PR TITLE
baguette 0.1.73 (new formula)

### DIFF
--- a/Formula/b/baguette.rb
+++ b/Formula/b/baguette.rb
@@ -1,0 +1,67 @@
+class Baguette < Formula
+  desc "Headless iOS Simulator manager and host-side input injection for iOS 26"
+  homepage "https://github.com/tddworks/baguette"
+  url "https://github.com/tddworks/baguette/archive/refs/tags/v0.1.73.tar.gz"
+  sha256 "77f46a1f8e0f0a4a9ecf084c0360d76394c6b9c603cf4d64abcd0650d183c058"
+  license "Apache-2.0"
+  head "https://github.com/tddworks/baguette.git", branch: "main"
+
+  depends_on xcode: ["26.0", :build]
+  depends_on arch: :arm64
+  depends_on macos: :tahoe
+
+  def install
+    # replace version like upstreams release process
+    inreplace "Sources/Baguette/App/Version.swift",
+              "let baguetteVersion = \"0.1.61\"",
+              %Q(let baguetteVersion = "#{version}")
+
+    # Build the iOS-Simulator virtual-camera dylib from source rather than
+    # using the prebuilt copy in the tarball. Mirrors upstream's
+    # VirtualCamera/build.sh, compiled against the iphonesimulator SDK for this
+    # formula's arch (arm64) straight into the SPM resource directory.
+    # `-target *-simulator` stamps the iOS-Simulator platform load command and
+    # `-Wl,-adhoc_codesign` ad-hoc signs the dylib at link time. Homebrew
+    # re-signs it during relocation, which is fine: at runtime baguette copies
+    # the dylib to a fresh content-hashed path before injecting it, so the
+    # simulator's dyld loads the ad-hoc signature without the page-hash-cache
+    # "invalid-page" rejection that only hits a replaced dylib at the same path.
+    arch = Hardware::CPU.arch.to_s
+    sdk = Utils.safe_popen_read("xcrun", "--sdk", "iphonesimulator", "--show-sdk-path").chomp
+    vc = "Sources/Baguette/Resources/VirtualCamera"
+    rm "#{vc}/VirtualCamera.dylib"
+    system "xcrun", "clang", "-arch", arch, "-isysroot", sdk,
+           "-target", "#{arch}-apple-ios17.0-simulator", "-dynamiclib",
+           "-framework", "Foundation", "-framework", "UIKit",
+           "-framework", "QuartzCore", "-framework", "CoreGraphics",
+           "-framework", "AVFoundation", "-framework", "ImageIO",
+           "-framework", "CoreServices", "-fobjc-arc", "-ldl",
+           "-install_name", "@rpath/VirtualCamera.dylib", "-Wl,-adhoc_codesign",
+           "-I", "VirtualCamera/Sources", "-o", "#{vc}/VirtualCamera.dylib",
+           "VirtualCamera/Sources/SimCamInject.m",
+           "VirtualCamera/Sources/SimCamPreviewLayerDriver.m",
+           "VirtualCamera/Sources/SimCamFakePhoto.m",
+           "VirtualCamera/Sources/SimCamSharedFrameReader.m"
+
+    system "swift", "build", "--disable-sandbox", "-c", "release"
+
+    # Binary and its SPM resource bundle must sit side-by-side at runtime —
+    # WebRoot resolves the bundle via dladdr from the executable's directory.
+    # Install both into libexec and symlink the binary into bin.
+    libexec.install ".build/release/Baguette" => "baguette"
+    libexec.install ".build/release/Baguette_Baguette.bundle"
+    bin.install_symlink libexec/"baguette"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/baguette --version")
+
+    # The top-level help lists the simulator-control subcommands, confirming
+    # the binary and its argument parser initialize without a booted device.
+    assert_match "Headless iOS simulator control", shell_output("#{bin}/baguette --help")
+
+    # Unknown subcommands are rejected with a usage error (exit code 64),
+    # exercising real argument parsing offline with no booted simulator.
+    assert_match "Usage: baguette", shell_output("#{bin}/baguette no-such-command 2>&1", 64)
+  end
+end


### PR DESCRIPTION
## Description

[baguette](https://github.com/tddworks/baguette) is a headless iOS Simulator manager and host-side input injector targeting iOS 26. It boots / shutdowns simulators, injects taps / swipes / pinches / pans through the 9-arg `IndigoHIDMessageForMouseNSEvent` digitizer path used by Xcode 26's preview-kit, and serves a 60 fps WebSocket stream + multi-device farm UI for browser-side control.

It is the only Apache-licensed open-source tool currently using the iOS 26 9-arg HID wire format — `idb` and `AXe` use the older 5-arg signature, which `backboardd` silently drops on iOS 26.

- **Homepage**: https://github.com/tddworks/baguette
- **License**: Apache-2.0
- **Stars / forks**: 1000+ / 58 at time of submission

## Notes

- macOS + Apple Silicon only (`depends_on arch: :arm64`); the binary links against private `SimulatorKit` / `CoreSimulator` frameworks shipped with Xcode 26, so `depends_on xcode: ["26.0", :build]` is required.
- Resource bundle `Baguette_Baguette.bundle` is installed alongside the binary in `libexec` (the executable resolves it via `dladdr`); a symlink in `bin` exposes `baguette` on `PATH`.
- Test asserts `--help` output since the CLI does not yet expose `--version`. Happy to add a version-asserting test in a follow-up once the upstream CLI gains a version flag.

## Checklist

- [x] `brew install --build-from-source baguette` works
- [x] `brew test baguette` passes
- [x] `brew audit --strict baguette` passes with 0 errors
- [x] Formula is in `Formula/b/baguette.rb` with matching class name
- [x] No conflict with existing formulae