### PR TITLE
openconnect: remove postinstall with caveat

### DIFF
--- a/Formula/o/openconnect.rb
+++ b/Formula/o/openconnect.rb
@@ -79,18 +79,11 @@ class Openconnect < Formula
     system "make", "install"
   end
 
-  def post_install
-    if (etc/"vpnc/vpnc-script.default").exist?
-      opoo <<~EOS
-        To avoid destroying any local changes you have made, a newer version of `vpnc-script` has
-        been installed as `vpnc-script.default`.
-      EOS
-    end
-  end
-
   def caveats
     <<~EOS
       A `vpnc-script` has been installed at #{etc}/vpnc/vpnc-script.
+      If you applied any local changes then newer versions will be
+      available at #{etc}/vpnc/vpnc-script.default
     EOS
   end
 


### PR DESCRIPTION
We may want to handle this as part of general brew install output since this does apply to many formulae (and often formulae require user to manually update their configuration on breaking upgrades).

Though would want to figure out a way to improve all caveats/etc messages to make it more readable before adding more to it.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
