### PR TITLE
sentry-cli: replace `on_ventura :ol_older` block with `uses_from_macos`

### DIFF
--- a/Formula/s/sentry-cli.rb
+++ b/Formula/s/sentry-cli.rb
@@ -24,11 +24,8 @@ class SentryCli < Formula
   depends_on "rust" => :build
   depends_on "openssl@3"
 
+  uses_from_macos "swift" => :build, since: :sonoma
   uses_from_macos "bzip2"
-
-  on_ventura :or_older do
-    depends_on "swift" => :build
-  end
 
   on_linux do
     depends_on "zlib-ng-compat"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
