### PR TITLE
libpq: use readline on macOS

### DIFF
--- a/Formula/lib/libpq.rb
+++ b/Formula/lib/libpq.rb
@@ -12,12 +12,13 @@ class Libpq < Formula
   end
 
   bottle do
-    sha256 arm64_tahoe:   "f94a7562414ac6fc936a1e5a4c8a9d15ab8ffa9e55f60d28de25829d940b0840"
-    sha256 arm64_sequoia: "330927e9bc9f8737be1f60ebf6c86c4e1b1b2cb0bf9d066d6b62d83ce4d1a742"
-    sha256 arm64_sonoma:  "296732cb2341b80b61bad7b17038cc63ea74b0adf775f5477bc78d8760892a81"
-    sha256 sonoma:        "e16b143662f9bec10d264e91e3ec77178ab8379f49897934ff3a202b389eb7e7"
-    sha256 arm64_linux:   "bce9273e2448b574f4a994aaf79dfe58c3b334f89d2c0ea15b0312fbe53a2ce7"
-    sha256 x86_64_linux:  "4a71086c769b0cd1c4dc273b26b958af2451f031ca6b0982238a27056d4a3769"
+    rebuild 1
+    sha256 arm64_tahoe:   "dc42d07661bb1abb1f023155fc506db7f61e5dcdbb236048654540699e4f1ee5"
+    sha256 arm64_sequoia: "1647097313da545e3742d17f2b9875a941079a96be8d743d1d11316895fa25d7"
+    sha256 arm64_sonoma:  "ee5d207f0924b765f19f7dda6802abc11aed8d790b8bc6b07564b3bfdddf6143"
+    sha256 sonoma:        "9a0549142e54c7aeaf023087a64729704e9209d200b867dd18aa0d8f072728fa"
+    sha256 arm64_linux:   "01389abb039d97d3178066b12a696c02151b767f0979e9ad520a993ddf6af9df"
+    sha256 x86_64_linux:  "6ba1e7e120c0e8208738bab6e22cf1adf316e7c1e299cc006454648dfbea7cc7"
   end
 
   keg_only "it conflicts with PostgreSQL"

--- a/Formula/lib/libpq.rb
+++ b/Formula/lib/libpq.rb
@@ -30,6 +30,7 @@ class Libpq < Formula
   # See https://github.com/Homebrew/homebrew-core/issues/47494.
   depends_on "krb5"
   depends_on "openssl@3"
+  depends_on "readline"
 
   uses_from_macos "bison" => :build
   uses_from_macos "flex" => :build
@@ -38,13 +39,14 @@ class Libpq < Formula
   uses_from_macos "curl"
 
   on_linux do
-    depends_on "readline"
     depends_on "zlib-ng-compat"
   end
 
   def install
     ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
     ENV.runtime_cpu_detection
+    ENV.prepend "CPPFLAGS", "-I#{formula_opt_include("readline")}"
+    ENV.prepend "LDFLAGS", "-L#{formula_opt_lib("readline")}"
 
     system "./configure", "--disable-debug",
                           "--prefix=#{prefix}",
@@ -96,5 +98,6 @@ class Libpq < Formula
     C
     system ENV.cc, "libpq.c", "-L#{lib}", "-I#{include}", "-lpq", "-o", "libpqtest"
     assert_equal "Connection to database attempted and failed", shell_output("./libpqtest")
+    assert_match "libreadline", shell_output("otool -L #{bin}/psql") if OS.mac?
   end
 end


### PR DESCRIPTION
-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source libpq`?
- [x] Is your test running fine `brew test libpq`?
- [x] Does your build pass `brew audit --strict libpq` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source libpq`)? If this is a new formula, does it pass `brew audit --new libpq`?

-----

- [x] AI was used to generate or assist with generating this PR. It was used to inspect the existing `libpq` and `postgresql@18` formulae, draft this minimal change, and prepare the PR. I manually verified the issue locally by checking that the current `libpq` `psql` links against macOS `libedit`, while `postgresql@18` `psql` links against Homebrew `readline`. I also ran `ruby -c Formula/lib/libpq.rb` and `brew style Formula/lib/libpq.rb`; the style command reports an existing `ENV.runtime_cpu_detection` warning in this formula unrelated to this change.

-----

The `libpq` formula currently builds `psql` against macOS `libedit`, while the versioned PostgreSQL formulae use Homebrew `readline`. This makes the lightweight client behave differently for interactive use: 

This changes `libpq` to depend on Homebrew `readline` on macOS as well, passes readline include/library paths during configure, and adds a macOS test assertion that `psql` links against `libreadline`.


TLDR: **Basically multiline paste is totally broken, I can't make queries work without these changes in the formula.**