### PR TITLE
gofumpt: fix version number failing to be baked in

### DIFF
--- a/Formula/g/gofumpt.rb
+++ b/Formula/g/gofumpt.rb
@@ -4,6 +4,7 @@ class Gofumpt < Formula
   url "https://github.com/mvdan/gofumpt/archive/refs/tags/v0.10.0.tar.gz"
   sha256 "5f3158f665d1d49a19f3ed48981366c892b68904b2b34cb893c6fe3ff8346929"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/mvdan/gofumpt.git", branch: "master"
 
   bottle do
@@ -18,11 +19,13 @@ class Gofumpt < Formula
   depends_on "go"
 
   def install
-    ldflags = "-s -w -X mvdan.cc/gofumpt/internal/version.version=#{version}"
+    ldflags = "-s -w -X main.version=#{version}"
     system "go", "build", *std_go_args(ldflags:)
   end
 
   test do
+    assert_match version.to_s, shell_output("#{bin}/gofumpt -version").split.first
+
     (testpath/"test.go").write <<~GO
       package foo
 

--- a/Formula/g/gofumpt.rb
+++ b/Formula/g/gofumpt.rb
@@ -8,12 +8,12 @@ class Gofumpt < Formula
   head "https://github.com/mvdan/gofumpt.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "c8a2552723980c41aaf04ea730a7f1a5f013e85d712f21df89b6b8bed8359f7c"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "c8a2552723980c41aaf04ea730a7f1a5f013e85d712f21df89b6b8bed8359f7c"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "c8a2552723980c41aaf04ea730a7f1a5f013e85d712f21df89b6b8bed8359f7c"
-    sha256 cellar: :any_skip_relocation, sonoma:        "a83edb0b9fa74e41b360584a285c3adfbf88310acba657950bc2f6acccaaad64"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "5f8a221bb7d92848ff2193fa7533528ea97464d784c874766f767053a9fb6dc8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3461fcf9a79bca4da5728705c5bed42370d01e08364c106109e86df515c4a3c7"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "e850602bcc582dd3614973dd3b21ab9ded99480fc731c3e9f545dc47abb2c699"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e850602bcc582dd3614973dd3b21ab9ded99480fc731c3e9f545dc47abb2c699"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "e850602bcc582dd3614973dd3b21ab9ded99480fc731c3e9f545dc47abb2c699"
+    sha256 cellar: :any_skip_relocation, sonoma:        "c17286157c80bddfe79f1773365b13f46e64bcda6decdb2d809b5f22140eadb5"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "a70db059495d952b95cf72e49c5d5976f1a213d6dcab0380bd540910ce0c80f3"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "fac66368cb5d80b7a4b807e9204b1e56e5e2d5668e411668b4a2ae6c920f67cf"
   end
 
   depends_on "go"


### PR DESCRIPTION
The variable `mvdan.cc/gofumpt/internal/version.version` in their Go source code no longer exists - they've gone back to a more conventional `main.version` approach.

**Before**
```console
$ gofumpt -version
(devel) (go1.26.3)
```
**After**
```console
$ gofumpt -version
0.10.0 (go1.26.3)
```

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
