### PR TITLE
binutils: remove workaround

### DIFF
--- a/Formula/b/binutils.rb
+++ b/Formula/b/binutils.rb
@@ -32,10 +32,6 @@ class Binutils < Formula
   link_overwrite "bin/dwp"
 
   def install
-    # Workaround https://sourceware.org/bugzilla/show_bug.cgi?id=28909
-    touch "gas/doc/.dirstamp", mtime: Time.utc(2022, 1, 1)
-    make_args = OS.mac? ? [] : ["MAKEINFO=true"] # for gprofng
-
     args = %W[
       --enable-deterministic-archives
       --infodir=#{info}
@@ -51,21 +47,21 @@ class Binutils < Formula
       --disable-nls
     ]
     system "./configure", *args, *std_configure_args
-    system "make", *make_args
-    system "make", "install", *make_args
+    system "make"
+    system "make", "install"
 
     if OS.mac?
-      Dir["#{bin}/*"].each do |f|
-        bin.install_symlink f => "g" + File.basename(f)
+      bin.each_child do |f|
+        bin.install_symlink f => "g#{f.basename}"
       end
     else
       # Reduce the size of the bottle.
       bin_files = bin.children.select(&:elf?)
       system "strip", *bin_files, *lib.glob("*.a")
-    end
 
-    # Allow ld to find brew glibc. A broken symlink falls back to /etc/ld.so.conf
-    (prefix/"etc").install_symlink etc/"ld.so.conf" if OS.linux?
+      # Allow ld to find brew glibc. A broken symlink falls back to /etc/ld.so.conf
+      (prefix/"etc").install_symlink etc/"ld.so.conf"
+    end
   end
 
   test do


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
