### PR TITLE
actions-up: ignore GitHub API rate limit

### DIFF
--- a/Formula/a/actions-up.rb
+++ b/Formula/a/actions-up.rb
@@ -35,8 +35,14 @@ class ActionsUp < Formula
             - run: npm install && npm test
     YAML
 
-    assert_match "Updates applied successfully!", shell_output("#{bin}/actions-up --yes")
-
-    assert_match(%r{.*?actions/checkout@[a-f0-9]{40}}, test_file.read)
+    begin
+      output = shell_output("#{bin}/actions-up --yes")
+    rescue Minitest::Assertion
+      # Ignore GitHub API rate limit errors which are common on CI runs
+      assert_match "⚠️ Rate Limit Exceeded", shell_output("#{bin}/actions-up --yes 2>&1", 1)
+    else
+      assert_match "Updates applied successfully!", output
+      assert_match(%r{.*?actions/checkout@[a-f0-9]{40}}, test_file.read)
+    end
   end
 end


### PR DESCRIPTION
We consistently hit this in Node PRs.

Alternatively could use Homebrew's CI token, but not sure if we want to use it for formulae tests.

There is a very unlikely scenario that rate limit will refresh between two `shell_output`. However, quite small chance as these will run back-to-back likely in less than a second.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
