### PR TITLE
smlnj 2026.1 (new formula)

### DIFF
--- a/Formula/s/smlnj.rb
+++ b/Formula/s/smlnj.rb
@@ -11,6 +11,15 @@ class Smlnj < Formula
     regex(%r{href=["']?[^"' >]*dist/working/v?(\d+(?:\.\d+)+)/(?:index\.html)?["' >]}i)
   end
 
+  bottle do
+    sha256 arm64_tahoe:   "93b1219027b0abcf80a71243e1607c50fc2a5849a734ae89190ce43d1168f5f6"
+    sha256 arm64_sequoia: "bb5a27da68e44310858f4df611cdc5f125c8da814d06c188191349ae0aafc113"
+    sha256 arm64_sonoma:  "13b5078c334318acab15ea2b2fd17ead939552f7a5e0c620d696f90feb42cf96"
+    sha256 sonoma:        "d6da8b8a343b1582f652980f6a08410d2f0f4e9ff0e6dd30ec32c2072347d3cc"
+    sha256 arm64_linux:   "141e547aa173e6a4c24667d29daa04547b2fefd2eaeeec702e3eb472036acb9a"
+    sha256 x86_64_linux:  "213f6ba81cdecb49d155373e72106177a625bb2310419df123e7292791dd06bf"
+  end
+
   depends_on "autoconf" => :build
   depends_on "cmake" => :build
   depends_on "python@3.14" => :build

--- a/Formula/s/smlnj.rb
+++ b/Formula/s/smlnj.rb
@@ -1,0 +1,72 @@
+class Smlnj < Formula
+  desc "Compiler and programming system for Standard ML"
+  homepage "https://www.smlnj.org/"
+  url "https://smlnj.org/dist/working/2026.1/smlnj-arm64-unix-2026.1.tgz"
+  sha256 "2549a8332a28c126313d8f170391fe500a232a5854dd3b05af3277c7b57a6859"
+  license "BSD-3-Clause"
+  head "https://github.com/smlnj/smlnj.git", branch: "main"
+
+  livecheck do
+    url :homepage
+    regex(%r{href=["']?[^"' >]*dist/working/v?(\d+(?:\.\d+)+)/(?:index\.html)?["' >]}i)
+  end
+
+  depends_on "autoconf" => :build
+  depends_on "cmake" => :build
+  depends_on "python@3.14" => :build
+
+  uses_from_macos "zlib"
+
+  resource "bootarchive" do
+    on_arm do
+      url "https://smlnj.org/dist/working/2026.1/boot.arm64-unix.tgz", using: :nounzip
+      sha256 "ab2807d27d7ade38b09b80ac96d3de082a47aa707108728fe4edb4199caad7fd"
+    end
+    on_intel do
+      url "https://smlnj.org/dist/working/2026.1/boot.amd64-unix.tgz", using: :nounzip
+      sha256 "71a160b8a92114e8e0243b5c39c17a6006f3165da74185dbb560a3bda0632faa"
+    end
+  end
+
+  def install
+    buildpath.install resource("bootarchive")
+
+    # Building the runtime system causes race conditions when parallel
+    # make is enabled
+    ENV.deparallelize
+
+    libexec.mkpath
+    cd buildpath do
+      ENV["INSTALLDIR"] = libexec.realpath.to_s
+      system "./build.sh"
+
+      %w[
+        sml asdlgen heap2exec ml-antlr ml-build ml-burg ml-makedepend ml-ulex ml-yacc
+      ].each do |cmd|
+        bin.write_exec_script libexec/"bin/#{cmd}"
+      end
+    end
+  end
+
+  test do
+    (testpath/"hello.sml").write <<~EOF
+      val () = print "Hello, Homebrew!\n";
+      val _ = (
+        CM.make "$/smlnj-lib.cm";
+        CM.make "$/controls-lib.cm";
+        CM.make "$/hash-cons-lib.cm";
+        CM.make "$/inet-lib.cm";
+        CM.make "$/json-lib.cm";
+        CM.make "$/reactive-lib.cm";
+        CM.make "$/regexp-lib.cm";
+        CM.make "$/sexp-lib.cm";
+        CM.make "$/unix-lib.cm";
+        CM.make "$/uuid-lib.cm";
+        CM.make "$/xml-lib.cm"
+      ) handle _ => OS.Process.exit OS.Process.failure
+    EOF
+    output = shell_output "#{bin}/sml < hello.sml"
+    banner = Regexp.new("Standard ML of New Jersey [[Version #{version}, 64-bit; .*]]")
+    assert_match banner, output
+  end
+end


### PR DESCRIPTION
This PR adds SML/NJ as a source-built formula.

SML/NJ is currently available in Homebrew as a cask that installs the published macOS `.pkg` installer. That installer is not notarized, and the cask is already scheduled for removal later this year. This formula provides a replacement.

In addition, while the cask installs the [legacy](https://github.com/smlnj/legacy) compiler, the formula installs the [development](https://github.com/smlnj/smlnj) compiler, which offers native ARM support.

The formula builds from the source distribution, using a bootstrapping compiler from the official website. The main installer script `./build.sh` runs completely offline when the bootstrapping compiler is present.

I am one of the maintainers of [SML/NJ](https://github.com/smlnj/smlnj), and I believe the formula-based installation is better-suited for Homebrew users. I am also happy to maintain this formula going forward.

Companion PR: Homebrew/homebrew-cask#262856.

**Note**: The current CI failure is due to the token conflict with the existing `smlnj` cask, which is being removed in the companion PR.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
