### PR TITLE
wasm-*: use append_to_rustflags in test

### DIFF
--- a/Formula/w/wasm-bindgen.rb
+++ b/Formula/w/wasm-bindgen.rb
@@ -78,7 +78,7 @@ class WasmBindgen < Formula
     ENV.delete "CARGO_ENCODED_RUSTFLAGS"
 
     # Explicitly enable reference-types to resolve "failed to find intrinsics" error
-    ENV["RUSTFLAGS"] = "-C target-feature=+reference-types"
+    ENV.append_to_rustflags "-C target-feature=+reference-types"
     system "cargo", "build", "--target", "wasm32-unknown-unknown", "--manifest-path", "Cargo.toml"
     system bin/"wasm-bindgen", "target/wasm32-unknown-unknown/debug/hello_world.wasm",
                               "--out-dir", "pkg", "--reference-types"

--- a/Formula/w/wasm-pack.rb
+++ b/Formula/w/wasm-pack.rb
@@ -35,7 +35,7 @@ class WasmPack < Formula
     ENV.delete "CARGO_ENCODED_RUSTFLAGS"
 
     # Explicitly enable reference-types to resolve "failed to find intrinsics" error
-    ENV["RUSTFLAGS"] = "-C target-feature=+reference-types"
+    ENV.append_to_rustflags "-C target-feature=+reference-types"
 
     system bin/"wasm-pack", "new", "hello-wasm"
     system bin/"wasm-pack", "build", "hello-wasm"


### PR DESCRIPTION
Trying this out to avoid this style in Homebrew/core.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
