### PR TITLE
unbound: migrate to openssl@4

### DIFF
--- a/Formula/u/unbound.rb
+++ b/Formula/u/unbound.rb
@@ -17,12 +17,12 @@ class Unbound < Formula
   end
 
   bottle do
-    sha256 arm64_tahoe:   "0ea9166a4b7231f0cd73b0c6e6fec63114b6e2697fcf0841bc36ac3b8dd00411"
-    sha256 arm64_sequoia: "3220d79628029b34d13352bcb00440debe10d24f0184c6180cf9be66a2e58c3c"
-    sha256 arm64_sonoma:  "a19a6712b6f63ac4fde2f7a1c82e6fd796f24d825e93d97b118d75d06165edd3"
-    sha256 sonoma:        "bb5bd5b4ce182c28df322993473db74c74928a7bec7cbe9d3d52f63039defde3"
-    sha256 arm64_linux:   "80096cbcb206668a12aca1c53f79f873797a75748b394586d6fe0af63ca6ee59"
-    sha256 x86_64_linux:  "1c318031b4e6cfde3ee65824946645f907f9393f310ea652733fffb1f198b953"
+    sha256 arm64_tahoe:   "670e2b1931adc953b71b505f04cc69785d24ad9c0c7dafba1d31a05df424c7f1"
+    sha256 arm64_sequoia: "48b04ba2e5f8b73e573c63c9efd3d98af3ea826923611808e3d4714ddb7b63b4"
+    sha256 arm64_sonoma:  "703644274144dd13e29bf4809df5928b9ae4e5c29d5c6dedff2a19ca0a4a9e96"
+    sha256 sonoma:        "f4b337ab6a6f1ff8b3fb457ee316f30e897cf572d377168baa67fe52431fb09c"
+    sha256 arm64_linux:   "6e06e02e097f97a3c358be39a3598ab9ecb3fce0f6f2c77cdf06ae484e5c880d"
+    sha256 x86_64_linux:  "38797000bffaeadbd02e0889d8b3f449c7d4153dc360ecfcfba6416662db92fa"
   end
 
   depends_on "libevent"

--- a/Formula/u/unbound.rb
+++ b/Formula/u/unbound.rb
@@ -4,6 +4,7 @@ class Unbound < Formula
   url "https://nlnetlabs.nl/downloads/unbound/unbound-1.25.0.tar.gz"
   sha256 "062a6eda723fe2f041bee4079b76981569f1d12e066bbd74800242fc1ebddec7"
   license "BSD-3-Clause"
+  revision 1
   compatibility_version 1
   head "https://github.com/NLnetLabs/unbound.git", branch: "master"
 
@@ -26,9 +27,12 @@ class Unbound < Formula
 
   depends_on "libevent"
   depends_on "libnghttp2"
-  depends_on "openssl@3"
+  depends_on "openssl@4"
 
   uses_from_macos "expat"
+
+  # OpenSSL 4 makes ASN1_BIT_STRING opaque.
+  patch :DATA
 
   def install
     expat_prefix = OS.mac? ? "#{MacOS.sdk_for_formula(self).path}/usr" : Formula["expat"].opt_prefix
@@ -41,7 +45,7 @@ class Unbound < Formula
       --with-libevent=#{Formula["libevent"].opt_prefix}
       --with-libexpat=#{expat_prefix}
       --with-libnghttp2=#{Formula["libnghttp2"].opt_prefix}
-      --with-ssl=#{Formula["openssl@3"].opt_prefix}
+      --with-ssl=#{Formula["openssl@4"].opt_prefix}
     ]
 
     system "./configure", *args
@@ -70,3 +74,29 @@ class Unbound < Formula
     system sbin/"unbound-control-setup", "-d", testpath
   end
 end
+
+__END__
+diff --git a/smallapp/unbound-anchor.c b/smallapp/unbound-anchor.c
+index 1e02503..d417564 100644
+--- a/smallapp/unbound-anchor.c
++++ b/smallapp/unbound-anchor.c
+@@ -1675,11 +1675,15 @@ get_usage_of_ex(X509* cert)
+ {
+ 	unsigned long val = 0;
+ 	ASN1_BIT_STRING* s;
++	const unsigned char* data;
++	int len;
+ 	if((s=X509_get_ext_d2i(cert, NID_key_usage, NULL, NULL))) {
+-		if(s->length > 0) {
+-			val = s->data[0];
+-			if(s->length > 1)
+-				val |= s->data[1] << 8;
++		data = ASN1_STRING_get0_data(s);
++		len = ASN1_STRING_length(s);
++		if(data && len > 0) {
++			val = data[0];
++			if(len > 1)
++				val |= data[1] << 8;
+ 		}
+ 		ASN1_BIT_STRING_free(s);
+ 	}


### PR DESCRIPTION
Migrates `unbound` from `openssl@3` to `openssl@4` as part of the staging migration.

References:
- Homebrew/homebrew-core#278366