### PR TITLE
gcli: use openssl@4

### DIFF
--- a/Formula/g/gcli.rb
+++ b/Formula/g/gcli.rb
@@ -4,6 +4,7 @@ class Gcli < Formula
   url "https://github.com/herrhotzenplotz/gcli/archive/refs/tags/v2.11.0.tar.gz"
   sha256 "ed6c618d9c67fedfca0fb4da79d8a0d9d27efdd82cc74b372d6fe5cd483d6456"
   license "BSD-2-Clause"
+  revision 1
   head "https://github.com/herrhotzenplotz/gcli.git", branch: "trunk"
 
   bottle do
@@ -18,7 +19,7 @@ class Gcli < Formula
   depends_on "pkgconf" => :build
   depends_on "readline" => :build
   depends_on "lowdown"
-  depends_on "openssl@3"
+  depends_on "openssl@4"
 
   uses_from_macos "bison" => :build
   uses_from_macos "flex" => :build

--- a/Formula/g/gcli.rb
+++ b/Formula/g/gcli.rb
@@ -8,12 +8,12 @@ class Gcli < Formula
   head "https://github.com/herrhotzenplotz/gcli.git", branch: "trunk"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "fa08502f495b8da28c73595e81a9bfbba39e6b02d6f757a0ebeeeb4c25d10096"
-    sha256 cellar: :any,                 arm64_sequoia: "380b2b85130a47601bdec226fd7532738974f8c51a76aeddd3eb3614703e569a"
-    sha256 cellar: :any,                 arm64_sonoma:  "9fcbf2ef78ca26c35678348a357ff9b4efdfdd00aedbb466fc965a3c6edc3acb"
-    sha256 cellar: :any,                 sonoma:        "b8b7629660e40871400d712dbef0b0b846dda685fbde24e2ca6101a3cc11efce"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "27951a21f506fdb8540527197be0d98a2fa6b9d48f27c5cad4bf2bdcd651df2c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "31eef2f32ed72556de1717ca1586265344e53758bb5b900b23cdd7d70a7a3799"
+    sha256 cellar: :any,                 arm64_tahoe:   "e05a791fe9cf499457c23029ac3a9d9f031cc2a80b87561b31008bf11cd8df45"
+    sha256 cellar: :any,                 arm64_sequoia: "cf656dd08da280b4d8b8a0da86cd47476ca0c79e3478f33c561c0de0bc682e4c"
+    sha256 cellar: :any,                 arm64_sonoma:  "5d1745ace7de107455d120b4c8b13e62b1e2207618efbe539e11da12b4306892"
+    sha256 cellar: :any,                 sonoma:        "3c9e9a1fe14bda6520b85e216f5e3c903158bfe634a685bb1d4f429000189886"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "94bbd3a0c4e44ae7dad685fcdbdb5670c438ba39abde3e35455130cd05658c07"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "27fc85b30a7717d207a60e475c8a4181b6c9ccff970baa160988cfd91a965c62"
   end
 
   depends_on "pkgconf" => :build


### PR DESCRIPTION
- [x] Have you followed the [Contributing guidelines](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>` where `formula` is the name of the formula you're updating?
- [x] Have you run `brew audit --strict <formula>` (after doing `brew install <formula>`) where `formula` is the name of the formula you're updating?

-----

This migrates `gcli` from `openssl@3` to `openssl@4` and bumps `revision`.

AI-assisted contribution by Codex (GPT-5). Validation (audit, source build, test, linkage check) performed by AI.

Built and tested locally on macOS (arm64).

https://github.com/Homebrew/homebrew-core/issues/278366
