### PR TITLE
codeberg-cli: deprecate

### DIFF
--- a/Formula/c/codeberg-cli.rb
+++ b/Formula/c/codeberg-cli.rb
@@ -15,6 +15,9 @@ class CodebergCli < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "12d605e557b17e8a81d430e8d5a8bae6aec6b6206b015506a4ed8adfc497a5d2"
   end
 
+  deprecate! date: "2026-05-13", because: :repo_archived, replacement_formula: "forgejo-cli"
+  disable! date: "2027-05-13", because: :repo_archived, replacement_formula: "forgejo-cli"
+
   depends_on "pkgconf" => :build
   depends_on "rust" => :build
   depends_on "openssl@3"


### PR DESCRIPTION
https://codeberg.org/Aviac/codeberg-cli#archived
> Due to the lack of time to properly maintain this project, it is discontinued starting with this commit. It was a fun ride while it lasted. If you want to use a similar tool that is well maintained and more official, then take a look at https://codeberg.org/forgejo-contrib/forgejo-cli. I personally adorse the project and can vouch for the maintainers.