### PR TITLE
aftman: remove OpenSSL dependency

### DIFF
--- a/Formula/a/aftman.rb
+++ b/Formula/a/aftman.rb
@@ -28,10 +28,6 @@ class Aftman < Formula
 
   uses_from_macos "bzip2"
 
-  on_linux do
-    depends_on "openssl@3"
-  end
-
   def install
     system "cargo", "install", *std_cargo_args
   end


### PR DESCRIPTION
```console
$ brew linkage aftman
System libraries:
  /lib/aarch64-linux-gnu/ld-linux-aarch64.so.1
  /lib/aarch64-linux-gnu/libc.so.6
  /lib/aarch64-linux-gnu/libgcc_s.so.1
Homebrew libraries:
  /home/linuxbrew/.linuxbrew/opt/bzip2/lib/libbz2.so.1.0 (bzip2)
```