### PR TITLE
ccusage: downgrade to 20.0.6

### DIFF
--- a/Formula/c/ccusage.rb
+++ b/Formula/c/ccusage.rb
@@ -1,17 +1,17 @@
 class Ccusage < Formula
   desc "CLI tool for analyzing Claude Code usage from local JSONL files"
   homepage "https://github.com/ryoppippi/ccusage"
-  url "https://github.com/ryoppippi/ccusage/archive/refs/tags/v20.1.0.tar.gz"
-  sha256 "210f291fbb1b1ca9abe6e59a806a2981130a173b37b8fe840bc6c007fafbec78"
+  url "https://github.com/ryoppippi/ccusage/archive/refs/tags/v20.0.6.tar.gz"
+  sha256 "166bd8205ab47d41335a6972ac4706dba71a0902f20ad3d7a2e885f002ed0155"
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "8cc8b54112f5a9eba3eb780479035f6eab1b0ef5097a4a4a246b7347d9451677"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "a37153a59edde9c171994b8f8f50472eb66dc2140afa9f97a44f4f024782f784"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "4c23f54ff7baf7a552c88101850d9b6d581ab25d17ccea99509c6f785cf84d96"
-    sha256 cellar: :any_skip_relocation, sonoma:        "304f408b2e22a553fd61d221d22ce3199f7277a6cc0d7a15993dad2315a9eb5b"
-    sha256 cellar: :any,                 arm64_linux:   "d4dbd04ab65fb097e5449f727dfc96653e896e324524fe14995e4bf9c8dd8fb9"
-    sha256 cellar: :any,                 x86_64_linux:  "02c91bce3e6c60aa231c4c48415a74c232808427c4f03d58a9b1d8488a1c5612"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "72c1d869ef12638a4b89c56527f0625e0fab18768c0c2ba5d90f8ffec1f1f3ba"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "d46f7e2c4ec0ec5eefe18e201f97dea014a32f9ed8b44dd3de0fafce5480ea04"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "9d4a658edef0f3cc77e9aa6186e804af0d6f713ef0faa4bec4e34e44f665c0f2"
+    sha256 cellar: :any_skip_relocation, sonoma:        "6cb39d9f53d77d9e72bc3f2dacd7be56382d282ffdb720dccf6d3636b44eb258"
+    sha256 cellar: :any,                 arm64_linux:   "05be2f9e4e6b1783a585d47d9c83be455dacef2bdcdf2562337ade7472d93f5f"
+    sha256 cellar: :any,                 x86_64_linux:  "65d16a7cef98cfa32b270140eba1669678132fc821a7c97476fae91fd9ab9bf0"
   end
 
   depends_on "rust" => :build


### PR DESCRIPTION
ccusage: downgrade to 20.0.6

- https://github.com/Homebrew/homebrew-core/pull/286845
- https://github.com/Homebrew/homebrew-core/pull/287992

<img width="1034" height="1003" alt="image" src="https://github.com/user-attachments/assets/544b31f0-648f-464c-b4c8-c9b54c05f10b" />
