### PR TITLE
speech 0.0.18 (new formula)

### DIFF
--- a/Formula/s/speech.rb
+++ b/Formula/s/speech.rb
@@ -1,0 +1,43 @@
+class Speech < Formula
+  desc "On-device speech toolkit for Apple Silicon: ASR, TTS, VAD, diarization"
+  homepage "https://github.com/soniqo/speech-swift"
+  url "https://github.com/soniqo/speech-swift/archive/refs/tags/v0.0.18.tar.gz"
+  sha256 "4117128a631782e7cf6f460aff4b9b6d1cf3658bce6d29c24f3df28ce5d0c460"
+  license "Apache-2.0"
+  head "https://github.com/soniqo/speech-swift.git", branch: "main"
+
+  depends_on xcode: ["16.0", :build]
+  depends_on arch: :arm64
+  depends_on macos: :sequoia
+
+  def install
+    system "swift", "build", "-c", "release", "--disable-sandbox"
+    system "./scripts/build_mlx_metallib.sh", "release"
+
+    %w[speech speech-server].each do |name|
+      libexec.install ".build/release/#{name}"
+      bin.write_exec_script libexec/name
+    end
+    libexec.install ".build/release/mlx.metallib"
+    libexec.install ".build/release/Qwen3Speech_KokoroTTS.bundle"
+  end
+
+  test do
+    # Error path: nonexistent input triggers the audio-loading code path and
+    # the binary exits non-zero with a CoreAudio error message.
+    output = shell_output("#{bin}/speech transcribe /nonexistent.wav 2>&1", 1)
+    assert_match "Error", output
+
+    # Server-startup: `speech-server` binds on a port without preloading any
+    # model and serves /health.
+    port = free_port
+    pid = spawn bin/"speech-server", "--host", "127.0.0.1", "--port", port.to_s
+
+    sleep 15
+    health = shell_output("curl -sf --max-time 5 http://127.0.0.1:#{port}/health")
+    assert_match "ok", health
+  ensure
+    Process.kill("TERM", pid)
+    Process.wait(pid)
+  end
+end

--- a/Formula/s/speech.rb
+++ b/Formula/s/speech.rb
@@ -6,6 +6,11 @@ class Speech < Formula
   license "Apache-2.0"
   head "https://github.com/soniqo/speech-swift.git", branch: "main"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "a1eaf234bf392704ca19b6ec63d5a3eedc6092b3b32c1e1a66c6481e11a4b508"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "a97e93af8b177daabb495cd99b63ab03a20f58c55596f588e0684ba2989a446a"
+  end
+
   depends_on xcode: ["16.0", :build]
   depends_on arch: :arm64
   depends_on macos: :sequoia


### PR DESCRIPTION
On-device speech toolkit (ASR, TTS, speech-to-speech, VAD, diarization, voice cloning, denoising, forced alignment, wake-word, translation) for Apple Silicon. Built on MLX + CoreML; models download on first use.

- Upstream: https://github.com/soniqo/speech-swift (Apache-2.0, 710★)
- Release: https://github.com/soniqo/speech-swift/releases/tag/v0.0.18
- Currently distributed via tap: https://github.com/soniqo/homebrew-tap

### Binary scope

`speech` is the canonical CLI; `speech-server` is its sibling HTTP/WebSocket server (OpenAI-compatible `/v1/realtime` endpoint). They share ~95% of the source tree and are built from a single SwiftPM package — same pattern as `ffmpeg` shipping `ffmpeg` + `ffprobe`.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source speech`?
- [x] Is your test running fine `brew test speech`?
- [x] Does your build pass `brew audit --strict speech` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source speech`)? If this is a new formula, does it pass `brew audit --new speech`?

-----

- [x] AI was used to generate or assist with generating this PR.

Claude Code assisted with drafting the formula and this description. Manual verification on an M-series Mac running macOS 15: \`brew audit --strict --new --online speech\` clean, \`brew style speech\` clean (one autocorrect for dependency ordering applied), \`brew install --build-from-source speech\` succeeded in 4m 43s (210 MB Cellar), \`brew test speech\` passed, both \`speech\` and \`speech-server\` binaries respond to \`--help\` on PATH. Formula reviewed end-to-end before commit.

-----
