### PR TITLE
codeburn 0.9.9 (new formula)

### DIFF
--- a/Formula/c/codeburn.rb
+++ b/Formula/c/codeburn.rb
@@ -1,0 +1,20 @@
+class Codeburn < Formula
+  desc "See where your AI coding tokens go - by task, tool, model, and project"
+  homepage "https://github.com/getagentseal/codeburn"
+  url "https://registry.npmjs.org/codeburn/-/codeburn-0.9.9.tgz"
+  sha256 "91f238d016ad156034b1c933c4cf902a2e54ed17dc3abdf92961ca03b6b53942"
+  license "MIT"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    output = shell_output("#{bin}/codeburn report --period today --format json")
+    assert_match "generated", output
+    assert_match "period", output
+  end
+end


### PR DESCRIPTION
CLI tool that tracks AI coding costs across 20+ providers (Claude Code, Codex, Cursor, Copilot, Windsurf, Cline, Gemini CLI, and more). Reads local session files only, nothing leaves your machine.

- Homepage: https://github.com/getagentseal/codeburn
- License: MIT
- npm: https://www.npmjs.com/package/codeburn
- 6.6k+ GitHub stars