### PR TITLE
workflows: remove deprecated eval-all flag and env var

### DIFF
--- a/.github/workflows/remove-disabled-packages.yml
+++ b/.github/workflows/remove-disabled-packages.yml
@@ -62,7 +62,7 @@ jobs:
         id: remove_disabled
         uses: Homebrew/actions/remove-disabled-packages@main
         env:
-          HOMEBREW_EVAL_ALL: 1
+          HOMEBREW_REQUIRE_TAP_TRUST: 1
 
       - name: Push commits
         if: fromJson(steps.remove_disabled.outputs.packages-removed)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -332,7 +332,9 @@ jobs:
 
       - name: Determine runners to use for test_deps job
         id: determine-dependent-runners
-        run: brew determine-test-runners --dependents --eval-all --dependent-shards="$DEPENDENT_SHARDS" "$TESTING_FORMULAE"
+        run: brew determine-test-runners --dependents --dependent-shards="$DEPENDENT_SHARDS" "$TESTING_FORMULAE"
+        env:
+          HOMEBREW_REQUIRE_TAP_TRUST: 1
 
   test_deps:
     needs:


### PR DESCRIPTION
Replace that with `HOMEBREW_REQUIRE_TAP_TRUST` as per https://github.com/Homebrew/brew/blob/8d77d38ee871c6142a5d92959b647d831f483672/Library/Homebrew/env_config.rb#L313.

Fixes error seen in e.g. https://github.com/Homebrew/homebrew-core/actions/runs/27135822780/job/80088138806?pr=286814.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
