### PR TITLE
kimi-code 0.11.0 (new formula)

### DIFF
--- a/Formula/k/kimi-code.rb
+++ b/Formula/k/kimi-code.rb
@@ -5,6 +5,15 @@ class KimiCode < Formula
   sha256 "4b6cbf522cbb4870d56e18e2852e20a6000b22a964bc605fe3448fba9603f489"
   license "MIT"
 
+  bottle do
+    sha256 cellar: :any,                 arm64_tahoe:   "898f79624c921cb7fc272d44e8bf787c1b6343ce0a6c3da7c5537fa11d68d3f5"
+    sha256 cellar: :any,                 arm64_sequoia: "5adbb209043654b4043a00b9d482c6f34ed554adbf7411d893199a7e3ba3e59d"
+    sha256 cellar: :any,                 arm64_sonoma:  "5adbb209043654b4043a00b9d482c6f34ed554adbf7411d893199a7e3ba3e59d"
+    sha256 cellar: :any,                 sonoma:        "25860f2b57b087a65dce5f8c88076819edb6d07a6a44a0946f8b31fe7aedad58"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "e685c9f755b0cd006cbc2d0dcfc24f5a5542260cb001d0fcbdee77f99e54c02f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c781f4835703b2841c046dd3291c8d57ad0ecdec71b3874246761464ef52d492"
+  end
+
   depends_on "node"
 
   def install

--- a/Formula/k/kimi-code.rb
+++ b/Formula/k/kimi-code.rb
@@ -1,0 +1,40 @@
+class KimiCode < Formula
+  desc "AI coding agent for your terminal"
+  homepage "https://github.com/MoonshotAI/kimi-code"
+  url "https://registry.npmjs.org/@moonshot-ai/kimi-code/-/kimi-code-0.11.0.tgz"
+  sha256 "4b6cbf522cbb4870d56e18e2852e20a6000b22a964bc605fe3448fba9603f489"
+  license "MIT"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink Dir[libexec/"bin/*"]
+
+    node_modules = libexec/"lib/node_modules/@moonshot-ai/kimi-code/node_modules"
+
+    # Remove non-native architecture binaries from `koffi`
+    if OS.mac?
+      if Hardware::CPU.arm?
+        rm_r node_modules/"koffi/build/koffi/darwin_x64"
+      elsif Hardware::CPU.intel?
+        rm_r node_modules/"koffi/build/koffi/darwin_arm64"
+      end
+    elsif OS.linux?
+      # koffi requires libc++ which is not available in Homebrew Linux;
+      # remove all prebuilt native binaries to avoid audit/linkage failures
+      rm_r node_modules/"koffi/build"
+    end
+
+    # Strip universal binary to native architecture for `clipboard`
+    if OS.mac?
+      deuniversalize_machos "#{node_modules}/@mariozechner/clipboard-darwin-universal/clipboard.darwin-universal.node"
+    end
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/kimi --version")
+    assert_match "No providers configured", shell_output("#{bin}/kimi provider list")
+    assert_match "No model configured", shell_output("#{bin}/kimi --prompt hello 2>&1", 1)
+  end
+end


### PR DESCRIPTION
[Kimi Code CLI](https://github.com/MoonshotAI/kimi-code) is an AI coding agent that runs in your terminal. It can read/edit code, run shell commands, search files, fetch web pages, and autonomously plan actions. Built by Moonshot AI, it features a TUI, MCP tools, ACP (Agent Client Protocol) for IDE integration, video input, subagents, and a plugin ecosystem.

This is a Node.js/TypeScript project built from source using pnpm workspaces and tsdown. Follows the same pattern as `tailwindcss-language-server`.

Formula structure:
- `pnpm install --frozen-lockfile` to install dependencies
- Build workspace packages first (`packages/*`), then the app
- Install `dist/main.mjs` as the `kimi` binary
- `livecheck` points to npm registry for automatic version bumps

-----

<!-- Do not tick a checkbox if you haven't performed its action. Honesty is indispensable for a smooth review process. -->
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --new <formula>`?