### PR TITLE
glibc: include C locale variants in postinstall

### DIFF
--- a/Formula/g/glibc.rb
+++ b/Formula/g/glibc.rb
@@ -310,9 +310,9 @@ class Glibc < Formula
     # Compile locale definition files
     mkdir_p lib/"locale"
 
-    # Get all extra installed locales from the system, except C locales
+    # Get all extra installed locales from the system, except C locale
     locales = ENV.filter_map do |k, v|
-      v if k[/^HOMEBREW_LANG$|^LANG$|^LC_/] && v != "C" && !v.start_with?("C.")
+      v if k[/^HOMEBREW_LANG$|^LANG$|^LC_/] && v != "C"
     end
 
     # en_US.UTF-8 is required by gawk make check

--- a/Formula/g/glibc.rb
+++ b/Formula/g/glibc.rb
@@ -53,9 +53,9 @@ class Glibc < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 arm64_linux:  "3afe478fb0d3f60b4817e3bc6a4055c6c18c986c9a6f6610be255bafcaa74afe"
-    sha256 x86_64_linux: "6a959a32fcfdcadcb1e27720f567c4921a289a2ccf0223abea7c271834780124"
+    rebuild 2
+    sha256 arm64_linux:  "8a092cc0773c766c14ac4af34fec15b825028aedba3ecb61995939fcbd4e46d2"
+    sha256 x86_64_linux: "a7e87f5dc33814f0d5aaf6beb6bebfbdd4b268ece9c0e45b5bcc6549db4e197d"
   end
 
   keg_only "it can shadow system glibc if linked"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Current postinstall filters out C locale variants like `C.UTF-8`, which is not available by default. This PR enables such variants in postinstall step.