### PR TITLE
openfortivpn: update license

### DIFF
--- a/Formula/o/openfortivpn.rb
+++ b/Formula/o/openfortivpn.rb
@@ -3,7 +3,7 @@ class Openfortivpn < Formula
   homepage "https://github.com/adrienverge/openfortivpn"
   url "https://github.com/adrienverge/openfortivpn/archive/refs/tags/v1.24.1.tar.gz"
   sha256 "c40d33acd97b89c2e943bfd839c19b69e5a7a5997052e2fc9a595602745c0465"
-  license "GPL-3.0-or-later" => { with: "openvpn-openssl-exception" }
+  license "GPL-3.0-or-later" => { with: "cryptsetup-OpenSSL-exception" }
   revision 1
   head "https://github.com/adrienverge/openfortivpn.git", branch: "master"
 


### PR DESCRIPTION
https://github.com/adrienverge/openfortivpn/blob/v1.24.1/LICENSE#L676-L687
```
                            Exception

  In addition, as a special exception, the copyright holders give permission
to link the code of portions of this program with the OpenSSL library under
certain conditions as described in each individual source file, and distribute
linked combinations including the two.
You must obey the GNU General Public License in all respects for all of the
code used other than OpenSSL.  If you modify file(s) with this exception, you
may extend this exception to your version of the file(s), but you are not
obligated to do so.  If you do not wish to do so, delete this exception
statement from your version.  If you delete this exception statement from all
source files in the program, then also delete it here.
```