### PR TITLE
snowflake-cli: replace patch with separate install step

### DIFF
--- a/Formula/s/snowflake-cli.rb
+++ b/Formula/s/snowflake-cli.rb
@@ -17,10 +17,10 @@ class SnowflakeCli < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "cc5c7437e0e891da9b2c047d1e307b5127aae66dcc62edaccaa1ef93213ec752"
   end
 
+  depends_on "protobuf" => :build
   depends_on "certifi" => :no_linkage
   depends_on "cryptography" => :no_linkage
   depends_on "libyaml"
-  depends_on "protobuf"
   depends_on "pydantic" => :no_linkage
   depends_on "python@3.13" # `snowflake-*-python` doesn't support Python 3.14, https://github.com/snowflakedb/snowflake-cli/issues/2669
 
@@ -257,12 +257,6 @@ class SnowflakeCli < Formula
   resource "snowflake-snowpark-python" do
     url "https://files.pythonhosted.org/packages/f3/3c/cc3a4b4c02aa080dc13ec47f4069cfe08557f67f33f9cd772b42dc317175/snowflake_snowpark_python-1.41.0.tar.gz"
     sha256 "19c90354eb103c37c6502e5b880b47235db6abb0fac1910c022aa98740331785"
-
-    # Remove `protoc-wheel-0` dependency, it can be replaced with `protobuf` formula
-    patch do
-      url "https://raw.githubusercontent.com/Homebrew/homebrew-core/0861b15cab638c9e7b66743dae68abf12149b919/Patches/snowflake-cli/snowflake-snowpark-python.diff"
-      sha256 "ef7b5a62b4083a08514b6eeb392c8810730c5e19b41e28bf68e71eded9e91a83"
-    end
   end
 
   resource "sortedcontainers" do
@@ -306,8 +300,13 @@ class SnowflakeCli < Formula
   end
 
   def install
-    without = %w[jeepney secretstorage] unless OS.linux?
+    without = %w[snowflake-snowpark-python]
+    without += %w[jeepney secretstorage] unless OS.linux?
     venv = virtualenv_install_with_resources(without:)
+
+    # run separately to avoid `protoc-wheel-0` dependency
+    ENV.append_path "PATH", venv.root/"bin"
+    venv.pip_install(resource("snowflake-snowpark-python"), build_isolation: false)
 
     generate_completions_from_executable(bin/"snow", shell_parameter_format: :typer)
 


### PR DESCRIPTION
We don't like permanent patches and it will require manually restoring every resource update. Should be possible to build `snowflake-snowpark-python` with already installed resources and `protobuf` formula

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
