### PR TITLE
links: update license exception

### DIFF
--- a/Formula/l/links.rb
+++ b/Formula/l/links.rb
@@ -3,7 +3,7 @@ class Links < Formula
   homepage "https://links.twibright.com/"
   url "https://links.twibright.com/download/links-2.30.tar.bz2"
   sha256 "c4631c6b5a11527cdc3cb7872fc23b7f2b25c2b021d596be410dadb40315f166"
-  license "GPL-2.0-or-later" => { with: "openvpn-openssl-exception" }
+  license "GPL-2.0-or-later" => { with: "cryptsetup-OpenSSL-exception" }
   revision 1
 
   livecheck do


### PR DESCRIPTION
From COPYING:
```
  In addition, as a special exception, the copyright holders give
  permission to link the code of portions of this program with the
  OpenSSL library under certain conditions as described in each
  individual source file, and distribute linked combinations
  including the two.
  You must obey the GNU General Public License in all respects
  for all of the code used other than OpenSSL.  If you modify
  file(s) with this exception, you may extend this exception to your
  version of the file(s), but you are not obligated to do so.  If you
  do not wish to do so, delete this exception statement from your
  version.  If you delete this exception statement from all source
  files in the program, then also delete it here.
```