### PR TITLE
freerdp: add WebAuthn deps libfido2 and libcbor

### DIFF
--- a/Formula/f/freerdp.rb
+++ b/Formula/f/freerdp.rb
@@ -23,6 +23,8 @@ class Freerdp < Formula
   depends_on "pkgconf" => :build
   depends_on "cjson"
   depends_on "ffmpeg"
+  depends_on "libcbor"
+  depends_on "libfido2"
   depends_on "jansson"
   depends_on "jpeg-turbo"
   depends_on "libusb"


### PR DESCRIPTION
This change adds the necessary dependencies to enable MS-RDPEWA (WebAuthn/FIDO2 redirection).

https://github.com/FreeRDP/FreeRDP/blob/master/docs/README.building#L119

> 11. WebAuthn / FIDO2 redirection (optional, disable with
>     -DCHANNEL_RDPEWA=OFF)
>
> The [MS-RDPEWA] WebAuthn Virtual Channel Extension allows forwarding
> WebAuthn/FIDO2 authenticator requests from the RDP server to the
> client's local security keys. This enables passwordless authentication
> (e.g. passkeys) and two-factor authentication inside the remote
> session using hardware security keys plugged into the client machine.
>
> Enabled automatically when the required libraries are found. Requires:
>
> * libcbor (CBOR encoding/decoding)
> * libfido2 (FIDO2/CTAP2 authenticator communication)
>
> On Debian/Ubuntu: apt install libcbor-dev libfido2-dev
> On Fedora: dnf install libcbor-devel libfido2-devel
>
> The channel is activated via the "redirectwebauthn" .rdp file setting
> (FreeRDP_RedirectWebAuthN).

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
