### PR TITLE
gixy 0.2.47 (new formula)

### DIFF
--- a/Formula/g/gixy.rb
+++ b/Formula/g/gixy.rb
@@ -7,6 +7,15 @@ class Gixy < Formula
   sha256 "6729f4ae6b24ce554925bce51cbbca9e51785c31a2f85b923834c40c8d200dd1"
   license "MPL-2.0"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "a30384b8f9bc80569038c265d514b768e08b10c79a2511562fef0bd13d7b82de"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "50f868e601223a4aef9e540147a945eccd3448b4ea003bb35969117ff1165f6d"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "f9a83f796cfa79fbbddee70b7c3de5cffbf250da1a31d03f439ae74f3ebc6e51"
+    sha256 cellar: :any_skip_relocation, sonoma:        "cc7a9b71c8623cbc513ff208c56d78441d2b9c0741203b800ad1c643405ab1e5"
+    sha256 cellar: :any,                 arm64_linux:   "d6b5b0e35eea7245d48ecd0fcd4aba3bd31f7c5755d299d2db3daa142b2a71b6"
+    sha256 cellar: :any,                 x86_64_linux:  "a3a605c5c9202e4413d2c8387a51884ea06cb18a26e35ab9b88c74876c552581"
+  end
+
   depends_on "python@3.14"
 
   resource "configargparse" do

--- a/Formula/g/gixy.rb
+++ b/Formula/g/gixy.rb
@@ -1,0 +1,53 @@
+class Gixy < Formula
+  include Language::Python::Virtualenv
+
+  desc "NGINX configuration static analyzer focused on security"
+  homepage "https://gixy.getpagespeed.com/"
+  url "https://files.pythonhosted.org/packages/3d/88/ef2d8958a63d901a32bb97aa94f2c00817d288ca876b734ae34fc7b5aefc/gixy_ng-0.2.47.tar.gz"
+  sha256 "6729f4ae6b24ce554925bce51cbbca9e51785c31a2f85b923834c40c8d200dd1"
+  license "MPL-2.0"
+
+  depends_on "python@3.14"
+
+  resource "configargparse" do
+    url "https://files.pythonhosted.org/packages/3f/0b/30328302903c55218ffc5199646d0e9d28348ff26c02ba77b2ffc58d294a/configargparse-1.7.5.tar.gz"
+    sha256 "e3f9a7bb6be34d66b2e3c4a2f58e3045f8dfae47b0dc039f87bcfaa0f193fb0f"
+  end
+
+  resource "jinja2" do
+    url "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz"
+    sha256 "0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d"
+  end
+
+  resource "markupsafe" do
+    url "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz"
+    sha256 "722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698"
+  end
+
+  resource "ngxparse" do
+    url "https://files.pythonhosted.org/packages/35/2e/b6247bc5ebaeb5a70c81c865451c140fa30d8c3a6e81598a659c0497e525/ngxparse-0.5.16.tar.gz"
+    sha256 "33746d1693d93903ab0c2b37ba16b8a4743a2767b1959dc125a2417d253b7e3b"
+  end
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/gixy --version")
+
+    (testpath/"vuln.conf").write <<~NGINX
+      http {
+        server {
+          listen 80;
+          location / {
+            return 301 http://$host$uri;
+          }
+        }
+      }
+    NGINX
+    # Gixy exits non-zero when issues are found, hence the trailing `:1`.
+    output = shell_output("#{bin}/gixy --format=json #{testpath}/vuln.conf 2>&1", 1)
+    assert_match "http_splitting", output
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you checked that there aren't other open pull requests for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

---

## Summary

[Gixy](https://gixy.getpagespeed.com/) is a static analyzer for NGINX configurations focused on security misconfigurations (HTTP response splitting, host spoofing, alias-traversal off-by-slash, missing `add_header` inheritance, weak SSL ciphers, etc.). Originally created at Yandex; this submission tracks the maintained PyPI distribution [`gixy-ng`](https://pypi.org/project/gixy-ng/), which is actively released (currently 0.2.47, May 2026) and ships fixes/plugins on top of the now-archived Yandex tree.

Useful for anyone editing nginx configs as part of a deploy. macOS-friendly: pure Python, no compiled deps.

## Notes

- Homepage points to the project docs site (https://gixy.getpagespeed.com/) since the GitHub-hosted code lives in a fork of the original Yandex repository.
- `MPL-2.0` license per upstream `LICENSE` file.
- Resources cover all runtime deps (`ngxparse`, `Jinja2` + `MarkupSafe`, `ConfigArgParse`). Optional `rich` and `requests` are intentionally omitted to keep the install lean; users who want them can `pip install` into a separate environment.
- `brew install --build-from-source gixy` succeeds on macOS arm64 (Apple Silicon).
- `brew test gixy` passes (`--version` and a real config that triggers `http_splitting`).
- `brew audit --strict --online --new gixy` is clean.