### PR TITLE
argon2: update license

### DIFF
--- a/Formula/a/argon2.rb
+++ b/Formula/a/argon2.rb
@@ -3,7 +3,7 @@ class Argon2 < Formula
   homepage "https://github.com/P-H-C/phc-winner-argon2"
   url "https://github.com/P-H-C/phc-winner-argon2/archive/refs/tags/20190702.tar.gz"
   sha256 "daf972a89577f8772602bf2eb38b6a3dd3d922bf5724d45e7f9589b5e830442c"
-  license "Apache-2.0"
+  license any_of: ["CC0-1.0", "Apache-2.0"]
   revision 1
   head "https://github.com/P-H-C/phc-winner-argon2.git", branch: "master"
 


### PR DESCRIPTION
https://github.com/P-H-C/phc-winner-argon2/blob/master/LICENSE
```
You may use this work under the terms of a Creative Commons CC0 1.0 
License/Waiver or the Apache Public License 2.0, at your option. The terms of
these licenses can be found at:

- CC0 1.0 Universal : https://creativecommons.org/publicdomain/zero/1.0
- Apache 2.0        : https://www.apache.org/licenses/LICENSE-2.0
```

This is necessary to avoid GPL-2.0-only incompatibility.