### PR TITLE
openjdk*: remove workaround for Xcode 16.0 - 16.1

### DIFF
--- a/Formula/o/openjdk.rb
+++ b/Formula/o/openjdk.rb
@@ -129,11 +129,6 @@ class Openjdk < Formula
     end
     args << "--with-extra-ldflags=#{ldflags.join(" ")}"
 
-    # Workaround for Xcode 16 bug: https://bugs.openjdk.org/browse/JDK-8340341.
-    if DevelopmentTools.clang_build_version == 1600
-      args << "--with-extra-cflags=-mllvm -enable-constraint-elimination=0"
-    end
-
     system "bash", "configure", *args
 
     ENV["MAKEFLAGS"] = "JOBS=#{ENV.make_jobs}"

--- a/Formula/o/openjdk@11.rb
+++ b/Formula/o/openjdk@11.rb
@@ -133,11 +133,6 @@ class OpenjdkAT11 < Formula
 
     args << "--with-extra-ldflags=#{ldflags.join(" ")}"
 
-    # Work around Xcode 16 bug: https://bugs.openjdk.org/browse/JDK-8340341
-    if DevelopmentTools.clang_build_version == 1600
-      args << "--with-extra-cflags=-mllvm -enable-constraint-elimination=0"
-    end
-
     # Fix: prevent clang C++ driver from receiving `-std=gnu23` (Homebrew CI macOS + Linux toolchains)
     args << "--with-extra-cxxflags=-std=gnu++17"
 

--- a/Formula/o/openjdk@17.rb
+++ b/Formula/o/openjdk@17.rb
@@ -130,10 +130,6 @@ class OpenjdkAT17 < Formula
     end
     args << "--with-extra-ldflags=#{ldflags.join(" ")}"
 
-    if DevelopmentTools.clang_build_version == 1600 && MacOS::Xcode.version < "16.2"
-      args << "--with-extra-cflags=-mllvm -enable-constraint-elimination=0"
-    end
-
     system "bash", "configure", *args
 
     ENV["MAKEFLAGS"] = "JOBS=#{ENV.make_jobs}"

--- a/Formula/o/openjdk@21.rb
+++ b/Formula/o/openjdk@21.rb
@@ -129,10 +129,6 @@ class OpenjdkAT21 < Formula
     end
     args << "--with-extra-ldflags=#{ldflags.join(" ")}"
 
-    if DevelopmentTools.clang_build_version == 1600
-      args << "--with-extra-cflags=-mllvm -enable-constraint-elimination=0"
-    end
-
     system "bash", "configure", *args
 
     ENV["MAKEFLAGS"] = "JOBS=#{ENV.make_jobs}"

--- a/Formula/o/openjdk@25.rb
+++ b/Formula/o/openjdk@25.rb
@@ -132,11 +132,6 @@ class OpenjdkAT25 < Formula
     end
     args << "--with-extra-ldflags=#{ldflags.join(" ")}"
 
-    # Workaround for Xcode 16 bug: https://bugs.openjdk.org/browse/JDK-8340341.
-    if DevelopmentTools.clang_build_version == 1600
-      args << "--with-extra-cflags=-mllvm -enable-constraint-elimination=0"
-    end
-
     system "bash", "configure", *args
 
     ENV["MAKEFLAGS"] = "JOBS=#{ENV.make_jobs}"

--- a/Formula/o/openjdk@8.rb
+++ b/Formula/o/openjdk@8.rb
@@ -176,9 +176,6 @@ class OpenjdkAT8 < Formula
         extra_cxxflags << "-F#{buildpath}"
       end
 
-      # Work around for Xcode 16 bug: https://bugs.openjdk.org/browse/JDK-8340341
-      extra_cflags << "-mllvm -enable-constraint-elimination=0" if DevelopmentTools.clang_build_version == 1600
-
       args << "--with-extra-cflags=#{extra_cflags.join(" ")}" unless extra_cflags.empty?
       args << "--with-extra-cxxflags=#{extra_cxxflags.join(" ")}" unless extra_cxxflags.empty?
     else


### PR DESCRIPTION
This was fixed in Xcode 16.2.
- Sonoma users are able to upgrade to 16.2 
- Sequoia users can upgrade to 26.3 or 16.4.

We usually don't carry a workaround for this scenario when issue only happens on outdated toolchain and there is an overlapping fixed version (i.e. Xcode 16.2 uses clang-1600 too)

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
