### PR TITLE
curl: migrate to openssl@4

### DIFF
--- a/Formula/c/curl.rb
+++ b/Formula/c/curl.rb
@@ -17,12 +17,12 @@ class Curl < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "bd670b96423f4df3ec9333188e58ce40b936f9d63359f201e17ff0e2219239ea"
-    sha256 cellar: :any,                 arm64_sequoia: "cb1366bbbd11a94a5824dafccdccbfb19d26d50b99a0b650e5863497ef39ea7e"
-    sha256 cellar: :any,                 arm64_sonoma:  "965f8c8ca3d582b5cc8b3e4ded8b34dfc7a59ef1c4e05c2c94ca3d093f1255b8"
-    sha256 cellar: :any,                 sonoma:        "76f4b92369879e1c6870afb34f9408926db80ed16f8476f7e0a98a0c7bf8b937"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "dd8bd30940ccb3181200e3fd93cb794d2dedac06e973fa67e8c3655b1ca11cde"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4e78a17c535b9e3fee4bd0794456b23254259484677721ea2685f8b4d4295b23"
+    sha256 cellar: :any,                 arm64_tahoe:   "292a95f8922562eb97609df58f6f2765a0c1f912899e161827ac2fd288146789"
+    sha256 cellar: :any,                 arm64_sequoia: "de32ed6b3ff9420e5559be0bab5944c9ee7f30078a69be57fd810746a21d06a3"
+    sha256 cellar: :any,                 arm64_sonoma:  "3cf2d6da13f3a932f80017c72058810eb5de2409f95d857ef96535049ff4b1f3"
+    sha256 cellar: :any,                 sonoma:        "842054ace2ad5405139509eb6a7e9f96d3691224ce1f8c41258118ec1d146a2a"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "32f7fbed23fd2d5c154afef0b9f99697b06115fd2d19f6b9ba5574bcd5a7471c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a56889f9aa7a44053503b64e77f68387d410d0c04bd5e9decaf08c48fcc846ea"
   end
 
   head do

--- a/Formula/c/curl.rb
+++ b/Formula/c/curl.rb
@@ -8,6 +8,7 @@ class Curl < Formula
   mirror "http://fresh-center.net/linux/www/legacy/curl-8.20.0.tar.bz2"
   sha256 "4be48e69cf467246cb97d369b85d78a08528f2b37cffef2418ee16e6a4eb596e"
   license "curl"
+  revision 1
   compatibility_version 1
 
   livecheck do
@@ -40,7 +41,7 @@ class Curl < Formula
   depends_on "libnghttp3"
   depends_on "libngtcp2"
   depends_on "libssh2"
-  depends_on "openssl@3"
+  depends_on "openssl@4"
   depends_on "zstd"
 
   uses_from_macos "krb5"
@@ -68,7 +69,7 @@ class Curl < Formula
 
     args = %W[
       --disable-silent-rules
-      --with-ssl=#{Formula["openssl@3"].opt_prefix}
+      --with-ssl=#{Formula["openssl@4"].opt_prefix}
       --without-ca-bundle
       --without-ca-path
       --with-ca-fallback
@@ -134,6 +135,8 @@ class Curl < Formula
 
     ENV["PKG_CONFIG_PATH"] = lib/"pkgconfig"
     ENV.append_path "PKG_CONFIG_PATH", Formula["zlib-ng-compat"].lib/"pkgconfig" unless OS.mac?
+    # TODO: remove when `openssl@4` is not keg_only anymore.
+    ENV.prepend_path "PKG_CONFIG_PATH", Formula["openssl@4"].opt_lib/"pkgconfig"
     system "pkgconf", "--cflags", "libcurl"
   end
 end

--- a/Formula/lib/libngtcp2.rb
+++ b/Formula/lib/libngtcp2.rb
@@ -10,12 +10,12 @@ class Libngtcp2 < Formula
   head "https://github.com/ngtcp2/ngtcp2.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "9b5ecd7bfaa9480d125e9dd5bf96ab2cde59557e9a8797f04ec6ee1af66ad9b5"
-    sha256 cellar: :any,                 arm64_sequoia: "ea867de81e1a2fbb1a8f8c76bbffbca05db53fede0b3da50f0ba7c9f1541158a"
-    sha256 cellar: :any,                 arm64_sonoma:  "c05e1d6ea7186865188cabe53b5e1f79afee3646fdaa408998ea7bdceb5414be"
-    sha256 cellar: :any,                 sonoma:        "6ef4ea330fbbbbfe6a94ad85d7bad8a4f78586bbe91f2824756c3a3eb0d2e48c"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "275827e764af82be486645dd0e4e27409f8b2c4883f68c58fdeb1fbbddc2f3aa"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "6cb712caac1c531346ad50dd0b40c30b7ba768aa5e3d332da82673f3dd16793a"
+    sha256 cellar: :any,                 arm64_tahoe:   "52b5b8c79f8009440874c39a1a240f5650a9d078a1a28ab748a61024582282ed"
+    sha256 cellar: :any,                 arm64_sequoia: "4ec7146e2f28d5c92b4fa874f3ce6bb8611b28a0dd822bba3d8e419696889a9d"
+    sha256 cellar: :any,                 arm64_sonoma:  "08bcad90a3dd1e799f9b328b5abaf7f09a3d424ab2b6b24a5a388b928d7176ad"
+    sha256 cellar: :any,                 sonoma:        "5b4656a5bea156d7f756b11fafb93da61322047a43b0a2092be0135132e24713"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "02a83e84e9ca2439e363935782e15fc785e370c809d0a7cbb104af5acd2ac78f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5f975bd5129012c3696d24abcb68caf39fd175d8077cf7a91412a6aa73f59dcf"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/lib/libngtcp2.rb
+++ b/Formula/lib/libngtcp2.rb
@@ -5,6 +5,7 @@ class Libngtcp2 < Formula
   mirror "http://fresh-center.net/linux/www/ngtcp2-1.22.1.tar.xz"
   sha256 "dfd2c68bd64b89847c611425b9487105c46e8447b5c21e6aeb00642c8fbe2ca8"
   license "MIT"
+  revision 1
   compatibility_version 1
   head "https://github.com/ngtcp2/ngtcp2.git", branch: "main"
 
@@ -18,7 +19,7 @@ class Libngtcp2 < Formula
   end
 
   depends_on "pkgconf" => :build
-  depends_on "openssl@3"
+  depends_on "openssl@4"
 
   def install
     system "./configure", "--disable-silent-rules", *std_configure_args


### PR DESCRIPTION
Migrates `curl` from `openssl@3` to `openssl@4` as part of the staging migration.

References:
- Homebrew/homebrew-core#278366