### PR TITLE
libfuse: clarify license

### DIFF
--- a/Formula/lib/libfuse.rb
+++ b/Formula/lib/libfuse.rb
@@ -3,7 +3,10 @@ class Libfuse < Formula
   homepage "https://github.com/libfuse/libfuse"
   url "https://github.com/libfuse/libfuse/releases/download/fuse-3.18.2/fuse-3.18.2.tar.gz"
   sha256 "f01de85717e20adf5f98aff324acd85dd73d61a5ca3834d573dcf0bd6e54a298"
-  license any_of: ["LGPL-2.1-only", "GPL-2.0-only"]
+  license all_of: [
+    "LGPL-2.1-only", # include/, lib/
+    "GPL-2.0-only",  # bin/, sbin/
+  ]
   compatibility_version 1
   head "https://github.com/libfuse/libfuse.git", branch: "master"
 

--- a/Formula/lib/libfuse@2.rb
+++ b/Formula/lib/libfuse@2.rb
@@ -3,7 +3,10 @@ class LibfuseAT2 < Formula
   homepage "https://github.com/libfuse/libfuse"
   url "https://github.com/libfuse/libfuse/releases/download/fuse-2.9.9/fuse-2.9.9.tar.gz"
   sha256 "d0e69d5d608cc22ff4843791ad097f554dd32540ddc9bed7638cc6fea7c1b4b5"
-  license any_of: ["LGPL-2.1-only", "GPL-2.0-only"]
+  license all_of: [
+    "LGPL-2.1-only", # include/, lib/
+    "GPL-2.0-only",  # bin/, sbin/
+  ]
   compatibility_version 1
 
   livecheck do


### PR DESCRIPTION
https://github.com/libfuse/libfuse/blob/fuse-3.18.2/LICENSE

Needs to be `all_of` to encompass all licenses in distribution. `any_of` means user can select either but that is incorrect here as defined by LICENSE file.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
