### PR TITLE
mdbtools: build ODBC driver against unixodbc.

### DIFF
--- a/Formula/m/mdbtools.rb
+++ b/Formula/m/mdbtools.rb
@@ -4,6 +4,7 @@ class Mdbtools < Formula
   url "https://github.com/mdbtools/mdbtools/releases/download/v1.0.1/mdbtools-1.0.1.tar.gz"
   sha256 "ff9c425a88bc20bf9318a332eec50b17e77896eef65a0e69415ccb4e396d1812"
   license "GPL-2.0-or-later"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "5469dde016c654a16a39ccda261395dfc81bd033600fd826250a80f424d9fc8f"
@@ -22,13 +23,18 @@ class Mdbtools < Formula
 
   depends_on "glib"
   depends_on "readline"
+  depends_on "unixodbc"
+
+  uses_from_macos "flex" => :build
 
   on_macos do
     depends_on "gettext"
   end
 
   def install
-    system "./configure", "--enable-man", *std_configure_args
+    system "./configure", "--enable-man",
+                          "--with-unixodbc=#{Formula["unixodbc"].opt_prefix}",
+                          *std_configure_args
     system "make", "install"
   end
 

--- a/Formula/m/mdbtools.rb
+++ b/Formula/m/mdbtools.rb
@@ -7,14 +7,12 @@ class Mdbtools < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "5469dde016c654a16a39ccda261395dfc81bd033600fd826250a80f424d9fc8f"
-    sha256 cellar: :any,                 arm64_sequoia: "3aab4c13461e0571b3ef4aa822417e0408fd7caad03f0d7d63bda9e20d102f20"
-    sha256 cellar: :any,                 arm64_sonoma:  "c247b94b87f1f09c26953f4b3f923f345ba18a8764d8f5ffc0ca8060e557a5fe"
-    sha256 cellar: :any,                 arm64_ventura: "ece916c2bc386781de20c67cc5e314430a369dc886d362f22039ea56d37771ee"
-    sha256 cellar: :any,                 sonoma:        "49722390bf0230475a1261a0c10d90540b6ff056a07c54b74680eab7276c3a04"
-    sha256 cellar: :any,                 ventura:       "2c2db546223c1b1ddfba20d70303761358fb5bba39362924976ff35d9710ae1e"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "1d367189a2aadd23bfe3dcc0aa062cb780d2ac8a6fa4d51a8b30b7f6d9486fa3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0e2ca3b97c784e7ce3e9d42e0bf58e15816b94944f2686c41d6ec698fc50ca0f"
+    sha256 cellar: :any,                 arm64_tahoe:   "80daadbae2b628dbc1e33e475a690da0c637cee4c0619e8f6fb462ec08833820"
+    sha256 cellar: :any,                 arm64_sequoia: "5f908724216744cf5088aa9ca1418608ca0837be3b34c50d279d1465c7f030b9"
+    sha256 cellar: :any,                 arm64_sonoma:  "0a2ee9cb19efc344da22dd3579c83100d225870c5dc2fd956c7ebf3ffdc1d07f"
+    sha256 cellar: :any,                 sonoma:        "3432d36eac18a64fa6031f2e0d6ed953abd4fb5d366e61654b1aea738cb6460b"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "ecb0e0f717a7c20e7ea65cc3027034bcb3bb1c3673e118cba2609aca30f681cc"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f4d76da42e34993527918db173bda6ba69364963dcd3fc4553d7b8def90a8ab0"
   end
 
   depends_on "bison" => :build


### PR DESCRIPTION
Adds unixodbc as a runtime dependency and passes --with-unixodbc to ./configure so the build produces libmdbodbc.dylib at lib/odbc/, matching the Linux odbc-mdbtools package. This lets pyodbc / unixODBC clients use DRIVER={MDBTools} on macOS without out-of-band setup.

Closes Homebrew/discussions#2438.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Tested locally on macOS arm64 (Tahoe): `brew style mdbtools`, `brew audit --strict mdbtools`, `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source mdbtools`, `brew test mdbtools`. After install, `pyodbc.connect("DRIVER={MDBTools};DBQ=…")` loads the driver successfully.
