### PR TITLE
llvm@16: skip parts of test on newer CLT

### DIFF
--- a/Formula/l/llvm@16.rb
+++ b/Formula/l/llvm@16.rb
@@ -31,6 +31,9 @@ class LlvmAT16 < Formula
 
   # https://llvm.org/docs/GettingStarted.html#requirement
   depends_on "cmake" => :build
+  # Fails to build with Xcode/CLT 26.4+. Also parts of test fail.
+  # sancov.cpp:521:42: error: chosen constructor is explicit in copy-initialization
+  depends_on maximum_macos: [:sequoia, :build]
   depends_on "ninja" => :build
   depends_on "swig" => :build
   depends_on "python@3.12"
@@ -348,7 +351,7 @@ class LlvmAT16 < Formula
     # These tests should ignore the usual SDK includes
     with_env(CPATH: nil) do
       # Testing Command Line Tools
-      if OS.mac? && MacOS::CLT.installed?
+      if OS.mac? && MacOS::CLT.installed? && MacOS::CLT.version < "26.4"
         toolchain_path = "/Library/Developer/CommandLineTools"
         cpp_base = (MacOS.version >= :big_sur) ? MacOS::CLT.sdk_path : toolchain_path
         system bin/"clang++", "-v",
@@ -364,7 +367,7 @@ class LlvmAT16 < Formula
       end
 
       # Testing Xcode
-      if OS.mac? && MacOS::Xcode.installed?
+      if OS.mac? && MacOS::Xcode.installed? && MacOS::Xcode.version < "26.4"
         cpp_base = (MacOS::Xcode.version >= "12.5") ? MacOS::Xcode.sdk_path : MacOS::Xcode.toolchain_path
         system bin/"clang++", "-v",
                "-isysroot", MacOS::Xcode.sdk_path,


### PR DESCRIPTION
These are failing and unlikely to be fixed

Also fails to build. Similar to LLVM 15 and older, mark this with maximum macOS so we don't fail CI. It was guaranteed to fail on Xcode 27 anyways due to `-ld_classic` usage.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
