### PR TITLE
mpv: remove reverted patch, drop unneeded env variables

### DIFF
--- a/Formula/m/mpv.rb
+++ b/Formula/m/mpv.rb
@@ -18,12 +18,13 @@ class Mpv < Formula
   end
 
   bottle do
-    sha256               arm64_tahoe:   "3c84e1634ee0debe5bccdf0cb3e6192254992271ae33126259d023b3f1cc3694"
-    sha256               arm64_sequoia: "21640782a669263ecb7a66f1ff314e438751287c19404fdf644ddb2c675354fc"
-    sha256               arm64_sonoma:  "01b85b9b778134021528913b6dad66a2b685f4a8039c59b09b150f9024d6848e"
-    sha256 cellar: :any, sonoma:        "87e0e5719dfb7ca3c51bf64ba46a7a4d21349ca8ba867934b497a70571e1e734"
-    sha256               arm64_linux:   "48fb6f68e500c5cbcf7548f4ba380f2caeb7b54dc8063470537a09cfde048a20"
-    sha256               x86_64_linux:  "d0b4356c5fcf5fc1d51eb9d428dd635edd47ec35255d22dc050af49c4e25d300"
+    rebuild 1
+    sha256               arm64_tahoe:   "41934b670839e3433d9d12325e3f539a99a9b1575ffffb23ed2a021c608ddf4e"
+    sha256               arm64_sequoia: "a0cc65cc453d5ce141714f8f9f67d7ab7ee23226ca6ce3131d3a59fe7e0a0b2e"
+    sha256               arm64_sonoma:  "9a73121b886e4998e256a51051e76e15a00b586bd19430c374d7f6ea3af1c318"
+    sha256 cellar: :any, sonoma:        "8ffd98ccedc02e523e34cce51261900bebec96e44aafdd4b106114640f8cdd85"
+    sha256               arm64_linux:   "ef61430986f3f57f9a7ee70af283ef7b341e5341696759ce2006cd4d7c7bd89e"
+    sha256               x86_64_linux:  "22c8015c799e22a7d758251e3699fb65c72256a03a34cd456c98d16cc9898989"
   end
 
   depends_on "docutils" => :build

--- a/Formula/m/mpv.rb
+++ b/Formula/m/mpv.rb
@@ -15,10 +15,6 @@ class Mpv < Formula
       url "https://github.com/mpv-player/mpv/commit/75b2ccfeb1ce4ed5a40ac9860fa74f3d1265e13f.patch?full_index=1"
       sha256 "3906b98b02071a0d5747a400406494ca69cef7afd8d3eee4a99fdbe40dc90c1f"
     end
-    patch do
-      url "https://github.com/mpv-player/mpv/commit/8aabba933bd600ea89924b97d4e5b2361b96f6fa.patch?full_index=1"
-      sha256 "96ccb2407a2e053299089c821f2f0f68919d79868d795a87af057ebe70910d09"
-    end
   end
 
   bottle do
@@ -77,17 +73,6 @@ class Mpv < Formula
   conflicts_with cask: "stolendata-mpv", because: "both install `mpv` binaries"
 
   def install
-    # LANG is unset by default on macOS and causes issues when calling getlocale
-    # or getdefaultlocale in docutils. Force the default c/posix locale since
-    # that's good enough for building the manpage.
-    ENV["LC_ALL"] = "C"
-
-    # force meson find ninja from homebrew
-    ENV["NINJA"] = which("ninja")
-
-    # libarchive is keg-only
-    ENV.prepend_path "PKG_CONFIG_PATH", Formula["libarchive"].opt_lib/"pkgconfig" if OS.mac?
-
     args = %W[
       -Dbuild-date=false
       -Dhtml-build=enabled
@@ -118,10 +103,9 @@ class Mpv < Formula
       # keg-only so it needs to look for the pkgconfig file in libarchive's opt
       # path.
       libarchive = Formula["libarchive"].opt_prefix
-      inreplace lib/"pkgconfig/mpv.pc" do |s|
-        s.gsub!(/^Requires\.private:(.*)\blibarchive\b(.*?)(,.*)?$/,
-                "Requires.private:\\1#{libarchive}/lib/pkgconfig/libarchive.pc\\3")
-      end
+      inreplace lib/"pkgconfig/mpv.pc",
+                /^Requires\.private:(.*)\blibarchive\b(.*?)(,.*)?$/,
+                "Requires.private:\\1#{libarchive}/lib/pkgconfig/libarchive.pc\\3"
     end
 
     bash_completion.install "etc/mpv.bash-completion" => "mpv"


### PR DESCRIPTION
Closes #285461

Reverted at https://github.com/mpv-player/mpv/commit/3650c67b6d6ec92ab44ab5f5995f8fd59585608e

For environment variables:
* LC_ALL should be set by brew
* NINJA usually isn't needed when using meson. CMake currently needs it to use shim.
* PKG_CONFIG_PATH should already contain keg-only formulae

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
