### PR TITLE
mcap 0.1.0

### DIFF
--- a/Formula/m/mcap.rb
+++ b/Formula/m/mcap.rb
@@ -1,8 +1,8 @@
 class Mcap < Formula
   desc "Serialization-agnostic container file format for pub/sub messages"
   homepage "https://mcap.dev"
-  url "https://github.com/foxglove/mcap/archive/refs/tags/releases/mcap-cli/v0.0.62.tar.gz"
-  sha256 "c0fcd10469cdbd30839b05678e2e35bb0cf64f17bc26b54115aa89df632c500e"
+  url "https://github.com/foxglove/mcap/archive/refs/tags/releases/mcap-cli/v0.1.0.tar.gz"
+  sha256 "f5c8debb20a68d136018b1bc7c0a5250fd647440134ed50dd1fc31ec30f43d4b"
   license "MIT"
   head "https://github.com/foxglove/mcap.git", branch: "main"
 
@@ -20,14 +20,11 @@ class Mcap < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "f50e7b18012cf9f724e5c337ead3ee11318969c02aed65de3ceb4b8bf8a960bc"
   end
 
-  depends_on "go" => :build
+  depends_on "rust" => :build
 
   def install
-    cd "go/cli/mcap" do
-      system "make", "build", "VERSION=v#{version}"
-      bin.install "bin/mcap"
-    end
-    generate_completions_from_executable(bin/"mcap", shell_parameter_format: :cobra)
+    system "cargo", "install", *std_cargo_args(path: "rust/cli")
+    generate_completions_from_executable(bin/"mcap", "completion")
   end
 
   test do
@@ -46,7 +43,7 @@ class Mcap < Formula
       sha256 "cb779e0296d288ad2290d3c1911a77266a87c0bdfee957049563169f15d6ba8e"
     end
 
-    assert_equal "v#{version}", shell_output("#{bin}/mcap version").strip
+    assert_match(%r{^mcap #{version} \([^)]+\) mcap-rust/}, shell_output("#{bin}/mcap --version").strip)
 
     resource("homebrew-testdata-OneMessage").stage do
       assert_equal "2 example [Example] [1 2 3]",

--- a/Formula/m/mcap.rb
+++ b/Formula/m/mcap.rb
@@ -12,12 +12,12 @@ class Mcap < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "dcfc09bff02929c8813f1d545e41e4738575bdfc1a48a99424cf8c6ef6fa0db9"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "7bfecbd2f17d2de2c3f4e43bf973d4582b30294c31b4d3eff2669b5103fd2fd8"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "754fb9a84373ce3fea7a87638498260b604aedc1d1b549dbcab0718881b2d8f7"
-    sha256 cellar: :any_skip_relocation, sonoma:        "32f7b0c66b3930630d4d7543f22c59fd0ae77945f3a404874aca550d9176ef71"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "90c6e2f435b64a6227ab7ec3221a804537e68aecc3f00423297554f399a39cd9"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f50e7b18012cf9f724e5c337ead3ee11318969c02aed65de3ceb4b8bf8a960bc"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "17e512520cb338d53df64ec487b0d79f4e9e5a65fb333a5257da8f81d3cf0834"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "ecdff917b0ede83b2602f050dfeaaef15e7537dacb75905cbba7d01b4471d9a8"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "4aa47270bae11a434733e6927abf925f5090bc801b025cbc6767df33cd6d3c23"
+    sha256 cellar: :any_skip_relocation, sonoma:        "600300856d1c6ff812793867df158edd9b24da33ee96cebf19b2d33dd9f7678a"
+    sha256 cellar: :any,                 arm64_linux:   "04ee777db81aa7dc232b7c5d59c1f8c5ff7a899691d68ec0eda3a98fe97885d2"
+    sha256 cellar: :any,                 x86_64_linux:  "932f961555176fbb3049103338138e0fbf114a7b03ced6b379541e2aa2027677"
   end
 
   depends_on "rust" => :build


### PR DESCRIPTION
Manual formula update because MCAP CLI has been rewritten from Go to Rust:

https://github.com/foxglove/mcap/releases/tag/releases%2Fmcap-cli%2Fv0.1.0

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

AI-assisted contribution by Cursor GPT-5.5 of most of the formula update. Validation steps were run locally by AI and reviewed by me (human).

Built and tested locally on macOS Tahoe 26.5 running arm64.

Updates `mcap` to 0.1.0, which ports the CLI from Go to Rust.