### PR TITLE
urx: remove OpenSSL dependency

### DIFF
--- a/Formula/u/urx.rb
+++ b/Formula/u/urx.rb
@@ -16,13 +16,8 @@ class Urx < Formula
 
   depends_on "pkgconf" => :build
   depends_on "rust" => :build
-  on_linux do
-    depends_on "openssl@3"
-  end
 
   def install
-    ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-
     system "cargo", "install", *std_cargo_args
   end
 


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-core/actions/runs/22563256932/job/65354401445#step:5:163
```
==> brew linkage --cached urx
System libraries:
  /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
  /lib/x86_64-linux-gnu/libc.so.6
  /lib/x86_64-linux-gnu/libgcc_s.so.1
  /lib/x86_64-linux-gnu/libm.so.6
```