### PR TITLE
wrkflw: remove OpenSSL dependency

### DIFF
--- a/Formula/w/wrkflw.rb
+++ b/Formula/w/wrkflw.rb
@@ -18,10 +18,6 @@ class Wrkflw < Formula
   depends_on "pkgconf" => :build
   depends_on "rust" => :build
 
-  on_linux do
-    depends_on "openssl@3"
-  end
-
   def install
     system "cargo", "install", *std_cargo_args(path: "crates/wrkflw")
   end


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-core/actions/runs/24751011258/job/72414343575#step:5:220
```
==> brew linkage --cached wrkflw
System libraries:
  /lib/aarch64-linux-gnu/ld-linux-aarch64.so.1
  /lib/aarch64-linux-gnu/libc.so.6
  /lib/aarch64-linux-gnu/libgcc_s.so.1
  /lib/aarch64-linux-gnu/libm.so.6
```