### PR TITLE
chapel 2.9.0 (dry-run)

### DIFF
--- a/Formula/c/chapel.rb
+++ b/Formula/c/chapel.rb
@@ -3,8 +3,8 @@ class Chapel < Formula
 
   desc "Programming language for productive parallel computing at scale"
   homepage "https://chapel-lang.org/"
-  url "https://github.com/chapel-lang/chapel/releases/download/2.8.0/chapel-2.8.0.tar.gz"
-  sha256 "80e8c3018e33e49674c7a2542e062547ea41d64d6595edb3b799e90c88f963f8"
+  url "https://chapel-lang.org/tmp/chapel-2.9.0.tar.gz"
+  sha256 "d91ececfc070f0e94c979dd08cdd3f6da84db4ee48fe06f3187ad259ea9553e7"
   license "Apache-2.0"
   head "https://github.com/chapel-lang/chapel.git", branch: "main"
 
@@ -23,7 +23,7 @@ class Chapel < Formula
   depends_on "gmp"
   depends_on "hwloc"
   depends_on "jemalloc"
-  depends_on "llvm@21"
+  depends_on "llvm"
   depends_on "pkgconf"
   depends_on "python@3.14"
 
@@ -117,6 +117,7 @@ class Chapel < Formula
 
       with_env(CHPL_PIP_FROM_SOURCE: "1") do
         system "make", "chpldoc"
+        system "make", "c2chapel"
         system "make", "chplcheck"
         system "make", "chpl-language-server"
       end
@@ -227,6 +228,8 @@ class Chapel < Formula
            "--print-commands", libexec/"examples/hello.chpl"
     system bin/"chpldoc", "--version"
     system bin/"mason", "--version"
+
+    system bin/"c2chapel", "--version"
 
     # Test chplcheck, if it works CLS probably does too.
     # chpl-language-server will hang indefinitely waiting for a LSP client

--- a/Formula/c/chapel.rb
+++ b/Formula/c/chapel.rb
@@ -3,7 +3,7 @@ class Chapel < Formula
 
   desc "Programming language for productive parallel computing at scale"
   homepage "https://chapel-lang.org/"
-  url "https://chapel-lang.org/tmp/chapel-2.9.0.tar.gz"
+  url "https://github.com/chapel-lang/chapel/releases/download/2.9.0/chapel-2.9.0.tar.gz"
   sha256 "d91ececfc070f0e94c979dd08cdd3f6da84db4ee48fe06f3187ad259ea9553e7"
   license "Apache-2.0"
   head "https://github.com/chapel-lang/chapel.git", branch: "main"


### PR DESCRIPTION
chapel 2.9.0 update (dry-run)


This updates the Chapel formula in preparation for next week's 2.9.0 release.  Specifically, it:
* updates the tar.gz URL and SHA to use a staged artifact
* unpins LLVM now that Chapel supports LLVM 22
* adds c2chapel to the formula, as with our other binary releases in Chapel 2.9

!! This PR is currently a draft, using a release candidate tarball in a temporary location. On the release day for Chapel 2.9 (June 18) it will be replaced with the final release tarball in its permanent location, most likely the same tarball.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
