### PR TITLE
bacon-ls: remove OpenSSL dependency

### DIFF
--- a/Formula/b/bacon-ls.rb
+++ b/Formula/b/bacon-ls.rb
@@ -15,12 +15,7 @@ class BaconLs < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "b7f9f3149741fccf804f00ee8a5be0d50a8861cc4e2bd7186840b48eae779510"
   end
 
-  depends_on "pkgconf" => :build
   depends_on "rust" => :build
-
-  on_linux do
-    depends_on "openssl@3"
-  end
 
   def install
     system "cargo", "install", *std_cargo_args


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-core/actions/runs/25001182117/job/73212932999#step:5:220
```
==> brew linkage --cached bacon-ls
System libraries:
  /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
  /lib/x86_64-linux-gnu/libc.so.6
  /lib/x86_64-linux-gnu/libgcc_s.so.1
  /lib/x86_64-linux-gnu/libm.so.6
```