### PR TITLE
otterdog: remove hardcoded SOURCE_DATE_EPOCH

### DIFF
--- a/Formula/o/otterdog.rb
+++ b/Formula/o/otterdog.rb
@@ -269,9 +269,6 @@ class Otterdog < Formula
   end
 
   def install
-    # hatch does not support a SOURCE_DATE_EPOCH before 1980.
-    # Remove after https://github.com/pypa/hatch/pull/1999 is released.
-    ENV["SOURCE_DATE_EPOCH"] = "1451574000"
     ENV["SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PLAYWRIGHT"] = resource("playwright").version
     venv = virtualenv_install_with_resources
 

--- a/Formula/o/otterdog.rb
+++ b/Formula/o/otterdog.rb
@@ -10,12 +10,13 @@ class Otterdog < Formula
   head "https://github.com/eclipse-csi/otterdog.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "3edc8254af2d0380401fcae86cad8d8f8a15826b8d8fbf29e60366aad08c3c03"
-    sha256 cellar: :any,                 arm64_sequoia: "19a16e55f7c3fc596a3d045b5de1a4e02aa96575db6ab88dc00f89786e9b1b73"
-    sha256 cellar: :any,                 arm64_sonoma:  "e65d75a45983ed4a2a3403273296b75ec2bc687e59458b5e0032020abf03a4df"
-    sha256 cellar: :any,                 sonoma:        "371b83bfe4d196f3602af4b10254187c693113fb0c60f69bcd01427591076571"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "107f0cf649742a473a9442f86a517833a7971462dd62fe72dd4c3076c9148dc0"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1d9fa69b23aaa08f1472a0a284c8428f3680b7833371d46c17b28337ca5c61c1"
+    rebuild 1
+    sha256 cellar: :any, arm64_tahoe:   "9506eebaf5801c19e54f09592986b3e1c473feb0b050d92558480446560cb457"
+    sha256 cellar: :any, arm64_sequoia: "ecb29c72afcace58e19d59bd80767b543b14ee869bada5686e965afa8ba32f3a"
+    sha256 cellar: :any, arm64_sonoma:  "c31ab8df84c63595146fe5131ae33963a32d9e1ee03c6b1ea25aa82774997907"
+    sha256 cellar: :any, sonoma:        "4a8bf038920065a7a8be9d4d69486735b49697dd33fc086e1710237bdee21207"
+    sha256 cellar: :any, arm64_linux:   "89b5524656f8e783eeaddc20ed1bdc5993d2a822a27b8747598f295de902d360"
+    sha256 cellar: :any, x86_64_linux:  "12ffc606e5291fc8bf8eb1a293ac57d4e38d2d53678238a2115b002887ba670a"
   end
 
   depends_on "rust" => :build # for rjsonnet


### PR DESCRIPTION
With brew changes, we now set time to greater of Last-Modified (set on cached tarball via `--remote-time`) and actual files' preserved timestamps.

Also, for Python formulae, a fixed `SOURCE_DATE_EPOCH` is bad as Python uses mtime to regenerate pyc files. This means `brew upgrade` can cause unexpected failures if mtime is not monotonically increasing per upgrade.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
