### PR TITLE
gnuradio: plan `gr-qtgui` removal after 6 months

### DIFF
--- a/Formula/g/gnuradio.rb
+++ b/Formula/g/gnuradio.rb
@@ -24,8 +24,8 @@ class Gnuradio < Formula
   end
 
   # Can undeprecate if new release with Qt 6 support is available.
-  deprecate! date: "2026-05-19", because: "needs end-of-life Qt 5"
-  disable! date: "2027-05-19", because: "needs end-of-life Qt 5"
+  # TODO: Remove `gr-qtgui` support after 6 months of deprecation if Qt 6 support is not added
+  deprecate! date: "2026-05-19", because: "needs end-of-life Qt 5. gr-qtgui support will be removed after 2026-11-19"
 
   depends_on "cmake" => :build
   depends_on "doxygen" => :build


### PR DESCRIPTION
Another update to deprecation message to specifically note we will only remove the `gr-qtgui` module rather than entire `gnuradio`.

6 months is what we consider a sufficiently "long time" for popular formulae (https://docs.brew.sh/Deprecating-Disabling-and-Removing#when-to-disable-formulae) and will be halfway point for deprecation period.

As far as I can tell, none of other modules we build need Qt.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
