### PR TITLE
vs-preview: deprecate as repo archived

### DIFF
--- a/Formula/v/vs-preview.rb
+++ b/Formula/v/vs-preview.rb
@@ -17,6 +17,10 @@ class VsPreview < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "7606801d7145e257743999ae28282c5aaba2ccd6a337b17ef63524f9905ccae8"
   end
 
+  # "This repository was archived by the owner on May 13, 2026"
+  deprecate! date: "2026-05-25", because: :repo_archived
+  disable! date: "2027-05-25", because: :repo_archived
+
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "jpeg" => :build
@@ -33,6 +37,7 @@ class VsPreview < Formula
   depends_on "vapoursynth"
 
   pypi_packages exclude_packages: %w[certifi matplotlib numpy pillow pyqt6 vapoursynth]
+
   resource "charset-normalizer" do
     url "https://files.pythonhosted.org/packages/1d/35/02daf95b9cd686320bb622eb148792655c9412dbb9b67abb5694e5910a24/charset_normalizer-3.4.5.tar.gz"
     sha256 "95adae7b6c42a6c5b5b559b1a99149f090a57128155daeea91732c8d970d8644"


### PR DESCRIPTION
https://github.com/Jaded-Encoding-Thaumaturgy/vs-preview
> This repository was archived by the owner on May 13, 2026. It is now read-only.

And https://github.com/Jaded-Encoding-Thaumaturgy#previewers calls it "Retired"
> - [vs-preview](https://github.com/Jaded-Encoding-Thaumaturgy/vs-preview) — Retired fork of the venerable vapoursynth-preview

Sounds like replaced by https://github.com/Jaded-Encoding-Thaumaturgy/vs-view though latter doesn't meet notability yet.


-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
