### PR TITLE
livekit-cli 2.16.6

### DIFF
--- a/Formula/l/livekit-cli.rb
+++ b/Formula/l/livekit-cli.rb
@@ -1,8 +1,8 @@
 class LivekitCli < Formula
   desc "Command-line interface to LiveKit"
   homepage "https://livekit.io"
-  url "https://github.com/livekit/livekit-cli/archive/refs/tags/v2.16.4.tar.gz"
-  sha256 "064070e62e3cd864c2e02f999eb6e000ce9ba5ecf7f7cbeffc2cf8d9685ffa7e"
+  url "https://github.com/livekit/livekit-cli/archive/refs/tags/v2.16.6.tar.gz"
+  sha256 "fddbe59b625114d244d65708c350b2fdf2bd1f2dab65e827db6f3abbd42a8823"
   license "Apache-2.0"
   head "https://github.com/livekit/livekit-cli.git", branch: "main"
 
@@ -16,10 +16,13 @@ class LivekitCli < Formula
   end
 
   depends_on "go" => :build
+  depends_on "pkgconf" => :build
+  depends_on "portaudio"
 
   def install
+    ENV["CGO_ENABLED"] = "1"
     ldflags = "-s -w"
-    system "go", "build", *std_go_args(ldflags:, output: bin/"lk"), "./cmd/lk"
+    system "go", "build", *std_go_args(ldflags:, tags: "portaudio_system", output: bin/"lk"), "./cmd/lk"
 
     bin.install_symlink "lk" => "livekit-cli"
 

--- a/Formula/l/livekit-cli.rb
+++ b/Formula/l/livekit-cli.rb
@@ -7,12 +7,12 @@ class LivekitCli < Formula
   head "https://github.com/livekit/livekit-cli.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "1b25fec81fad7aa299d8fbaf5fd8a11303c4056a1d8fe50b9c657f16e4a0d90c"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "0dfde6c510b3afa4edcfb524c1b6abf6cebccd12a468015b93fa2e5a081b0965"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "b2f5d630d9a1ee6d8cb3a4c77e1f3c4f0a5c825e511f6d07c973cbec4afcd62b"
-    sha256 cellar: :any_skip_relocation, sonoma:        "505a80c580f10a255a066405fec80a60a8004eb6450a98b3d9e8cb435511c9d1"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "f4c5840ab902cbcbf7de9ce18768a5d68eaae9e1f87b0ca2d6e56b358ba7c9d8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "516a94f44404a990e277d914478f83d6e3d732c72a6ff2bbdc4b40e08ee3de08"
+    sha256 cellar: :any, arm64_tahoe:   "f400fa8bae30d2b74c2409223d0f08827757afa0cb5b8af840cb4707481c2a44"
+    sha256 cellar: :any, arm64_sequoia: "15575e16de1d58660ab9f31a4b3935c5c69da8e12bd718323fac1b9e86f12054"
+    sha256 cellar: :any, arm64_sonoma:  "b51dd35b6c127f93b601a56b5e56310734f0bd0bad8dbb6ca88050e890bd34f7"
+    sha256 cellar: :any, sonoma:        "3203598a2a2654ba87e007d6704511e8e6ffa63edb23b69677bc55e22dc13a0f"
+    sha256 cellar: :any, arm64_linux:   "ec108d02799b3704663f195d7ae5e071b0291ad240ae0f2572619f7e82ec3c3d"
+    sha256 cellar: :any, x86_64_linux:  "740bff5df71a54323ddf7bcc0fa5b2b926fe1367a795244dd9dee1f5e93ceada"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
Updates `livekit-cli` to version `2.16.6` and updates formula to include new build requirements:
- Adds `portaudio` as a dependency
- `CGO_ENABLED=1` is now required to build the binary, since we compile in parts of the `webrtc` C library

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Claude was used to help identify the issue of the `portaudio` git submodule being excluded from version tarball, and to vendor a pinned version of it at build time.

-----
