### PR TITLE
bun 1.3.14 (new formula)

### DIFF
--- a/Formula/b/bun.rb
+++ b/Formula/b/bun.rb
@@ -1,0 +1,177 @@
+class Bun < Formula
+  desc "Incredibly fast JavaScript runtime, bundler, test runner, and package manager"
+  homepage "https://bun.com/"
+  # Need git checkout to build. Alternatively could set GIT_SHA if we extract the commit.
+  url "https://github.com/oven-sh/bun.git",
+      tag:      "bun-v1.3.14",
+      revision: "0d9b296af33f2b851fcbf4df3e9ec89751734ba4"
+  license all_of: [
+    "MIT",
+    "LGPL-2.0-or-later", # JavaScriptCore
+
+    # Other libraries, https://github.com/oven-sh/bun/blob/main/LICENSE.md#linked-libraries
+    # Ignoring ICU which is dynamically linked and reducing dual licenses to minimal set:
+    "Apache-2.0",        # boringssl, simdutf, uSockets, highway, uWebsockets, Tigerbeetle
+    "BSD-2-Clause",      # libarchive, libbase64, libspng
+    "BSD-3-Clause",      # lol-html, libwebp, zstd
+    "IJG",               # libjpeg-turbo
+    "LGPL-2.1-or-later", # tinycc
+    "Zlib",              # zlib-ng
+    "Apache-2.0" => { with: "LLVM-exception" }, # __cxa_thread_atexit
+  ]
+
+  livecheck do
+    url :stable
+    regex(/^bun[._-]v?(\d+(?:\.\d+)+)$/i)
+  end
+
+  depends_on "cmake" => :build
+  depends_on "llvm@21" => :build
+  depends_on "ninja" => :build
+  depends_on "rust" => :build
+
+  uses_from_macos "llvm" => :build
+  uses_from_macos "perl" => :build # for webkit
+  uses_from_macos "python" => :build # for webkit
+  uses_from_macos "ruby" => :build # for webkit
+  uses_from_macos "unzip" => :build
+
+  on_linux do
+    # We use a workaround to prevent patchelf of the `bun` binary but this
+    # means brew cannot rewrite paths for users on non-default prefix
+    pour_bottle? only_if: :default_prefix
+
+    depends_on "lld@21" => :build
+    depends_on "icu4c@78"
+  end
+
+  fails_with :gcc do
+    cause "uses clang-specific flags"
+  end
+
+  # Bootstrap with the same Bun version as upstream CI,
+  # https://github.com/oven-sh/bun/blob/bun-v#{version}/.buildkite/Dockerfile
+  resource "bootstrap" do
+    on_macos do
+      on_arm do
+        url "https://github.com/oven-sh/bun/releases/download/bun-v1.3.13/bun-darwin-aarch64.zip"
+        version "1.3.13"
+        sha256 "5467e3f65dba526b9fea98f0cce04efafc0c63e169733ec27b876a3ad32da190"
+      end
+      on_intel do
+        url "https://github.com/oven-sh/bun/releases/download/bun-v1.3.13/bun-darwin-x64-baseline.zip"
+        sha256 "a98ba6a480f22fda9b343626b906a4e26aa53618bf85d2bc5928ecf2ba45f0ed"
+      end
+    end
+    on_linux do
+      on_arm do
+        url "https://github.com/oven-sh/bun/releases/download/bun-v1.3.13/bun-linux-aarch64.zip"
+        version "1.3.13"
+        sha256 "70bae41b3908b0a120e1e58c5c8af30e74afae3b8d11b0d3fdd8e787ddfb4b22"
+      end
+      on_intel do
+        url "https://github.com/oven-sh/bun/releases/download/bun-v1.3.13/bun-linux-x64-baseline.zip"
+        sha256 "9d8a24292a7068090205daac0a5a223f5f69736f5287e37bf88d3b4031edc750"
+      end
+    end
+  end
+
+  # Performing a manual shallow git clone since a full clone of WebKit repo is ~18GB in size
+  # and brew's unpack strategy will duplicate a resource requiring over 36GB of disk space.
+  # This exceeds limit of GitHub-hosted runners. A shallow git clone is instead ~7GB.
+  def fetch_webkit
+    webkit_version = File.read("scripts/build/deps/webkit.ts")[/WEBKIT_VERSION = "(\h+)"/i, 1]
+    odie "Unable to find WebKit version!" if webkit_version.blank?
+
+    clone_args = %W[
+      --branch=autobuild-#{webkit_version}
+      --config=advice.detachedHead=false
+      --config=core.fsmonitor=false
+      --depth=1
+    ]
+    system "git", "clone", *clone_args, "https://github.com/oven-sh/WebKit.git", "vendor/WebKit"
+  end
+
+  # Based on https://github.com/oven-sh/bun/blob/main/CONTRIBUTING.md#building-webkit-locally--debug-mode-of-jsc
+  def install
+    bootstrap_version = File.read(".buildkite/Dockerfile")[/OLD_BUN_VERSION="v?(\d+(?:\.\d+)+)"/i, 1]
+    odie "Update bootstrap to #{bootstrap_version}" if resource("bootstrap").version != bootstrap_version
+
+    # Avoid `rustup` dependency by removing usage of nightly Rust features
+    # TODO: Try removing in the next release
+    inreplace "scripts/build/deps/lolhtml.ts", "if (cfg.release && canBuildStdImmediateAbort)", "if (false)"
+
+    zig_cpu = case ENV.effective_arch
+    when :arm_vortex_tempest then "apple_m1" # See `zig targets`.
+    when :armv8 then "xgene1" # Closest to `-march=armv8-a`
+    else ENV.effective_arch
+    end
+
+    # Upstream only allows building for specific microarchitectures they support
+    # so we need to patch build scripts to be compatible with our CPU targets
+    # as part of compilation occurs outside of our superenv.
+    inreplace "scripts/build/zig.ts", "-Dcpu=${zigCpu(cfg)}", "-Dcpu=#{zig_cpu}"
+    inreplace "scripts/build/flags.ts", "-march=nehalem", "-march=#{ENV.effective_arch}" if Hardware::CPU.intel?
+
+    fetch_webkit
+    resource("bootstrap").stage("bootstrap")
+    ENV.prepend_path "PATH", buildpath/"bootstrap"
+
+    args = ["--canary=off"]
+    args << "--baseline=on" if Hardware::CPU.intel?
+
+    system "bun", "run", "build:release:local", *args
+    bin.install "build/release-local/bun"
+    bin.install_symlink bin/"bun" => "bunx"
+
+    bash_completion.install "completions/bun.bash" => "bun"
+    fish_completion.install "completions/bun.fish"
+    zsh_completion.install "completions/bun.zsh" => "_bun"
+
+    # Work around patchelf corrupting the binary and causing segfault.
+    # FIXME: Add a DSL to skip patchelf
+    if OS.linux? && build.bottle?
+      prefix.install bin/"bun"
+      Utils::Gzip.compress(prefix/"bun")
+      (bin/"bun").write <<~SHELL
+        #!/bin/bash
+        echo 'ERROR: Need to run `brew postinstall #{name}`' >&2
+        exit 1
+      SHELL
+    end
+  end
+
+  def post_install
+    if (prefix/"bun.gz").exist?
+      system "gunzip", prefix/"bun.gz"
+      (prefix/"bun").chmod 0755
+      bin.install prefix/"bun"
+    end
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/bun --version")
+    refute_match "canary", shell_output("#{bin}/bun --revision")
+
+    system bin/"bun", "init", "--yes"
+    assert_equal "Hello via Bun!", shell_output("#{bin}/bun run index.ts").chomp
+
+    system bin/"bun", "build", "--compile", "--outfile=test", "index.ts"
+    assert_equal "Hello via Bun!", shell_output("./test").chomp
+
+    assert_match "< hello bun >", shell_output("#{bin}/bunx cowsay hello bun")
+
+    # Test SQLite API which loads system library on macOS
+    (testpath/"db.ts").write <<~TYPESCRIPT
+      import { Database } from "bun:sqlite";
+      const db = new Database(":memory:");
+      db.run("create table students (name text, age integer)");
+      db.run("insert into students (name, age) values ('Bob', 14)");
+      db.run("insert into students (name, age) values ('Sue', 12)");
+      db.run("insert into students (name, age) values ('Tim', 13)");
+      const query = db.query("select name from students order by age asc");
+      console.log(query.values().flat());
+    TYPESCRIPT
+    assert_equal '[ "Sue", "Tim", "Bob" ]', shell_output("#{bin}/bun run db.ts").chomp
+  end
+end

--- a/Formula/b/bun.rb
+++ b/Formula/b/bun.rb
@@ -25,6 +25,15 @@ class Bun < Formula
     regex(/^bun[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 
+  bottle do
+    sha256                               arm64_tahoe:   "d2dec7e845cbfb74c96e0f7b8a06a85d555fb36275744036df71cbe81c4b3e35"
+    sha256                               arm64_sequoia: "ef73f22cd191639a8a951421c823a59aa648e0c01c75eec83089fa8b788ac4a5"
+    sha256                               arm64_sonoma:  "b25c23f3ab10fe268dc705cebaea79e803fe7cf53abd0ea123178b88730715d1"
+    sha256 cellar: :any_skip_relocation, sonoma:        "830c03414478f7edea283d58a32783385a6462aa4c5ef29ef7877b30ce458c9a"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "5a1bae01b22520515d132f3b5b208e7666ec9251bb2848f8a84452a0ae69c6bb"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a7f23ed0cc52b0ddc553a9d95af48bc030146f965639d9c03ed811c96757dc28"
+  end
+
   depends_on "cmake" => :build
   depends_on "llvm@21" => :build
   depends_on "ninja" => :build

--- a/style_exceptions/binary_bootstrap_formula_urls_allowlist.json
+++ b/style_exceptions/binary_bootstrap_formula_urls_allowlist.json
@@ -1,4 +1,5 @@
 [
+  "bun",
   "cabal-install",
   "clozure-cl",
   "crystal",


### PR DESCRIPTION
Also going to try looking into Bun given increase in prebuilt binaries in other formulae.

Kind of want a shallow git clone here as WebKit repo is 18 GB and brew will duplicate it during build so need 36 GB. For now will see how far we get without it.

Trying to avoid the Rustup dependency but we may be forced to use it at some point due to upstream move to Rust which may increase usage of nightly features is used. For now, only used to optimize `lolhtml`:
- https://github.com/oven-sh/bun/blob/bun-v1.3.14/scripts/build/deps/lolhtml.ts#L74-L84

Didn't seem worth trying to hack up build system to support Core 2 on Linux given upstream isn't going to support it. Rather than carrying a permanent patch for that, just going with a baseline (Nehalem) build. Upstream's main build is Haswell (AVX2) so there may be a performance gap in Intel bottles.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
