### PR TITLE
proxytunnel: update license

### DIFF
--- a/Formula/p/proxytunnel.rb
+++ b/Formula/p/proxytunnel.rb
@@ -3,7 +3,7 @@ class Proxytunnel < Formula
   homepage "https://github.com/proxytunnel/proxytunnel"
   url "https://github.com/proxytunnel/proxytunnel/archive/refs/tags/v1.12.3.tar.gz"
   sha256 "106cfba7aba91faccb158e1c12a4a7c4c65adc95aa1f81b76b987882a68c5afb"
-  license "GPL-2.0-or-later" => { with: "openvpn-openssl-exception" }
+  license "GPL-2.0-or-later" => { with: "x11vnc-openssl-exception" }
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "b6003b5468d9eb16d028cfac02ad7700bb173650fbcb7b4c1be87cf3267a636f"


### PR DESCRIPTION
https://github.com/proxytunnel/proxytunnel/blob/master/LICENSE.txt
```
Linking to OpenSSL

In addition, as a special exception, Mark Janssen and Jos Visser
give permission to link the code of proxytunnel with the OpenSSL
project's "OpenSSL" library (or with modified versions of it that
use the same license as the "OpenSSL" library), and distribute the
linked executables. You must obey the GNU General Public License in
all respects for all of the code used other than "OpenSSL". If you
modify this file, you may extend this exception to your version of
the file, but you are not obligated to do so. If you do not wish to
do so, delete this exception statement from your version.
```