### PR TITLE
baresip: use openssl@4

### DIFF
--- a/Formula/b/baresip.rb
+++ b/Formula/b/baresip.rb
@@ -4,6 +4,7 @@ class Baresip < Formula
   url "https://github.com/baresip/baresip/archive/refs/tags/v4.7.0.tar.gz"
   sha256 "fa281d041e6c5d02f9f71b88524ca8fe05b54d37bbdf985f44fb6a034e02a604"
   license "BSD-3-Clause"
+  revision 1
 
   bottle do
     sha256 arm64_tahoe:   "03f6a32353e1147a8a70e483ddf28a4f0423b6932f2e8028a0c8a1d2ee03a541"
@@ -19,7 +20,7 @@ class Baresip < Formula
   depends_on "libre"
 
   on_macos do
-    depends_on "openssl@3"
+    depends_on "openssl@4"
   end
 
   def install

--- a/Formula/lib/libre.rb
+++ b/Formula/lib/libre.rb
@@ -4,6 +4,7 @@ class Libre < Formula
   url "https://github.com/baresip/re/archive/refs/tags/v4.7.0.tar.gz"
   sha256 "b9fd286e30df103b3e06be2f821503d6f21551002737c4b8f47cf8db30dd5e19"
   license "BSD-3-Clause"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "c4849b9398137a10a5ba3ffab29c7a1a6223b84c62defb5443cf2a308082abe9"
@@ -15,7 +16,7 @@ class Libre < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "openssl@3"
+  depends_on "openssl@4"
 
   on_linux do
     depends_on "zlib-ng-compat"


### PR DESCRIPTION
- [x] Have you followed the [Contributing guidelines](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>` where `formula` is the name of the formula you're updating?
- [x] Have you run `brew audit --strict <formula>` (after doing `brew install <formula>`) where `formula` is the name of the formula you're updating?

-----

This migrates `baresip` from `openssl@3` to `openssl@4` and bumps `revision`.

AI-assisted contribution by Codex (GPT-5). Validation (audit, source build, test, linkage check) performed by AI.

Built and tested locally on macOS (arm64).

https://github.com/Homebrew/homebrew-core/issues/278366
