### PR TITLE
nghttp2: drop workaround

### DIFF
--- a/Formula/n/nghttp2.rb
+++ b/Formula/n/nghttp2.rb
@@ -34,7 +34,6 @@ class Nghttp2 < Formula
 
   on_macos do
     depends_on "llvm" => :build if DevelopmentTools.clang_build_version <= 1500
-    depends_on macos: :sonoma # Needs C++20 features not available on Ventura
   end
 
   on_linux do
@@ -52,10 +51,6 @@ class Nghttp2 < Formula
   end
 
   def install
-    # fix for clang not following C++14 behaviour
-    # https://github.com/macports/macports-ports/commit/54d83cca9fc0f2ed6d3f873282b6dd3198635891
-    inreplace "src/shrpx_client_handler.cc", "return dconn;", "return std::move(dconn);"
-
     # Don't build nghttp2 library - use the previously built one.
     inreplace "Makefile.in", /(SUBDIRS =) lib/, "\\1"
     inreplace Dir["**/Makefile.in"] do |s|


### PR DESCRIPTION
Workaround mentions C++14 but build is on C++20 now.

Also remove Sonoma constraint as that was added back when LLVM was mixing headers.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
