### PR TITLE
container: fix system start with 1.0.0 plugin layout

### DIFF
--- a/Formula/c/container.rb
+++ b/Formula/c/container.rb
@@ -4,6 +4,7 @@ class Container < Formula
   url "https://github.com/apple/container/archive/refs/tags/1.0.0.tar.gz"
   sha256 "9f5379d400d23b6f296b7bae8f71f982dfdc1d52bf072ac81318472a734d21f7"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/apple/container.git", branch: "main"
 
   bottle do
@@ -34,22 +35,38 @@ class Container < Formula
     codesign "--identifier=com.apple.container.cli", bin/"container"
     codesign "--identifier=com.apple.container.apiserver", bin/"container-apiserver"
 
-    {
-      "container-core-images"   => "CoreImages",
-      "container-network-vmnet" => "NetworkVMNet",
-      "container-runtime-linux" => "RuntimeLinux",
-    }.each do |bin_name, source|
-      (libexec/"container-plugins/#{bin_name}/bin").install release_dir/bin_name
-      (libexec/"container-plugins/#{bin_name}").install "Sources/Plugins/#{source}/config.toml"
+    plugins = {
+      "container-core-images"   => { source: "CoreImages",       entitlements: false },
+      "container-network-vmnet" => { source: "NetworkVMNet",     entitlements: true  },
+      "container-runtime-linux" => { source: "RuntimeLinux",     entitlements: true  },
+      "machine-apiserver"       => { source: "MachineAPIServer", entitlements: false,
+                                     resources: ["init", "create-user.sh"] },
+    }
+    plugins.each do |bin_name, opts|
+      plugin_dir = libexec/"container-plugins/#{bin_name}"
+      (plugin_dir/"bin").install release_dir/bin_name
+      plugin_dir.install "Sources/Plugins/#{opts[:source]}/config.toml"
+      opts[:resources]&.each do |resource|
+        (plugin_dir/"resources").install "Sources/Plugins/#{opts[:source]}/Resources/#{resource}"
+      end
 
       entitlement_args = []
-      entitlement_args << "--entitlements=signing/#{bin_name}.entitlements" if bin_name != "container-core-images"
+      entitlement_args << "--entitlements=signing/#{bin_name}.entitlements" if opts[:entitlements]
 
       codesign "--prefix=com.apple.container.", *entitlement_args,
-libexec/"container-plugins/#{bin_name}/bin/#{bin_name}"
+               plugin_dir/"bin/#{bin_name}"
     end
 
     generate_completions_from_executable bin/"container", "--generate-completion-script"
+
+    # Relocate the binaries under libexec and replace them in bin with shim
+    # wrappers. The CLI resolves its install root as the lexical grandparent
+    # of the running executable (see Sources/ContainerPlugin/InstallRoot.swift),
+    # so the binaries must live one directory below the keg root for the
+    # bundled plugins under libexec/container-plugins/ to be discovered.
+    # CONTAINER_INSTALL_ROOT is also exported by the wrappers for the code
+    # paths that honour the environment variable.
+    bin.env_script_all_files libexec, CONTAINER_INSTALL_ROOT: opt_prefix
   end
 
   def codesign(*args)

--- a/Formula/c/container.rb
+++ b/Formula/c/container.rb
@@ -8,8 +8,8 @@ class Container < Formula
   head "https://github.com/apple/container.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "90c8c729df08ff62c39c11a06c64fc9e966fc5db37a5048f1313d83a8be5d5f2"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "d4ad56a2548b02a20824284c768c24d4debfe8c6406debb53ef3461afb4bad54"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "371fc0f685b7ca0499117a9a0b9d28498bc3bd178918f7bd79c233a7fb0674e8"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "3bf19c9addbff90135818cadbd3bcc6fcbb76a22a886706888538e6f57ca3f5d"
   end
 
   depends_on xcode: ["26.0", :build]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://docs.brew.sh/Formula-Cookbook#contributing-to-homebrew)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your changes locally with `brew install --build-from-source <formula>`?
- [x] Have you successfully run `brew test <formula>`?
- [x] Have you successfully run `brew audit --strict <formula>` (or `brew audit --new <formula>` for new formulae)?

## Summary

Fix two regressions in `container` 1.0.0 that together prevent `container system start` from completing. The apiserver fails to find its plugins and the new `container machine` subsystem cannot start at all.

## Root causes

### 1. Stale `inreplace` patch becomes a silent no-op in 1.0.0

The previous formula patched `Sources/ContainerPlugin/InstallRoot.swift` via `inreplace` to hard-code the keg prefix as the install root. Upstream [apple/container#1558](https://github.com/apple/container/pull/1558) (May 2026) renamed the symbols the `inreplace` targeted:

- `CommandLine.executablePathUrl` → `CommandLine.executablePath`
- `deletingLastPathComponent` → `removingLastComponent`

So the substitution silently became a no-op when 1.0.0 was bumped. The apiserver now resolves its install root as the lexical grandparent of the running executable **without symlink resolution** ([source comment](https://github.com/apple/container/blob/1.0.0/Sources/ContainerPlugin/InstallRoot.swift#L28-L32)). When invoked as `/opt/homebrew/bin/container`, the resolved install root is `/opt/homebrew`, where no `libexec/container-plugins` directory exists.

The apiserver crash-loops with `"cannot find any plugins with type network"` and `container system start` hangs at `Testing access to container-apiserver...`.

**Fix:** replace the source-patch with a clean install layout. Move the binaries into `libexec/` and use `bin.env_script_all_files` to generate shim wrappers in `bin/` that `exec` the real binaries via their absolute keg path. The kernel-reported executable path now has the `opt_prefix` as its lexical grandparent, putting the plugin search exactly on top of `opt_prefix/libexec/container-plugins/`. The wrappers also export `CONTAINER_INSTALL_ROOT=opt_prefix` for the code paths that honour the environment variable. No more source patching, so the formula stops being fragile to upstream symbol renames.

### 2. Missing `machine-apiserver` plugin in 1.0.0

The 1.0.0 release added a new `machine-apiserver` plugin ([apple/container#1662](https://github.com/apple/container/pull/1662), the new `container machine` subsystem) under `Sources/Plugins/MachineAPIServer` that the formula never picks up. `container system start` fails at the `Verifying machine API server is running...` step without it.

The new plugin also requires two runtime resources (`init`, `create-user.sh`) under `<plugin>/resources/` that the upstream Makefile installs.

**Fix:** refactor the plugin installation loop into a data-driven structure so adding the new plugin (with its `config.toml` plus `init` and `create-user.sh` resources from `Sources/Plugins/MachineAPIServer/Resources/`) is a one-line addition. Codesigning mirrors what the upstream Makefile does for that binary (`--prefix` only, no entitlements; no `signing/machine-apiserver.entitlements` exists upstream).

## Why one PR

Per `AGENTS.md` PRs should be scoped to one change. I've kept the two fixes together intentionally because `container system start` is broken without **both**:

1. Without first fix, the apiserver crash-loops before any plugin can be reached.
2. Even with first fix, `system start` fails at `Verifying machine API server is running...` because the `machine-apiserver` plugin is absent.

Splitting would land an intermediate commit that's no more functional than the current 1.0.0. Happy to split if the maintainers prefer.

## Local verification

```console
$ HOMEBREW_NO_INSTALL_FROM_API=1 brew audit --strict --online container
$ HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source container
$ HOMEBREW_NO_INSTALL_FROM_API=1 brew test container

$ container system start
Launching container-apiserver...
Testing access to container-apiserver...
Verifying machine API server is running...

$ container system status
FIELD              VALUE
status             running
appRoot            /Users/.../Library/Application Support/com.apple.container/
installRoot        /opt/homebrew/Cellar/container/1.0.0/
...

$ container list
ID  IMAGE  OS  ARCH  STATE  IP  CPUS  MEMORY  STARTED

$ container machine create alpine:3.22 --name brewtest
brewtest

$ container machine list
NAME      CREATED              IP            CPUS  MEMORY  DISK  STATE    DEFAULT
brewtest  2026-06-09 01:14:03  192.168.64.2  6     9G      75M   running
```

All four plugins (`container-core-images`, `container-network-vmnet`, `container-runtime-linux`, `machine-apiserver`) register cleanly and the API and machine subsystems function end-to-end.
