### PR TITLE
formulae: make `nasm` intel-only

### DIFF
--- a/Formula/a/av1an.rb
+++ b/Formula/a/av1an.rb
@@ -22,11 +22,14 @@ class Av1an < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "358e252cb21347a5d92519bcb0eb7ba256a1f22410f8735efff523bc10a6ba05"
   end
 
-  depends_on "nasm" => :build
   depends_on "rust" => :build
   depends_on "ffmpeg"
   depends_on "mkvtoolnix"
   depends_on "vapoursynth"
+
+  on_intel do
+    depends_on "nasm" => :build
+  end
 
   def install
     ENV["VERGEN_GIT_COMMIT_DATE"] = time.iso8601

--- a/Formula/d/dssim.rb
+++ b/Formula/d/dssim.rb
@@ -16,8 +16,11 @@ class Dssim < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "9cf26940ab54503cb8be6c091610aa90b2e12cd46b05c9a5b8a7a15298ecb190"
   end
 
-  depends_on "nasm" => :build
   depends_on "rust" => :build
+
+  on_intel do
+    depends_on "nasm" => :build
+  end
 
   def install
     system "cargo", "install", *std_cargo_args

--- a/Formula/m/mvtools.rb
+++ b/Formula/m/mvtools.rb
@@ -16,12 +16,15 @@ class Mvtools < Formula
   end
 
   depends_on "meson" => :build
-  depends_on "nasm" => :build
   depends_on "ninja" => :build
   depends_on "pkgconf" => :build
 
   depends_on "fftw"
   depends_on "vapoursynth"
+
+  on_intel do
+    depends_on "nasm" => :build
+  end
 
   def install
     # Replace vendored path to homebrew formula path

--- a/Formula/o/openh264.rb
+++ b/Formula/o/openh264.rb
@@ -25,7 +25,9 @@ class Openh264 < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "9a5b7c2ddbf8e02c9590b66e49e25119cf06ca2ff1ca48bb85f89c498828304e"
   end
 
-  depends_on "nasm" => :build
+  on_intel do
+    depends_on "nasm" => :build
+  end
 
   def install
     system "make", "install-shared", "PREFIX=#{prefix}"

--- a/Formula/s/svt-av1.rb
+++ b/Formula/s/svt-av1.rb
@@ -22,7 +22,10 @@ class SvtAv1 < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "nasm" => :build
+
+  on_intel do
+    depends_on "nasm" => :build
+  end
 
   def install
     # Features are enabled based on compiler support, and then the appropriate


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
