### PR TITLE
sniffnet: remove OpenSSL dependency

### DIFF
--- a/Formula/s/sniffnet.rb
+++ b/Formula/s/sniffnet.rb
@@ -17,7 +17,6 @@ class Sniffnet < Formula
 
   depends_on "pkgconf" => :build
   depends_on "rust" => :build
-  depends_on "openssl@3"
 
   uses_from_macos "libpcap"
 


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-core/actions/runs/24407439550/job/71295918632#step:5:220
```
==> brew linkage --cached sniffnet
System libraries:
  /lib/x86_64-linux-gnu/libc.so.6
  /lib/x86_64-linux-gnu/libgcc_s.so.1
  /lib/x86_64-linux-gnu/libm.so.6
Homebrew libraries:
  /home/linuxbrew/.linuxbrew/opt/alsa-lib/lib/libasound.so.2 (alsa-lib)
  /home/linuxbrew/.linuxbrew/opt/libpcap/lib/libpcap.so.1 (libpcap)
```