### PR TITLE
testssl: fix `openssl@4` path

### DIFF
--- a/Formula/t/testssl.rb
+++ b/Formula/t/testssl.rb
@@ -7,8 +7,8 @@ class Testssl < Formula
   head "https://github.com/testssl/testssl.sh.git", branch: "3.3dev"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, all: "ce2cda77f85f1288f3cdd3aa1c33631adc7d1d83910e61d12168740a7b190fe1"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, all: "9e385c68f0225f517f2aac0a60f28a3caa6516c726e228e28dac60e5d1b0d1e9"
   end
 
   depends_on "openssl@4"

--- a/Formula/t/testssl.rb
+++ b/Formula/t/testssl.rb
@@ -23,7 +23,7 @@ class Testssl < Formula
     man1.install "doc/testssl.1"
     prefix.install "etc"
     env = {
-      PATH:                "#{Formula["openssl@3"].opt_bin}:$PATH",
+      PATH:                "#{Formula["openssl@4"].opt_bin}:$PATH",
       TESTSSL_INSTALL_DIR: prefix,
     }
     bin.env_script_all_files(libexec/"bin", env)


### PR DESCRIPTION
Dependency was migrated but path wasn't 


-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
