### PR TITLE
marp-cli promptfoo: use `node@24`

### DIFF
--- a/Formula/m/marp-cli.rb
+++ b/Formula/m/marp-cli.rb
@@ -14,7 +14,7 @@ class MarpCli < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "b04223816db0be200154326ab586378c9e4b24ac6c0a42ecb495631c694ec3c9"
   end
 
-  depends_on "node"
+  depends_on "node@24"
 
   def install
     system "npm", "install", *std_npm_args

--- a/Formula/m/marp-cli.rb
+++ b/Formula/m/marp-cli.rb
@@ -6,12 +6,13 @@ class MarpCli < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "04b9f331aeecaeabf8f020c30f761b5590852079b55044432b783ac2568a2837"
-    sha256 cellar: :any,                 arm64_sequoia: "a858c7aef2d71a4db630f8cb491d20f70b23fb3c0012daf8bc93f6a6674da730"
-    sha256 cellar: :any,                 arm64_sonoma:  "a858c7aef2d71a4db630f8cb491d20f70b23fb3c0012daf8bc93f6a6674da730"
-    sha256 cellar: :any,                 sonoma:        "a4f4bf0d5fc9868d51e1e65ea6c9a10e78eafc35ab78bc770fde4613fb3a6c4f"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "1f965d91918dd090e78cd9946784b7074bd9fd50341ff81eaec3bd31344194bd"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b04223816db0be200154326ab586378c9e4b24ac6c0a42ecb495631c694ec3c9"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "b736b6057fbd2362e98098260ea5f7a4bc45083811f7a4416b64ef7ec2aae4e8"
+    sha256 cellar: :any,                 arm64_sequoia: "1022c802fe2927d93d68153550089cd61706c6694fa7c29f30f003d8d1b5e908"
+    sha256 cellar: :any,                 arm64_sonoma:  "1022c802fe2927d93d68153550089cd61706c6694fa7c29f30f003d8d1b5e908"
+    sha256 cellar: :any,                 sonoma:        "cbf7d9124137a38d4b9c67d7a752d3536b11fa0d2a8c72d83ebe8e4ac12e2344"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "ff3c7f6fdf1cc304498e76b34cfeb40b72d9f7d0be28f9814793607400f0031d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "bd0296008c2e6062bc4e1774188cbc676c67b4c7f79875b164ea943f8e665a31"
   end
 
   depends_on "node@24"

--- a/Formula/p/promptfoo.rb
+++ b/Formula/p/promptfoo.rb
@@ -6,12 +6,13 @@ class Promptfoo < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "3276507685cb03e7d526984999075244587aff30f282f8dbb083a1dc11c57551"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "11e0bb90ee913890cfe02d4a1851fbffd320e548ff1822eb2e07f9ead5d54435"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "e5abcdc342022891975a62595abbf81c87db29832dc36a5ae3d6540417d68d91"
-    sha256 cellar: :any_skip_relocation, sonoma:        "52898573fdc8e9cd2014477f0c7a6df4282881c4571cba86bc8aaa531bdba571"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "7a0a63b90224503e19c05e2562eb65f7f054278e747909a1693f3e2e5c74c8f8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f92c2f58c40e046ad62d5a9ef880a20b61a93e9dc24eb3fe3d4c72b58b8e0328"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "88b2fa0b7d68786833b6a2ad9c28fa622a097a17c6a3b45b42aa859a2f4668ac"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "8c1a097678f49b6270ce80fbe4871d087ef43b7a986d693820c1f433d75487a4"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "291d1bc8f4e8331ed08e9e69df7b6252028c5fa276cfae21fb49f04863a47512"
+    sha256 cellar: :any_skip_relocation, sonoma:        "c4aa480a697f5dcfc5e256631bcda845803d2689994cd623cf27362db49080ba"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "16bc17c8797230f3325c4d3b58ffea5f6b0c20d07896f0a837699c9e479cf6b2"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1dacfd958a9308086dbfd29af1b0d55339fe9070890fedf0fcdfde5182ca6e95"
   end
 
   depends_on "node@24"

--- a/Formula/p/promptfoo.rb
+++ b/Formula/p/promptfoo.rb
@@ -14,7 +14,7 @@ class Promptfoo < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "f92c2f58c40e046ad62d5a9ef880a20b61a93e9dc24eb3fe3d4c72b58b8e0328"
   end
 
-  depends_on "node"
+  depends_on "node@24"
 
   on_macos do
     depends_on "llvm" => :build if DevelopmentTools.clang_build_version < 1700


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

It seems that they are not compatible with node 26 yet, I guess EMS and CommonJS cannot be mixed now. So for ESM module, `require` cannot be used. For now we could use `node@24` and once upstream fix or send a patch, then later we could upgrade it again. 