### PR TITLE
ghc: use `MacOS.sdk_path`

### DIFF
--- a/Formula/g/ghc.rb
+++ b/Formula/g/ghc.rb
@@ -136,8 +136,8 @@ class Ghc < Formula
 
     if OS.mac?
       # https://gitlab.haskell.org/ghc/ghc/-/issues/22595#note_468423
-      args << "--with-ffi-libraries=#{MacOS.sdk_path_if_needed}/usr/lib"
-      args << "--with-ffi-includes=#{MacOS.sdk_path_if_needed}/usr/include/ffi"
+      args << "--with-ffi-libraries=#{MacOS.sdk_path}/usr/lib"
+      args << "--with-ffi-includes=#{MacOS.sdk_path}/usr/include/ffi"
     end
 
     system "./configure", "--prefix=#{prefix}", "--disable-numa", "--with-system-libffi", *args


### PR DESCRIPTION
Replaces deprecated method
https://github.com/Homebrew/brew/blob/39dc982f371ce4a9d014699501c54a3e271050c3/Library/Homebrew/os/mac.rb#L169

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
