### PR TITLE
infracost 2.0.0

### DIFF
--- a/Formula/i/infracost.rb
+++ b/Formula/i/infracost.rb
@@ -12,12 +12,12 @@ class Infracost < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "12a68a6ec410dd1883c8cf5a63b594631678cead882d7af914f0a5a08d3df06f"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "12a68a6ec410dd1883c8cf5a63b594631678cead882d7af914f0a5a08d3df06f"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "12a68a6ec410dd1883c8cf5a63b594631678cead882d7af914f0a5a08d3df06f"
-    sha256 cellar: :any_skip_relocation, sonoma:        "e86f96207d558bac70c4a3dda6961cffdb918d33a415fef56cb29fdd77d60cdf"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "177cd3e7ebf2c55adc1e241e0df892e02e8607b0cba1ef8914825fa97255f155"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0a31d56b9fc59a944c1f56dc2afb2edf9d56cc491f46a02e42d72bd3d9ce7558"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "6bb069db1c641df3375b724b872141cc1ed1cfd129d2d68aa83f68f5020b0306"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "6bb069db1c641df3375b724b872141cc1ed1cfd129d2d68aa83f68f5020b0306"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "6bb069db1c641df3375b724b872141cc1ed1cfd129d2d68aa83f68f5020b0306"
+    sha256 cellar: :any_skip_relocation, sonoma:        "963770a189b8cea78ae89b1de8490100448b0b0d6fe50cfc4b68203e867b59af"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "5d3f5966325bf7db2f0ff119494da65ca805e0b6c5826f8f4563b9720a6e93d3"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e0fc593501ddf05b010a0da1668cc1b2d4c4a056068e6666de6b63f744e87db8"
   end
 
   depends_on "go" => :build

--- a/Formula/i/infracost.rb
+++ b/Formula/i/infracost.rb
@@ -1,10 +1,15 @@
 class Infracost < Formula
-  desc "Cost estimates for Terraform"
+  desc "Cost estimates for Terraform, Terragrunt, and CloudFormation"
   homepage "https://www.infracost.io/docs/"
-  url "https://github.com/infracost/infracost/archive/refs/tags/v0.10.44.tar.gz"
-  sha256 "638ac6155c15886bcdc1eda4f633ae54f64243f61b8b8676791e0003ddd836d7"
+  url "https://github.com/infracost/cli/archive/refs/tags/v2.0.0.tar.gz"
+  sha256 "649f124545c4b71332b093cc15b020315e1eb3372d7cfeca61e05dfceac5b2a6"
   license "Apache-2.0"
-  head "https://github.com/infracost/infracost.git", branch: "master"
+  head "https://github.com/infracost/cli.git", branch: "main"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "12a68a6ec410dd1883c8cf5a63b594631678cead882d7af914f0a5a08d3df06f"
@@ -19,16 +24,17 @@ class Infracost < Formula
 
   def install
     ENV["CGO_ENABLED"] = "0"
-    ldflags = "-X github.com/infracost/infracost/internal/version.Version=v#{version}"
-    system "go", "build", *std_go_args(ldflags:), "./cmd/infracost"
+    ldflags = "-X github.com/infracost/cli/version.Version=v#{version}"
+    system "go", "build", *std_go_args(output: bin/"infracost", ldflags:), "main.go"
 
-    generate_completions_from_executable(bin/"infracost", "completion", "--shell")
+    generate_completions_from_executable(bin/"infracost", "completion")
   end
 
   test do
     assert_match "v#{version}", shell_output("#{bin}/infracost --version 2>&1")
 
-    output = shell_output("#{bin}/infracost breakdown --no-color 2>&1", 1)
-    assert_match "Error: INFRACOST_API_KEY is not set but is required", output
+    ENV["INFRACOST_CLI_AUTHENTICATION_TOKEN"] = "dummy"
+    output = shell_output("#{bin}/infracost setup --no-color 2>&1", 1)
+    assert_match "setup requires interactive login", output
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. AI-assisted contribution by Claude Opus 4.7 — approximately 90% of the work. Claude made the formula changes and ran `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source`, `brew test`, `brew audit --strict`, and `brew style` locally. Human (Infracost CLI maintainer) directed the strategy and reviewed.

-----

Built and tested locally on macOS Tahoe 26 (Darwin 25.3.0) running arm64.

Updates `infracost` to v2.0.0, sourced from the new `infracost/cli` repository.

This is a continuation of the existing `infracost` project, not a new tool. The v2 codebase has been moved to `infracost/cli` so that v1 and v2 release tooling and triage can live separately; both repositories ship the same `infracost` binary. v2 is the next major version of the CLI, with breaking changes from the v0.x line — users on v0.x will see this on their next `brew upgrade`.

Earlier we explored a versioned-formula split (sibling PRs #281191 / #281192) to give users a migration window. Per maintainer feedback that versioned formulae aren't intended for migration paths, we're dropping that approach and updating the main formula directly.

Notes on the diff:
- New `livecheck` block: `infracost/cli` carries unrelated plugin tags (e.g. `infracost-parser-plugin/v0.1.2`); the regex restricts autobump to numeric `vX.Y.Z` tags so plugin tags are ignored.
- Build target switches from `./cmd/infracost` to `main.go` and ldflags path updates to `github.com/infracost/cli/version.Version` to match the v2 layout.
- Completion syntax changes from `completion --shell <shell>` to cobra's default `completion <shell>`.
- Test now exercises `infracost setup` (the v2 flow) instead of `infracost breakdown`.