### PR TITLE
cataclysm: update test for sdl2-compat

### DIFF
--- a/Formula/c/cataclysm.rb
+++ b/Formula/c/cataclysm.rb
@@ -82,11 +82,18 @@ class Cataclysm < Formula
     end
     user_config_dir.mkpath
 
-    # run cataclysm for 30 seconds
+    # "Error while initializing the interface: SDL_Init failed: No available video device"
+    ENV["SDL_VIDEODRIVER"] = "dummy" if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"]
+
+    # run cataclysm for 50 seconds
+    tries = 0
     pid = spawn bin/"cataclysm"
     begin
-      sleep 50
+      sleep 5
       assert_path_exists user_config_dir/"config", "User config directory should exist"
+    rescue Minitest::Assertion
+      retry if (tries += 1) < 10
+      raise
     ensure
       Process.kill("TERM", pid)
       Process.wait(pid)


### PR DESCRIPTION
SDL3 seems to be noisier on missing video. Not sure if it used to fall back or something else but can use dummy driver similar to how we use minimal for Qt.

Also end test earlier rather than always waiting 50 seconds.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
