### PR TITLE
nvi2 2.2.2 (new formula)

### DIFF
--- a/Formula/n/nvi.rb
+++ b/Formula/n/nvi.rb
@@ -35,6 +35,8 @@ class Nvi < Formula
 
   uses_from_macos "ncurses"
 
+  conflicts_with "nvi2", because: "nvi also provides a binary named nvi"
+
   # Patches per MacPorts
   # The first corrects usage of BDB flags.
   patch :p0 do

--- a/Formula/n/nvi2.rb
+++ b/Formula/n/nvi2.rb
@@ -1,0 +1,31 @@
+class Nvi2 < Formula
+  desc "Multibyte fork of the nvi editor for BSD"
+  homepage "https://github.com/lichray/nvi2"
+  url "https://github.com/lichray/nvi2/archive/refs/tags/v2.2.2.tar.gz"
+  sha256 "a1ad5d7c880913992a116cba56e28ee8e7d1f59a7f10e5a9b2ce6d105decb59c"
+  license "BSD-3-Clause"
+
+  depends_on "cmake" => :build
+  depends_on "ninja" => :build
+
+  # It won't actually build on Linux because it relies on Berkeley
+  # DB 1.x features not provided by libdb1-compat.
+  uses_from_macos "libiconv"
+
+  conflicts_with "nvi", because: "nvi2 also provides a binary named nvi"
+
+  def install
+    system "cmake", "-G", "Ninja Multi-Config", "-B", "build"
+    system "ninja", "-C", "build", "-f", "build-Release.ninja"
+
+    File.rename("man/vi.1", "man/nvi.1")
+    man1.install "man/nvi.1"
+    bin.install "build/Release/nvi"
+  end
+
+  test do
+    (testpath/"test").write("This is toto!\n")
+    pipe_output("#{bin}/nvi -e test", "%s/toto/tutu/g\nwq\n")
+    assert_equal "This is tutu!\n", File.read("test")
+  end
+end


### PR DESCRIPTION
-----

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [X] Is your test running fine `brew test <formula>`?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Adds nvi2. It's a multibyte (Unicode capable) fork of the nvi already available.

I don't believe it's possible to build nvi2 on Linux in a straightforward way at present; see https://github.com/lichray/nvi2/issues/84