### PR TITLE
aws-c-cal: use openssl@4

### DIFF
--- a/Formula/a/aws-c-cal.rb
+++ b/Formula/a/aws-c-cal.rb
@@ -4,7 +4,7 @@ class AwsCCal < Formula
   url "https://github.com/awslabs/aws-c-cal/archive/refs/tags/v0.9.13.tar.gz"
   sha256 "80b7c6087b0af461b4483e4c9483aea2e0dac5d9fb2289b057159ea6032409e1"
   license "Apache-2.0"
-  revision 1
+  revision 2
   compatibility_version 1
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [Contributing guidelines](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>` where `formula` is the name of the formula you're updating?
- [x] Have you run `brew audit --strict <formula>` (after doing `brew install <formula>`) where `formula` is the name of the formula you're updating?

-----

This migrates `aws-c-cal` from `openssl@3` to `openssl@4` and bumps `revision`.

AI-assisted contribution by Codex (GPT-5). Validation (audit, source build, test) performed by AI.

Built and tested locally on macOS (arm64).

https://github.com/Homebrew/homebrew-core/issues/278366


~ some idiot (who is 100% not me 😉) was unable to properly use git in #281014, and also closed it prematurely. (yes it was done by codex but I (not the idiot) rebased onto main) ~

Some also other human (defenetly not me) looks for existing migrations inside main not the staging branch. 