### PR TITLE
python@*: update livecheck

### DIFF
--- a/Formula/p/python@3.10.rb
+++ b/Formula/p/python@3.10.rb
@@ -8,8 +8,8 @@ class PythonAT310 < Formula
   compatibility_version 1
 
   livecheck do
-    url "https://www.python.org/ftp/python/"
-    regex(%r{href=.*?v?(3\.10(?:\.\d+)*)/?["' >]}i)
+    url "https://www.python.org/downloads/source/"
+    regex(%r{href=.*?/Python[._-]v?(3\.10(?:\.\d+)*)\.t}i)
   end
 
   bottle do

--- a/Formula/p/python@3.11.rb
+++ b/Formula/p/python@3.11.rb
@@ -8,8 +8,8 @@ class PythonAT311 < Formula
   compatibility_version 1
 
   livecheck do
-    url "https://www.python.org/ftp/python/"
-    regex(%r{href=.*?v?(3\.11(?:\.\d+)*)/?["' >]}i)
+    url "https://www.python.org/downloads/source/"
+    regex(%r{href=.*?/Python[._-]v?(3\.11(?:\.\d+)*)\.t}i)
   end
 
   bottle do

--- a/Formula/p/python@3.12.rb
+++ b/Formula/p/python@3.12.rb
@@ -8,8 +8,8 @@ class PythonAT312 < Formula
   compatibility_version 1
 
   livecheck do
-    url "https://www.python.org/ftp/python/"
-    regex(%r{href=.*?v?(3\.12(?:\.\d+)*)/?["' >]}i)
+    url "https://www.python.org/downloads/source/"
+    regex(%r{href=.*?/Python[._-]v?(3\.12(?:\.\d+)*)\.t}i)
   end
 
   bottle do

--- a/Formula/p/python@3.13.rb
+++ b/Formula/p/python@3.13.rb
@@ -8,8 +8,8 @@ class PythonAT313 < Formula
   compatibility_version 1
 
   livecheck do
-    url "https://www.python.org/ftp/python/"
-    regex(%r{href=.*?v?(3\.13(?:\.\d+)*)/?["' >]}i)
+    url "https://www.python.org/downloads/source/"
+    regex(%r{href=.*?/Python[._-]v?(3\.13(?:\.\d+)*)\.t}i)
   end
 
   bottle do


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

This updates the `livecheck` block for Python formulae to check the first-party [source code download page](https://www.python.org/downloads/source/), which links to the stable tarballs that the formulae use.

As discussed in the [PR for `python@3.14`](https://github.com/Homebrew/homebrew-core/pull/281068) (currently the main `python` formula), the directory listing page that we currently check doesn't differentiate between stable and unstable versions and that would require making multiple requests to check the version directory pages to identify stable versions. For example, there's currently a directory for 3.14.5 but the only files inside are 3.14.5rc1, as there isn't a stable release yet. The source code download page links to this version but the `livecheck` block regex skips unstable versions, so it correctly returns 3.14.4 as the newest stable 3.14 version.