### PR TITLE
rustup: stop symlinking `rustup-init`

### DIFF
--- a/Formula/r/rustup.rb
+++ b/Formula/r/rustup.rb
@@ -32,9 +32,10 @@ class Rustup < Formula
   def install
     system "cargo", "install", *std_cargo_args(features: "no-self-update")
 
+    mv bin/"rustup-init", bin/"rustup"
     %w[cargo cargo-clippy cargo-fmt cargo-miri clippy-driver rls rust-analyzer
-       rust-gdb rust-gdbgui rust-lldb rustc rustdoc rustfmt rustup].each do |name|
-      bin.install_symlink bin/"rustup-init" => name
+       rust-gdb rust-gdbgui rust-lldb rustc rustdoc rustfmt].each do |name|
+      bin.install_symlink bin/"rustup" => name
     end
 
     (buildpath/"settings.toml").write <<~TOML
@@ -47,7 +48,7 @@ class Rustup < Formula
   end
 
   def post_install
-    (HOMEBREW_PREFIX/"bin").install_symlink bin/"rustup", bin/"rustup-init"
+    (HOMEBREW_PREFIX/"bin").install_symlink bin/"rustup"
   end
 
   def caveats
@@ -73,12 +74,5 @@ class Rustup < Formula
       assert_equal "Hello, world!", shell_output("./main").chomp
       assert_empty shell_output("#{bin}/cargo clippy")
     end
-
-    # Check for stale symlinks
-    system bin/"rustup-init", "-y"
-    bins = bin.glob("*").to_set(&:basename).delete(Pathname("rustup-init"))
-    expected = testpath.glob(".cargo/bin/*").to_set(&:basename)
-    assert (extra = bins - expected).empty?, "Symlinks need to be removed: #{extra.join(",")}"
-    assert (missing = expected - bins).empty?, "Symlinks need to be added: #{missing.join(",")}"
   end
 end


### PR DESCRIPTION
-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Using the `rustup-init` binary has been unnecessary since the formula started installing the proxy binaries for you. In fact, using that is a worse version of `curl https://sh.rustup.rs | sh` as this will install a _non-self-updating_ version of `rustup` (in `$CARGO_HOME/bin`) that **will not** be managed by Homebrew.