### PR TITLE
sha2: use Fedora source URL

### DIFF
--- a/Formula/s/sha2.rb
+++ b/Formula/s/sha2.rb
@@ -1,14 +1,16 @@
 class Sha2 < Formula
   desc "Implementation of SHA-256, SHA-384, and SHA-512 hash algorithms"
-  homepage "https://aarongifford.com/computers/sha.html"
-  url "https://aarongifford.com/computers/sha2-1.0.1.tgz"
+  homepage "https://src.fedoraproject.org/rpms/sha2"
+  url "https://src.fedoraproject.org/repo/pkgs/sha2/sha2-1.0.1.tgz/5c050ef4edb9d5198e7d57e759c4996f/sha2-1.0.1.tgz"
   sha256 "67bc662955c6ca2fa6a0ce372c4794ec3d0cd2c1e50b124e7a75af7e23dd1d0c"
   license "BSD-3-Clause"
 
   livecheck do
-    url :homepage
+    url "https://src.fedoraproject.org/repo/pkgs/sha2/"
     regex(/href=.*?sha2[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
+
+  no_autobump! because: :incompatible_version_format
 
   bottle do
     rebuild 4


### PR DESCRIPTION
Related to #139929.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

I used OpenAI Codex to investigate the unreachable upstream host, identify Fedora's archived source tarball, draft this small formula change, and run local validation. I reviewed the final diff and verified the replacement source manually.

-----

The current `aarongifford.com` homepage/source host does not respond. Fedora still packages `sha2` and keeps the same upstream tarball in its lookaside cache, matching the current SHA-256. This follows existing homebrew-core precedent for using `src.fedoraproject.org/repo/pkgs/...` source URLs.

Validated locally:
- `curl -IL --max-time 20 --connect-timeout 8 https://aarongifford.com/computers/sha2-1.0.1.tgz` fails to connect.
- Fedora `sources` lists MD5 `5c050ef4edb9d5198e7d57e759c4996f  sha2-1.0.1.tgz`.
- Downloaded `https://src.fedoraproject.org/repo/pkgs/sha2/sha2-1.0.1.tgz/5c050ef4edb9d5198e7d57e759c4996f/sha2-1.0.1.tgz` and verified SHA-256 `67bc662955c6ca2fa6a0ce372c4794ec3d0cd2c1e50b124e7a75af7e23dd1d0c`.
- Checked no open PRs with `sha2` in the title.
- `brew style Formula/s/sha2.rb`
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew audit --formula sha2`
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew fetch --formula --retry --build-from-source sha2`
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew reinstall --build-from-source sha2`
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew test sha2`
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew audit --strict --formula sha2`