### PR TITLE
erlang: migrate to openssl@4

### DIFF
--- a/Formula/e/erlang.rb
+++ b/Formula/e/erlang.rb
@@ -15,12 +15,12 @@ class Erlang < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "daa2848108d9e6e7846fc2eef58edc6110db36fc98904848a08a449e79769c3f"
-    sha256 cellar: :any,                 arm64_sequoia: "8209918941581913927ef89e5db6ebe6e35d6effefd0ab98aa80417fef5d4ac9"
-    sha256 cellar: :any,                 arm64_sonoma:  "bc0099f5fb427c7e395ba7de4ec7cdd870ec14531d2d482d370acc7a05f1d3c1"
-    sha256 cellar: :any,                 sonoma:        "193274c7a2ec91ae253ca64bbb80515bdd508b617295c67b203790c7453c9c52"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "70ae5cbde5bb6e40a44a25fbc0d5b9d379cbb75a246d0f933bb148b6b874f1ad"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8a50091e8d4bb22531f3cf4179128d03bc9aba3d834c8324fc05511c7c663c8f"
+    sha256 cellar: :any,                 arm64_tahoe:   "58d22f9fc5aa58a5ff80affb238882a8941830519327cc1babcd26f12520cf3b"
+    sha256 cellar: :any,                 arm64_sequoia: "f80d2d0afa8e87a76b96a0a384928edb6094f76207c45724d9499c0876e95757"
+    sha256 cellar: :any,                 arm64_sonoma:  "0a8788aaa6e1d9cba5d7f0d134f4ee969ad57f4861eac1cca6f5eb8fe9758ad8"
+    sha256 cellar: :any,                 sonoma:        "d6f7b69ff5d2956ee10b5e6888b97e73e74a1549c94ac462d8deb38071391ce9"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "714e49b8a9f01d987831f2fcc53e3bb5c60cb965c135645ebf7ee5f674a7ba36"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "49449b0d4faa054a8f827bc21cdfb983b6bb4e7a03a7fc17522cb1f841f5338b"
   end
 
   head do

--- a/Formula/e/erlang.rb
+++ b/Formula/e/erlang.rb
@@ -6,6 +6,7 @@ class Erlang < Formula
   url "https://github.com/erlang/otp/releases/download/OTP-28.5/otp_src_28.5.tar.gz"
   sha256 "2c7e8ca23e6864eb20eff5d44738bfa123aed8cd21ed6d98e533d751eee28d9c"
   license "Apache-2.0"
+  revision 1
   compatibility_version 1
 
   livecheck do
@@ -29,7 +30,7 @@ class Erlang < Formula
     depends_on "libtool" => :build
   end
 
-  depends_on "openssl@3"
+  depends_on "openssl@4"
   depends_on "unixodbc"
   depends_on "wxwidgets@3.2" # for GUI apps like observer
 
@@ -80,7 +81,7 @@ class Erlang < Formula
     args = %W[
       --enable-dynamic-ssl-lib
       --with-odbc=#{Formula["unixodbc"].opt_prefix}
-      --with-ssl=#{Formula["openssl@3"].opt_prefix}
+      --with-ssl=#{Formula["openssl@4"].opt_prefix}
       --without-javac
       --with-wx-config=#{wx_config}
     ]

--- a/Formula/t/teslamate.rb
+++ b/Formula/t/teslamate.rb
@@ -7,12 +7,12 @@ class Teslamate < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "365e32212184579cd3ad2e8645994e88d5a2d19e5bf46ac32ebcab53ff0f1b99"
-    sha256 cellar: :any,                 arm64_sequoia: "a009b56e79cab4ad8ab6cc93a724009b905fedc6c16b719ab99355105d7be9bd"
-    sha256 cellar: :any,                 arm64_sonoma:  "051fee5157e21481b9365da64058189babfb80efe0f53a15110244734b42913d"
-    sha256 cellar: :any,                 sonoma:        "c761eaccdc2122fb4544aa9521e9b7d5d4e411a34907228fd60c13e8966cf03e"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "44b5037040201b926c88283fa5f582fbd638f78744fbd66586aa3b4b477097d2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "15897cb1032f908f271565db40062499ee6fb30b4793a657600c559470ec242b"
+    sha256 cellar: :any,                 arm64_tahoe:   "422fbb319b72f80b329972f0980ddedc0320e7d5376b1b44d8de4e142b371944"
+    sha256 cellar: :any,                 arm64_sequoia: "1cb0cbbc58a7bf8575c6e02c88fe8997d89a43115e73de6e1f90f77a3259b7be"
+    sha256 cellar: :any,                 arm64_sonoma:  "3cfe91fbb755ce931627711dfd28383c6561bfcb096cd7ef578465eda2c567e6"
+    sha256 cellar: :any,                 sonoma:        "f8873255f56222b52a1ae1f36f597bffa2889dc06b9938603b84541537758ada"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "b50992381b06287f0dead17e28eb32b242c1606457f474884ef73bcbbe0a01c7"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "fcb3754463ba8579c5a912ac2ad299d63957b0731bff3bb570cb17f5d52faf7c"
   end
 
   depends_on "node" => :build

--- a/Formula/t/teslamate.rb
+++ b/Formula/t/teslamate.rb
@@ -4,6 +4,7 @@ class Teslamate < Formula
   url "https://github.com/teslamate-org/teslamate/archive/refs/tags/v3.0.0.tar.gz"
   sha256 "a4a7267df27982cf5844e453d59ff866c6daf3ae126bcda05c0abe87dee43b45"
   license "AGPL-3.0-or-later"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "365e32212184579cd3ad2e8645994e88d5a2d19e5bf46ac32ebcab53ff0f1b99"
@@ -18,7 +19,7 @@ class Teslamate < Formula
   depends_on "postgresql@18" => :test
   depends_on "elixir"
   depends_on "erlang"
-  depends_on "openssl@3"
+  depends_on "openssl@4"
 
   uses_from_macos "ncurses"
 


### PR DESCRIPTION
Migrates `erlang` from `openssl@3` to `openssl@4` as part of the staging migration.

References:
- Homebrew/homebrew-core#278366