### PR TITLE
arx-libertatis: fix cmake data directory inclusion

### DIFF
--- a/Formula/a/arx-libertatis.rb
+++ b/Formula/a/arx-libertatis.rb
@@ -53,6 +53,12 @@ class ArxLibertatis < Formula
       -DWITH_SDL=2
     ]
 
+    if OS.mac?
+      # Add additional localisation dir flags
+      args << "-DDATA_DIR_PREFIXES=/Applications:#{HOMEBREW_PREFIX}/share/games"
+      args << "-DDATA_DIR=ArxLibertatis:arx"
+    end
+
     # Install prebuilt icons to avoid inkscape and imagemagick deps
     if build.head?
       (buildpath/"arx-libertatis-data").install resource("arx-libertatis-data")


### PR DESCRIPTION
Using the GOG installer as specified at the end of the installer script the localization files are not present in the expected location. There are missing strings which are being substituted in the interface and most likely elsewhere in the game. Adding the additional cmake flags will include the default installation location under /opt/homebrew/share/games/ so that the appropriate localization files from Arx Libertatis are being used.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [X] Is your test running fine `brew test <formula>`?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [X] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

claude.ai -> Sonnet 4.6 -> Adaptive

Used claude to deduce what the cmake flag additions needed to be. 
- I looked at the cmake file to ensure the flags were present and would be appropriate.

To test, I wiped Arx Libertatis from my machine entirely, ```brew remove arx-libertatis```, and removed the /Applications/ArxLibertatis and ~/Library/Application Support/ArxLibertatis folders that are created from the installation process. I installed the default untouched formula to verify the issue exists. I then ran ```brew remove arx-libertatis``` again and followed the homebrew guide to fork and edit the formula file, finally ran the installation command  ```HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source  arx-libertatis``` and ensured the text would show up properly. Attached are screenshots of before, and after fix. Following the validation and screenshots I ran the test and audit commands. 

Before 1
<img width="1718" height="1086" alt="before-fix-1" src="https://github.com/user-attachments/assets/43f1bf41-97aa-403b-98c3-83e77565389c" />
After 1
<img width="1628" height="1094" alt="after-fix-1" src="https://github.com/user-attachments/assets/98cd9c25-5c0a-4cf0-a5e5-c506ff94cb0e" />

Before 2
<img width="1718" height="1086" alt="before-fix-2" src="https://github.com/user-attachments/assets/9b1a039e-0e13-4e58-b99d-5a9f06bbd831" />
After 2
<img width="1584" height="1050" alt="after-fix-2" src="https://github.com/user-attachments/assets/d3b520d2-3e5b-4a62-8359-1cc1f158547d" />

Before 3
<img width="1718" height="1086" alt="before-fix-3" src="https://github.com/user-attachments/assets/8afc3e63-4131-48b9-8ee3-047fdbcdb1fd" />
After 3
<img width="1718" height="1086" alt="after-fix-3" src="https://github.com/user-attachments/assets/97182af9-81e7-4c33-9817-52ee2e1958f9" />

-----
