### PR TITLE
icu4c: update license

### DIFF
--- a/Formula/i/icu4c@75.rb
+++ b/Formula/i/icu4c@75.rb
@@ -4,7 +4,7 @@ class Icu4cAT75 < Formula
   url "https://github.com/unicode-org/icu/releases/download/release-75-1/icu4c-75_1-src.tgz"
   version "75.1"
   sha256 "cb968df3e4d2e87e8b11c49a5d01c787bd13b9545280fc6642f826527618caef"
-  license "ICU"
+  license "Unicode-3.0"
   revision 1
 
   bottle do

--- a/Formula/i/icu4c@76.rb
+++ b/Formula/i/icu4c@76.rb
@@ -4,7 +4,7 @@ class Icu4cAT76 < Formula
   url "https://github.com/unicode-org/icu/releases/download/release-76-1/icu4c-76_1-src.tgz"
   version "76.1"
   sha256 "dfacb46bfe4747410472ce3e1144bf28a102feeaa4e3875bac9b4c6cf30f4f3e"
-  license "ICU"
+  license "Unicode-3.0"
   revision 2
 
   bottle do

--- a/Formula/i/icu4c@77.rb
+++ b/Formula/i/icu4c@77.rb
@@ -4,7 +4,7 @@ class Icu4cAT77 < Formula
   url "https://github.com/unicode-org/icu/releases/download/release-77-1/icu4c-77_1-src.tgz"
   version "77.1"
   sha256 "588e431f77327c39031ffbb8843c0e3bc122c211374485fa87dc5f3faff24061"
-  license "ICU"
+  license "Unicode-3.0"
   revision 1
 
   bottle do

--- a/Formula/i/icu4c@78.rb
+++ b/Formula/i/icu4c@78.rb
@@ -3,7 +3,7 @@ class Icu4cAT78 < Formula
   homepage "https://icu.unicode.org/home"
   url "https://github.com/unicode-org/icu/releases/download/release-78.3/icu4c-78.3-sources.tgz"
   sha256 "3a2e7a47604ba702f345878308e6fefeca612ee895cf4a5f222e7955fabfe0c0"
-  license "ICU"
+  license "Unicode-3.0"
   compatibility_version 1
 
   # We allow the livecheck to detect new `icu4c` major versions in order to


### PR DESCRIPTION
Upstream stopped using ICU license after ICU 57.1

They also added SPDX in ICU 75
- https://github.com/unicode-org/icu/commit/ea1c6da07fa345dd485408caee51703bc95c0454

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
