### PR TITLE
formulae: align deprecation with `dotnet@*`

### DIFF
--- a/Formula/c/carla.rb
+++ b/Formula/c/carla.rb
@@ -36,8 +36,8 @@ class Carla < Formula
   end
 
   # Can undeprecate if new release with Qt 6 support is available.
-  deprecate! date: "2026-05-19", because: "is for end-of-life Qt 5"
-  disable! date: "2027-05-19", because: "is for end-of-life Qt 5"
+  deprecate! date: "2026-05-19", because: "needs end-of-life Qt 5"
+  disable! date: "2027-05-19", because: "needs end-of-life Qt 5"
 
   depends_on "pkgconf" => :build
 

--- a/Formula/d/dafny.rb
+++ b/Formula/d/dafny.rb
@@ -15,6 +15,10 @@ class Dafny < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "af77022b146755d7d3504323a153d62fd2d234fd23b831884555d1d6a037e16f"
   end
 
+  # Aligned to .NET dependency. Can remove if updated to latest .NET
+  deprecate! date: "2026-11-10", because: "needs end-of-life .NET 8"
+  disable! date: "2027-11-10", because: "needs end-of-life .NET 8"
+
   # Upstream uses v8 and v9 is not yet compatible
   depends_on "gradle@8" => :build
   depends_on "openjdk" => [:build, :test]

--- a/Formula/g/gnuradio.rb
+++ b/Formula/g/gnuradio.rb
@@ -24,8 +24,8 @@ class Gnuradio < Formula
   end
 
   # Can undeprecate if new release with Qt 6 support is available.
-  deprecate! date: "2026-05-19", because: "is for end-of-life Qt 5"
-  disable! date: "2027-05-19", because: "is for end-of-life Qt 5"
+  deprecate! date: "2026-05-19", because: "needs end-of-life Qt 5"
+  disable! date: "2027-05-19", because: "needs end-of-life Qt 5"
 
   depends_on "cmake" => :build
   depends_on "doxygen" => :build

--- a/Formula/j/jackett.rb
+++ b/Formula/j/jackett.rb
@@ -14,6 +14,10 @@ class Jackett < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "5b065a6079fb83b3682e6e1483a243ca1215c20f3718b30108b0563923cb7f7f"
   end
 
+  # Aligned to .NET dependency. Can remove if updated to latest .NET
+  deprecate! date: "2026-11-10", because: "needs end-of-life .NET 9"
+  disable! date: "2027-11-10", because: "needs end-of-life .NET 9"
+
   depends_on "dotnet@9"
 
   def install

--- a/Formula/m/marksman.rb
+++ b/Formula/m/marksman.rb
@@ -15,7 +15,11 @@ class Marksman < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "9d7dc81a783f1866894aaaa40d440034da2230c09389c74a4411697ea9293990"
   end
 
-  depends_on "dotnet@9"
+  # Aligned to .NET dependency. Can remove if updated to latest .NET
+  deprecate! date: "2026-11-10", because: "needs end-of-life .NET 9"
+  disable! date: "2027-11-10", because: "needs end-of-life .NET 9"
+
+  depends_on "dotnet@9" # https://github.com/artempyanykh/marksman/pull/446
 
   on_linux do
     depends_on "zlib-ng-compat"

--- a/Formula/s/sbom-tool.rb
+++ b/Formula/s/sbom-tool.rb
@@ -23,6 +23,10 @@ class SbomTool < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "3ee862f5f6b5c288e44ae1be6f39976b76e7a52a3c5c1cbcae09a076822d4ff5"
   end
 
+  # Aligned to .NET dependency. Can remove if updated to latest .NET
+  deprecate! date: "2026-11-10", because: "needs end-of-life .NET 8"
+  disable! date: "2027-11-10", because: "needs end-of-life .NET 8"
+
   depends_on "dotnet@8"
 
   on_linux do


### PR DESCRIPTION
Propagating these to minimize impact in upcoming deprecations.

Also improve language in reason for `gnuradio` and `carla` 

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
