### PR TITLE
ruby dependents: add `--ignore-dependencies`

### DIFF
--- a/Formula/c/classifier.rb
+++ b/Formula/c/classifier.rb
@@ -17,13 +17,14 @@ class Classifier < Formula
   depends_on "ruby"
 
   def install
+    ENV["BUNDLE_FORCE_RUBY_PLATFORM"] = "1"
     ENV["BUNDLE_VERSION"] = "system"
     ENV["BUNDLE_WITHOUT"] = "development:test"
     ENV["GEM_HOME"] = libexec
 
     system "bundle", "install"
-    system "gem", "build", "classifier.gemspec"
-    system "gem", "install", "classifier-#{version}.gem"
+    system "gem", "build", "#{name}.gemspec"
+    system "gem", "install", "--ignore-dependencies", "#{name}-#{version}.gem"
 
     bin.install libexec/"bin/classifier"
     bin.env_script_all_files(libexec/"bin", GEM_HOME: ENV["GEM_HOME"])

--- a/Formula/p/pedump.rb
+++ b/Formula/p/pedump.rb
@@ -21,7 +21,7 @@ class Pedump < Formula
 
     system "bundle", "install"
     system "gem", "build", "#{name}.gemspec"
-    system "gem", "install", "#{name}-#{version}.gem"
+    system "gem", "install", "--ignore-dependencies", "#{name}-#{version}.gem"
 
     bin.install libexec/"bin/#{name}"
     bin.env_script_all_files(libexec/"bin", GEM_HOME: ENV["GEM_HOME"])

--- a/Formula/r/rails-mcp-server.rb
+++ b/Formula/r/rails-mcp-server.rb
@@ -25,7 +25,7 @@ class RailsMcpServer < Formula
 
     system "bundle", "install"
     system "gem", "build", "#{name}.gemspec"
-    system "gem", "install", "#{name}-#{version}.gem"
+    system "gem", "install", "--ignore-dependencies", "#{name}-#{version}.gem"
 
     bin.install libexec/"bin/rails-mcp-server"
     bin.env_script_all_files(libexec/"bin", GEM_HOME: ENV["GEM_HOME"])

--- a/Formula/r/ruby-lsp.rb
+++ b/Formula/r/ruby-lsp.rb
@@ -24,7 +24,7 @@ class RubyLsp < Formula
 
     system "bundle", "install"
     system "gem", "build", "#{name}.gemspec"
-    system "gem", "install", "#{name}-#{version}.gem"
+    system "gem", "install", "--ignore-dependencies", "#{name}-#{version}.gem"
 
     bin.install libexec/"bin/#{name}"
     bin.env_script_all_files libexec/"bin",

--- a/Formula/s/sugarjar.rb
+++ b/Formula/s/sugarjar.rb
@@ -27,14 +27,14 @@ class Sugarjar < Formula
 
     system "bundle", "install"
     system "gem", "build", "#{name}.gemspec"
-    system "gem", "install", "#{name}-#{version}.gem"
+    system "gem", "install", "--ignore-dependencies", "#{name}-#{version}.gem"
 
     bin.install libexec/"bin/sj"
     bin.env_script_all_files(libexec/"bin", GEM_HOME: ENV["GEM_HOME"])
     bash_completion.install "extras/sugarjar_completion.bash" => "sj"
 
     # Remove mkmf.log files to avoid shims references
-    rm Dir["#{libexec}/extensions/*/*/*/mkmf.log"]
+    rm libexec.glob("extensions/*/*/*/mkmf.log")
   end
 
   test do

--- a/Formula/t/try.rb
+++ b/Formula/t/try.rb
@@ -19,14 +19,14 @@ class Try < Formula
 
   def install
     ENV["BUNDLE_FORCE_RUBY_PLATFORM"] = "1"
+    ENV["BUNDLE_VERSION"] = "system" # Avoid installing Bundler into the keg
     ENV["BUNDLE_WITHOUT"] = "development test"
-    ENV["BUNDLE_VERSION"] = "system"
     ENV["GEM_HOME"] = libexec
 
     gem_name = "try-cli"
     system "bundle", "install"
     system "gem", "build", "#{gem_name}.gemspec"
-    system "gem", "install", "#{gem_name}-#{version}.gem"
+    system "gem", "install", "--ignore-dependencies", "#{gem_name}-#{version}.gem"
 
     bin.install libexec/"bin/#{name}"
     bin.env_script_all_files(libexec/"bin", GEM_HOME: ENV["GEM_HOME"])


### PR DESCRIPTION
Currently assumed but can make this explicit to make sure nothing unwanted is installed.

This standardizes more of `gem install` style.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
