### PR TITLE
balena-cli: depend on node@24

### DIFF
--- a/Formula/b/balena-cli.rb
+++ b/Formula/b/balena-cli.rb
@@ -21,7 +21,7 @@ class BalenaCli < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "8ba992739437f046667a1e0620c1c3ce9e3e609496c2045fd1c86ddc01c7cc7d"
   end
 
-  depends_on "node"
+  depends_on "node@24"
 
   on_linux do
     depends_on "libusb"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Claude Sonnet 4.6 guided me through the process, all actions performed directly by me with full understand of what they were doing.

-----

### Why

`balena-cli` 25.1.6 declares in its `package.json`:

```json
"engines": { "node": ">=24.11.0 <25" }
```

and upstream's [`INSTALL-ADVANCED.md`](https://github.com/balena-io/balena-cli/blob/master/INSTALL-ADVANCED.md) explicitly states: *"The balena CLI currently requires Node.js version > 24.11.0. Versions 25 and later are not yet fully supported."*

The formula currently uses `depends_on "node"`, which resolves to `node` 26, two majors ahead of the supported window. Every `balena` invocation prints:

```
[Warn] Node.js version "26.0.0" does not satisfy requirement ">=24.11.0 <25"
[Warn] This may cause unexpected behavior.
```

Beyond the warning, balena-cli ships several native modules (`bcrypt`, `lzma-native`, `xxhash-addon`, etc. — see the rebuild logic in `install`) which aren't tested by upstream against Node 25/26 ABI.

This PR pins to `node@24` to match upstream's declared support range, following the [Node for Formula Authors](https://docs.brew.sh/Node-for-Formula-Authors) guidance: *"If your formula requires being executed with an older Node version you should use one of its versioned formulae (e.g. node@20)."*

The pin can be relaxed once balena-cli widens its engines range.

### Related

- Closes #272139
- Related discussion in #256283 (proposal to make `node` track LTS)

-----
