### PR TITLE
cozyvalues-gen 1.5.0 (new formula)

### DIFF
--- a/Formula/c/cozyvalues-gen.rb
+++ b/Formula/c/cozyvalues-gen.rb
@@ -1,0 +1,39 @@
+class CozyvaluesGen < Formula
+  desc "Code generator for Go structs, CRDs, and JSON schemas from annotated YAML"
+  homepage "https://github.com/cozystack/cozyvalues-gen"
+  url "https://github.com/cozystack/cozyvalues-gen/archive/refs/tags/v1.5.0.tar.gz"
+  sha256 "c4ee78d8cacb7d931306fd2263110e9f093f7f7ac54a88bc0a8b3664863bbbd9"
+  license "Apache-2.0"
+  head "https://github.com/cozystack/cozyvalues-gen.git", branch: "main"
+
+  depends_on "go" => [:build, :test]
+
+  def install
+    ldflags = "-s -w -X main.Version=#{version}"
+    system "go", "build", *std_go_args(ldflags:)
+  end
+
+  test do
+    assert_match "Version: #{version}", shell_output("#{bin}/cozyvalues-gen --version")
+
+    (testpath/"values.yaml").write <<~YAML
+      ## @param {string} name - Resource name
+      ## @param {int} replicas - Number of replicas
+      name: "demo"
+      replicas: 1
+    YAML
+
+    system bin/"cozyvalues-gen",
+           "--values", testpath/"values.yaml",
+           "--schema", testpath/"schema.json",
+           "--debug-go", testpath/"values.go"
+
+    schema = (testpath/"schema.json").read
+    assert_match "\"type\": \"string\"", schema
+    assert_match "\"default\": \"demo\"", schema
+
+    go_code = (testpath/"values.go").read
+    assert_match "Name string `json:\"name\"`", go_code
+    assert_match "Replicas int `json:\"replicas\"`", go_code
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Code generator for the Cozystack ecosystem: turns JSDoc-annotated Helm `values.yaml` into Go structs, Kubernetes CustomResourceDefinitions, and JSON schemas.

Cozystack is a [CNCF Sandbox project](https://www.cncf.io/projects/cozystack/). Three sibling Cozystack tools are already in homebrew-core: `talm` (#259703), `cozyhr` (#264858), and `cozypkg` (#284647). Like `talm` and `cozyhr`, this tool lives in its own repository, so `brew audit --new` flags it as not notable on its own (3 stars); requesting the same notability waiver previously granted to those formulae.

- **Homepage:** https://github.com/cozystack/cozyvalues-gen
- **License:** Apache-2.0
