### PR TITLE
jetty-runner: fix deprecation date

### DIFF
--- a/Formula/j/jetty-runner.rb
+++ b/Formula/j/jetty-runner.rb
@@ -15,7 +15,8 @@ class JettyRunner < Formula
   end
 
   # See: https://github.com/jetty/jetty.project/issues/1905#issuecomment-409662335
-  deprecate! date: "2018-08-02", because: :deprecated_upstream
+  deprecate! date: "2025-06-04", because: :deprecated_upstream
+  disable! date: "2026-06-04", because: :deprecated_upstream
 
   depends_on "openjdk"
 


### PR DESCRIPTION
This was incorrectly backdated which we do not allow, see https://docs.brew.sh/Deprecating-Disabling-and-Removing#deprecate

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
