### PR TITLE
apr-util: migrate to openssl@4

### DIFF
--- a/Formula/a/apr-util.rb
+++ b/Formula/a/apr-util.rb
@@ -5,7 +5,7 @@ class AprUtil < Formula
   mirror "https://archive.apache.org/dist/apr/apr-util-1.6.3.tar.bz2"
   sha256 "a41076e3710746326c3945042994ad9a4fcac0ce0277dd8fea076fec3c9772b5"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   bottle do
     sha256 arm64_tahoe:    "c1b6ca1239679046b74a5ea73032f87a83cbc9c503455a0cf3bc12a54777a03d"
@@ -25,7 +25,7 @@ class AprUtil < Formula
   keg_only :shadowed_by_macos, "Apple's CLT provides apr (but not apr-util)"
 
   depends_on "apr"
-  depends_on "openssl@3"
+  depends_on "openssl@4"
 
   uses_from_macos "expat"
   uses_from_macos "libxcrypt"
@@ -38,7 +38,7 @@ class AprUtil < Formula
   def install
     system "./configure", "--with-apr=#{Formula["apr"].opt_prefix}",
                           "--with-crypto",
-                          "--with-openssl=#{Formula["openssl@3"].opt_prefix}",
+                          "--with-openssl=#{Formula["openssl@4"].opt_prefix}",
                           "--without-pgsql",
                           *std_configure_args
     system "make"

--- a/Formula/a/apr-util.rb
+++ b/Formula/a/apr-util.rb
@@ -8,18 +8,12 @@ class AprUtil < Formula
   revision 2
 
   bottle do
-    sha256 arm64_tahoe:    "c1b6ca1239679046b74a5ea73032f87a83cbc9c503455a0cf3bc12a54777a03d"
-    sha256 arm64_sequoia:  "6d3282873dffcfed602c5cfb7eb5ddad4b7115aaa954e191dfd4b733a58ef43e"
-    sha256 arm64_sonoma:   "e21a775a4cd6e721ad4f09cd7ed0355b5a1181ca8ad6834911a045c8f076eb01"
-    sha256 arm64_ventura:  "cb73075171b2079d2b8e8028f42766dffa5db08882261c3f5aff59d8eb9638a9"
-    sha256 arm64_monterey: "e4a7a42c82ae44bb192b2f718af4ced48d34560325b63d5c653a5c569edf759f"
-    sha256 arm64_big_sur:  "689fd5b76d98449ae31a78ac1380412248ce10a91409c7c1e16d4e2efbd2a32e"
-    sha256 sonoma:         "a59301c0e98b321c57fc3c8fac679a1e1bcdd5bce470fef60adc240f9c575674"
-    sha256 ventura:        "127d4d4523d49a73e7dbf610f3e439ac2051a383edbf28cc18438faf78945ef0"
-    sha256 monterey:       "1d6b4a8fed8cbec1e7056432a378b27455454f7b69de61a227d452a7b4671551"
-    sha256 big_sur:        "92bfab4310f0b384081f1997054f207e0d03c97e067407a328e19148a0132375"
-    sha256 arm64_linux:    "830c11d6eb7e0d08d27adeac35c24865e6a49c1bef237b6dc704ca4057062a7d"
-    sha256 x86_64_linux:   "5ad68f7525d3368b7e1fae3157c0338fffad2d33a907413c87ce8728c2e19378"
+    sha256 arm64_tahoe:   "b8b6b9150a95ec16cdbe29a2712842307f1c6d1710d91e526f4e3738e9c49a9f"
+    sha256 arm64_sequoia: "9533295fcdcfe68958c5410fe24a2f06e85f9fda26c47e873f7ada59fde464af"
+    sha256 arm64_sonoma:  "97126c7077bf1d168412019a2f9a067577212c808e313335bc1d375f6c8cb18d"
+    sha256 sonoma:        "1fc4da33f74a570b51daec5004db858f1858c00db8cd69785baa65e9dcf066b6"
+    sha256 arm64_linux:   "957fed45ce87cf4252aa3288c042f3b4637936cecf0ff98a62cf32dcaadfcaff"
+    sha256 x86_64_linux:  "80b3368cce3bb652c57c617655d52ce77a4d995e6003c4905e2f7e03f231ebaf"
   end
 
   keg_only :shadowed_by_macos, "Apple's CLT provides apr (but not apr-util)"


### PR DESCRIPTION
Migrates `apr-util` from `openssl@3` to `openssl@4` as part of the staging migration.

References:
- Homebrew/homebrew-core#278366