### PR TITLE
formulae: remove clang 1100 references

### DIFF
--- a/Formula/f/fbthrift.rb
+++ b/Formula/f/fbthrift.rb
@@ -33,18 +33,9 @@ class Fbthrift < Formula
   uses_from_macos "flex" => :build
   uses_from_macos "python" => :build
 
-  on_macos do
-    depends_on "llvm" if DevelopmentTools.clang_build_version <= 1100
-  end
-
   on_linux do
     depends_on "boost"
     depends_on "zlib-ng-compat"
-  end
-
-  fails_with :clang do
-    build 1100
-    cause "error: 'asm goto' constructs are not supported yet"
   end
 
   def install

--- a/Formula/f/folly.rb
+++ b/Formula/f/folly.rb
@@ -34,21 +34,8 @@ class Folly < Formula
 
   uses_from_macos "bzip2"
 
-  on_macos do
-    depends_on "llvm" if DevelopmentTools.clang_build_version <= 1100
-  end
-
   on_linux do
     depends_on "zlib-ng-compat"
-  end
-
-  fails_with :clang do
-    build 1100
-    # https://github.com/facebook/folly/issues/1545
-    cause <<~EOS
-      Undefined symbols for architecture x86_64:
-        "std::__1::__fs::filesystem::path::lexically_normal() const"
-    EOS
   end
 
   # Workaround for arm64 Linux error "Missing variable is: CMAKE_ASM_CREATE_SHARED_LIBRARY"

--- a/Formula/g/grpc.rb
+++ b/Formula/g/grpc.rb
@@ -36,17 +36,8 @@ class Grpc < Formula
   depends_on "protobuf"
   depends_on "re2"
 
-  on_macos do
-    depends_on "llvm" => :build if DevelopmentTools.clang_build_version <= 1100
-  end
-
   on_linux do
     depends_on "zlib-ng-compat"
-  end
-
-  fails_with :clang do
-    build 1100
-    cause "Requires C++17 features not yet implemented"
   end
 
   def install

--- a/Formula/m/matplotplusplus.rb
+++ b/Formula/m/matplotplusplus.rb
@@ -28,11 +28,6 @@ class Matplotplusplus < Formula
     depends_on "zlib-ng-compat"
   end
 
-  fails_with :clang do
-    build 1100
-    cause "cannot run simple program using std::filesystem"
-  end
-
   def install
     system "cmake", "-S", ".", "-B", "build",
                     "-DBUILD_SHARED_LIBS=ON",

--- a/Formula/m/mavsdk.rb
+++ b/Formula/m/mavsdk.rb
@@ -35,20 +35,8 @@ class Mavsdk < Formula
   depends_on "tinyxml2"
   depends_on "xz"
 
-  on_macos do
-    depends_on "llvm" if DevelopmentTools.clang_build_version <= 1100
-  end
-
   on_linux do
     depends_on "zlib-ng-compat"
-  end
-
-  fails_with :clang do
-    build 1100
-    cause <<~EOS
-      Undefined symbols for architecture x86_64:
-        "std::__1::__fs::filesystem::__status(std::__1::__fs::filesystem::path const&, std::__1::error_code*)"
-    EOS
   end
 
   # Git is required to fetch submodules

--- a/Formula/n/node@18.rb
+++ b/Formula/n/node@18.rb
@@ -35,17 +35,6 @@ class NodeAT18 < Formula
   uses_from_macos "python"
   uses_from_macos "zlib"
 
-  on_macos do
-    depends_on "llvm" => :build if DevelopmentTools.clang_build_version <= 1100
-  end
-
-  fails_with :clang do
-    build 1100
-    cause <<~EOS
-      error: calling a private constructor of class 'v8::internal::(anonymous namespace)::RegExpParserImpl<uint8_t>'
-    EOS
-  end
-
   # Backport support for ICU 76+
   patch do
     url "https://github.com/nodejs/node/commit/81517faceac86497b3c8717837f491aa29a5e0f9.patch?full_index=1"

--- a/Formula/n/node@20.rb
+++ b/Formula/n/node@20.rb
@@ -37,19 +37,8 @@ class NodeAT20 < Formula
 
   uses_from_macos "python"
 
-  on_macos do
-    depends_on "llvm" => :build if DevelopmentTools.clang_build_version <= 1100
-  end
-
   on_linux do
     depends_on "zlib-ng-compat"
-  end
-
-  fails_with :clang do
-    build 1100
-    cause <<~EOS
-      error: calling a private constructor of class 'v8::internal::(anonymous namespace)::RegExpParserImpl<uint8_t>'
-    EOS
   end
 
   def install

--- a/Formula/n/node@22.rb
+++ b/Formula/n/node@22.rb
@@ -45,19 +45,8 @@ class NodeAT22 < Formula
 
   uses_from_macos "python"
 
-  on_macos do
-    depends_on "llvm" => :build if DevelopmentTools.clang_build_version <= 1100
-  end
-
   on_linux do
     depends_on "zlib-ng-compat"
-  end
-
-  fails_with :clang do
-    build 1100
-    cause <<~EOS
-      error: calling a private constructor of class 'v8::internal::(anonymous namespace)::RegExpParserImpl<uint8_t>'
-    EOS
   end
 
   def install

--- a/Formula/p/pdnsrec.rb
+++ b/Formula/p/pdnsrec.rb
@@ -28,18 +28,6 @@ class Pdnsrec < Formula
   uses_from_macos "python" => :build
   uses_from_macos "curl"
 
-  on_macos do
-    depends_on "llvm" => :build if DevelopmentTools.clang_build_version <= 1100
-  end
-
-  fails_with :clang do
-    build 1100
-    cause <<~EOS
-      Undefined symbols for architecture x86_64:
-        "MOADNSParser::init(bool, std::__1::basic_string_view<char, std::__1::char_traits<char> > const&)"
-    EOS
-  end
-
   def install
     args = %W[
       --sysconfdir=#{etc}/powerdns

--- a/Formula/s/snappy.rb
+++ b/Formula/s/snappy.rb
@@ -21,16 +21,6 @@ class Snappy < Formula
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
 
-  # Fix issue where Mojave clang fails due to entering a __GNUC__ block
-  on_macos do
-    depends_on "llvm" => :build if DevelopmentTools.clang_build_version <= 1100
-  end
-
-  fails_with :clang do
-    build 1100
-    cause "error: invalid output constraint '=@ccz' in asm"
-  end
-
   # Fix issue where `snappy` setting -fno-rtti causes build issues on `folly`
   # `folly` issue ref: https://github.com/facebook/folly/issues/1583
   patch :DATA

--- a/Formula/x/xgboost.rb
+++ b/Formula/x/xgboost.rb
@@ -22,17 +22,7 @@ class Xgboost < Formula
   depends_on "cmake" => :build
 
   on_macos do
-    depends_on "llvm" => :build if DevelopmentTools.clang_build_version <= 1100
     depends_on "libomp"
-  end
-
-  fails_with :clang do
-    build 1100
-    cause <<~EOS
-      clang: error: unable to execute command: Segmentation fault: 11
-      clang: error: clang frontend command failed due to signal (use -v to see invocation)
-      make[2]: *** [src/CMakeFiles/objxgboost.dir/tree/updater_quantile_hist.cc.o] Error 254
-    EOS
   end
 
   def install


### PR DESCRIPTION
Not much benefit in these. Catalina users should be able to use Xcode 11.4 - 12.4.

From the minority of Catalina users, only the even smaller minority on Xcode < 11.4 would be impacted. And then the minority of the minority that can successfully build LLVM from source would benefit.

Even if there were some users here, Homebrew won't run on their system in 3 months. So may as well clean these up now.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
