### PR TITLE
a2ps - adr-tools: add sandbox network controls

### DIFF
--- a/Formula/a/a2ps.rb
+++ b/Formula/a/a2ps.rb
@@ -19,6 +19,8 @@ class A2ps < Formula
   depends_on "bdw-gc"
   depends_on "libpaper"
 
+  deny_network_access!
+
   def install
     system "./configure", "--sysconfdir=#{etc}",
                           "--with-lispdir=#{elisp}",

--- a/Formula/a/aalib.rb
+++ b/Formula/a/aalib.rb
@@ -37,6 +37,8 @@ class Aalib < Formula
     sha256 "9843e109d580e7112291871248140b8657108faac6d90ce5caf66cd25e8d0d1e"
   end
 
+  deny_network_access!
+
   def install
     # Workaround for newer Clang
     ENV.append_to_cflags "-Wno-implicit-int" if DevelopmentTools.clang_build_version >= 1403

--- a/Formula/a/aamath.rb
+++ b/Formula/a/aamath.rb
@@ -32,6 +32,8 @@ class Aamath < Formula
     sha256 "9443881d7950ac8d2da217a23ae3f2c936fbd6880f34dceba717f1246d8608f1"
   end
 
+  deny_network_access!
+
   def install
     unless OS.mac?
       inreplace "Makefile" do |s|

--- a/Formula/a/aarch64-elf-binutils.rb
+++ b/Formula/a/aarch64-elf-binutils.rb
@@ -30,6 +30,8 @@ class Aarch64ElfBinutils < Formula
     depends_on "zlib-ng-compat"
   end
 
+  deny_network_access!
+
   def install
     target = "aarch64-elf"
     system "./configure", "--target=#{target}",

--- a/Formula/a/aarch64-elf-gcc.rb
+++ b/Formula/a/aarch64-elf-gcc.rb
@@ -30,6 +30,8 @@ class Aarch64ElfGcc < Formula
     depends_on "zlib-ng-compat"
   end
 
+  deny_network_access!
+
   def install
     target = "aarch64-elf"
     mkdir "aarch64-elf-gcc-build" do

--- a/Formula/a/aarch64-elf-gdb.rb
+++ b/Formula/a/aarch64-elf-gdb.rb
@@ -47,6 +47,8 @@ class Aarch64ElfGdb < Formula
     depends_on "zlib-ng-compat"
   end
 
+  deny_network_access!
+
   def install
     target = "aarch64-elf"
     args = %W[

--- a/Formula/a/ab-av1.rb
+++ b/Formula/a/ab-av1.rb
@@ -19,6 +19,8 @@ class AbAv1 < Formula
   depends_on "rust" => :build
   depends_on "ffmpeg"
 
+  deny_network_access! [:postinstall, :test]
+
   def install
     system "cargo", "install", *std_cargo_args
     generate_completions_from_executable(bin/"ab-av1", "print-completions", shells: [:bash, :zsh, :fish, :pwsh])

--- a/Formula/a/abcl.rb
+++ b/Formula/a/abcl.rb
@@ -34,6 +34,8 @@ class Abcl < Formula
   depends_on "openjdk"
   depends_on "rlwrap"
 
+  deny_network_access! [:postinstall, :test]
+
   def install
     ENV["JAVA_HOME"] = Formula["openjdk"].opt_prefix
 

--- a/Formula/a/abcm2ps.rb
+++ b/Formula/a/abcm2ps.rb
@@ -26,6 +26,8 @@ class Abcm2ps < Formula
     depends_on "gnu-sed" => :build
   end
 
+  deny_network_access!
+
   def install
     if OS.mac?
       ENV.prepend_path "PATH", Formula["gnu-sed"].libexec/"gnubin"

--- a/Formula/a/abcmidi.rb
+++ b/Formula/a/abcmidi.rb
@@ -19,6 +19,8 @@ class Abcmidi < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "a7e18e30ba126e43de705ad6de42c36f6d3222c0524ebba31eba6f8fc64d56e9"
   end
 
+  deny_network_access!
+
   def install
     system "./configure", *std_configure_args
     system "make", "install"

--- a/Formula/a/abduco.rb
+++ b/Formula/a/abduco.rb
@@ -22,6 +22,8 @@ class Abduco < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "2129c6039968a818f71997e800575b581128b56f8783eeb32c990f8a5e8b81ad"
   end
 
+  deny_network_access!
+
   def install
     ENV.append_to_cflags "-D_DARWIN_C_SOURCE"
     system "make", "PREFIX=#{prefix}", "install"

--- a/Formula/a/abi-dumper.rb
+++ b/Formula/a/abi-dumper.rb
@@ -16,6 +16,8 @@ class AbiDumper < Formula
   depends_on "universal-ctags"
   depends_on "vtable-dumper"
 
+  deny_network_access!
+
   def install
     # We pass `--program-prefix=elfutils-` when building `elfutils`.
     inreplace "abi-dumper.pl", "eu-readelf", "elfutils-readelf"

--- a/Formula/a/abi3audit.rb
+++ b/Formula/a/abi3audit.rb
@@ -118,6 +118,10 @@ class Abi3audit < Formula
     sha256 "231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"
   end
 
+  # Although the virtualenv_install_with_resources uses the package resources listed above,
+  # pip still needs to fetch the project's chosen build system via the network.
+  deny_network_access! [:postinstall]
+
   def install
     virtualenv_install_with_resources
   end

--- a/Formula/a/abnfgen.rb
+++ b/Formula/a/abnfgen.rb
@@ -25,6 +25,8 @@ class Abnfgen < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "76f35d17e3a1bad80de9ef0c2fb654882619b43a70f00cc23293b7d63c3fc513"
   end
 
+  deny_network_access!
+
   def install
     system "./configure", *std_configure_args
     system "make", "install"

--- a/Formula/a/abook.rb
+++ b/Formula/a/abook.rb
@@ -45,6 +45,8 @@ class Abook < Formula
     depends_on "gettext"
   end
 
+  deny_network_access!
+
   def install
     ENV.append "CFLAGS", "-std=gnu17" if DevelopmentTools.clang_build_version >= 1700
     system "autoreconf", "--force", "--install", "--verbose"

--- a/Formula/a/abpoa.rb
+++ b/Formula/a/abpoa.rb
@@ -19,6 +19,8 @@ class Abpoa < Formula
     depends_on "zlib-ng-compat"
   end
 
+  deny_network_access!
+
   def install
     system "make"
     bin.install "bin/abpoa"

--- a/Formula/a/abricate.rb
+++ b/Formula/a/abricate.rb
@@ -137,6 +137,8 @@ class Abricate < Formula
     end
   end
 
+  deny_network_access!
+
   def install
     ENV.prepend_path "PERL5LIB", Formula["bioperl"].opt_libexec/"lib/perl5"
 

--- a/Formula/a/abyss.rb
+++ b/Formula/a/abyss.rb
@@ -39,6 +39,8 @@ class Abyss < Formula
     depends_on "libomp"
   end
 
+  deny_network_access! [:build, :postinstall]
+
   def install
     # Help link to libomp on macOS
     ENV["ac_cv_prog_cxx_openmp"] = "-Xpreprocessor -fopenmp -lomp" if OS.mac?

--- a/Formula/a/ace.rb
+++ b/Formula/a/ace.rb
@@ -23,6 +23,8 @@ class Ace < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "6f7c1c5865d3faf699ed79c109fa3828aab4f08d0886619a02cb4d12d2ecdbab"
   end
 
+  deny_network_access!
+
   def install
     os = OS.mac? ? "macosx" : "linux"
     ln_sf "config-#{os}.h", "ace/config.h"

--- a/Formula/a/aces_container.rb
+++ b/Formula/a/aces_container.rb
@@ -24,6 +24,8 @@ class AcesContainer < Formula
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
 
+  deny_network_access!
+
   def install
     # Workaround for newer Clang
     ENV.append_to_cflags "-Wno-c++11-narrowing" if DevelopmentTools.clang_build_version >= 1403

--- a/Formula/a/ack.rb
+++ b/Formula/a/ack.rb
@@ -28,6 +28,8 @@ class Ack < Formula
 
   uses_from_macos "perl"
 
+  deny_network_access!
+
   def install
     if build.head?
       ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"

--- a/Formula/a/acme.rb
+++ b/Formula/a/acme.rb
@@ -29,6 +29,8 @@ class Acme < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "fcb14a109abee4d1af24a79bc4991a851a6b1b75fd64999e815715fc54a4c834"
   end
 
+  deny_network_access!
+
   def install
     system "make", "-C", "src", "install", "BINDIR=#{bin}"
     doc.install Dir["docs/*"]

--- a/Formula/a/acme.sh.rb
+++ b/Formula/a/acme.sh.rb
@@ -9,6 +9,8 @@ class AcmeSh < Formula
     sha256 cellar: :any_skip_relocation, all: "f323095950742f7e7899c48f5295433b55c6edfb7092eade86e16fcc74618037"
   end
 
+  deny_network_access!
+
   def install
     libexec.install [
       "acme.sh",

--- a/Formula/a/acpica.rb
+++ b/Formula/a/acpica.rb
@@ -24,6 +24,8 @@ class Acpica < Formula
   uses_from_macos "flex" => :build
   uses_from_macos "m4" => :build
 
+  deny_network_access!
+
   def install
     # ACPI_PACKED_POINTERS_NOT_SUPPORTED:
     # https://github.com/acpica/acpica/issues/781#issuecomment-1718084901

--- a/Formula/a/acronym.rb
+++ b/Formula/a/acronym.rb
@@ -69,6 +69,10 @@ class Acronym < Formula
     sha256 "7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb"
   end
 
+  # Although the virtualenv_install_with_resources uses the package resources listed above,
+  # pip still needs to fetch the project's chosen build system via the network.
+  deny_network_access! [:postinstall]
+
   def install
     virtualenv_install_with_resources
   end

--- a/Formula/a/act.rb
+++ b/Formula/a/act.rb
@@ -17,6 +17,8 @@ class Act < Formula
 
   depends_on "go" => :build
 
+  deny_network_access! [:postinstall]
+
   def install
     system "make", "build", "VERSION=#{version}"
     bin.install "dist/local/act"

--- a/Formula/a/action-docs.rb
+++ b/Formula/a/action-docs.rb
@@ -11,6 +11,8 @@ class ActionDocs < Formula
 
   depends_on "node"
 
+  deny_network_access! [:postinstall, :test]
+
   def install
     system "npm", "install", *std_npm_args
     bin.install_symlink libexec.glob("bin/*")

--- a/Formula/a/action-validator.rb
+++ b/Formula/a/action-validator.rb
@@ -18,6 +18,8 @@ class ActionValidator < Formula
 
   depends_on "rust" => :build
 
+  deny_network_access! [:postinstall, :test]
+
   def install
     ENV["GEN_DIR"] = buildpath
     system "cargo", "install", *std_cargo_args

--- a/Formula/a/actionlint.rb
+++ b/Formula/a/actionlint.rb
@@ -20,6 +20,8 @@ class Actionlint < Formula
   depends_on "ronn" => :build
   depends_on "shellcheck"
 
+  deny_network_access! [:postinstall, :test]
+
   def install
     ldflags = %W[
       -s -w

--- a/Formula/a/actions-batch.rb
+++ b/Formula/a/actions-batch.rb
@@ -21,6 +21,8 @@ class ActionsBatch < Formula
 
   depends_on "go" => :build
 
+  deny_network_access! [:postinstall]
+
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w")
 

--- a/Formula/a/actions-up.rb
+++ b/Formula/a/actions-up.rb
@@ -11,6 +11,8 @@ class ActionsUp < Formula
 
   depends_on "node"
 
+  deny_network_access! [:postinstall]
+
   def install
     system "npm", "install", *std_npm_args
     bin.install_symlink libexec.glob("bin/*")

--- a/Formula/a/activemq-cpp.rb
+++ b/Formula/a/activemq-cpp.rb
@@ -33,6 +33,8 @@ class ActivemqCpp < Formula
     sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
   end
 
+  deny_network_access!
+
   def install
     system "./configure", "--prefix=#{prefix}"
     system "make"

--- a/Formula/a/activemq.rb
+++ b/Formula/a/activemq.rb
@@ -18,6 +18,8 @@ class Activemq < Formula
   depends_on "java-service-wrapper"
   depends_on "openjdk"
 
+  deny_network_access!
+
   def install
     if OS.mac?
       wrapper_dir = "macosx"

--- a/Formula/a/ad.rb
+++ b/Formula/a/ad.rb
@@ -17,6 +17,8 @@ class Ad < Formula
 
   depends_on "rust" => :build
 
+  deny_network_access! [:postinstall, :test]
+
   def install
     system "cargo", "install", *std_cargo_args
     man.install buildpath/"docs/man/ad.1"

--- a/Formula/a/adamstark-audiofile.rb
+++ b/Formula/a/adamstark-audiofile.rb
@@ -10,6 +10,8 @@ class AdamstarkAudiofile < Formula
     sha256 cellar: :any_skip_relocation, all: "dce0123d95e01e4609051018ea590c2811908a0e75cb97f7c445c491d21de87e"
   end
 
+  deny_network_access!
+
   def install
     include.install "AudioFile.h"
   end

--- a/Formula/a/adapterremoval.rb
+++ b/Formula/a/adapterremoval.rb
@@ -27,6 +27,8 @@ class Adapterremoval < Formula
     depends_on "zlib-ng-compat"
   end
 
+  deny_network_access!
+
   def install
     args = %w[
       -Db_coverage=false

--- a/Formula/a/adaptivecpp.rb
+++ b/Formula/a/adaptivecpp.rb
@@ -30,6 +30,8 @@ class Adaptivecpp < Formula
     depends_on "numactl"
   end
 
+  deny_network_access!
+
   def install
     args = if OS.mac?
       libomp_root = Formula["libomp"].opt_prefix

--- a/Formula/a/adb-enhanced.rb
+++ b/Formula/a/adb-enhanced.rb
@@ -28,6 +28,10 @@ class AdbEnhanced < Formula
     sha256 "0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372"
   end
 
+  # Although the virtualenv_install_with_resources uses the package resources listed above,
+  # pip still needs to fetch the project's chosen build system via the network.
+  deny_network_access! [:postinstall, :test]
+
   def install
     virtualenv_install_with_resources
   end

--- a/Formula/a/add-determinism.rb
+++ b/Formula/a/add-determinism.rb
@@ -24,6 +24,10 @@ class AddDeterminism < Formula
     depends_on "zlib-ng-compat"
   end
 
+  # Although the virtualenv_install_with_resources uses the package resources listed above,
+  # pip still needs to fetch the project's chosen build system via the network.
+  deny_network_access! [:postinstall, :test]
+
   def install
     ENV["RUSTFLAGS"] = "-C link-arg=-lselinux" if OS.linux?
     system "cargo", "install", *std_cargo_args

--- a/Formula/a/addlicense.rb
+++ b/Formula/a/addlicense.rb
@@ -19,6 +19,8 @@ class Addlicense < Formula
 
   depends_on "go" => :build
 
+  deny_network_access! [:postinstall, :test]
+
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w")
   end

--- a/Formula/a/addons-linter.rb
+++ b/Formula/a/addons-linter.rb
@@ -11,6 +11,8 @@ class AddonsLinter < Formula
 
   depends_on "node"
 
+  deny_network_access! [:postinstall, :test]
+
   def install
     system "npm", "install", *std_npm_args
     bin.install_symlink libexec.glob("bin/*")

--- a/Formula/a/adios2.rb
+++ b/Formula/a/adios2.rb
@@ -56,6 +56,8 @@ class Adios2 < Formula
   # Apple clang version 14.0.0 (clang-1400.0.29.202)
   fails_with :clang if DevelopmentTools.clang_build_version == 1400
 
+  deny_network_access!
+
   def python3
     "python3.14"
   end

--- a/Formula/a/admesh.rb
+++ b/Formula/a/admesh.rb
@@ -21,6 +21,8 @@ class Admesh < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "6d06691e618a708b7c30459acdc5e70f2abed11d5a2f8c7622b1fc6f8ef353f8"
   end
 
+  deny_network_access!
+
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",

--- a/Formula/a/adns.rb
+++ b/Formula/a/adns.rb
@@ -22,6 +22,8 @@ class Adns < Formula
 
   uses_from_macos "m4" => :build
 
+  deny_network_access!
+
   def install
     system "./configure", "--prefix=#{prefix}", "--disable-dynamic"
     system "make"

--- a/Formula/a/adplay.rb
+++ b/Formula/a/adplay.rb
@@ -31,6 +31,8 @@ class Adplay < Formula
     depends_on "alsa-lib"
   end
 
+  deny_network_access! [:build, :postinstall]
+
   def install
     system "autoreconf", "--force", "--install", "--verbose" if build.head?
     # SDL output works better than libao

--- a/Formula/a/adplug.rb
+++ b/Formula/a/adplug.rb
@@ -31,6 +31,8 @@ class Adplug < Formula
     depends_on "texinfo" => :build
   end
 
+  deny_network_access! [:build, :postinstall]
+
   def install
     # Workaround for arm64 linux, issue ref: https://github.com/adplug/adplug/issues/246
     ENV.append_to_cflags "-fsigned-char" if OS.linux? && Hardware::CPU.arm?

--- a/Formula/a/adr-tools.rb
+++ b/Formula/a/adr-tools.rb
@@ -10,6 +10,8 @@ class AdrTools < Formula
     sha256 cellar: :any_skip_relocation, all: "893bca3baa1fdb9dfad37f81cc58ccc5d6e3c3b7b9c03336d5ac365700eeec10"
   end
 
+  deny_network_access!
+
   def install
     config = buildpath/"src/adr-config"
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Start adding `deny_network_access` to formulae alphabetically, from `a2ps` to `adr-tools`, except:
- Deprecated/disabled formulae: `abcde`, `abi-compliance-checker`, `access`
- Formulae with non-trivial dependents (may take longer in CI): `abseil`, `ada-url`
- Formulae that have trouble building: `acl2`, `a52dec`
- Formulae that have dependents which fail tests: `acl`

I've spot-tested a few where it was not clear if network access is used. Note that `resource` blocks inside `test` blocks require network access (the fetch of the `resource` is run by the sandboxed process).

Added `long build` label in case this takes a while, `CI-no-bottles` since we probably want to confirm that compilation works and that dependents aren't broken but don't need to re-bottle for this.