### PR TITLE
Add head URL to scc.rb formula

### DIFF
--- a/Formula/s/scc.rb
+++ b/Formula/s/scc.rb
@@ -3,6 +3,7 @@ class Scc < Formula
   homepage "https://github.com/boyter/scc/"
   url "https://github.com/boyter/scc/archive/refs/tags/v3.7.0.tar.gz"
   sha256 "447233f70ebcc24f1dafb27b093afdd17d3a1d662de96e8226130c5308b02d01"
+  head "https://github.com/boyter/scc/archive/refs/heads/master.tar.gz"
   license any_of: ["MIT", "Unlicense"]
 
   livecheck do

--- a/Formula/s/scc.rb
+++ b/Formula/s/scc.rb
@@ -3,7 +3,7 @@ class Scc < Formula
   homepage "https://github.com/boyter/scc/"
   url "https://github.com/boyter/scc/archive/refs/tags/v3.7.0.tar.gz"
   sha256 "447233f70ebcc24f1dafb27b093afdd17d3a1d662de96e8226130c5308b02d01"
-  head "https://github.com/boyter/scc/archive/refs/heads/master.tar.gz"
+  head "https://github.com/boyter/scc.git", branch: "master"
   license any_of: ["MIT", "Unlicense"]
 
   livecheck do


### PR DESCRIPTION
Add head URL for the latest development version.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
