### PR TITLE
openssl@3: add caveat on downgrade to LTS

### DIFF
--- a/Formula/o/openssl@3.rb
+++ b/Formula/o/openssl@3.rb
@@ -130,6 +130,9 @@ class OpensslAT3 < Formula
 
       and run
         #{opt_bin}/c_rehash
+
+      OpenSSL 3.6 is only supported until 2026-11-01 so the `openssl@3`
+      formula will be downgraded to OpenSSL 3.5 (LTS) in a future update.
     EOS
   end
 


### PR DESCRIPTION
Not sure on exact time frame we want to do this so a bit vague.

We could wait for final OpenSSL 3.6 release likely around EOL (November).

Or could handle earlier after 1-2 patch releases, i.e. we are on 3.6.2, so most users will see message on 3.6.3.

Alternatively, we could replace `openssl@3` formula with alias to `openssl@3.5`, but this will require updating all dependents that we were unable to migrate to `openssl@4`.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
