### PR TITLE
gmp-ecm: add more dependencies

### DIFF
--- a/Formula/g/gmp-ecm.rb
+++ b/Formula/g/gmp-ecm.rb
@@ -7,12 +7,13 @@ class GmpEcm < Formula
   head "https://gitlab.inria.fr/zimmerma/ecm.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "c1e7785b052a5bd0e6500f603ea2408f96fb6d41ecb6856855dd54db6386b1e9"
-    sha256 cellar: :any,                 arm64_sequoia: "4d5f67adff90c862e4b85a8e3292bf63b4d93c5d362ced8f2575441b392e8766"
-    sha256 cellar: :any,                 arm64_sonoma:  "76f07b6c8e39b0ea818de44ce2e5cea6027ff9a80f4955fd2725f019b8d7949a"
-    sha256 cellar: :any,                 sonoma:        "4759ddec865273414af8373a30b4a17e0a01dfab539b4ae0393a935b03b12734"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "7500b4a76e6329df21c2930008e8884687663d66d7c11666ea563c94c4dbd020"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b3a28934ddb13feff78f9e5a3f7f1c0b7a8552848b3f3eaa8dc46506029dbe52"
+    rebuild 1
+    sha256 cellar: :any, arm64_tahoe:   "910a4e7d0f0571f1c81ff8911ce572848b8a0f9b0418078b14212f2631b54e03"
+    sha256 cellar: :any, arm64_sequoia: "2751998af4e5ac3635c65af6e7ad8cc9d6903e12f10fd4c8d0fea310a3d37f08"
+    sha256 cellar: :any, arm64_sonoma:  "208c99b0b737ee4c2a49a253c1e66d6ee60cb0cb7f2b250cd674d92afd39cc28"
+    sha256 cellar: :any, sonoma:        "548c687bccc54579afdfde56b4f3f22efd32c38aaed35774ecab1549933aeae3"
+    sha256 cellar: :any, arm64_linux:   "8f397ecad250210a53655b2f102c034d1ff25aba705be4160abef37f82720c4f"
+    sha256 cellar: :any, x86_64_linux:  "434fca76ae486e7df0ca2ce4fbb365b497963b81ed8e30c38879dc40b7bb9a6c"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/g/gmp-ecm.rb
+++ b/Formula/g/gmp-ecm.rb
@@ -19,15 +19,17 @@ class GmpEcm < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "gmp"
+  depends_on "primesieve"
 
   uses_from_macos "m4" => :build
 
+  on_macos do
+    depends_on "libomp"
+  end
+
   def install
     system "autoreconf", "--force", "--install"
-    system "./configure", "--with-gmp=#{Formula["gmp"].prefix}",
-                          "--enable-shared",
-                          *std_configure_args
-    system "make"
+    system "./configure", "--enable-openmp", "--enable-shared", "--disable-silent-rules", *std_configure_args
     system "make", "install"
   end
 
@@ -66,7 +68,8 @@ class GmpEcm < Formula
     C
     system ENV.cc, "test.c", "-o", "test",
            "-I#{include}", "-L#{lib}", "-L#{Formula["gmp"].lib}",
-           "-lecm", "-lgmp"
+           "-L#{Formula["primesieve"].lib}",
+           "-lecm", "-lgmp", "-lprimesieve"
     system "./test"
   end
 end


### PR DESCRIPTION
This adds two more dependencies (already present in Homebrew) to allow for more efficient computations.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
