### PR TITLE
rustup: restore test

### DIFF
--- a/Formula/r/rustup.rb
+++ b/Formula/r/rustup.rb
@@ -74,7 +74,7 @@ class Rustup < Formula
       To use rustup, ensure you have "$(brew --prefix rustup)/bin" in your $PATH:
         #{Formatter.url("https://rust-lang.github.io/rustup/installation/already-installed-rust.html")}
 
-      This formula does not provide `rustup-init`.
+      This formula no longer provides `rustup-init`.
     EOS
   end
 
@@ -96,5 +96,13 @@ class Rustup < Formula
 
     # Check that Homebrew only exposes the packaged `rustup` entrypoint.
     refute_path_exists bin/"rustup-init"
+
+    # Check for stale symlinks
+    testpath.install_symlink libexec/"bin/rustup" => "rustup-init"
+    system testpath/"rustup-init", "-y"
+    bins = bin.glob("*").to_set(&:basename)
+    expected = testpath.glob(".cargo/bin/*").to_set(&:basename)
+    assert (extra = bins - expected).empty?, "Symlinks need to be removed: #{extra.join(",")}"
+    assert (missing = expected - bins).empty?, "Symlinks need to be added: #{missing.join(",")}"
   end
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

We dropped this when removing `rustup-init` in #283934, however it's still a useful test as it ensures we install the same symlinks as upstream