### PR TITLE
pygobject3: remove `gobject-introspection` dependency

### DIFF
--- a/Formula/p/pygobject3.rb
+++ b/Formula/p/pygobject3.rb
@@ -23,8 +23,7 @@ class Pygobject3 < Formula
 
   depends_on "cairo"
   depends_on "glib"
-  depends_on "gobject-introspection"
-  depends_on "py3cairo"
+  depends_on "py3cairo" => :no_linkage
 
   uses_from_macos "libffi"
 


### PR DESCRIPTION
It switched to newer `glib` provided libraries.

I think only needed if building tests: https://gitlab.gnome.org/GNOME/pygobject/-/blob/main/meson.build?ref_type=heads#L223-232

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
