### PR TITLE
Gate macOS requirement for multi-platform formulae

### DIFF
--- a/Formula/a/arm-linux-gnueabihf-binutils.rb
+++ b/Formula/a/arm-linux-gnueabihf-binutils.rb
@@ -20,10 +20,13 @@ class ArmLinuxGnueabihfBinutils < Formula
   end
 
   depends_on "pkgconf" => :build
-  # Requires the <uchar.h> header
-  # https://sourceware.org/bugzilla/show_bug.cgi?id=31320
-  depends_on macos: :ventura
   depends_on "zstd"
+
+  on_macos do
+    # Requires the <uchar.h> header
+    # https://sourceware.org/bugzilla/show_bug.cgi?id=31320
+    depends_on macos: :ventura
+  end
 
   on_system :linux, macos: :ventura_or_newer do
     depends_on "texinfo" => :build

--- a/Formula/b/bitcoin.rb
+++ b/Formula/b/bitcoin.rb
@@ -30,10 +30,13 @@ class Bitcoin < Formula
   depends_on "pkgconf" => :build
   depends_on "capnp"
   depends_on "libevent"
-  depends_on macos: :sonoma # Needs C++20 features not available on Ventura
   depends_on "zeromq"
 
   uses_from_macos "sqlite"
+
+  on_macos do
+    depends_on macos: :sonoma # Needs C++20 features not available on Ventura
+  end
 
   fails_with :gcc do
     version "11"

--- a/Formula/e/ecl.rb
+++ b/Formula/e/ecl.rb
@@ -21,8 +21,12 @@ class Ecl < Formula
   depends_on "texinfo" => :build # Apple's is too old
   depends_on "bdw-gc"
   depends_on "gmp"
-  depends_on macos: :sequoia
+
   uses_from_macos "libffi"
+
+  on_macos do
+    depends_on macos: :sequoia
+  end
 
   # does not build on macOS 14
 

--- a/Formula/f/fastfec.rb
+++ b/Formula/f/fastfec.rb
@@ -31,12 +31,11 @@ class Fastfec < Formula
   depends_on "pkgconf" => :build
   # TODO: depends_on "zig" => :build
   depends_on "zstd" => :build # for zig resource
-  depends_on macos: :big_sur # for zig resource - https://github.com/ziglang/zig/issues/13313
-
   uses_from_macos "ncurses" => :build # for zig resource
   uses_from_macos "zlib" => :build # for zig resource
 
   on_macos do
+    depends_on macos: :big_sur # for zig resource - https://github.com/ziglang/zig/issues/13313
     # Zig attempts to link with `libpcre.a` on Linux.
     # This fails because it was not compiled with `-fPIC`.
     # Use Homebrew PCRE on Linux when upstream resolves

--- a/Formula/f/fastnetmon.rb
+++ b/Formula/f/fastnetmon.rb
@@ -22,13 +22,16 @@ class Fastnetmon < Formula
   depends_on "grpc"
   depends_on "hiredis"
   depends_on "log4cpp"
-  depends_on macos: :big_sur # We need C++ 20 available for build which is available from Big Sur
   depends_on "mongo-c-driver"
   depends_on "openssl@3"
   depends_on "protobuf"
 
   uses_from_macos "libpcap"
   uses_from_macos "ncurses"
+
+  on_macos do
+    depends_on macos: :big_sur # We need C++ 20 available for build which is available from Big Sur
+  end
 
   on_linux do
     depends_on "elfutils"

--- a/Formula/f/func-e.rb
+++ b/Formula/f/func-e.rb
@@ -16,9 +16,12 @@ class FuncE < Formula
   end
 
   depends_on "go" => :build
-  # archive-envoy does not support macos-11
-  # https://github.com/Homebrew/homebrew-core/pull/119899#issuecomment-1374663837
-  depends_on macos: :monterey
+
+  on_macos do
+    # archive-envoy does not support macos-11
+    # https://github.com/Homebrew/homebrew-core/pull/119899#issuecomment-1374663837
+    depends_on macos: :monterey
+  end
 
   def install
     ldflags = %W[

--- a/Formula/g/go.rb
+++ b/Formula/g/go.rb
@@ -30,7 +30,9 @@ class Go < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "56903f4984295f41158e23dfa81889f939ff2e4bd03c9abb12326789db3983ad"
   end
 
-  depends_on macos: :monterey
+  on_macos do
+    depends_on macos: :monterey
+  end
 
   # Don't update this unless this version cannot bootstrap the new version.
   resource "gobootstrap" do

--- a/Formula/g/gopass-jsonapi.rb
+++ b/Formula/g/gopass-jsonapi.rb
@@ -17,7 +17,10 @@ class GopassJsonapi < Formula
 
   depends_on "go" => :build
   depends_on "gopass"
-  depends_on macos: :sonoma # for SCScreenshotManager
+
+  on_macos do
+    depends_on macos: :sonoma # for SCScreenshotManager
+  end
 
   def install
     ldflags = "-s -w -X main.version=#{version}"

--- a/Formula/g/groestlcoin.rb
+++ b/Formula/g/groestlcoin.rb
@@ -21,10 +21,13 @@ class Groestlcoin < Formula
   depends_on "pkgconf" => :build
   depends_on "capnp"
   depends_on "libevent"
-  depends_on macos: :big_sur
   depends_on "zeromq"
 
   uses_from_macos "sqlite"
+
+  on_macos do
+    depends_on macos: :big_sur
+  end
 
   on_linux do
     depends_on "util-linux" => :build # for `hexdump`

--- a/Formula/n/nghttp2.rb
+++ b/Formula/n/nghttp2.rb
@@ -28,13 +28,13 @@ class Nghttp2 < Formula
   depends_on "jemalloc"
   depends_on "libev"
   depends_on "libnghttp2"
-  depends_on macos: :sonoma # Needs C++20 features not available on Ventura
   depends_on "openssl@3"
 
   uses_from_macos "libxml2"
 
   on_macos do
     depends_on "llvm" => :build if DevelopmentTools.clang_build_version <= 1500
+    depends_on macos: :sonoma # Needs C++20 features not available on Ventura
   end
 
   on_linux do

--- a/Formula/p/podman.rb
+++ b/Formula/p/podman.rb
@@ -28,11 +28,12 @@ class Podman < Formula
 
   depends_on "go" => :build
   depends_on "go-md2man" => :build
-  depends_on macos: :ventura # see discussions in https://github.com/containers/podman/issues/22121
+
   uses_from_macos "python" => :build
 
   on_macos do
     depends_on "make" => :build
+    depends_on macos: :ventura # see discussions in https://github.com/containers/podman/issues/22121
   end
 
   on_linux do

--- a/Formula/p/protoc-gen-grpc-swift.rb
+++ b/Formula/p/protoc-gen-grpc-swift.rb
@@ -20,12 +20,15 @@ class ProtocGenGrpcSwift < Formula
   end
 
   depends_on xcode: ["15.0", :build]
-  # https://swiftpackageindex.com/grpc/grpc-swift/documentation/grpccore/compatibility#Platforms
-  depends_on macos: :sequoia
   depends_on "protobuf"
   depends_on "swift-protobuf"
 
   uses_from_macos "swift" => :build
+
+  on_macos do
+    # https://swiftpackageindex.com/grpc/grpc-swift/documentation/grpccore/compatibility#Platforms
+    depends_on macos: :sequoia
+  end
 
   def install
     args = if OS.mac?

--- a/Formula/p/publish.rb
+++ b/Formula/p/publish.rb
@@ -20,10 +20,13 @@ class Publish < Formula
 
   # https://github.com/JohnSundell/Publish#system-requirements
   depends_on xcode: ["13.0", :build]
-  # missing `libswift_Concurrency.dylib` on big_sur`
-  depends_on macos: :monterey
 
   uses_from_macos "swift" => :build
+
+  on_macos do
+    # missing `libswift_Concurrency.dylib` on big_sur`
+    depends_on macos: :monterey
+  end
 
   def install
     args = if OS.mac?

--- a/Formula/p/pytorch.rb
+++ b/Formula/p/pytorch.rb
@@ -31,7 +31,6 @@ class Pytorch < Formula
   depends_on "eigen"
   depends_on "libuv"
   depends_on "libyaml"
-  depends_on macos: :monterey # MPS backend only supports 12.3 and above
   depends_on "numpy"
   depends_on "onnx"
   depends_on "openblas"
@@ -41,6 +40,7 @@ class Pytorch < Formula
 
   on_macos do
     depends_on "libomp"
+    depends_on macos: :monterey # MPS backend only supports 12.3 and above
   end
 
   pypi_packages package_name:     "torch[opt-einsum]",

--- a/Formula/q/qtmultimedia.rb
+++ b/Formula/q/qtmultimedia.rb
@@ -34,13 +34,12 @@ class Qtmultimedia < Formula
   depends_on "qtshadertools" => :build
   depends_on "vulkan-headers" => :build
   depends_on "pkgconf" => :test
-
-  depends_on macos: :ventura
   depends_on "qtbase"
   depends_on "qtdeclarative"
   depends_on "qtquick3d"
 
   on_macos do
+    depends_on macos: :ventura
     depends_on "qtshadertools"
   end
 

--- a/Formula/r/recc.rb
+++ b/Formula/r/recc.rb
@@ -23,12 +23,15 @@ class Recc < Formula
   depends_on "abseil"
   depends_on "c-ares"
   depends_on "grpc"
-  depends_on macos: :sonoma # Needs C++20 features not in Ventura
   depends_on "openssl@3"
   depends_on "protobuf"
   depends_on "re2"
 
   uses_from_macos "curl"
+
+  on_macos do
+    depends_on macos: :sonoma # Needs C++20 features not in Ventura
+  end
 
   on_linux do
     depends_on "pkgconf" => :build

--- a/Formula/r/rpm.rb
+++ b/Formula/r/rpm.rb
@@ -44,8 +44,6 @@ class Rpm < Formula
   depends_on "libarchive"
   depends_on "libmagic"
   depends_on "lua"
-  # See https://github.com/rpm-software-management/rpm/issues/2222 for details.
-  depends_on macos: :ventura
   depends_on "openssl@3" # for rpm-sequoia
   depends_on "pkgconf"
   depends_on "popt"
@@ -59,6 +57,8 @@ class Rpm < Formula
   on_macos do
     depends_on "gettext"
     depends_on "libomp"
+    # See https://github.com/rpm-software-management/rpm/issues/2222 for details.
+    depends_on macos: :ventura
   end
 
   on_linux do

--- a/Formula/r/rv.rb
+++ b/Formula/r/rv.rb
@@ -21,7 +21,10 @@ class Rv < Formula
   end
 
   depends_on "rust" => :build
-  depends_on macos: :sonoma
+
+  on_macos do
+    depends_on macos: :sonoma
+  end
 
   conflicts_with "rv-r", because: "both install `rv` binary"
 

--- a/Formula/s/screenpipe.rb
+++ b/Formula/s/screenpipe.rb
@@ -20,9 +20,12 @@ class Screenpipe < Formula
   depends_on "pkgconf" => :build
   depends_on "rust" => :build
   depends_on "ffmpeg"
-  depends_on macos: :sonoma
 
   uses_from_macos "llvm" # for libclang
+
+  on_macos do
+    depends_on macos: :sonoma
+  end
 
   on_linux do
     depends_on "alsa-lib"

--- a/Formula/s/swiftlint.rb
+++ b/Formula/s/swiftlint.rb
@@ -18,12 +18,15 @@ class Swiftlint < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "d8408453159a1aae0ea8abfc5bf3c8c3b3275891099130e13f96bfbd53a0bedb"
   end
 
-  depends_on macos: :ventura
   depends_on xcode: "8.0"
 
   uses_from_macos "swift" => :build, since: :sonoma # swift 5.10+
   uses_from_macos "curl"
   uses_from_macos "libxml2"
+
+  on_macos do
+    depends_on macos: :ventura
+  end
 
   def install
     if OS.mac?

--- a/Formula/u/unxip.rb
+++ b/Formula/u/unxip.rb
@@ -16,9 +16,11 @@ class Unxip < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "f980d6217df53dc0c7e7c976a4a8bca29e7c38028876ce17184917df790253f9"
   end
 
-  depends_on macos: :sonoma
-
   uses_from_macos "swift" => :build
+
+  on_macos do
+    depends_on macos: :sonoma
+  end
 
   on_sequoia :or_older do
     depends_on xcode: ["16.0", :build]

--- a/Formula/v/vapor.rb
+++ b/Formula/v/vapor.rb
@@ -14,9 +14,12 @@ class Vapor < Formula
   end
 
   depends_on xcode: ["26.0", :build]
-  depends_on macos: :sequoia
 
   uses_from_macos "swift" => :build
+
+  on_macos do
+    depends_on macos: :sequoia
+  end
 
   def install
     args = if OS.mac?

--- a/Formula/x/x86_64-linux-gnu-binutils.rb
+++ b/Formula/x/x86_64-linux-gnu-binutils.rb
@@ -20,12 +20,15 @@ class X8664LinuxGnuBinutils < Formula
   end
 
   depends_on "pkgconf" => :build
-  # Requires the <uchar.h> header
-  # https://sourceware.org/bugzilla/show_bug.cgi?id=31320
-  depends_on macos: :ventura
   depends_on "zstd"
 
   uses_from_macos "llvm" => :test
+
+  on_macos do
+    # Requires the <uchar.h> header
+    # https://sourceware.org/bugzilla/show_bug.cgi?id=31320
+    depends_on macos: :ventura
+  end
 
   on_system :linux, macos: :ventura_or_newer do
     depends_on "texinfo" => :build

--- a/Formula/z/zig.rb
+++ b/Formula/z/zig.rb
@@ -24,10 +24,10 @@ class Zig < Formula
   depends_on "cmake" => :build
   depends_on "lld@21"
   depends_on "llvm@21"
-  depends_on macos: :big_sur # https://github.com/ziglang/zig/issues/13313
 
   # NOTE: `z3` should be macOS-only dependency whenever we need to re-add
   on_macos do
+    depends_on macos: :big_sur # https://github.com/ziglang/zig/issues/13313
     depends_on "zstd"
   end
 

--- a/Formula/z/zig@0.14.rb
+++ b/Formula/z/zig@0.14.rb
@@ -31,9 +31,9 @@ class ZigAT014 < Formula
   depends_on "cmake" => :build
   depends_on "lld@19"
   depends_on "llvm@19"
-  depends_on macos: :big_sur # https://github.com/ziglang/zig/issues/13313
 
   on_macos do
+    depends_on macos: :big_sur # https://github.com/ziglang/zig/issues/13313
     depends_on "zstd"
   end
 

--- a/Formula/z/zig@0.15.rb
+++ b/Formula/z/zig@0.15.rb
@@ -29,9 +29,9 @@ class ZigAT015 < Formula
   depends_on "cmake" => :build
   depends_on "lld@20"
   depends_on "llvm@20"
-  depends_on macos: :big_sur # https://github.com/ziglang/zig/issues/13313
 
   on_macos do
+    depends_on macos: :big_sur # https://github.com/ziglang/zig/issues/13313
     depends_on "zstd"
   end
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

We have a few formulae that support both macOS and Linux and have a `depends_on macos:` call at the top level. This should only apply to macOS, so this moves the call into an `on_macos` block. A top-level `depends_on macos:` call will not only set the macOS requirement but also specify that the formula is macOS-only (https://github.com/Homebrew/brew/pull/22187), so we need to update these formulae in light of this recent change.

I'm not sure if this needs bottles but I've set CI to skip bottles for now and to skip dependents as well. Feel free to change the labels if this isn't the correct approach.