### PR TITLE
webp: remove TIFF input support to remove webp circular dependency for libtiff

### DIFF
--- a/Formula/w/webp.rb
+++ b/Formula/w/webp.rb
@@ -27,11 +27,11 @@ class Webp < Formula
   depends_on "giflib"
   depends_on "jpeg-turbo"
   depends_on "libpng"
-  depends_on "libtiff"
 
   def install
     args = %W[
       -DCMAKE_INSTALL_RPATH=#{rpath}
+      -DCMAKE_DISABLE_FIND_PACKAGE_TIFF=ON
     ]
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args, "-DBUILD_SHARED_LIBS=ON", *args
     system "cmake", "--build", "build"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. 

AI was used to help diagnose the initial circular dependency issue with libtiff / webp and to come up with some the `-DCMAKE_DISABLE_FIND_PACKAGE_TIFF=ON` option to break the automatic `webp` depenency on `libtiff`.

Code was tested by hand and code was reviewed by eye and tools.

-----

Remove `libtiff` support from the `webp` formula so that `libtiff` can depend on `webp` without creating a circular dependency.

This is intended to allow a follow-up change enabling WebP compression support in `libtiff`, which is needed by downstream consumers such as GDAL for WebP-compressed TIFF/COG files.

As a consequence, `cwebp` cli will lose the ability to read TIFF input files. It continues to support the other documented input formats: WebP, JPEG, PNG, PNM (PGM, PPM, PAM).