### PR TITLE
wireguard-tools: use brew `bash` on macOS-only

### DIFF
--- a/Formula/w/wireguard-tools.rb
+++ b/Formula/w/wireguard-tools.rb
@@ -20,8 +20,11 @@ class WireguardTools < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "0af7756dee0ec6ea3053e5b055259b66b45a6a67a80862a8d280028be5c6aa54"
   end
 
-  depends_on "bash"
   depends_on "wireguard-go"
+
+  on_macos do
+    depends_on "bash" # Bash 4+
+  end
 
   def install
     if HOMEBREW_PREFIX.to_s != HOMEBREW_DEFAULT_PREFIX


### PR DESCRIPTION
All Linux have Bash 4+:

[![Packaging status](https://repology.org/badge/vertical-allrepos/bash.svg?minversion=4&columns=4)](https://repology.org/project/bash/versions)


-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
