### PR TITLE
sdl2_gfx: link to libm on Linux for `sdl2-compat`

### DIFF
--- a/Formula/s/sdl2_gfx.rb
+++ b/Formula/s/sdl2_gfx.rb
@@ -5,6 +5,7 @@ class Sdl2Gfx < Formula
   mirror "https://sources.voidlinux.org/SDL2_gfx-1.0.4/SDL2_gfx-1.0.4.tar.gz"
   sha256 "63e0e01addedc9df2f85b93a248f06e8a04affa014a835c2ea34bfe34e576262"
   license "Zlib"
+  revision 1
 
   livecheck do
     url :homepage
@@ -34,7 +35,11 @@ class Sdl2Gfx < Formula
     args << "--disable-mmx" if Hardware::CPU.arm?
 
     # Help old config scripts identify arm64 linux
-    args << "--build=aarch64-unknown-linux-gnu" if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+    args << "--build=aarch64-unknown-linux-gnu" if OS.linux? && Hardware::CPU.arm64?
+
+    # Workaround to avoid undefined references with `sdl2-compat`.
+    # Not actively maintained with last activity in 2018
+    ENV.append "LIBS", "-lm" if OS.linux?
 
     system "./configure", "--disable-sdltest", *args, *std_configure_args
     system "make", "install"

--- a/Formula/s/sdl2_gfx.rb
+++ b/Formula/s/sdl2_gfx.rb
@@ -13,19 +13,12 @@ class Sdl2Gfx < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:    "e47f4d00e05f9f9f5329cf59d7b850c6825def067848db1bf34d2aa06727972e"
-    sha256 cellar: :any,                 arm64_sequoia:  "0edb8d3b267ce8edd5135b4ab15a2e050204ba10a38b4340e83fe468b78bc8fd"
-    sha256 cellar: :any,                 arm64_sonoma:   "ce7aacaf54e17f764780e7480ea8c6ea032f9736565974537bbf3a09645cbc01"
-    sha256 cellar: :any,                 arm64_ventura:  "9c294fad8fbad927f3041868451946dc56c35f1d90f9aeef625e803113e65d09"
-    sha256 cellar: :any,                 arm64_monterey: "7c17dcf54036d30d7bbc8d76bfcd51b8c966cc1653c886a7b188a897a483da94"
-    sha256 cellar: :any,                 arm64_big_sur:  "7c632415953aecce33ea6b66b0d0b75461db7987bf560802e408d308bcd9b653"
-    sha256 cellar: :any,                 sonoma:         "3678d4052241eb8785cca53190d302d8ccb69d05a4f12f28eb1d09af05070de6"
-    sha256 cellar: :any,                 ventura:        "07ced752aa459a1242b44edb51e3ad95146ac3a0920a904ce85d00ff22389906"
-    sha256 cellar: :any,                 monterey:       "befe6548ad09bcdb75ce8363af39231065da928283ed7628daf7a5776725462c"
-    sha256 cellar: :any,                 big_sur:        "9466b3ad0c9a29ca01a8c804b529ad7c89bd42c4d8b79b37bc079419464cc9f2"
-    sha256 cellar: :any,                 catalina:       "9db41c0f2fd4897456594769a4a549b5261c3027dde8fc6da7160faf7db0a539"
-    sha256 cellar: :any_skip_relocation, arm64_linux:    "4774eb2e827ddefb293a54c297cd292530b2aad4ffffafae52385fed9eda3497"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "9a779702029d05cd1923b70eff455385362d0069fcf31e0e0c1211279893ae5a"
+    sha256 cellar: :any, arm64_tahoe:   "656d8e9d2503d3e176165c70e240c4acd3d8fb6d8845a5da300439c9c4c92990"
+    sha256 cellar: :any, arm64_sequoia: "4495c158a58866ad66a946ba06222a9041a1b670dc255c62cae1a6251981e87c"
+    sha256 cellar: :any, arm64_sonoma:  "726280db5aa92a0ace6d293c1b6b807ee6eb34fd76665208d85b562445dff99b"
+    sha256 cellar: :any, sonoma:        "8efc5bff6b68d8598d6097bd16f62360452415d294a22c30f81132c4a0f64480"
+    sha256 cellar: :any, arm64_linux:   "d6c4321fa7c217877cad6c6815f5bc671b5fd3f390aef62061018f03dfbbbab3"
+    sha256 cellar: :any, x86_64_linux:  "63a286ac8e097c5048702a8b88c70a04f33148e0d98e1ba9aeb52a631538e53c"
   end
 
   depends_on "sdl2"


### PR DESCRIPTION
This likely worked when directly linking to real `sdl2`, but upcoming `sdl2-compat` is just a layer that dynamically loads `sdl3`.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
