### PR TITLE
command-not-found: fix CI auth, prune daily

### DIFF
--- a/.github/workflows/prune-command-not-found-db.yml
+++ b/.github/workflows/prune-command-not-found-db.yml
@@ -1,0 +1,37 @@
+name: Prune command-not-found DB
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/prune-command-not-found-db.yml
+  schedule:
+    # Once every day at 2AM
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash -xeuo pipefail {0}
+
+concurrency:
+  group: command-not-found-db
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  delete-old-command-not-found-db-versions:
+    if: github.repository_owner == 'Homebrew'
+    runs-on: ubuntu-slim
+    permissions:
+      packages: write
+    steps:
+      - name: Delete old versions from GitHub Packages
+        uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
+        with:
+          package-name: command-not-found/executables
+          package-type: container
+          min-versions-to-keep: 0
+          delete-only-untagged-versions: true

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -578,7 +578,7 @@ jobs:
 
       - name: Log in to GitHub Packages
         if: fromJson(steps.update-db.outputs.updated)
-        run: echo "${{secrets.GITHUB_TOKEN}}" | oras login ghcr.io --username brewtestbot --password-stdin
+        run: echo "${{secrets.HOMEBREW_CORE_GITHUB_PACKAGES_TOKEN}}" | oras login ghcr.io --username brewtestbot --password-stdin
 
       - name: Push to GitHub Packages
         if: fromJson(steps.update-db.outputs.updated)
@@ -594,18 +594,3 @@ jobs:
           rm -f executables.txt
           oras pull ghcr.io/homebrew/command-not-found/executables:latest
           shasum --algorithm=256 --check executables.txt.sha256
-
-  delete-old-command-not-found-db-versions:
-    needs: update-command-not-found-db
-    runs-on: ubuntu-slim
-    if: needs.update-command-not-found-db.outputs.updated == 'true'
-    permissions:
-      packages: write
-    steps:
-      - name: Delete old versions from GitHub Packages
-        uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
-        with:
-          package-name: command-not-found/executables
-          package-type: container
-          min-versions-to-keep: 0
-          delete-only-untagged-versions: true


### PR DESCRIPTION
- Authenticate `oras` with `HOMEBREW_CORE_GITHUB_PACKAGES_TOKEN` so `brewtestbot` actually has write access to the `homebrew/command-not-found/executables` GHCR package; the default `GITHUB_TOKEN` is the `github-actions[bot]` token and lacks `write_package` on packages owned by another repository.
- Move untagged version pruning into a daily scheduled workflow so it no longer runs after every bottle publish.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Claude Code Opus 4.7 xhigh with manual review and listing.

-----
