### PR TITLE
claudectl 0.49.3 (new formula)

### DIFF
--- a/Formula/c/claudectl.rb
+++ b/Formula/c/claudectl.rb
@@ -1,0 +1,36 @@
+class Claudectl < Formula
+  desc "Supervise, orchestrate, and connect Claude Code coding agents"
+  homepage "https://github.com/mercurialsolo/claudectl"
+  url "https://github.com/mercurialsolo/claudectl/archive/refs/tags/v0.49.3.tar.gz"
+  sha256 "601bad4b04822b5910ddd05833de955d238874476270f0a0a26262a8a513b6fd"
+  license "MIT"
+  head "https://github.com/mercurialsolo/claudectl.git", branch: "main"
+
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args(path: ".")
+
+    generate_completions_from_executable(bin/"claudectl", "completions")
+
+    (man1/"claudectl.1").write Utils.safe_popen_read(bin/"claudectl", "man")
+  end
+
+  test do
+    assert_match "_claudectl", shell_output("#{bin}/claudectl completions bash")
+    assert_match "#compdef claudectl", shell_output("#{bin}/claudectl completions zsh")
+    assert_match "complete -c claudectl", shell_output("#{bin}/claudectl completions fish")
+
+    assert_match ".TH claudectl 1", shell_output("#{bin}/claudectl man")
+
+    assert_match version.to_s, shell_output("#{bin}/claudectl --version")
+
+    ENV["HOME"] = testpath
+    system bin/"claudectl", "--list"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you checked that there aren't other open pull requests for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict --new --online <formula>` (after doing `brew install <formula>`)?

---

`claudectl` is a TUI + headless control plane for Claude Code (Anthropic's CLI coding agent). It supervises sessions, enforces per-session budgets, exposes a local-LLM "brain" that can approve/deny tool calls, and gossips knowledge between agents on a mesh.

- **Upstream:** https://github.com/mercurialsolo/claudectl
- **Notability:** 173 stars, 19 forks, MIT licensed, stable tag history (v0.29 → v0.49.3 over the last year).
- **License:** MIT, vendored cleanly via Cargo.
- **Build:** pure Rust, builds offline with `cargo install` once dependencies are fetched; no native deps beyond `rust`.
- **Self-submission:** I am the upstream author. The tool is already shipping via my own tap (`mercurialsolo/homebrew-tap`, prebuilt binaries) and crates.io; this PR is the source-built core formula so `brew install claudectl` resolves without a tap.

Locally on macOS 26 (Tahoe) / arm64:

- `brew install --build-from-source mercurialsolo/local-test/claudectl` — clean, 1 min build, 3.4 MB installed.
- `brew test mercurialsolo/local-test/claudectl` — passes. The test block exercises shell completions for bash/zsh/fish, the rendered man page, `--version`, and `--list` against a sandboxed `HOME`.
- `brew audit --strict --new --online mercurialsolo/local-test/claudectl` — clean.

The formula uses `livecheck` (`:github_latest`) so the auto-bumper can pick up future releases.