### PR TITLE
capnp: use openssl@4

### DIFF
--- a/Formula/c/capnp.rb
+++ b/Formula/c/capnp.rb
@@ -4,6 +4,7 @@ class Capnp < Formula
   url "https://github.com/capnproto/capnproto/archive/refs/tags/v1.4.0.tar.gz"
   sha256 "d14a9149b79c055fee9d5aa778defe8e8cee0d2a11f0729865cd30dcc345eef2"
   license "MIT"
+  revision 1
   compatibility_version 2
   head "https://github.com/capnproto/capnproto.git", branch: "v2"
 
@@ -24,7 +25,7 @@ class Capnp < Formula
   depends_on "cmake" => :build
 
   on_linux do
-    depends_on "openssl@3"
+    depends_on "openssl@4"
     depends_on "zlib-ng-compat"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [Contributing guidelines](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>` where `formula` is the name of the formula you're updating?
- [x] Have you run `brew audit --strict <formula>` (after doing `brew install <formula>`) where `formula` is the name of the formula you're updating?

-----

This migrates `capnp` from `openssl@3` to `openssl@4` and bumps `revision`.

AI-assisted contribution by Codex (GPT-5). Validation (audit, source build, test, linkage check) performed by AI.

Built and tested locally on macOS (arm64).

https://github.com/Homebrew/homebrew-core/issues/278366
