### PR TITLE
redis@6.2: explicit disable date

### DIFF
--- a/Formula/r/redis@6.2.rb
+++ b/Formula/r/redis@6.2.rb
@@ -26,6 +26,7 @@ class RedisAT62 < Formula
 
   # See EOL, https://redis.io/docs/latest/operate/rs/installing-upgrading/product-lifecycle/
   deprecate! date: "2025-04-24", because: :unsupported
+  disable! date: "2026-04-24", because: :unsupported
 
   depends_on "openssl@3"
 


### PR DESCRIPTION
Explicit date to match message:
```console
❯ brew info redis@6.2 | grep disable
Deprecated because it is not supported upstream! It was disabled on 2026-04-24.
```