### PR TITLE
termusic: update dependencies

### DIFF
--- a/Formula/t/termusic.rb
+++ b/Formula/t/termusic.rb
@@ -18,14 +18,12 @@ class Termusic < Formula
   depends_on "pkgconf" => :build
   depends_on "protobuf" => :build
   depends_on "rust" => :build
-  depends_on "openssl@3"
   depends_on "opus"
 
   uses_from_macos "llvm" => :build # for libclang
 
   on_linux do
     depends_on "alsa-lib"
-    depends_on "libgccjit"
   end
 
   def install


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-core/actions/runs/25414757715/job/74544199584#step:5:220
```
==> brew linkage --cached termusic
System libraries:
  /lib/x86_64-linux-gnu/libc.so.6
  /lib/x86_64-linux-gnu/libgcc_s.so.1
  /lib/x86_64-linux-gnu/libm.so.6
  /lib/x86_64-linux-gnu/libstdc++.so.6
Homebrew libraries:
  /home/linuxbrew/.linuxbrew/opt/alsa-lib/lib/libasound.so.2 (alsa-lib)
  /home/linuxbrew/.linuxbrew/opt/opus/lib/libopus.so.0 (opus)
Dependencies with no linkage:
  libgccjit
```