### PR TITLE
airspy: deprecate and remove non-FOSS head build

### DIFF
--- a/Formula/a/airspy.rb
+++ b/Formula/a/airspy.rb
@@ -1,29 +1,12 @@
 class Airspy < Formula
   desc "Driver and tools for a software-defined radio"
   homepage "https://airspy.com/"
+  url "https://github.com/airspy/airspyone_host/archive/refs/tags/v1.0.10.tar.gz"
+  sha256 "fcca23911c9a9da71cebeffeba708c59d1d6401eec6eb2dd73cae35b8ea3c613"
   license "GPL-2.0-or-later"
-  head "https://github.com/airspy/airspyone_host.git", branch: "master"
 
-  stable do
-    url "https://github.com/airspy/airspyone_host/archive/refs/tags/v1.0.10.tar.gz"
-    sha256 "fcca23911c9a9da71cebeffeba708c59d1d6401eec6eb2dd73cae35b8ea3c613"
-
-    # CMake 4 build patch, remove in the next release
-    # PR refs:
-    # - https://github.com/airspy/airspyone_host/pull/80
-    # - https://github.com/airspy/airspyone_host/pull/103
-    patch do
-      url "https://github.com/airspy/airspyone_host/commit/7290309a663ced66e1e51dc65c1604e563752310.patch?full_index=1"
-      sha256 "982559d6b900aa9aa2de546197153aae4e0de7b852d0cf4404a92ec3c5f00d11"
-    end
-    patch do
-      url "https://github.com/airspy/airspyone_host/commit/3cf6f97976611c2ff6363f7927fe76c465995801.patch?full_index=1"
-      sha256 "0d78db431a2c11622200655cbd446cae3543c333eb6fa2fa1a0909b6d72d24e2"
-    end
-    patch do
-      url "https://github.com/airspy/airspyone_host/commit/f467acd587617640741ecbfade819d10ecd032c2.patch?full_index=1"
-      sha256 "5b7cc28179b55245caf379b002ed54eb52ee48b66cc8814b6740bc3d94dc48cf"
-    end
+  livecheck do
+    skip "cannot update due to non-FOSS terms in newer code"
   end
 
   bottle do
@@ -42,9 +25,43 @@ class Airspy < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "b1705571f2f7cc979706ceb8340ee737fde0b538002c3942145f35355b9b41d3"
   end
 
+  # libairspy/src/iqconverter_* files were modified to a non-FOSS license.
+  # https://github.com/airspy/airspyone_host/blob/master/libairspy/src/iqconverter_float.c#L10-L12
+  #
+  # > Any redistribution, publication, sublicensing, or commercial use outside the
+  # > Airspy ecosystem is strictly prohibited without prior written consent from the
+  # > copyright holders.
+  #
+  # This has been pointed out by one of the main authors:
+  # * https://github.com/airspy/airspyone_host/pull/103#issuecomment-3359538126
+  #
+  # Fedora thread also agrees this is non-free:
+  # * https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/ZODYXEUOUNFYAYKQKRKK2RTIHEVVGMPN/
+  #
+  # Can be undeprecated if upstream switches to a FOSS license.
+  deprecate! date: "2026-05-30", because: "has code relicensed to non-FOSS after 1.0.10"
+  disable! date: "2027-05-30", because: "has code relicensed to non-FOSS after 1.0.10"
+
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
   depends_on "libusb"
+
+  # CMake 4 build patch, remove in the next release
+  # PR refs:
+  # - https://github.com/airspy/airspyone_host/pull/80
+  # - https://github.com/airspy/airspyone_host/pull/103
+  patch do
+    url "https://github.com/airspy/airspyone_host/commit/7290309a663ced66e1e51dc65c1604e563752310.patch?full_index=1"
+    sha256 "982559d6b900aa9aa2de546197153aae4e0de7b852d0cf4404a92ec3c5f00d11"
+  end
+  patch do
+    url "https://github.com/airspy/airspyone_host/commit/3cf6f97976611c2ff6363f7927fe76c465995801.patch?full_index=1"
+    sha256 "0d78db431a2c11622200655cbd446cae3543c333eb6fa2fa1a0909b6d72d24e2"
+  end
+  patch do
+    url "https://github.com/airspy/airspyone_host/commit/f467acd587617640741ecbfade819d10ecd032c2.patch?full_index=1"
+    sha256 "5b7cc28179b55245caf379b002ed54eb52ee48b66cc8814b6740bc3d94dc48cf"
+  end
 
   def install
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args


### PR DESCRIPTION
Current code is still okay, but any future release would be under non-FOSS terms.

License in https://github.com/airspy/airspyone_host/blob/master/libairspy/src/iqconverter_float.c says

> ... to use, copy, modify, merge, and distribute the Software **exclusively as part of the Airspy ecosystem** ...
>
> Any redistribution, publication, sublicensing, or commercial use outside the Airspy ecosystem is **strictly prohibited without prior written consent from the copyright holders.**

Homebrew/core requires DFSG-compatible licenses and new terms run counter to multiple clauses in https://www.debian.org/social_contract#guidelines

> 1. Free Redistribution
> 
> The license of a Debian component may not restrict any party from selling or giving away the software as a component of an aggregate software distribution containing programs from several different sources. The license may not require a royalty or other fee for such sale.

> 3. Derived Works
> 
> The license must allow modifications and derived works, and must allow them to be distributed under the same terms as the license of the original software.
> 


-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
