### PR TITLE
libunistring: update license

### DIFF
--- a/Formula/lib/libunistring.rb
+++ b/Formula/lib/libunistring.rb
@@ -5,7 +5,7 @@ class Libunistring < Formula
   mirror "https://ftp.gnu.org/gnu/libunistring/libunistring-1.4.2.tar.gz"
   mirror "http://ftp.gnu.org/gnu/libunistring/libunistring-1.4.2.tar.gz"
   sha256 "e82664b170064e62331962126b259d452d53b227bb4a93ab20040d846fec01d8"
-  license any_of: ["GPL-2.0-only", "LGPL-3.0-or-later"]
+  license any_of: ["GPL-2.0-or-later", "LGPL-3.0-or-later"]
   compatibility_version 1
 
   bottle do


### PR DESCRIPTION
https://www.gnu.org/software/libunistring/manual/libunistring.html#Licenses

> The `libunistring` library and its header files are dual-licensed under "the GNU LGPLv3+ or the GNU GPLv2+".

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
