### PR TITLE
freeswitch: support `mod_shout`

### DIFF
--- a/Formula/f/freeswitch.rb
+++ b/Formula/f/freeswitch.rb
@@ -35,13 +35,16 @@ class Freeswitch < Formula
 
   depends_on "freetype"
   depends_on "jpeg-turbo"
+  depends_on "lame"
   depends_on "ldns"
   depends_on "libks"
   depends_on "libpng"
   depends_on "libpq"
+  depends_on "libshout"
   depends_on "libsndfile"
   depends_on "libtiff"
   depends_on "lua"
+  depends_on "mpg123"
   depends_on "opencore-amr"
   depends_on "openssl@3"
   depends_on "opus"
@@ -191,6 +194,9 @@ class Freeswitch < Formula
     # Ref: https://github.com/signalwire/freeswitch/blob/master/src/mod/applications/mod_av/mod_av.c#L5
     odie "MPL-1.1 is incompatible with FFmpeg's GPL license" if deps.any? { |dep| dep.name.start_with? "ffmpeg" }
     inreplace "modules.conf", %r{^applications/mod_av$}, "#\\0"
+
+    ## support mod_shout - disabled by default for building
+    inreplace "modules.conf", %r{^#formats/mod_shout$}, "formats/mod_shout"
 
     # Workaround for opus_parse.h using true/false which are keywords in C23
     ENV.append "CFLAGS", "-std=gnu17" if DevelopmentTools.clang_build_version >= 1700


### PR DESCRIPTION

`mod_shout` is quiet useful to play `.mp3` sounds.
It's addition is quiet simple.

Tests were applied with ARM.

<img width="1138" height="500" alt="image" src="https://github.com/user-attachments/assets/5abc9503-f408-4de4-9ef9-c2fcfc2bdbc8" />

<img width="1252" height="100" alt="image" src="https://github.com/user-attachments/assets/556e9fa9-bd7d-4a5f-bd01-3482771a26da" />

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
