### PR TITLE
depsguard 0.1.38 (new formula)

### DIFF
--- a/Formula/d/depsguard.rb
+++ b/Formula/d/depsguard.rb
@@ -1,0 +1,24 @@
+class Depsguard < Formula
+  desc "Harden package manager configs against supply chain attacks"
+  homepage "https://depsguard.com"
+  url "https://github.com/arnica/depsguard/archive/refs/tags/v0.1.38.tar.gz"
+  sha256 "dcddbf0826245f33efa908a2d24b5c4c78bea587771a44a435a0f739d695587d"
+  license "MIT"
+  head "https://github.com/arnica/depsguard.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  deny_network_access!
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/depsguard --version")
+
+    # With no package manager configs present, scanning the current directory
+    # finds nothing to harden and exits successfully.
+    system bin/"depsguard", "scan", "--no-search"
+  end
+end

--- a/Formula/d/depsguard.rb
+++ b/Formula/d/depsguard.rb
@@ -6,6 +6,15 @@ class Depsguard < Formula
   license "MIT"
   head "https://github.com/arnica/depsguard.git", branch: "main"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "b36f9fce889576d0e23f0c0c7cfdbfdaef5176361090b0dd297232abc500d65d"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "b3342942fd269b00626a022365a4aba9b8a605a8a7d5a3b83ecfd02c83f3ee0c"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "7e7d4d50a4f982cce505a4bad2b02537e7c796c75eb357f34e7be11db64adc82"
+    sha256 cellar: :any_skip_relocation, sonoma:        "2796da5257ee97e14b6df87b923f04b4472a8dacddd2f8ced3b36b05e46dbb9c"
+    sha256 cellar: :any,                 arm64_linux:   "32300323892a77749891db3112970ebd9f1537273a85940d84decab636bb4ac7"
+    sha256 cellar: :any,                 x86_64_linux:  "a76141692ac4d20029f4a237802367695a96cb12de9270cc13254cdd30272929"
+  end
+
   depends_on "rust" => :build
 
   deny_network_access!


### PR DESCRIPTION
Adds `depsguard`, a CLI that hardens package manager configurations against software supply chain attacks. It scans npm, pnpm, bun, uv, and yarn configs/lockfiles for security misconfigurations and can apply fixes.

- Homepage: https://depsguard.com
- Source: https://github.com/arnica/depsguard
- License: MIT

Built from source from the tagged release tarball. The crate has no external dependencies, so `cargo install` works in the offline build sandbox.

A previous submission (#275968) was opened before the project met notability; it now satisfies the requirements, so this resubmits at the current stable version.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open pull requests for the same formula update/change?
- [x] `brew style` reported no offenses for the formula.
- [ ] `brew install --build-from-source`, `brew test`, and `brew audit --new` to be verified by BrewTestBot CI.
