### PR TITLE
spidermonkey: replace -ld_classic patch with lld

### DIFF
--- a/Formula/s/spidermonkey.rb
+++ b/Formula/s/spidermonkey.rb
@@ -35,6 +35,12 @@ class Spidermonkey < Formula
   uses_from_macos "llvm" => :build # for llvm-objdump
   uses_from_macos "m4" => :build
 
+  on_macos do
+    # Use LLD to work around lack of support for modern Apple ld
+    # Issue ref: https://bugzilla.mozilla.org/show_bug.cgi?id=1844694
+    depends_on "lld" => :build if DevelopmentTools.clang_build_version >= 1500
+  end
+
   on_linux do
     depends_on "zlib-ng-compat"
   end
@@ -72,6 +78,7 @@ class Spidermonkey < Formula
 
   def install
     ENV.runtime_cpu_detection
+    ENV.O3 if DevelopmentTools.clang_build_version >= 1500 # lld doesn't support -Os
 
     # Vendored encoding_rs 0.8.35 fails to build with rust 1.95 (Mask::select moved
     # to a trait method). Use cargo's `[patch.crates-io]` to redirect to the upstream
@@ -86,9 +93,6 @@ class Spidermonkey < Formula
 
     if OS.mac?
       inreplace "build/moz.configure/toolchain.configure" do |s|
-        # Help the build script detect ld64 as it expects logs from LD_PRINT_OPTIONS=1 with -Wl,-version
-        # Issue ref: https://bugzilla.mozilla.org/show_bug.cgi?id=1844694
-        s.sub! '"-Wl,--version"', '"-Wl,-ld_classic,-v"' if DevelopmentTools.clang_build_version >= 1500
         # Allow using brew libraries on macOS (not officially supported)
         s.sub!(/^(\s*def no_system_lib_in_sysroot\(.*\n\s*if )bootstrapped and value:/, "\\1False:")
         # Work around upstream only allowing build on limited macOS SDK (14.4 as of Spidermonkey 128)


### PR DESCRIPTION
Will stop working in Xcode 27 and better to use officially supported option (i.e. lld) rather than patching.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
