### PR TITLE
gmp: fix deprecated syntax for Clang 15+

### DIFF
--- a/Formula/g/gmp.rb
+++ b/Formula/g/gmp.rb
@@ -35,6 +35,11 @@ class Gmp < Formula
 
   uses_from_macos "m4" => :build
 
+  # gmpxx.h uses deprecated literal operator syntax (space between "" and identifier)
+  # which Clang 15+ treats as an error under -Wdeprecated-literal-operator.
+  # Fixed upstream: https://gmplib.org/repo/gmp/rev/1e504d187571
+  patch :DATA
+
   def install
     if build.head?
       system "./.bootstrap"
@@ -90,3 +95,32 @@ class Gmp < Formula
     system "./test"
   end
 end
+
+__END__
+--- a/gmpxx.h
++++ b/gmpxx.h
+@@ -2160,20 +2160,20 @@
+
+ /**************** User-defined literals ****************/
+
+ #if __GMPXX_USE_CXX11
+-inline mpz_class operator"" _mpz(const char* s)
++inline mpz_class operator""_mpz(const char* s)
+ {
+   return mpz_class(s);
+ }
+
+-inline mpq_class operator"" _mpq(const char* s)
++inline mpq_class operator""_mpq(const char* s)
+ {
+   mpq_class q;
+   q.get_num() = s;
+   return q;
+ }
+
+-inline mpf_class operator"" _mpf(const char* s)
++inline mpf_class operator""_mpf(const char* s)
+ {
+   return mpf_class(s);
+ }
+ #endif


### PR DESCRIPTION
`gmpxx.h` uses `operator"" _mpz` (with a space) which Clang 15+ rejects as `-Wdeprecated-literal-operator`. Backport the fix from upstream changeset https://gmplib.org/repo/gmp/rev/1e504d187571.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [X] Is your test running fine `brew test <formula>`?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [X] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.
Patch is tiny, just a syntax formatting change. LLM was used to write the patch file as this was my first commit to the home-brew project and I didn't know the format. LLM was also used to find the existing patch in the archives.

All code was reviewed (not much of it), and made sure all the run-books passed manually. Also that all links were correct.
-----
