### PR TITLE
ccal: use Salix source URL

### DIFF
--- a/Formula/c/ccal.rb
+++ b/Formula/c/ccal.rb
@@ -1,13 +1,12 @@
 class Ccal < Formula
   desc "Create Chinese calendars for print or browsing"
-  homepage "https://ccal.chinesebay.com/ccal/ccal.htm"
-  url "https://ccal.chinesebay.com/ccal/ccal-2.5.3.tar.gz"
+  homepage "https://slackbuilds.org/repository/15.0/office/ccal/"
+  url "https://backup.salixos.org/monthly.4/repo/x86_64/extra-14.2/source/office/ccal/ccal-2.5.3.tar.gz"
   sha256 "3d4cbdc9f905ce02ab484041fbbf7f0b7a319ae6a350c6c16d636e1a5a50df96"
   license "GPL-2.0-or-later"
 
   livecheck do
-    url :homepage
-    regex(/href=.*?ccal[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    skip "No reliable upstream source"
   end
 
   bottle do


### PR DESCRIPTION
Related to #139929.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

I used OpenAI Codex to investigate the unreachable upstream host, compare available distro mirrors, draft this formula change, and run local validation. I reviewed the final diff and verified the replacement source manually.

-----

The current `ccal.chinesebay.com` homepage/source host times out. SlackBuilds has a reachable package page for `ccal 2.5.3` and still documents the original source tarball. The Salix source mirror provides the same `ccal-2.5.3.tar.gz` tarball matching the current SHA-256, so this keeps the formula installable while avoiding the dead upstream host.

I skipped livecheck because there does not appear to be a reliable upstream release source now that the original host is unavailable.

Validated locally:
- `curl -IL --max-time 20 --connect-timeout 8 https://ccal.chinesebay.com/ccal/ccal-2.5.3.tar.gz` times out.
- `curl -IL --max-time 20 --connect-timeout 8 https://slackbuilds.org/repository/15.0/office/ccal/` returns HTTP 200.
- Downloaded `https://backup.salixos.org/monthly.4/repo/x86_64/extra-14.2/source/office/ccal/ccal-2.5.3.tar.gz` and verified SHA-256 `3d4cbdc9f905ce02ab484041fbbf7f0b7a319ae6a350c6c16d636e1a5a50df96`.
- Checked no open PRs with `ccal` in the title.
- `brew style Formula/c/ccal.rb`
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew audit --formula ccal`
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew audit --strict --formula ccal`
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew fetch --formula --retry --build-from-source ccal`
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew reinstall --build-from-source ccal`
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew test ccal`