### PR TITLE
cilium-cli: simplify build flags

### DIFF
--- a/Formula/c/cilium-cli.rb
+++ b/Formula/c/cilium-cli.rb
@@ -26,13 +26,9 @@ class CiliumCli < Formula
   depends_on "go" => :build
 
   def install
-    cilium_version_url = "https://raw.githubusercontent.com/cilium/cilium/main/stable.txt"
-    cilium_version = Utils.safe_popen_read("curl", cilium_version_url).strip
-
     ldflags = %W[
       -s -w
       -X github.com/cilium/cilium/cilium-cli/defaults.CLIVersion=v#{version}
-      -X github.com/cilium/cilium/cilium-cli/defaults.Version=#{cilium_version}
     ]
     system "go", "build", *std_go_args(ldflags:, output: bin/"cilium"), "./cmd/cilium"
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

This weird custom fetch logic not very safe or reproducible. Fortunately, it's not necessary anymore: https://github.com/cilium/cilium-cli/commit/7d7878ff5c64024dc3725eda3265b491217eef2f