### PR TITLE
vsd-0.5.0: updated build deps

### DIFF
--- a/Formula/v/vsd.rb
+++ b/Formula/v/vsd.rb
@@ -1,5 +1,5 @@
 class Vsd < Formula
-  desc "Download video streams over HTTP, DASH (.mpd), and HLS (.m3u8)"
+  desc "A command-line utility for downloading streams from DASH .mpd manifests and HLS .m3u8 playlists."
   homepage "https://github.com/clitic/vsd"
   url "https://github.com/clitic/vsd/archive/refs/tags/vsd-0.5.0.tar.gz"
   sha256 "d47092ce89c22d36d0fd976bd558fa9f895384025cb98e568adbf9793134d7dc"
@@ -19,18 +19,12 @@ class Vsd < Formula
     sha256 cellar: :any,                 x86_64_linux:  "9cf551ab8f7248233379b7bd4245de341380deb146e780d207c579b8c0271517"
   end
 
-  depends_on "pkgconf" => :build
+  depends_on "cmake" => :build
   depends_on "protobuf" => :build
   depends_on "rust" => :build
   depends_on "ffmpeg"
 
-  on_linux do
-    depends_on "openssl@3"
-  end
-
   def install
-    ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-
     inreplace "vsd/Cargo.toml", ", path = \"../vsd-mp4\"", ""
 
     system "cargo", "install", *std_cargo_args(path: "vsd")


### PR DESCRIPTION
updated description, add cmake build dep and removed pkgconf build deps because vsd now uses rustls backend by default.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
