### PR TITLE
gocr: use Debian source URL

### DIFF
--- a/Formula/g/gocr.rb
+++ b/Formula/g/gocr.rb
@@ -1,14 +1,14 @@
 class Gocr < Formula
   desc "Optical Character Recognition (OCR), converts images back to text"
-  homepage "https://wasd.urz.uni-magdeburg.de/jschulen/ocr/"
-  url "https://wasd.urz.uni-magdeburg.de/jschulen/ocr/gocr-0.52.tar.gz"
+  homepage "https://jocr.sourceforge.net/"
+  url "https://deb.debian.org/debian/pool/main/g/gocr/gocr_0.52.orig.tar.gz"
   sha256 "df906463105f5f4273becc2404570f187d4ea52bd5769d33a7a8661a747b8686"
   license "GPL-2.0-or-later"
   revision 2
 
   livecheck do
-    url "https://wasd.urz.uni-magdeburg.de/jschulen/ocr/download.html"
-    regex(%r{href=(?:["']?|.*?/)gocr[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url "https://deb.debian.org/debian/pool/main/g/gocr/"
+    regex(/href=.*?gocr[._-]v?(\d+(?:\.\d+)+)\.orig\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
Related to #139929.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

I used OpenAI Codex to investigate the unreachable upstream host, draft this small formula change, and run local validation. I reviewed the final diff and verified the replacement source manually.

-----

The current `wasd.urz.uni-magdeburg.de` homepage/source host times out, so this switches the formula to a reachable official project homepage and Debian's copy of the upstream source tarball. The Debian tarball matches the current SHA-256.

Validated locally:
- `curl -IL --max-time 20 --connect-timeout 8 https://wasd.urz.uni-magdeburg.de/jschulen/ocr/gocr-0.52.tar.gz` times out.
- `curl -IL --max-time 20 --connect-timeout 8 https://jocr.sourceforge.net/` returns HTTP 200.
- Downloaded `https://deb.debian.org/debian/pool/main/g/gocr/gocr_0.52.orig.tar.gz` and verified SHA-256 `df906463105f5f4273becc2404570f187d4ea52bd5769d33a7a8661a747b8686`.
- Checked no open PRs with `gocr` in the title.
- `brew style Formula/g/gocr.rb`
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew audit --formula gocr`
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew audit --strict --formula gocr`
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew fetch --formula --retry --build-from-source gocr`
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew reinstall --build-from-source gocr`
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew test gocr`