### PR TITLE
taskopen: backport to drop pcre usage on Linux

### DIFF
--- a/Formula/t/taskopen.rb
+++ b/Formula/t/taskopen.rb
@@ -24,12 +24,13 @@ class Taskopen < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "88c6ca32bc458061057c90fa56237a7e0d0c7e7325a9b8f18e8750b6bb822b5f"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "f5ad079b35dabb3834b719543b3f3ec64373cd538bf9920a8c801543f43c408a"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "19ab00cba3ecabd049d3852c0dfed545462ccab1bce5072591eb4d27c5758071"
-    sha256 cellar: :any_skip_relocation, sonoma:        "7a0350d52c91cd2aa71a76feeb6197551d65a6eb3e9e2cd9150691742e0c6549"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "822855f8d7f1453c212863347f73a256b63f7939a9f32a03f6ff216816557d9a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c58603d593ac29b6893b614cdde533fac5c6c3271383303698081e11e9fdc364"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "9da42ed8caf399acc74ddd682209d6673a47eed66c23172fa9856882554113de"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "38746ec6070116946d4d63fffceebd884df4db71e8092958d0197356ae693ea8"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "edf50c36fb82f0096fba1700cf00c68f27a6da173fa49a2c09e7935c7e60ad5b"
+    sha256 cellar: :any_skip_relocation, sonoma:        "078950525ce9f618c1a98b4e552e73417ad094500be2494e4061a3c2d1474bb6"
+    sha256 cellar: :any,                 arm64_linux:   "82fee5c6862258f84333118f2916ad4dee8b3ab4449f8f2f96f101486c71d260"
+    sha256 cellar: :any,                 x86_64_linux:  "f1150a5b56acd30150070169ca2a96ac3f41caf9d5b2cdb39b311d02aa5202a9"
   end
 
   depends_on "nim" => :build

--- a/Formula/t/taskopen.rb
+++ b/Formula/t/taskopen.rb
@@ -1,11 +1,27 @@
 class Taskopen < Formula
   desc "Tool for taking notes and open urls with taskwarrior"
   homepage "https://codeberg.org/jschlatow/taskopen"
-  # TODO: Switch to codeberg on next release. Deferred to avoid checksum change
-  url "https://github.com/jschlatow/taskopen/archive/refs/tags/v2.0.3.tar.gz"
-  sha256 "fe16f839279e8baff96dcead55feb03997aebdaa3cee7a421dadc8e7cb8c1581"
   license "GPL-2.0-only"
   head "https://codeberg.org/jschlatow/taskopen.git", branch: "master"
+
+  stable do
+    # TODO: Switch to codeberg on next release. Deferred to avoid checksum change
+    url "https://github.com/jschlatow/taskopen/archive/refs/tags/v2.0.3.tar.gz"
+    sha256 "fe16f839279e8baff96dcead55feb03997aebdaa3cee7a421dadc8e7cb8c1581"
+
+    # Backport replacement of PCRE as Linux distros may not provide system copy
+    # and brew `pcre` is deprecated. On macOS, can still use system PCRE.
+    on_linux do
+      patch do
+        url "https://codeberg.org/jschlatow/taskopen/commit/555e27161057b38b5d30c1d9e2b0778d66b93622.diff"
+        sha256 "b0356a7fd6dc47b77b6099b4c8fc38ed7a5932a6e059a0923985f85172e716f9"
+      end
+      patch do
+        url "https://codeberg.org/jschlatow/taskopen/commit/2e89ece66cbc9a038f50774f1a15e9e93f4d2dac.diff"
+        sha256 "2b30129c16bdf43761294a9f7c93653ce973bf81665c7b470f5e9ee487b6593d"
+      end
+    end
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "88c6ca32bc458061057c90fa56237a7e0d0c7e7325a9b8f18e8750b6bb822b5f"
@@ -21,7 +37,7 @@ class Taskopen < Formula
 
   def install
     # Workaround for https://codeberg.org/jschlatow/taskopen/issues/180
-    inreplace "taskopen.nimble", '"2.0.0alpha"', "\"#{stable.version}\"" if build.head?
+    inreplace "taskopen.nimble", '"2.0.0alpha"', "\"#{stable.version}\""
 
     system "make", "install", "PREFIX=#{prefix}", "VERSION=#{version}"
   end


### PR DESCRIPTION
Avoid failures on Linux runners

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
