### PR TITLE
git-hooks-go: deprecate

### DIFF
--- a/Formula/g/git-hooks-go.rb
+++ b/Formula/g/git-hooks-go.rb
@@ -22,6 +22,9 @@ class GitHooksGo < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "a2e2a568a671db87621def2f35483cb89b4e7b58605ef724db8912868c76a327"
   end
 
+  deprecate! date: "2026-07-09", because: :checksum_mismatch
+  disable! date: "2027-07-09", because: :checksum_mismatch
+
   depends_on "go" => :build
 
   def install


### PR DESCRIPTION
1) Checksum mismatch 
  ```
  curl -sL https://github.com/git-hooks/git-hooks/archive/refs/tags/v1.3.1.tar.gz | shasum -a 256
  370f6b7fbacbeb698b8f547d0854c64c16034abc7a3a5af2ebc75241c9003531  -
  ```
2) Stuck with 6 years old release https://github.com/git-hooks/git-hooks/releases/tag/v1.3.1
3) Unmaintained (no commits) since that release 6 years ago https://github.com/git-hooks/git-hooks/compare/v1.3.1...master
4) Few installs https://formulae.brew.sh/formula/git-hooks-go

Ref:
* https://github.com/Homebrew/homebrew-core/pull/288803

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
