### PR TITLE
apib: use openssl@4

### DIFF
--- a/Formula/a/apib.rb
+++ b/Formula/a/apib.rb
@@ -4,6 +4,7 @@ class Apib < Formula
   url "https://github.com/apigee/apib/archive/refs/tags/APIB_1_2_1.tar.gz"
   sha256 "e47f639aa6ffc14a2e5b03bf95e8b0edc390fa0bb2594a521f779d6e17afc14c"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/apigee/apib.git", branch: "master"
 
   livecheck do
@@ -36,7 +37,7 @@ class Apib < Formula
 
   depends_on "cmake" => :build
   depends_on "libev"
-  depends_on "openssl@3"
+  depends_on "openssl@4"
 
   def install
     # Workaround to build with CMake 4


### PR DESCRIPTION
- [x] Have you followed the [Contributing guidelines](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>` where `formula` is the name of the formula you're updating?
- [x] Have you run `brew audit --strict <formula>` (after doing `brew install <formula>`) where `formula` is the name of the formula you're updating?

-----

This migrates `apib` from `openssl@3` to `openssl@4` and bumps `revision`.

AI-assisted contribution by Codex (GPT-5). Validation (audit, source build, test) performed by AI.

Built and tested locally on macOS (arm64).

https://github.com/Homebrew/homebrew-core/issues/278366

Note:

I explicitly allowed codex to do disabled formulae, because even though they are disabled doesnt mean I/we need to abadon them fully before they are deleted. Might seem stupid, but I think we dont exclude because of disability 
