### PR TITLE
block-goose-cli: update repo location and homepage

### DIFF
--- a/Formula/b/block-goose-cli.rb
+++ b/Formula/b/block-goose-cli.rb
@@ -1,10 +1,10 @@
 class BlockGooseCli < Formula
   desc "Open source, extensible AI agent that goes beyond code suggestions"
-  homepage "https://block.github.io/goose/"
-  url "https://github.com/block/goose/archive/refs/tags/v1.37.0.tar.gz"
+  homepage "https://goose-docs.ai/"
+  url "https://github.com/aaif-goose/goose/archive/refs/tags/v1.37.0.tar.gz"
   sha256 "e037a24517d422eca06575ac90cd74b46e0bb256483ecfec3b5fa2d03159be47"
   license "Apache-2.0"
-  head "https://github.com/block/goose.git", branch: "main"
+  head "https://github.com/aaif-goose/goose.git", branch: "main"
 
   livecheck do
     url :stable


### PR DESCRIPTION
block-goose-cli: update repo location and homepage

---

- https://goose-docs.ai/blog/2026/04/07/goose-moves-to-aaif/