### PR TITLE
netatalk: update license

### DIFF
--- a/Formula/n/netatalk.rb
+++ b/Formula/n/netatalk.rb
@@ -4,13 +4,16 @@ class Netatalk < Formula
   url "https://github.com/Netatalk/netatalk/releases/download/netatalk-4-4-3/netatalk-4.4.3.tar.xz"
   sha256 "863d640ecc99f4923ead6c58e8d3406ab3a1ca9dd3b0d47ccdf6fdebb6efe3ab"
   license all_of: [
-    "GPL-2.0-only",
     "GPL-2.0-or-later",
-    "LGPL-2.0-only",
-    "LGPL-2.1-or-later",
-    "BSD-2-Clause",
-    "BSD-3-Clause",
-    "MIT",
+
+    # Licenses covering individual source files or modules. MIT is omitted because we don't install Webmin module
+    "BSD-2-Clause",      # config/pap.in
+    "BSD-3-Clause",      # bin/nad/nad_{cp,util}.c, etc/afpd/nfsquota.c, etc/papd/{lp,printcap}.c, ...
+    "HPND",              # COPYRIGHT (Regents of The University of Michigan)
+    "HPND-Pbmplus",      # COPYRIGHT (Adrian Sun)
+    "Kazlib",            # etc/afpd/hash.*, include/atalk/hash.h
+    "LGPL-2.0-or-later", # libatalk/unicode/charsets/mac_{centraleurope,cyrillic,greek,hebrew,turkish}.h
+    "LGPL-2.1-or-later", # bin/nad/ftw.*
   ]
   head "https://github.com/Netatalk/netatalk.git", branch: "main"
 


### PR DESCRIPTION
GPL-2.0-only can be removed due to:
- https://github.com/Netatalk/netatalk/issues/1193

All occurrences of LGPL-2.0 included "any later version" clause so can make LGPL-2.0-or-later

I didn't see anything using MIT license that is installed. There are a couple licenses that are "MIT"-style which have more accurate SPDX matches:
- Kazlib
- HPND
- HPND-Pbmplus

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
