### PR TITLE
rmux 0.5.0 (new formula)

### DIFF
--- a/Formula/r/rmux.rb
+++ b/Formula/r/rmux.rb
@@ -5,6 +5,15 @@ class Rmux < Formula
   sha256 "c3ef5daf05ff928f4616d950a6bc1d0c8358a679c368c7049e3a2a3c79846f98"
   license any_of: ["MIT", "Apache-2.0"]
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "f2bb2adceb01b39576383661c2e83920920b710d7870c95e51d8d9a982db7e5f"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "3ebbc973c170ac9bf587b850e85176732fb0c77950850dc70b1770c48e154531"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "18d30185f2d0a9ffade11bbeab852c4e4b22facd3a741325ad97f4987a7e36b9"
+    sha256 cellar: :any_skip_relocation, sonoma:        "84751c79f98d8680bca622b676788c8130d7e431a429d5db0529f00142205007"
+    sha256 cellar: :any,                 arm64_linux:   "97e9f170f8bf3eb8f33a77f3f7b04ca68150232858c3c5d9948993bf20e0ea1c"
+    sha256 cellar: :any,                 x86_64_linux:  "0f51c542bebc268733cb2d47f4d19f1b9a23b1a61533b983ea74470ae77eba83"
+  end
+
   depends_on "rust" => :build
 
   def install

--- a/Formula/r/rmux.rb
+++ b/Formula/r/rmux.rb
@@ -1,0 +1,22 @@
+class Rmux < Formula
+  desc "Terminal multiplexer with a tmux-style CLI and daemon runtime"
+  homepage "https://rmux.io"
+  url "https://static.crates.io/crates/rmux/rmux-0.5.0.crate"
+  sha256 "c3ef5daf05ff928f4616d950a6bc1d0c8358a679c368c7049e3a2a3c79846f98"
+  license any_of: ["MIT", "Apache-2.0"]
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+    man1.install "rmux.1"
+  end
+
+  test do
+    require "json"
+
+    assert_match "rmux #{version}", shell_output("#{bin}/rmux -V")
+    diagnostics = JSON.parse(shell_output("#{bin}/rmux diagnose --json"))
+    assert_equal version.to_s, diagnostics.fetch("version")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source rmux`?
- [x] Is your test running fine `brew test rmux`?
- [x] Does your build pass `brew audit --strict rmux`? If this is a new formula, does it pass `brew audit --new rmux`?

-----

- [x] AI was used to generate or assist with generating this PR. AI was used to help draft the formula and PR text. The formula was reviewed manually, and the Homebrew build, test, and audit commands below were run locally before submission.

-----

Adds RMUX, a Rust terminal multiplexer with a tmux-style CLI, daemon-backed persistent sessions, and a Rust SDK.

- Upstream: https://github.com/Helvesec/rmux
- Website: https://rmux.io
- License: MIT OR Apache-2.0
- Notability: 1.5k+ GitHub stars
- Published on crates.io: https://crates.io/crates/rmux

Validated locally on macOS arm64:

- `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source rmux`
- `brew test rmux`
- `brew audit --new --strict --online rmux`