### PR TITLE
gh: remove no_autobump!

### DIFF
--- a/Formula/g/gh.rb
+++ b/Formula/g/gh.rb
@@ -12,8 +12,6 @@ class Gh < Formula
     strategy :github_latest
   end
 
-  no_autobump! because: :bumped_by_upstream
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "4eb5c69f4666a1cac19d67ecf870389c76257130db90075c870587f1afcec75a"
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "3192c6e260a00cae347ce9d1e16f3a5680f9adfbf03f6046e92ebd08add93e44"


### PR DESCRIPTION
## Description

As upstream maintainers of `gh`, we have historically bumped the formula as part of our [release process](https://github.com/cli/cli/blob/6bbaae0f9a554bfdd643b6ba301617d13205cd65/.github/workflows/deployment.yml#L418-L427). Revisiting this decision, we're not sure the juice is worth the squeeze in maintaining a fairly privileged token (requiring a legacy PAT to create a PR from a personal fork to upstream).

We'd rather rely on `autobump`, and manually open PRs as necessary.

Here is the equivalent PR where we remove the homebrew bump from our process: https://github.com/cli/cli/pull/13479

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
