### PR TITLE
appwrite 22.0.0

### DIFF
--- a/Formula/a/appwrite.rb
+++ b/Formula/a/appwrite.rb
@@ -1,9 +1,15 @@
 class Appwrite < Formula
   desc "Command-line tool for Appwrite"
   homepage "https://appwrite.io"
-  url "https://registry.npmjs.org/appwrite-cli/-/appwrite-cli-21.0.1.tgz"
-  sha256 "af79417d56ecdcc9bad6d7a805c2a967e013d04f38a3a95681b95994135e2d16"
+  url "https://github.com/appwrite/sdk-for-cli/archive/refs/tags/22.0.0.tar.gz"
+  sha256 "aebf5766048c292aa04d72cdde40dc7a9afdf45409f65a62ecca2837795254ac"
   license "BSD-3-Clause"
+  head "https://github.com/appwrite/sdk-for-cli.git", branch: "master"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "51f537279f972c970a46b2003d254c03a055d768c8459e1cc82753525e85c04c"
@@ -14,21 +20,45 @@ class Appwrite < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "a787b01e9dfe15c0f04b8602a000de3588bc135817203d7dd2846c3b33a149f0"
   end
 
-  depends_on "node"
+  depends_on "bun" => :build
+
+  on_linux do
+    on_arm do
+      depends_on "patchelf" => :build
+    end
+
+    depends_on "icu4c@78"
+  end
 
   def install
-    system "npm", "install", *std_npm_args
-    bin.install_symlink libexec.glob("bin/*")
+    system "bun", "install", "--frozen-lockfile"
 
-    node_modules = libexec/"lib/node_modules/appwrite-cli/node_modules"
-    machos = %w[fsevents/fsevents.node app-path/main]
-    machos.each { |macho| deuniversalize_machos node_modules/macho } if OS.mac?
+    if OS.linux? && Hardware::CPU.arm?
+      system "bun", "build", "cli.ts", "--compile", "--target=bun-linux-arm64", "--outfile", "appwrite"
+
+      libexec.install "appwrite"
+      mkdir_p libexec/"lib"
+
+      icu = Formula["icu4c@78"].opt_lib
+      (libexec/"lib").install_symlink icu/"libicui18n.so.78"
+      (libexec/"lib").install_symlink icu/"libicuuc.so.78"
+      (libexec/"lib").install_symlink icu/"libicudata.so.78"
+
+      system "patchelf", "--set-interpreter", "/lib/ld-linux-aarch64.so.1",
+                         "--set-rpath", "$ORIGIN/lib", libexec/"appwrite"
+
+      bin.install_symlink libexec/"appwrite"
+    else
+      system "bun", "build", "cli.ts", "--compile", "--outfile", "appwrite"
+      bin.install "appwrite"
+    end
+
+    generate_completions_from_executable(bin/"appwrite", "completion")
   end
 
   test do
-    output = shell_output("#{bin}/appwrite client --endpoint http://localhost/v1 2>&1", 1)
-    assert_match "Error: Invalid endpoint", output
-
     assert_match version.to_s, shell_output("#{bin}/appwrite --version")
+    assert_match "#compdef appwrite", shell_output("#{bin}/appwrite completion zsh")
+    assert_match "_appwrite_completion", shell_output("#{bin}/appwrite completion bash")
   end
 end


### PR DESCRIPTION
Bumps `appwrite` to 22.0.0 and switches it from the `appwrite-cli` npm package to building the standalone binary from source.

## What changed

- `url` now points at the tagged **source** tarball (`appwrite/sdk-for-cli`) instead of the npm registry tarball.
- Build from source with `bun` (`bun build cli.ts --compile`) instead of `npm install`, producing a self-contained executable.
- Drops the `node` runtime dependency; `bun` is a build-time dependency only.
- Adds shell completions via `generate_completions_from_executable`.
- Updates the test to match current CLI behavior (the old `client --endpoint` "Invalid endpoint" assertion no longer applies in 22.x).

## Why

Upstream's primary distribution for the CLI is now a standalone compiled binary (the same artifact shipped via the project's own install script and Homebrew tap). Building it from source here removes the Node runtime requirement and ships a single self-contained executable, in the same spirit as other compiled-from-source CLIs in core.

## Verification (local, Apple Silicon)

- [x] `brew install --build-from-source appwrite` — builds in ~15s
- [x] `brew test appwrite` — passes
- [x] `brew audit --strict --online appwrite` — no offenses
- [x] `brew style appwrite` — no offenses

---

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open pull requests for the same change?
- [x] Have you built your formula locally with `brew install --build-from-source appwrite`?
- [x] Is your test running fine `brew test appwrite`?
- [x] Have you run `brew audit --strict appwrite`?