### PR TITLE
lizard-analyzer: add jinja2 dependency

### DIFF
--- a/Formula/l/lizard-analyzer.rb
+++ b/Formula/l/lizard-analyzer.rb
@@ -7,13 +7,21 @@ class LizardAnalyzer < Formula
   sha256 "39f6a44fb04b8d5edb9c4b95194fd3f8a7d29b2ec4ef30c6774a68f3561bd362"
   license "MIT"
 
-  bottle do
-    sha256 cellar: :any_skip_relocation, all: "f585fcbe2d8782c7dcf82c118b700f83a2832eff828ccd1e8ecd406c86d8aa18"
-  end
-
   depends_on "python@3.14"
 
   conflicts_with "lizard", because: "both install `lizard` binaries"
+
+  pypi_packages extra_packages: "jinja2"
+
+  resource "jinja2" do
+    url "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz"
+    sha256 "0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d"
+  end
+
+  resource "markupsafe" do
+    url "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz"
+    sha256 "722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698"
+  end
 
   resource "pathspec" do
     url "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz"
@@ -43,6 +51,9 @@ class LizardAnalyzer < Formula
       }
     SWIFT
 
-    assert_match "1 file analyzed.", shell_output("#{bin}/lizard -l swift #{testpath}/test.swift")
+    output = shell_output("#{bin}/lizard --languages swift #{testpath}/test.swift")
+    assert_match "1 file analyzed.", output
+    html_output = shell_output("#{bin}/lizard --html --languages swift #{testpath}/test.swift")
+    assert_match "<!DOCTYPE HTML PUBLIC", html_output
   end
 end

--- a/Formula/l/lizard-analyzer.rb
+++ b/Formula/l/lizard-analyzer.rb
@@ -7,6 +7,16 @@ class LizardAnalyzer < Formula
   sha256 "39f6a44fb04b8d5edb9c4b95194fd3f8a7d29b2ec4ef30c6774a68f3561bd362"
   license "MIT"
 
+  bottle do
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "2fca471436191bc804490040f8e38a1def3085a6b11c80861d9db17ee4d8ec85"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "346d212bdd1f3ed423ee8c195ea7983552ed550db18b2134f65d10c740af58c8"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "8ab89843fb215652afadc467f9ee2863741e5ba0e596513c49949ba36ca7b29b"
+    sha256 cellar: :any_skip_relocation, sonoma:        "bab881807c4c16db0292ec9c608b2c827a7794c61519bdfd5970d5f1c35b4345"
+    sha256 cellar: :any,                 arm64_linux:   "bcde872a9d3e9e2322c7e25776d6e767251dd50691f3b62079df3d218eca22ac"
+    sha256 cellar: :any,                 x86_64_linux:  "e5fb1a165de8c7a6721cdf821743102417a71686860cdbc4b8cdab56f741a472"
+  end
+
   depends_on "python@3.14"
 
   conflicts_with "lizard", because: "both install `lizard` binaries"


### PR DESCRIPTION
lizard-analyzer needs jinja2 for its HTML output

```console
$ lizard -H src/
HTML Output depends on jinja2. `pip install jinja2` first 
```

Here I added jinja2 as an extra resource, and markupsafe which jinja2 requires.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
