### PR TITLE
vte3: update comment to Apple documentation

### DIFF
--- a/Formula/v/vte3.rb
+++ b/Formula/v/vte3.rb
@@ -51,7 +51,7 @@ class Vte3 < Formula
     depends_on "systemd"
   end
 
-  # https://en.cppreference.com/cpp/compiler_support/23#cpp_lib_out_ptr_202106L
+  # https://developer.apple.com/xcode/cpp/#c++23
   fails_with :clang do
     build 1699
     cause "Requires C++23 std::out_ptr"


### PR DESCRIPTION
Cppreference is usually still okay, i.e. ignore Apple column and use Clang libc++ instead which can then be used to map LLVM version back to Xcode release

However, Apple sometimes backports/modifies LLVM code so official reference is likely more accurate.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
