### PR TITLE
scc: add HEAD

### DIFF
--- a/Formula/s/scc.rb
+++ b/Formula/s/scc.rb
@@ -4,6 +4,7 @@ class Scc < Formula
   url "https://github.com/boyter/scc/archive/refs/tags/v3.7.0.tar.gz"
   sha256 "447233f70ebcc24f1dafb27b093afdd17d3a1d662de96e8226130c5308b02d01"
   license any_of: ["MIT", "Unlicense"]
+  head "https://github.com/boyter/scc.git", branch: "master"
 
   livecheck do
     url :homepage


### PR DESCRIPTION
Adds a `head` spec to `scc` so the latest development version can be built with `brew install --HEAD scc`.

- URL: `https://github.com/boyter/scc.git`
- Branch: `master` (upstream's default branch)

Local verification:
- `brew style scc` — no offenses
- `brew audit --strict --online scc` — no findings
- `brew fetch --HEAD scc` — successfully cloned `HEAD-3b14a63`

---

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open pull requests for the same change?
- [x] Have you successfully run `brew audit --strict scc`?
- [x] Have you successfully run `brew style scc`?
