### PR TITLE
llvm: disable `z3` on older macOS to avoid dependency loop

### DIFF
--- a/Formula/l/llvm.rb
+++ b/Formula/l/llvm.rb
@@ -41,12 +41,17 @@ class Llvm < Formula
   depends_on "swig" => :build # for lldb
   depends_on "python@3.14"
   depends_on "xz" # for lldb
-  depends_on "z3"
   depends_on "zstd"
 
   uses_from_macos "libedit"
   uses_from_macos "libffi"
   uses_from_macos "ncurses" # for lldb
+
+  # Z3 needs C++20 std::format which is only available in Xcode 15.3 or later.
+  # To avoid a dependency loop, we disable Z3 support on older macOS.
+  on_system :linux, macos: :sonoma_or_newer do
+    depends_on "z3"
+  end
 
   on_linux do
     depends_on "binutils" => :build # needed for LLVMgold plugin
@@ -82,6 +87,7 @@ class Llvm < Formula
     ]
 
     unless versioned_formula?
+      enable_z3 = deps.map(&:name).include?("z3")
       projects << "lldb"
 
       if OS.mac?
@@ -118,7 +124,7 @@ class Llvm < Formula
       -DLLVM_INCLUDE_DOCS=OFF
       -DLLVM_INCLUDE_TESTS=OFF
       -DLLVM_INSTALL_UTILS=ON
-      -DLLVM_ENABLE_Z3_SOLVER=#{versioned_formula? ? "OFF" : "ON"}
+      -DLLVM_ENABLE_Z3_SOLVER=#{enable_z3 ? "ON" : "OFF"}
       -DLLVM_OPTIMIZED_TABLEGEN=ON
       -DLLVM_TARGETS_TO_BUILD=all
       -DLLVM_USE_RELATIVE_PATHS_IN_FILES=ON


### PR DESCRIPTION
Currently older macOS will have a dependency loop as Z3 will need to be built with libc++ to align C++ implementation but system libc++ may be too old. This means Z3 will require LLVM but that requires Z3.

Since Z3 isn't mandatory for most essential parts of LLVM, we can limit dependency.

I expect this to help reduce the spike in Z3 build failures:
- Currently the most failures with > 11k - https://formulae.brew.sh/analytics/build-error/30d/

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
