### PR TITLE
eas-cli 20.1.0 (new formula)

### DIFF
--- a/Formula/e/eas-cli.rb
+++ b/Formula/e/eas-cli.rb
@@ -1,0 +1,20 @@
+class EasCli < Formula
+  desc "Command-line tool for working with Expo Application Services"
+  homepage "https://docs.expo.dev/eas/"
+  url "https://registry.npmjs.org/eas-cli/-/eas-cli-20.1.0.tgz"
+  sha256 "658c055798bc225fc08dc9338fa6dc83b6267381a6fe2f8cbf41018607b5d4e5"
+  license "MIT"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink libexec.glob("bin/*")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/eas --version")
+    assert_match "Run this command inside a project directory",
+                 shell_output("#{bin}/eas diagnostics 2>&1", 1)
+  end
+end

--- a/Formula/e/eas-cli.rb
+++ b/Formula/e/eas-cli.rb
@@ -5,6 +5,10 @@ class EasCli < Formula
   sha256 "658c055798bc225fc08dc9338fa6dc83b6267381a6fe2f8cbf41018607b5d4e5"
   license "MIT"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, all: "c214a719cb15018a390dcc2baf967736db6f672666e606b20727d565f19d11fe"
+  end
+
   depends_on "node"
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source eas-cli`?
- [x] Is your test running fine `brew test eas-cli`?
- [x] Does your build pass `brew audit --strict eas-cli` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source eas-cli`)? If this is a new formula, does it pass `brew audit --new eas-cli`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

`eas-cli` is the command-line tool for Expo Application Services (EAS).

- Upstream: https://github.com/expo/eas-cli

Validated locally on macOS arm64:

- `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source eas-cli`
- `brew test eas-cli`
- `brew audit --new --strict --online eas-cli`

AI/LLM disclosure: The formula was drafted with assistance from Claude with [oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent). All Homebrew validation above was performed and verified manually by me.
