### PR TITLE
Update command-not-found in CI

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -374,6 +374,13 @@ jobs:
         with:
           subject-path: '${{steps.pr-pull.outputs.bottle_path}}/*.tar.gz'
 
+      - name: Upload bottle metadata artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: command-not-found-bottle-json
+          path: ${{steps.pr-pull.outputs.bottle_path}}/*.bottle.json
+          if-no-files-found: error
+
       - name: Upload bottles to GitHub Packages
         id: pr-upload
         working-directory: ${{steps.pr-pull.outputs.bottle_path}}
@@ -502,3 +509,103 @@ jobs:
           body: ":warning: @${{github.actor}} [Failed to enable automerge](${{env.RUN_URL}})."
           bot_body: ":warning: [Failed to enable automerge](${{env.RUN_URL}})."
           bot: github-actions[bot]
+
+  update-command-not-found-db:
+    needs: [check, upload]
+    if: >
+      always() &&
+      github.repository_owner == 'Homebrew' &&
+      needs.check.result == 'success' &&
+      fromJson(needs.check.outputs.requires_merge) &&
+      fromJson(needs.check.outputs.bottles) &&
+      !fromJson(needs.check.outputs.replace) &&
+      needs.upload.result == 'success'
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/homebrew/brew:main
+    concurrency:
+      group: command-not-found-db
+      cancel-in-progress: false
+    permissions:
+      actions: read # for actions/download-artifact
+      contents: read # for `gh pr checkout`
+      packages: write
+      pull-requests: read # for `gh pr checkout`
+    outputs:
+      updated: ${{steps.update-db.outputs.updated}}
+    steps:
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@main
+        with:
+          core: true
+          cask: false
+
+      - name: Checkout PR branch
+        working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
+        env:
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: gh pr checkout "$PR" --repo "$GITHUB_REPOSITORY"
+
+      - name: Install oras for interacting with GitHub Packages
+        uses: Homebrew/actions/cache-homebrew-prefix@main
+        with:
+          install: oras
+          workflow-key: command-not-found-db-entry
+          uninstall: true
+
+      - name: Download bottle metadata artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: command-not-found-bottle-json
+          path: bottle-json
+
+      - name: Pull executables.txt from GitHub Packages
+        run: oras pull ghcr.io/homebrew/command-not-found/executables:latest
+
+      - name: Update database
+        id: update-db
+        working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+          brew which-update \
+            --pull-request="$PR" \
+            --repository="$GITHUB_REPOSITORY" \
+            --bottle-json-dir="$GITHUB_WORKSPACE/bottle-json" \
+            --summary-file="$GITHUB_STEP_SUMMARY" \
+            "$GITHUB_WORKSPACE/executables.txt"
+
+      - name: Log in to GitHub Packages
+        if: fromJson(steps.update-db.outputs.updated)
+        run: echo "${{secrets.GITHUB_TOKEN}}" | oras login ghcr.io --username brewtestbot --password-stdin
+
+      - name: Push to GitHub Packages
+        if: fromJson(steps.update-db.outputs.updated)
+        run: |
+          oras push --artifact-type application/vnd.homebrew.command-not-found.executables \
+            ghcr.io/homebrew/command-not-found/executables:latest \
+            executables.txt:text/plain
+
+      - name: Check upload
+        if: fromJson(steps.update-db.outputs.updated)
+        run: |
+          shasum --algorithm=256 executables.txt > executables.txt.sha256
+          rm -f executables.txt
+          oras pull ghcr.io/homebrew/command-not-found/executables:latest
+          shasum --algorithm=256 --check executables.txt.sha256
+
+  delete-old-command-not-found-db-versions:
+    needs: update-command-not-found-db
+    runs-on: ubuntu-slim
+    if: needs.update-command-not-found-db.outputs.updated == 'true'
+    permissions:
+      packages: write
+    steps:
+      - name: Delete old versions from GitHub Packages
+        uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
+        with:
+          package-name: command-not-found/executables
+          package-type: container
+          min-versions-to-keep: 0
+          delete-only-untagged-versions: true


### PR DESCRIPTION
- Call `brew which-update` from bottle publishing so database updates share Homebrew's command code instead of workflow-local Ruby.
- Pass bottle metadata and pull request context to the command so the workflow only handles GHCR transport.
- Keep GHCR writes queued and prune old untagged versions only after a new database has been pushed.

Requires https://github.com/Homebrew/brew/pull/22231
Fixes https://github.com/Homebrew/brew/issues/20752
Closes https://github.com/Homebrew/brew/pull/21790
Closes https://github.com/Homebrew/homebrew-core/pull/272976

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

OpenAI Codex 5.5 xhigh with a bunch of local review and tweaking.

-----
