### PR TITLE
frotz: switch to stable tarball to avoid gitattributes checksum change

### DIFF
--- a/Formula/f/frotz.rb
+++ b/Formula/f/frotz.rb
@@ -1,8 +1,8 @@
 class Frotz < Formula
   desc "Infocom-style interactive fiction player"
   homepage "https://661.org/proj/if/frotz/"
-  url "https://gitlab.com/DavidGriffith/frotz/-/archive/2.55/frotz-2.55.tar.bz2"
-  sha256 "235a8606aa1e654aa5a5a41b5c7b5ae1e934aab30fb2e2b18e2e35a4eafcd745"
+  url "https://www.ifarchive.org/if-archive/infocom/interpreters/frotz/frotz-2.55.tar.gz"
+  sha256 "e3d6912ff94bca724759fe59aa222c1ee23aa4d35ffa15a0b40f72f97887d871"
   license "GPL-2.0-or-later"
   head "https://gitlab.com/DavidGriffith/frotz.git", branch: "master"
 


### PR DESCRIPTION
The gitlab archive tarball had a checksum mismatch as the repository uses git attributes to substitute values when generating archive, see https://gitlab.com/DavidGriffith/frotz/-/blob/2.55/Makefile#L341

Verified by using Gentoo's copy of checksum matching tarball:
```console
❯ curl -s https://distfiles.gentoo.org/distfiles/fd/frotz-2.55.tar.bz2 | sha256
235a8606aa1e654aa5a5a41b5c7b5ae1e934aab30fb2e2b18e2e35a4eafcd745
```

And running diffoscope to see only difference is from Makefile:
```
│ │ -GIT_HASH_SHORT = acf20558
│ │ +GIT_HASH_SHORT = acf2055
```

Rather than using auto-generated archive, this PR switches to official tarballs. It uses the homepage tarball and falls back to mirror from officially listed https://gitlab.com/DavidGriffith/frotz#downloads

```console
❯ curl -s https://661.org/proj/if/files/frotz-2.55.tar.gz | sha256
e3d6912ff94bca724759fe59aa222c1ee23aa4d35ffa15a0b40f72f97887d871
❯ curl -s https://www.ifarchive.org/if-archive/infocom/interpreters/frotz/frotz-2.55.tar.gz | sha256
e3d6912ff94bca724759fe59aa222c1ee23aa4d35ffa15a0b40f72f97887d871
```

-----

Comparison between Gentoo's copy of bz2 and official ifarchive tarball shows contents are identical and only compression format is different:
```console
❯ curl -sLO https://distfiles.gentoo.org/distfiles/fd/frotz-2.55.tar.bz2

❯ curl -sLO https://www.ifarchive.org/if-archive/infocom/interpreters/frotz/frotz-2.55.tar.gz

❯ diffoscope frotz-2.55.tar.bz2 frotz-2.55.tar.gz
--- frotz-2.55.tar.bz2
+++ frotz-2.55.tar.gz
├── filetype from file(1)
│ @@ -1 +1 @@
│ -bzip2 compressed data, block size = 900k
│ +gzip compressed data, from Unix
├── filetype from diffoscope
│ @@ -1 +1 @@
│ -Bzip2File
│ +GzipFile

❯ bunzip2 frotz-2.55.tar.bz2

❯ mv frotz-2.55.tar  frotz-2.55.gentoo.tar

❯ gunzip frotz-2.55.tar.gz

❯ diffoscope frotz-2.55.gentoo.tar frotz-2.55.tar; echo $?
0
```