### PR TITLE
mpv: fix install directories

### DIFF
--- a/Formula/m/mpv.rb
+++ b/Formula/m/mpv.rb
@@ -18,13 +18,12 @@ class Mpv < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256               arm64_tahoe:   "41934b670839e3433d9d12325e3f539a99a9b1575ffffb23ed2a021c608ddf4e"
-    sha256               arm64_sequoia: "a0cc65cc453d5ce141714f8f9f67d7ab7ee23226ca6ce3131d3a59fe7e0a0b2e"
-    sha256               arm64_sonoma:  "9a73121b886e4998e256a51051e76e15a00b586bd19430c374d7f6ea3af1c318"
-    sha256 cellar: :any, sonoma:        "8ffd98ccedc02e523e34cce51261900bebec96e44aafdd4b106114640f8cdd85"
-    sha256               arm64_linux:   "ef61430986f3f57f9a7ee70af283ef7b341e5341696759ce2006cd4d7c7bd89e"
-    sha256               x86_64_linux:  "22c8015c799e22a7d758251e3699fb65c72256a03a34cd456c98d16cc9898989"
+    sha256               arm64_tahoe:   "649109b87d486e369e3ee9c8b6703c3cb17229476881b4b509ca91f0441a17f2"
+    sha256               arm64_sequoia: "484dec512afcfcc30f51aad01022b1bd97aac0fe7c85aafc3b341a25996dd49c"
+    sha256               arm64_sonoma:  "5dd9a950ca0a81ad4319a3f2a203b6e0bd7142b6dc597859ea4acf6dabfadbab"
+    sha256 cellar: :any, sonoma:        "6992a25c76e33dda932ddff26da1e75602e9b402bfe9717792ede3989c2c4ac5"
+    sha256               arm64_linux:   "4df7a2cc6a6a73ab89d69635eedddd00e89176423ace64351c7767813f45a579"
+    sha256               x86_64_linux:  "d795ebc793a8cb4c8548a3dc018fac38a33de14465390ec9d66e586e0fe6c7be"
   end
 
   depends_on "docutils" => :build

--- a/Formula/m/mpv.rb
+++ b/Formula/m/mpv.rb
@@ -2,7 +2,7 @@ class Mpv < Formula
   desc "Media player based on MPlayer and mplayer2"
   homepage "https://mpv.io"
   license all_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later"]
-  revision 5
+  revision 6
   compatibility_version 1
   head "https://github.com/mpv-player/mpv.git", branch: "master"
 
@@ -75,6 +75,7 @@ class Mpv < Formula
 
   def install
     args = %W[
+      --sysconfdir=#{etc}
       -Dbuild-date=false
       -Dhtml-build=enabled
       -Djavascript=enabled
@@ -83,9 +84,6 @@ class Mpv < Formula
       -Dlibarchive=enabled
       -Duchardet=enabled
       -Dvulkan=enabled
-      --sysconfdir=#{pkgetc}
-      --datadir=#{pkgshare}
-      --mandir=#{man}
     ]
     if OS.linux?
       args += %w[
@@ -98,19 +96,24 @@ class Mpv < Formula
     system "meson", "setup", "build", *args, *std_meson_args
     system "meson", "compile", "-C", "build", "--verbose"
     system "meson", "install", "-C", "build"
+    bash_completion.install share/"bash-completion/completions/mpv"
 
-    if OS.mac?
-      # `pkg-config --libs mpv` includes libarchive, but that package is
-      # keg-only so it needs to look for the pkgconfig file in libarchive's opt
-      # path.
-      libarchive = Formula["libarchive"].opt_prefix
-      inreplace lib/"pkgconfig/mpv.pc",
-                /^Requires\.private:(.*)\blibarchive\b(.*?)(,.*)?$/,
-                "Requires.private:\\1#{libarchive}/lib/pkgconfig/libarchive.pc\\3"
-    end
+    return unless OS.mac?
 
-    bash_completion.install "etc/mpv.bash-completion" => "mpv"
-    zsh_completion.install "etc/_mpv.zsh" => "_mpv"
+    # `pkg-config --libs mpv` includes libarchive, but that package is
+    # keg-only so it needs to look for the pkgconfig file in libarchive's opt
+    # path.
+    libarchive = Formula["libarchive"].opt_prefix
+    inreplace lib/"pkgconfig/mpv.pc",
+              /^Requires\.private:(.*)\blibarchive\b(.*?)(,.*)?$/,
+              "Requires.private:\\1#{libarchive}/lib/pkgconfig/libarchive.pc\\3"
+  end
+
+  def caveats
+    <<~EOS
+      The global configuration directory is now #{pkgetc}/
+      You may need to migrate any data in previous #{pkgetc}/mpv/
+    EOS
   end
 
   test do


### PR DESCRIPTION
For directories:
* `datadir` should be default share so that installation directory structure is standard and can be found by other formulae
* `mandir` is unneeded as it is using default after fixing `datadir`
* `sysconfdir` is used in mpv as `#{sysconfdir}/mpv` so `pkgetc` results in a nested mpv directory. This looks like an accidental change during switch to meson in c894ef135f02d055d9bed8adf5980577ed224ac8 as old `--confdir` is not the same as `sysconfdir`

Also remove duplicate completion files

-----

sysconfdir in meson build is before appending "/mpv" - https://github.com/mpv-player/mpv/blob/v0.41.0/meson.build#L1752
```meson
conf_data.set_quoted('MPV_CONFDIR', join_paths(get_option('prefix'), get_option('sysconfdir'), 'mpv'))
```

While confdir in waf is after appending "/mpv" - https://github.com/mpv-player/mpv/blob/v0.36.0/wscript#L963
```py
    ('confdir', '${SYSCONFDIR}/mpv',  'configuration files'),
```