### PR TITLE
stevenblack-hosts 3.16.87 (new formula)

### DIFF
--- a/Formula/s/stevenblack-hosts.rb
+++ b/Formula/s/stevenblack-hosts.rb
@@ -1,0 +1,89 @@
+class StevenblackHosts < Formula
+  desc "Unified hosts file with optional extensions"
+  homepage "https://github.com/StevenBlack/hosts"
+  url "https://github.com/StevenBlack/hosts/archive/refs/tags/3.16.87.tar.gz"
+  sha256 "47963cac59f4bf11e1976636e7d08344261428e77f0540310aec98778964023d"
+  license "MIT"
+
+  def install
+    pkgshare.install "hosts", "alternates", "extensions", "readme.md"
+
+    (bin/"stevenblack-hosts").write <<~SH
+      #!/bin/sh
+      set -eu
+
+      root="#{pkgshare}"
+
+      usage() {
+        cat <<'USAGE'
+      Usage:
+        stevenblack-hosts --list
+        stevenblack-hosts --path VARIANT
+        stevenblack-hosts --cat VARIANT
+
+      Variants:
+        base      Default StevenBlack hosts file.
+        <name>    Directory name under alternates/.
+      USAGE
+      }
+
+      variant_path() {
+        case "$1" in
+          ""|base|default|none)
+            printf '%s\\n' "$root/hosts"
+            ;;
+          *)
+            printf '%s\\n' "$root/alternates/$1/hosts"
+            ;;
+        esac
+      }
+
+      case "${1:-}" in
+        --list)
+          printf '%s\\n' base
+          find "$root/alternates" -mindepth 1 -maxdepth 1 -type d -exec basename {} \\; | sort
+          ;;
+        --path)
+          if [ "$#" -ne 2 ]; then
+            usage >&2
+            exit 64
+          fi
+          path="$(variant_path "$2")"
+          if [ ! -f "$path" ]; then
+            printf 'Unknown variant: %s\\n' "$2" >&2
+            exit 66
+          fi
+          printf '%s\\n' "$path"
+          ;;
+        --cat)
+          if [ "$#" -ne 2 ]; then
+            usage >&2
+            exit 64
+          fi
+          path="$(variant_path "$2")"
+          if [ ! -f "$path" ]; then
+            printf 'Unknown variant: %s\\n' "$2" >&2
+            exit 66
+          fi
+          cat "$path"
+          ;;
+        -h|--help)
+          usage
+          ;;
+        *)
+          usage >&2
+          exit 64
+          ;;
+      esac
+    SH
+  end
+
+  test do
+    assert_path_exists pkgshare/"hosts"
+    assert_path_exists pkgshare/"alternates/fakenews-gambling/hosts"
+    assert_match "fakenews-gambling", shell_output("#{bin}/stevenblack-hosts --list")
+    assert_match "alternates/fakenews-gambling/hosts",
+                 shell_output("#{bin}/stevenblack-hosts --path fakenews-gambling")
+    assert_match "StevenBlack/hosts", shell_output("#{bin}/stevenblack-hosts --cat base")
+  end
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

I used OpenAI Codex (GPT-5) to help draft and validate this formula. I reviewed the generated formula and PR text before submission, verified the installed files and helper command behavior locally, and ran the checks listed below.

-----

This adds a new formula for StevenBlack/hosts. The formula installs the versioned upstream hosts data files and a small helper command for listing available variants, printing a variant path, or outputting a variant. It does not download from master at runtime, install a background service, or write to /etc/hosts.

Tested locally:

- `HOMEBREW_NO_INSTALL_FROM_API=1 brew audit --new --online --formula stevenblack-hosts`
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew audit --strict --online --formula stevenblack-hosts`
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew style Formula/s/stevenblack-hosts.rb`
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source homebrew/core/stevenblack-hosts`
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew test homebrew/core/stevenblack-hosts`
