### PR TITLE
git: use openssl@4

### DIFF
--- a/Formula/g/git.rb
+++ b/Formula/g/git.rb
@@ -20,12 +20,12 @@ class Git < Formula
   end
 
   bottle do
-    sha256 arm64_tahoe:   "0907a55ddd94935d16e13351e3238892d7a57f4ccaa58e20ba2609c4f2a1c4c0"
-    sha256 arm64_sequoia: "d12f1bafed785a94c45d0bffb303c28cbc0aaec5ab9a8b4939c51f216de1f2d9"
-    sha256 arm64_sonoma:  "538bdc752f5a51e98124b0cdce5493339e5821a50a03fd3a78fe7754038ea1c4"
-    sha256 sonoma:        "7286fead4972e9e8374dd85a420d7e55da5bbba9e4b34fa90cb6c183d31663bb"
-    sha256 arm64_linux:   "67e05269b64b7cbcb24739519817b56a081696e350fe1913282b08bbfe90368e"
-    sha256 x86_64_linux:  "81874ce3bd63063dc77f6d1cc85e30c52108e172f32b232ae865f9b2e55001e1"
+    sha256 arm64_tahoe:   "2df5dc22af595f129aba88cf995f6b7a77619b4ab41bbf762846c49e40e5208c"
+    sha256 arm64_sequoia: "4871d59ef5320bb40415c56460d4257d22e0565c1d240bd8f92b34c10065f822"
+    sha256 arm64_sonoma:  "7b4572e5ad46b280750f2512a8461b5219c7fff18284094194d1a6e07ecbc9d3"
+    sha256 sonoma:        "e37987cdad78fb6a729ad4b3baaa9cbeb0037c32ffdbe3abcb19092b25a38945"
+    sha256 arm64_linux:   "0e8a14d21ddc2a9266cec2d3a7a4b70defdd5cef2bf15c8845fe7f2107f32b23"
+    sha256 x86_64_linux:  "593b9279d1c5df7823a51c7b908d8f69fc4d785525de3676093dfa4d761bc5d2"
   end
 
   depends_on "gettext" => :build

--- a/Formula/g/git.rb
+++ b/Formula/g/git.rb
@@ -10,6 +10,7 @@ class Git < Formula
     "BSD-3-Clause",      # xdiff/xhistogram.c; reftable/
     "MIT",               # khash.h; sha1dc/
   ]
+  revision 1
   compatibility_version 1
   head "https://github.com/git/git.git", branch: "master"
 
@@ -42,7 +43,7 @@ class Git < Formula
   end
 
   on_linux do
-    depends_on "openssl@3" # for git-imap-send (GPL-2.0-or-later), uses CommonCrypto on macOS
+    depends_on "openssl@4" # for git-imap-send (GPL-2.0-or-later), uses CommonCrypto on macOS
     depends_on "zlib-ng-compat"
   end
 
@@ -116,7 +117,7 @@ class Git < Formula
     args += if OS.mac?
       %w[NO_OPENSSL=1 APPLE_COMMON_CRYPTO=1]
     else
-      openssl_prefix = Formula["openssl@3"].opt_prefix
+      openssl_prefix = Formula["openssl@4"].opt_prefix
 
       %W[NO_APPLE_COMMON_CRYPTO=1 OPENSSLDIR=#{openssl_prefix}]
     end


### PR DESCRIPTION
- [x] Have you followed the [Contributing guidelines](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>` where `formula` is the name of the formula you're updating?
- [x] Have you run `brew audit --strict <formula>` (after doing `brew install <formula>`) where `formula` is the name of the formula you're updating?

-----

This migrates `git` from `openssl@3` to `openssl@4` and bumps `revision`.

AI-assisted contribution by Codex (GPT-5). Validation (audit, source build, test, linkage check) performed by AI.

Built and tested locally on macOS (arm64).

https://github.com/Homebrew/homebrew-core/issues/278366
