### PR TITLE
surfer: remove OpenSSL dependency

### DIFF
--- a/Formula/s/surfer.rb
+++ b/Formula/s/surfer.rb
@@ -19,10 +19,6 @@ class Surfer < Formula
   depends_on "pkgconf" => :build
   depends_on "rust" => :build
 
-  on_linux do
-    depends_on "openssl@3"
-  end
-
   def install
     system "cargo", "install", *std_cargo_args(path: "surfer")
   end


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-core/actions/runs/25013621596/job/73256325699#step:5:220
```
==> brew linkage --cached surfer
System libraries:
  /lib/x86_64-linux-gnu/libc.so.6
  /lib/x86_64-linux-gnu/libgcc_s.so.1
  /lib/x86_64-linux-gnu/libm.so.6
```