### PR TITLE
qt@5: add conflict with `qt*` due to auto-link behavior

### DIFF
--- a/Formula/q/qt3d.rb
+++ b/Formula/q/qt3d.rb
@@ -37,6 +37,8 @@ class Qt3d < Formula
   depends_on "qtdeclarative"
   depends_on "qtshadertools"
 
+  conflicts_with "qt@5", because: "both link conflicting binaries"
+
   # Apply Arch Linux patches for assimp 6 support
   # Issue ref: https://bugreports.qt.io/browse/QTBUG-137996
   patch do

--- a/Formula/q/qt@5.rb
+++ b/Formula/q/qt@5.rb
@@ -87,6 +87,12 @@ class QtAT5 < Formula
     depends_on "zlib-ng-compat"
   end
 
+  # Specify conflict due to auto-linking of keg-only versioned formulae
+  conflicts_with "qt3d", "qtbase", "qtcharts", "qtconnectivity", "qtdatavis3d", "qtdeclarative",
+                 "qtmultimedia", "qtnetworkauth", "qtpositioning", "qtquick3d", "qtremoteobjects", "qtscxml",
+                 "qtsensors", "qtserialport", "qtspeech", "qtsvg", "qttools", "qtwebchannel", "qtwebsockets",
+                 because: "both link conflicting binaries"
+
   # Fix build with ICU 75
   patch do
     on_linux do

--- a/Formula/q/qtbase.rb
+++ b/Formula/q/qtbase.rb
@@ -84,6 +84,8 @@ class Qtbase < Formula
     pour_bottle? only_if: :default_prefix
   end
 
+  conflicts_with "qt@5", because: "both link conflicting binaries"
+
   def install
     # Allow -march options to be passed through, as Qt builds
     # arch-specific code with runtime detection of capabilities:

--- a/Formula/q/qtcharts.rb
+++ b/Formula/q/qtcharts.rb
@@ -32,6 +32,8 @@ class Qtcharts < Formula
   depends_on "qtbase"
   depends_on "qtdeclarative"
 
+  conflicts_with "qt@5", because: "both link conflicting binaries"
+
   def install
     args = ["-DCMAKE_STAGING_PREFIX=#{prefix}"]
     args << "-DQT_NO_APPLE_SDK_AND_XCODE_CHECK=ON" if OS.mac?

--- a/Formula/q/qtconnectivity.rb
+++ b/Formula/q/qtconnectivity.rb
@@ -38,6 +38,8 @@ class Qtconnectivity < Formula
     depends_on "bluez"
   end
 
+  conflicts_with "qt@5", because: "both link conflicting binaries"
+
   def install
     args = ["-DCMAKE_STAGING_PREFIX=#{prefix}"]
     args << "-DQT_NO_APPLE_SDK_AND_XCODE_CHECK=ON" if OS.mac?

--- a/Formula/q/qtdatavis3d.rb
+++ b/Formula/q/qtdatavis3d.rb
@@ -32,6 +32,8 @@ class Qtdatavis3d < Formula
   depends_on "qtbase"
   depends_on "qtdeclarative"
 
+  conflicts_with "qt@5", because: "both link conflicting binaries"
+
   def install
     args = ["-DCMAKE_STAGING_PREFIX=#{prefix}"]
     args << "-DQT_NO_APPLE_SDK_AND_XCODE_CHECK=ON" if OS.mac?

--- a/Formula/q/qtdeclarative.rb
+++ b/Formula/q/qtdeclarative.rb
@@ -38,6 +38,8 @@ class Qtdeclarative < Formula
 
   uses_from_macos "python" => :build
 
+  conflicts_with "qt@5", because: "both link conflicting binaries"
+
   def install
     args = ["-DCMAKE_STAGING_PREFIX=#{prefix}"]
     args << "-DQT_NO_APPLE_SDK_AND_XCODE_CHECK=ON" if OS.mac?

--- a/Formula/q/qtmultimedia.rb
+++ b/Formula/q/qtmultimedia.rb
@@ -59,6 +59,8 @@ class Qtmultimedia < Formula
     depends_on "pulseaudio"
   end
 
+  conflicts_with "qt@5", because: "both link conflicting binaries"
+
   def install
     args = ["-DCMAKE_STAGING_PREFIX=#{prefix}"]
     if OS.mac?

--- a/Formula/q/qtnetworkauth.rb
+++ b/Formula/q/qtnetworkauth.rb
@@ -31,6 +31,8 @@ class Qtnetworkauth < Formula
 
   depends_on "qtbase"
 
+  conflicts_with "qt@5", because: "both link conflicting binaries"
+
   def install
     args = ["-DCMAKE_STAGING_PREFIX=#{prefix}"]
     args << "-DQT_NO_APPLE_SDK_AND_XCODE_CHECK=ON" if OS.mac?

--- a/Formula/q/qtpositioning.rb
+++ b/Formula/q/qtpositioning.rb
@@ -35,6 +35,8 @@ class Qtpositioning < Formula
   depends_on "qtdeclarative"
   depends_on "qtserialport"
 
+  conflicts_with "qt@5", because: "both link conflicting binaries"
+
   def install
     args = ["-DCMAKE_STAGING_PREFIX=#{prefix}"]
     args << "-DQT_NO_APPLE_SDK_AND_XCODE_CHECK=ON" if OS.mac?

--- a/Formula/q/qtquick3d.rb
+++ b/Formula/q/qtquick3d.rb
@@ -44,6 +44,8 @@ class Qtquick3d < Formula
     depends_on "zlib-ng-compat"
   end
 
+  conflicts_with "qt@5", because: "both link conflicting binaries"
+
   def install
     rm_r("src/3rdparty/assimp")
 

--- a/Formula/q/qtremoteobjects.rb
+++ b/Formula/q/qtremoteobjects.rb
@@ -33,6 +33,8 @@ class Qtremoteobjects < Formula
   depends_on "qtbase"
   depends_on "qtdeclarative"
 
+  conflicts_with "qt@5", because: "both link conflicting binaries"
+
   def install
     args = ["-DCMAKE_STAGING_PREFIX=#{prefix}"]
     args << "-DQT_NO_APPLE_SDK_AND_XCODE_CHECK=ON" if OS.mac?

--- a/Formula/q/qtscxml.rb
+++ b/Formula/q/qtscxml.rb
@@ -33,6 +33,8 @@ class Qtscxml < Formula
   depends_on "qtbase"
   depends_on "qtdeclarative"
 
+  conflicts_with "qt@5", because: "both link conflicting binaries"
+
   def install
     args = ["-DCMAKE_STAGING_PREFIX=#{prefix}"]
     args << "-DQT_NO_APPLE_SDK_AND_XCODE_CHECK=ON" if OS.mac?

--- a/Formula/q/qtsensors.rb
+++ b/Formula/q/qtsensors.rb
@@ -32,6 +32,8 @@ class Qtsensors < Formula
   depends_on "qtbase"
   depends_on "qtdeclarative"
 
+  conflicts_with "qt@5", because: "both link conflicting binaries"
+
   def install
     args = ["-DCMAKE_STAGING_PREFIX=#{prefix}"]
     args << "-DQT_NO_APPLE_SDK_AND_XCODE_CHECK=ON" if OS.mac?

--- a/Formula/q/qtserialport.rb
+++ b/Formula/q/qtserialport.rb
@@ -36,6 +36,8 @@ class Qtserialport < Formula
     depends_on "systemd"
   end
 
+  conflicts_with "qt@5", because: "both link conflicting binaries"
+
   def install
     args = ["-DCMAKE_STAGING_PREFIX=#{prefix}"]
     args << "-DQT_NO_APPLE_SDK_AND_XCODE_CHECK=ON" if OS.mac?

--- a/Formula/q/qtspeech.rb
+++ b/Formula/q/qtspeech.rb
@@ -33,6 +33,8 @@ class Qtspeech < Formula
   depends_on "qtdeclarative"
   depends_on "qtmultimedia"
 
+  conflicts_with "qt@5", because: "both link conflicting binaries"
+
   def install
     args = ["-DCMAKE_STAGING_PREFIX=#{prefix}"]
     args << "-DQT_NO_APPLE_SDK_AND_XCODE_CHECK=ON" if OS.mac?

--- a/Formula/q/qtsvg.rb
+++ b/Formula/q/qtsvg.rb
@@ -35,6 +35,8 @@ class Qtsvg < Formula
     depends_on "zlib-ng-compat"
   end
 
+  conflicts_with "qt@5", because: "both link conflicting binaries"
+
   def install
     args = ["-DCMAKE_STAGING_PREFIX=#{prefix}"]
     args << "-DQT_NO_APPLE_SDK_AND_XCODE_CHECK=ON" if OS.mac?

--- a/Formula/q/qttools.rb
+++ b/Formula/q/qttools.rb
@@ -39,6 +39,8 @@ class Qttools < Formula
     depends_on "gumbo-parser"
   end
 
+  conflicts_with "qt@5", because: "both link conflicting binaries"
+
   def install
     rm_r("src/assistant/qlitehtml/src/3rdparty/litehtml")
 

--- a/Formula/q/qtwebchannel.rb
+++ b/Formula/q/qtwebchannel.rb
@@ -32,6 +32,8 @@ class Qtwebchannel < Formula
   depends_on "qtbase"
   depends_on "qtdeclarative"
 
+  conflicts_with "qt@5", because: "both link conflicting binaries"
+
   def install
     args = ["-DCMAKE_STAGING_PREFIX=#{prefix}"]
     args << "-DQT_NO_APPLE_SDK_AND_XCODE_CHECK=ON" if OS.mac?

--- a/Formula/q/qtwebsockets.rb
+++ b/Formula/q/qtwebsockets.rb
@@ -32,6 +32,8 @@ class Qtwebsockets < Formula
   depends_on "qtbase"
   depends_on "qtdeclarative"
 
+  conflicts_with "qt@5", because: "both link conflicting binaries"
+
   def install
     args = ["-DCMAKE_STAGING_PREFIX=#{prefix}"]
     args << "-DQT_NO_APPLE_SDK_AND_XCODE_CHECK=ON" if OS.mac?

--- a/style_exceptions/versioned_formulae_conflicts_allowlist.json
+++ b/style_exceptions/versioned_formulae_conflicts_allowlist.json
@@ -1,3 +1,4 @@
 [
-  "bash-completion@2"
+  "bash-completion@2",
+  "qt@5"
 ]


### PR DESCRIPTION
The new auto link causes issues in CI right now as test-bot cannot properly unlink these conflicts. Explicitly specify a conflict between these to avoid CI failures and allow test-bot to automatically run unlink/link commands.

As side effect, this will cause `brew install qt@5` to fail when Qt6 is installed as we have no way of disabling the new feature. No flag or env config properly avoids the link (closest is `--skip-link` but it skips opt links which will break formula).

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
