### PR TITLE
Annotate patches with type/resolves (demo for brew#22466)

### DIFF
--- a/Formula/g/gecode.rb
+++ b/Formula/g/gecode.rb
@@ -23,6 +23,7 @@ class Gecode < Formula
   patch do
     url "https://github.com/Gecode/gecode/commit/c0ca0e5f4406099be22f87236ea8547c2f31ded3.patch?full_index=1"
     sha256 "233b266a943c0619b027b4cb19912e2a8c9d1f8e4323a3627765cb32b47c59fe"
+    type :cherry_pick
   end
 
   def install

--- a/Formula/g/glibc.rb
+++ b/Formula/g/glibc.rb
@@ -147,6 +147,7 @@ class Glibc < Formula
     url "https://archive.ubuntu.com/ubuntu/pool/main/g/glibc/glibc_2.39-0ubuntu8.7.debian.tar.xz"
     mirror "https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/glibc/2.39-0ubuntu8.7/glibc_2.39-0ubuntu8.7.debian.tar.xz"
     sha256 "9642284fbb90ca3b56af777e3e5d6989bf3f80ba5d0c37c4ec0c94fb37912b70"
+    type :backport
     apply "patches/any/CVE-2024-2961.patch",
           "patches/any/CVE-2024-33599.patch",
           "patches/any/CVE-2024-33600_1.patch",
@@ -163,6 +164,7 @@ class Glibc < Formula
   # Backport of various test suite fixes
   patch do
     file "Patches/glibc/2.39-test-fixes.patch"
+    type :backport
   end
 
   def install

--- a/Formula/i/innoextract.rb
+++ b/Formula/i/innoextract.rb
@@ -20,6 +20,8 @@ class Innoextract < Formula
     patch do
       url "https://github.com/dscharrer/innoextract/commit/264c2fe6b84f90f6290c670e5f676660ec7b2387.patch?full_index=1"
       sha256 "f968a9c0521083dd4076ce5eed56127099a9c9888113fc50f476b914396045cc"
+      type :backport
+      resolves "https://github.com/dscharrer/innoextract/pull/169"
     end
   end
 

--- a/Formula/lib/libquicktime.rb
+++ b/Formula/lib/libquicktime.rb
@@ -32,6 +32,10 @@ class Libquicktime < Formula
   patch do
     url "https://deb.debian.org/debian/pool/main/libq/libquicktime/libquicktime_1.2.4-12.debian.tar.xz"
     sha256 "e5b5fa3ec8391b92554d04528568d04ea9eb5145835e0c246eac7961c891a91a"
+    type :backport
+    resolves "CVE-2016-2399",
+             "CVE-2017-9122", "CVE-2017-9123", "CVE-2017-9124", "CVE-2017-9125",
+             "CVE-2017-9126", "CVE-2017-9127", "CVE-2017-9128"
     apply "patches/CVE-2016-2399.patch"
     apply "patches/CVE-2017-9122_et_al.patch"
   end
@@ -39,6 +43,7 @@ class Libquicktime < Formula
   # Fix -flat_namespace being used on Big Sur and later.
   patch do
     file "Patches/libtool/configure-pre-0.4.2.418-big_sur.diff"
+    type :unofficial
   end
 
   def install


### PR DESCRIPTION
Demo of the `type` and `resolves` patch annotations proposed in Homebrew/brew#22466 (discussion: https://github.com/orgs/Homebrew/discussions/6869). One formula per case:

- `libquicktime`: `:backport` with explicit CVE `resolves`, plus `:unofficial` for the libtool/Big Sur fix
- `glibc`: `:backport` with no explicit `resolves`, to show CVE inference from `apply` paths
- `innoextract`: `:backport` with an issue-URL `resolves` (serialised as `"type": "defect"`)
- `gecode`: `:cherry_pick` for a commit taken from a release branch rather than the development tip

These are metadata-only additions inside existing `patch do` blocks; no `url`/`sha256`/`apply` changes, so bottles are unaffected.

CI will fail until Homebrew/brew#22466 is merged because released `brew` doesn't recognise the new stanzas. That's expected.

<details>
<summary>Serialised <code>brew info --json</code> output</summary>

```json
{
  "name": "libquicktime",
  "patches": [
    {
      "strip": "p1",
      "url": "https://deb.debian.org/debian/pool/main/libq/libquicktime/libquicktime_1.2.4-12.debian.tar.xz",
      "sha256": "e5b5fa3ec8391b92554d04528568d04ea9eb5145835e0c246eac7961c891a91a",
      "apply": ["patches/CVE-2016-2399.patch", "patches/CVE-2017-9122_et_al.patch"],
      "type": "backport",
      "resolves": [
        {"type": "security", "id": "CVE-2016-2399"},
        {"type": "security", "id": "CVE-2017-9122"},
        {"type": "security", "id": "CVE-2017-9123"},
        {"type": "security", "id": "CVE-2017-9124"},
        {"type": "security", "id": "CVE-2017-9125"},
        {"type": "security", "id": "CVE-2017-9126"},
        {"type": "security", "id": "CVE-2017-9127"},
        {"type": "security", "id": "CVE-2017-9128"}
      ]
    },
    {
      "strip": "p1",
      "url": "https://raw.githubusercontent.com/Homebrew/homebrew-core/1cf441a0/Patches/libtool/configure-pre-0.4.2.418-big_sur.diff",
      "sha256": "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923",
      "type": "unofficial"
    }
  ]
}
{
  "name": "glibc",
  "patches": [
    {
      "strip": "p1",
      "url": "https://archive.ubuntu.com/ubuntu/pool/main/g/glibc/glibc_2.39-0ubuntu8.7.debian.tar.xz",
      "sha256": "9642284fbb90ca3b56af777e3e5d6989bf3f80ba5d0c37c4ec0c94fb37912b70",
      "type": "backport",
      "resolves": [
        {"type": "security", "id": "CVE-2024-2961"},
        {"type": "security", "id": "CVE-2024-33599"},
        {"type": "security", "id": "CVE-2024-33600"},
        {"type": "security", "id": "CVE-2024-33601"},
        {"type": "security", "id": "CVE-2025-0395"},
        {"type": "security", "id": "CVE-2025-5702"},
        {"type": "security", "id": "CVE-2025-8058"},
        {"type": "security", "id": "CVE-2025-15281"},
        {"type": "security", "id": "CVE-2026-0861"},
        {"type": "security", "id": "CVE-2026-0915"}
      ]
    },
    {
      "strip": "p1",
      "url": "https://raw.githubusercontent.com/Homebrew/homebrew-core/431b170696708f36aa0bd51139406e26ade0a7eb/Patches/glibc/2.39-test-fixes.patch",
      "sha256": "1a7a6481d03ce23bdc2385413ac1784684e3e1f72f68ce7f720755abfae2f4e9",
      "type": "backport"
    }
  ]
}
{
  "name": "innoextract",
  "patches": [
    {
      "strip": "p1",
      "url": "https://github.com/dscharrer/innoextract/commit/264c2fe6b84f90f6290c670e5f676660ec7b2387.patch?full_index=1",
      "sha256": "f968a9c0521083dd4076ce5eed56127099a9c9888113fc50f476b914396045cc",
      "type": "backport",
      "resolves": [{"type": "defect", "id": "https://github.com/dscharrer/innoextract/pull/169"}]
    }
  ]
}
{
  "name": "gecode",
  "patches": [
    {
      "strip": "p1",
      "url": "https://github.com/Gecode/gecode/commit/c0ca0e5f4406099be22f87236ea8547c2f31ded3.patch?full_index=1",
      "sha256": "233b266a943c0619b027b4cb19912e2a8c9d1f8e4323a3627765cb32b47c59fe",
      "type": "cherry-pick"
    }
  ]
}
```

</details>

The `glibc` block has no explicit `resolves` in the formula; the ten CVEs above are all inferred from the `apply` filenames. Inference misses `CVE-2024-33602` because the file is named `CVE-2024-33601_33602.patch` and only the first ID matches the pattern, which is the sort of case where an explicit `resolves` is still useful.

A wider backfill across the ~935 `patch do` blocks in core would follow separately, scripted by URL heuristic rather than hand-edited.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`? *Metadata-only change; no source/build difference.*
- [ ] Is your test running fine `brew test <formula>`? *As above.*
- [ ] Does your build pass `brew audit --strict <formula>`? *Cannot pass until Homebrew/brew#22466 lands; `brew style` against the brew PR branch is clean.*

-----

- [x] AI was used to generate or assist with generating this PR.

Written with Claude Code. I've reviewed the diff, run `brew style` on each file against the Homebrew/brew#22466 branch, and verified the JSON output above with `brew ruby` + `Formulary.from_contents`.

-----