### PR TITLE
precice: add ginkgo

### DIFF
--- a/Formula/k/kokkos.rb
+++ b/Formula/k/kokkos.rb
@@ -13,12 +13,12 @@ class Kokkos < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "fd81e59530910c3e3b4f262f4e97374d07c979799038b739d6505c62419ed36d"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "cb0bc4671c24161a1f0ba4735d8e35305509daf02ba0aaa6e90e903ebc4d7d17"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "bb13450f99bdfb220a14392fccc93b453e1bd7743afc459a1074753f2242fece"
-    sha256 cellar: :any_skip_relocation, sonoma:        "50f8dcfc5e85bc06b0984fde599f94477fbdf550fa2e1800311504b6cd92de4d"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "88ef2037f2aa3a781ce6f05f9946534f9f404dca5dc662e7151741d97e91af2a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "384ff655ff681fa3c212dd34e13a444469bc6ede5b5bba7ed3d03e4a531469d4"
+    sha256 cellar: :any,                 arm64_tahoe:   "67df6bee45072b72e93fd0558234bff4e761f8205921c7213460c82167ad1f24"
+    sha256 cellar: :any,                 arm64_sequoia: "f95bda78be3db9f757a285a7b83dfa4d562438e9f4d7d388bb0e1fbefa1cd183"
+    sha256 cellar: :any,                 arm64_sonoma:  "45a5269e3b68ef17296a4f02d31e31fac57bac302407692cabb69c57609b6278"
+    sha256 cellar: :any,                 sonoma:        "4ad47a155b302b6c3740cf88273cb000fdd9da93673b90dd1bcdca8fbb06a9ef"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "e991ab7077e883453986fdf5b95539c3626abc77da9d3a3cabae7483ebe1150f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "7418f122faf85fff6bc17a369cb11f24bbd747fd33570545d42f9eac2f21d68b"
   end
 
   depends_on "cmake" => :build

--- a/Formula/k/kokkos.rb
+++ b/Formula/k/kokkos.rb
@@ -4,6 +4,7 @@ class Kokkos < Formula
   url "https://github.com/kokkos/kokkos/releases/download/5.1.1/kokkos-5.1.1.tar.gz"
   sha256 "8bdbee0f0ac383436743ad8a9e3e928705b34b31a25a92dc5179c52a3aa98519"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/kokkos/kokkos.git", branch: "develop"
 
   livecheck do
@@ -27,11 +28,13 @@ class Kokkos < Formula
   end
 
   def install
-    args = %w[
+    args = %W[
       -DKokkos_ENABLE_OPENMP=ON
       -DKokkos_ENABLE_TESTS=OFF
       -DKokkos_ENABLE_EXAMPLES=OFF
       -DKokkos_ENABLE_BENCHMARKS=OFF
+      -DBUILD_SHARED_LIBS=ON
+      -DCMAKE_INSTALL_RPATH=#{rpath}
     ]
 
     system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args

--- a/Formula/p/precice.rb
+++ b/Formula/p/precice.rb
@@ -8,12 +8,12 @@ class Precice < Formula
   head "https://github.com/precice/precice.git", branch: "develop"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "3ca16c163b36f0d115124712a61f2a4809b8911de069e97642d1ac8c21ac5b74"
-    sha256 cellar: :any,                 arm64_sequoia: "b31411478c096a03cc8b24c42a78ec7e963251176fde430f6c0a6d56e695f02f"
-    sha256 cellar: :any,                 arm64_sonoma:  "2f988d38ce801ca479e3e4167361296224fb59a9e7008946be7a696cd92efd7b"
-    sha256 cellar: :any,                 sonoma:        "4b2c3d7c27f7507d00d3d92d22ca984f24aadec0f9f18c2a05a1a089e7cd2069"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "92fb9eb1b2f8dab23ac35c791b75c12d0b71ef6276dd79b09f6101cf13937669"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "ac0ef4bfdae534767f77e81ef979caa39ac34b1370ae4c24af87243391bcf26f"
+    sha256 cellar: :any,                 arm64_tahoe:   "841f6e73e7352de0557d5782f3158e0e2f770943e62d5cdfeb12d5b84ad65e20"
+    sha256 cellar: :any,                 arm64_sequoia: "757dc3095d5c4eec539da00e46b18b8bbfee24a0ecaffb4958d008675941bb6c"
+    sha256 cellar: :any,                 arm64_sonoma:  "d5634c836d089b0e2570488dcfb02ee3211fa1c79a27d23a69f47d45c3c3e8fd"
+    sha256 cellar: :any,                 sonoma:        "4cfae1f50c4be5722fe5a2ee98cef3da748b1e422c9e30ba4b3c6f3c91835b64"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "75c3638840987563f681eff6f907e7f55f0a42c968c8dd9c57bbde48c01627ad"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "40ceb07952ea39e22be757eb52498f1768c862715228e4fda9fe4bb17e7fd80c"
   end
 
   depends_on "cmake" => :build

--- a/Formula/p/precice.rb
+++ b/Formula/p/precice.rb
@@ -4,6 +4,7 @@ class Precice < Formula
   url "https://github.com/precice/precice/archive/refs/tags/v3.4.1.tar.gz"
   sha256 "ef4713c938a1b2000d0b071175e1b45f9ec55c7aec4bbe7b65c3992edcc74ac7"
   license "LGPL-3.0-or-later"
+  revision 1
   head "https://github.com/precice/precice.git", branch: "develop"
 
   bottle do
@@ -18,7 +19,9 @@ class Precice < Formula
   depends_on "cmake" => :build
 
   depends_on "boost"
-  depends_on "eigen"
+  depends_on "eigen" => :no_linkage
+  depends_on "ginkgo"
+  depends_on "kokkos"
   depends_on "numpy"
   depends_on "open-mpi"
   depends_on "petsc"
@@ -26,8 +29,17 @@ class Precice < Formula
 
   uses_from_macos "libxml2"
 
+  on_macos do
+    depends_on "libomp"
+  end
+
   def install
-    system "cmake", "-S", ".", "-B", "build", "-DCMAKE_INSTALL_RPATH=#{rpath}", *std_cmake_args
+    args = %W[
+      -DPRECICE_FEATURE_GINKGO_MAPPING=ON
+      -DCMAKE_INSTALL_RPATH=#{rpath}
+    ]
+
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
   end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

## Planned commits
- `precice: add ginkgo`
## Validation summary
- `precice`: style: pass, test: pass, audit: pass


This enables the use of OpenMP for radial-basis function mappings through ginkgo.

Also made eigen no linkage as I got got a note that eigen was not used to link. (even before this pr)


EDIT: Had to enable shared libs in kokkos, as you cant link .a to a .so on linux