### PR TITLE
workflows/triage: add `libcap` to CI-skip-recursive-dependents

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -348,7 +348,6 @@ jobs:
                 jasper|\
                 jpeg-turbo|\
                 jpeg-xl|\
-                libcap|\
                 libgcrypt|\
                 libgpg-error|\
                 libidn2|\
@@ -416,6 +415,7 @@ jobs:
                 gettext|\
                 glib|\
                 harfbuzz|\
+                libcap|\
                 openssl@3|\
                 rust|\
                 sqlite|\
@@ -442,7 +442,6 @@ jobs:
             - label: CI-linux-self-hosted-deps
               path: "Formula/.+/(\
                 glib|\
-                libcap|\
                 libva|\
                 libxml2|\
                 mesa|\


### PR DESCRIPTION
Previous runs exceeded 1.5 days and we merged them without a clean run which means the most important dependents, i.e. direct dependents, were not properly tested.

* https://github.com/Homebrew/homebrew-core/actions/runs/24036215374/usage
* https://github.com/Homebrew/homebrew-core/actions/runs/18842575207/usage

Even with parallel dependents, this won't be possible to recursively test as we would need to run all 4 shards on a self-hosted runner, but we have only 1 runner which will serialize the jobs and likely hit the waiting timeout.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
