### PR TITLE
doltlite 0.10.5 (new formula)

### DIFF
--- a/Formula/d/doltlite.rb
+++ b/Formula/d/doltlite.rb
@@ -1,0 +1,31 @@
+class Doltlite < Formula
+  desc "SQLite fork with Git-style version control via prolly trees"
+  homepage "https://github.com/dolthub/doltlite"
+  url "https://github.com/dolthub/doltlite/releases/download/v0.10.5/doltlite-autoconf-0.10.5.tar.gz"
+  sha256 "8918db0aab0e5aa41e627be6f2beeb55e528005b6317173213446453df44723c"
+  license "Apache-2.0"
+  head "https://github.com/dolthub/doltlite.git", branch: "master"
+
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
+  depends_on "zlib"
+
+  def install
+    mkdir "build" do
+      system "../configure"
+      system "make", "doltlite", "doltlite-remotesrv", "doltlite-lib"
+      bin.install "doltlite", "doltlite-remotesrv"
+      include.install "sqlite3.h" => "doltlite.h"
+      lib.install "libdoltlite.a"
+      lib.install OS.mac? ? "libdoltlite.dylib" : "libdoltlite.so"
+    end
+  end
+
+  test do
+    output = shell_output("#{bin}/doltlite :memory: 'SELECT dolt_version();'")
+    assert_match(/v?\d+\.\d+\.\d+/, output)
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing? **YES**
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change? **YES**
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`? **YES**
- [x] Is your test running fine `brew test <formula>`? **YES**
- [x] Does your build pass `brew audit --new <formula>`? **`brew style` passes; full audit deferred to CI**

---

[DoltLite](https://github.com/dolthub/doltlite) is a SQLite fork that replaces the B-tree storage engine with a content-addressed [prolly tree](https://docs.dolthub.com/architecture/storage-engine/prolly-tree), giving Git-style version control on a SQL database while keeping the SQLite VDBE, query planner, and parser unchanged. It's the embedded counterpart to [Dolt](https://github.com/dolthub/dolt) (already in homebrew-core).

The formula installs:

- `bin/doltlite` — the SQL shell (drop-in for `sqlite3`)
- `bin/doltlite-remotesrv` — remote sync server
- `include/doltlite.h` — header for embedding
- `lib/libdoltlite.a`, `lib/libdoltlite.{so,dylib}` — static and shared libraries

Notability: the project has 90 stars, an [introductory blog post](https://www.dolthub.com/blog/2026-04-27-why-doltlite/) on the dolthub.com engineering blog, and is the embedded peer to `dolt` and `doltgres` (both established in their ecosystems).

The build is autoconf-style C, no special dependencies beyond zlib. The `test do` block exercises `doltlite :memory: 'SELECT dolt_version();'` to verify both the binary and the storage engine come up. The `livecheck` block points at GitHub's `latest` release endpoint so `BrewTestBot` can autobump future versions.