### PR TITLE
mesa-glu: update license

### DIFF
--- a/Formula/m/mesa-glu.rb
+++ b/Formula/m/mesa-glu.rb
@@ -3,7 +3,7 @@ class MesaGlu < Formula
   homepage "https://gitlab.freedesktop.org/mesa/glu"
   url "https://archive.mesa3d.org/glu/glu-9.0.3.tar.xz"
   sha256 "bd43fe12f374b1192eb15fe20e45ff456b9bc26ab57f0eee919f96ca0f8a330f"
-  license any_of: ["GPL-3.0-or-later", "GPL-2.0-or-later", "MIT", "SGI-B-2.0"]
+  license all_of: ["SGI-B-1.1", "SGI-B-2.0"]
   compatibility_version 1
   head "https://gitlab.freedesktop.org/mesa/glu.git", branch: "master"
 


### PR DESCRIPTION
Based on meson.build license https://gitlab.freedesktop.org/mesa/glu/-/blob/glu-9.0.3/meson.build?ref_type=tags#L9

But removing `MIT` which is only used in meson build scripts.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
