### PR TITLE
formulae: align deprecation with Qt 5

### DIFF
--- a/Formula/c/carla.rb
+++ b/Formula/c/carla.rb
@@ -35,6 +35,10 @@ class Carla < Formula
     depends_on "qtsvg"
   end
 
+  # Can undeprecate if new release with Qt 6 support is available.
+  deprecate! date: "2026-05-19", because: "is for end-of-life Qt 5"
+  disable! date: "2027-05-19", because: "is for end-of-life Qt 5"
+
   depends_on "pkgconf" => :build
 
   depends_on "fluid-synth"

--- a/Formula/g/gnuradio.rb
+++ b/Formula/g/gnuradio.rb
@@ -23,6 +23,10 @@ class Gnuradio < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "2ec015bf6a0f0091abf7502acefccb202895e590b3beeae8e9edb0dbf6946fd1"
   end
 
+  # Can undeprecate if new release with Qt 6 support is available.
+  deprecate! date: "2026-05-19", because: "is for end-of-life Qt 5"
+  disable! date: "2027-05-19", because: "is for end-of-life Qt 5"
+
   depends_on "cmake" => :build
   depends_on "doxygen" => :build
   depends_on "pkgconf" => :build

--- a/Formula/m/mgba.rb
+++ b/Formula/m/mgba.rb
@@ -36,6 +36,10 @@ class Mgba < Formula
     depends_on "sdl3"
   end
 
+  # Can undeprecate if new release with Qt 6 support is available.
+  deprecate! date: "2026-05-19", because: "needs end-of-life Qt 5"
+  disable! date: "2027-05-19", because: "needs end-of-life Qt 5"
+
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
 


### PR DESCRIPTION
Same as all other Qt5 dependents. I thought I added a deprecation date already but looks like I left them expecting a new release with support (all had either support in HEAD or active PR).

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
