### PR TITLE
ppsspp: disable yasm

### DIFF
--- a/Formula/p/ppsspp.rb
+++ b/Formula/p/ppsspp.rb
@@ -17,7 +17,6 @@ class Ppsspp < Formula
 
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
-  depends_on "yasm" => :build
 
   depends_on "libzip"
   depends_on "miniupnpc"
@@ -50,6 +49,12 @@ class Ppsspp < Formula
     # See https://github.com/Homebrew/homebrew-core/issues/84737.
     cd "ffmpeg" do
       if OS.mac?
+        # Yasm is unmaintained and has multiple CVEs so will be deprecated
+        # soon in Homebrew/core. The bundled FFmpeg 3 build system is not
+        # able to correctly detect nasm so just disabling x86_64 asm which
+        # matches Linux build script.
+        ENV["extraopts"] = "--disable-yasm"
+
         rm_r("macosx")
         system "./mac-build.sh"
       else


### PR DESCRIPTION
Linux build script already disables yasm: https://github.com/hrydgard/ppsspp-ffmpeg/blob/master/linux_x86-64.sh#L89

Since PPSSPP is built natively, this should only impact Intel macOS which is going to be phased out next year.

We also have Cask which is usually our preferred installation for GUI apps. We could consider tap migration if we add Linux appimage to Cask.
- https://formulae.brew.sh/cask/ppsspp-emulator#default

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
