### PR TITLE
libpq: use readline on macOS

### DIFF
--- a/Formula/lib/libpq.rb
+++ b/Formula/lib/libpq.rb
@@ -31,6 +31,7 @@ class Libpq < Formula
   # See https://github.com/Homebrew/homebrew-core/issues/47494.
   depends_on "krb5"
   depends_on "openssl@3"
+  depends_on "readline"
 
   uses_from_macos "bison" => :build
   uses_from_macos "flex" => :build
@@ -39,13 +40,14 @@ class Libpq < Formula
   uses_from_macos "curl"
 
   on_linux do
-    depends_on "readline"
     depends_on "zlib-ng-compat"
   end
 
   def install
     ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
     ENV.runtime_cpu_detection
+    ENV.prepend "CPPFLAGS", "-I#{Formula["readline"].opt_include}"
+    ENV.prepend "LDFLAGS", "-L#{Formula["readline"].opt_lib}"
 
     system "./configure", "--disable-debug",
                           "--prefix=#{prefix}",
@@ -97,5 +99,6 @@ class Libpq < Formula
     C
     system ENV.cc, "libpq.c", "-L#{lib}", "-I#{include}", "-lpq", "-o", "libpqtest"
     assert_equal "Connection to database attempted and failed", shell_output("./libpqtest")
+    assert_match "libreadline", shell_output("otool -L #{bin}/psql") if OS.mac?
   end
 end


### PR DESCRIPTION
-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source libpq`?
- [ ] Is your test running fine `brew test libpq`?
- [ ] Does your build pass `brew audit --strict libpq` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source libpq`)? If this is a new formula, does it pass `brew audit --new libpq`?

-----

- [x] AI was used to generate or assist with generating this PR. It was used to inspect the existing `libpq` and `postgresql@18` formulae, draft this minimal change, and prepare the PR text. I manually verified the issue locally by checking that the current `libpq` `psql` links against macOS `libedit`, while `postgresql@18` `psql` links against Homebrew `readline`. I also ran `ruby -c Formula/lib/libpq.rb` and `brew style Formula/lib/libpq.rb`; the style command reports an existing `ENV.runtime_cpu_detection` warning in this formula unrelated to this change.

-----

The `libpq` formula currently builds `psql` against macOS `libedit`, while the versioned PostgreSQL formulae use Homebrew `readline`. This makes the lightweight client behave differently for interactive use: readline configuration such as `~/.inputrc` is not honored, and bracketed paste handling differs for multiline SQL in `psql`.

This changes `libpq` to depend on Homebrew `readline` on macOS as well, passes readline include/library paths during configure, and adds a macOS test assertion that `psql` links against `libreadline`.