### PR TITLE
keyd 2.6.0 (new formula)

### DIFF
--- a/Formula/k/keyd.rb
+++ b/Formula/k/keyd.rb
@@ -6,6 +6,11 @@ class Keyd < Formula
   license "MIT"
   head "https://github.com/rvaiya/keyd.git", branch: "master"
 
+  bottle do
+    sha256 arm64_linux:  "ec0b6c7eb5cc05f443806d1b83ed19057c7625be96c64bab28b7df7e771c6d65"
+    sha256 x86_64_linux: "b064222519572ae5ac23b65a5d5fc17d3347b9d20e9c2385a8ad218608378592"
+  end
+
   depends_on :linux
 
   def install

--- a/Formula/k/keyd.rb
+++ b/Formula/k/keyd.rb
@@ -1,0 +1,47 @@
+class Keyd < Formula
+  desc "Key remapping daemon for Linux"
+  homepage "https://github.com/rvaiya/keyd"
+  url "https://github.com/rvaiya/keyd/archive/refs/tags/v2.6.0.tar.gz"
+  sha256 "697089681915b89d9e98caf93d870dbd4abce768af8a647d54650a6a90744e26"
+  license "MIT"
+  head "https://github.com/rvaiya/keyd.git", branch: "master"
+
+  depends_on :linux
+
+  def install
+    args = %W[
+      PREFIX=#{prefix}
+      CONFIG_DIR=#{etc}/keyd
+    ]
+    system "make", *args, "SOCKET_PATH=#{var}/run/keyd.socket"
+    system "make", "install", *args
+  end
+
+  service do
+    run [opt_bin/"keyd"]
+    keep_alive true
+    require_root true
+    log_path var/"log/keyd.log"
+    error_log_path var/"log/keyd.log"
+  end
+
+  def caveats
+    <<~EOS
+      Default configuration goes in #{etc}/keyd/default.conf
+    EOS
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/keyd --version")
+
+    # Verify check command works with a valid config
+    (testpath/"test.conf").write <<~CONF
+      [ids]
+      *
+
+      [main]
+      capslock = esc
+    CONF
+    assert_match "No errors found", shell_output("#{bin}/keyd check #{testpath}/test.conf")
+  end
+end


### PR DESCRIPTION
[keyd](https://github.com/rvaiya/keyd) is a key remapping daemon for Linux that supports dynamic keymap modification (no reload needed), scriptable changes, and per-application remapping. It is already [present](https://repology.org/project/keyd/information) in many package repositories.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

  I provided detailed instructions to the coding agent, reviewed the resulting formula manually and made adjustments where appropriate, ensured the resulting formula passed the tests and audit, and manually tested the build binary to confirm it worked as expected. 
-----
