### PR TITLE
task: add with-native-tls-roots option

### DIFF
--- a/Formula/t/task.rb
+++ b/Formula/t/task.rb
@@ -39,8 +39,15 @@ class Task < Formula
     sha256 "a5775db70a678f8d666bd69f31aef0bccb98cf252f15d3d28f05233a6bd3b720"
   end
 
+  # Taskwarrior 3.x uses rustls with tls-webpki-roots by default, which embeds Mozilla's CA list at compile time
+  # and bypasses the system keychain entirely. Building with ENABLE_TLS_NATIVE_ROOTS=ON switches to tls-native-roots,
+  # and reads from the macOS Keychain at runtime.
+
   def install
-    system "cmake", "-S", ".", "-B", "build", "-DSYSTEM_CORROSION=ON", *std_cmake_args
+    system "cmake", "-S", ".", "-B", "build",
+                                     "-DSYSTEM_CORROSION=ON",
+                                     "-DENABLE_TLS_NATIVE_ROOTS=ON",
+                                     *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
     bash_completion.install "scripts/bash/task.sh"


### PR DESCRIPTION
Adds a build option to use macOS Keychain for TLS root certificates instead of the bundled Mozilla CA list. This is required in environments where a TLS-intercepting proxy re-signs connections using an enterprise CA that is not in Mozilla's public bundle.

Taskwarrior 3.x uses rustls with tls-webpki-roots by default, which embeds Mozilla's CA list at compile time and bypasses the system keychain entirely. Building with ENABLE_TLS_NATIVE_ROOTS=ON switches to tls-native-roots, which reads from the macOS Keychain at runtime.

Fixes sync failure: 'tls connection init failed: invalid peer certificate: UnknownIssuer' "

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
