### PR TITLE
rover: remove OpenSSL dependency

### DIFF
--- a/Formula/r/rover.rb
+++ b/Formula/r/rover.rb
@@ -21,16 +21,12 @@ class Rover < Formula
   end
 
   depends_on "rust" => :build
-  depends_on "openssl@3"
 
   on_linux do
     depends_on "zlib-ng-compat"
   end
 
   def install
-    # Ensure that the `openssl` crate picks up the intended library.
-    ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-
     system "cargo", "install", *std_cargo_args
 
     generate_completions_from_executable(bin/"rover", "completion", shells: [:bash, :zsh])


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-core/actions/runs/24802167722/job/72588011099#step:5:220
```
==> brew linkage --cached rover
System libraries:
  /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
  /lib/x86_64-linux-gnu/libc.so.6
  /lib/x86_64-linux-gnu/libgcc_s.so.1
  /lib/x86_64-linux-gnu/libm.so.6
Homebrew libraries:
  /home/linuxbrew/.linuxbrew/opt/zlib-ng-compat/lib/libz.so.1 (zlib-ng-compat)
```