### PR TITLE
goproxy: test fix

### DIFF
--- a/Formula/g/goproxy.rb
+++ b/Formula/g/goproxy.rb
@@ -34,8 +34,9 @@ class Goproxy < Formula
     begin
       server = IO.popen("#{bin}/goproxy -proxy=https://goproxy.io -listen=#{bind_address}", err: [:child, :out])
       sleep 1
+      sleep 2 if OS.mac? && Hardware::CPU.intel?
       ENV["GOPROXY"] = "http://#{bind_address}"
-      system "go", "install", "golang.org/x/tools/cmd/guru@latest"
+      system "go", "install", "golang.org/x/tools/cmd/goimports@latest"
     ensure
       Process.kill("SIGINT", server.pid)
     end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Test in recent
* https://github.com/Homebrew/homebrew-core/pull/285926
* https://github.com/Homebrew/homebrew-core/pull/281434

failed with:
```
  ==> Testing goproxy (again)
  ==> go install golang.org/x/tools/cmd/guru@latest
  go: downloading golang.org/x/tools v0.44.0
  go: golang.org/x/tools/cmd/guru@latest: module golang.org/x/tools@latest found (v0.44.0), but does not contain package golang.org/x/tools/cmd/guru
```

because `guru` tool was deleted:
* https://github.com/golang/go/issues/65880
* in https://github.com/golang/tools/commit/1f580da07881ed47f85cf39907a0b5c8e0d649b7

and is apparently not cached anymore at https://goproxy.io/