### PR TITLE
sfcgal: Add support for eigen

### DIFF
--- a/Formula/s/sfcgal.rb
+++ b/Formula/s/sfcgal.rb
@@ -16,6 +16,7 @@ class Sfcgal < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "eigen" => :build
   depends_on "nlohmann-json" => :build
   depends_on "boost"
   depends_on "cgal"
@@ -23,7 +24,9 @@ class Sfcgal < Formula
   depends_on "mpfr"
 
   def install
-    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    # TODO: Drop SFCGAL_WITH_EIGEN=ON once SFCGAL enbles it when Eigen is detected
+    # See: https://gitlab.com/sfcgal/SFCGAL/-/merge_requests/778
+    system "cmake", "-S", ".", "-B", "build", "-DSFCGAL_WITH_EIGEN=ON", *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
   end

--- a/Formula/s/sfcgal.rb
+++ b/Formula/s/sfcgal.rb
@@ -7,12 +7,13 @@ class Sfcgal < Formula
   compatibility_version 1
 
   bottle do
-    sha256 cellar: :any, arm64_tahoe:   "670b480cb5d2bc39b82cd44eb88036db3c5760662650f942ccdb0601fad7214e"
-    sha256 cellar: :any, arm64_sequoia: "9479bc005dd3623c205bbb219050dd6d8fd4126a49eefad7763ba9da8bf1371f"
-    sha256 cellar: :any, arm64_sonoma:  "2ab6ae6bdf02ffc9e14eddd124492cccc1e44ba6ff3b025bf3d127dc7c6a4af0"
-    sha256 cellar: :any, sonoma:        "947e01f26a488842713b55d4b2c6c378f0518233f253bc564e47f3572f925993"
-    sha256 cellar: :any, arm64_linux:   "4494d02b8b01087ff8ee0c2c8b6432f56942df2df68427d4f3bc3ed83480bb4d"
-    sha256 cellar: :any, x86_64_linux:  "76fba11c983750b09a694fb1ccb933d32990cc32da98027491f8de8772e83fb8"
+    rebuild 1
+    sha256 cellar: :any, arm64_tahoe:   "a19e4d45890a856c054b0d205241cd77f76d78f9aaace0f7db26142f013777cf"
+    sha256 cellar: :any, arm64_sequoia: "49d024ceba5c90ae0afcbcbd701892ea279768354a75f3c7a623ee635b25152c"
+    sha256 cellar: :any, arm64_sonoma:  "00f313d58946f951077954e2cad228202aa2e226f7270118973291e12d498a0e"
+    sha256 cellar: :any, sonoma:        "1059b7f6a43637396f4b4f5844ff3e1bdefe680bed9bc7176f30edaaf1e0b9ed"
+    sha256 cellar: :any, arm64_linux:   "b9723d309477b59bfabdba6453076aaa7f7cac4e26cd718aaf8108dab4b4bd3e"
+    sha256 cellar: :any, x86_64_linux:  "f19dc9fb3c41efdb00a9a2aeced333f475604ef629f3f7d0e6ad82e487e3dc17"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
SFCGAL 2.3.0 has a new optional dependency: eigen. This allows to add support for more simplification strategies in the new surface simplification algorithm.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR: no AI tool used

-----
