### PR TITLE
temporal: persist server state with --db-filename by default

### DIFF
--- a/Formula/t/temporal.rb
+++ b/Formula/t/temporal.rb
@@ -31,11 +31,13 @@ class Temporal < Formula
   end
 
   service do
-    run [opt_bin/"temporal", "server", "start-dev"]
+    run [opt_bin/"temporal", "server", "start-dev",
+         "--db-filename", var/"temporal/temporal.db",
+         "--ui-port", "8233"]
     keep_alive true
     error_log_path var/"log/temporal.log"
     log_path var/"log/temporal.log"
-    working_dir var
+    working_dir var/"temporal"
   end
 
   test do


### PR DESCRIPTION
## Summary

Without `--db-filename`, `temporal server start-dev` runs in pure in-memory
mode: all workflow history, schedules, and task queue registrations are lost
every time the service restarts (reboot, `brew services restart`, or crash).
This makes the `brew services`-managed Temporal nearly unusable for iterative
development where you need to inspect past runs or replay workflows.

The `--db-filename` flag tells Temporal to use a SQLite backend at the given
path, persisting state across restarts. This is the documented approach for
durable local dev:
https://docs.temporal.io/cli/server#--db-filename

## Changes

- Pass `--db-filename $(var)/temporal/temporal.db` so state survives restarts
  (SQLite, zero external dependencies — same engine `start-dev` already uses internally)
- Pass `--ui-port 8233` (Temporal's own default; explicit for self-documentation)
- Set `working_dir` to `$(var)/temporal` so the SQLite file lands in a
  predictable brew-managed location

## Why this is the right default

Even for a *development* server, losing all state on restart is actively harmful:
- You cannot inspect a failed workflow after the server restarts
- Schedules and registered task queues must be recreated on every reboot
- The SQLite backend has identical semantics to in-memory for local dev; the
  only difference is durability

This follows the same pattern as other brew services that default to a persistent
data directory: `postgresql@17` → `var/postgresql@17`, `redis` → `var/db/redis.rdb`.

## Testing

```bash
brew services start temporal
temporal workflow list  # note any existing workflows
brew services restart temporal
temporal workflow list  # same workflows still present
```