### PR TITLE
pcre: deprecate with extended deprecation period

### DIFF
--- a/Formula/p/pcre.rb
+++ b/Formula/p/pcre.rb
@@ -26,6 +26,19 @@ class Pcre < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "c0ad29b4ac581f0b18367f131f43583b10d2fd4832d80a47e8b80364f939257d"
   end
 
+  # Final release on 2021-06-22. As an exception, PCRE is given an extended
+  # deprecation period with removal set for 10 years after last release.
+  #
+  # PCRE was also removed in major Linux distros like Debian 13, RHEL 10,
+  # Ubuntu 26.04 and Fedora 45.
+  #
+  # The dates set should allow most maintained projects to migrate as it
+  # happens after:
+  # * Debian 12 LTS ends on 2028-06-30 removing PCRE from all maintained Debian
+  # * Ubuntu 24.04 security support ends on 2029-05-31 which will lead to
+  #   removal from CI runners like GitHub Actions
+  disable! date: "2030-06-22", because: :unmaintained, replacement_formula: "pcre2"
+
   uses_from_macos "bzip2"
 
   on_linux do


### PR DESCRIPTION
Aligning plans with major Linux distros (Debian/Ubuntu and Fedora/RHEL). Also avoid any new core formulae from using this as dependency.

Giving PCRE a rare extended deprecation period as some common language packages (e.g. OCaml, Haskell, Nim, etc) are taking a while to propagate alternatives.

Went with total of 10 years (i.e. disable on 2030-06-22 so that removal happens on 2031-06-22). This allows Ubuntu 24.04 to go out of security support (2029-05-31) which should cascade across CI runners and reduce availability of PCRE.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
