### PR TITLE
cyclonedx-gomod: keep Git repo to set version info

### DIFF
--- a/Formula/c/cyclonedx-gomod.rb
+++ b/Formula/c/cyclonedx-gomod.rb
@@ -1,8 +1,9 @@
 class CyclonedxGomod < Formula
   desc "Creates CycloneDX Software Bill of Materials (SBOM) from Go modules"
   homepage "https://cyclonedx.org/"
-  url "https://github.com/CycloneDX/cyclonedx-gomod/archive/refs/tags/v1.10.0.tar.gz"
-  sha256 "14d71dcce1164ada13832c6f61b6bb4f804e21966b03ff937b47609752b112f8"
+  url "https://github.com/CycloneDX/cyclonedx-gomod.git",
+      tag:      "v1.10.0",
+      revision: "ba940a6cad4202a4a6d2f9aeef33463c0011ff5f"
   license "Apache-2.0"
   head "https://github.com/CycloneDX/cyclonedx-gomod.git", branch: "main"
 
@@ -18,10 +19,13 @@ class CyclonedxGomod < Formula
   depends_on "go" => [:build, :test]
 
   def install
+    ENV["CGO_ENABLED"] = "0"
     system "go", "build", *std_go_args(ldflags: "-s -w"), "./cmd/cyclonedx-gomod"
   end
 
   test do
+    assert_match version.to_s, shell_output("#{bin}/cyclonedx-gomod version")
+
     (testpath/"go.mod").write <<~GOMOD
       module github.com/Homebrew/brew-test
 

--- a/Formula/c/cyclonedx-gomod.rb
+++ b/Formula/c/cyclonedx-gomod.rb
@@ -8,12 +8,13 @@ class CyclonedxGomod < Formula
   head "https://github.com/CycloneDX/cyclonedx-gomod.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "dd7b3ce89ec8361b5c32558c62582a62f21f3574fcfd4d7f39ddfeffaa89ceef"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "dd7b3ce89ec8361b5c32558c62582a62f21f3574fcfd4d7f39ddfeffaa89ceef"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "dd7b3ce89ec8361b5c32558c62582a62f21f3574fcfd4d7f39ddfeffaa89ceef"
-    sha256 cellar: :any_skip_relocation, sonoma:        "8c59b92233c8beba9f3a9ac8f3ee90d86239eef28e3db002f0c30566d57787c0"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "d20cbef64f5f8167a18d0edd98d5f9780df07032683c1ddf0c6882791f1c367b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0264d8f7838c67048cfebe524bad1caf684ccde316a8140300d15c01d41d696d"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "c8c772c3ecfbe31b2cdce31b6cc1a291d4f15c81a9161b8435446f0a4f475e71"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "c8c772c3ecfbe31b2cdce31b6cc1a291d4f15c81a9161b8435446f0a4f475e71"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "c8c772c3ecfbe31b2cdce31b6cc1a291d4f15c81a9161b8435446f0a4f475e71"
+    sha256 cellar: :any_skip_relocation, sonoma:        "25ccaedda49b499c01d12508cbcde51d2fe36eccb484fed41b98bdd0b3cd2cdd"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "9e6c2bcb322ba197f018acb5db58ffe6a27c944a00b3d0ff87cb0d81ff7829be"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1d82bd5cff3ef13fac8645a62c87d96837c54a863d7e9b9b5efdc15def0335f3"
   end
 
   depends_on "go" => [:build, :test]


### PR DESCRIPTION
It builds and runs fine with cgo disabled. And as is typical for Go module apps, it uses Git repository metadata to inject version and some build-related info at build time.

Output of `cyclonedx-gomod version` before:

```
Version:	v0.0.0-unknown
GoVersion:	go1.25.6
OS:		darwin
Arch:		arm64
```

After:

```
Version:	v1.10.0
Commit:		ba940a6cad4202a4a6d2f9aeef33463c0011ff5f
CommitDate:	2026-01-31 20:34:22 +0000 UTC
Modified:	false
GoVersion:	go1.26.4
OS:		darwin
Arch:		arm64
```

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
