### PR TITLE
zerolang: add livecheck

### DIFF
--- a/Formula/z/zerolang.rb
+++ b/Formula/z/zerolang.rb
@@ -6,6 +6,11 @@ class Zerolang < Formula
   license "Apache-2.0"
   head "https://github.com/vercel-labs/zero.git", branch: "main"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "a6d2d5f995b6bb318a53e6d23aac277b982b7e00114df671ae0aa7672a5e783a"
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "52841475c560559e4b286c62b6bfb6c0c40847faceec9b455a98397b9b731c65"


### PR DESCRIPTION
Exclude repo-owned Zig toolchain from livecheck
https://github.com/Homebrew/homebrew-core/actions/runs/27187360524/job/80259155186#step:6:32115

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
