### PR TITLE
perl-dbd-mysql: use `MacOS.sdk_path`

### DIFF
--- a/Formula/p/perl-dbd-mysql.rb
+++ b/Formula/p/perl-dbd-mysql.rb
@@ -62,7 +62,7 @@ class PerlDbdMysql < Formula
       # Work around macOS DBI generating broken Makefile
       inreplace "Makefile" do |s|
         old_dbi_instarch_dir = s.get_make_var("DBI_INSTARCH_DIR")
-        new_dbi_instarch_dir = "#{MacOS.sdk_path_if_needed}#{old_dbi_instarch_dir}"
+        new_dbi_instarch_dir = "#{MacOS.sdk_path}#{old_dbi_instarch_dir}"
         s.change_make_var! "DBI_INSTARCH_DIR", new_dbi_instarch_dir
         s.gsub! " #{old_dbi_instarch_dir}/Driver_xst.h", " #{new_dbi_instarch_dir}/Driver_xst.h"
       end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
Replace deprecated `MacOS.sdk_path_if_needed` method with `MacOS.sdk_path` (https://github.com/Homebrew/brew/blob/af9b9db642bcb25e62a9e8511699901d9f135db4/Library/Homebrew/os/mac.rb#L169)