### PR TITLE
mp4ff 0.52.0

### DIFF
--- a/Formula/m/mp4ff.rb
+++ b/Formula/m/mp4ff.rb
@@ -1,8 +1,8 @@
 class Mp4ff < Formula
   desc "Tools for parsing and manipulating MP4/ISOBMFF files"
   homepage "https://github.com/Eyevinn/mp4ff"
-  url "https://github.com/Eyevinn/mp4ff/archive/refs/tags/v0.51.0.tar.gz"
-  sha256 "8318a6045e26bb9e901442773aac2a8827bfda3f9d77e72468ca0f1ea8ac1efe"
+  url "https://github.com/Eyevinn/mp4ff/archive/refs/tags/v0.52.0.tar.gz"
+  sha256 "9cd54f4ff69039c211326a08a79a865669276a4b0761a7f6ef57e5a4831151be"
   license "MIT"
 
   bottle do
@@ -21,35 +21,29 @@ class Mp4ff < Formula
   end
 
   def install
-    ldflags = %W[
-      -s -w
-      -X github.com/Eyevinn/mp4ff/internal.commitVersion=v#{version}
-      -X github.com/Eyevinn/mp4ff/internal.commitDate=#{time.iso8601}
-    ]
-
     tools.each do |tool|
-      system "go", "build", *std_go_args(ldflags:, output: bin/tool), "./cmd/#{tool}"
+      system "go", "build", *std_go_args(ldflags: "-s -w", output: bin/tool), "./cmd/#{tool}"
     end
   end
 
   test do
     resource "homebrew-init" do
-      url "https://raw.githubusercontent.com/Eyevinn/mp4ff/v0.51.0/mp4/testdata/init.mp4"
+      url "https://raw.githubusercontent.com/Eyevinn/mp4ff/v0.52.0/mp4/testdata/init.mp4"
       sha256 "09a99ab8be9a39c80dc41ac6d4c9539b16947aab95abbadec903bfcb7a322221"
     end
 
     resource "homebrew-segment" do
-      url "https://raw.githubusercontent.com/Eyevinn/mp4ff/v0.51.0/mp4/testdata/1.m4s"
+      url "https://raw.githubusercontent.com/Eyevinn/mp4ff/v0.52.0/mp4/testdata/1.m4s"
       sha256 "00dd5f29bc6ba64a9d8540cdbeda7a3e5be0f0ed67475ab307506d7462fc2d98"
     end
 
     resource "homebrew-prog" do
-      url "https://raw.githubusercontent.com/Eyevinn/mp4ff/v0.51.0/mp4/testdata/prog_8s.mp4"
+      url "https://raw.githubusercontent.com/Eyevinn/mp4ff/v0.52.0/mp4/testdata/prog_8s.mp4"
       sha256 "86651d2aa80c714440fee3499ac3dd258b75043c4ceb455d70babb7873b16feb"
     end
 
     resource "homebrew-subs" do
-      url "https://raw.githubusercontent.com/Eyevinn/mp4ff/v0.51.0/cmd/mp4ff-subslister/testdata/multi_vttc.mp4"
+      url "https://raw.githubusercontent.com/Eyevinn/mp4ff/v0.52.0/cmd/mp4ff-subslister/testdata/multi_vttc.mp4"
       sha256 "1518ba79c86f28414f9285910f8118e00d3b70aa07c6a48ebb1f80b476b1192a"
     end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR.

AI-assisted contribution by Claude Code (Opus 4.7). The AI made the formula edits and ran the local validation (build, audit, test); the human author reviewed the diff and the validation output before pushing, but has not independently re-run the commands.

-----

Built and tested locally on macOS 26.4.1 running arm64 (validation run by the AI).

Bumps `mp4ff` to v0.52.0 and drops the ldflags-based version injection: it was overwriting `commitDate` with an ISO-8601 string that the upstream code parses with `strconv.Atoi`, causing every tool to report `date: 1970-01-01`. v0.52.0 ships correct hardcoded defaults, so the binaries now report `v0.52.0, date: 2026-05-12`.