### PR TITLE
libavif: livecheck resource, remove `nasm`

### DIFF
--- a/Formula/lib/libavif.rb
+++ b/Formula/lib/libavif.rb
@@ -16,7 +16,6 @@ class Libavif < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "nasm" => :build
   depends_on "aom"
   depends_on "dav1d"
   depends_on "jpeg-turbo"
@@ -28,7 +27,13 @@ class Libavif < Formula
 
   resource "libargparse" do
     url "https://github.com/kmurray/libargparse/archive/ee74d1b53bd680748af14e737378de57e2a0a954.tar.gz"
+    version "ee74d1b53bd680748af14e737378de57e2a0a954"
     sha256 "7727b0498851e5b6a6fcd734eb667a8a231897e2c86a357aec51cc0664813060"
+
+    livecheck do
+      url "https://raw.githubusercontent.com/AOMediaCodec/libavif/refs/tags/v#{LATEST_VERSION}/cmake/Modules/LocalLibargparse.cmake"
+      regex(/\(AVIF_LIBARGPARSE_GIT_TAG (\h+)\)/i)
+    end
   end
 
   def install


### PR DESCRIPTION
```console
❯ brew lc libavif --autobump -r
libavif: 1.4.1 ==> 1.4.1
  libargparse: ee74d1b53bd680748af14e737378de57e2a0a954 ==> ee74d1b53bd680748af14e737378de57e2a0a954
```

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
