### PR TITLE
spotifyd: use `MacOS.sdk_path`

### DIFF
--- a/Formula/s/spotifyd.rb
+++ b/Formula/s/spotifyd.rb
@@ -37,7 +37,7 @@ class Spotifyd < Formula
 
   def install
     if OS.mac?
-      ENV["COREAUDIO_SDK_PATH"] = MacOS.sdk_path_if_needed
+      ENV["COREAUDIO_SDK_PATH"] = MacOS.sdk_path
       args = %w[--no-default-features]
       features = %w[portaudio_backend]
     end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
Replace deprecated `MacOS.sdk_path_if_needed` method with `MacOS.sdk_path` (https://github.com/Homebrew/brew/blob/af9b9db642bcb25e62a9e8511699901d9f135db4/Library/Homebrew/os/mac.rb#L169)