### PR TITLE
poppler-qt6 26.06.0 (new formula)

### DIFF
--- a/Formula/p/poppler-qt6.rb
+++ b/Formula/p/poppler-qt6.rb
@@ -55,7 +55,7 @@ class PopplerQt6 < Formula
   end
 
   def install
-    args = std_cmake_args + %W[
+    args = %W[
       -DBUILD_GTK_TESTS=OFF
       -DENABLE_BOOST=OFF
       -DENABLE_GLIB=ON
@@ -66,11 +66,11 @@ class PopplerQt6 < Formula
       -DCMAKE_INSTALL_RPATH=#{rpath}
     ]
 
-    system "cmake", "-S", ".", "-B", "build_shared", *args
+    system "cmake", "-S", ".", "-B", "build_shared", *args, *std_cmake_args
     system "cmake", "--build", "build_shared"
     system "cmake", "--install", "build_shared"
 
-    system "cmake", "-S", ".", "-B", "build_static", *args, "-DBUILD_SHARED_LIBS=OFF"
+    system "cmake", "-S", ".", "-B", "build_static", *args, *std_cmake_args, "-DBUILD_SHARED_LIBS=OFF"
     system "cmake", "--build", "build_static"
     lib.install "build_static/libpoppler.a"
     lib.install "build_static/cpp/libpoppler-cpp.a"

--- a/Formula/p/poppler-qt6.rb
+++ b/Formula/p/poppler-qt6.rb
@@ -1,0 +1,90 @@
+class PopplerQt6 < Formula
+  desc "PDF rendering library (based on the xpdf-3.0 code base)"
+  homepage "https://poppler.freedesktop.org/"
+  url "https://poppler.freedesktop.org/poppler-26.06.0.tar.xz"
+  sha256 "4cb4e5a3dc8cb5eec751c8a23c8ba19f61f96dedc0cd07d2aee6b0c8e2cf6ba4"
+  license any_of: ["GPL-2.0-only", "GPL-3.0-only"] # see README-XPDF
+  compatibility_version 1
+  head "https://gitlab.freedesktop.org/poppler/poppler.git", branch: "master"
+
+  livecheck do
+    formula "poppler"
+  end
+
+  keg_only "it conflicts with poppler"
+
+  depends_on "cmake" => :build
+  depends_on "gettext" => :build
+  depends_on "gobject-introspection" => :build
+  depends_on "pkgconf" => :build
+
+  depends_on "cairo"
+  depends_on "fontconfig"
+  depends_on "freetype"
+  depends_on "glib"
+  depends_on "gpgmepp"
+  depends_on "jpeg-turbo"
+  depends_on "libpng"
+  depends_on "libtiff"
+  depends_on "little-cms2"
+  depends_on "nspr"
+  depends_on "nss"
+  depends_on "openjpeg"
+  depends_on "qtbase"
+
+  uses_from_macos "gperf" => :build
+  uses_from_macos "curl"
+
+  on_macos do
+    depends_on "gettext"
+    depends_on "gpgme"
+  end
+
+  on_linux do
+    depends_on "zlib-ng-compat"
+  end
+
+  resource "font-data" do
+    url "https://poppler.freedesktop.org/poppler-data-0.4.12.tar.gz"
+    sha256 "c835b640a40ce357e1b83666aabd95edffa24ddddd49b8daff63adb851cdab74"
+
+    livecheck do
+      url "https://poppler.freedesktop.org/"
+      regex(/href=.*?poppler-data[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    end
+  end
+
+  def install
+    args = std_cmake_args + %W[
+      -DBUILD_GTK_TESTS=OFF
+      -DENABLE_BOOST=OFF
+      -DENABLE_GLIB=ON
+      -DENABLE_QT5=OFF
+      -DENABLE_QT6=ON
+      -DENABLE_UNSTABLE_API_ABI_HEADERS=ON
+      -DWITH_GObjectIntrospection=ON
+      -DCMAKE_INSTALL_RPATH=#{rpath}
+    ]
+
+    system "cmake", "-S", ".", "-B", "build_shared", *args
+    system "cmake", "--build", "build_shared"
+    system "cmake", "--install", "build_shared"
+
+    system "cmake", "-S", ".", "-B", "build_static", *args, "-DBUILD_SHARED_LIBS=OFF"
+    system "cmake", "--build", "build_static"
+    lib.install "build_static/libpoppler.a"
+    lib.install "build_static/cpp/libpoppler-cpp.a"
+    lib.install "build_static/glib/libpoppler-glib.a"
+
+    # Add extra metafiles for licensing information
+    prefix.install "COPYING3", "README-XPDF"
+
+    resource("font-data").stage do
+      system "make", "install", "prefix=#{prefix}"
+    end
+  end
+
+  test do
+    system bin/"pdfinfo", test_fixtures("test.pdf")
+  end
+end


### PR DESCRIPTION
Modelled after the now deprecated poppler-qt5

Only tested on Linux so far.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
