### PR TITLE
gemini-cli: deprecate and disable

### DIFF
--- a/Formula/g/gemini-cli.rb
+++ b/Formula/g/gemini-cli.rb
@@ -14,6 +14,9 @@ class GeminiCli < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "f24c9cc13ab892508fc2aefdecb0781ce422df2bb3ae7feae94e3774363d7ddc"
   end
 
+  deprecate! date: "2026-06-18", because: :unsupported, replacement_cask: "antigravity-cli"
+  disable! date: "2026-12-18", because: :unsupported, replacement_cask: "antigravity-cli"
+
   depends_on "node"
 
   on_linux do


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Google announced this will be unsupported and should move to `antigravity-cli`.
- https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/