### PR TITLE
Use vacuum cask instead of formula

### DIFF
--- a/Formula/v/vacuum.rb
+++ b/Formula/v/vacuum.rb
@@ -15,6 +15,9 @@ class Vacuum < Formula
     sha256 cellar: :any,                 x86_64_linux:  "c07a87bffe884f103f097f4654864156d053060f9136c413317f2df4772684c7"
   end
 
+  deprecate! date: "2026-06-03", because: :unsupported, replacement_cask: "daveshanley/vacuum/vacuum"
+  disable! date: "2026-12-03", because: :unsupported, replacement_cask: "daveshanley/vacuum/vacuum"
+
   depends_on "go" => :build
   depends_on "node" => :build
   depends_on "yarn" => :build


### PR DESCRIPTION
vacuum is distributed by upstream as a signed/prebuilt cask via GoReleaser. The Homebrew core formula builds from source and omits the html_report_ui build tag, so it does not match upstream release behavior.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI reviewed the docs, code, and changes for me and ran the builds/audit.

-----
