### PR TITLE
rustup: remove rustup-init

### DIFF
--- a/Formula/r/rustup.rb
+++ b/Formula/r/rustup.rb
@@ -9,13 +9,12 @@ class Rustup < Formula
   head "https://github.com/rust-lang/rustup.git", branch: "main"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "19a521c95dbdf554cfbf099448be40f523bfbea161d1736ad192cf89beb28092"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "c9d847dcbef495560deb088e50dc43dd7bdf81f5c8e631f981250363b3df805d"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "ea9ef9d8a8947364c20a9ecec3cface8c9a4b0d5e7e25308663c6b48f3878cd0"
-    sha256 cellar: :any_skip_relocation, sonoma:        "33ff8e2f74daa8ecf16698ede00d659d367a92dbc62357aeaa2f280d9b8f3fdd"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "44046e67b0a58611beb5fce43a61d522b2e1c13571aab6cfb8e2d1ec34611378"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c8f97a2a8630656873cf63e816e083e58cc9623b839e8188c36cd55c8daea767"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "040e2eb689f99acefa1849bd9c5f7591ba100fda29323901859b7a86e68d6bf5"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "94400995ac4847eee9753117cf8833beed89d9154304a5ea58d736e4d297b9c7"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "f977dd0fd72ed019b2c6aef6195e1052e5d09e502a846f1c65b6b49f3e5c501d"
+    sha256 cellar: :any_skip_relocation, sonoma:        "d6b80251f606dee170ceb341dc13b4f890dcc24b5a7d65eeaa0e14aec1506c21"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "98763babc2873c4af6a48531c80314659bd8f13ce782d7ed6d427868085f7526"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "81179ed5f8f61f32cd181b5f278a60616a345f8b01e39949501674f0ec85e744"
   end
 
   keg_only "it conflicts with rust"

--- a/Formula/r/rustup.rb
+++ b/Formula/r/rustup.rb
@@ -4,6 +4,7 @@ class Rustup < Formula
   url "https://github.com/rust-lang/rustup/archive/refs/tags/1.29.0.tar.gz"
   sha256 "de73d1a62f4d5409a2f6bdb1c523d8dc08aa6d9d63588db62493c19ca8f8bf55"
   license any_of: ["Apache-2.0", "MIT"]
+  revision 1
   compatibility_version 1
   head "https://github.com/rust-lang/rustup.git", branch: "main"
 
@@ -32,9 +33,13 @@ class Rustup < Formula
   def install
     system "cargo", "install", *std_cargo_args(features: "no-self-update")
 
+    # Upstream installs this binary as `rustup-init`, but Homebrew packages
+    # `rustup` directly and should not provide a separate installer entrypoint.
+    mv bin/"rustup-init", bin/"rustup"
+
     %w[cargo cargo-clippy cargo-fmt cargo-miri clippy-driver rls rust-analyzer
-       rust-gdb rust-gdbgui rust-lldb rustc rustdoc rustfmt rustup].each do |name|
-      bin.install_symlink bin/"rustup-init" => name
+       rust-gdb rust-gdbgui rust-lldb rustc rustdoc rustfmt].each do |name|
+      bin.install_symlink bin/"rustup" => name
     end
 
     (buildpath/"settings.toml").write <<~TOML
@@ -47,14 +52,20 @@ class Rustup < Formula
   end
 
   def post_install
-    (HOMEBREW_PREFIX/"bin").install_symlink bin/"rustup", bin/"rustup-init"
+    (HOMEBREW_PREFIX/"bin").install_symlink bin/"rustup"
+
+    # Remove the old Homebrew-created symlink during upgrades, but leave any
+    # user-managed `rustup-init` file alone.
+    rustup_init = HOMEBREW_PREFIX/"bin/rustup-init"
+    rustup_init.unlink if rustup_init.symlink? && rustup_init.readlink.to_s.match?(%r{(?:Cellar|opt)/rustup/})
   end
 
   def caveats
     <<~EOS
-      If you have `rust` installed, ensure you have "$(brew --prefix rustup)/bin"
-      before "$(brew --prefix)/bin" in your $PATH:
+      To use rustup, ensure you have "$(brew --prefix rustup)/bin" in your $PATH:
         #{Formatter.url("https://rust-lang.github.io/rustup/installation/already-installed-rust.html")}
+
+      This formula does not provide `rustup-init`; use `rustup default stable`.
     EOS
   end
 
@@ -74,11 +85,7 @@ class Rustup < Formula
       assert_empty shell_output("#{bin}/cargo clippy")
     end
 
-    # Check for stale symlinks
-    system bin/"rustup-init", "-y"
-    bins = bin.glob("*").to_set(&:basename).delete(Pathname("rustup-init"))
-    expected = testpath.glob(".cargo/bin/*").to_set(&:basename)
-    assert (extra = bins - expected).empty?, "Symlinks need to be removed: #{extra.join(",")}"
-    assert (missing = expected - bins).empty?, "Symlinks need to be added: #{missing.join(",")}"
+    # Check that Homebrew only exposes the packaged `rustup` entrypoint.
+    refute_path_exists bin/"rustup-init"
   end
 end


### PR DESCRIPTION
- Pick the documented `rustup` packaging model instead of carrying the `rustup-init` compatibility wrapper from #283834.
- Avoid preserving cached `~/.cargo/bin` layouts that can outlive Homebrew formula changes and fail again later.
- Point users at `rustup default stable` as the migration path.

Closes https://github.com/Homebrew/homebrew-core/pull/283834 (it's an alternative)
Fixes https://github.com/Homebrew/homebrew-core/issues/283801

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

OpenAI Codex 5.5 xhigh with local review and tweaking.

-----
