### PR TITLE
stoken: revision bump to use `libtomcrypt`

### DIFF
--- a/Formula/s/stoken.rb
+++ b/Formula/s/stoken.rb
@@ -7,12 +7,12 @@ class Stoken < Formula
   revision 2
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "120ccd4eea9a910df80ea95e8041919027ef03d74fa87f982e25da2dea11bd72"
-    sha256 cellar: :any,                 arm64_sequoia: "1506760360fda777047ae3f92e7fabd9b912d89a1684d55bd523850438b77bda"
-    sha256 cellar: :any,                 arm64_sonoma:  "6b0705d78068002077390e931ffe342184ef0f63a0fe8dbbd9fbe3a1e7b6b145"
-    sha256 cellar: :any,                 sonoma:        "1655d0e1253f345ab475d8038d627266a714d2a055a9d0f84d636ed9f867cefc"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "48fb52e148c6e57cc6ff3423f04f7ced5302bf5c64c3eee2144272e2675288bf"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "99879a1ca2556a68d5c70e0e48d1ba6fcb05dae8eeed6b5899b09a3fc192595c"
+    sha256 cellar: :any,                 arm64_tahoe:   "13f7f789acd86bfb43e32a93a22c14e281f0182333228f649c1fdc18bbd3d53a"
+    sha256 cellar: :any,                 arm64_sequoia: "6dd71ade20837819b4d7278cff667d12707a25506af24d3c0fd63f146f21be52"
+    sha256 cellar: :any,                 arm64_sonoma:  "964feda555eeeb9f2546af0830baa11d8a2340c56ecdb6c13d078b7b0c18ff5d"
+    sha256 cellar: :any,                 sonoma:        "e42c126e6b6c3e2f721d1d0dad2066a07b60f5e9e9ddee3ef57576ad4c9499e3"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "0a61f32a5b5a333616b1a350b6ecf3f6f4359fff2628d56f6f5326367ca7ec9b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "38224776fd91dcdef6e5e4b0330583ed6b3800f1f6cc1b8a3153832e4afe3ffb"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/s/stoken.rb
+++ b/Formula/s/stoken.rb
@@ -3,8 +3,8 @@ class Stoken < Formula
   homepage "https://github.com/stoken-dev/stoken"
   url "https://github.com/stoken-dev/stoken/archive/refs/tags/v0.93.tar.gz"
   sha256 "102e2d112b275efcdc20ef438670e4f24f08870b9072a81fda316efcc38aef9c"
-  license "LGPL-2.1-only"
-  revision 1
+  license "LGPL-2.1-or-later"
+  revision 2
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "120ccd4eea9a910df80ea95e8041919027ef03d74fa87f982e25da2dea11bd72"
@@ -19,8 +19,7 @@ class Stoken < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkgconf" => :build
-  depends_on "gmp"
-  depends_on "nettle"
+  depends_on "libtomcrypt"
 
   uses_from_macos "libxml2"
 


### PR DESCRIPTION
`stoken` is not compatible with Nettle 4 and using `nettle@3` results in multiple Nettle versions in `openconnect` so switch to `libtomcrypt`.

Also update license
https://github.com/stoken-dev/stoken/blob/v0.93/README.md#misc

> License: LGPLv2.1+

---

Part of #266125. Was considering alternatives I mentioned there but wanted to avoid versioned Nettle given lack of activity in `stoken`. This makes it easier to plan deprecation for `nettle@3`

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
