### PR TITLE
eatmemory: make test less brittle

### DIFF
--- a/Formula/e/eatmemory.rb
+++ b/Formula/e/eatmemory.rb
@@ -19,33 +19,26 @@ class Eatmemory < Formula
   end
 
   test do
-    # test version match
-    assert_match version.to_s, shell_output("#{bin}/eatmemory --help")
+    assert_match "eatmemory #{version}", shell_output("#{bin}/eatmemory --help")
 
-    # test for expected output
-    out = shell_output "#{bin}/eatmemory -t 0 10M"
-    assert_match(
-      /^|\nEating 10485760 bytes in chunks of 1024\.\.\.\nDone, sleeping for 0 seconds before exiting\.\.\.\n/, out
-    )
+    out = shell_output("#{bin}/eatmemory -t 0 10M")
+    assert_match(/^Eating .+ in chunks of .+\.\.\.$/, out)
+    assert_match(/^Done, sleeping for 0 seconds before exiting\.\.\.$/, out)
 
-    # test for memory correctly consumed
-    memory_list = [10, 20, 100]
-    memory_list.each do |memory_mb|
-      memory_column = 5
-      memory_column = 4 if OS.linux?
+    pid = spawn bin/"eatmemory", "-t", "60", "10M", [:out, :err] => File::NULL
+    sleep 5
 
-      fork do
-        shell_output "#{prefix}/bin/eatmemory -t 60 #{memory_mb}M 2>&1"
+    rss_kb = shell_output("ps -o rss= -p #{pid}").to_i
+    assert_operator rss_kb, :>=, 10 * 1024
+    assert_operator rss_kb, :<, 20 * 1024
+  ensure
+    if pid
+      begin
+        Process.kill("TERM", pid)
+        Process.wait(pid)
+      rescue Errno::ESRCH, Errno::ECHILD
+        nil
       end
-      sleep 5 # sleep to allow the forked process to initialize and eat the memory
-
-      out = shell_output \
-        "COLUMNS=500 ps aux | grep -v grep | grep -v 'sh -c' | grep '#{prefix}/bin/eatmemory -t 60 #{memory_mb}'"
-
-      columns = out.split
-      used_bytes = columns[memory_column].to_i
-      assert_operator used_bytes, ">=", memory_mb * 1024
-      assert_operator used_bytes, "<", memory_mb * 2 * 1024
     end
   end
 end


### PR DESCRIPTION
## What

- Keep the `eatmemory` formula test exercising the installed binary and real memory consumption.
- Loosen the exact output assertions so upstream output-format changes do not break otherwise valid formula updates.
- Replace `ps aux | grep` parsing with a PID-targeted `ps -o rss=` check.

## Why

`eatmemory` 1.0.0 has been released upstream with substantially better platform/backend support and a stronger end-to-end test suite. Homebrew livecheck already detects the new release correctly, so the formula is ready for BrewTestBot autobumps.

The current formula test is likely to block that flow because it hard-codes output from an older release:

```ruby
Eating 10485760 bytes in chunks of 1024...
```

Newer releases may format that same operation differently while still behaving correctly. The formula test should verify the installed program works, not pin Homebrew to a specific presentation string from an old version.

The current memory check is also more fragile than necessary because it scans `ps aux` output with `grep`, depends on command-line width, and uses OS-specific column positions. This change keeps the same important coverage, but checks RSS for the exact spawned process instead.

This PR intentionally does not bump the formula version or touch bottles. It only makes the existing test more robust so the follow-up autobump PR for `1.0.0` can validate the actual formula update.

## Testing

- `HOMEBREW_NO_INSTALL_FROM_API=1 brew reinstall --build-from-source --formula /opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/e/eatmemory.rb`
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew test /opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/e/eatmemory.rb`
- `brew style /opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/e/eatmemory.rb`
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew audit --strict eatmemory`
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew lgtm --online`
