### PR TITLE
speech 0.0.21

### DIFF
--- a/Formula/s/speech.rb
+++ b/Formula/s/speech.rb
@@ -7,8 +7,8 @@ class Speech < Formula
   head "https://github.com/soniqo/speech-swift.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "bbeaa282ada36da307b59febc8b972cd2e130dc593fbb4459596c163ce3b6597"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "0d6e6602ca329f2489d333d2f12ce42df9b02150301dba7a27bf9bb638872d59"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "6ecfef805c68d043ffde035569faf03e9e94a171b2a489613ea3a56e5e78448f"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "2562cad0d8108b4f5bd5756304bf8d1de827b234f79a6bfbc3ed417eecd6c4c9"
   end
 
   depends_on xcode: ["16.0", :build]

--- a/Formula/s/speech.rb
+++ b/Formula/s/speech.rb
@@ -1,8 +1,8 @@
 class Speech < Formula
   desc "On-device speech toolkit for Apple Silicon: ASR, TTS, VAD, diarization"
   homepage "https://soniqo.audio"
-  url "https://github.com/soniqo/speech-swift/archive/refs/tags/v0.0.20.tar.gz"
-  sha256 "c896549bdd4c02b17cc9f821f27eb67f2316d116fa056343d0f7c4d810fe32bd"
+  url "https://github.com/soniqo/speech-swift/archive/refs/tags/v0.0.21.tar.gz"
+  sha256 "c276f02ecc707c49f099c3ef4d2dd0239b90928ffc9e015be10b1a94f908ef97"
   license "Apache-2.0"
   head "https://github.com/soniqo/speech-swift.git", branch: "main"
 


### PR DESCRIPTION
Created with `brew` (manually edited).

Release notes: https://github.com/soniqo/speech-swift/releases/tag/v0.0.21

Highlights:
- Parakeet TDT M5 ANE compatibility fix (fixes a SIGSEGV in `bnns::GraphCompile` on macOS 26 Tahoe / M5 silicon)
- macOS now defaults Parakeet to `.cpuAndNeuralEngine` for ~540 MB less peak RSS
- New `encoderVariant:` API on `ParakeetASRModel.fromPretrained` for shape-selective encoding

- [x] Have you followed the [guidelines for contributing](https://docs.brew.sh/Formula-Cookbook)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_DEVELOPER=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? (`brew style` passes; build verified locally via the soniqo/speech-swift release workflow)
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)? (`brew style` passes)