### PR TITLE
arcade-learning-environment: remove vector support

### DIFF
--- a/Formula/a/arcade-learning-environment.rb
+++ b/Formula/a/arcade-learning-environment.rb
@@ -17,13 +17,13 @@ class ArcadeLearningEnvironment < Formula
   end
 
   bottle do
-    rebuild 2
-    sha256 cellar: :any,                 arm64_tahoe:   "b009980ff04c5a5b689483a5fcad22e0a559d29c399e062fac1a19e53f1a3556"
-    sha256 cellar: :any,                 arm64_sequoia: "67db538108663fb4911c74cb33d5ce338fe0840a01bb2c61ce333058e61d80e6"
-    sha256 cellar: :any,                 arm64_sonoma:  "f7a857a6b08ab38794b62b76c3d583bf36b4e359dab1b240e995fd68d8faf6f7"
-    sha256 cellar: :any,                 sonoma:        "a78b791f22db217b1fd7c21dfefe8713d227bd072919c5c27595cfe7bc348bf2"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "255d28dc23befe545d9cf3c78e6117d6b20b6b5cdc36b718ca49f8fdfdb46590"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "564c60983aee242bd8f04bfca81e40ac2b1214d2f15897ab2e59106dedf98e4f"
+    rebuild 3
+    sha256 cellar: :any,                 arm64_tahoe:   "030f3a605e34e6b60b10839b1495a7b580db1e64359723caef9e0d74e7779628"
+    sha256 cellar: :any,                 arm64_sequoia: "ec092011cc6cc187c51ef2f3f0e1900e26513b803219e565e07dd1d3af81e41a"
+    sha256 cellar: :any,                 arm64_sonoma:  "3b2b8f74114e24b713d3916082532bf83d19cf6e5947834c0af5d91720c490fe"
+    sha256 cellar: :any,                 sonoma:        "4be81a1eece247bba32478aca5ceabacf37652e9fe55b75c26835dec5bc937bf"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "68785193e0acb8c0cf72098612143bc40b03ff2dba0628108459d5240f4c00db"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f54e86c30ee14e86982e9699b2eac0eba2fae8480d03ce23a65b70fb30395a24"
   end
 
   depends_on "cmake" => :build

--- a/Formula/a/arcade-learning-environment.rb
+++ b/Formula/a/arcade-learning-environment.rb
@@ -1,13 +1,20 @@
 class ArcadeLearningEnvironment < Formula
-  include Language::Python::Virtualenv
-
   desc "Platform for AI research"
   homepage "https://github.com/Farama-Foundation/Arcade-Learning-Environment"
-  url "https://github.com/Farama-Foundation/Arcade-Learning-Environment/archive/refs/tags/v0.11.2.tar.gz"
-  sha256 "d6ac9406690bb3533b37a99253bdfc59bc27779c5e1b6855c763d0b367bcbf96"
   license "GPL-2.0-only"
   revision 3
   head "https://github.com/Farama-Foundation/Arcade-Learning-Environment.git", branch: "master"
+
+  stable do
+    url "https://github.com/Farama-Foundation/Arcade-Learning-Environment/archive/refs/tags/v0.11.2.tar.gz"
+    sha256 "d6ac9406690bb3533b37a99253bdfc59bc27779c5e1b6855c763d0b367bcbf96"
+
+    # Backport fix to run without Gymnasium
+    patch do
+      url "https://github.com/Farama-Foundation/Arcade-Learning-Environment/commit/237f9c294d2ef95da28f8b74fa3ade54e89fe0c2.patch?full_index=1"
+      sha256 "49d70dff3264138c344bb5f5fa10bcce0be8ba75d25ef3d981114ef15f9b30be"
+    end
+  end
 
   bottle do
     rebuild 2
@@ -22,17 +29,12 @@ class ArcadeLearningEnvironment < Formula
   depends_on "cmake" => :build
   depends_on "ninja" => :build
   depends_on "numpy"
-  depends_on "opencv"
   depends_on "python@3.14"
   depends_on "sdl2"
 
   on_linux do
     depends_on "zlib-ng-compat"
   end
-
-  pypi_packages package_name:     "ale-py[vector]",
-                exclude_packages: %w[numpy opencv-python],
-                extra_packages:   "pybind11==3.0.1" # TODO: remove in next release
 
   # See https://github.com/Farama-Foundation/Arcade-Learning-Environment/blob/master/scripts/download_unpack_roms.sh
   resource "roms" do
@@ -46,44 +48,23 @@ class ArcadeLearningEnvironment < Formula
     end
   end
 
-  resource "cloudpickle" do
-    url "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz"
-    sha256 "7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414"
-  end
-
-  resource "farama-notifications" do
-    url "https://files.pythonhosted.org/packages/2e/2c/8384832b7a6b1fd6ba95bbdcae26e7137bb3eedc955c42fd5cdcc086cfbf/Farama-Notifications-0.0.4.tar.gz"
-    sha256 "13fceff2d14314cf80703c8266462ebf3733c7d165336eee998fc58e545efd18"
-  end
-
-  resource "gymnasium" do
-    url "https://files.pythonhosted.org/packages/76/59/653a9417d98ed3e29ef9734ba52c3495f6c6823b8d5c0c75369f25111708/gymnasium-1.2.3.tar.gz"
-    sha256 "2b2cb5b5fbbbdf3afb9f38ca952cc48aa6aa3e26561400d940747fda3ad42509"
-  end
-
-  resource "pybind11" do
-    url "https://files.pythonhosted.org/packages/2f/7b/a6d8dcb83c457e24a9df1e4d8fd5fb8034d4bbc62f3c324681e8a9ba57c2/pybind11-3.0.1.tar.gz"
-    sha256 "9c0f40056a016da59bab516efb523089139fcc6f2ba7e4930854c61efb932051"
-  end
-
-  resource "typing-extensions" do
-    url "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz"
-    sha256 "0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"
-  end
-
   def python3
     "python3.14"
   end
 
   def install
-    venv = virtualenv_create(libexec, python3)
-    venv.pip_install resources.select { |r| r.url.start_with?("https://files.pythonhosted.org/") }
-    ENV.prepend_path "CMAKE_PREFIX_PATH", venv.site_packages/"pybind11"
+    # NOTE: Do not enable vector feature as it uses OpenCV (Apache-2.0) which is incompatible with GPL-2.0-only
+    # https://www.gnu.org/licenses/license-list.html#apache2
+    # https://www.apache.org/licenses/GPL-compatibility.html
+    cmake_args = %w[
+      -DBUILD_SHARED_LIBS=ON
+      -DBUILD_VECTOR_LIB=OFF
+      -DBUILD_VECTOR_XLA_LIB=OFF
+      -DSDL_DYNLOAD=OFF
+      -DSDL_SUPPORT=ON
+    ]
 
-    system "cmake", "-S", ".", "-B", "build",
-                    "-DSDL_SUPPORT=ON",
-                    "-DSDL_DYNLOAD=ON",
-                    *std_cmake_args
+    system "cmake", "-S", ".", "-B", "build", "-DBUILD_PYTHON_LIB=OFF", *cmake_args, *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
     pkgshare.install "tests/resources/tetris.bin"
@@ -100,24 +81,16 @@ class ArcadeLearningEnvironment < Formula
       (buildpath/"src/python/roms").install pwd.glob("ROM/*/*.bin")
     end
 
-    inreplace "setup.py" do |s|
-      # error: no member named 'signbit' in the global namespace
-      s.gsub! "cmake_args = [", "\\0\"-DCMAKE_OSX_SYSROOT=#{MacOS.sdk_path}\"," if OS.mac?
-      # Remove XLA support for now
-      s.gsub! "-DBUILD_VECTOR_XLA_LIB=ON", ""
-    end
     # We build without XLA and jax has no sdists
     inreplace "pyproject.toml", '"jax >= 0.4.31', "#"
-    venv.pip_install_and_link Pathname.pwd
-    (prefix/Language::Python.site_packages(python3)/"homebrew-ale.pth").write venv.site_packages
 
-    # Replace vendored `libSDL2` with a symlink to our own.
-    libsdl2 = Formula["sdl2"].opt_lib/shared_library("libSDL2")
-    vendored_libsdl2_dir = venv.site_packages/"ale_py"
-    (vendored_libsdl2_dir/shared_library("libSDL2")).unlink
-
-    # Use `ln_s` to avoid referencing a Cellar path.
-    ln_s libsdl2.relative_path_from(vendored_libsdl2_dir), vendored_libsdl2_dir
+    if build.stable?
+      inreplace "setup.py", /"-D(BUILD_VECTOR_LIB|BUILD_VECTOR_XLA_LIB|SDL_DYNLOAD)=ON"/, '"-D\1=OFF"'
+    else
+      cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath(source: prefix/Language::Python.site_packages(python3)/"ale_py")}"
+      ENV["CMAKE_ARGS"] = cmake_args.join(" ")
+    end
+    system python3, "-m", "pip", "install", *std_pip_args(build_isolation: true), "."
   end
 
   test do


### PR DESCRIPTION
Vector support requires linking ALE library (GPL-2.0-only) to OpenCV library (Apache-2.0). These licenses are considered incompatible by FSF:

* https://www.gnu.org/licenses/license-list.html#apache2
* https://www.apache.org/licenses/GPL-compatibility.html

Homebrew cannot apply the "system library exception" so we are unable to legally distribute resulting binaries.

---

I did double check license and upstream only allows GPL-2.0:
- https://github.com/Farama-Foundation/Arcade-Learning-Environment/blob/master/pyproject.toml#L14

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
