### PR TITLE
todoist-cli 1.65.0 (new formula)

### DIFF
--- a/Formula/t/todoist-cli-go.rb
+++ b/Formula/t/todoist-cli-go.rb
@@ -18,10 +18,6 @@ class TodoistCliGo < Formula
       This formula was renamed from "todoist-cli" to "todoist-cli-go" to
       free up the "todoist-cli" name for the official Doist CLI
       (https://github.com/Doist/todoist-cli).
-
-      The "todoist-cli" name will be transferred to Doist soon. Please
-      ensure you run `brew upgrade` before then to stay on this
-      (sachaos/todoist) implementation.
     EOS
   end
 

--- a/Formula/t/todoist-cli-go.rb
+++ b/Formula/t/todoist-cli-go.rb
@@ -6,6 +6,15 @@ class TodoistCliGo < Formula
   license "MIT"
   head "https://github.com/sachaos/todoist.git", branch: "master"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "705fc9c1566919b2194cd3181d28bbd54b8e2adc244007ed6817df8990fdfcda"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "705fc9c1566919b2194cd3181d28bbd54b8e2adc244007ed6817df8990fdfcda"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "705fc9c1566919b2194cd3181d28bbd54b8e2adc244007ed6817df8990fdfcda"
+    sha256 cellar: :any_skip_relocation, sonoma:        "01abdd671c2f6e2419edc45945480b49e8ee2f6f6be4b7b88b8acecd275dd844"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "061e8e55f6db1d06adbf2aebd788bdcd783d0b835a9257db6a9595dc1bf0c27b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4a90b3ad25e91084e4630a2d801670cc6b361f04b81ac30f74695072b165f5b2"
+  end
+
   depends_on "go" => :build
 
   def install

--- a/Formula/t/todoist-cli-go.rb
+++ b/Formula/t/todoist-cli-go.rb
@@ -1,4 +1,4 @@
-class TodoistCli < Formula
+class TodoistCliGo < Formula
   desc "CLI for Todoist"
   homepage "https://github.com/sachaos/todoist"
   url "https://github.com/sachaos/todoist/archive/refs/tags/v0.24.0.tar.gz"
@@ -6,20 +6,23 @@ class TodoistCli < Formula
   license "MIT"
   head "https://github.com/sachaos/todoist.git", branch: "master"
 
-  bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "3e76e81f52e18234babc96982bcb2610cf65931d5ecd6b8ca64a49f67e586e28"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "3e76e81f52e18234babc96982bcb2610cf65931d5ecd6b8ca64a49f67e586e28"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "3e76e81f52e18234babc96982bcb2610cf65931d5ecd6b8ca64a49f67e586e28"
-    sha256 cellar: :any_skip_relocation, sonoma:        "1c94087d6916eb0664300379de1872d977f5653a785faacfc00d18b09516d08e"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "81e1f3ffdf796e7ea5df27e49f35348878c618cfc774caf2f77529029d19e133"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "12308761800834d8f19f565a017031928153aa376e31ccbca57efc73f7673911"
-  end
-
   depends_on "go" => :build
 
   def install
     ldflags = "-s -w -X main.version=#{version}"
     system "go", "build", *std_go_args(output: bin/"todoist", ldflags:)
+  end
+
+  def caveats
+    <<~EOS
+      This formula was renamed from "todoist-cli" to "todoist-cli-go" to
+      free up the "todoist-cli" name for the official Doist CLI
+      (https://github.com/Doist/todoist-cli).
+
+      The "todoist-cli" name will be transferred to Doist soon. Please
+      ensure you run `brew upgrade` before then to stay on this
+      (sachaos/todoist) implementation.
+    EOS
   end
 
   test do

--- a/Formula/t/todoist-cli.rb
+++ b/Formula/t/todoist-cli.rb
@@ -1,0 +1,30 @@
+class TodoistCli < Formula
+  desc "Official command-line interface for Todoist"
+  homepage "https://github.com/Doist/todoist-cli"
+  url "https://registry.npmjs.org/@doist/todoist-cli/-/todoist-cli-1.65.0.tgz"
+  sha256 "d17d69cbfffcfe6ff269c3e41c66f9b204e11a8c599173de7a8cfcf58c40f301"
+  license "MIT"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink libexec.glob("bin/*")
+
+    return unless OS.mac?
+
+    deuniversalize_machos libexec/"lib/node_modules/@doist/todoist-cli/node_modules/app-path/main"
+  end
+
+  def caveats
+    <<~EOS
+      Looking for the third-party Go CLI previously published under this
+      name (by sachaos)? It has been renamed. Install it with:
+        brew install todoist-cli-go
+    EOS
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/td --version")
+  end
+end

--- a/Formula/t/todoist-cli.rb
+++ b/Formula/t/todoist-cli.rb
@@ -5,6 +5,15 @@ class TodoistCli < Formula
   sha256 "d17d69cbfffcfe6ff269c3e41c66f9b204e11a8c599173de7a8cfcf58c40f301"
   license "MIT"
 
+  bottle do
+    sha256 cellar: :any,                 arm64_tahoe:   "a9e743129b30e5c3e8cc1b6e0940bf36ff2c8852cc874e7f776a7527e3dfa033"
+    sha256 cellar: :any,                 arm64_sequoia: "a155243ac5b77809b85e6c966f3bf384c1521b7bd655a95107c1307d262e5a46"
+    sha256 cellar: :any,                 arm64_sonoma:  "a155243ac5b77809b85e6c966f3bf384c1521b7bd655a95107c1307d262e5a46"
+    sha256 cellar: :any,                 sonoma:        "3e539a59270a206c717c7818c2a0a0972a285c77456971247e2f895f7dc24eb3"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "3041e0b74330087b4c26779ecea267aaa418db52b782289a5ebe34d0e6f39d2b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1fb87ba6fd633a63d9a463f1e1575f77ef23bf17b8c0985af884d5b17acf1208"
+  end
+
   depends_on "node"
 
   def install

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -186,7 +186,6 @@
   "thors-mongo": "thors-anvil",
   "thors-serializer": "thors-anvil",
   "todoist": "todoist-cli-go",
-  "todoist-cli": "todoist-cli-go",
   "todolist": "ultralist",
   "tomee-jax-rs": "tomee-plus",
   "tracker": "tinysparql",

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -186,6 +186,7 @@
   "thors-mongo": "thors-anvil",
   "thors-serializer": "thors-anvil",
   "todoist": "todoist-cli",
+  "todoist-cli": "todoist-cli-go",
   "todolist": "ultralist",
   "tomee-jax-rs": "tomee-plus",
   "tracker": "tinysparql",

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -185,7 +185,7 @@
   "tepl": "libgedit-tepl",
   "thors-mongo": "thors-anvil",
   "thors-serializer": "thors-anvil",
-  "todoist": "todoist-cli",
+  "todoist": "todoist-cli-go",
   "todoist-cli": "todoist-cli-go",
   "todolist": "ultralist",
   "tomee-jax-rs": "tomee-plus",


### PR DESCRIPTION
Renames the existing third-party `todoist-cli` (sachaos's Go CLI) to `todoist-cli-go`, and adds the official Doist Todoist CLI as the new `todoist-cli` at version 1.65.0.

This supersedes #283506 — the rename and the new formula are bundled here so the migration lands atomically. With sachaos's agreement (see #283506), there is no time-bound migration window; instead the user-confusion concern is handled durably via `caveats` blocks visible on every `brew install` / `brew upgrade`:

- The new `todoist-cli` carries a `caveats` block pointing anyone who wanted the prior Go CLI to `todoist-cli-go`.
- `todoist-cli-go` keeps its own rename `caveats` block for users upgrading from the old name.

## Notability (todoist-cli)

- Repository: https://github.com/Doist/todoist-cli (public, MIT)
- npm package: https://www.npmjs.com/package/@doist/todoist-cli
- 187 stars, 15 forks, ~4 months old, actively maintained by Doist
- Meets notability requirements (30+ stars / 30+ forks / 30+ watchers OR 30+ days notable)

## Changes

- Renamed: `Formula/t/todoist-cli.rb` (sachaos's Go CLI) -> `Formula/t/todoist-cli-go.rb`, with `formula_renames.json` updated to chain old names to `todoist-cli-go`.
- New: `Formula/t/todoist-cli.rb` (Doist) — pulls the published npm tarball, installs via `npm install` with `std_npm_args`, symlinks the `td` binary, asserts version in `test do`, and adds the `caveats` block above. Modeled on `aws-cdk.rb` and `vercel-cli.rb`.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same change?