### PR TITLE
Revert "ci: parallelise dependent tests"

### DIFF
--- a/.github/workflows/scripts/check-labels.js
+++ b/.github/workflows/scripts/check-labels.js
@@ -61,14 +61,6 @@ module.exports = async ({github, context, core}, formulae_detect, dependent_test
         console.log('No "long dependent tests" label found. Setting short GitHub Actions timeout.')
         core.setOutput('long-timeout', false)
       }
-
-      if (label_names.includes('CI-parallel-dependents')) {
-        console.log('CI-parallel-dependents label found. Splitting dependent tests into 4 shards.')
-        core.setOutput('dependent-shards', '4')
-      } else {
-        console.log('No CI-parallel-dependents label found. Running dependent tests without sharding.')
-        core.setOutput('dependent-shards', '1')
-      }
     } else {
       if (label_names.includes('long build')) {
         console.log('"long build" label found. Setting long GitHub Actions timeout.')

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -268,7 +268,6 @@ jobs:
       fail-fast: ${{ steps.check-labels.outputs.fail-fast }}
       test-dependents: ${{ steps.check-labels.outputs.test-dependents }}
       long-timeout: ${{ steps.check-labels.outputs.long-timeout }}
-      dependent-shards: ${{ steps.check-labels.outputs.dependent-shards }}
       test-bot-formulae-args: ${{ steps.check-labels.outputs.test-bot-formulae-args }}
       test-bot-dependents-args: ${{ steps.check-labels.outputs.test-bot-dependents-args }}
       download-concurrency: ${{ steps.check-labels.outputs.download-concurrency }}
@@ -318,7 +317,6 @@ jobs:
     env:
       HOMEBREW_LINUX_RUNNER: ${{needs.setup_dep_tests.outputs.linux-runner}}
       HOMEBREW_MACOS_LONG_TIMEOUT: ${{needs.setup_dep_tests.outputs.long-timeout}}
-      DEPENDENT_SHARDS: ${{needs.setup_dep_tests.outputs.dependent-shards}}
       TESTING_FORMULAE: ${{needs.formulae_detect.outputs.testing_formulae}}
     steps:
       - name: Set up Homebrew
@@ -330,7 +328,7 @@ jobs:
 
       - name: Determine runners to use for test_deps job
         id: determine-dependent-runners
-        run: brew determine-test-runners --dependents --eval-all --dependent-shards="$DEPENDENT_SHARDS" "$TESTING_FORMULAE"
+        run: brew determine-test-runners --dependents --eval-all "$TESTING_FORMULAE"
 
   test_deps:
     needs:
@@ -371,18 +369,12 @@ jobs:
 
       - name: Test dependents
         run: |
-          if [[ -n "$FORMULAE_DEPENDENTS_SHARD" ]]
-          then
-            TEST_BOT_DEPENDENTS_ARGS="${TEST_BOT_DEPENDENTS_ARGS} --formulae-dependents-shard=${FORMULAE_DEPENDENTS_SHARD}"
-          fi
-
           xargs -t brew test-bot \
             --testing-formulae="$TESTING_FORMULAE" \
             --tested-formulae="$TESTED_FORMULAE" \
             <<<"$TEST_BOT_DEPENDENTS_ARGS"
         env:
           HOMEBREW_DOWNLOAD_CONCURRENCY: ${{ needs.setup_dep_tests.outputs.download-concurrency }}
-          FORMULAE_DEPENDENTS_SHARD: ${{ matrix.formulae_dependents_shard || '' }}
           TEST_BOT_DEPENDENTS_ARGS: ${{ needs.setup_dep_tests.outputs.test-bot-dependents-args }}
           TESTED_FORMULAE: ${{ needs.formulae_detect.outputs.testing_formulae }}
         working-directory: ${{ env.BOTTLES_DIR }}


### PR DESCRIPTION
Reverts Homebrew/homebrew-core#282147 which I guess wasn't ready for a merge yet.