### PR TITLE
workflows/tests: limit recursive CI typechecking

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,6 @@ env:
   HOMEBREW_GITHUB_ACTIONS: 1
   HOMEBREW_NO_AUTO_UPDATE: 1
   HOMEBREW_NO_INSTALL_FROM_API: 1
-  # TODO: Disable this for `tap_syntax`, `brew audit` and `brew readall`.
-  HOMEBREW_SORBET_RECURSIVE: 1
   HOMEBREW_TEST_BOT_ANALYTICS: 1
   HOMEBREW_ENFORCE_SBOM: 1
   HOMEBREW_NO_BUILD_ERROR_ISSUES: 1
@@ -64,6 +62,8 @@ jobs:
           restore-keys: style-cache-${{ matrix.stable && 'stable-' || 'main-' }}
 
       - run: brew test-bot --only-tap-syntax ${{ matrix.stable && '--stable' || '' }}
+        env:
+          HOMEBREW_SORBET_RECURSIVE: 1
 
   formulae_detect:
     if: github.repository_owner == 'Homebrew' && github.event_name != 'push'


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Currently has a noticeable performance impact, at least on Linux where CI runs takes 2-3x longer.

From internal discussion, we can turn this off now.

Perhaps can selectively reenable if needed or after tuning performance to not have as serious degradation. Would likely need adjustments on brew side as Homebrew/core can only set at test-bot level.