### PR TITLE
balena-cli: fetch @balena/compose-parser binary

### DIFF
--- a/Formula/b/balena-cli.rb
+++ b/Formula/b/balena-cli.rb
@@ -14,12 +14,12 @@ class BalenaCli < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "d549ecd48c8b1bc19e35a53c2a2ecad2bd3fe35a3d85aeeab8569cd4306fc156"
-    sha256 cellar: :any,                 arm64_sequoia: "57b4937c4f51ebd621d1b3c7d435fbda194f1cf1658b29bdd24a363da4ed7025"
-    sha256 cellar: :any,                 arm64_sonoma:  "57b4937c4f51ebd621d1b3c7d435fbda194f1cf1658b29bdd24a363da4ed7025"
-    sha256 cellar: :any,                 sonoma:        "971057bd1f085ce25748495de792e1ec37ca308e2e29b8be26a3bed521a6e763"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "11af051e822fa9af09e4cb6b9e1a220547dc9b2add60d33ba6ea3e48e72fabf6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8ba992739437f046667a1e0620c1c3ce9e3e609496c2045fd1c86ddc01c7cc7d"
+    sha256 cellar: :any,                 arm64_tahoe:   "3d6635cf90d54d1ba5121ed57cf58e26efe5f2dac9977c8828b2786ab126ce99"
+    sha256 cellar: :any,                 arm64_sequoia: "b713cac8902d75c79540cc080daf7707074324c1b5ddee947fef57df8afc8b23"
+    sha256 cellar: :any,                 arm64_sonoma:  "b713cac8902d75c79540cc080daf7707074324c1b5ddee947fef57df8afc8b23"
+    sha256 cellar: :any,                 sonoma:        "1df8b9e69593b5914500d8c544f37d0696c7d247120e8d5956868f96f848231f"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "dd33ee3a1ec476a745ce81e783d8db9c6015f83990f1e4987ff077e3e4484269"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "27a9e96d461f657a2d010d74fe188676f7b6836a6756feaf98c3fe678636caa7"
   end
 
   depends_on "go" => :build

--- a/Formula/b/balena-cli.rb
+++ b/Formula/b/balena-cli.rb
@@ -4,6 +4,7 @@ class BalenaCli < Formula
   url "https://registry.npmjs.org/balena-cli/-/balena-cli-25.1.6.tgz"
   sha256 "1f526868af152797136a680d76096ad3e48f0dac6e45411b0c5cc426ffcede47"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     url "https://registry.npmjs.org/balena-cli/latest"
@@ -21,6 +22,7 @@ class BalenaCli < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "8ba992739437f046667a1e0620c1c3ce9e3e609496c2045fd1c86ddc01c7cc7d"
   end
 
+  depends_on "go" => :build
   depends_on "node"
 
   on_linux do
@@ -34,6 +36,13 @@ class BalenaCli < Formula
 
     system "npm", "install", *std_npm_args
     bin.install_symlink libexec.glob("bin/*")
+
+    # Build dependency @balena/compose-parser from vendored Go source
+    compose_parser = libexec/"lib/node_modules/balena-cli/node_modules/@balena/compose-parser"
+    cd compose_parser do
+      ENV["CGO_ENABLED"] = "0"
+      system "go", "build", "-C", "lib", *std_go_args(output: "../bin/balena-compose-parser")
+    end
 
     # Remove incompatible pre-built binaries
     os = OS.kernel_name.downcase


### PR DESCRIPTION
@balena/compose-parser bundles a Go binary that its postinstall script downloads from GitHub releases. std_npm_args passes --ignore-scripts, so the binary is missing and 'balena push/build/deploy' fails with 'Unexpected end of JSON input'. Fetch it explicitly after npm install.

Closes: https://github.com/balena-io/balena-cli/issues/3104

Note: I am a maintainer of @balena/compose-parser so can confirm that the `node scripts/fetch-binary.js` call will not change with newer balena-cli versions.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Used Claude Code to investigate the root cause and draft the formula change. Specifically, the AI:
- Identified that std_npm_args in Library/Homebrew/language/node.rb passes --ignore-scripts by default
- Drafted the formula diff plus revision bump.

Manual verification I performed:
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source balena-cli`: succeeded on arm64_tahoe / Darwin 25.3.0
- Confirmed balena-compose-parser binary is present at libexec/lib/node_modules/balena-cli/node_modules/@balena/compose-parser/bin/ after install, where it wasn't previously.
- `brew test balena-cli`
- `brew audit --strict balena-cli`
- `brew style ./Formula/b/balena-cli.rb`

-----
