### PR TITLE
gdal: migrate to openssl@4

### DIFF
--- a/Formula/g/gdal.rb
+++ b/Formula/g/gdal.rb
@@ -4,6 +4,7 @@ class Gdal < Formula
   url "https://github.com/OSGeo/gdal/releases/download/v3.12.4/gdal-3.12.4.tar.gz"
   sha256 "68844ae29557b7efae4292c3b4cb3a3b8a79d14b765b89c5a7b17cbae7fa715a"
   license "MIT"
+  revision 1
   compatibility_version 1
 
   livecheck do
@@ -59,7 +60,7 @@ class Gdal < Formula
   depends_on "numpy"
   depends_on "openexr"
   depends_on "openjpeg"
-  depends_on "openssl@3"
+  depends_on "openssl@4"
   depends_on "pcre2"
   depends_on "poppler"
   depends_on "proj"


### PR DESCRIPTION
Migrates `gdal` from `openssl@3` to `openssl@4` as part of the staging migration.

References:
- Homebrew/homebrew-core#278366