### PR TITLE
cpr: use openssl@4

### DIFF
--- a/Formula/c/cpr.rb
+++ b/Formula/c/cpr.rb
@@ -4,6 +4,7 @@ class Cpr < Formula
   url "https://github.com/libcpr/cpr/archive/refs/tags/1.14.2.tar.gz"
   sha256 "b9b529b47083bfe80bba855ca5308d12d767ae7c7b629aef5ef018c4343cf62b"
   license "MIT"
+  revision 1
   head "https://github.com/libcpr/cpr.git", branch: "master"
 
   bottle do
@@ -19,7 +20,7 @@ class Cpr < Formula
   uses_from_macos "curl", since: :monterey # Curl 7.68+
 
   on_linux do
-    depends_on "openssl@3"
+    depends_on "openssl@4"
   end
 
   def install

--- a/Formula/c/cpr.rb
+++ b/Formula/c/cpr.rb
@@ -8,12 +8,12 @@ class Cpr < Formula
   head "https://github.com/libcpr/cpr.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "a0f3e8ed113b1279c1128726e802fc8ae395195b2a0d3f730503234056b393fa"
-    sha256 cellar: :any,                 arm64_sequoia: "a98d8951a3f0155093e1378fff9b44279958871c18a1832f19e91d573572682d"
-    sha256 cellar: :any,                 arm64_sonoma:  "e5f8c5c9bf4f844e78fdde1720e3251d62e39f2ac3927bae55df110e88898979"
-    sha256 cellar: :any,                 sonoma:        "e2c8046007a51247012c7243e18324ee09571a5f88dfe62abfc8729c53cf6d9f"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "67ed191360edc4aefc104c06fc5149be59c234fbdf2ee636ae1f92f1a67d877f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "75cf39467eb0f010d6c26ccd5b09fe2a1da6b6a00b75bce3287c1004f2c98b63"
+    sha256 cellar: :any,                 arm64_tahoe:   "2813c443cf3657848713409377512a1562bddedc87f1e8966c4b262cbf6e5fd6"
+    sha256 cellar: :any,                 arm64_sequoia: "6f14508fda6d35e670b7ef0b1d921c8baf38abbf89b36351fef80319924a5071"
+    sha256 cellar: :any,                 arm64_sonoma:  "f905603be3eb805b499cefe9b18ebcaa13128335d3a02377ccdf7092bf1ac276"
+    sha256 cellar: :any,                 sonoma:        "e7c26d9dd7fd115043749ee4afaa8963e541ea8a2ca7eae1dd914879a1fec5d1"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "7dde32c9cbb9f65f9cb216eb8f5faf929cd3097a80d36f1940a93a454a81de7d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "30fdf2ef6b122f1dfae08299675f5f3b5d11044f0dd3de813d56d6b6effc7044"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
- [x] Have you followed the [Contributing guidelines](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>` where `formula` is the name of the formula you're updating?
- [x] Have you run `brew audit --strict <formula>` (after doing `brew install <formula>`) where `formula` is the name of the formula you're updating?

-----

This migrates `cpr` from `openssl@3` to `openssl@4` and bumps `revision`.

AI-assisted contribution by Codex (GPT-5). Validation (audit, source build, test, linkage check) performed by AI.

Built and tested locally on macOS (arm64).

https://github.com/Homebrew/homebrew-core/issues/278366
