### PR TITLE
azure-core-cpp azure-storage-common-cpp: use openssl@4

### DIFF
--- a/Formula/a/azure-core-cpp.rb
+++ b/Formula/a/azure-core-cpp.rb
@@ -4,6 +4,7 @@ class AzureCoreCpp < Formula
   url "https://github.com/Azure/azure-sdk-for-cpp/archive/refs/tags/azure-core_1.16.3.tar.gz"
   sha256 "70d5d2aea5ece95148ee8b71fb302ae35a1178e58b58150a14df8866a0c54464"
   license "MIT"
+  revision 1
   compatibility_version 1
 
   livecheck do
@@ -21,9 +22,15 @@ class AzureCoreCpp < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "openssl@3"
+  depends_on "openssl@4"
 
   uses_from_macos "curl"
+
+  # Backport openssl4 support
+  patch do
+    url "https://github.com/Azure/azure-sdk-for-cpp/commit/4c2e11fd9239ab5c157493f22b9ddd0b5ec90402.patch?full_index=1"
+    sha256 "2909545705162851ff48b16c650763605492df077f59be969f589540acb079fb"
+  end
 
   def install
     ENV["AZURE_SDK_DISABLE_AUTO_VCPKG"] = "1"

--- a/Formula/a/azure-storage-common-cpp.rb
+++ b/Formula/a/azure-storage-common-cpp.rb
@@ -4,7 +4,7 @@ class AzureStorageCommonCpp < Formula
   url "https://github.com/Azure/azure-sdk-for-cpp/archive/refs/tags/azure-storage-common_12.12.0.tar.gz"
   sha256 "0d835b22c03358f6e837044c70b3f9d93902cf710c27ac9ee22b2544ffdec27c"
   license "MIT"
-  revision 2
+  revision 3
 
   livecheck do
     url :stable
@@ -22,7 +22,7 @@ class AzureStorageCommonCpp < Formula
 
   depends_on "cmake" => :build
   depends_on "azure-core-cpp"
-  depends_on "openssl@3"
+  depends_on "openssl@4"
 
   uses_from_macos "libxml2"
 


### PR DESCRIPTION
- [x] Have you followed the [Contributing guidelines](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>` where `formula` is the name of the formula you're updating?
- [x] Have you run `brew audit --strict <formula>` (after doing `brew install <formula>`) where `formula` is the name of the formula you're updating?

-----

This migrates `azure-storage-common-cpp` from `openssl@3` to `openssl@4` and bumps `revision`.

AI-assisted contribution by Codex (GPT-5). Validation (audit, source build, test, linkage check) performed by AI.

Built and tested locally on macOS (arm64).

https://github.com/Homebrew/homebrew-core/issues/278366
