### PR TITLE
encfs: undeprecate as upstream is active again

### DIFF
--- a/Formula/e/encfs.rb
+++ b/Formula/e/encfs.rb
@@ -1,13 +1,20 @@
 class Encfs < Formula
   desc "Encrypted pass-through FUSE file system"
   homepage "https://vgough.github.io/encfs/"
-  url "https://github.com/vgough/encfs/archive/refs/tags/v1.9.5.tar.gz"
-  sha256 "4709f05395ccbad6c0a5b40a4619d60aafe3473b1a79bafb3aa700b1f756fd63"
   # The code comprising the EncFS library (libencfs) is licensed under the LGPL.
   # The main programs (encfs, encfsctl, etc) are licensed under the GPL.
   license "GPL-3.0-or-later"
   revision 5
-  head "https://github.com/vgough/encfs.git", branch: "master"
+
+  stable do
+    url "https://github.com/vgough/encfs/archive/refs/tags/v1.9.5.tar.gz"
+    sha256 "4709f05395ccbad6c0a5b40a4619d60aafe3473b1a79bafb3aa700b1f756fd63"
+
+    depends_on "cmake" => :build
+    depends_on "gettext" => :build
+    depends_on "libfuse@2"
+    depends_on "tinyxml2"
+  end
 
   bottle do
     rebuild 1
@@ -15,25 +22,29 @@ class Encfs < Formula
     sha256 x86_64_linux: "4a267698818351ffbddfb482e139d6bece4a37b266c0dca025fd12bbf9ab365d"
   end
 
-  # see commit, https://github.com/vgough/encfs/commit/aa106e6eddcc16ce7f763c63e5f20dd9eb7f0f52
-  deprecate! date: "2025-04-01", because: :unmaintained
+  head do
+    url "https://github.com/vgough/encfs.git", branch: "master"
 
-  depends_on "cmake" => :build
-  depends_on "gettext" => :build
+    depends_on "rust" => :build
+    depends_on "libfuse"
+  end
+
   depends_on "pkgconf" => :build
-  depends_on "libfuse@2"
   depends_on :linux # on macOS, requires closed-source macFUSE
   depends_on "openssl@4"
-  depends_on "tinyxml2"
 
   def install
-    system "cmake", "-S", ".", "-B", "build",
-                    "-DBUILD_UNIT_TESTS=OFF",
-                    "-DUSE_INTERNAL_TINYXML=OFF",
-                    "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
-                    *std_cmake_args
-    system "cmake", "--build", "build"
-    system "cmake", "--install", "build"
+    if build.head?
+      system "cargo", "install", *std_cargo_args
+    else
+      system "cmake", "-S", ".", "-B", "build",
+                      "-DBUILD_UNIT_TESTS=OFF",
+                      "-DUSE_INTERNAL_TINYXML=OFF",
+                      "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
+                      *std_cmake_args
+      system "cmake", "--build", "build"
+      system "cmake", "--install", "build"
+    end
   end
 
   test do


### PR DESCRIPTION
I originally deprecated this due to upstream stopping development, but seems to be active again with work on Rust port so restoring.

May deprecate if no release before FUSE 2 deprecation plans.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
