### PR TITLE
aws-sam-cli: migrate to `python@3.14`

### DIFF
--- a/Formula/a/aws-sam-cli.rb
+++ b/Formula/a/aws-sam-cli.rb
@@ -9,12 +9,13 @@ class AwsSamCli < Formula
   head "https://github.com/aws/aws-sam-cli.git", branch: "develop"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "c589e10bab0b3aff3bb59673cf4e1c19b229a99bdefef798d3599562896776c8"
-    sha256 cellar: :any,                 arm64_sequoia: "9d0af25e999371b36878d7b234c7910eb384ec2d519e8ba6fda555f305f09adc"
-    sha256 cellar: :any,                 arm64_sonoma:  "b1922a0d854f30d824b1da7b4bd1b2596a92cf9ef45847bda73bdc72b78bbaa6"
-    sha256 cellar: :any,                 sonoma:        "ba1ab984f85a8e5d70822f227ef711626073a996aaf4337b4fd03d2b59e46c61"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "530654e8d2cbdf80999208f51c6a9bdbecfe711db486ce75ce5a1304243f8b7d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "058837e56bd38be000120e8ac150f93127c08ef8a02087bb2aa399298d6867c4"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_tahoe:   "62579c3c3c3414a1a6200da1ad308286d5f6e97d0b3dcdff23c9ca686c12b11e"
+    sha256 cellar: :any,                 arm64_sequoia: "46560dee70462864a47c9a80019690cfaac7b5541f927437f54fb995d36fd389"
+    sha256 cellar: :any,                 arm64_sonoma:  "fb86cebf4925817846344e5664ca06cf8fa6be81c5b0c1a7744d12957242f1a7"
+    sha256 cellar: :any,                 sonoma:        "cab9b4a1f7615a0a008417725b78ecf3fa8e031c6e73cdc566a54e70ed8ce48a"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "0febbf1be275408bd4b6798d7af269ef229bb56d41d20d6b1b19239753fe3e08"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d369c7f0c2d676891dc06788e582cd22efe1a8da22b218dece7c518ccb694165"
   end
 
   depends_on "cmake" => :build # for `awscrt`

--- a/Formula/a/aws-sam-cli.rb
+++ b/Formula/a/aws-sam-cli.rb
@@ -6,6 +6,7 @@ class AwsSamCli < Formula
   url "https://files.pythonhosted.org/packages/70/fa/3c34809a6bf157b2211da06a209bb92241c5bf94565fb2a4fe4c44e6b44b/aws_sam_cli-1.161.0.tar.gz"
   sha256 "fb30911845bfc8b46f354679e3287e4a3ca330105a84a23d0d2d37020afd69a2"
   license "Apache-2.0"
+  head "https://github.com/aws/aws-sam-cli.git", branch: "develop"
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "c589e10bab0b3aff3bb59673cf4e1c19b229a99bdefef798d3599562896776c8"
@@ -24,7 +25,7 @@ class AwsSamCli < Formula
   depends_on "libyaml"
   depends_on "openssl@3" # for `awscrt`
   depends_on "pydantic" => :no_linkage
-  depends_on "python@3.13" # Pydantic v1 is incompatible with Python 3.14, issue ref: https://github.com/aws/serverless-application-model/issues/3831
+  depends_on "python@3.14"
   depends_on "rpds-py" => :no_linkage
 
   uses_from_macos "libffi"
@@ -72,13 +73,13 @@ class AwsSamCli < Formula
   end
 
   resource "boto3-stubs" do
-    url "https://files.pythonhosted.org/packages/5f/57/52ca31c8cd3356e7bdefb9e45cbb6ce558404f700cf46468b06a386dc16a/boto3_stubs-1.43.13.tar.gz"
-    sha256 "6e301825b4082dd8d121cf2aa4ac7d9c654e9bb3333b3fc1d1000f4ec4a70a51"
+    url "https://files.pythonhosted.org/packages/78/24/25bab1f05f1692e915c3227258735219c0abf1ee75f1450f92d842da8cac/boto3_stubs-1.43.14.tar.gz"
+    sha256 "18f3d402cf811d638c8fcb3cd935d0e459753db5cbfa3d37b7d25d7dfde2cb20"
   end
 
   resource "botocore" do
-    url "https://files.pythonhosted.org/packages/c3/34/58790c6d2e8e074e7a6286ec9d41c26237edd453c573aaf613eb621d8ae9/botocore-1.43.13.tar.gz"
-    sha256 "10df003c71847b4f1501b98b1c03e1cb6399583b6cc5136ca7ff849e00c4797f"
+    url "https://files.pythonhosted.org/packages/78/3c/798d2f7deb118241930c7c6bcfb0b970d3f0245bf580700663199aeed2c3/botocore-1.43.14.tar.gz"
+    sha256 "b9e500737e43d2f147c9d4e23b54360335e77d4c0ba90a318f51b65e06cb8516"
   end
 
   resource "botocore-stubs" do
@@ -217,8 +218,8 @@ class AwsSamCli < Formula
   end
 
   resource "mypy-boto3-s3" do
-    url "https://files.pythonhosted.org/packages/c8/f9/f6bb5e1b3d8d9087ab9e2142df640a1be853e371ec5e16ea519a60061b56/mypy_boto3_s3-1.43.5.tar.gz"
-    sha256 "ba67dbc3da825b6818839db3823722f3b12304dd116e94ed398eb7ade86b0f62"
+    url "https://files.pythonhosted.org/packages/04/2c/fc409f9ff5904a02cf4c2c1518c34d20cb56f22b2368b35fd0adda2926f3/mypy_boto3_s3-1.43.14.tar.gz"
+    sha256 "73d54c1d0999c73c403dc9a9a3da4a9722715aba116595af08c0d4675f8bc670"
   end
 
   resource "mypy-boto3-schemas" do
@@ -405,13 +406,10 @@ class AwsSamCli < Formula
     end
   end
 
-  def python3
-    "python3.13"
-  end
-
   def install
     ENV["AWS_CRT_BUILD_USE_SYSTEM_LIBCRYPTO"] = "1"
 
+    python3 = "python3.14"
     venv = virtualenv_create(libexec, python3, system_site_packages: false)
     venv.pip_install resources.reject { |r| ["awscrt", "aws-lambda-rie"].include?(r.name) }
     # CPU detection is available in AWS C libraries
@@ -422,7 +420,7 @@ class AwsSamCli < Formula
     generate_completions_from_executable(bin/"sam", shell_parameter_format: :click)
 
     # Rebuild pre-built binaries where source is available
-    rapid_dir = venv.root/Language::Python.site_packages(python3)/"samcli/local/rapid"
+    rapid_dir = venv.site_packages/"samcli/local/rapid"
     resource("aws-lambda-rie").stage do
       { "arm64" => "arm64", "x86_64" => "amd64" }.each do |arch, goarch|
         with_env(CGO_ENABLED: "0", GOOS: "linux", GOARCH: goarch) do


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

3.14 support was added in https://github.com/aws/serverless-application-model/commit/6689aa3049495e3eb97185914101ee68be99860a and released in `1.110.0`, which #284362 picked up 