### PR TITLE
mp3blaster: deprecate

### DIFF
--- a/Formula/m/mp3blaster.rb
+++ b/Formula/m/mp3blaster.rb
@@ -22,6 +22,10 @@ class Mp3blaster < Formula
     sha256 x86_64_linux:   "2ecc188df98ee829da61e43203f0f1d9601eb7a362b4821638ab08bba6f8c2b5"
   end
 
+  # Last release on 2017-05-15 and still needs SDL 1.2
+  deprecate! date: "2026-06-01", because: :unmaintained
+  disable! date: "2027-06-01", because: :unmaintained
+
   depends_on "sdl12-compat"
 
   uses_from_macos "ncurses"


### PR DESCRIPTION
Deprecating formulae that haven't no activity in many years (with 0 dependents) that are still on SDL 1.2

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
