### PR TITLE
ctl: update urls, drop support for aces-container

### DIFF
--- a/Formula/c/ctl.rb
+++ b/Formula/c/ctl.rb
@@ -7,12 +7,13 @@ class Ctl < Formula
   head "https://github.com/aces-aswf/CTL.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "ca511a0c2b48007131b0582bb71116f5cc0eac17087434738e6f7a6c50397d91"
-    sha256 cellar: :any,                 arm64_sequoia: "45d8158cce14a51d6974e9cc1603b88c0329e26c76574ccbeaf9372d687bf05d"
-    sha256 cellar: :any,                 arm64_sonoma:  "46d3f74998db9417edb5725421b181e05a11e1a35dbd6cd19aa961a443c7b04c"
-    sha256 cellar: :any,                 sonoma:        "29d9deebf5250fa3faa927ce5ee71a4488ea49dd00c595c1f6443006e8106899"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "9ec0a75ad70ea5c05ce1165095a98a1a69cf898cf09eb7206c7885e752fb7045"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0d035e411659b169fb4d073389599ddb0337c3a5b43cdb088e57496cff47709e"
+    rebuild 1
+    sha256 cellar: :any, arm64_tahoe:   "47ab02f6566688c853c02238bcbd7eb1c625c58ec5715a10699ec2d3254f968b"
+    sha256 cellar: :any, arm64_sequoia: "cae61bd17827cf4258fd0ed62d3b0cc4c1e5f225cdcefd0f93d1f2714f9ed2ba"
+    sha256 cellar: :any, arm64_sonoma:  "ae55a5403c29344467d027fbe63f833d239c25a8e98a866bb1bbbb5289d4a0cd"
+    sha256 cellar: :any, sonoma:        "b992a7caddeacea47fe70eac3a6472a0469182352049d12df3505d17ada69eef"
+    sha256 cellar: :any, arm64_linux:   "d81b51797f7a0d4924d4a25718f98140e11f0fda57f39264fc8d79df9885b990"
+    sha256 cellar: :any, x86_64_linux:  "ccf4269d792537b2a2af10e3c4c1afb6ee37ffd97038e0583713ba20941765be"
   end
 
   depends_on "cmake" => :build

--- a/Formula/c/ctl.rb
+++ b/Formula/c/ctl.rb
@@ -1,10 +1,10 @@
 class Ctl < Formula
   desc "Programming language for digital color management"
-  homepage "https://github.com/ampas/CTL"
-  url "https://github.com/ampas/CTL/archive/refs/tags/ctl-1.5.5.tar.gz"
+  homepage "https://github.com/aces-aswf/CTL"
+  url "https://github.com/aces-aswf/CTL/archive/refs/tags/ctl-1.5.5.tar.gz"
   sha256 "b6a36ac31e0a79224216e4fc41b56982939cec7a1afd4e80165cec3f1c37d265"
   license "AMPAS"
-  head "https://github.com/ampas/CTL.git", branch: "master"
+  head "https://github.com/aces-aswf/CTL.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "ca511a0c2b48007131b0582bb71116f5cc0eac17087434738e6f7a6c50397d91"
@@ -16,7 +16,6 @@ class Ctl < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "aces_container"
   depends_on "imath"
   depends_on "libtiff"
   depends_on "openexr"


### PR DESCRIPTION
Organization change:
```console
❯ curl -sI https://github.com/ampas/CTL | grep location:
location: https://github.com/aces-aswf/CTL
```

While `aces_container` was archived
- https://github.com/aces-aswf/aces_container

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
