### PR TITLE
virtuoso: update license

### DIFF
--- a/Formula/v/virtuoso.rb
+++ b/Formula/v/virtuoso.rb
@@ -3,7 +3,7 @@ class Virtuoso < Formula
   homepage "https://virtuoso.openlinksw.com"
   url "https://github.com/openlink/virtuoso-opensource/releases/download/v7.2.17/virtuoso-opensource-7.2.17.tar.gz"
   sha256 "41e0afd6d37c1c41b993282ce11c5cf68f7bb7c0bd7887ef2ff558c452570216"
-  license "GPL-2.0-only" => { with: "openvpn-openssl-exception" }
+  license "GPL-2.0-only" => { with: "x11vnc-openssl-exception" }
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "8710e5d0b65eaf9dc44253015f08bcae16225aad0f1dd4ee38cbe27d8da45428"


### PR DESCRIPTION
https://github.com/openlink/virtuoso-opensource/blob/v7.2.17/LICENSE.md#openssl-exemption

Phrasing is closer to https://spdx.org/licenses/x11vnc-openssl-exception.html than https://spdx.org/licenses/openvpn-openssl-exception.html