### PR TITLE
cdo: remove non-upstreamable patch and instead use compatible compiler

### DIFF
--- a/Formula/c/cdo.rb
+++ b/Formula/c/cdo.rb
@@ -30,7 +30,11 @@ class Cdo < Formula
   uses_from_macos "python" => :build
 
   on_macos do
-    depends_on "llvm" => :build if DevelopmentTools.clang_build_version <= 1500
+    depends_on "llvm" => :build if DevelopmentTools.clang_build_version <= 1699
+  end
+
+  on_sequoia do
+    depends_on xcode: ["26.0", :build] if DevelopmentTools.clang_build_version >= 1700
   end
 
   on_linux do
@@ -38,17 +42,11 @@ class Cdo < Formula
   end
 
   fails_with :clang do
-    build 1500
-    cause "Requires C++20 support"
+    build 1699
+    cause "needs C++20 std::jthreads"
   end
 
   def install
-    # Upstream switched std::thread → std::jthread in 2.6.1 but doesn't use any jthread-specific feature.
-    # macOS 14/15 SDK libc++ lacks std::jthread, so revert to std::thread.
-    if OS.mac? && MacOS.version <= :sequoia
-      inreplace ["src/workerthread.h", "src/workerthread.cc"], "std::jthread", "std::thread"
-    end
-
     args = %W[
       --disable-openmp
       --with-eccodes=#{Formula["eccodes"].opt_prefix}


### PR DESCRIPTION
We don't want to maintain non-upstreamable patches.

Compiler-specific failures should instead be fixed by using a correct compiler.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
