### PR TITLE
silk: remove OpenSSL dependency

### DIFF
--- a/Formula/s/silk.rb
+++ b/Formula/s/silk.rb
@@ -29,7 +29,6 @@ class Silk < Formula
 
   on_macos do
     depends_on "gettext"
-    depends_on "openssl@3"
   end
 
   on_linux do


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-core/actions/runs/24809239739/job/72610705644#step:4:220
```
==> brew linkage --cached silk
System libraries:
  /usr/lib/libSystem.B.dylib
  /usr/lib/libpcap.A.dylib
  /usr/lib/libz.1.dylib
Homebrew libraries:
  /opt/homebrew/opt/gettext/lib/libintl.8.dylib (gettext)
  /opt/homebrew/opt/glib/lib/libglib-2.0.0.dylib (glib)
  /opt/homebrew/opt/libfixbuf/lib/libfixbuf.9.dylib (libfixbuf)
  /opt/homebrew/Cellar/silk/3.24.1/lib/libflowsource.20.dylib (silk)
  /opt/homebrew/Cellar/silk/3.24.1/lib/libsilk-thrd.5.dylib (silk)
  /opt/homebrew/Cellar/silk/3.24.1/lib/libsilk.29.dylib (silk)
```