### PR TITLE
terraformer: use ld range

### DIFF
--- a/Formula/t/terraformer.rb
+++ b/Formula/t/terraformer.rb
@@ -26,7 +26,7 @@ class Terraformer < Formula
   def install
     ldflags = %w[-s -w]
     # Work around failure: ld: B/BL out of range -162045188 (max +/-128MB)
-    ldflags << "-extldflags=-ld_classic" if DevelopmentTools.clang_build_version == 1500 && Hardware::CPU.arm?
+    ldflags << "-extldflags=-ld_classic" if DevelopmentTools.ld64_version.between?("1015.7", "1022.1")
 
     system "go", "build", *std_go_args(ldflags:)
   end


### PR DESCRIPTION
Better to constrain ld_classic on ld versions. Using well known range of problematic ld that shipped early on with Xcode 15

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
