### PR TITLE
srt: migrate to openssl@4

### DIFF
--- a/Formula/s/srt.rb
+++ b/Formula/s/srt.rb
@@ -4,6 +4,7 @@ class Srt < Formula
   url "https://github.com/Haivision/srt/archive/refs/tags/v1.5.5.tar.gz"
   sha256 "c3518bc43a71b5289032395b2db4c3e09e73d78b54247d56c14553a503b491cf"
   license "MPL-2.0"
+  revision 1
   compatibility_version 1
   head "https://github.com/Haivision/srt.git", branch: "master"
 
@@ -23,10 +24,10 @@ class Srt < Formula
 
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
-  depends_on "openssl@3"
+  depends_on "openssl@4"
 
   def install
-    openssl = Formula["openssl@3"]
+    openssl = Formula["openssl@4"]
 
     args = %W[
       -DWITH_OPENSSL_INCLUDEDIR=#{openssl.opt_include}

--- a/Formula/s/srt.rb
+++ b/Formula/s/srt.rb
@@ -14,12 +14,12 @@ class Srt < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "f201e850fa33ee027f7e8360ab55474461c6d20c996ed261bf9d17198a9d0e85"
-    sha256 cellar: :any,                 arm64_sequoia: "fc5bbd1fed835b6bbcb15cb62c7297e137ae526250c5ca1b21dc6b4979ed22e2"
-    sha256 cellar: :any,                 arm64_sonoma:  "b69a133af8ac9cf43a298423cd4b08614395b36c0df3c9b7e1ade63b9587a304"
-    sha256 cellar: :any,                 sonoma:        "be1c49b063c22ff0edf2a822e09585ec85649a7845dcd770681217659655ca2e"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "f4daed54a610f9835b41b63d5dd16027e2d1dfd879aea01c1fc85d65d38a61ff"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0d7d47c199ff8c9e1e6de7b409dc3a81c6573f49be3b02bb37aacdb335a6b623"
+    sha256 cellar: :any,                 arm64_tahoe:   "c9efbdc89f5cdc3e9dbb553beb2d3715aa318f0dae16272e70eb1d5c317e32a9"
+    sha256 cellar: :any,                 arm64_sequoia: "62d4e875692e2a09d5d82ebe3efc4bb6c0664df5255f532f19ade10724259079"
+    sha256 cellar: :any,                 arm64_sonoma:  "c0efb2121ddc659a49371268e935c02b33db19d7d5084b30a9ebe246a096a485"
+    sha256 cellar: :any,                 sonoma:        "64c0ace35271f71495a98eede14c90e6fb51a6e27c42db187cf7c50df7300bf5"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "fb0393ab5005b3222c168bb8f4cc605cf0c3959bdab3eb4f8fe5bb039695b3a5"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8149b38aef0937e3146f89666ea90bdd77575a6fcc84169ff7f00163559f9c33"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
Migrates `srt` from `openssl@3` to `openssl@4` as part of the staging migration.

References:
- Homebrew/homebrew-core#278366