### PR TITLE
awscli@1: deprecate when maintenance mode starts (2026-07-15)

### DIFF
--- a/Formula/a/awscli@1.rb
+++ b/Formula/a/awscli@1.rb
@@ -25,6 +25,10 @@ class AwscliAT1 < Formula
 
   keg_only :versioned_formula
 
+  # https://aws.amazon.com/blogs/developer/cli-v1-maintenance-mode-announcement/
+  deprecate! date: "2026-07-15", because: :deprecated_upstream, replacement_formula: "awscli"
+  disable! date: "2027-07-15", because: :deprecated_upstream, replacement_formula: "awscli"
+
   depends_on "libyaml"
   depends_on "python@3.14"
 


### PR DESCRIPTION
And disable on EOL. See:
- https://aws.amazon.com/blogs/developer/cli-v1-maintenance-mode-announcement/
- https://github.com/aws/aws-cli#entering-maintenance-mode-on-july-15-2026

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
