### PR TITLE
infracost@2 2.0.0 (new formula)

### DIFF
--- a/Aliases/infracost@0
+++ b/Aliases/infracost@0
@@ -1,0 +1,1 @@
+../Formula/i/infracost.rb

--- a/Formula/i/infracost@2.rb
+++ b/Formula/i/infracost@2.rb
@@ -1,0 +1,31 @@
+class InfracostAT2 < Formula
+  desc "Cost estimates for Terraform, Terragrunt, and CloudFormation"
+  homepage "https://www.infracost.io/docs/"
+  url "https://github.com/infracost/cli/archive/refs/tags/v2.0.0.tar.gz"
+  sha256 "649f124545c4b71332b093cc15b020315e1eb3372d7cfeca61e05dfceac5b2a6"
+  license "Apache-2.0"
+
+  livecheck do
+    url :stable
+    regex(/^v?(2(?:\.\d+)+)$/i)
+    strategy :git
+  end
+
+  keg_only :versioned_formula
+
+  depends_on "go" => :build
+
+  def install
+    ENV["CGO_ENABLED"] = "0"
+    ldflags = "-X github.com/infracost/cli/version.Version=v#{version}"
+    system "go", "build", *std_go_args(output: bin/"infracost", ldflags:), "main.go"
+  end
+
+  test do
+    assert_match "v#{version}", shell_output("#{bin}/infracost --version 2>&1")
+
+    ENV["INFRACOST_CLI_AUTHENTICATION_TOKEN"] = "dummy"
+    output = shell_output("#{bin}/infracost setup --no-color 2>&1", 1)
+    assert_match "setup requires interactive login", output
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. AI-assisted contribution by Claude Opus 4.7 — approximately 90% of the work. Claude drafted the formula and ran `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source`, `brew test`, and `brew audit --new --strict` locally. Human (Infracost CLI maintainer) directed the v1/v2 split strategy and reviewed the formula and PR description.

-----

Built and tested locally on macOS Tahoe 26 (Darwin 25.3.0) running arm64.

Adds `infracost@2` at v2.0.0. `keg_only :versioned_formula`.

This is a continuation of the existing `infracost` project, not a new tool. Infracost has been distributed via Homebrew as `infracost` for several years (existing `Formula/i/infracost.rb`); this PR introduces the v2 codebase under the same project, just hosted in a new repository.

The v2 codebase has been moved to `infracost/cli` so that v1 and v2 release tooling and triage can live separately. The v1 codebase remains where it has always been at `infracost/infracost`. Both repositories ship the same `infracost` binary; the move is operational, not a fresh start — the project, its users, and its history are continuous with the existing Homebrew formula.

`infracost@2` is the next major version of `infracost`, **not a complementary tool**. The sibling PR adds `infracost@1` (the v1 line, also `keg_only`). The unversioned `infracost` formula will stay pointed at v1 for now — we'll switch it to v2 in a later PR after a rollout period, so we don't push a breaking change on existing users without notice.

The `livecheck` block constrains to `v2.x.x` tags because `infracost/cli` also carries unrelated plugin tags (e.g. `infracost-parser-plugin/v0.1.2`) that autobump should ignore.