### PR TITLE
asccli 0.18.1 (new formula)

### DIFF
--- a/Formula/a/asccli.rb
+++ b/Formula/a/asccli.rb
@@ -1,0 +1,32 @@
+class Asccli < Formula
+  desc "App Store Connect CLI to manage apps, versions, and screenshots"
+  homepage "https://github.com/tddworks/asc-cli"
+  url "https://github.com/tddworks/asc-cli/archive/refs/tags/v0.18.1.tar.gz"
+  sha256 "7141fca15206f05d041c1f9bd4bbf6ec245f3217e94199ab48264add1eafc2ac"
+  license "MIT"
+
+  depends_on xcode: ["26.0", :build]
+  depends_on macos: :sequoia
+
+  uses_from_macos "swift" => :build
+
+  def install
+    inreplace "Sources/ASCCommand/Version.swift", 'let ascVersion = "0.1.3"', %Q(let ascVersion = "#{version}")
+    system "swift", "build", "--disable-sandbox", "-c", "release"
+    bin.install ".build/release/asc" => "asccli"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/asccli --version")
+
+    # `auth check` resolves credentials from the environment and prints the
+    # account status as JSON, exercising real functionality with no network
+    # access. Throwaway credentials keep the test self-contained.
+    ENV["ASC_KEY_ID"] = "TESTKEYID"
+    ENV["ASC_ISSUER_ID"] = "00000000-0000-0000-0000-000000000000"
+    ENV["ASC_PRIVATE_KEY"] = "-----BEGIN PRIVATE KEY-----\nTEST\n-----END PRIVATE KEY-----"
+    status = shell_output("#{bin}/asccli auth check")
+    assert_match "keyID", status
+    assert_match "issuerID", status
+  end
+end


### PR DESCRIPTION
-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source asccli`?
- [x] Is your test running fine `brew test asccli`?
- [x] Does your build pass `brew audit --strict asccli` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source asccli`)? If this is a new formula, does it pass `brew audit --new asccli`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

AI-assisted contribution by Claude (Claude Code, Opus 4.8). The AI updated the formula (`url`/`sha256` to v0.18.1 and a build-time `inreplace` to set the version) and ran all validation. Build, test, audit (`--new --strict`), and style were executed and verified by the AI. The human author added the project's `LICENSE` file and cut the v0.18.1 release.

Built and tested locally on macOS 26.4 running arm64 (Xcode 26.4).

`asc` is an App Store Connect CLI for managing iOS/macOS apps (versions, builds, screenshots) from the terminal. The binary is installed as `asccli` to avoid a generic `asc` name.
