### PR TITLE
fsh 0.2.0 (new formula)

### DIFF
--- a/Formula/f/fsh.rb
+++ b/Formula/f/fsh.rb
@@ -1,0 +1,23 @@
+class Fsh < Formula
+  desc "FreeBSD sh(1) ported to macOS — Bourne-lineage shell with faithful echo"
+  homepage "https://github.com/dotike/freebsd-sh-macos"
+  url "https://github.com/dotike/freebsd-sh-macos/archive/refs/tags/v0.2.0.tar.gz"
+  sha256 "aafd630a6c100334bad1a55eb81abb5d0ec05168e213b1948eb5be22ce7187fe"
+  license "BSD-2-Clause"
+
+  depends_on "libedit"
+  depends_on :macos
+
+  def install
+    system "make", "LIBEDIT_PREFIX=#{Formula["libedit"].opt_prefix}",
+                   "PREFIX=#{prefix}"
+    system "make", "install", "LIBEDIT_PREFIX=#{Formula["libedit"].opt_prefix}",
+                              "PREFIX=#{prefix}"
+  end
+
+  test do
+    # echo must be faithful: no escape interpretation
+    assert_equal "hello\\nworld",
+      shell_output("#{bin}/fsh -c 'echo \"hello\\nworld\"'").strip
+  end
+end

--- a/Formula/f/fsh.rb
+++ b/Formula/f/fsh.rb
@@ -1,8 +1,8 @@
 class Fsh < Formula
   desc "FreeBSD sh(1) ported to macOS — Bourne-lineage shell with faithful echo"
-  homepage "https://github.com/dotike/freebsd-sh-macos"
-  url "https://github.com/dotike/freebsd-sh-macos/archive/refs/tags/v0.2.0.tar.gz"
-  sha256 "aafd630a6c100334bad1a55eb81abb5d0ec05168e213b1948eb5be22ce7187fe"
+  homepage "https://github.com/dotike/fsh"
+  url "https://github.com/dotike/fsh/archive/refs/tags/v0.2.0.tar.gz"
+  sha256 "d5558cd419c8d46bdc958064cb97f963d1ea793866414c025906ec15033512ed"
   license "BSD-2-Clause"
 
   depends_on "libedit"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

The fsh porting project is a co-authorship between Isaac (.ike) Levy and G.R. Emlin (Anthropic Opus 4.6).  The compat shim, Makefile, and formula were developed collaboratively. All builds, tests, and audits were run locally by the human author on macOS 26.5.1 arm64 with CLT 26.5. The formula was tested through multiple iterations of `brew install --build-from-source`, `brew test`, `brew audit --strict --new`, and `brew style`, all passing clean.

-----


## Description

FreeBSD sh(1) ported to macOS. Binary name `fsh`.

A minimal port of FreeBSD's /bin/sh to macOS/Darwin with a small compat shim for platform differences. Full line editing, history, and tab completion via Homebrew libedit. ~275KB binary. BSD-2-Clause.
  
FreeBSD sh is a Bourne-lineage shell descended from Kenneth Almquist's ash via 4.4BSD-Lite. It is the default shell on FreeBSD but is not available on macOS or in Homebrew. Now it is.

## Checks
  
- `brew audit --strict --new` passes (0 problems)
- `brew style` passes (0 offenses)
- `brew test` passes
- Builds clean with -j8 (parallel-safe Makefile)
- macOS only (`depends_on :macos`)
  
## Source

https://github.com/dotike/freebsd-sh-macos

Shell source from FreeBSD src main branch, commit ed03776ca7f4 (2023-02-18). Upstream: https://cgit.freebsd.org/src/tree/bin/sh
