### PR TITLE
libmpeg2 libdca: add C `-std` to only CFLAGS

### DIFF
--- a/Formula/lib/libdca.rb
+++ b/Formula/lib/libdca.rb
@@ -33,7 +33,7 @@ class Libdca < Formula
   def install
     # Fixes "duplicate symbol ___sputc" error when building with clang
     # https://github.com/Homebrew/homebrew/issues/31456
-    ENV.append_to_cflags "-std=gnu89"
+    ENV.append "CFLAGS", "-std=gnu89"
 
     system "autoreconf", "--force", "--install", "--verbose"
     system "./configure", *std_configure_args

--- a/Formula/lib/libmpeg2.rb
+++ b/Formula/lib/libmpeg2.rb
@@ -33,9 +33,14 @@ class Libmpeg2 < Formula
   depends_on "libtool" => :build
   depends_on "sdl12-compat"
 
+  on_linux do
+    depends_on "libx11"
+    depends_on "libxext"
+  end
+
   def install
     # Otherwise compilation fails in clang with `duplicate symbol ___sputc`
-    ENV.append_to_cflags "-std=gnu89"
+    ENV.append "CFLAGS", "-std=gnu89"
 
     system "autoreconf", "--force", "--install", "--verbose"
     system "./configure", *std_configure_args


### PR DESCRIPTION
Avoid incorrectly adding C standard to CXXFLAGS/etc.

Removing these to avoid copying into other formulae.

C standard should only be `CFLAGS` or `CC`. C++ standard should only be `CXXFLAGS` or `CXX`.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
