### PR TITLE
aircrack-ng: use openssl@4

### DIFF
--- a/Formula/a/aircrack-ng.rb
+++ b/Formula/a/aircrack-ng.rb
@@ -8,7 +8,7 @@ class AircrackNg < Formula
     "GPL-2.0-or-later",
     "GPL-2.0-or-later" => { with: "cryptsetup-OpenSSL-exception" },
   ]
-  revision 1
+  revision 2
 
   livecheck do
     url :homepage
@@ -29,7 +29,7 @@ class AircrackNg < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkgconf" => :build
-  depends_on "openssl@3"
+  depends_on "openssl@4"
   depends_on "pcre2"
   depends_on "sqlite"
 

--- a/Formula/a/aircrack-ng.rb
+++ b/Formula/a/aircrack-ng.rb
@@ -16,13 +16,12 @@ class AircrackNg < Formula
   end
 
   bottle do
-    rebuild 3
-    sha256                               arm64_tahoe:   "c1461024ee7d85a1f0024b7e79aee529a2ffc577b4e7f55df1b93bce01a4a9c0"
-    sha256                               arm64_sequoia: "240101a996380066deb81a5f2baa3df5c940231082f13bb5f6955ba815a760eb"
-    sha256                               arm64_sonoma:  "8e0f9fda43350ce0365407b05c02bbbe59edb719612e7522e431bfa12de6a83b"
-    sha256                               sonoma:        "e5e3a8ae160dcdca43edb6382efc2873748e6a02f537cbcb27003b2321e7c44d"
-    sha256                               arm64_linux:   "73fe80cec55d4e7058ed7d3bf9fc5a57e30d39941fd665714ed90d74c63d2ab5"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4aa4f09ec6d620ea76c8a799abebea56382ed5c055b4a4aed414a6339a7a3591"
+    sha256                               arm64_tahoe:   "79663b102bfc2f2c70886c84e262cb77814c6138b87e26fa722cfa3e460eeb14"
+    sha256                               arm64_sequoia: "f60653d0f5b9b9f0db0a83aa34198d89f1a33239ce025fec8a723f5c0d1dff53"
+    sha256                               arm64_sonoma:  "a69ff428aa1336b3cee2ca71431e198abb038d60a715927af3123a0e995bfbe8"
+    sha256                               sonoma:        "9b8730410869255d5872b50ae285849c706a6540b625b5adea88ee855c450961"
+    sha256                               arm64_linux:   "ed587ea52be90ca308c2a598b6f0ade096d05d070a0096b623f0465e7ad50cdf"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "ed0b981f61d925712e4296374229cde3f819aeb38f957d17a37c1500fea1ce8d"
   end
 
   depends_on "autoconf" => :build


### PR DESCRIPTION
- [x] Have you followed the [Contributing guidelines](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>` where `formula` is the name of the formula you're updating?
- [x] Have you run `brew audit --strict <formula>` (after doing `brew install <formula>`) where `formula` is the name of the formula you're updating?

-----

This migrates `aircrack-ng` from `openssl@3` to `openssl@4` and bumps `revision`.

AI-assisted contribution by Codex (GPT-5). Validation (audit, source build, test, linkage check) performed by AI.

Built and tested locally on macOS (arm64).

https://github.com/Homebrew/homebrew-core/issues/278366
