### PR TITLE
portable-ruby: update resources

### DIFF
--- a/Formula/p/portable-ruby.rb
+++ b/Formula/p/portable-ruby.rb
@@ -6,6 +6,7 @@ class PortableRuby < PortableFormula
   url "https://cache.ruby-lang.org/pub/ruby/4.0/ruby-4.0.5.tar.gz"
   sha256 "7d6149079a63f8ae1d326c9fa65c6019ba2dc3155eae7b39159817911c88958e"
   license "Ruby"
+  revision 1
 
   # This regex restricts matching to versions other than X.Y.0.
   livecheck do
@@ -43,8 +44,8 @@ class PortableRuby < PortableFormula
   end
 
   resource "bootsnap" do
-    url "https://rubygems.org/downloads/bootsnap-1.24.4.gem"
-    sha256 "a4d939fc2cc5242a83d3a7cb4fb97743ac58475afe91e0600479a3df6f117541"
+    url "https://rubygems.org/downloads/bootsnap-1.24.5.gem"
+    sha256 "36b677448524d279b470469aabd5dff4a980e3fa4931a0df68da4a500eb1b6c4"
 
     livecheck do
       url "https://rubygems.org/api/v1/versions/bootsnap.json"

--- a/Formula/p/portable-ruby.rb
+++ b/Formula/p/portable-ruby.rb
@@ -15,10 +15,10 @@ class PortableRuby < PortableFormula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_big_sur: "d5dbe0bbfd7e00136344e7872fc26ad1db935cf7c6421c5888e42bab6cc2f6b3"
-    sha256 cellar: :any_skip_relocation, catalina:      "9ceb962508dce8cc2468095292fbff2b69fd86e0b9ecca813bf8ead72d4effa1"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "ca91ffae5583800407ee3f87d682c986d72133c17959fa55f9d36ef1903e0a07"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1e759412bed0a0a57c8939634b35ccfba178bba4c9831000d0a28e1104d6942c"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur: "4ba8d535df01e4bf97e6661c3815796fd77364ea2552606e891659133a76f0e1"
+    sha256 cellar: :any_skip_relocation, catalina:      "a731026301924336a5ee2051689788cd91ab09c2d42cb7b51c280e8fdcd85c7d"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "ca348cde9326562ed43c90f58886ee15c0a4e2c0dfd489686f56f059f9e77ca8"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2627985aa990199b93efb66d8e6752e8234c4901fa3a365fa13875ba45a4059e"
   end
 
   depends_on "pkgconf" => :build


### PR DESCRIPTION
Ref: https://github.com/Homebrew/brew/pull/22236#issuecomment-4519248728

Bootsnap 1.24.x look for a config file at `$PWD/config/bootsnap.rb`, this is a problem with homebrew because if it's invoked from a directory that has such a config file, it end up loaded inside homebrew and likely breaks.

Bootsnap 1.24.5 no longer load that file when configured the way Homebrew configures bootsnap.
