### PR TITLE
codeburn 0.9.10 (new formula)

### DIFF
--- a/Formula/c/codeburn.rb
+++ b/Formula/c/codeburn.rb
@@ -1,0 +1,21 @@
+class Codeburn < Formula
+  desc "See where your AI coding tokens go - by task, tool, model, and project"
+  homepage "https://github.com/getagentseal/codeburn"
+  url "https://registry.npmjs.org/codeburn/-/codeburn-0.9.10.tgz"
+  sha256 "ce8f37bf6144b6dc8b9b35c4bc17024f12b15a2346e499ce77c5dcd2e1553cea"
+  license "MIT"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    output = shell_output("#{bin}/codeburn report --period today --format json")
+    assert_match "\"generated\"", output
+    assert_match "\"period\":", output
+    assert_match "\"overview\"", output
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

AI-assisted contribution by Claude Opus 4.7 of ~80% of the work (formula update, PR description). The three required local checks (`brew install --build-from-source`, `brew test`, `brew audit --strict --new`) were executed in the user's shell with output verified by the user.

Built and tested locally on macOS 26 (Darwin 25.4.0) running arm64.

Resubmits #283255 (closed for missing PR template) bumped to v0.9.10. GitHub refused to reopen the prior PR because the branch was force-pushed.

`codeburn` is a CLI that reads local AI coding session files (Claude Code, Codex, Cursor, Copilot, Windsurf, Cline, Gemini CLI and 13 other providers) and reports per-task, per-tool, per-model, and per-project token spend. Nothing leaves the user's machine.

- Homepage: https://github.com/getagentseal/codeburn
- License: MIT
- npm: https://www.npmjs.com/package/codeburn
- 6.6k+ GitHub stars

Test asserts on three structural JSON keys (`generated`, `period`, `overview`) so a regression in the report shape fails the formula audit.