### PR TITLE
ocrmypdf: recommend verapdf in caveats

### DIFF
--- a/Formula/o/ocrmypdf.rb
+++ b/Formula/o/ocrmypdf.rb
@@ -137,6 +137,14 @@ class Ocrmypdf < Formula
     fish_completion.install "misc/completion/ocrmypdf.fish"
   end
 
+  def caveats
+    <<~EOS
+      OCRmyPDF works without veraPDF, but installing it enables faster
+      PDF/A validation and is recommended for the best PDF/A experience:
+        brew install verapdf
+    EOS
+  end
+
   test do
     system bin/"ocrmypdf", "-f", "-q", "--deskew",
                            test_fixtures("test.pdf"), "ocr.pdf"


### PR DESCRIPTION
This adds a caveat to the `ocrmypdf` formula recommending the optional **veraPDF** tool. (For context, I'm the upstream maintainer of OCRmyPDF.)

OCRmyPDF can use veraPDF at runtime to validate and accelerate its PDF/A output via a speculative-conversion path — it shells out to the `verapdf` binary when present (see [`src/ocrmypdf/_exec/verapdf.py`](https://github.com/ocrmypdf/OCRmyPDF/blob/main/src/ocrmypdf/_exec/verapdf.py) and the [installation docs](https://ocrmypdf.readthedocs.io/en/latest/installation.html)). It meaningfully improves the default PDF/A workflow, but it is **not required**: Ghostscript remains the required PDF/A path, so OCRmyPDF works fully without veraPDF.

Since `verapdf` pulls in `openjdk`, and `homebrew-core` doesn't support `:recommended`/`:optional` dependencies, a hard `depends_on "verapdf"` would force a JRE on every user for an optional feature — contrary to keeping the default dependency tree minimal. A caveat is the least-intrusive way to surface the recommendation.

This is a metadata-only change (no build/runtime impact). `brew style` and `brew audit --strict` both pass locally.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open pull requests for the same change?
- [ ] Have you built your formula locally with `brew install --build-from-source ocrmypdf`? — N/A: caveats-only change with no build impact.
- [x] Is your test running fine `brew test ocrmypdf`? — unchanged by this PR.
- [x] Have you run `brew audit --strict ocrmypdf`? — passes with no offenses.
