### PR TITLE
node@*: move npmrc to bottle

### DIFF
--- a/Formula/n/node@20.rb
+++ b/Formula/n/node@20.rb
@@ -87,9 +87,7 @@ class NodeAT20 < Formula
 
     system "./configure", *args
     system "make", "install"
-  end
 
-  def post_install
     (lib/"node_modules/npm/npmrc").atomic_write("prefix = #{HOMEBREW_PREFIX}\n")
   end
 
@@ -117,5 +115,7 @@ class NodeAT20 < Formula
     assert_path_exists bin/"npx", "npx must exist"
     assert_predicate bin/"npx", :executable?, "npx must be executable"
     assert_match "< hello >", shell_output("#{bin}/npx --yes cowsay hello")
+
+    assert_equal HOMEBREW_PREFIX.to_s, shell_output("#{bin}/npm config get prefix").chomp
   end
 end

--- a/Formula/n/node@20.rb
+++ b/Formula/n/node@20.rb
@@ -11,12 +11,13 @@ class NodeAT20 < Formula
   end
 
   bottle do
-    sha256 arm64_tahoe:   "cfab6d6c08ea8cef44130a4903d1c006686a837f4b69d3fb20b62577b3173ae3"
-    sha256 arm64_sequoia: "cba9df52d19c5c11b09ecba5b8a8e38e9a3db1aa2a2ccfed849ada4a73c224b0"
-    sha256 arm64_sonoma:  "29fb1d06f966cb33effea66a8319ae85666731eb0899bb4eedf7d63e7de05d4b"
-    sha256 sonoma:        "fc5d3c9b95e5151bce6dc7bcfb71e8adbaa185c620b31f8293e6fff946e3d9ca"
-    sha256 arm64_linux:   "61d93138a6ceea6f3e69541930d741281a915ff05d202762af2a44d00ad07529"
-    sha256 x86_64_linux:  "1f6bd6a359bd340669d24fbd562a073cf296c5aa5a25be432feb45c4fd5a351c"
+    rebuild 1
+    sha256 arm64_tahoe:   "ecdcb6357c02e973fe7bed1b85fa142166e743aecde394046a4278e8d7acfa65"
+    sha256 arm64_sequoia: "76829440870e8535079d7b600a15e3c2c66f31499981ac91bd4f6b7a10af91ed"
+    sha256 arm64_sonoma:  "b85e5e17778b5d29753616507b9c54bc1a98f07094f1deecd829b1310098f0f2"
+    sha256 sonoma:        "51df24b083cec403185e1cc43b79e2845600a3c8936340ae6578cac011b6ce81"
+    sha256 arm64_linux:   "220c54e9d8cf434846cd20392f6e73b156e5e67a51f1b24d99fa70585579dbda"
+    sha256 x86_64_linux:  "6f741ad57671a0997c93de0bbfeef6d22769eadd7de4ca6f333aeedbfc901f8f"
   end
 
   keg_only :versioned_formula

--- a/Formula/n/node@22.rb
+++ b/Formula/n/node@22.rb
@@ -132,16 +132,11 @@ class NodeAT22 < Formula
 
     system "./configure", *args
     system "make", "install"
-  end
 
-  def post_install
     (lib/"node_modules/npm/npmrc").atomic_write("prefix = #{HOMEBREW_PREFIX}\n")
   end
 
   test do
-    # Make sure Mojave does not have `CC=llvm_clang`.
-    ENV.clang if OS.mac?
-
     path = testpath/"test.js"
     path.write "console.log('hello');"
 
@@ -165,5 +160,7 @@ class NodeAT22 < Formula
     assert_path_exists bin/"npx", "npx must exist"
     assert_predicate bin/"npx", :executable?, "npx must be executable"
     assert_match "< hello >", shell_output("#{bin}/npx --yes cowsay hello")
+
+    assert_equal HOMEBREW_PREFIX.to_s, shell_output("#{bin}/npm config get prefix").chomp
   end
 end

--- a/Formula/n/node@22.rb
+++ b/Formula/n/node@22.rb
@@ -12,12 +12,13 @@ class NodeAT22 < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "02324491602549ef17b82677db2d4b662d7940c9ff1040400f2ac9826edc0415"
-    sha256 cellar: :any,                 arm64_sequoia: "6caf12083a7b916b4c8d758546eab03e92ab423b621468897d9f462c1d9509ee"
-    sha256 cellar: :any,                 arm64_sonoma:  "b14e0f06928ef072e8a55761cb4e067f1965821f2fa0e65005a850b32785a1d8"
-    sha256 cellar: :any,                 sonoma:        "1d9aec34dfa3fd8ee6fa25a184234524e20537fea71697b9b7b761c38de3b4e1"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "da5c9cdb6cbbea3ccdc77aa3b44869dfbd06618b5cc5bceb650c246f55a30df5"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f76e8ef91851f01b80cc5f17b2c9b5b1d12baa2968b468eec72bfaf591d15788"
+    rebuild 1
+    sha256 cellar: :any, arm64_tahoe:   "b816f097e858bd782fdabaa7c43cdf6d9b61e40798ddd596413b8368c491cf49"
+    sha256 cellar: :any, arm64_sequoia: "2a6149417ac1727912ae188e597bf00a0629a8e513e3f370c5c0c30c59693af9"
+    sha256 cellar: :any, arm64_sonoma:  "382349bf29b095ab27fdfb85b1b22ddd6750237cdd4080dfd23303aea7ecbbb7"
+    sha256 cellar: :any, sonoma:        "8f871c730de49ba722d15bb6c0b29a9d56b9401bea7fb4927144616acdf18ea8"
+    sha256 cellar: :any, arm64_linux:   "9908fc1f7cc87b3b3ff6709a1761c9604d8103056504fa9d252b7b3b9014920f"
+    sha256 cellar: :any, x86_64_linux:  "5ef46a3ae4c97d48ce205bebaa642088783ed58d93fcba5f3a85ff7a86313a14"
   end
 
   keg_only :versioned_formula

--- a/Formula/n/node@24.rb
+++ b/Formula/n/node@24.rb
@@ -153,9 +153,7 @@ class NodeAT24 < Formula
 
     system "./configure", *args
     system "make", "install"
-  end
 
-  def post_install
     (lib/"node_modules/npm/npmrc").atomic_write("prefix = #{HOMEBREW_PREFIX}\n")
   end
 
@@ -183,6 +181,8 @@ class NodeAT24 < Formula
     assert_path_exists bin/"npx", "npx must exist"
     assert_predicate bin/"npx", :executable?, "npx must be executable"
     assert_match "< hello >", shell_output("#{bin}/npx --yes cowsay hello")
+
+    assert_equal HOMEBREW_PREFIX.to_s, shell_output("#{bin}/npm config get prefix").chomp
 
     # Test `uvwasi` is linked correctly
     (testpath/"wasi-smoke-test.mjs").write <<~JAVASCRIPT

--- a/Formula/n/node@24.rb
+++ b/Formula/n/node@24.rb
@@ -12,12 +12,13 @@ class NodeAT24 < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "c487f4c8dcb5f6a81e3a3ac074d6f0df8e6e0e23160e901af98d6ef0f01d8b08"
-    sha256 cellar: :any,                 arm64_sequoia: "d0208bdc66f721afb0847ee46611523316bfbb28c28c704a4426d1702bf2d230"
-    sha256 cellar: :any,                 arm64_sonoma:  "80ddd5c54e7d4b7c059c7cc65b3c987ae18943df3cb4cdf01fb51b90419c113f"
-    sha256 cellar: :any,                 sonoma:        "f7dbfd735308a6f63ab41f1af83224c0ce5182576e2fd5eb9eae405438a3d522"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "5ccc8c7a133d1c88ba6aa8f76b88896feab769e83c1eb44a2b509a447daa2776"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "7c170a3f4e9809ce06db9739014b7ed4fe95e4446789d7a3b019da325b5bc44f"
+    rebuild 1
+    sha256 cellar: :any, arm64_tahoe:   "5121cfd30e74636fb2e68f049f0547f93d2d5c4332c6538d77ce875857c175f7"
+    sha256 cellar: :any, arm64_sequoia: "8158cdc05f05f520d70a5dc47818aa3dc88760d01959265455d2fff3733073cb"
+    sha256 cellar: :any, arm64_sonoma:  "0d239da024c3a3782d737a09f61aad51575b01e502ad9e29b591eb6d8badcecc"
+    sha256 cellar: :any, sonoma:        "c4bf23a92f6a4521e725c66963bf8f08d143271f37e9d6b4a764faa85d2fb17b"
+    sha256 cellar: :any, arm64_linux:   "ea62f644e77cb3b007effa3b7c06f8b177c3737abbf6c843326654d8fa021e5b"
+    sha256 cellar: :any, x86_64_linux:  "38d332bad403d573569a0551f00cd06051c1863b740d1d2c538af5cdf824efc3"
   end
 
   keg_only :versioned_formula


### PR DESCRIPTION
Not sure what why this was created in postinstall. For versioned formulae, this should be managed by Homebrew as it is installed inside keg and will be replaced on every `brew upgrade`.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
