### PR TITLE
mongo-c-driver: migrate to `openssl@4`

### DIFF
--- a/Formula/m/mongo-c-driver.rb
+++ b/Formula/m/mongo-c-driver.rb
@@ -4,6 +4,7 @@ class MongoCDriver < Formula
   url "https://github.com/mongodb/mongo-c-driver/archive/refs/tags/2.3.0.tar.gz"
   sha256 "0edd0e143af77861309d59c5c029d2408df7348c429c5e1f483c7ba449cb35ce"
   license "Apache-2.0"
+  revision 1
   compatibility_version 1
   head "https://github.com/mongodb/mongo-c-driver.git", branch: "master"
 
@@ -24,10 +25,10 @@ class MongoCDriver < Formula
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
   depends_on "sphinx-doc" => :build
-  depends_on "openssl@3"
   depends_on "zstd"
 
   on_linux do
+    depends_on "openssl@4"
     depends_on "zlib-ng-compat"
   end
 

--- a/Formula/m/mongo-c-driver.rb
+++ b/Formula/m/mongo-c-driver.rb
@@ -14,12 +14,12 @@ class MongoCDriver < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "336926859b333b66f2d74164b652b5a0c0a3e1b99524e0e29087db3ce8f69537"
-    sha256 cellar: :any,                 arm64_sequoia: "ebb36242b858213ae11773aacc11ec7c2df90da4a06d2f5a851dbf5eaa8999fa"
-    sha256 cellar: :any,                 arm64_sonoma:  "cc736db383f037928e0635bd19b196e68a2ec401b1ddf01a1db0275dfb6906f9"
-    sha256 cellar: :any,                 sonoma:        "5681798f8425885c4eb5cb5d751887b5bd68465b0ee12735271ec101ba659712"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "9499499331e8470642bdc2fe7d32c6ed3ae663fc4ea80dac1504263d2da79a06"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "ace76b739e8a16294c95c3982b57d581c8154d3df299b445a4edb35373126d17"
+    sha256 cellar: :any,                 arm64_tahoe:   "49e03cb97bc513a0e729604fda55de40ed5d712914b4f1c9bdd5c358570d2e36"
+    sha256 cellar: :any,                 arm64_sequoia: "f04f48be920942ce4010b585d4f55a1b56219dcec8ece7ce7b19ff3a4d0a3cc8"
+    sha256 cellar: :any,                 arm64_sonoma:  "0cc93ceece73967a24a740143e154bda2aad3038f4414070908996299c0d725a"
+    sha256 cellar: :any,                 sonoma:        "baeac8488db093b88e23a03ac580d3fb2f00da5a69d4e4e3c698f31ebbe8b891"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "73cdc05c79fd9906b16f5ff29efb464a9df1d88f4b068e74ee4edcad69c8a3b3"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "97aac3e9301f693aaa6345be9ceab4355e1d47624086cbc56b6afa8e1b639cad"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Migrate to `openssl@4` and limit depencency to linux, native tls is used on macos
- https://github.com/Homebrew/homebrew-core/issues/278366