### PR TITLE
nvi2: make macOS only

### DIFF
--- a/Formula/n/nvi2.rb
+++ b/Formula/n/nvi2.rb
@@ -13,8 +13,7 @@ class Nvi2 < Formula
   end
 
   depends_on "cmake" => :build
-
-  uses_from_macos "libiconv"
+  depends_on :macos
 
   def install
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args


### PR DESCRIPTION
Implicitly done via `libiconv`. We don't want references to brew `libiconv` so should remove that. macOS has its own FreeBSD-based iconv not GNU libiconv.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
