### PR TITLE
sngrep: migrate to OpenSSL 4, update license exception

### DIFF
--- a/Formula/s/sngrep.rb
+++ b/Formula/s/sngrep.rb
@@ -7,12 +7,12 @@ class Sngrep < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "061db6e59e8b46db369feba26f33ad4d50082baf87580affeff0bdfbcb42f566"
-    sha256 cellar: :any,                 arm64_sequoia: "7cff7081ff7899992673f68269bfafa11e62a143b39c9de3ad9731136ae72123"
-    sha256 cellar: :any,                 arm64_sonoma:  "d128fa1a31902c76abfb557e18552670b54087cec17a9a32d7599ba93ad251f8"
-    sha256                               sonoma:        "dd3ceac2f13d770f905b245f456f553fc6d0aa3335cb1513f28efa21068fff91"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "c5a86128da8d87abf69575b2dbd298c2e2a75e3ccbe88b14624df356e723bbe6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2ab8d1e61cb58f5ab80ee2e230da31057941225c29cf867d176ca70ef3123da2"
+    sha256 cellar: :any,                 arm64_tahoe:   "f72b1586ed174b41ce35ef705d6ae4c339ed026cc5df4406ccd60460e767307d"
+    sha256 cellar: :any,                 arm64_sequoia: "77c7c05b46cdd48fcb7333e73c520c0f62ca97c66c0c60500c26f2d4922d6f9e"
+    sha256 cellar: :any,                 arm64_sonoma:  "b76869c116279f94af0bed24bd7cbe1743ba3d5a11003b264bf5a68de24ba896"
+    sha256                               sonoma:        "88813c882e63445fdc564f63232669d8408a326578dcdfe61779720bc2a2f3f3"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "d8a72a6e8dc6a76f0414f7091114110655930f2d2a59817d7193529efd40db4e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d000c2019a4cf2b7c0032beb1cf0c5b69df2d89958482b98ea8605e4765dace0"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/s/sngrep.rb
+++ b/Formula/s/sngrep.rb
@@ -3,7 +3,8 @@ class Sngrep < Formula
   homepage "https://github.com/irontec/sngrep"
   url "https://github.com/irontec/sngrep/releases/download/v1.8.3/sngrep-1.8.3.tar.gz"
   sha256 "794224f4cd08978a6115a767e9945f756fdf7cbc7c1a34eabca293e0293b21b8"
-  license "GPL-3.0-or-later" => { with: "openvpn-openssl-exception" }
+  license "GPL-3.0-or-later" => { with: "cryptsetup-OpenSSL-exception" }
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "061db6e59e8b46db369feba26f33ad4d50082baf87580affeff0bdfbcb42f566"
@@ -19,18 +20,17 @@ class Sngrep < Formula
   depends_on "pkgconf" => :build
 
   depends_on "ncurses"
-  depends_on "openssl@3"
+  depends_on "openssl@4"
 
   uses_from_macos "libpcap"
 
-  on_linux do
-    depends_on "libgcrypt"
+  # Backport fix for build
+  patch do
+    url "https://github.com/irontec/sngrep/commit/b84f0663e47de6f238d9f81eed67612a9ab616ef.patch?full_index=1"
+    sha256 "5212687f15f3e3e8f364634b18981e49ee022d612620079ed75c08d2a32a2f10"
   end
 
   def install
-    # Fix compile with newer Clang
-    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
-
     ENV.append_to_cflags "-I#{Formula["ncurses"].opt_include}/ncursesw" if OS.linux?
 
     system "./bootstrap.sh"


### PR DESCRIPTION
Isolated part of OpenSSL deps tree so can be migrated separately.

License exception text https://github.com/irontec/sngrep#license
```
In addition, as a special exception, the copyright holders give
permission to link the code of portions of this program with the
OpenSSL library under certain conditions as described in each
individual source file, and distribute linked combinations
including the two.
You must obey the GNU General Public License in all respects
for all of the code used other than OpenSSL.  If you modify
file(s) with this exception, you may extend this exception to your
version of the file(s), but you are not obligated to do so.  If you
do not wish to do so, delete this exception statement from your
version.  If you delete this exception statement from all source
files in the program, then also delete it here.
```

Matches https://spdx.org/licenses/cryptsetup-OpenSSL-exception.html, e.g. "under certain conditions as described in each individual source file" which is not present in other exception