### PR TITLE
moc: modernize

### DIFF
--- a/Formula/m/moc.rb
+++ b/Formula/m/moc.rb
@@ -2,7 +2,7 @@ class Moc < Formula
   desc "Terminal-based music player"
   homepage "https://moc.daper.net/"
   license "GPL-2.0-or-later"
-  revision 10
+  revision 11
 
   stable do
     url "https://ftp.daper.net/pub/soft/moc/stable/moc-2.5.2.tar.bz2"
@@ -35,6 +35,21 @@ class Moc < Formula
       url "https://raw.githubusercontent.com/Homebrew/homebrew-core/1cf441a0/Patches/moc/05-audio4-2.5.2.patch"
       sha256 "9a75ac8479ed895d07725ac9b7d86ceb6c8a1a15ee942c35eb5365f4c3cc7075"
     end
+
+    # 06 and 07 take 2.5.2 the rest of the way to FFmpeg 5+/8 and Berkeley DB
+    # 18 compatibility, removing the need for the keg-only ffmpeg@4 and
+    # berkeley-db@5 pins. Closes https://moc.daper.net/node/3644.
+    # The commit SHA in these URLs should be replaced with the merged
+    # homebrew-core commit SHA when this PR lands.
+    patch do
+      url "https://raw.githubusercontent.com/jagajaga/homebrew-core/f4be5dcb6c0970f7dde2a9009299fe44276db0e3/Patches/moc/06-ffmpeg5-2.5.2.patch"
+      sha256 "5ac15cf37db3b39fe679f08eb82838815a3f3f2053daf11cfc15e4b27533f970"
+    end
+
+    patch do
+      url "https://raw.githubusercontent.com/jagajaga/homebrew-core/f4be5dcb6c0970f7dde2a9009299fe44276db0e3/Patches/moc/07-bdb18-2.5.2.patch"
+      sha256 "6b511b16a1e6d3b97c5e7dcffbdad4e5dffdebb7e1030c0d608966cdc34e3637"
+    end
   end
 
   livecheck do
@@ -64,8 +79,11 @@ class Moc < Formula
   depends_on "automake" => :build
   depends_on "gettext" => :build
   depends_on "pkgconf" => :build
+  # Keep berkeley-db@5 to match the version jack depends on, otherwise
+  # brew audit flags conflicting recursive bdb versions. Patch 07 is
+  # guarded on DB_VERSION_MAJOR and is a no-op against bdb 5.
   depends_on "berkeley-db@5"
-  depends_on "ffmpeg@4" # FFmpeg 5 issue: https://moc.daper.net/node/3644
+  depends_on "ffmpeg"
   depends_on "flac"
   depends_on "jack"
   depends_on "libmodplug"
@@ -85,6 +103,11 @@ class Moc < Formula
     # macOS iconv implementation is slightly broken since Sonoma.
     # upstream bug report: https://savannah.gnu.org/bugs/index.php?66541
     ENV["am_cv_func_iconv_works"] = "yes" if OS.mac? && MacOS.version >= :sequoia
+
+    # AX_PTHREAD's internal probe writes a test program that fails under
+    # clang's -Wunused-but-set-parameter + -Werror combination, so configure
+    # bails with "I don't know how to compile pthreads code". Relax it.
+    ENV.append "CFLAGS", "-Wno-error=unused-but-set-parameter"
 
     ENV.append_path "ACLOCAL_PATH", Formula["gettext"].pkgshare/"m4"
 

--- a/Patches/moc/06-ffmpeg5-2.5.2.patch
+++ b/Patches/moc/06-ffmpeg5-2.5.2.patch
@@ -1,0 +1,249 @@
+--- a/decoder_plugins/ffmpeg/ffmpeg.c
++++ b/decoder_plugins/ffmpeg/ffmpeg.c
+@@ -67,6 +67,11 @@
+ # include <libavformat/avformat.h>
+ GCC_DIAG_ON(deprecated-declarations)
+ 
++/* FFmpeg 5 split <libavformat/avformat.h> so it no longer transitively
++ * defines LIBAVCODEC_VERSION_INT or AVCodecContext. Include avcodec.h
++ * explicitly so the version-gated #ifs below work and the type is in scope. */
++# include <libavcodec/avcodec.h>
++
+ # include <libavutil/mathematics.h>
+ # ifdef HAVE_AV_GET_CHANNEL_LAYOUT_NB_CHANNELS
+ #  if HAVE_LIBAVUTIL_CHANNEL_LAYOUT_H
+@@ -106,6 +111,22 @@
+ # define AV_CODEC_FLAG_TRUNCATED CODEC_FLAG_TRUNCATED
+ #endif
+ 
++/* FFmpeg 5.1 (libavcodec 59.24.100) introduced the AVChannelLayout struct
++ * and deprecated AVCodecContext.channels / channel_layout /
++ * request_channel_layout; FFmpeg 7.0 (libavcodec 61) removed them outright. */
++#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(59,24,100)
++# define MOC_HAVE_CH_LAYOUT 1
++#endif
++
++static inline int moc_nb_channels (const AVCodecContext *ctx)
++{
++#ifdef MOC_HAVE_CH_LAYOUT
++	return ctx->ch_layout.nb_channels;
++#else
++	return ctx->channels;
++#endif
++}
++
+ /* Set SEEK_IN_DECODER to 1 if you'd prefer seeking to be delay until
+  * the next time ffmpeg_decode() is called.  This will provide seeking
+  * in formats for which FFmpeg falsely reports seek errors, but could
+@@ -208,9 +229,9 @@
+ 	AVFormatContext *ic;
+ 	AVStream *stream;
+ 	AVCodecContext *enc;
+-	AVCodec *codec;
++	const AVCodec *codec;
+ 
+-#ifndef HAVE_AVCODEC_DECODE_AUDIO4
++#if !defined(HAVE_AVCODEC_DECODE_AUDIO4) && !defined(HAVE_AVCODEC_RECEIVE_FRAME)
+ 	int avbuf_size;
+ 	char *avbuf;
+ #endif
+@@ -520,8 +541,10 @@
+ 	av_log_set_level (AV_LOG_ERROR);
+ #endif
+ 	av_log_set_callback (ffmpeg_log_cb);
++#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58,10,100)
+ 	avcodec_register_all ();
+ 	av_register_all ();
++#endif
+ 
+ 	supported_extns = lists_strs_new (16);
+ 	load_audio_extns (supported_extns);
+@@ -871,18 +894,27 @@
+ /* Downmix multi-channel audios to stereo. */
+ static void set_downmixing (struct ffmpeg_data *data)
+ {
+-#ifdef HAVE_AV_GET_CHANNEL_LAYOUT_NB_CHANNELS
++#ifdef MOC_HAVE_CH_LAYOUT
++	/* FFmpeg 7 removed request_channel_layout. The modern replacement
++	 * is the per-codec "downmix" AVOption (only AC-3 honours it), so
++	 * just leave the codec at native layout and let MOC's
++	 * audio_conversion layer downmix to the output's channel count. */
++	(void)data;
++	return;
++#else
++# ifdef HAVE_AV_GET_CHANNEL_LAYOUT_NB_CHANNELS
+ 	if (av_get_channel_layout_nb_channels (data->enc->channel_layout) <= 2)
+ 		return;
+-#else
++# else
+ 	if (data->enc->channels <= 2)
+ 		return;
+-#endif
++# endif
+ 
+-#ifdef HAVE_STRUCT_AVCODECCONTEXT_REQUEST_CHANNELS
++# ifdef HAVE_STRUCT_AVCODECCONTEXT_REQUEST_CHANNELS
+ 	set_request_channels (data->enc, 2);
+-#else
++# else
+ 	data->enc->request_channel_layout = AV_CH_LAYOUT_STEREO;
++# endif
+ #endif
+ }
+ 
+@@ -903,7 +935,7 @@
+ 	data->bitrate = 0;
+ 	data->avg_bitrate = 0;
+ 
+-#if !defined(HAVE_AVCODEC_DECODE_AUDIO4) && defined(HAVE_POSIX_MEMALIGN)
++#if !defined(HAVE_AVCODEC_DECODE_AUDIO4) && !defined(HAVE_AVCODEC_RECEIVE_FRAME) && defined(HAVE_POSIX_MEMALIGN)
+ 	/* The sample buffer should be 16 byte aligned (because of SSE); a
+ 	 * segmentation fault may occur otherwise.  We allocate it dynamically
+ 	 * (to avoid overflowing OpenBSD's default pthread stack size) and once
+@@ -1025,8 +1057,11 @@
+ #endif
+ 
+ 	set_downmixing (data);
++#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(59,0,100)
++	/* Truncated mode was removed in FFmpeg 5. */
+ 	if (data->codec->capabilities & AV_CODEC_CAP_TRUNCATED)
+ 		data->enc->flags |= AV_CODEC_FLAG_TRUNCATED;
++#endif
+ 
+ #ifdef HAVE_AVCODEC_OPEN2
+ 	if (avcodec_open2 (data->enc, data->codec, NULL) < 0)
+@@ -1249,7 +1284,7 @@
+ #ifdef HAVE_AVCODEC_RECEIVE_FRAME
+   GCC_DIAG_OFF(deprecated-declarations)
+ #endif
+-#ifndef HAVE_AVCODEC_DECODE_AUDIO4
++#if !defined(HAVE_AVCODEC_DECODE_AUDIO4) && !defined(HAVE_AVCODEC_RECEIVE_FRAME)
+ /* Decode samples from packet data using pre-avcodec_decode_audio4(). */
+ static int decode_packet (struct ffmpeg_data *data, AVPacket *pkt,
+                           char *buf, int buf_len)
+@@ -1312,8 +1347,46 @@
+ }
+ #endif
+ 
+-#ifdef HAVE_AVCODEC_DECODE_AUDIO4
+-/* Decode samples from packet data using avcodec_decode_audio4(). */
++#if defined(HAVE_AVCODEC_DECODE_AUDIO4) || defined(HAVE_AVCODEC_RECEIVE_FRAME)
++
++#ifdef HAVE_AVCODEC_RECEIVE_FRAME
++/* FFmpeg 5 removed avcodec_decode_audio4. Wrap send_packet/receive_frame to
++ * keep the rest of decode_packet's shape unchanged. */
++static int decode_audio (AVCodecContext *ctx, AVFrame *frame,
++                         int *got_frame_ptr, const AVPacket *pkt)
++{
++	int rc, result = 0;
++
++	*got_frame_ptr = 0;
++
++	rc = avcodec_send_packet (ctx, pkt);
++	if (rc != 0 && rc != AVERROR(EAGAIN) && rc != AVERROR_EOF)
++		return rc;
++
++	result = pkt->size;
++
++	rc = avcodec_receive_frame (ctx, frame);
++	switch (rc) {
++	case 0:
++		*got_frame_ptr = 1;
++		break;
++	case AVERROR(EAGAIN):
++		break;
++	case AVERROR_EOF:
++		avcodec_flush_buffers (ctx);
++		break;
++	default:
++		result = rc;
++	}
++
++	return result;
++}
++#else
++# define decode_audio avcodec_decode_audio4
++#endif
++
++/* Decode samples from packet data using avcodec_decode_audio4() (or
++ * send_packet/receive_frame on FFmpeg 5+). */
+ static int decode_packet (struct ffmpeg_data *data, AVPacket *pkt,
+                           char *buf, int buf_len)
+ {
+@@ -1330,7 +1403,7 @@
+ 	do {
+ 		int len, got_frame, is_planar, packed_size, copied;
+ 
+-		len = avcodec_decode_audio4 (data->enc, frame, &got_frame, pkt);
++		len = decode_audio (data->enc, frame, &got_frame, pkt);
+ 
+ 		if (len < 0) {
+ 			/* skip frame */
+@@ -1354,17 +1427,17 @@
+ 
+ 		is_planar = av_sample_fmt_is_planar (data->enc->sample_fmt);
+ 		packed = (char *)frame->extended_data[0];
+-		packed_size = frame->nb_samples * data->sample_width
+-		                                * data->enc->channels;
++		int nb_ch = moc_nb_channels (data->enc);
++		packed_size = frame->nb_samples * data->sample_width * nb_ch;
+ 
+-		if (is_planar && data->enc->channels > 1) {
++		if (is_planar && nb_ch > 1) {
+ 			int sample, ch;
+ 
+ 			packed = xmalloc (packed_size);
+ 
+ 			for (sample = 0; sample < frame->nb_samples; sample += 1) {
+-				for (ch = 0; ch < data->enc->channels; ch += 1)
+-					memcpy (packed + (sample * data->enc->channels + ch)
++				for (ch = 0; ch < nb_ch; ch += 1)
++					memcpy (packed + (sample * nb_ch + ch)
+ 					                         * data->sample_width,
+ 					        (char *)frame->extended_data[ch] + sample * data->sample_width,
+ 					        data->sample_width);
+@@ -1436,8 +1509,15 @@
+ 		seek_ts += data->stream->start_time;
+ 	}
+ 
++#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(59,0,100)
++	/* AVStream.cur_dts became private in FFmpeg 5; without it we can't
++	 * tell seek direction. Always set BACKWARD so the seek lands
++	 * at-or-before the target (correct for audio in either direction). */
++	flags |= AVSEEK_FLAG_BACKWARD;
++#else
+ 	if (data->stream->cur_dts > seek_ts)
+ 		flags |= AVSEEK_FLAG_BACKWARD;
++#endif
+ 
+ 	rc = av_seek_frame (data->ic, data->stream->index, seek_ts, flags);
+ 	if (rc < 0) {
+@@ -1478,7 +1558,7 @@
+ 		return 0;
+ 
+ 	/* FFmpeg claims to always return native endian. */
+-	sound_params->channels = data->enc->channels;
++	sound_params->channels = moc_nb_channels (data->enc);
+ 	sound_params->rate = data->enc->sample_rate;
+ 	sound_params->fmt = data->fmt | SFMT_NE;
+ 
+@@ -1583,7 +1663,7 @@
+ 		free_remain_buf (data);
+ 	}
+ 
+-#if !defined(HAVE_AVCODEC_DECODE_AUDIO4) && defined(HAVE_POSIX_MEMALIGN)
++#if !defined(HAVE_AVCODEC_DECODE_AUDIO4) && !defined(HAVE_AVCODEC_RECEIVE_FRAME) && defined(HAVE_POSIX_MEMALIGN)
+ 	free (data->avbuf);
+ #endif
+ 
+@@ -1675,7 +1755,9 @@
+ 
+ struct decoder *plugin_init ()
+ {
+-#if defined(HAVE_AVCODEC_DECODE_AUDIO4)
++#if defined(HAVE_AVCODEC_RECEIVE_FRAME)
++	logit ("Using avcodec_send_packet()/avcodec_receive_frame()");
++#elif defined(HAVE_AVCODEC_DECODE_AUDIO4)
+ 	logit ("Using avcodec_decode_audio4()");
+ #elif defined(HAVE_POSIX_MEMALIGN)
+ 	logit ("Using posix_memalign()");

--- a/Patches/moc/07-bdb18-2.5.2.patch
+++ b/Patches/moc/07-bdb18-2.5.2.patch
@@ -1,0 +1,15 @@
+--- a/tags_cache.c
++++ b/tags_cache.c
+@@ -876,7 +876,12 @@
+ #endif
+ 
+ #ifdef HAVE_DB_H
++#if DB_VERSION_MAJOR >= 18
++static void db_msg_cb (const DB_ENV *dbenv ATTR_UNUSED,
++                       const char *prefix ATTR_UNUSED, const char *msg)
++#else
+ static void db_msg_cb (const DB_ENV *dbenv ATTR_UNUSED, const char *msg)
++#endif
+ {
+ 	assert (msg);
+ 


### PR DESCRIPTION
## moc: drop ffmpeg@4 / berkeley-db@5 pins via two new patches

Two new patches on top of the existing 01–05 series take MOC 2.5.2 the rest of the way to **FFmpeg 5+/8** and **Berkeley DB 18** compatibility, eliminating the need for the keg-only `ffmpeg@4` and `berkeley-db@5` pins. Together they close the long-standing https://moc.daper.net/node/3644.

### `06-ffmpeg5-2.5.2.patch` — `decoder_plugins/ffmpeg/ffmpeg.c`

- Add explicit `#include <libavcodec/avcodec.h>`. Modern `<libavformat/avformat.h>` no longer transitively pulls it in, which silently makes every `LIBAVCODEC_VERSION_INT` guard in the file evaluate as "ancient libav" and drags in removed APIs.
- Migrate channel access to the `AVChannelLayout` API (libavcodec ≥ 59.24.100) via a small `moc_nb_channels()` helper. `set_downmixing` becomes a no-op on the new path — MOC's audio_conversion layer handles channel reduction.
- Guard `avcodec_register_all()` / `av_register_all()` and the legacy `decode_packet` variants on `LIBAVCODEC_VERSION_INT` / `HAVE_AVCODEC_RECEIVE_FRAME` so they only compile against pre-5 FFmpeg.
- Wrap the `avcodec_decode_audio4` call site in a `decode_audio()` helper that dispatches to `avcodec_send_packet`/`avcodec_receive_frame` on FFmpeg 5+.
- Guard `AV_CODEC_CAP_TRUNCATED` / `AV_CODEC_FLAG_TRUNCATED` usage with `LIBAVCODEC_VERSION_INT < 59.0.100` (truncated mode removed in FFmpeg 5).
- Replace the now-private `AVStream.cur_dts` seek-direction hint with `AVSEEK_FLAG_BACKWARD` unconditionally on FFmpeg 5+ (correct at-or-before semantics either direction).
- `AVCodec *codec` → `const AVCodec *codec` for the new `avcodec_find_decoder` return type.

### `07-bdb18-2.5.2.patch` — `tags_cache.c`

- Guard `db_msg_cb` with `DB_VERSION_MAJOR >= 18`. BDB 18 added a third `prefix` argument to the `set_msgcall` callback.

### Formula changes

- `berkeley-db@5` → `berkeley-db`
- `ffmpeg@4` → `ffmpeg`
- Add a `CFLAGS=-Wno-error=unused-but-set-parameter` env tweak so the AX_PTHREAD configure probe (which writes a test program that fails clang's `-Werror -Wunused-but-set-parameter`) doesn't abort with "I don't know how to compile pthreads code".
- `revision 10` → `11`.

The patch URLs currently point at `jagajaga/homebrew-core@f4be5dcb…`; please rewrite them to the corresponding `Homebrew/homebrew-core` commit SHA on merge.

### Verification

Built and tested locally on macOS 26 / Apple Silicon (Homebrew /opt/homebrew). All 7 patches apply cleanly in sequence. Final binary links against:
- `libavcodec.62.dylib` (FFmpeg 8.1.1)
- `libdb-18.1.dylib`

Playback through JACK + CoreAudio confirmed end-to-end for `mp3`, `m4a` (AAC), `opus`, `flac`, `ogg` (Vorbis), and `wav` — three different decoder plugins (ffmpeg, flac, vorbis, sndfile) all loaded and decoded their test files to EOF with the correct sample rate / bit rate reported by `mocp --info`.

---

- [x] Have you followed the [[guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [[commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [[pull requests](https://github.com/Homebrew/homebrew-core/pulls)](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

- [x] AI was used to generate or assist with generating this PR.

> Claude (Anthropic) wrote the two new patches and the formula edits in this PR. Specifically: it diagnosed why the existing 01–05 patches stop short of FFmpeg 5+ (modern `<libavformat/avformat.h>` no longer transitively defines `LIBAVCODEC_VERSION_INT`, so version-gated `#if`s silently pulled in removed APIs), derived the `AVChannelLayout` / `cur_dts` / `AV_CODEC_CAP_TRUNCATED` / const-correctness changes from FFmpeg's own headers, and produced the BDB 18 callback shim.
>
> Manual verification I performed before opening: (1) the same conceptual port was first implemented against the unreleased MOC 2.6-alpha3 in `jagajaga/mocp@MacOS` and exercised end-to-end (https://github.com/jagajaga/mocp/tree/MacOS) — playback confirmed for mp3/aac/opus/flac/ogg/wav through JACK→CoreAudio; (2) I then re-derived the patches against MOC 2.5.2 on top of the existing 01–05 series, dry-ran the full chain to confirm no fuzz, and (3) rebuilt the brew formula from scratch and re-ran the same six-format playback matrix against the brew-installed binary. (4) `brew test` and `brew audit --strict` both pass on macOS 26 / arm64.