### PR TITLE
llnode: remove llvm test dependency for non-CI tested macOS

### DIFF
--- a/Formula/l/llnode.rb
+++ b/Formula/l/llnode.rb
@@ -23,7 +23,7 @@ class Llnode < Formula
 
   depends_on "llvm" => :build
   depends_on "node" => [:build, :test]
-  depends_on "llvm" => :test if DevelopmentTools.clang_build_version == 1403
+
   uses_from_macos "llvm"
 
   def llnode_so(root = lib)
@@ -59,7 +59,6 @@ class Llnode < Formula
   end
 
   test do
-    ENV.prepend_path "PATH", Formula["llvm"].opt_bin if DevelopmentTools.clang_build_version == 1403
     lldb_out = pipe_output "lldb", <<~EOS
       plugin load #{llnode_so}
       help v8


### PR DESCRIPTION
clang 1403 is no longer tested in CI.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
