### PR TITLE
taskopen: update homepage/head to codeberg

### DIFF
--- a/Formula/t/taskopen.rb
+++ b/Formula/t/taskopen.rb
@@ -1,10 +1,11 @@
 class Taskopen < Formula
   desc "Tool for taking notes and open urls with taskwarrior"
-  homepage "https://github.com/jschlatow/taskopen"
+  homepage "https://codeberg.org/jschlatow/taskopen"
+  # TODO: Switch to codeberg on next release. Deferred to avoid checksum change
   url "https://github.com/jschlatow/taskopen/archive/refs/tags/v2.0.3.tar.gz"
   sha256 "fe16f839279e8baff96dcead55feb03997aebdaa3cee7a421dadc8e7cb8c1581"
   license "GPL-2.0-only"
-  head "https://github.com/jschlatow/taskopen.git", branch: "master"
+  head "https://codeberg.org/jschlatow/taskopen.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "88c6ca32bc458061057c90fa56237a7e0d0c7e7325a9b8f18e8750b6bb822b5f"
@@ -19,6 +20,9 @@ class Taskopen < Formula
   depends_on "task"
 
   def install
+    # Workaround for https://codeberg.org/jschlatow/taskopen/issues/180
+    inreplace "taskopen.nimble", '"2.0.0alpha"', "\"#{stable.version}\"" if build.head?
+
     system "make", "install", "PREFIX=#{prefix}", "VERSION=#{version}"
   end
 


### PR DESCRIPTION
See https://github.com/jschlatow/taskopen/commit/03c6c6108fd8429c087dbf28fb8933edd6e1d73d

Deferring url update to avoid checksum change

Also add a workaround to build HEAD until fixed upstream.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
