### PR TITLE
sslscan: update license

### DIFF
--- a/Formula/s/sslscan.rb
+++ b/Formula/s/sslscan.rb
@@ -3,7 +3,7 @@ class Sslscan < Formula
   homepage "https://github.com/rbsec/sslscan"
   url "https://github.com/rbsec/sslscan/archive/refs/tags/2.2.2.tar.gz"
   sha256 "a1b4e4f1a52920089aaade85a7b900c8f2683937f49025c821b9c9f2b25db9a1"
-  license "GPL-3.0-or-later" => { with: "openvpn-openssl-exception" }
+  license "GPL-3.0-or-later" => { with: "cryptsetup-OpenSSL-exception" }
   head "https://github.com/rbsec/sslscan.git", branch: "master"
 
   bottle do


### PR DESCRIPTION
https://github.com/rbsec/sslscan/blob/2.2.2/sslscan.c#L23-L34
```
 *   In addition, as a special exception, the copyright holders give       *
 *   permission to link the code of portions of this program with the      *
 *   OpenSSL library under certain conditions as described in each         *
 *   individual source file, and distribute linked combinations            *
 *   including the two.                                                    *
 *   You must obey the GNU General Public License in all respects          *
 *   for all of the code used other than OpenSSL.  If you modify           *
 *   file(s) with this exception, you may extend this exception to your    *
 *   version of the file(s), but you are not obligated to do so.  If you   *
 *   do not wish to do so, delete this exception statement from your       *
 *   version.  If you delete this exception statement from all source      *
 *   files in the program, then also delete it here.                       *
```

https://spdx.org/licenses/cryptsetup-OpenSSL-exception.html has the "each individual source file" text