### PR TITLE
wdc: use indirect OpenSSL from `curl` on Linux

### DIFF
--- a/Formula/w/wdc.rb
+++ b/Formula/w/wdc.rb
@@ -17,10 +17,13 @@ class Wdc < Formula
 
   depends_on "boost" => :build
   depends_on "cmake" => :build
-  depends_on "openssl@4"
   depends_on "pugixml"
 
   uses_from_macos "curl"
+
+  on_macos do
+    depends_on "openssl@4"
+  end
 
   def install
     inreplace "CMakeLists.txt", "CURL CONFIG REQUIRED", "CURL REQUIRED"


### PR DESCRIPTION
Avoid mixing multiple OpenSSL by using indirect OpenSSL from curl on Linux This is possible as the libraries aren't directly used (so linkage is stripped out by `--as-needed`).

There are still references in installed CMake files but those would be resolved indirectly. And we care more about runtime dependencies than "devel" dependencies.