### PR TITLE
travelshield 2.0.1 (new formula)

### DIFF
--- a/Formula/t/travelshield.rb
+++ b/Formula/t/travelshield.rb
@@ -1,0 +1,35 @@
+# Homebrew formula for TravelShield
+class Travelshield < Formula
+  desc "Single-key TUI to toggle TPM2 LUKS auto-unlock — arm your disk for the road"
+  homepage "https://github.com/Okazakee/homebrew-travelshield"
+  url "https://github.com/Okazakee/homebrew-travelshield/archive/refs/tags/v2.0.2.tar.gz"
+  sha256 "b50e352ade8454738b782910b672de1f7920faed6aed2728c0d8f09af52a240e"
+
+  license "Unlicense"
+
+  head "https://github.com/Okazakee/homebrew-travelshield.git", branch: "main"
+
+  def install
+    bin.install "travelshield.sh" => "travelshield"
+  end
+
+  def caveats
+    <<~EOS
+      TravelShield requires a TPM2 LUKS unlock backend:
+        - systemd-cryptenroll (built into systemd >= 248) — recommended
+        - clevis-luks + tpm2-tools
+
+      Optional: tpm2-tools for PCR7 fingerprint verification.
+        Arch/CachyOS:  sudo pacman -S tpm2-tools
+        Debian/Ubuntu: sudo apt install tpm2-tools
+        Fedora/RHEL:   sudo dnf install tpm2-tools
+
+      After toggling travel mode, rebuild your initramfs before rebooting.
+      Run with: sudo travelshield
+    EOS
+  end
+
+  test do
+    assert_match "TravelShield", shell_output("#{bin}/travelshield --version")
+  end
+end


### PR DESCRIPTION
## Description

[TravelShield](https://github.com/Okazakee/homebrew-travelshield) is a single-key TUI tool to manage TPM2 LUKS auto-unlock. It toggles between "travel mode ON" (TPM slot wiped, passphrase required at boot) and "travel mode OFF" (TPM auto-unlock enabled).

- Supports both `systemd-cryptenroll` (systemd >= 248) and `clevis-luks` + `tpm2-tools`
- PCR7 fingerprinting detects stale TPM bindings after firmware updates
- Distro-agnostic — uses `lsblk`/`findmnt` from util-linux
- Single-key navigation — no Enter required

## Checklist

- [x] `brew audit --new travelshield` passes
- [x] `brew style Formula/t/travelshield.rb` passes
- [x] Formula uses stable URL and SHA256
- [x] License is Unlicense (public domain)