### PR TITLE
ollama: bundle llama-server component

### DIFF
--- a/Formula/o/ollama.rb
+++ b/Formula/o/ollama.rb
@@ -17,12 +17,12 @@ class Ollama < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "99547afa6799bedad7f2607f19b32eff5d85c9620284bfc3219f10a627f549d5"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "48dbd4cc197514600c67c53560261a2adae0b46b29dd731681eb6adcf89d2389"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "dda0b4d2366167f1ac106a9a013cb2161ac3fb1ac34d1679deca03f591dae79c"
-    sha256 cellar: :any_skip_relocation, sonoma:        "0527a39614bee568dd08ac51c7cb5e95d8a228c1d96cfccfc7ecb6d0dd60d9ee"
-    sha256 cellar: :any,                 arm64_linux:   "4588379be978cc09c3cbb38791bb15cdc839a57368c072b5e4101a03ad96e084"
-    sha256 cellar: :any,                 x86_64_linux:  "65439b0f0cc794103fa26575264b0f03cb2c3ddfa9e732a1e8bfee4e0fed8667"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "e8c10db5193b2af8f3b6184f0074e72d7ce790a74fddaf0f9c867ecba33e4bae"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "171187466fa58658536fe14c309b4ee0fb48996d66d828e415f58496a6c5b061"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "547d17538b7803f39816a8b697f2e6c87389c7e9891422dacbd9eaeba7281194"
+    sha256 cellar: :any,                 sonoma:        "568ba5495e8d889aa8fed6699eca5ca97d46169461f819c4a5b88606ddc869a2"
+    sha256 cellar: :any,                 arm64_linux:   "d0322f0a305bd44fc8ff0c588637882dd635cf91704e65998bbd7c0570a33462"
+    sha256 cellar: :any,                 x86_64_linux:  "5e758ce3de05dbf74ce196180215e4037f68594ed341d1128112493f60dd6305"
   end
 
   depends_on "cmake" => :build

--- a/Formula/o/ollama.rb
+++ b/Formula/o/ollama.rb
@@ -5,6 +5,7 @@ class Ollama < Formula
       tag:      "v0.30.7",
       revision: "f0078ae4766d0d570e196158f20dde309bd96124"
   license "MIT"
+  revision 1
   head "https://github.com/ollama/ollama.git", branch: "main"
 
   # Upstream creates releases that use a stable tag (e.g., `v1.2.3`) but are
@@ -44,7 +45,42 @@ class Ollama < Formula
 
   conflicts_with cask: "ollama-app"
 
+  # Pinned dependency required by llama-server
+  resource "llama.cpp" do
+    url "https://github.com/ggml-org/llama.cpp.git",
+        tag:      "b9509",
+        revision: "6f3a9f3dee3c27545371044a3a38005721ac8a8e"
+
+    livecheck do
+      url "https://raw.githubusercontent.com/ollama/ollama/refs/tags/v#{LATEST_VERSION}/LLAMA_CPP_VERSION"
+      regex(/^v?b(\d+)$/i)
+    end
+
+    # fix: don't build AMX by default with Apple clang
+    patch do
+      url "https://github.com/ggml-org/llama.cpp/commit/1f92170dc9d4620b5aadb9bacba502c726e5b587.patch?full_index=1"
+      sha256 "1e51afe4b8cfed5653289270064370d926258b5bbd662a93eac240d7a37f2735"
+    end
+  end
+
   def install
+    # Build llama-server
+    llama_source_dir = buildpath/"llama.cpp"
+    llama_source_dir.install resource("llama.cpp")
+
+    preset = (OS.mac? && Hardware::CPU.arm?) ? "darwin" : "cpu"
+
+    args = %W[
+      --preset #{preset}
+      -DFETCHCONTENT_SOURCE_DIR_LLAMA_CPP=#{llama_source_dir}
+      -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON
+      -DCMAKE_INSTALL_RPATH=#{loader_path}
+    ]
+
+    system "cmake", "-S", "llama/server", "-B", "llama-server", *args, *std_cmake_args(install_prefix: libexec)
+    system "cmake", "--build", "llama-server"
+    system "cmake", "--install", "llama-server", "--component", "llama-server"
+
     # Remove ui app directory
     rm_r("app")
 
@@ -110,6 +146,31 @@ class Ollama < Formula
       output = shell_output("DYLD_PRINT_LIBRARIES=1 #{bin}/ollama --help 2>&1")
       assert_match "libmlxc.dylib", output
       assert_match "libmlx.dylib", output
+    end
+
+    # Check llama-server binary
+    require "pty"
+
+    output = +""
+    r, _w, pid = PTY.spawn(libexec/"lib/ollama/llama-server")
+    begin
+      timeout = Time.now + 20
+      until output.include?("starting router server")
+        raise "timed out waiting for llama-server to start\n#{output}" if Time.now > timeout
+
+        begin
+          output << r.read_nonblock(1024)
+        rescue IO::WaitReadable
+          sleep 0.1
+        rescue EOFError
+          break
+        end
+      end
+
+      assert_match "starting router server", output
+    ensure
+      Process.kill "TERM", pid
+      Process.wait pid
     end
   end
 end


### PR DESCRIPTION
Adds the llama-server component to the ollama formula to resolve the runtime crashes on v0.30.0 onwards.

Included fix ensures proper linking on both macOS and Linux by allowing necessary shared objects in the distribution.

I've disabled that building AMX extensions on MacOS as the build was failing by default, and furthermore, there are no Macs with AMX support anyway so it's safe to work around that.

Fixes #285917

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

I used AI to assist with writing the changes to the formula and resolving issues. Any workarounds I have used have been documented above. I have tried to follow best practice employed by other Homebrew formulae to ensure I am not introducing code smells or regressions.

The forumla has been verified on both a Mac and Linux machine.