### PR TITLE
node: enable Temporal support

### DIFF
--- a/Formula/n/node.rb
+++ b/Formula/n/node.rb
@@ -23,6 +23,7 @@ class Node < Formula
 
   depends_on "pkgconf" => :build
   depends_on "python@3.14" => :build
+  depends_on "rust" => :build
   depends_on "ada-url"
   depends_on "brotli"
   depends_on "c-ares"
@@ -242,6 +243,9 @@ class Node < Formula
 
     output = shell_output("#{bin}/node -e 'console.log(new Intl.NumberFormat(\"de-DE\").format(1234.56))'").strip
     assert_equal "1.234,56", output
+
+    output = shell_output("#{bin}/node -p 'typeof globalThis.Temporal?.Now?.zonedDateTimeISO'").strip
+    assert_equal "function", output
 
     # make sure npm can find node
     ENV.prepend_path "PATH", opt_bin


### PR DESCRIPTION
- enable V8 Temporal support when building Node.js
- assert the Node formula exposes `Temporal.Now.zonedDateTimeISO`

Fixes #281625.

The upstream Node.js v26.0.0 darwin-arm64 binary has `process.config.variables.v8_enable_temporal_support === 1` and exposes `globalThis.Temporal`, while the current Homebrew bottle reports `0` and leaves `globalThis.Temporal` undefined.

Verification:
- `brew style node`
- `brew audit --strict node`

I did not run `brew test node` against the current installed bottle because the bottle was built before this configure flag change and now correctly fails the new Temporal assertion. The PR CI/source build should verify the rebuilt formula.
