### PR TITLE
libxsd-frontend: add comment on license exception

### DIFF
--- a/Formula/lib/libxsd-frontend.rb
+++ b/Formula/lib/libxsd-frontend.rb
@@ -3,7 +3,7 @@ class LibxsdFrontend < Formula
   homepage "https://www.codesynthesis.com/projects/libxsd-frontend/"
   url "https://www.codesynthesis.com/download/xsd/4.2/libxsd-frontend-2.1.0.tar.gz"
   sha256 "98321b9c2307d7c4e1eba49da6a522ffa81bdf61f7e3605e469aa85bfcab90b1"
-  license "GPL-2.0-only"
+  license "GPL-2.0-only" # with Xerces-C++ linking exception (non-SPDX)
 
   # Versions of libxsd-frontend beyond 2.0.0 (from 2014) are provided as XSD
   # dependencies, so we have to check within XSD releases.


### PR DESCRIPTION
Add comment placeholder for license exception. Doesn't seem to have a SPDX entry. Similar to `openvpn-openssl-exception` but using **Xerces-C++** rather than **OpenSSL**

Could consider adding `AdditionRef-*` support in Homebrew which could be made into visible placeholders.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

