### PR TITLE
为 DyldHeaders 公式中的 install 方法添加文档注释

### DIFF
--- a/Formula/d/dyld-headers.rb
+++ b/Formula/d/dyld-headers.rb
@@ -11,6 +11,7 @@ class DyldHeaders < Formula
 
   keg_only :provided_by_macos
 
+  # Install header files to the include directory.
   def install
     include.install Dir["include/*"]
   end


### PR DESCRIPTION
## 问题背景
在 Homebrew/homebrew-core 仓库的 `Formula/d/dyld-headers.rb` 文件中，公共方法 `install` 缺乏文档说明，这降低了代码的可读性和可维护性。作为开源贡献者，清晰的文档有助于新用户和维护者理解方法的功能。

## 修改内容
在 `def install` 行前添加了注释行 `# Install header files to the include directory.`，以明确解释该方法的作用：将头文件安装到 include 目录中。这是一个纯文档性的改动，不涉及任何代码逻辑或功能变更。

## 验证方式
1. **代码审查**：直接查看修改后的文件，确认注释已正确添加。
2. **功能测试**：由于改动不影响功能，可以运行 Homebrew 的测试套件（例如 `brew test dyld-headers`）来验证公式的行为保持不变。
3. **兼容性检查**：确保修改不破坏向后兼容性，因为仅添加了注释，未改变任何 API 或行为。