### PR TITLE
cadaver neon: use openssl@4

### DIFF
--- a/Formula/c/cadaver.rb
+++ b/Formula/c/cadaver.rb
@@ -4,6 +4,7 @@ class Cadaver < Formula
   url "https://notroj.github.io/cadaver/cadaver-0.28.tar.gz"
   sha256 "33e3a54bd54b1eb325b48316a7cacc24047c533ef88e6ef98b88dfbb60e12734"
   license "GPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url :homepage
@@ -30,7 +31,7 @@ class Cadaver < Formula
 
   depends_on "pkgconf" => :build
   depends_on "neon"
-  depends_on "openssl@3"
+  depends_on "openssl@4"
   depends_on "readline"
 
   on_macos do
@@ -43,7 +44,7 @@ class Cadaver < Formula
       system "./autogen.sh"
     end
     system "./configure", "--with-ssl=openssl",
-                          "--with-libs=#{Formula["openssl@3"].opt_prefix}",
+                          "--with-libs=#{Formula["openssl@4"].opt_prefix}",
                           "--with-neon=#{Formula["neon"].opt_prefix}",
                           *std_configure_args
     system "make"

--- a/Formula/n/neon.rb
+++ b/Formula/n/neon.rb
@@ -23,7 +23,7 @@ class Neon < Formula
 
   depends_on "pkgconf" => :build
   depends_on "xmlto" => :build
-  depends_on "openssl@3"
+  depends_on "openssl@4"
 
   uses_from_macos "libxml2"
 
@@ -41,7 +41,7 @@ class Neon < Formula
                           "--disable-static",
                           "--disable-nls",
                           "--with-ssl=openssl",
-                          "--with-libs=#{Formula["openssl@3"].opt_prefix}",
+                          "--with-libs=#{Formula["openssl@4"].opt_prefix}",
                           *std_configure_args
     system "make", "install"
   end


### PR DESCRIPTION
- [x] Have you followed the [Contributing guidelines](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>` where `formula` is the name of the formula you're updating?
- [x] Have you run `brew audit --strict <formula>` (after doing `brew install <formula>`) where `formula` is the name of the formula you're updating?

-----

This migrates `cadaver` from `openssl@3` to `openssl@4` and bumps `revision`.

AI-assisted contribution by Codex (GPT-5). Validation (audit, source build, test, linkage check) performed by AI.

Built and tested locally on macOS (arm64).

https://github.com/Homebrew/homebrew-core/issues/278366
