### PR TITLE
cryptopp: use GitHub release source

### DIFF
--- a/Formula/c/cryptopp.rb
+++ b/Formula/c/cryptopp.rb
@@ -1,8 +1,7 @@
 class Cryptopp < Formula
   desc "Free C++ class library of cryptographic schemes"
-  homepage "https://cryptopp.com/"
-  url "https://cryptopp.com/cryptopp890.zip"
-  mirror "https://github.com/weidai11/cryptopp/releases/download/CRYPTOPP_8_9_0/cryptopp890.zip"
+  homepage "https://github.com/weidai11/cryptopp"
+  url "https://github.com/weidai11/cryptopp/releases/download/CRYPTOPP_8_9_0/cryptopp890.zip"
   version "8.9.0"
   sha256 "4cc0ccc324625b80b695fcd3dee63a66f1a460d3e51b71640cdbfc4cd1a3779c"
   license all_of: [:public_domain, "BSL-1.0"]


### PR DESCRIPTION
Related to #139929.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

I used OpenAI Codex to investigate the failing source/homepage check, draft this small formula change, and run local validation. I reviewed the final diff and verified the replacement source manually.

-----

`cryptopp.com` currently fails TLS verification due an expired certificate, which makes the formula's homepage/source URL fail online checks. The existing GitHub release mirror is the upstream release asset and matches the current SHA-256, so this makes the GitHub release the primary source and homepage.

Validated locally:
- `curl -fsSL -I --max-time 15 https://cryptopp.com/` fails with certificate expired.
- Downloaded `https://github.com/weidai11/cryptopp/releases/download/CRYPTOPP_8_9_0/cryptopp890.zip` and verified SHA-256 `4cc0ccc324625b80b695fcd3dee63a66f1a460d3e51b71640cdbfc4cd1a3779c`.
- Checked no open PRs with `cryptopp` in the title.
- `brew style Formula/c/cryptopp.rb`
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew audit --formula cryptopp`
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew audit --strict --formula cryptopp`
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew reinstall --build-from-source cryptopp`
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew test cryptopp`

`brew audit --online --formula cryptopp` could not complete locally because the anonymous GitHub API rate limit was exhausted.