### PR TITLE
docker-completion: deprecate and don't sync versions with docker

### DIFF
--- a/Formula/d/docker-completion.rb
+++ b/Formula/d/docker-completion.rb
@@ -15,6 +15,9 @@ class DockerCompletion < Formula
     sha256 cellar: :any_skip_relocation, all: "3b610d95bf47634f39625917d7886bf41c1ddd28e5ca0f1e760d292278a005ef"
   end
 
+  deprecate! date: "2026-05-31", because: :deprecated_upstream, replacement_formula: "docker"
+  disable! date: "2027-05-31", because: :deprecated_upstream, replacement_formula: "docker"
+
   conflicts_with cask: "docker-desktop"
 
   # These used to also be provided by the `docker` formula.
@@ -22,9 +25,6 @@ class DockerCompletion < Formula
   link_overwrite "share/fish/vendor_completions.d/docker.fish"
   link_overwrite "share/zsh/site-functions/_docker"
 
-  deprecate! date: "2026-05-31", because: :deprecated_upstream, replacement_formula: "docker"
-  disable! date: "2027-05-31", because: :deprecated_upstream, replacement_formula: "docker"
-  
   def install
     bash_completion.install "contrib/completion/bash/docker"
     fish_completion.install "contrib/completion/fish/docker.fish"

--- a/Formula/d/docker-completion.rb
+++ b/Formula/d/docker-completion.rb
@@ -22,6 +22,9 @@ class DockerCompletion < Formula
   link_overwrite "share/fish/vendor_completions.d/docker.fish"
   link_overwrite "share/zsh/site-functions/_docker"
 
+  deprecate! date: "2026-05-31", because: :deprecated_upstream, replacement_formula: "docker"
+  disable! date: "2027-05-31", because: :deprecated_upstream, replacement_formula: "docker"
+  
   def install
     bash_completion.install "contrib/completion/bash/docker"
     fish_completion.install "contrib/completion/fish/docker.fish"

--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -23,7 +23,6 @@
   ["dart-sdk", "dartaotruntime"],
   ["dbhash", "lemon", "sqldiff", "sqlite", "sqlite-analyzer", "sqlite-rsync"],
   ["dmd", "dtools"],
-  ["docker", "docker-completion"],
   ["etl", "synfig"],
   ["file-formula", "libmagic"],
   ["edencommon", "fb303", "fbthrift", "fizz", "folly", "mvfst", "proxygen", "wangle", "watchman"],


### PR DESCRIPTION
- `docker-completion` is no longer a dependency of `docker` (version sync should have probably been removed as part of the PR below).
- Manually maintained completion scripts are being phased out in favor of the generated completion scripts.

Please see https://github.com/Homebrew/homebrew-core/pull/284545

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
