### PR TITLE
cups: add license exception, drop unused `krb5`, remove unused arg

### DIFF
--- a/Formula/c/cups.rb
+++ b/Formula/c/cups.rb
@@ -5,7 +5,7 @@ class Cups < Formula
   # https://lists.debian.org/debian-printing/2020/12/msg00006.html
   url "https://github.com/OpenPrinting/cups/releases/download/v2.4.19/cups-2.4.19-source.tar.gz"
   sha256 "820984b12a67f98705785aae2dd1347fe0ac097828001d4583ff64574aed6389"
-  license "Apache-2.0"
+  license "Apache-2.0" => { with: "LLVM-exception" }
   head "https://github.com/OpenPrinting/cups.git", branch: "master"
 
   livecheck do
@@ -27,8 +27,6 @@ class Cups < Formula
   depends_on "pkgconf" => :build
   depends_on "openssl@3"
 
-  uses_from_macos "krb5"
-
   on_linux do
     depends_on "zlib-ng-compat"
   end
@@ -36,7 +34,6 @@ class Cups < Formula
   def install
     system "./configure", "--with-components=core",
                           "--with-tls=openssl",
-                          "--without-bundledir",
                           *std_configure_args
     system "make", "install"
   end


### PR DESCRIPTION
https://github.com/OpenPrinting/cups/blob/v2.4.19/NOTICE#L38-L52 https://github.com/OpenPrinting/cups/commit/4c03ad129603c3224c1d08274b0926aa46cce1c4 https://github.com/OpenPrinting/cups/commit/b8e942ede6b3773b4bc28f00711774b555ce0ad1

---

In follow up, we may need to also switch OpenSSL to GnuTLS since OpenSSL does not have a similar license exception so is incompatible with any dependents that are GPL-2.0-only.

Specifically need to check on `netatalk` and `htmldoc`. Also need to check if OpenJDK license exception (Classpath-exception-2.0) provides linking permissions to Apache-2.0 dependencies.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
