### PR TITLE
flexiblas: avoid exposing HOMEBREW_CC

### DIFF
--- a/Formula/f/flexiblas.rb
+++ b/Formula/f/flexiblas.rb
@@ -28,6 +28,10 @@ class Flexiblas < Formula
   depends_on "gcc" # for gfortran
   depends_on "openblas"
 
+  on_macos do
+    depends_on "libomp"
+  end
+
   def blas_backends
     backends = %w[OpenBLASOpenMP NETLIB]
     on_sonoma :or_newer do
@@ -40,8 +44,8 @@ class Flexiblas < Formula
   end
 
   def install
-    # Need to build with same GCC as GFortran for LTO on Linux
-    ENV["HOMEBREW_CC"] = Formula["gcc"].opt_bin/"gcc-#{Formula["gcc"].version.major}" if OS.linux?
+    # CMake FortranCInterface_VERIFY fails with LTO on Linux due to different GCC and GFortran versions
+    ENV.append "FFLAGS", "-fno-lto" if OS.linux?
 
     # Remove -flat_namespace usage
     flat_namespace_files = %w[


### PR DESCRIPTION
Switching workaround to minimize manipulation of brew internals (implementation details) like HOMEBREW_CC.

FFLAGS is a standard environment variable. It may impact LTO but we don't enable LTO on macOS anyways. Also, probably only see a noticeable impact when using fallback Netlib as other backends use libraries outside the formula, e.g. OpenBLAS formula or Apple system libraries.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
