### PR TITLE
grafana-alloy: Update grafana alloy formula

### DIFF
--- a/Formula/g/grafana-alloy.rb
+++ b/Formula/g/grafana-alloy.rb
@@ -16,7 +16,7 @@ class GrafanaAlloy < Formula
   end
 
   depends_on "go" => :build
-  depends_on "node" => :build
+  depends_on "node@24" => :build
 
   on_linux do
     depends_on "systemd" # for go-systemd (dlopen-ed)
@@ -41,7 +41,7 @@ class GrafanaAlloy < Formula
     ]
 
     # https://github.com/grafana/alloy/blob/main/tools/make/packaging.mk
-    tags = %w[netgo embedalloyui]
+    tags = %w[netgo embedalloyui gore2regex]
     tags << "promtail_journal_enabled" if OS.linux?
 
     cd "internal/web/ui" do
@@ -51,16 +51,42 @@ class GrafanaAlloy < Formula
 
     system "go", "build", "-C", "collector", *std_go_args(ldflags:, tags:, output: bin/"alloy")
 
-    generate_completions_from_executable(bin/"alloy", "completion")
+    generate_completions_from_executable(bin/"alloy", shell_parameter_format: :cobra)
+
+    # Create an empty files for environment variables and extra command line arguments.
     pkgetc.mkpath
+    (pkgetc/"config.env").write ""
+    (pkgetc/"extra-args.txt").write ""
+
+    # Generate a wrapper script to run Alloy as service with custom env vars and flags from files.
+    system "go", "run",
+      "-C", "packaging/homebrew/service-wrapper-gen", ".",
+      "-alloy-bin", "#{opt_bin}/alloy",
+      "-config-path", pkgetc.to_s,
+      "-env-file", "#{pkgetc}/config.env",
+      "-extra-args-file", "#{pkgetc}/extra-args.txt",
+      "-otel-extra-args-file", "#{pkgetc}/otel-extra-args.txt",
+      "-storage-path", "#{var}/lib/grafana-alloy/data",
+      "-out", "#{buildpath}/alloy-wrapper"
+
+    bin.install "alloy-wrapper"
   end
 
   def caveats
-    "Alloy configuration directory is #{pkgetc}"
+    <<~EOS
+      Alloy configuration directory is #{pkgetc}.
+      Customize environment variables in #{pkgetc}/config.env.
+      Add extra CLI arguments in #{pkgetc}/extra-args.txt.
+
+      To enable the OTel Engine:
+      - Set "ALLOY_OTEL_MODE=1" in #{pkgetc}/config.env
+      - Create collector config in #{pkgetc}/config.yaml
+      - If necessary, create #{pkgetc}/otel-extra-args.txt to add command line arguments.
+    EOS
   end
 
   service do
-    run [opt_bin/"alloy", "run", "--storage.path=#{var}/lib/grafana-alloy/data", etc/"grafana-alloy"]
+    run [opt_bin/"alloy-wrapper"]
     keep_alive true
     log_path var/"log/grafana-alloy.log"
     error_log_path var/"log/grafana-alloy.log"


### PR DESCRIPTION

This PR backports some changes from [Alloy formula in `homebrew-grafana`](https://github.com/grafana/homebrew-grafana/blob/master/alloy.rb):

* Adds `gore2regex` build tag which is used by `loki.secretfilter` ([source](https://github.com/grafana/alloy/blob/main/Makefile#L140))
* Pins Node version to `node@24`, as upstream does
* Adds a wrapper script for launchd unit that allows supplying custom environment variables and command-line arguments for Alloy ([source](https://github.com/grafana/homebrew-grafana/blob/master/alloy.rb#L58)).
  * This is useful to enable experimental feature gate with `--stability.level=experimental`.
* Add [OTel engine mode](https://grafana.com/docs/alloy/latest/set-up/otel_engine/) mention in caveats.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Claude Code was used for initial code review and generating Alloy and OTel engine test configs to test launchd service wrapper.

Test results verification was done manually.

-----
