### PR TITLE
tcl-tk@8: migrate to openssl@4

### DIFF
--- a/Formula/t/tcl-tk@8.rb
+++ b/Formula/t/tcl-tk@8.rb
@@ -4,6 +4,7 @@ class TclTkAT8 < Formula
   url "https://downloads.sourceforge.net/project/tcl/Tcl/8.6.17/tcl8.6.17-src.tar.gz"
   sha256 "a3903371efcce8a405c5c245d029e9f6850258a60fa3761c4d58995610949b31"
   license "TCL"
+  revision 1
   compatibility_version 1
 
   livecheck do
@@ -23,7 +24,7 @@ class TclTkAT8 < Formula
 
   keg_only :versioned_formula
 
-  depends_on "openssl@3"
+  depends_on "openssl@4"
 
   on_linux do
     depends_on "freetype" => :build
@@ -46,6 +47,9 @@ class TclTkAT8 < Formula
   resource "tcltls" do
     url "https://core.tcl-lang.org/tcltls/uv/tcltls-1.7.22.tar.gz"
     sha256 "e84e2b7a275ec82c4aaa9d1b1f9786dbe4358c815e917539ffe7f667ff4bc3b4"
+
+    # OpenSSL 4 makes ASN1_UTCTIME opaque.
+    patch :DATA
   end
 
   resource "tk" do
@@ -117,7 +121,7 @@ class TclTkAT8 < Formula
 
     resource("tcltls").stage do
       system "./configure", "--with-ssl=openssl",
-                            "--with-openssl-dir=#{Formula["openssl@3"].opt_prefix}",
+                            "--with-openssl-dir=#{Formula["openssl@4"].opt_prefix}",
                             "--prefix=#{prefix}",
                             "--mandir=#{man}"
       system "make", "install"
@@ -191,3 +195,26 @@ class TclTkAT8 < Formula
     assert_equal "OK\n", pipe_output("#{bin}/wish", test_itk), "Itk test failed"
   end
 end
+
+__END__
+diff --git a/tlsX509.c b/tlsX509.c
+index afde377..961b1f0 100644
+--- a/tlsX509.c
++++ b/tlsX509.c
+@@ -38,11 +38,13 @@ ASN1_UTCTIME_tostr(ASN1_UTCTIME *tm)
+         "Jan","Feb","Mar","Apr","May","Jun",
+         "Jul","Aug","Sep","Oct","Nov","Dec"};
+     int i;
++    const unsigned char *data;
+     int y=0,M=0,d=0,h=0,m=0,s=0;
+     
+-    i=tm->length;
+-    v=(char *)tm->data;
+-    
++    i=ASN1_STRING_length(tm);
++    data=ASN1_STRING_get0_data(tm);
++    v=(char *)data;
++    
+     if (i < 10) goto err;
+     if (v[i-1] == 'Z') gmt=1;
+     for (i=0; i<10; i++)

--- a/Formula/t/tcl-tk@8.rb
+++ b/Formula/t/tcl-tk@8.rb
@@ -13,13 +13,12 @@ class TclTkAT8 < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 arm64_tahoe:   "c3cef13113dc7af58e7636256289cea7e3f362347f06f96e9417895f5c84494d"
-    sha256 arm64_sequoia: "a5dc8687fecd89ea1ce437a409f3e8938161f8f9fd728679d7ba98aaf9a4a121"
-    sha256 arm64_sonoma:  "5d0e9ae8eebb1e442cb2c27d491b90ac1fdb4b97f0403eaf4de208c1ef2a499c"
-    sha256 sonoma:        "06138d4241d0aa4b4b552dde04215678194643cb5435067b43cf0e8be2b5551e"
-    sha256 arm64_linux:   "baea2f270066d9f00cdb3fc43d4657e1c566d21965b6602cefa310c6bbf586ab"
-    sha256 x86_64_linux:  "dd71d9dee7ad8ff7ac1306e5696471b106ed15081dbf3ff227173a1bccc78fdc"
+    sha256 arm64_tahoe:   "1797f9f71b4169c08c9d205629b6ab156d9b56fdab63bc8cbde37c4996dd17e3"
+    sha256 arm64_sequoia: "3a4f0641ea67fbe31c387c47ffbc8bb7730d64d491e54d80a83b1d3909e36d9d"
+    sha256 arm64_sonoma:  "6a37964adf5d0a0ffbed08421bc0cfa5921dd1425d553c32bf0c921e8f90ddd3"
+    sha256 sonoma:        "c59a63f6c4e2bac8890a47ddd169555f5f533b4559b46fc034e3225d38443346"
+    sha256 arm64_linux:   "e6d29135b80a56c2c73d0ba2c55b281bdee37c6fb5dddb9dca26713ef2d40e69"
+    sha256 x86_64_linux:  "e94936d57ac2edba0fbdcfe41fa62944683cc8e9f9a6e5b376f91f05a28abd7e"
   end
 
   keg_only :versioned_formula


### PR DESCRIPTION
Migrates `tcl-tk@8` from `openssl@3` to `openssl@4` as part of the staging migration.

References:
- Homebrew/homebrew-core#278366