### PR TITLE
bkmr: use openssl@4

### DIFF
--- a/Formula/b/bkmr.rb
+++ b/Formula/b/bkmr.rb
@@ -13,12 +13,12 @@ class Bkmr < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "e3573e528ecdd67acce010304200e88910c748da4d57c26aca455a7499f8a416"
-    sha256 cellar: :any,                 arm64_sequoia: "42678af503147c19c60dd07bdc9f7c67fc59e626cd06ecf3e47828f6c8420984"
-    sha256 cellar: :any,                 arm64_sonoma:  "2580fb34a65550b98b536f367527b7015e50cd79b3af6e4d628962d0a11040ba"
-    sha256 cellar: :any_skip_relocation, sonoma:        "fca0bfbea683e90e2c0ea473743cae564c4e2f34c7f5348c237c5e40505c5766"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "720173b01baf907d07e7b989e403723edb2b256a8cf36c1324d6790aa4bb7f19"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "47b4661576651f6939460d5b99d6bc7ba404e2d4ce71053be55ba7f19944fbcb"
+    sha256 cellar: :any,                 arm64_tahoe:   "c0605f0008e996454fa355ac05e9c96cb5d53d117363672c50d966d7c08a0336"
+    sha256 cellar: :any,                 arm64_sequoia: "8158d063e199e9ef465c8310ccd6f894b3f6dc05a0ff927b072d2a71525713b9"
+    sha256 cellar: :any,                 arm64_sonoma:  "a84faf363872d3298b6eae41b95bc04e28afaea83a84720e74e7a002f37c2057"
+    sha256 cellar: :any_skip_relocation, sonoma:        "46d5dbf749c9cb1fb5db2fee2f5d74620789758ddf0ede9541cf83d519fbf2b4"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "a547f574487d9e1e9a3d9303b1cdb1b3261394a8332621575b9dd1eec7302d8c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b9679584a7bec6f6c8ef16925ab27465c04db5e5a8cb576eae86433d66933dec"
   end
 
   depends_on "rust" => :build

--- a/Formula/b/bkmr.rb
+++ b/Formula/b/bkmr.rb
@@ -4,6 +4,7 @@ class Bkmr < Formula
   url "https://github.com/sysid/bkmr/archive/refs/tags/v7.6.2.tar.gz"
   sha256 "09b3f6db7675d2b036b22b9b1a4856b5ed5eead98fc9da781e5f780e2c1bd845"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/sysid/bkmr.git", branch: "main"
 
   livecheck do
@@ -22,7 +23,7 @@ class Bkmr < Formula
 
   depends_on "rust" => :build
   depends_on "onnxruntime"
-  depends_on "openssl@3"
+  depends_on "openssl@4"
 
   uses_from_macos "python"
 
@@ -30,7 +31,7 @@ class Bkmr < Formula
     cd "bkmr" do
       # Ensure that the `openssl` crate picks up the intended library.
       # https://docs.rs/openssl/latest/openssl/#manual
-      ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
+      ENV["OPENSSL_DIR"] = Formula["openssl@4"].opt_prefix
 
       # Add Homebrew lib to rpath so dlopen("libonnxruntime.dylib") finds it at runtime
       ENV.append "RUSTFLAGS", "-C link-args=-Wl,-rpath,#{HOMEBREW_PREFIX}/lib"


### PR DESCRIPTION
- [x] Have you followed the [Contributing guidelines](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>` where `formula` is the name of the formula you're updating?
- [x] Have you run `brew audit --strict <formula>` (after doing `brew install <formula>`) where `formula` is the name of the formula you're updating?

-----

This migrates `bkmr` from `openssl@3` to `openssl@4` and bumps `revision`.

AI-assisted contribution by Codex (GPT-5). Validation (audit, source build, test) performed by AI.

Built and tested locally on macOS (arm64).

https://github.com/Homebrew/homebrew-core/issues/278366
