### PR TITLE
aqbanking: use openssl@4

### DIFF
--- a/Formula/a/aqbanking.rb
+++ b/Formula/a/aqbanking.rb
@@ -4,7 +4,7 @@ class Aqbanking < Formula
   url "https://www.aquamaniac.de/rdm/attachments/download/652/aqbanking-6.9.1.tar.gz"
   sha256 "fc94a2bebfbb4fc26b98dc93c8fa36a8026298cd7995f79821c480db35587f6b"
   license "GPL-2.0-or-later"
-  revision 2
+  revision 3
 
   livecheck do
     url "https://www.aquamaniac.de/rdm/projects/aqbanking/files"
@@ -28,7 +28,7 @@ class Aqbanking < Formula
   depends_on "libxml2"
   depends_on "libxmlsec1"
   depends_on "libxslt" # Our libxslt links with libgcrypt
-  depends_on "openssl@3"
+  depends_on "openssl@4"
   depends_on "pkgconf" # aqbanking-config needs pkg-config for execution
 
   on_macos do

--- a/Formula/g/gwenhywfar.rb
+++ b/Formula/g/gwenhywfar.rb
@@ -4,6 +4,7 @@ class Gwenhywfar < Formula
   url "https://www.aquamaniac.de/rdm/attachments/download/630/gwenhywfar-5.14.1.tar.gz"
   sha256 "8916feaa99cb954f963f2cba8dd2dffe57cacf7f284daf00eab071aad6fe2ab3"
   license "LGPL-2.1-or-later"
+  revision 1
 
   livecheck do
     url "https://www.aquamaniac.de/rdm/projects/gwenhywfar/files"
@@ -26,7 +27,7 @@ class Gwenhywfar < Formula
   depends_on "gnutls"
   depends_on "libgcrypt"
   depends_on "libgpg-error"
-  depends_on "openssl@3"
+  depends_on "openssl@4"
   depends_on "pkgconf" # gwenhywfar-config needs pkg-config for execution
   depends_on "qtbase"
 

--- a/Formula/lib/libxmlsec1.rb
+++ b/Formula/lib/libxmlsec1.rb
@@ -5,6 +5,7 @@ class Libxmlsec1 < Formula
   mirror "https://www.aleksey.com/xmlsec/download/xmlsec1-1.3.11.tar.gz"
   sha256 "53675e98fa83b48201d24f7bfbcaeaa1b51496b8b19ff969785856bdeb196af3"
   license "MIT"
+  revision 1
   compatibility_version 3
 
   # Checking the first-party download page persistently fails in the autobump
@@ -26,7 +27,7 @@ class Libxmlsec1 < Formula
   depends_on "pkgconf" => :build
   depends_on "gnutls" # Yes, it wants both ssl/tls variations
   depends_on "libxml2"
-  depends_on "openssl@3"
+  depends_on "openssl@4"
   uses_from_macos "libxslt"
 
   # Add HOMEBREW_PREFIX/lib to dl load path
@@ -40,7 +41,7 @@ class Libxmlsec1 < Formula
       --disable-mscng
       --without-nss
       --without-nspr
-      --with-openssl=#{Formula["openssl@3"].opt_prefix}
+      --with-openssl=#{Formula["openssl@4"].opt_prefix}
     ]
 
     system "./configure", *args, *std_configure_args

--- a/Formula/q/qtbase.rb
+++ b/Formula/q/qtbase.rb
@@ -7,6 +7,7 @@ class Qtbase < Formula
     "BSD-3-Clause", # *.cmake
     "GFDL-1.3-no-invariants-only", # *.qdoc
   ]
+  revision 1
   compatibility_version 1
   head "https://code.qt.io/qt/qtbase.git", branch: "dev"
 
@@ -57,7 +58,7 @@ class Qtbase < Formula
   depends_on "libb2"
   depends_on "libpng"
   depends_on "md4c"
-  depends_on "openssl@3"
+  depends_on "openssl@4"
   depends_on "pcre2"
   depends_on "zstd"
 


### PR DESCRIPTION
- [x] Have you followed the [Contributing guidelines](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>` where `formula` is the name of the formula you're updating?
- [x] Have you run `brew audit --strict <formula>` (after doing `brew install <formula>`) where `formula` is the name of the formula you're updating?

-----

This migrates `aqbanking` from `openssl@3` to `openssl@4` and bumps `revision`.

AI-assisted contribution by Codex (GPT-5). Validation (audit, source build, test, linkage check) performed by AI.

Built and tested locally on macOS (arm64).

https://github.com/Homebrew/homebrew-core/issues/278366
