### PR TITLE
linux-headers@6.8: add license exception

### DIFF
--- a/Formula/l/linux-headers@5.15.rb
+++ b/Formula/l/linux-headers@5.15.rb
@@ -3,7 +3,7 @@ class LinuxHeadersAT515 < Formula
   homepage "https://kernel.org/"
   url "https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.15.206.tar.gz"
   sha256 "125d430ae3f469c6feeb46d5aabf449e83ff93d2cbe98a456049fe74e7d438a5"
-  license "GPL-2.0-only"
+  license "GPL-2.0-only" => { with: "Linux-syscall-note" }
   compatibility_version 1
 
   livecheck do

--- a/Formula/l/linux-headers@6.8.rb
+++ b/Formula/l/linux-headers@6.8.rb
@@ -3,7 +3,7 @@ class LinuxHeadersAT68 < Formula
   homepage "https://kernel.org/"
   url "https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.8.12.tar.gz"
   sha256 "1f6134265066aa2bef94103c1e4485d6ed8c2e08ba2a24202ea0c757c6c2c0de"
-  license "GPL-2.0-only"
+  license "GPL-2.0-only" => { with: "Linux-syscall-note" }
   revision 1
 
   livecheck do


### PR DESCRIPTION
From COPYING
```
The Linux Kernel is provided under:

        SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note

Being under the terms of the GNU General Public License version 2 only,
according with:

        LICENSES/preferred/GPL-2.0

With an explicit syscall exception, as stated at:

        LICENSES/exceptions/Linux-syscall-note
```

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
