### PR TITLE
glassfish: fix orphaned process in test

### DIFF
--- a/Formula/g/glassfish.rb
+++ b/Formula/g/glassfish.rb
@@ -50,11 +50,15 @@ class Glassfish < Formula
     cp_r libexec/"glassfish/domains", testpath
     inreplace testpath/"domains/domain1/config/domain.xml", "port=\"4848\"", "port=\"#{port}\""
 
-    spawn bin/"asadmin", "start-domain", "--domaindir=#{testpath}/domains", "domain1"
+    pid = spawn bin/"asadmin", "start-domain", "--domaindir=#{testpath}/domains", "domain1"
 
     output = shell_output("curl --silent --retry 5 --retry-connrefused -X GET localhost:#{port}")
     assert_match "GlassFish Server", output
 
     assert_match version.to_s, shell_output("#{bin}/asadmin version")
+  ensure
+    system bin/"asadmin", "stop-domain", "--domaindir=#{testpath}/domains", "domain1"
+    Process.kill("TERM", pid)
+    Process.wait(pid)
   end
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

First this is related to issues in #279619 

In that pr, we observed that during install but also during deps test, after a while all formulae reported things like OOM, fork unavailable etc.

So in short the issue was that some formulae `glassfish` and `opensearch`, spawn processes in their tests but did not terminate those, which consumed max pids, and therefore the other installs failed because they could not create forks.

This pr fixes `glassfish`, by stopping the spawned server and also killing the child.
