### PR TITLE
probe-rs-tools: use completions helper

### DIFF
--- a/Formula/p/probe-rs-tools.rb
+++ b/Formula/p/probe-rs-tools.rb
@@ -34,16 +34,11 @@ class ProbeRsTools < Formula
   def install
     system "cargo", "install", *std_cargo_args(path: "probe-rs-tools")
 
-    # probe-rs completion forces the use of the --shell parameter in the middle of the command line,
-    # so we cannot use the generate_completions_from_executable function
-    (zsh_completion/"_probe-rs").write Utils.safe_popen_read({ "SHELL" => "zsh" }, bin/"probe-rs", "complete",
-    "--shell=zsh", "install", "--manual")
-    (bash_completion/"probe-rs").write Utils.safe_popen_read({ "SHELL" => "bash" }, bin/"probe-rs", "complete",
-    "--shell=bash", "install", "--manual")
-    (fish_completion/"probe-rs.fish").write Utils.safe_popen_read({ "SHELL" => "fish" }, bin/"probe-rs", "complete",
-    "--shell=fish", "install", "--manual")
-    (pwsh_completion/"_probe-rs.ps1").write Utils.safe_popen_read({ "SHELL" => "pwsh" }, bin/"probe-rs", "complete",
-    "--shell=powershell", "install", "--manual")
+    generate_completions_from_executable(bin/"probe-rs", "complete", "install", "--manual",
+                                         shell_parameter_format: :none)
+    # clap_complete only recognizes SHELL=powershell but our helper sets SHELL=pwsh
+    (pwsh_completion/"_probe-rs.ps1").write Utils.safe_popen_read({ "SHELL" => "powershell" },
+                                            bin/"probe-rs", "complete", "install", "--manual")
   end
 
   test do


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

[probe-rs](https://github.com/probe-rs/probe-rs/blob/cdcb14d01eac0fa7966dc246a5b3572e0494c8ad/probe-rs-tools/src/bin/probe-rs/cmd/complete.rs#L30) reads from $SHELL before falling back to the command line, so we can use our helper here