### PR TITLE
docker: replace docker-completion with generated completion

### DIFF
--- a/Formula/d/docker.rb
+++ b/Formula/d/docker.rb
@@ -13,12 +13,13 @@ class Docker < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "67c1b6eaacbc6f4637c4aa6206a74f7e7ab9cf7b522ee0845f170f8bb2f53820"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "d6689c2cbec6e37f37f9710652f01b49dc1f21c00b1920f346346d1b264ad976"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "38d25ff7d588f8480152f89e2177e3a91e10cd4e1738c3b45347f57acabde1b2"
-    sha256 cellar: :any_skip_relocation, sonoma:        "87320c07cf4a823d89eab0f58e39c528375a1ed0e4c5622aaced68ec3a5f38de"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "82fd1665d954f502b3f76d00a2145e734847d2c621dc03f5b6eaf9164e4b0fc7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "37ee45e00a7bc8b980a41c0c48e8a502bb9c6b6839501c1b4dfdce5ad2ba4dbf"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "dd87549832caa868fc769b2ddc9a0142297af04f741685f1e6213c459525ca57"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "6bcc923f7f78a07188230a6f044ed91cf008739e3c799f5c80d3419a03585e65"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "4900e3000786beac086d8ddd8f55dddaf7eeacfa1ed8f2d4f100bc8a4ac40cf9"
+    sha256 cellar: :any_skip_relocation, sonoma:        "3b0db7da24a1713e9d83804e69571c0181bfc2d6b9b808570ae049b77e4b4b67"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "366cbe02beb75ceda26392b849e037c08111117f5047f32f2f9cbccee2ece328"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a0d5d44efb6ade00bb3aa96f76884382023a6096305cbaebbaebd70b30451218"
   end
 
   depends_on "go" => :build

--- a/Formula/d/docker.rb
+++ b/Formula/d/docker.rb
@@ -23,7 +23,6 @@ class Docker < Formula
 
   depends_on "go" => :build
   depends_on "go-md2man" => :build
-  depends_on "docker-completion"
 
   conflicts_with cask: "docker-desktop"
 
@@ -49,6 +48,8 @@ class Docker < Formula
       (man/"man#{section}").mkpath
       system "go-md2man", "-in=#{md}", "-out=#{man}/man#{section}/#{md.stem}"
     end
+
+    generate_completions_from_executable(bin/"docker", "completion", shells: [:bash, :zsh, :fish, :pwsh])
   end
 
   def caveats


### PR DESCRIPTION
From the [upstream]( https://github.com/docker/cli/issues/6231#issuecomment-4446088571):

> the manually maintained completion scripts in contrib are being phased out in favor of the generated completion scripts (see `docker completion --help`)

Reopens https://github.com/Homebrew/homebrew-core/pull/231793

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
