### PR TITLE
aliasman 0.1.0

### DIFF
--- a/Formula/a/aliasman.rb
+++ b/Formula/a/aliasman.rb
@@ -1,0 +1,20 @@
+class Aliasman < Formula
+  desc "Terminal alias manager with semantic search and Claude Code integration"
+  homepage "https://github.com/adityak74/aliasman-mac"
+  url "https://github.com/adityak74/aliasman-mac/archive/refs/tags/v0.1.0.tar.gz"
+  sha256 "650d2a12515cd7422bdec8a6b96f2daf99ebad39e2c2be989cd5271e66f1418d"
+  license "MIT"
+  head "https://github.com/adityak74/aliasman-mac.git", branch: "main"
+
+  depends_on "protobuf" => :build
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/aliasman --version")
+    assert_match "Usage:", shell_output("#{bin}/aliasman --help")
+  end
+end


### PR DESCRIPTION
Adds **aliasman**, a terminal alias manager for macOS with semantic search and Claude Code integration.

Changes included:

* Builds from the `v0.1.0` source tag using Cargo
* Installs the `aliasman` CLI
* Adds a basic version/help test

Validation run locally:

```bash
brew audit --new --strict --online adityak74/core/aliasman
brew style adityak74/core/aliasman
brew install --build-from-source adityak74/core/aliasman
brew test adityak74/core/aliasman
```

Note: The initial `v0.0.1` source tag was not source-buildable because it lacked `Cargo.lock` and contained compile errors that were later fixed on `main`, so this PR now targets `v0.1.0`.