### PR TITLE
imessage-ruby: make macOS-only, use brew Ruby, use gemspec description

### DIFF
--- a/Formula/i/imessage-ruby.rb
+++ b/Formula/i/imessage-ruby.rb
@@ -1,5 +1,5 @@
 class ImessageRuby < Formula
-  desc "Command-line tool to send iMessage"
+  desc "Command-line tool to send text and attachment in Message.app"
   homepage "https://github.com/linjunpop/imessage"
   url "https://github.com/linjunpop/imessage/archive/refs/tags/v0.4.0.tar.gz"
   sha256 "09031e60548f34f05e07faeb0e26b002aeb655488d152dd811021fba8d850162"
@@ -22,14 +22,14 @@ class ImessageRuby < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "584a4e42785d258568915c287d02ea037c685bd577812c66844350425fea5df3"
   end
 
-  uses_from_macos "ruby"
+  depends_on :macos # uses Message.app
+  depends_on "ruby"
 
   def install
     ENV["GEM_HOME"] = libexec
-    ENV["GEM_PATH"] = libexec
 
     system "gem", "build", "imessage.gemspec", "-o", "imessage-#{version}.gem"
-    system "gem", "install", "--local", "--verbose", "imessage-#{version}.gem", "--no-document"
+    system "gem", "install", "--ignore-dependencies", "--no-document", "imessage-#{version}.gem"
 
     bin.install libexec/"bin/imessage"
     bin.env_script_all_files(libexec/"bin", GEM_HOME: ENV["GEM_HOME"])

--- a/Formula/i/imessage-ruby.rb
+++ b/Formula/i/imessage-ruby.rb
@@ -7,19 +7,8 @@ class ImessageRuby < Formula
   head "https://github.com/linjunpop/imessage.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:    "e0ddafd03ceedaf46157074627f10b5bc2ae1095803c7da7ff4259f8972c2c7f"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "676022be294ea2d4654c968012a952dac36f61e573e44f3fd99b52f071767372"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "9b325f6945c083382956ed3f81d453e17151a0a09f4eff7d5f84c7208d1a1cd7"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "a05553e529ee3f7d2a212033b5353e1bae2534a7651e0b4ac4ac66c2301c6f96"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "a05553e529ee3f7d2a212033b5353e1bae2534a7651e0b4ac4ac66c2301c6f96"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "97031cd42ff2a4338b973493629d314f1ad1e7a79ca7e912503f68585f5bfc61"
-    sha256 cellar: :any_skip_relocation, sonoma:         "9b325f6945c083382956ed3f81d453e17151a0a09f4eff7d5f84c7208d1a1cd7"
-    sha256 cellar: :any_skip_relocation, ventura:        "a05553e529ee3f7d2a212033b5353e1bae2534a7651e0b4ac4ac66c2301c6f96"
-    sha256 cellar: :any_skip_relocation, monterey:       "a05553e529ee3f7d2a212033b5353e1bae2534a7651e0b4ac4ac66c2301c6f96"
-    sha256 cellar: :any_skip_relocation, big_sur:        "97031cd42ff2a4338b973493629d314f1ad1e7a79ca7e912503f68585f5bfc61"
-    sha256 cellar: :any_skip_relocation, catalina:       "97031cd42ff2a4338b973493629d314f1ad1e7a79ca7e912503f68585f5bfc61"
-    sha256 cellar: :any_skip_relocation, arm64_linux:    "98197a6b45c3c46674268c2033a0648ce4afe2c89904a56f959d1c37a2f2a902"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "584a4e42785d258568915c287d02ea037c685bd577812c66844350425fea5df3"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "6c9c93e10c1079ddab1763ced2e4dd34ccbacabdfd6dc6445186927f1e51abf4"
   end
 
   depends_on :macos # uses Message.app


### PR DESCRIPTION
Won't work on Linux as it uses applescripts to communicate with Message.app.

Updating description to match upstream gemspec description. Could alternatively use new summary
- https://github.com/linjunpop/imessage/commit/c2fe4d56a380410c1e340078f65d126a7ee1f103

And reducing system Ruby usage.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
