### PR TITLE
libevent: migrate to openssl@4

### DIFF
--- a/Formula/lib/libevent.rb
+++ b/Formula/lib/libevent.rb
@@ -13,18 +13,12 @@ class Libevent < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:    "c442ba9d640780f91257a853002b25840439b9c6b1c568864111901b760d328e"
-    sha256 cellar: :any,                 arm64_sequoia:  "65fc7c61fec0f5ae0c5dfc8fc7e3b6b0507d3f1c7c308a332802541f00334963"
-    sha256 cellar: :any,                 arm64_sonoma:   "38a3eb3510a7e0cd4096e4592d0095c562eb1bbad572d951f1923009a14ad702"
-    sha256 cellar: :any,                 arm64_ventura:  "a75d453a7fe2aba1eaba334621b7bd9f0ff6f9e1f04aa400565f68711a9f6db4"
-    sha256 cellar: :any,                 arm64_monterey: "a24d682548fb7cb11c127932240cced5d6fdb16feaaa6dc2ab3a7f0833e5df2e"
-    sha256 cellar: :any,                 arm64_big_sur:  "0c3deccd564c0ed001cb3613ddc10d7e46e78deb5f8882fde74f8935557d5cba"
-    sha256 cellar: :any,                 sonoma:         "5d54f13cd93d87185bd7bb592cb945d1f64cac3e88d1e46c2fb5d9ea538d9623"
-    sha256 cellar: :any,                 ventura:        "79a1036d3428c6ad8325803912e9ff0f74b8a8202908ae8594959c27e998c90b"
-    sha256 cellar: :any,                 monterey:       "d0557018f19021fb4675a20d9cefda5e13646558c276ab7b4f01f96144b432f8"
-    sha256 cellar: :any,                 big_sur:        "042923957c025a4298465d320a63db6127414644fde58fcdc0d29e8c28fd2993"
-    sha256 cellar: :any_skip_relocation, arm64_linux:    "2ebd43e299f937313fc4dc17c21a7446b53d5a46d7dad29922a763df1761acac"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "83ef4ce689a91f6fca013d6b4b0b2fcda3706080f8e0cccd056a3d94d6bc0f17"
+    sha256 cellar: :any,                 arm64_tahoe:   "12e6b088b3636a24573d91eaa2f6a6bfbe7fafc3bb50e779954d1afee3cd220d"
+    sha256 cellar: :any,                 arm64_sequoia: "439f517244b007ffe7fa78f73397462acf27d32cd0d569d354cbc07caf2f29fe"
+    sha256 cellar: :any,                 arm64_sonoma:  "b771c9a3b605191b37eb567e68dbb127797b1f049d0707b01517f57bcdf704b9"
+    sha256 cellar: :any,                 sonoma:        "0d0a088b74c2200290b688959dbd1db4aaf7f88d405c296a019f4cb9b265657e"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "8df54de5285f5b884e43a3befcd10d9a63568886493a6e0a58f5af70ec7ed508"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5432edb3ce2cc87adac40896e471d305d21474cdbbd149bdc6d3c5222ee3e20c"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/lib/libevent.rb
+++ b/Formula/lib/libevent.rb
@@ -4,7 +4,7 @@ class Libevent < Formula
   url "https://github.com/libevent/libevent/archive/refs/tags/release-2.1.12-stable.tar.gz"
   sha256 "7180a979aaa7000e1264da484f712d403fcf7679b1e9212c4e3d09f5c93efc24"
   license "BSD-3-Clause"
-  revision 1
+  revision 2
   compatibility_version 1
 
   livecheck do
@@ -31,7 +31,7 @@ class Libevent < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkgconf" => :build
-  depends_on "openssl@3"
+  depends_on "openssl@4"
 
   def install
     system "./autogen.sh"


### PR DESCRIPTION
Migrates `libevent` from `openssl@3` to `openssl@4` as part of the staging migration.

References:
- Homebrew/homebrew-core#278366