### PR TITLE
kubernetes-cli kubernetes-cli@1.35: remove `rsync` dependency

### DIFF
--- a/Formula/k/kubernetes-cli.rb
+++ b/Formula/k/kubernetes-cli.rb
@@ -23,8 +23,6 @@ class KubernetesCli < Formula
 
   depends_on "go" => :build
 
-  uses_from_macos "rsync" => :build
-
   on_macos do
     depends_on "bash" => :build
     depends_on "coreutils" => :build

--- a/Formula/k/kubernetes-cli@1.35.rb
+++ b/Formula/k/kubernetes-cli@1.35.rb
@@ -27,8 +27,6 @@ class KubernetesCliAT135 < Formula
 
   depends_on "go" => :build
 
-  uses_from_macos "rsync" => :build
-
   on_macos do
     depends_on "bash" => :build
     depends_on "coreutils" => :build


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

https://github.com/kubernetes/kubernetes/commit/cf991024a240fb649464e6f4505714a0e27e9c1b