### PR TITLE
nvi: deprecate

### DIFF
--- a/Formula/n/nvi.rb
+++ b/Formula/n/nvi.rb
@@ -27,6 +27,12 @@ class Nvi < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "d8eb6c0c8a8eef36a09bf55e35ced6d2e2afb4d75a70d93d96e88d9cbd5c4b56"
   end
 
+  # Last release in 2007 and build requires many patches from MacPorts and Debian.
+  # Also, nvi has been removed from Alpine, Fedora, FreeBSD Ports and Gentoo
+  # See: https://repology.org/project/nvi/history
+  deprecate! date: "2026-05-21", because: :unmaintained
+  disable! date: "2027-05-21", because: :unmaintained
+
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build


### PR DESCRIPTION
Part of effort to reduce BDB formulae usage.

Something we've been considering for a while now:
https://github.com/Homebrew/homebrew-core/blob/e6009e47cb7f6164893702784588455831918cbe/Formula/n/nvi.rb#L60-L61

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
