### PR TITLE
observal-cli 0.7.0 (new formula)

### DIFF
--- a/Formula/o/observal-cli.rb
+++ b/Formula/o/observal-cli.rb
@@ -1,0 +1,138 @@
+class ObservalCli < Formula
+  include Language::Python::Virtualenv
+
+  desc "Discover, share, and monitor AI coding agents with observability built-in"
+  homepage "https://github.com/BlazeUp-AI/Observal"
+  url "https://files.pythonhosted.org/packages/5f/6b/2d3ed92b9d1366e72e82c045344172f2f4876bb5207e13c7e7dc63eb9d06/observal_cli-0.7.0.tar.gz"
+  sha256 "637455e05d0d51cf859672c05f003f9b3bf269822c8b18af9c6c58c2ddd34cdc"
+  license "AGPL-3.0-only"
+  head "https://github.com/BlazeUp-AI/Observal.git", branch: "main"
+
+  depends_on "rust" => :build # asyncpg has a small C+Rust build step on non-wheel installs
+  depends_on "certifi" => :no_linkage
+  depends_on "libyaml" # pyyaml
+  depends_on "python@3.14"
+
+  pypi_packages exclude_packages: "certifi"
+
+  resource "annotated-doc" do
+    url "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz"
+    sha256 "fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4"
+  end
+
+  resource "anyio" do
+    url "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz"
+    sha256 "334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc"
+  end
+
+  resource "asyncpg" do
+    url "https://files.pythonhosted.org/packages/fe/cc/d18065ce2380d80b1bcce927c24a2642efd38918e33fd724bc4bca904877/asyncpg-0.31.0.tar.gz"
+    sha256 "c989386c83940bfbd787180f2b1519415e2d3d6277a70d9d0f0145ac73500735"
+  end
+
+  resource "charset-normalizer" do
+    url "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz"
+    sha256 "ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5"
+  end
+
+  resource "click" do
+    url "https://files.pythonhosted.org/packages/23/e4/796662cd90cf80e3a363c99db2b88e0e394b988a575f60a17e16440cd011/click-8.4.0.tar.gz"
+    sha256 "638f1338fe1235c8f4e008e4a8a254fb5c5fbdcbb40ece3c9142ebb78e792973"
+  end
+
+  resource "docker" do
+    url "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz"
+    sha256 "ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c"
+  end
+
+  resource "h11" do
+    url "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz"
+    sha256 "4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"
+  end
+
+  resource "httpcore" do
+    url "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz"
+    sha256 "6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"
+  end
+
+  resource "httpx" do
+    url "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz"
+    sha256 "75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"
+  end
+
+  resource "idna" do
+    url "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz"
+    sha256 "ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc"
+  end
+
+  resource "markdown-it-py" do
+    url "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz"
+    sha256 "04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49"
+  end
+
+  resource "mdurl" do
+    url "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz"
+    sha256 "bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"
+  end
+
+  resource "prompt-toolkit" do
+    url "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz"
+    sha256 "28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855"
+  end
+
+  resource "pygments" do
+    url "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz"
+    sha256 "6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"
+  end
+
+  resource "pyyaml" do
+    url "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz"
+    sha256 "d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f"
+  end
+
+  resource "questionary" do
+    url "https://files.pythonhosted.org/packages/f6/45/eafb0bba0f9988f6a2520f9ca2df2c82ddfa8d67c95d6625452e97b204a5/questionary-2.1.1.tar.gz"
+    sha256 "3d7e980292bb0107abaa79c68dd3eee3c561b83a0f89ae482860b181c8bd412d"
+  end
+
+  resource "requests" do
+    url "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz"
+    sha256 "f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed"
+  end
+
+  resource "rich" do
+    url "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz"
+    sha256 "edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36"
+  end
+
+  resource "shellingham" do
+    url "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz"
+    sha256 "8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"
+  end
+
+  resource "typer" do
+    url "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz"
+    sha256 "9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc"
+  end
+
+  resource "urllib3" do
+    url "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz"
+    sha256 "231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"
+  end
+
+  resource "wcwidth" do
+    url "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz"
+    sha256 "90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0"
+  end
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/observal --version")
+
+    output = shell_output("#{bin}/observal auth whoami 2>&1", 1)
+    assert_match "Not configured", output
+  end
+end


### PR DESCRIPTION
<!-- Do not tick a checkbox if you haven't performed its action. Honesty is indispensable for a smooth review process. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source observal-cli`?
- [x] Is your test running fine `brew test observal-cli`?
- [x] Does your build pass `brew audit --strict observal-cli` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source observal-cli`)? If this is a new formula, does it pass `brew audit --new observal-cli`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

### AI disclosure

Claude (Anthropic) was used as a pair-programming assistant to scaffold the formula and the resource blocks. Specifically:

- The runtime dep list (`url`, `sha256`, every `resource` block) was machine-derived from a clean `pip install observal-cli==0.7.0` in a throwaway `uv venv`, then each `(url, sha256)` pair was fetched directly from `https://pypi.org/pypi/<name>/<version>/json`. No values were generated from model memory.
- The formula skeleton (depends_on, install method, test block) was adapted by hand from existing homebrew-core Python virtualenv formulae such as `octodns.rb` and `harlequin.rb`.
- Manual verification I performed locally on macOS 26.3 (arm64, Tier 2) before opening this PR:
  - `brew style observal-cli` → no offenses.
  - `brew audit --strict --online --new --formula observal-cli` → exit 0.
  - `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source observal-cli` → installs from sdist cleanly.
  - `brew test observal-cli` → exit 0.
  - `observal --version` from the brew prefix prints `observal 0.7.0`.
  - `ruby -c Formula/o/observal-cli.rb` is clean.

-----

## What is `observal-cli`?

`observal-cli` is the command-line interface for [Observal](https://github.com/BlazeUp-AI/Observal), an open-source (AGPL-3.0) self-hosted AI agent registry with built-in observability. The CLI lets users:

- Browse and install AI coding-agent configurations from a registry (think Docker Hub for AI agents).
- Publish their own agents bundled with MCP servers, skills, hooks, prompts and sandboxes.
- Authenticate with a self-hosted Observal server and connect supported IDEs (Claude Code, Kiro, Cursor, Gemini CLI, Codex CLI, OpenCode, VS Code, Copilot CLI) so every interaction produces traces, spans and session telemetry.

Upstream is at <https://github.com/BlazeUp-AI/Observal> (1,100+ stars, 140+ forks, AGPL-3.0-only, stable Beta — the 0.7.0 sdist published to PyPI carries `Classifier: Development Status :: 4 - Beta`).

## Notes

- Pure-Python virtualenv formula using `Language::Python::Virtualenv`. The only system deps are `rust` (build-time, for `asyncpg`'s small native shim when wheels aren't preferred) and `libyaml` (for `pyyaml`).
- The optional `[migrate]` extra (which adds `pyarrow` for Parquet export/import) is deliberately omitted from the formula; users who need the migration commands can install via `pip install 'observal-cli[migrate]'` or `uv tool install 'observal-cli[migrate]'` separately. This avoids dragging Apache Arrow into a default install.
- `head` is wired to the upstream `main` branch for HEAD installs.
- Upstream maintains its own tap at <https://github.com/BlazeUp-AI/homebrew-observal> shipping the PyInstaller release binaries; this PR is the source-build formula intended for `homebrew-core`.