### PR TITLE
asimov: remove require_root from service block

### DIFF
--- a/Formula/a/asimov.rb
+++ b/Formula/a/asimov.rb
@@ -7,8 +7,8 @@ class Asimov < Formula
   head "https://github.com/stevegrunwell/asimov.git", branch: "develop"
 
   bottle do
-    rebuild 2
-    sha256 cellar: :any_skip_relocation, all: "86f8b1f739784ed4e90e99090a27454e9b2852787fe6110f9bf15b991e3fe4c4"
+    rebuild 3
+    sha256 cellar: :any_skip_relocation, all: "3af345aae1664e1077e95f587e8439f5f580da014a3dc4b0ffea7058d14492dd"
   end
 
   def install

--- a/Formula/a/asimov.rb
+++ b/Formula/a/asimov.rb
@@ -19,7 +19,6 @@ class Asimov < Formula
   service do
     run opt_bin/"asimov"
     run_type :interval
-    require_root true
     interval 86400 # 24 hours = 60 * 60 * 24
   end
 


### PR DESCRIPTION
## Problem

`asimov` scans `$HOME` for development dependency directories (e.g. `node_modules`, `vendor`, `.venv`) and excludes them from Time Machine backups via `tmutil addexclusion`. The current formula declares `require_root true`, which forces `brew services` to install it as a root-owned LaunchDaemon. Under root, `$HOME` resolves to `/var/root`, so asimov scans the wrong directory and excludes nothing.

This is confirmed in upstream issue [stevegrunwell/asimov#72](https://github.com/stevegrunwell/asimov/issues/72) (open since 2021-07-20, re-confirmed 2025-09-02).

`tmutil addexclusion <path>` (the only privileged-looking operation asimov performs) does **not** require root on user-owned paths.

## Fix

Remove `require_root true` from the `service do` block. `brew services` will then install asimov as a per-user LaunchAgent under `~/Library/LaunchAgents/`, where `$HOME` correctly resolves to the user's home directory — matching the tool's intended scope.

`require_root true` was added in commit [`c753867`](https://github.com/Homebrew/homebrew-core/commit/c7538676504bf5a36a99d56675ee43c99c8ecab3) (2022-11-06) alongside the `plist_options` removal, without rationale. The original service block in [`a0cfc81`](https://github.com/Homebrew/homebrew-core/commit/a0cfc81a9d4cb5a2cc95977d90741de714920f6c) (2021-11-06) did not include it.

## Verification (local, macOS 15 on Apple Silicon)

```
$ brew style asimov
1 file inspected, no offenses detected

$ HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source asimov
🍺  /opt/homebrew/Cellar/asimov/0.3.0: 10 files, 17.7KB, built in 2 seconds

$ brew test asimov
==> Testing asimov
==> /opt/homebrew/Cellar/asimov/0.3.0/bin/asimov

$ brew audit --strict asimov            # clean
$ brew audit --strict --online asimov   # clean
```

Caveats updated correctly (no `sudo` prefix):
```
==> Caveats
To restart asimov after an upgrade:
  brew services restart asimov
```

End-to-end behavior:
```
$ HOMEBREW_NO_INSTALL_FROM_API=1 brew services start asimov
==> Successfully started `asimov` (label: homebrew.mxcl.asimov)

$ launchctl print "gui/$(id -u)/homebrew.mxcl.asimov" | grep -E "path|state"
    path = /Users/.../Library/LaunchAgents/homebrew.mxcl.asimov.plist
    state = running
```

No `sudo`, installs to the user LaunchAgent path, runs cleanly.

## Notes for reviewers

- No `revision` bump: this change only affects the plist generated by `brew services` at install/start time; the bottle's binary is unchanged.
- No bottle re-roll required.
- Related: upstream `asimov` repository may also want a defensive guard against `$EUID == 0` so manually `sudo`-invoking the script doesn't silently scan `/var/root`. That's a separate change for the upstream project; this PR addresses the brew-services side.

---

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>`?

---

- [x] AI was used to assist with researching this PR (issue history, formula DSL semantics, and drafting). The fix is a single-line removal; all test commands were executed locally by the contributor and the behavior change was independently verified via `launchctl print`. Upstream evidence (asimov source code reading `$HOME`, issue #72, and the commit that introduced `require_root true`) was reviewed directly on GitHub.
