### PR TITLE
automake: configure acdir correctly

### DIFF
--- a/Formula/a/automake.rb
+++ b/Formula/a/automake.rb
@@ -5,6 +5,7 @@ class Automake < Formula
   mirror "https://ftp.gnu.org/gnu/automake/automake-1.18.1.tar.xz"
   sha256 "168aa363278351b89af56684448f525a5bce5079d0b6842bd910fdd3f1646887"
   license "GPL-2.0-or-later"
+  revision 1
   compatibility_version 1
 
   bottle do
@@ -25,18 +26,28 @@ class Automake < Formula
   def install
     ENV["PERL"] = "/usr/bin/perl" if OS.mac?
 
-    system "./configure", "--prefix=#{prefix}"
+    # We specify `HOMEBREW_PREFIX` so that aclocal is compiled with the
+    # correct system value for acdir (`HOMEBREW_PREFIX/share/aclocal`)
+    # We also patch `configure` so that the normal installation prefix
+    # is used when we call `make install`
+    inreplace "configure", "${datadir}", "${datarootdir}"
+    system "./configure", "--sysconfdir=#{etc}",
+                          "--localstatedir=#{var}",
+                          "--datarootdir=#{share}",
+                          "--datadir=#{HOMEBREW_PREFIX}/share",
+                          *std_configure_args
     system "make", "install"
 
-    # Our aclocal must go first. See:
-    # https://github.com/Homebrew/homebrew/issues/10618
+    # Use dirlist to add common search dirs for aclocal
     (share/"aclocal/dirlist").write <<~EOS
-      #{HOMEBREW_PREFIX}/share/aclocal
       /usr/share/aclocal
     EOS
   end
 
   test do
+    # Check that the compiled system value for acdir does not use automake's versioned path
+    assert_equal "#{HOMEBREW_PREFIX}/share/aclocal", shell_output("#{bin}/aclocal --print-ac-dir").chomp
+
     (testpath/"test.c").write <<~C
       int main() { return 0; }
     C

--- a/Formula/a/automake.rb
+++ b/Formula/a/automake.rb
@@ -9,16 +9,14 @@ class Automake < Formula
   compatibility_version 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "7298e979d484b938f42b96dfd4b270353e64f61ab0f31e0718799b29dc1570fc"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "3c00a332610983c37659eee42e4a93341a3051892481362d223a40f5435b7555"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "3c00a332610983c37659eee42e4a93341a3051892481362d223a40f5435b7555"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "3c00a332610983c37659eee42e4a93341a3051892481362d223a40f5435b7555"
-    sha256 cellar: :any_skip_relocation, tahoe:         "78ea48a55a4f8b088e5e83a5284e29307981cc6c265487e026824baad283c3b9"
-    sha256 cellar: :any_skip_relocation, sequoia:       "bddfb6ebd600671dbeb0c3e665a98bc971c97834f9b5fdfc15c17f6e3cd44de8"
-    sha256 cellar: :any_skip_relocation, sonoma:        "bddfb6ebd600671dbeb0c3e665a98bc971c97834f9b5fdfc15c17f6e3cd44de8"
-    sha256 cellar: :any_skip_relocation, ventura:       "bddfb6ebd600671dbeb0c3e665a98bc971c97834f9b5fdfc15c17f6e3cd44de8"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "c5bc18b0f438a2b7776c8a2cec9f9c5a4189a46dd35b79046249ad9d3abd4da1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c5bc18b0f438a2b7776c8a2cec9f9c5a4189a46dd35b79046249ad9d3abd4da1"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "a1c4b30862df532469570dc672c7d1e9b0644d54641c2b384d9f9466f13cd792"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "a1c4b30862df532469570dc672c7d1e9b0644d54641c2b384d9f9466f13cd792"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "a1c4b30862df532469570dc672c7d1e9b0644d54641c2b384d9f9466f13cd792"
+    sha256 cellar: :any_skip_relocation, tahoe:         "b903bd0af0e9b92893627e57a9f2ba912741665bd66585fd5439325f6e333927"
+    sha256 cellar: :any_skip_relocation, sequoia:       "b903bd0af0e9b92893627e57a9f2ba912741665bd66585fd5439325f6e333927"
+    sha256 cellar: :any_skip_relocation, sonoma:        "b903bd0af0e9b92893627e57a9f2ba912741665bd66585fd5439325f6e333927"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "82e16310fa008f762e8b82fba625f8eb57852b97da5cf372fceb8a500f7c6bfd"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "82e16310fa008f762e8b82fba625f8eb57852b97da5cf372fceb8a500f7c6bfd"
   end
 
   depends_on "autoconf"


### PR DESCRIPTION
-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

While working on #283454 to add the HEAD method, I stumbled upon an unusual bug with the `automake` formula that only became apparent because the `autogen.sh` script [would attempt to invoke `aclocal --print-ac-dir`](https://github.com/Homebrew/homebrew-core/blob/52ce57cb28250d54b387f44fad9aaa71df249e0d/Formula/n/nano.rb#L49-L51).

Using that flag is generally [discouraged](https://www.gnu.org/software/automake/manual/automake.html#index-_002d_002dprint_002dac_002ddir), but I figured that there must be others that uses it anyways, so I thought it was still worth fixing it.

At the moment, the way the `automake` formula is built produces an `aclocal` binary that will search for `.m4` files in the following directories (in that exact order - as indicated by the [documentation](https://www.gnu.org/software/automake/manual/automake.html#Macro-Search-Path-1)):

```
$HOMEBREW_PREFIX/Cellar/automake/1.18.1/share/aclocal-1.18  # 1. Compiled-in value from system acdir
$HOMEBREW_PREFIX/Cellar/automake/1.18.1/share/aclocal       # 2. Compiled-in value from system acdir
$HOMEBREW_PREFIX/share/aclocal                              # 3. Added by the dirlist file
/usr/share/aclocal                                          # 4. Added by the dirlist file
```

With the changes from this PR, `aclocal` should now be compiled with the correct `acdir` value, thus fixing `--print-ac-dir` and removing the need to include `$HOMEBREW_PREFIX/share/aclocal` in the `dirlist` file. So the search should now be as follows (in that exact order):

```
$HOMEBREW_PREFIX/share/aclocal-1.18  # 1. Compiled-in value from system acdir
$HOMEBREW_PREFIX/share/aclocal       # 2. Compiled-in value from system acdir
/usr/share/aclocal                   # 3. Added by the dirlist file
```