### PR TITLE
libvncserver x11vnc: migrate to OpenSSL 4

### DIFF
--- a/Formula/lib/libvncserver.rb
+++ b/Formula/lib/libvncserver.rb
@@ -4,6 +4,7 @@ class Libvncserver < Formula
   url "https://github.com/LibVNC/libvncserver/archive/refs/tags/LibVNCServer-0.9.15.tar.gz"
   sha256 "62352c7795e231dfce044beb96156065a05a05c974e5de9e023d688d8ff675d7"
   license "GPL-2.0-or-later"
+  revision 1
   head "https://github.com/LibVNC/libvncserver.git", branch: "master"
 
   livecheck do
@@ -23,9 +24,8 @@ class Libvncserver < Formula
 
   depends_on "cmake" => :build
   depends_on "jpeg-turbo"
-  depends_on "libgcrypt"
   depends_on "libpng"
-  depends_on "openssl@3"
+  depends_on "openssl@4"
 
   on_linux do
     depends_on "zlib-ng-compat"
@@ -35,11 +35,15 @@ class Libvncserver < Formula
     args = %W[
       -DJPEG_INCLUDE_DIR=#{Formula["jpeg-turbo"].opt_include}
       -DJPEG_LIBRARY=#{Formula["jpeg-turbo"].opt_lib/shared_library("libjpeg")}
-      -DOPENSSL_ROOT_DIR=#{Formula["openssl@3"].opt_prefix}
+      -DOPENSSL_ROOT_DIR=#{Formula["openssl@4"].opt_prefix}
       -DWITH_EXAMPLES=OFF
+      -DWITH_GCRYPT=OFF
+      -DWITH_GNUTLS=OFF
+      -DWITH_OPENSSL=ON
     ]
     # Workaround for CMake 4 compatibility
     args << "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+
     system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
     system "cmake", "--build", "build"
     system "ctest", "--test-dir", "build", "--verbose"

--- a/Formula/lib/libvncserver.rb
+++ b/Formula/lib/libvncserver.rb
@@ -13,13 +13,12 @@ class Libvncserver < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_tahoe:   "ce1472b68ae1ac5412007a81f99ddec58cec02d3d13b4e9cceb1fe90202ab912"
-    sha256 cellar: :any,                 arm64_sequoia: "4a3d1fee5603436a04b846cb9502e70fbee34a787d6a5201e1888845242de4f2"
-    sha256 cellar: :any,                 arm64_sonoma:  "30629338dbd5ba92cb3726419a559cb9dfa0e7f39cce27976ce3967c1d0d4075"
-    sha256 cellar: :any,                 sonoma:        "b7e7461e4689b9265688597301f7a15ac6b49f77a6a97ae8a5748c8ea6fffcfc"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "8cb88d51bf4a691357fe3020a78e367687b6329db0394eff5de2af46c439fed6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1e4f2fb7d81aa49887b2c26579ca48af09812947fedca499f70d832e269cd516"
+    sha256 cellar: :any,                 arm64_tahoe:   "865a4376a6361437e19230eb55c8baaa89c837e693e7a352d080a91050c7c2ee"
+    sha256 cellar: :any,                 arm64_sequoia: "09c5d54a804cd66267e2f453978281e19edbcacd434b6507bef2d928da69a79d"
+    sha256 cellar: :any,                 arm64_sonoma:  "18f58d8fedea600268bb9a70a470fb279c1afe0086b09b8282e1454904bf3c0c"
+    sha256 cellar: :any,                 sonoma:        "7a127ab1078d09af7ad9d28f554a8ce44fcc32e0259db44031b2ac8ece3b41ce"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "9a66daa25ce9cdb07ed0000ff45f93f3f6101621188f712f8a2d97b216891af8"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3ce999949a58f1263bd09e67af8a39f1709c0f5d8a055696151b0594a1793fda"
   end
 
   depends_on "cmake" => :build

--- a/Formula/x/x11vnc.rb
+++ b/Formula/x/x11vnc.rb
@@ -8,14 +8,12 @@ class X11vnc < Formula
   head "https://github.com/LibVNC/x11vnc.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "f1a4ed13ffea08fefdfaed2e5b5405a29d302c3e1dfe0ea8f8be69bee9cb4d9c"
-    sha256 cellar: :any,                 arm64_sequoia: "04683ae07f04702dffa93bf7fda5c4019e61d64505539c712559ed4dbe82a41d"
-    sha256 cellar: :any,                 arm64_sonoma:  "dd9d309ac45e10b7fd969b4dd4d08a63612728ef746c3efffee2317b4c996425"
-    sha256 cellar: :any,                 arm64_ventura: "54c171880e9966130ce503f32af1ad3fb48175a86cfe7d07f05bb21a37fca4db"
-    sha256 cellar: :any,                 sonoma:        "88e64a8742c4ade347ddc88ccf385b94b02da30b6be1f90cfd9793ff4cfe421b"
-    sha256 cellar: :any,                 ventura:       "1a49795ee32fa6a062d2106375a0fc639c3498ab14042e5dd3a8e2af462b574e"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "a0f7c9f45cf87d7609f58dd039c0f0a8ef1c3cfe2eec0afcb5a6d817829b3f82"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "676b00ad2fdec853d0f1e29c3b31f33ec88be24b1ec75f1bbf05b4449d9146f4"
+    sha256 cellar: :any,                 arm64_tahoe:   "102cee00c05c862c030ae03b910f7c8ec47f48248bcc770776887d1d9e132b01"
+    sha256 cellar: :any,                 arm64_sequoia: "7ebcb43dc4ccf3d7ac18cf408a2d5d21cc362ff3e7098c9026fb569e532ced4d"
+    sha256 cellar: :any,                 arm64_sonoma:  "3e370889f63e85701db1dd0edd825a150618e98fa4f398ace038d20b11c53b9b"
+    sha256 cellar: :any,                 sonoma:        "49441c4a528e64ebbee615cb01c827e3de19405439c434f5097727bd981bd59b"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "f754c6e86c60c7926e3ef94f8b5ca5df4e6970d49ca3e2192b65f36dd90117d6"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f53a15699255263ebc83de67d31010a0f4c84245a2b3305d82d64b3e5cd5154f"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/x/x11vnc.rb
+++ b/Formula/x/x11vnc.rb
@@ -4,6 +4,7 @@ class X11vnc < Formula
   url "https://github.com/LibVNC/x11vnc/archive/refs/tags/0.9.17.tar.gz"
   sha256 "3ab47c042bc1c33f00c7e9273ab674665b85ab10592a8e0425589fe7f3eb1a69"
   license "GPL-2.0-or-later" => { with: "x11vnc-openssl-exception" }
+  revision 1
   head "https://github.com/LibVNC/x11vnc.git", branch: "master"
 
   bottle do
@@ -21,7 +22,7 @@ class X11vnc < Formula
   depends_on "automake" => :build
   depends_on "pkgconf" => :build
   depends_on "libvncserver"
-  depends_on "openssl@3"
+  depends_on "openssl@4"
 
   uses_from_macos "libxcrypt"
 
@@ -29,6 +30,7 @@ class X11vnc < Formula
     # Fix compile with newer Clang
     ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
     ENV.append_to_cflags "-Wno-int-conversion" if DevelopmentTools.clang_build_version >= 1500
+    ENV.append "CFLAGS", "-std=gnu17" if DevelopmentTools.clang_build_version >= 1700
 
     system "./autogen.sh", "--disable-silent-rules",
                            "--mandir=#{man}",


### PR DESCRIPTION
Should be able to migrate these outside staging branch. No other dependents for these and runtime dependency versions are all same.

Can drop libgcrypt following https://github.com/LibVNC/libvncserver/tree/LibVNCServer-0.9.15#how-to-build since OpenSSL provides both crypto and TLS support. 