### PR TITLE
megatools: update license

### DIFF
--- a/Formula/m/megatools.rb
+++ b/Formula/m/megatools.rb
@@ -3,7 +3,7 @@ class Megatools < Formula
   homepage "https://xff.cz/megatools/"
   url "https://xff.cz/megatools/builds/megatools-1.11.5.20250706.tar.gz"
   sha256 "51f78a03748a64b1066ce28a2ca75d98dbef5f00fe9789dc894827f9a913b362"
-  license "GPL-2.0-or-later" => { with: "openvpn-openssl-exception" }
+  license "GPL-2.0-or-later" => { with: "cryptsetup-OpenSSL-exception" }
 
   livecheck do
     url "https://xff.cz/megatools/builds/"


### PR DESCRIPTION
```
OpenSSL Exemption
-----------------

In addition, as a special exception, the copyright holders give
permission to link the code of portions of this program with the OpenSSL
library under certain conditions as described in each individual source
file, and distribute linked combinations including the two.

You must obey the GNU General Public License in all respects for all of
the code used other than OpenSSL.  If you modify file(s) with this
exception, you may extend this exception to your version of the file(s),
but you are not obligated to do so.  If you do not wish to do so, delete
this exception statement from your version.  If you delete this
exception statement from all source files in the program, then also
delete it here.
```