### PR TITLE
rojo: remove OpenSSL dependency

### DIFF
--- a/Formula/r/rojo.rb
+++ b/Formula/r/rojo.rb
@@ -19,12 +19,8 @@ class Rojo < Formula
 
   depends_on "pkgconf" => :build
   depends_on "rust" => :build
-  depends_on "openssl@3"
 
   def install
-    # Ensure that the `openssl` crate picks up the intended library.
-    ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-
     system "cargo", "install", *std_cargo_args
   end
 


### PR DESCRIPTION
```console
$ brew linkage rojo
System libraries:
  /lib/aarch64-linux-gnu/ld-linux-aarch64.so.1
  /lib/aarch64-linux-gnu/libc.so.6
  /lib/aarch64-linux-gnu/libgcc_s.so.1
  /lib/aarch64-linux-gnu/libm.so.6
```