### PR TITLE
memcached: use openssl@4

### DIFF
--- a/Formula/m/memcached.rb
+++ b/Formula/m/memcached.rb
@@ -4,6 +4,7 @@ class Memcached < Formula
   url "https://www.memcached.org/files/memcached-1.6.41.tar.gz"
   sha256 "e097073c156eeff9e12655b054f446d57374cfba5c132dcdbe7fac64e728286a"
   license "BSD-3-Clause"
+  revision 1
 
   livecheck do
     url :homepage
@@ -27,7 +28,7 @@ class Memcached < Formula
   end
 
   depends_on "libevent"
-  depends_on "openssl@3"
+  depends_on "openssl@4"
 
   def install
     system "./autogen.sh" if build.head?


### PR DESCRIPTION
- [x] Have you followed the [Contributing guidelines](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [Pull Requests](https://github.com/Homebrew/homebrew-core/pulls) for the same change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>` where `formula` is the name of the formula you're updating?
- [x] Have you run `brew audit --strict <formula>` (after doing `brew install <formula>`) where `formula` is the name of the formula you're updating?

-----

This migrates `memcached` from `openssl@3` to `openssl@4` and bumps `revision`.

AI-assisted contribution by Codex (GPT-5). Validation (audit, source build, test, linkage check) performed by AI.

Built and tested locally on macOS (arm64).

https://github.com/Homebrew/homebrew-core/issues/278366
