### PR TITLE
scikit-image scipy: remove postinstall

### DIFF
--- a/Formula/s/scikit-image.rb
+++ b/Formula/s/scikit-image.rb
@@ -60,10 +60,6 @@ class ScikitImage < Formula
     virtualenv_install_with_resources
   end
 
-  def post_install
-    HOMEBREW_PREFIX.glob("lib/python*.*/site-packages/skimage/**/*.pyc").map(&:unlink)
-  end
-
   test do
     (testpath/"test.py").write <<~PYTHON
       import skimage as ski

--- a/Formula/s/scipy.rb
+++ b/Formula/s/scipy.rb
@@ -44,10 +44,6 @@ class Scipy < Formula
     end
   end
 
-  def post_install
-    HOMEBREW_PREFIX.glob("lib/python*.*/site-packages/scipy/**/*.pyc").map(&:unlink)
-  end
-
   test do
     (testpath/"test.py").write <<~PYTHON
       from scipy import special


### PR DESCRIPTION
Not sure on original reason but usually pyc files shouldn't cause issues if new versions have newer mtime.

Current bottles were built with reasonable SOURCE_DATE_EPOCH so should try letting Python handle these automatically

For scikit-image, may deprecate in follow up as it is a library-only virtualenv.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
