### PR TITLE
scummvm: revision bump due to broken reason

### DIFF
--- a/Formula/s/scummvm.rb
+++ b/Formula/s/scummvm.rb
@@ -4,6 +4,7 @@ class Scummvm < Formula
   url "https://downloads.scummvm.org/frs/scummvm/2026.2.0/scummvm-2026.2.0.tar.xz"
   sha256 "4e10ed977daa36780c97a9b3bd7c124842f5ed9b0bfea4e8e35eda4658fa60f3"
   license "GPL-3.0-or-later"
+  revision 1
   head "https://github.com/scummvm/scummvm.git", branch: "master"
 
   livecheck do


### PR DESCRIPTION
I wanted to use this formula but for some reason the linkage wtih musepack on Arm macOS Tahoe was broken:
```
~ $ scummvm
dyld[83856]: Library not loaded:
/opt/homebrew/opt/musepack/lib/libmpcdec.7.dylib
  Referenced from: <16BF9465-9E35-3E94-8A73-B74DAEC8899E>
/opt/homebrew/Cellar/scummvm/2026.2.0/bin/scummvm
  Reason: tried: '/opt/homebrew/opt/musepack/lib/libmpcdec.7.dylib' (no
such file),
'/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/opt/musepack/lib/libmpcdec.7.dylib' (no such file), '/opt/homebrew/opt/musepack/lib/libmpcdec.7.dylib' (no such file), '/opt/homebrew/Cellar/musepack/r475/lib/libmpcdec.7.dylib' (no such file),
'/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/Cellar/musepack/r475/lib/libmpcdec.7.dylib' (no such file),
'/opt/homebrew/Cellar/musepack/r475/lib/libmpcdec.7.dylib' (no such file)
zsh: abort      scummvm
~ $ brew reinstall scummvm
==> Fetching downloads for: scummvm
✔︎ Bottle Manifest scummvm (2026.2.0)
Downloaded   49.8KB/ 49.8KB
✔︎ Bottle scummvm (2026.2.0)
Downloaded  113.1MB/113.1MB
==> Reinstalling scummvm
==> Pouring scummvm--2026.2.0.arm64_tahoe.bottle.tar.gz
Broken dependencies:
  /opt/homebrew/opt/musepack/lib/libmpcdec.7.dylib (musepack)
Warning: scummvm has broken dynamic library links:
  T::Private::Types::Void::VOID
Rebuild this from source with:
  brew reinstall --build-from-source scummvm
If that's successful, file an issue here:
  https://github.com/Homebrew/homebrew-core/issues
```

No idea why it was not detected

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
