### PR TITLE
grpc: migrate to openssl@4

### DIFF
--- a/Formula/g/grpc.rb
+++ b/Formula/g/grpc.rb
@@ -5,6 +5,7 @@ class Grpc < Formula
       tag:      "v1.80.0",
       revision: "f5e2d6e856176c2f6b7691032adfefe21e5f64c1"
   license "Apache-2.0"
+  revision 1
   compatibility_version 2
   head "https://github.com/grpc/grpc.git", branch: "master"
 
@@ -32,7 +33,7 @@ class Grpc < Formula
   depends_on "pkgconf" => :test
   depends_on "abseil"
   depends_on "c-ares"
-  depends_on "openssl@3"
+  depends_on "openssl@4"
   depends_on "protobuf"
   depends_on "re2"
 
@@ -48,6 +49,9 @@ class Grpc < Formula
     build 1100
     cause "Requires C++17 features not yet implemented"
   end
+
+  # OpenSSL 4 makes X509_CRL_get_issuer return a const pointer.
+  patch :DATA
 
   def install
     args = %W[
@@ -77,10 +81,25 @@ class Grpc < Formula
       }
     CPP
 
-    ENV.prepend_path "PKG_CONFIG_PATH", Formula["openssl@3"].opt_lib/"pkgconfig"
+    ENV.prepend_path "PKG_CONFIG_PATH", Formula["openssl@4"].opt_lib/"pkgconfig"
     ENV.prepend_path "PKG_CONFIG_PATH", Formula["zlib-ng-compat"].opt_lib/"pkgconfig" if OS.linux?
     flags = shell_output("pkgconf --cflags --libs libcares protobuf re2 grpc++").chomp.split
     system ENV.cc, "test.cpp", "-L#{Formula["abseil"].opt_lib}", *flags, "-o", "test"
     system "./test"
   end
 end
+
+__END__
+diff --git a/src/core/credentials/transport/tls/grpc_tls_crl_provider.cc b/src/core/credentials/transport/tls/grpc_tls_crl_provider.cc
+index 4f46545..c39cae5 100644
+--- a/src/core/credentials/transport/tls/grpc_tls_crl_provider.cc
++++ b/src/core/credentials/transport/tls/grpc_tls_crl_provider.cc
+@@ -56,7 +56,7 @@ absl::StatusOr<std::string> IssuerFromCrl(X509_CRL* crl) {
+   if (crl == nullptr) {
+     return absl::InvalidArgumentError("crl cannot be null");
+   }
+-  X509_NAME* issuer = X509_CRL_get_issuer(crl);
++  const X509_NAME* issuer = X509_CRL_get_issuer(crl);
+   if (issuer == nullptr) {
+     return absl::InvalidArgumentError("crl cannot have null issuer");
+   }


### PR DESCRIPTION
Migrates `grpc` from `openssl@3` to `openssl@4` as part of the staging migration.

References:
- Homebrew/homebrew-core#278366