### PR TITLE
infracost: drop no_autobump!

### DIFF
--- a/Formula/i/infracost.rb
+++ b/Formula/i/infracost.rb
@@ -6,8 +6,6 @@ class Infracost < Formula
   license "Apache-2.0"
   head "https://github.com/infracost/infracost.git", branch: "master"
 
-  no_autobump! because: :bumped_by_upstream
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "12a68a6ec410dd1883c8cf5a63b594631678cead882d7af914f0a5a08d3df06f"
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "12a68a6ec410dd1883c8cf5a63b594631678cead882d7af914f0a5a08d3df06f"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. AI-assisted contribution by Claude Opus 4.7 — approximately 90% of the work. Claude made the change and ran `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source`, `brew test`, and `brew audit --strict` locally. Human (Infracost CLI maintainer) directed the change and reviewed.

-----

Built and tested locally on macOS Tahoe 26 (Darwin 25.3.0) running arm64.

Removes the `no_autobump! because: :bumped_by_upstream` line from `infracost.rb`. The upstream `infracost/infracost` repository is dropping its explicit homebrew-bump CI job, so the formula can rely on Homebrew's autobump bot going forward.