### PR TITLE
blink: backport fix

### DIFF
--- a/Formula/b/blink.rb
+++ b/Formula/b/blink.rb
@@ -1,10 +1,19 @@
 class Blink < Formula
   desc "Tiniest x86-64-linux emulator"
   homepage "https://github.com/jart/blink"
-  url "https://github.com/jart/blink/archive/refs/tags/1.1.0.tar.gz"
-  sha256 "2649793e1ebf12027f5e240a773f452434cefd9494744a858cd8bff8792dba68"
   license "ISC"
   head "https://github.com/jart/blink.git", branch: "master"
+
+  stable do
+    url "https://github.com/jart/blink/archive/refs/tags/1.1.0.tar.gz"
+    sha256 "2649793e1ebf12027f5e240a773f452434cefd9494744a858cd8bff8792dba68"
+
+    # Backport fix for `pointer not aligned at _kWhence+0x4`
+    patch do
+      url "https://github.com/jart/blink/commit/f93880dd38877914b71c2276bb476329a9e24ed0.patch?full_index=1"
+      sha256 "c7f6b41eaf9c0edee25191b6aa9e8dd21d29734c1474919f5f67685893bf20d7"
+    end
+  end
 
   bottle do
     rebuild 2
@@ -27,10 +36,6 @@ class Blink < Formula
   end
 
   def install
-    # newer linker cause issue as `pointer not aligned at _kWhence+0x4`
-    # upstream bug report, https://github.com/jart/blink/issues/166
-    ENV.append "LDFLAGS", "-Wl,-ld_classic" if DevelopmentTools.clang_build_version >= 1500
-
     system "./configure", "--prefix=#{prefix}", "--enable-vfs"
     # Call `make` as `gmake` to use Homebrew `make`.
     system "gmake" # must be separate steps.


### PR DESCRIPTION
To avoid `-ld_classic` workaround

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
