### PR TITLE
hiredis: migrate to openssl@4

### DIFF
--- a/Formula/h/hiredis.rb
+++ b/Formula/h/hiredis.rb
@@ -4,6 +4,7 @@ class Hiredis < Formula
   url "https://github.com/redis/hiredis/archive/refs/tags/v1.3.0.tar.gz"
   sha256 "25cee4500f359cf5cad3b51ed62059aadfc0939b05150c1f19c7e2829123631c"
   license "BSD-3-Clause"
+  revision 1
   compatibility_version 1
   head "https://github.com/redis/hiredis.git", branch: "master"
 
@@ -18,7 +19,7 @@ class Hiredis < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "0280a87a599747410042bebf2811c9c20bbe2ca577e066daa784a5ad5e1ffa31"
   end
 
-  depends_on "openssl@3"
+  depends_on "openssl@4"
 
   def install
     system "make", "install", "PREFIX=#{prefix}", "USE_SSL=1"

--- a/Formula/h/hiredis.rb
+++ b/Formula/h/hiredis.rb
@@ -9,14 +9,12 @@ class Hiredis < Formula
   head "https://github.com/redis/hiredis.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "a56da7fea50b3da5242b05db22d6311b0edd6f885b8793687572098d5bf02f12"
-    sha256 cellar: :any,                 arm64_sequoia: "d3bb6a7fd40584c74321d404d0c459f11e3d612c329a5f95367c372cb21bbdca"
-    sha256 cellar: :any,                 arm64_sonoma:  "68e9423a13a8c5dc27884296ec0ee6ab25930aaa85d3b6e5e8726855fd864211"
-    sha256 cellar: :any,                 arm64_ventura: "fa65af1fbbc772155907ee6332c3a21c8780a3ce8491b762470d05cf3ae57c85"
-    sha256 cellar: :any,                 sonoma:        "d7ed68aa281c0ccd51c7e28ffe6eef652478b7a03cd0e7ffd239cdd54f9412c6"
-    sha256 cellar: :any,                 ventura:       "d08d4992b894522efb41ad2f502a1fa4b0e48b7a3ada25a87c7b73a03bbb6cfb"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "0760d1e33d3c044724b3c8c1053514f85a6fc12d55edfa3745cec4ed5dcf0fa3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0280a87a599747410042bebf2811c9c20bbe2ca577e066daa784a5ad5e1ffa31"
+    sha256 cellar: :any,                 arm64_tahoe:   "74eb2e4780a211d5a29d9695b455ce7dbcc72f1d800db208c7cfcd22577e5667"
+    sha256 cellar: :any,                 arm64_sequoia: "74568195832c3e0f6df78f7d8cc20b0b26c00ccdac7d21f26b92a672e50b7969"
+    sha256 cellar: :any,                 arm64_sonoma:  "771c9ddf9487b9ca90736deb3d0c7e6d60ab17195d4539aaba1590c108c1c6f4"
+    sha256 cellar: :any,                 sonoma:        "868c742fc2016692f1f7f1842f10d0b0d7505684d53a03053c84911f5c9071da"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "4468062dfe9d64cef30ed32b69a33b17bdf62ba1030cd66a84291009c50d1e36"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "24c948abd177e9d17ff1f3d7ca8cfb4f90c924f8ab02cde18e18dfa7ea1886a1"
   end
 
   depends_on "openssl@4"


### PR DESCRIPTION
Migrates `hiredis` from `openssl@3` to `openssl@4` as part of the staging migration.

References:
- Homebrew/homebrew-core#278366