### PR TITLE
python@3.9: use `MacOS.sdk_path`

### DIFF
--- a/Formula/p/python@3.9.rb
+++ b/Formula/p/python@3.9.rb
@@ -142,11 +142,11 @@ class PythonAT39 < Formula
       args << "--enable-framework=#{frameworks}"
       args << "--with-dtrace"
 
-      if MacOS.sdk_path_if_needed
+      if (sdk_path = MacOS.sdk_path)
         # Help Python's build system (setuptools/pip) to build things on SDK-based systems
         # The setup.py looks at "-isysroot" to get the sysroot (and not at --sysroot)
-        cflags  << "-isysroot #{MacOS.sdk_path}"
-        ldflags << "-isysroot #{MacOS.sdk_path}"
+        cflags  << "-isysroot #{sdk_path}"
+        ldflags << "-isysroot #{sdk_path}"
       end
       # Avoid linking to libgcc https://mail.python.org/pipermail/python-dev/2012-February/116205.html
       args << "MACOSX_DEPLOYMENT_TARGET=#{MacOS.version}"


### PR DESCRIPTION
Replaces deprecated method
https://github.com/Homebrew/brew/blob/39dc982f371ce4a9d014699501c54a3e271050c3/Library/Homebrew/os/mac.rb#L169

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
