### PR TITLE
crystal deadfinder amber: use openssl@4

### DIFF
--- a/Formula/a/amber.rb
+++ b/Formula/a/amber.rb
@@ -4,7 +4,7 @@ class Amber < Formula
   url "https://github.com/amberframework/amber/archive/refs/tags/v1.4.1.tar.gz"
   sha256 "92664a859fb27699855dfa5d87dc9bf2e4a614d3e54844a8344196d2807e775c"
   license "MIT"
-  revision 2
+  revision 3
 
   bottle do
     rebuild 1
@@ -20,7 +20,7 @@ class Amber < Formula
   depends_on "crystal"
   depends_on "libevent"
   depends_on "libyaml"
-  depends_on "openssl@3"
+  depends_on "openssl@4"
   depends_on "pcre2"
   depends_on "sqlite"
 
@@ -36,6 +36,10 @@ class Amber < Formula
   end
 
   def install
+    ENV.prepend_path "PKG_CONFIG_PATH", Formula["openssl@4"].opt_lib/"pkgconfig"
+    ENV["OPENSSL_DIR"] = Formula["openssl@4"].opt_prefix
+    ENV["OPENSSL_ROOT_DIR"] = Formula["openssl@4"].opt_prefix
+
     system "shards", "install"
     system "make", "install", "PREFIX=#{prefix}"
   end

--- a/Formula/c/crystal.rb
+++ b/Formula/c/crystal.rb
@@ -2,6 +2,7 @@ class Crystal < Formula
   desc "Fast and statically typed, compiled language with Ruby-like syntax"
   homepage "https://crystal-lang.org/"
   license "Apache-2.0"
+  revision 1
   compatibility_version 1
 
   stable do
@@ -40,7 +41,7 @@ class Crystal < Formula
   depends_on "gmp" => :no_linkage # std uses it but it's not linked
   depends_on "libyaml"
   depends_on "llvm"
-  depends_on "openssl@3" # std uses it but it's not linked
+  depends_on "openssl@4" # std uses it but it's not linked
   depends_on "pcre2"
   depends_on "pkgconf" # @[Link] will use pkg-config if available
 

--- a/Formula/d/deadfinder.rb
+++ b/Formula/d/deadfinder.rb
@@ -4,6 +4,7 @@ class Deadfinder < Formula
   url "https://github.com/hahwul/deadfinder/archive/refs/tags/2.0.2.tar.gz"
   sha256 "13d3d4b0392d6b1548071d44dc03a14e790ea161781d5a57a196577316a97543"
   license "MIT"
+  revision 1
   head "https://github.com/hahwul/deadfinder.git", branch: "main"
 
   bottle do
@@ -21,7 +22,7 @@ class Deadfinder < Formula
   depends_on "bdw-gc"
   depends_on "libevent"
   depends_on "libyaml"
-  depends_on "openssl@3"
+  depends_on "openssl@4"
   depends_on "pcre2"
 
   uses_from_macos "libxml2"
@@ -31,6 +32,7 @@ class Deadfinder < Formula
   end
 
   def install
+    ENV.prepend_path "PKG_CONFIG_PATH", Formula["openssl@4"].opt_lib/"pkgconfig"
     system "shards", "build", "--production", "--release", "--no-debug"
     bin.install "bin/deadfinder"
 


### PR DESCRIPTION
- [x] Have you followed the [Contributing guidelines](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>` where `formula` is the name of the formula you're updating?
- [x] Have you run `brew audit --strict <formula>` (after doing `brew install <formula>`) where `formula` is the name of the formula you're updating?

-----

This migrates `amber` from `openssl@3` to `openssl@4` and bumps `revision`.

AI-assisted contribution by Codex (GPT-5). Validation (audit, source build, test, linkage check) performed by AI.

Built and tested locally on macOS (arm64).

https://github.com/Homebrew/homebrew-core/issues/278366


depends on python