### PR TITLE
mas: replace `on_sonoma :or_older` block with `uses_from_macos`

### DIFF
--- a/Formula/m/mas.rb
+++ b/Formula/m/mas.rb
@@ -22,14 +22,10 @@ class Mas < Formula
   depends_on :macos
 
   uses_from_macos "swift" => :build, since: :sequoia # swift 6.2+
+  uses_from_macos "jq", since: :sequoia
 
   on_sequoia :or_newer do
     depends_on xcode: ["26.0", :build]
-  end
-
-  on_sonoma :or_older do
-    depends_on "swift" => :build
-    depends_on "jq"
   end
 
   def install


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
