### PR TITLE
cnats: use openssl@4

### DIFF
--- a/Formula/c/cnats.rb
+++ b/Formula/c/cnats.rb
@@ -4,6 +4,7 @@ class Cnats < Formula
   url "https://github.com/nats-io/nats.c/archive/refs/tags/v3.12.0.tar.gz"
   sha256 "06b64d7045fd618c98e5608001b384bdbfa6a17718dba64e732ba72a6f00649b"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "d6b6a71f904ece5d05e820a00279676169c201dd29af015760f14ec90eedf6c3"
@@ -17,7 +18,7 @@ class Cnats < Formula
   depends_on "cmake" => :build
   depends_on "libevent"
   depends_on "libuv"
-  depends_on "openssl@3"
+  depends_on "openssl@4"
   depends_on "protobuf-c"
 
   def install

--- a/Formula/c/cnats.rb
+++ b/Formula/c/cnats.rb
@@ -7,12 +7,12 @@ class Cnats < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "d6b6a71f904ece5d05e820a00279676169c201dd29af015760f14ec90eedf6c3"
-    sha256 cellar: :any,                 arm64_sequoia: "4802784048ccef88363702e5db80b98657daa8dd7ebd90d545535329c516de18"
-    sha256 cellar: :any,                 arm64_sonoma:  "f693d5fc84ab27feef7ef4d67b8674a88f36f42a05039ced84312f5a065d6ef2"
-    sha256 cellar: :any,                 sonoma:        "da0021e25b526acac1a1e0d4f6fbed9aae416f2986f4b000b31b1b80b72741b9"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "f811f0043da5c8aa249aa337e7a983fa76c8e82eb1f5f99c88934551ebfb3882"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1891557d88308406f2cb6525cd9825777c4bc280becc0b68878d471a82f9c2b5"
+    sha256 cellar: :any,                 arm64_tahoe:   "7112434cd21aea4f66a5d40b2be3df44bd766af00c927c31effcbd231ed74455"
+    sha256 cellar: :any,                 arm64_sequoia: "4981e38ca26b18b2aa389208b48f4d7952c4d3a5ac47821554e56a2e52d5e00c"
+    sha256 cellar: :any,                 arm64_sonoma:  "18493a3f33204a6900e359ebd36536e71797331ec508dd459fafa8f13590a5db"
+    sha256 cellar: :any,                 sonoma:        "69eb294ebb1b670be5cecd720f408a35cad8168701ce247d782a3bd9ca37191e"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "bc62cff7a81bba4164f59fa7bddaf318a9f71ed5c94a4b48db2f7279289a80c2"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2e3ad544ee19cfe6048497c56f7c0a5fc6282e6c65d854577dbd277016120db4"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
- [x] Have you followed the [Contributing guidelines](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>` where `formula` is the name of the formula you're updating?
- [x] Have you run `brew audit --strict <formula>` (after doing `brew install <formula>`) where `formula` is the name of the formula you're updating?

-----

This migrates `cnats` from `openssl@3` to `openssl@4` and bumps `revision`.

AI-assisted contribution by Codex (GPT-5). Validation (audit, source build, test, linkage check) performed by AI.

Built and tested locally on macOS (arm64).

https://github.com/Homebrew/homebrew-core/issues/278366
