### PR TITLE
tenere: backport commits to use newer libgit2

### DIFF
--- a/Formula/t/tenere.rb
+++ b/Formula/t/tenere.rb
@@ -6,13 +6,13 @@ class Tenere < Formula
   license "GPL-3.0-or-later"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_tahoe:   "394e418c603576f516051602ce4dcde40e0970374f6870788c96ab2115dddcc5"
-    sha256 cellar: :any,                 arm64_sequoia: "ebe0a56a1115a368c245168f523acea3382e95ba384ebc2aa717cdaeb2e6ff90"
-    sha256 cellar: :any,                 arm64_sonoma:  "54e52ab6ce214bdc60df7fb5ff5b3ff67b35e63088967a561c057d67cec3b2ef"
-    sha256 cellar: :any,                 sonoma:        "0f4d5cdeaa01cf72db185cdbf9d376092cd7ebd08e1afc62b1059389b74766d0"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "e1320139ad039b5060bd4085fc819b1eff3c32a9e8ecd47c5f3dead25b615e66"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d4d51f8d4287fddeee124a6620602dc13716c2835b39898a7864b6a9ceb7a899"
+    rebuild 2
+    sha256 cellar: :any,                 arm64_tahoe:   "c38603fac8a4260aa58239dd60db6e0022749b1900c9162c8e8446c8147004a9"
+    sha256 cellar: :any,                 arm64_sequoia: "421869a74b7a05778db1ff54c259378e9820626ec6b52958809de541456b8148"
+    sha256 cellar: :any,                 arm64_sonoma:  "646fd6a0a9a6dbcda15941833cd9a1fd6cb474fd8dede32ff999c1bd832f2a4e"
+    sha256 cellar: :any,                 sonoma:        "d564c7b38a91c93378324ff974d52ee2778886b10259a25f171d170317fdbe31"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "15da638b1771ce1b364619ed5315649b9cc396e42eb48acfc9520d23be3ebf14"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f8b4eb67044e1c04716e143ab3b72285519147f658d678aff35fa67c4e0084b8"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/t/tenere.rb
+++ b/Formula/t/tenere.rb
@@ -17,11 +17,21 @@ class Tenere < Formula
 
   depends_on "pkgconf" => :build
   depends_on "rust" => :build
-  depends_on "libgit2@1.8"
+  depends_on "libgit2"
   depends_on "oniguruma"
 
   on_linux do
     depends_on "zlib-ng-compat"
+  end
+
+  # Backport dependency updates to use newer libgit2
+  patch do
+    url "https://github.com/pythops/tenere/commit/2cf22cc3b669c1f2be2c5e9e2c495ed8ab1c95fb.patch?full_index=1"
+    sha256 "61759013e19e930e8183df312f5980f5ccfdbd27320dff58c2da943064e1b9d6"
+  end
+  patch do
+    url "https://github.com/pythops/tenere/commit/f6e1ba6734258e3fb0d81778d5ed7d9685ed5bbb.patch?full_index=1"
+    sha256 "fa2fef89c41669dd304366bd3e1a5ea85625a09a12096b83c1bb81deffbdf7e4"
   end
 
   def install


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
