### PR TITLE
sdl12-compat: drop unneeded args

### DIFF
--- a/Aliases/sdl
+++ b/Aliases/sdl
@@ -1,0 +1,1 @@
+../Formula/s/sdl12-compat.rb

--- a/Formula/s/sdl12-compat.rb
+++ b/Formula/s/sdl12-compat.rb
@@ -23,22 +23,19 @@ class Sdl12Compat < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "sdl2-compat"
+  depends_on "sdl2-compat" => :no_linkage
 
   def install
-    system "cmake", "-S", ".", "-B", "build",
-                    "-DSDL2_PATH=#{Formula["sdl2-compat"].opt_prefix}",
-                    "-DCMAKE_INSTALL_RPATH=#{rpath(target: Formula["sdl2-compat"].opt_lib)}",
-                    "-DSDL12DEVEL=ON",
-                    "-DSDL12TESTS=OFF",
-                    *std_cmake_args
-    system "cmake", "--build", "build"
-    system "cmake", "--install", "build"
-    (lib/"pkgconfig").install_symlink "sdl12_compat.pc" => "sdl.pc"
+    args = ["-DSDL12TESTS=OFF"]
+    args << "-DCMAKE_INSTALL_RPATH=#{rpath(target: Formula["sdl2-compat"].opt_lib)}" if OS.mac?
 
-    # we have to do this because most build scripts assume that all sdl modules
+    # We override install_prefix to make sure substituted CMAKE_INSTALL_FULL_* use
+    # HOMEBREW_PREFIX path because most build scripts assume that all SDL modules
     # are installed to the same prefix. Consequently SDL stuff cannot be keg-only
-    inreplace [bin/"sdl-config", lib/"pkgconfig/sdl12_compat.pc"], prefix, HOMEBREW_PREFIX
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args(install_prefix: HOMEBREW_PREFIX)
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build", "--prefix", prefix
+    (lib/"pkgconfig").install_symlink "sdl12_compat.pc" => "sdl.pc"
   end
 
   test do

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -157,7 +157,6 @@
   "rtx": "mise",
   "rustfmt": "rust",
   "rustup-init": "rustup",
-  "sdl": "sdl12-compat",
   "selenium-server-standalone": "selenium-server",
   "server-go": "openiothub-server",
   "sheen-bidi": "sheenbidi",


### PR DESCRIPTION
Changes:
* Drop SDL2_PATH as default path should find sdl2-compat
* Drop SDL12DEVEL which is default value
* Only add CMAKE_INSTALL_RPATH on macOS as shim always adds absolute RPATHs on Linux.
* Use supported CMake commands to avoid inreplace
* Replace rename with alias

This makes formula closer to `sdl2-compat`.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
