### PR TITLE
dot-vault 0.2.7 (new formula)

### DIFF
--- a/Formula/d/dot-vault.rb
+++ b/Formula/d/dot-vault.rb
@@ -1,0 +1,25 @@
+class DotVault < Formula
+  desc "CLI for DotVault — secure environment variable management"
+  homepage "https://github.com/lucerowb/dot-vault"
+  url "https://registry.npmjs.org/@lucerowb/dot-vault/-/dot-vault-0.2.7.tgz"
+  sha256 "75d52137cc138fb2de711457712c39144c98bf52b1e3ad8a604eaf4d19808a28"
+  license "MIT"
+
+  livecheck do
+    url "https://registry.npmjs.org/@lucerowb/dot-vault/latest"
+    strategy :json do |json|
+      json["version"]
+    end
+  end
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink libexec.glob("bin/*")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/dv --version")
+  end
+end


### PR DESCRIPTION
## Summary

Adds [DotVault](https://github.com/lucerowb/dot-vault) CLI (`dv`, `dot-vault`, `dotvault`) — open-source (MIT) command-line client for encrypted `.env` sync against a self-hosted or cloud DotVault server.

- Published on npm as `@lucerowb/dot-vault` (v0.2.7)
- Node.js CLI installed via `std_npm_args` (same pattern as `todoist-cli`)
- Upstream tap (for users before core acceptance): `brew tap lucerowb/dot-vault https://github.com/lucerowb/dot-vault`

**Self-submission note:** I am the upstream author. I understand [notability requirements](https://docs.brew.sh/Acceptable-Formulae) for self-submitted software (≥225 GitHub stars / equivalent). The project is early; happy to keep distribution via the project tap until metrics improve if maintainers prefer.

## Test plan

- [ ] `brew install --build-from-source dot-vault`
- [ ] `brew test dot-vault`
- [ ] `brew audit --strict --new dot-vault`