### PR TITLE
infracost@1 0.10.44 (new formula)

### DIFF
--- a/Aliases/infracost@0
+++ b/Aliases/infracost@0
@@ -1,0 +1,1 @@
+../Formula/i/infracost.rb

--- a/Formula/i/infracost@1.rb
+++ b/Formula/i/infracost@1.rb
@@ -1,0 +1,26 @@
+class InfracostAT1 < Formula
+  desc "Cost estimates for Terraform"
+  homepage "https://www.infracost.io/docs/"
+  url "https://github.com/infracost/infracost/archive/refs/tags/v0.10.44.tar.gz"
+  sha256 "638ac6155c15886bcdc1eda4f633ae54f64243f61b8b8676791e0003ddd836d7"
+  license "Apache-2.0"
+
+  keg_only :versioned_formula
+
+  depends_on "go" => :build
+
+  def install
+    ENV["CGO_ENABLED"] = "0"
+    ldflags = "-X github.com/infracost/infracost/internal/version.Version=v#{version}"
+    system "go", "build", *std_go_args(output: bin/"infracost", ldflags:), "./cmd/infracost"
+
+    generate_completions_from_executable(bin/"infracost", "completion", "--shell")
+  end
+
+  test do
+    assert_match "v#{version}", shell_output("#{bin}/infracost --version 2>&1")
+
+    output = shell_output("#{bin}/infracost breakdown --no-color 2>&1", 1)
+    assert_match "Error: INFRACOST_API_KEY is not set but is required", output
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. AI-assisted contribution by Claude Opus 4.7 — approximately 90% of the work. Claude drafted the formula and ran `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source`, `brew test`, and `brew audit --new --strict` locally. Human (Infracost CLI maintainer) directed the v1/v2 split strategy and reviewed the formula and PR description.

-----

Built and tested locally on macOS Tahoe 26 (Darwin 25.3.0) running arm64.

Adds `infracost@1` pinned to v0.10.44, the current latest of the v1 line. `keg_only :versioned_formula`.

This is part of the existing `infracost` project, not a new tool. Infracost has been distributed via Homebrew as `infracost` for several years (existing `Formula/i/infracost.rb`); this PR formally pins the v1 line under a versioned formula so v1 users have a stable target as we prepare to move the unversioned formula to v2.

Note on naming: the v1 line never released a `v1.0.0`; it has stayed on `v0.x.y` throughout its lifetime. The `@1` suffix refers to the v1 product line, not the upstream version number.

Sibling PR adds `infracost@2` (v2.0.0). The v2 codebase has been moved to a separate repository (`infracost/cli`) so that v1 and v2 release tooling and triage can live separately; the v1 line remains where it has always been at `infracost/infracost`. The project, its users, and its history are continuous with the existing Homebrew formula.

The unversioned `infracost` formula will stay pointed at v1 for now. We don't want to push a breaking change on existing users without notice — introducing the versioned formulae first gives v1 users a stable target before flipping `infracost` to v2 in a later PR.