### PR TITLE
esbmc 8.3.0 (new formula)

### DIFF
--- a/Formula/e/esbmc.rb
+++ b/Formula/e/esbmc.rb
@@ -1,0 +1,61 @@
+class Esbmc < Formula
+  desc "Efficient SMT-based context-bounded model checker for C, C++, and Python"
+  homepage "https://esbmc.github.io/"
+  url "https://github.com/esbmc/esbmc/archive/refs/tags/v8.3.tar.gz"
+  sha256 "3898c7bd799fb495c4709a72296805e2123bd23f410aac5038ca2e6e3c33d257"
+  license "Apache-2.0"
+  head "https://github.com/esbmc/esbmc.git", branch: "master"
+
+  depends_on "bison" => :build # cmake requires bison >= 2.6.1; macOS ships 2.3
+  depends_on "cmake" => :build
+  depends_on "csmith" => :build
+  depends_on "boost"
+  depends_on "fmt"
+  depends_on "gmp"
+  depends_on "llvm" # requires Clang developer libraries not provided by system Clang
+  depends_on "nlohmann-json"
+  depends_on "python@3.14"
+  depends_on "yaml-cpp"
+  depends_on "z3"
+
+  uses_from_macos "flex" => :build
+
+  def install
+    python3 = Formula["python@3.14"].opt_bin/"python3.14"
+
+    args = %W[
+      -DCMAKE_BUILD_TYPE=RelWithDebInfo
+      -DCMAKE_INSTALL_PREFIX=#{prefix}
+      -DLLVM_DIR=#{Formula["llvm"].opt_lib}/cmake/llvm
+      -DClang_DIR=#{Formula["llvm"].opt_lib}/cmake/clang
+      -DPython3_EXECUTABLE=#{python3}
+      -DENABLE_CSMITH=ON
+      -DENABLE_PYTHON_FRONTEND=ON
+      -DENABLE_FUZZER=OFF
+      -DENABLE_Z3=ON
+      -DZ3_DIR=#{Formula["z3"].opt_lib}/cmake/z3
+      -DENABLE_BOOLECTOR=OFF
+      -DENABLE_BITWUZLA=OFF
+      -DENABLE_GOTO_CONTRACTOR=OFF
+      -DBUILD_STATIC=OFF
+    ]
+    args << "-DC2GOTO_SYSROOT=#{MacOS.sdk_path}" if OS.mac?
+    args << "-DENABLE_BUNDLE_LIBC_32BIT=OFF" if OS.linux?
+    system "cmake", "-S", ".", "-B", "build", *args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <assert.h>
+      int main() {
+        int x = 5;
+        assert(x == 5);
+        return 0;
+      }
+    EOS
+    assert_match "VERIFICATION SUCCESSFUL",
+      shell_output("#{bin}/esbmc #{testpath}/test.c --no-bounds-check --no-pointer-check 2>&1")
+  end
+end


### PR DESCRIPTION
ESBMC (Efficient SMT-based Context-Bounded Model Checker) is a tool for formally verifying C, C++, and Python programs using SMT solvers. It detects bugs such as buffer overflows, arithmetic overflow, and assertion violations, or proves their absence.

- Homepage: https://esbmc.org
- License: Apache-2.0

## Formula notes

- Builds from source with Z3 and Python frontend enabled
- `C2GOTO_SYSROOT` set to macOS SDK path on macOS, `/` on Linux (needed for clang to find `bits/libc-header-start.h` during c2goto build)
- `brew audit --new --strict`, `brew style`, and `brew test` all pass locally on macOS Apple Silicon

Supersedes #282934 (closed due to a bad rebase that produced a large unrelated diff).

## Checklist

- [x] Have you followed the guidelines for contributing?
- [x] Have you ensured that your commits follow the commit style guide?
- [x] Have you checked that there aren't other open pull requests for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>`? Does it pass `brew audit --new <formula>`?
- [x] AI was used to generate or assist with generating this PR.

AI disclosure: Claude (Claude Code) was used to assist with debugging the Linux build failure and identifying the C2GOTO_SYSROOT sysroot fix. All changes were manually reviewed and tested locally on macOS Apple Silicon.