### PR TITLE
gjs: make `gobject-introspection` build dependency

### DIFF
--- a/Formula/g/gjs.rb
+++ b/Formula/g/gjs.rb
@@ -16,12 +16,13 @@ class Gjs < Formula
     sha256 x86_64_linux:  "500a526ee59d19864fd08b18a441d3e01e2759236928b6e5257697ec4e7a2995"
   end
 
+  depends_on "gobject-introspection" => :build # for generate_gir
   depends_on "meson" => :build
   depends_on "ninja" => :build
+  depends_on "pkgconf" => :build
 
   depends_on "cairo"
   depends_on "glib"
-  depends_on "gobject-introspection"
   depends_on "libx11"
   depends_on "readline"
   depends_on "spidermonkey"


### PR DESCRIPTION
https://gitlab.gnome.org/GNOME/gjs/-/commit/63329f7183900e95a7fddde871d79ee264d4ecb3

Still needed at build-time to generate gir

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
