### PR TITLE
hookdeck 2.2.0 (new formula)

### DIFF
--- a/Formula/h/hookdeck.rb
+++ b/Formula/h/hookdeck.rb
@@ -6,6 +6,15 @@ class Hookdeck < Formula
   license "Apache-2.0"
   head "https://github.com/hookdeck/hookdeck-cli.git", branch: "main"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "82842652d46c2aa163d214dd0eef4c89979d81467dfd88ec9ee27333f00ba964"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "82842652d46c2aa163d214dd0eef4c89979d81467dfd88ec9ee27333f00ba964"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "82842652d46c2aa163d214dd0eef4c89979d81467dfd88ec9ee27333f00ba964"
+    sha256 cellar: :any_skip_relocation, sonoma:        "927d3b9258f0bdd43ca5d72e44bf6edb5a057ca96e037dde4370438be7889bb5"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "d625c0c4e6415a973eb5eb8fbf38c3a4b3edabdc9bd8ce5eacf65853ba3c59fa"
+    sha256 cellar: :any,                 x86_64_linux:  "3b431cb4472e2b08289199d194e95138d0217ac4454c379b1680c3729c1e0f74"
+  end
+
   depends_on "go" => :build
 
   def install

--- a/Formula/h/hookdeck.rb
+++ b/Formula/h/hookdeck.rb
@@ -1,0 +1,24 @@
+class Hookdeck < Formula
+  desc "Forward webhook events from Hookdeck to a local server"
+  homepage "https://hookdeck.com"
+  url "https://github.com/hookdeck/hookdeck-cli/archive/refs/tags/v2.2.0.tar.gz"
+  sha256 "e869c5cccfb6e37d711add229ea14717516e61912af5a883e31a47588e4f61b6"
+  license "Apache-2.0"
+  head "https://github.com/hookdeck/hookdeck-cli.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = "-s -w -X github.com/hookdeck/hookdeck-cli/pkg/version.Version=#{version}"
+    system "go", "build", *std_go_args(ldflags:)
+
+    generate_completions_from_executable(bin/"hookdeck", "completion",
+                                         shell_parameter_format: "--shell=",
+                                         shells:                 [:bash, :zsh])
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/hookdeck --version")
+    assert_match "Provide a project API key", shell_output("#{bin}/hookdeck ci 2>&1", 1)
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

The initial formula was drafted by Claude Code, using existing homebrew-core Go-based CLI formulae (`goreleaser`, `gh`) as references for structure (`livecheck`, `std_go_args`, `generate_completions_from_executable`). I reviewed every line, validated the upstream behaviour change that makes `generate_completions_from_executable` work (stdout-based completion output landed in [hookdeck-cli v2.2.0](https://github.com/hookdeck/hookdeck-cli/releases/tag/v2.2.0)), and ran the full local validation cycle (`brew install --build-from-source`, `brew test`, `brew audit --strict --new --online`, `brew style`) before opening this PR.

-----

## Summary

[Hookdeck CLI](https://github.com/hookdeck/hookdeck-cli) is the command-line client for [Hookdeck](https://hookdeck.com)'s event infrastructure. Its most-used command, `hookdeck listen`, forwards events received at a Hookdeck-hosted permanent URL to a local web server — typically used to receive webhooks (Stripe, Shopify, GitHub, etc.) during local development. It works without signup (a free guest profile is created on first use) and is an alternative to `ngrok` for event-driven workflows.

Other commands (for authenticated users) manage Hookdeck event-gateway resources from the shell and run an MCP server for AI/agent integration. Apache-2.0; first released 2021.

## Notes

- Pure-Go source build — no `import "C"` anywhere in the codebase; the formula uses `std_go_args` with `depends_on "go" => :build`.
- Version injection mirrors the upstream GoReleaser config: `-X github.com/hookdeck/hookdeck-cli/pkg/version.Version=#{version}`.
- Completions generated via `generate_completions_from_executable` with `shell_parameter_format: "--shell="` and `shells: [:bash, :zsh]` — the CLI supports bash and zsh; fish is not supported upstream.
- `livecheck` uses `:github_latest`, which excludes pre-releases, so beta tags (e.g. `vX.Y.Z-beta.N`) won't trigger autobump PRs.
- `test do` uses `--version` (cobra's built-in version flag) — no network calls, validates ldflag-based version injection.
- The existing `hookdeck/homebrew-hookdeck` tap will gain a `tap_migrations.json` pointing `hookdeck` → `homebrew/core` after this merges, so existing tap users are auto-migrated. The beta channel (`hookdeck-beta`) stays in the tap since homebrew-core doesn't accept pre-releases.