### PR TITLE
gobject-introspection: disable building tests

### DIFF
--- a/Formula/g/glib.rb
+++ b/Formula/g/glib.rb
@@ -69,10 +69,6 @@ class Glib < Formula
     # Avoid the sandbox violation when an empty directory is created outside of the formula prefix.
     inreplace "gio/meson.build", "install_emptydir(glib_giomodulesdir)", ""
 
-    # build patch for `ld: missing LC_LOAD_DYLIB (must link with at least libSystem.dylib) \
-    # in ../gobject-introspection-1.80.1/build/tests/offsets/liboffsets-1.0.1.dylib`
-    ENV.append "LDFLAGS", "-Wl,-ld_classic" if OS.mac? && MacOS.version == :ventura
-
     # Disable dtrace; see https://trac.macports.org/ticket/30413
     # and https://gitlab.gnome.org/GNOME/glib/-/issues/653
     args = %W[
@@ -97,7 +93,7 @@ class Glib < Formula
     ENV.append_path "LD_LIBRARY_PATH", lib if OS.linux?
 
     resource("gobject-introspection").stage do
-      system "meson", "setup", "build", "-Dcairo=disabled", "-Ddoctool=disabled", *staging_meson_args
+      system "meson", "setup", "build", "-Dcairo=disabled", "-Ddoctool=disabled", "-Dtests=false", *staging_meson_args
       system "meson", "compile", "-C", "build", "--verbose"
       system "meson", "install", "-C", "build"
     end

--- a/Formula/g/gobject-introspection.rb
+++ b/Formula/g/gobject-introspection.rb
@@ -65,9 +65,6 @@ class GobjectIntrospection < Formula
     ENV.prepend_path "PATH", venv.root/"bin"
 
     ENV["GI_SCANNER_DISABLE_CACHE"] = "true"
-    if OS.mac? && MacOS.version == :ventura && DevelopmentTools.clang_build_version == 1500
-      ENV.append "LDFLAGS", "-Wl,-ld_classic"
-    end
 
     inreplace "giscanner/transformer.py", "/usr/share", "#{HOMEBREW_PREFIX}/share"
     inreplace "meson.build",
@@ -76,6 +73,7 @@ class GobjectIntrospection < Formula
 
     system "meson", "setup", "build", "-Dpython=#{venv.root}/bin/python",
                                       "-Dextra_library_paths=#{HOMEBREW_PREFIX}/lib",
+                                      "-Dtests=false",
                                       *std_meson_args
     system "meson", "compile", "-C", "build", "--verbose"
     system "meson", "install", "-C", "build"


### PR DESCRIPTION
Originally added `-ld_classic` for test failure so dropping this for now. If user still hits issue, then can consider a better conditional based on ld version, e.g. `DevelopmentTools.ld64_version.between?("1015.7", "1022.1")`

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
