### PR TITLE
s3fs: use OpenSSL to match libcurl

### DIFF
--- a/Formula/s/s3fs.rb
+++ b/Formula/s/s3fs.rb
@@ -4,6 +4,7 @@ class S3fs < Formula
   url "https://github.com/s3fs-fuse/s3fs-fuse/archive/refs/tags/v1.97.tar.gz"
   sha256 "28413457cbf923b9b81e546caffabb8edd5c18f263e698ad86f564fd4b5b344d"
   license "GPL-2.0-or-later"
+  revision 1
   head "https://github.com/s3fs-fuse/s3fs-fuse.git", branch: "master"
 
   bottle do
@@ -15,16 +16,14 @@ class S3fs < Formula
   depends_on "automake" => :build
   depends_on "pkgconf" => :build
   depends_on "curl"
-  depends_on "gnutls"
   depends_on "libfuse"
-  depends_on "libgcrypt"
   depends_on "libxml2"
   depends_on :linux # on macOS, requires closed-source macFUSE
-  depends_on "nettle"
+  depends_on "openssl@3"
 
   def install
     system "./autogen.sh"
-    system "./configure", "--with-gnutls", *std_configure_args
+    system "./configure", "--with-openssl", *std_configure_args
     system "make", "install"
   end
 

--- a/Formula/s/s3fs.rb
+++ b/Formula/s/s3fs.rb
@@ -8,8 +8,8 @@ class S3fs < Formula
   head "https://github.com/s3fs-fuse/s3fs-fuse.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_linux:  "98936a769c49e9d9d7fe5e654304a08906a4fd9276f507d468f1d667a016528a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "3fd8a38dd94f3523cfe03b544b4e12cd3dbfe724a34098c3e7373bbe799bee11"
+    sha256 cellar: :any_skip_relocation, arm64_linux:  "b9a799bfed9371edbb6542c9c93afae3fa3681ce520ce7d775c2368fe007118e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "0e81020206b9b2fa2b3e5abd51d7d32ecf4d45683b6d7a75da2bd9d07197e2c3"
   end
 
   depends_on "autoconf" => :build


### PR DESCRIPTION
https://github.com/s3fs-fuse/s3fs-fuse/wiki/Installation-Notes#common-for-building1-2

Also revision bump to avoid broken linkage after Nettle 4

EDIT: OpenSSL 4 will require staging branch after curl.