### PR TITLE
macbee 1.0.0 (new formula)

### DIFF
--- a/Formula/m/macbee.rb
+++ b/Formula/m/macbee.rb
@@ -1,0 +1,17 @@
+class Macbee < Formula
+  desc "Update all apps on macOS — Sparkle, Homebrew Casks, Mac App Store"
+  homepage "https://github.com/yakushevhk/OpenMacUpdate"
+  url "https://github.com/yakushevhk/OpenMacUpdate/archive/refs/tags/v1.0.0.tar.gz"
+  sha256 "ad0b1fac1d04f15a53719c1e49082fdc5da5ad4ecad7986c2cc76350d5c17007"
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args(ldflags: "-s -w"), "."
+  end
+
+  test do
+    assert_match "OpenMacUpdate", shell_output("#{bin}/macbee --help")
+  end
+end


### PR DESCRIPTION
## macbee 1.0.0 (new formula)

OpenMacUpdate — update all apps on macOS via Sparkle, Homebrew Casks, and Mac App Store.

### Features
- Scans `/Applications` and `~/Applications`
- Checks 60,000+ apps via Sparkle appcast XML feeds
- Integrates with `brew outdated --cask` and `mas outdated`
- Parallel checking for speed
- ARM/Intel feed selection
- Terminal UI built with Bubble Tea
- Remote database synced from GitHub (always up-to-date)

### Checklist
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`?
- [x] Have you tested your formula with `brew test <formula>`?
- [x] Have you run `brew audit --new <formula>`?

### Links
- [GitHub](https://github.com/yakushevhk/OpenMacUpdate)
- [Releases](https://github.com/yakushevhk/OpenMacUpdate/releases)