### PR TITLE
amqp-cpp: use openssl@4

### DIFF
--- a/Formula/a/amqp-cpp.rb
+++ b/Formula/a/amqp-cpp.rb
@@ -13,14 +13,12 @@ class AmqpCpp < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "f300647f32576320289d224bdf7f4500522765a6c2ed8f10711372547d24114b"
-    sha256 cellar: :any,                 arm64_sequoia: "d42884b0048b3524ff2503b74e3606a415534df02f36b76daa738005f801c660"
-    sha256 cellar: :any,                 arm64_sonoma:  "6088a49ef4492292f4643805af8808a6d3942a1f3b4e1fda5b29aefb08bc96c6"
-    sha256 cellar: :any,                 arm64_ventura: "052fb79e01072ebee63a343fca762f19fb3d3586502e6049c0e8666db559663e"
-    sha256 cellar: :any,                 sonoma:        "58aa9b3ed88fa9452bab84e4265c04ff686abb23cfefd9ce1b40066fa50cdacd"
-    sha256 cellar: :any,                 ventura:       "a0549cf3274f68d0dd55199876406836104d0df3af6dbc4ffa56031a2b8859ce"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "8951f9439fa4acf6c6616b1130c7a2cbffe3ef79e9443865592448baca178ea9"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "61ccf7cf9045f334afa3df40778602bdf1382d681c0ae5811ac34e6863906fcb"
+    sha256 cellar: :any,                 arm64_tahoe:   "e45212f8e035ad4f6e765889bb949bcf8f60fef844b0646eb7006fad0b959605"
+    sha256 cellar: :any,                 arm64_sequoia: "2f0ec346eb00e3280870884df2cb742dab7b834a3a1135ea566d57717c65ea5f"
+    sha256 cellar: :any,                 arm64_sonoma:  "c15637ad6b4fe3af89f006ea4fb6ee9ea3a412723ce407bb10c5cb5f0de8f2f0"
+    sha256 cellar: :any,                 sonoma:        "a2675cb6a8ee1b421da6bbcb903868014aee17270a5a634fcbc39b4ac9473715"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "10f0d0088d8c57a1d507dd2c249610cbc71439276ac7dfdd6aca04c59322841c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "10421912a7018eaed19fb9701b6c2aef0af19e9bd654ddf24fb0ccfd30a60b83"
   end
 
   depends_on "cmake" => :build

--- a/Formula/a/amqp-cpp.rb
+++ b/Formula/a/amqp-cpp.rb
@@ -4,6 +4,7 @@ class AmqpCpp < Formula
   url "https://github.com/CopernicaMarketingSoftware/AMQP-CPP/archive/refs/tags/v4.3.27.tar.gz"
   sha256 "af649ef8b14076325387e0a1d2d16dd8395ff3db75d79cc904eb6c179c1982fe"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/CopernicaMarketingSoftware/AMQP-CPP.git", branch: "master"
 
   livecheck do
@@ -23,7 +24,7 @@ class AmqpCpp < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "openssl@3"
+  depends_on "openssl@4"
 
   # Backport fix for CMake 4
   # PR ref: https://github.com/CopernicaMarketingSoftware/AMQP-CPP/pull/541


### PR DESCRIPTION
- [x] Have you followed the [Contributing guidelines](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>` where `formula` is the name of the formula you're updating?
- [x] Have you run `brew audit --strict <formula>` (after doing `brew install <formula>`) where `formula` is the name of the formula you're updating?

-----

This migrates `amqp-cpp` from `openssl@3` to `openssl@4` and bumps `revision`.

AI-assisted contribution by Codex (GPT-5). Validation (audit, source build, test, linkage check) performed by AI.

Built and tested locally on macOS (arm64).

https://github.com/Homebrew/homebrew-core/issues/278366
