### PR TITLE
search-that-hash: deprecate by unmaintained

### DIFF
--- a/Formula/s/search-that-hash.rb
+++ b/Formula/s/search-that-hash.rb
@@ -13,6 +13,9 @@ class SearchThatHash < Formula
     sha256 cellar: :any_skip_relocation, all: "42e0c7eb93061ad01c4644c50bce1039d5561830e92cbc12e7a8507e0e3f5360"
   end
 
+  deprecate! date: "2026-05-23", because: :unmaintained
+  disable! date: "2027-05-23", because: :unmaintained
+
   depends_on "certifi" => :no_linkage
   depends_on "python@3.14"
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

It seems that upstream api is fine but response is broken, not working as expected. Let's deprecate.

```
install-on-request: 33 (30 days), 71 (90 days), 322 (365 days)
```

Found from
- https://github.com/Homebrew/homebrew-core/actions/runs/26224548808/job/77393214451?pr=284001