### PR TITLE
freerdp: enable CHANNEL_RDPEWA for webauthn

### DIFF
--- a/Formula/f/freerdp.rb
+++ b/Formula/f/freerdp.rb
@@ -6,13 +6,13 @@ class Freerdp < Formula
   license "Apache-2.0"
 
   bottle do
-    rebuild 1
-    sha256 arm64_tahoe:   "a202f286e39636d655384eb055be0f9f27bc67cfb639cf287185ab4d1e84d02c"
-    sha256 arm64_sequoia: "efb49df2ab5f460614901a0c11a170a44e7a195076d1e4e225cd057c1c5a3506"
-    sha256 arm64_sonoma:  "d43741bd49062e9c4e07b1a3906185f77d838e8dbf91f9ea310dd7326458c361"
-    sha256 sonoma:        "a29d7d6dee88d80eabd6cc942983410ff3c7c6e9f79b522325b451ebc152fd90"
-    sha256 arm64_linux:   "9fe52e5167712864fa727d1e45bfbcd1a412b8735f5d7e1cf741475383d6b786"
-    sha256 x86_64_linux:  "d2b7f1b176007c42ee630d1c3e8780bd18e90bb659f66e81a408061c6ddab1e9"
+    rebuild 2
+    sha256 arm64_tahoe:   "ac70a9135a54e403bd549bcccd30a09311f6078e963424699626fb595967e2d8"
+    sha256 arm64_sequoia: "ebbf0738e4dc87d57fa743677796a25f589125b16a1883d51a9fbe92c4874d19"
+    sha256 arm64_sonoma:  "995c50609d84d23efc997fa3be5d814c5c3b3cf1ac8df4b8d7c7243c4352381b"
+    sha256 sonoma:        "10a4468f28bced415ab62acb4c1a5233d404dfe056d0718252e37464c6a9c34c"
+    sha256 arm64_linux:   "e8e4f6cf5785b3b248a8faa2ed7cc9cd38e22bad3494e0a1bc7fe63643c33f44"
+    sha256 x86_64_linux:  "f7816d32c8817eaa24d3e8b84c36d3270d9f6ff9e741ec40a14280281b81aa5a"
   end
 
   head do

--- a/Formula/f/freerdp.rb
+++ b/Formula/f/freerdp.rb
@@ -68,6 +68,7 @@ class Freerdp < Formula
       -DWITH_CLIENT_SDL=ON
       -DWITH_CLIENT_SDL2=OFF
       -DWITH_CLIENT_SDL3=ON
+      -DCHANNEL_RDPEWA=ON
     ]
 
     # Native macOS client and server implementations are unmaintained and use APIs that are obsolete on Sequoia.


### PR DESCRIPTION
Enable CHANNEL_RDPEWA at compile time to utilize recently added dependencies:

https://github.com/Homebrew/homebrew-core/pull/288485

This enables WebAuthn / FIDO2 redirection.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
