### PR TITLE
python@3.11: migrate to openssl@4

### DIFF
--- a/Formula/p/python@3.11.rb
+++ b/Formula/p/python@3.11.rb
@@ -13,13 +13,12 @@ class PythonAT311 < Formula
   end
 
   bottle do
-    sha256 arm64_tahoe:   "abaacb2e82e32b769740e858730428b002cee22ae504f843d73a04cd8beb630e"
-    sha256 arm64_sequoia: "62f553d780355491bae1947d400cba7e507a32635775a04f814ad2280fa73dbe"
-    sha256 arm64_sonoma:  "aca94837020f9e365ea7a91c95317f589c883bb08d0777643640fcb5846d9bb4"
-    sha256 sequoia:       "efa4ff7214ed3d6ded539b4b178a73d21070e87fc017505d4ea497055554299b"
-    sha256 sonoma:        "ad1368aa265328d053233afea65c1c77ab84a76c7398fc0a033b19bded91e791"
-    sha256 arm64_linux:   "5a7a0da63d7a3f71dbdb483b317917a32ec019aef328f6cab2d9c2d9cc16fde3"
-    sha256 x86_64_linux:  "df042532f7a65999e50c38536f00d5dc628afdc7d81ded658258a66c4efa0658"
+    sha256 arm64_tahoe:   "d1034388d80515ae1cf069e823119512d8e2364e95e708461d4182d46efdfb75"
+    sha256 arm64_sequoia: "02bfec4b0c10731dd5c2c9c018fd445272eea2652595024c8d23aa7ae024fbf0"
+    sha256 arm64_sonoma:  "d700e405a4d01886e2e462312c8209900a32a612e7d2cbef23a09fbbc6341f9a"
+    sha256 sonoma:        "9984baa4e82df57353402c69cbd1151ba8791b77222ab5e954eb512a501b92af"
+    sha256 arm64_linux:   "c589642ba6d93b48174441b6f3c13ae0b23efc4b327abdfa498ff253a4ae008d"
+    sha256 x86_64_linux:  "d2e2d3bcadd49f3ddb671e15fb98c3b30a05598f89f35b09fe4ddc690dbb7228"
   end
 
   # setuptools remembers the build flags python is built with and uses them to

--- a/Formula/p/python@3.11.rb
+++ b/Formula/p/python@3.11.rb
@@ -4,7 +4,7 @@ class PythonAT311 < Formula
   url "https://www.python.org/ftp/python/3.11.15/Python-3.11.15.tgz"
   sha256 "f4de1b10bd6c70cbb9fa1cd71fc5038b832747a74ee59d599c69ce4846defb50"
   license "Python-2.0"
-  revision 1
+  revision 2
   compatibility_version 1
 
   livecheck do
@@ -28,7 +28,7 @@ class PythonAT311 < Formula
 
   depends_on "pkgconf" => :build
   depends_on "mpdecimal"
-  depends_on "openssl@3"
+  depends_on "openssl@4"
   depends_on "sqlite"
   depends_on "xz"
 
@@ -91,6 +91,9 @@ class PythonAT311 < Formula
     sha256 "d1a29b3c9ecf8aecd65e1e54efc42fb1422b2f5d05cba0c747178f4ef8a69683"
   end
 
+  # Backport OpenSSL 4 compatibility, upstream issue python/cpython#146207.
+  patch :DATA
+
   def lib_cellar
     on_macos do
       return frameworks/"Python.framework/Versions"/version.major_minor/"lib/python#{version.major_minor}"
@@ -138,7 +141,7 @@ class PythonAT311 < Formula
       --datadir=#{share}
       --without-ensurepip
       --enable-loadable-sqlite-extensions
-      --with-openssl=#{Formula["openssl@3"].opt_prefix}
+      --with-openssl=#{Formula["openssl@4"].opt_prefix}
       --enable-optimizations
       --with-system-expat
       --with-system-libmpdec
@@ -201,7 +204,7 @@ class PythonAT311 < Formula
     # `brew install enchant && pip install pyenchant`
     inreplace "./Lib/ctypes/macholib/dyld.py" do |f|
       f.gsub! "DEFAULT_LIBRARY_FALLBACK = [",
-              "DEFAULT_LIBRARY_FALLBACK = [ '#{HOMEBREW_PREFIX}/lib', '#{Formula["openssl@3"].opt_lib}',"
+              "DEFAULT_LIBRARY_FALLBACK = [ '#{HOMEBREW_PREFIX}/lib', '#{Formula["openssl@4"].opt_lib}',"
       f.gsub! "DEFAULT_FRAMEWORK_FALLBACK = [", "DEFAULT_FRAMEWORK_FALLBACK = [ '#{HOMEBREW_PREFIX}/Frameworks',"
     end
 
@@ -534,3 +537,88 @@ class PythonAT311 < Formula
     system bin/"pip#{version.major_minor}", "list", "--format=columns"
   end
 end
+
+__END__
+--- a/Modules/_ssl.c
++++ b/Modules/_ssl.c
+@@ -120,6 +120,17 @@
+ #include "_ssl_data.h"
+ #endif
+ 
++#if (OPENSSL_VERSION_NUMBER >= 0x40000000L)
++#  define OPENSSL_NO_SSL3
++#  define OPENSSL_NO_TLS1
++#  define OPENSSL_NO_TLS1_1
++#  define OPENSSL_NO_TLS1_2
++#  define OPENSSL_NO_SSL3_METHOD
++#  define OPENSSL_NO_TLS1_METHOD
++#  define OPENSSL_NO_TLS1_1_METHOD
++#  define OPENSSL_NO_TLS1_2_METHOD
++#endif
++
+ /* OpenSSL API 1.1.0+ does not include version methods */
+ #ifndef OPENSSL_NO_SSL3_METHOD
+ extern const SSL_METHOD *SSLv3_method(void);
+@@ -1346,15 +1357,15 @@
+                 }
+                 PyTuple_SET_ITEM(t, 0, v);
+ 
+-                if (name->d.ip->length == 4) {
+-                    unsigned char *p = name->d.ip->data;
++                if (ASN1_STRING_length(name->d.ip) == 4) {
++                    const unsigned char *p = ASN1_STRING_get0_data(name->d.ip);
+                     v = PyUnicode_FromFormat(
+                         "%d.%d.%d.%d",
+                         p[0], p[1], p[2], p[3]
+                     );
+-                } else if (name->d.ip->length == 16) {
++                } else if (ASN1_STRING_length(name->d.ip) == 16) {
+                     /* PyUnicode_FromFormat() does not support %X */
+-                    unsigned char *p = name->d.ip->data;
++                    const unsigned char *p = ASN1_STRING_get0_data(name->d.ip);
+                     len = sprintf(
+                         buf,
+                         "%X:%X:%X:%X:%X:%X:%X:%X",
+@@ -1487,8 +1498,9 @@
+             continue;
+         }
+         uri = ad->location->d.uniformResourceIdentifier;
+-        ostr = PyUnicode_FromStringAndSize((char *)uri->data,
+-                                           uri->length);
++        ostr = PyUnicode_FromStringAndSize(
++                   (const char *)ASN1_STRING_get0_data(uri),
++                   ASN1_STRING_length(uri));
+         if (ostr == NULL) {
+             goto fail;
+         }
+@@ -1554,8 +1566,9 @@
+                 continue;
+             }
+             uri = gn->d.uniformResourceIdentifier;
+-            ouri = PyUnicode_FromStringAndSize((char *)uri->data,
+-                                               uri->length);
++            ouri = PyUnicode_FromStringAndSize(
++                       (const char *)ASN1_STRING_get0_data(uri),
++                       ASN1_STRING_length(uri));
+             if (ouri == NULL)
+                 goto done;
+ 
+@@ -5991,12 +6004,18 @@
+                             PY_SSL_VERSION_TLS_CLIENT);
+     PyModule_AddIntConstant(m, "PROTOCOL_TLS_SERVER",
+                             PY_SSL_VERSION_TLS_SERVER);
++#ifndef OPENSSL_NO_TLS1
+     PyModule_AddIntConstant(m, "PROTOCOL_TLSv1",
+                             PY_SSL_VERSION_TLS1);
++#endif
++#ifndef OPENSSL_NO_TLS1_1
+     PyModule_AddIntConstant(m, "PROTOCOL_TLSv1_1",
+                             PY_SSL_VERSION_TLS1_1);
++#endif
++#ifndef OPENSSL_NO_TLS1_2
+     PyModule_AddIntConstant(m, "PROTOCOL_TLSv1_2",
+                             PY_SSL_VERSION_TLS1_2);
++#endif
+ 
+ #define ADD_OPTION(NAME, VALUE) if (sslmodule_add_option(m, NAME, (VALUE)) < 0) return -1
+ 


### PR DESCRIPTION
Migrates `python@3.11` from `openssl@3` to `openssl@4` as part of the staging migration.

References:
- Homebrew/homebrew-core#278366