### PR TITLE
kandev 0.52.0 (new formula)

### DIFF
--- a/Formula/k/kandev.rb
+++ b/Formula/k/kandev.rb
@@ -1,0 +1,82 @@
+class Kandev < Formula
+  desc "Manage tasks, orchestrate agents, review changes, and ship value"
+  homepage "https://github.com/kdlbs/kandev"
+  url "https://github.com/kdlbs/kandev/archive/refs/tags/v0.52.0.tar.gz"
+  sha256 "048f581049a008d8232df87dc0c3999ba2739c3e99bdfa99bd69acef9d68af64"
+  license "AGPL-3.0-only"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
+  depends_on "go"   => :build
+  depends_on "pnpm" => :build
+  depends_on "node"
+
+  uses_from_macos "rsync" => :build
+  uses_from_macos "sqlite"
+
+  def install
+    ENV["KANDEV_VERSION"] = version.to_s
+
+    system "pnpm", "-C", "apps", "install", "--frozen-lockfile"
+    system "pnpm", "-C", "apps", "--filter", "@kandev/web", "build"
+    system "./scripts/release/package-web.sh"
+    system "./scripts/release/package-cli.sh"
+
+    bundle = buildpath/"dist/kandev"
+    (bundle/"bin").mkpath
+
+    cd "apps/backend" do
+      # kandev backend needs cgo for mattn/go-sqlite3.
+      with_env(CGO_ENABLED: "1") do
+        system "go", "build",
+               *std_go_args(ldflags: "-s -w -X main.Version=#{version}",
+                            output:  bundle/"bin/kandev"),
+               "./cmd/kandev"
+      end
+      # agentctl is pure-Go; build it static to avoid a dynamic linker
+      # crash observed on Linuxbrew arm64 bottle CI.
+      with_env(CGO_ENABLED: "0") do
+        system "go", "build",
+               *std_go_args(ldflags: "-s -w", output: bundle/"bin/agentctl"),
+               "./cmd/agentctl"
+      end
+    end
+
+    system "./scripts/release/package-bundle.sh"
+
+    # The Next.js standalone tracer pulls platform-tagged native modules
+    # into the bundle, including musl-libc variants of sharp, @swc/core,
+    # and lightningcss that brew linkage --test flags on glibc-only
+    # Linuxbrew. Strip them — rm_r handles both directory trees (the
+    # current shape) and bare .node files (in case a future bundler
+    # version inlines them). The exist? guard handles the glob
+    # returning a parent dir and its musl-named children together —
+    # removing the parent makes the child paths vanish before we get
+    # to them.
+    bundle.glob("web/**/*musl*").each { |p| rm_r(p) if p.exist? }
+
+    libexec.install Dir[bundle/"*"]
+
+    (bin/"kandev").write_env_script libexec/"cli/bin/cli.js",
+      KANDEV_BUNDLE_DIR: libexec.to_s,
+      KANDEV_VERSION:    version.to_s
+  end
+
+  test do
+    # Wrapper sanity: confirms write_env_script wired KANDEV_BUNDLE_DIR
+    # and the launcher reads the bundled package.json version.
+    assert_match version.to_s, shell_output("#{bin}/kandev --version")
+
+    # Functional test: exercise the agentctl sidecar's CLI subcommand
+    # dispatcher. Boots the Go binary, parses flags, dispatches to the
+    # kandev subcommand handler, and prints usage when called without
+    # arguments. Verifies the binary loads correctly across platforms
+    # without requiring HTTP listeners, port binds, or subprocesses —
+    # which can be problematic in sandboxed build environments.
+    output = shell_output("#{libexec}/bin/agentctl kandev 2>&1", 1)
+    assert_match "Usage: agentctl kandev", output
+  end
+end


### PR DESCRIPTION
Adds `kandev`, a self-hosted kanban + agent orchestrator. Source build: Go backend (cgo, links sqlite), Next.js standalone web bundle, and a TypeScript CLI launcher. The `bin/kandev` wrapper sets `KANDEV_BUNDLE_DIR` so the launcher in `libexec/cli` finds the backend binary and web bundle.

Homepage: https://github.com/kdlbs/kandev
License:  AGPL-3.0-only
Runtime:  node
Build: go, pnpm

A binary-install tap ([kdlbs/homebrew-kandev](https://github.com/kdlbs/homebrew-kandev)) already exists for users who don't want the build time. This source-build formula lets `brew install kandev` work without adding a tap.

Tested on macOS arm64 (Tahoe) by creating a local tap:
```
HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source local/test/kandev
brew test local/test/kandev
brew audit --strict --new --online local/test/kandev # no offenses
brew style local/test/kandev # no offenses
```

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [X] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --strict --new <formula>`?
- [X] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*: Mainly help with adhering to repo guidelines and composing the formula. Manually verifying the changes involved testing the formula by creating a local tap, installing from it, and running tests/audit/style to see if there were no issues, initially there were some but fixed after some back and forth.