### PR TITLE
libfido2: migrate to openssl@4

### DIFF
--- a/Formula/lib/libfido2.rb
+++ b/Formula/lib/libfido2.rb
@@ -4,6 +4,7 @@ class Libfido2 < Formula
   url "https://github.com/Yubico/libfido2/archive/refs/tags/1.17.0.tar.gz"
   sha256 "ace062d14a482ff9325410ff63d06c8b5fe87e79ebc18dda07add2bc0188c77f"
   license "BSD-2-Clause"
+  revision 1
   compatibility_version 1
 
   bottle do
@@ -19,7 +20,7 @@ class Libfido2 < Formula
   depends_on "mandoc" => :build
   depends_on "pkgconf" => [:build, :test]
   depends_on "libcbor"
-  depends_on "openssl@3"
+  depends_on "openssl@4"
 
   on_linux do
     depends_on "systemd" # for libudev


### PR DESCRIPTION
Migrates `libfido2` from `openssl@3` to `openssl@4` as part of the staging migration.

References:
- Homebrew/homebrew-core#278366