### PR TITLE
circumflex: drop less dependency and install shell completions

### DIFF
--- a/Formula/c/circumflex.rb
+++ b/Formula/c/circumflex.rb
@@ -7,12 +7,13 @@ class Circumflex < Formula
   head "https://github.com/bensadeh/circumflex.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "82a4d31a5eb00cf571a421d8ad04afe3bba3a61a3d2488e37ab6ce165dcf7777"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "82a4d31a5eb00cf571a421d8ad04afe3bba3a61a3d2488e37ab6ce165dcf7777"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "82a4d31a5eb00cf571a421d8ad04afe3bba3a61a3d2488e37ab6ce165dcf7777"
-    sha256 cellar: :any_skip_relocation, sonoma:        "7acb0988fa0e0e38e9b99eaf036e3027126bff2830981330ef33ea503272936f"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "f7a0c4809eb6ae9f352745078e68639baaf561635b4df4519497beec0d377710"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "266a0692420b33841d22f764b43f2b1eb28a9b6ec9adfe72a4b5178c1a82f6b4"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "950e2d99874688e36c1b0950dacbca36068b0d22a8b2be58fa49761de5461b70"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "950e2d99874688e36c1b0950dacbca36068b0d22a8b2be58fa49761de5461b70"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "950e2d99874688e36c1b0950dacbca36068b0d22a8b2be58fa49761de5461b70"
+    sha256 cellar: :any_skip_relocation, sonoma:        "a34efb5434e33d6f180906091ffbf36f6d8ae97f5f3ec5ea23b31797f96f4fe6"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "110ac9e04a50ca218c7590a158608d23babc29001f90a942d568183e1a613280"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "9045e704896543669129c725e4aae147a51e49b516126ce7960163164f8b670d"
   end
 
   depends_on "go" => :build

--- a/Formula/c/circumflex.rb
+++ b/Formula/c/circumflex.rb
@@ -16,11 +16,13 @@ class Circumflex < Formula
   end
 
   depends_on "go" => :build
-  depends_on "less"
 
   def install
     system "go", "build", *std_go_args(output: bin/"clx", ldflags: "-s -w"), "./cmd/clx"
     man1.install "share/man/clx.1"
+    bash_completion.install "share/completions/clx.bash" => "clx"
+    zsh_completion.install  "share/completions/_clx"     => "_clx"
+    fish_completion.install "share/completions/clx.fish"
   end
 
   test do


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Used Claude to draft the formula diff (dropping the unused less dep, adding *_completion.install lines for the completions shipped in the 4.1.1 tarball, and adding revision 1 since install logic changed). Verified manually: confirmed the completion files exist in the 4.1.1 git tag, and ran brew style clean. Did not run brew install --build-from-source / brew test / brew audit locally.

-----
