### PR TITLE
`qt@5` dependents: add disable date

### DIFF
--- a/Formula/c/color-code.rb
+++ b/Formula/c/color-code.rb
@@ -26,6 +26,7 @@ class ColorCode < Formula
   # No means of contact or public tracker page to discuss/view Qt 6 status.
   # Can undeprecate if new release with Qt 6 support is available.
   deprecate! date: "2026-05-19", because: "needs end-of-life Qt 5"
+  disable! date: "2027-05-19", because: "needs end-of-life Qt 5"
 
   depends_on "cmake" => :build
   depends_on "qt@5"

--- a/Formula/d/dspdfviewer.rb
+++ b/Formula/d/dspdfviewer.rb
@@ -19,6 +19,7 @@ class Dspdfviewer < Formula
   # Last release on 2016-09-13, last commit on 2023-04-27.
   # Can undeprecate if new release with Qt 6 support is available.
   deprecate! date: "2026-05-19", because: "needs end-of-life Qt 5"
+  disable! date: "2027-05-19", because: "needs end-of-life Qt 5"
 
   depends_on "cmake" => :build
   depends_on "gobject-introspection" => :build
@@ -34,7 +35,7 @@ class Dspdfviewer < Formula
   depends_on "libtiff"
   depends_on "openjpeg"
   depends_on "poppler-qt5"
-  depends_on "qt@5"
+  depends_on "qt@5" # https://github.com/dannyedel/dspdfviewer/issues/236
 
   on_macos do
     depends_on "gettext"

--- a/Formula/p/poppler-qt5.rb
+++ b/Formula/p/poppler-qt5.rb
@@ -24,6 +24,7 @@ class PopplerQt5 < Formula
   keg_only "it conflicts with poppler"
 
   deprecate! date: "2026-05-19", because: "is for end-of-life Qt 5"
+  disable! date: "2027-05-19", because: "is for end-of-life Qt 5"
 
   depends_on "cmake" => :build
   depends_on "gettext" => :build

--- a/Formula/p/pyqt@5.rb
+++ b/Formula/p/pyqt@5.rb
@@ -17,6 +17,7 @@ class PyqtAT5 < Formula
   end
 
   deprecate! date: "2026-05-19", because: "is for end-of-life Qt 5"
+  disable! date: "2027-05-19", because: "is for end-of-life Qt 5"
 
   depends_on "pyqt-builder" => :build
   depends_on "python@3.14"

--- a/Formula/q/qsoas.rb
+++ b/Formula/q/qsoas.rb
@@ -33,6 +33,7 @@ class Qsoas < Formula
 
   # Can undeprecate if new release with Qt 6 support is available.
   deprecate! date: "2026-05-19", because: "needs end-of-life Qt 5"
+  disable! date: "2027-05-19", because: "needs end-of-life Qt 5"
 
   depends_on "bison" => :build
   depends_on "gsl"

--- a/Formula/q/qtads.rb
+++ b/Formula/q/qtads.rb
@@ -30,6 +30,7 @@ class Qtads < Formula
   # PR for Qt 6 open since 2023-10-28: https://github.com/realnc/qtads/pull/21
   # Can undeprecate if new release with Qt 6 support is available.
   deprecate! date: "2026-05-19", because: "needs end-of-life Qt 5"
+  disable! date: "2027-05-19", because: "needs end-of-life Qt 5"
 
   depends_on "pkgconf" => :build
   depends_on "fluid-synth"

--- a/Formula/q/qwt-qt5.rb
+++ b/Formula/q/qwt-qt5.rb
@@ -25,6 +25,7 @@ class QwtQt5 < Formula
   keg_only "it conflicts with qwt"
 
   deprecate! date: "2026-05-19", because: "is for end-of-life Qt 5"
+  disable! date: "2027-05-19", because: "is for end-of-life Qt 5"
 
   depends_on "qt@5"
 

--- a/Formula/t/tarsnap-gui.rb
+++ b/Formula/t/tarsnap-gui.rb
@@ -27,6 +27,7 @@ class TarsnapGui < Formula
   # Last release on 2018-08-23
   # Can undeprecate if new release with Qt 6 support is available.
   deprecate! date: "2026-05-19", because: "needs end-of-life Qt 5"
+  disable! date: "2027-05-19", because: "needs end-of-life Qt 5"
 
   depends_on "qt@5"
   depends_on "tarsnap"


### PR DESCRIPTION
Add disable date for everything that is Qt5-specific or no activity for over a year so unlikely to get support.

Remaining formulae are still active upstreams so will need to analyze what is best approach, e.g.
- leave deprecated if upstream is on pace to migrate within a year,
- backport support or use unstable release if support is available in HEAD,
- see if possible to disable Qt-specific feature

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
