### PR TITLE
pixtuoid 0.15.0 (new formula)

### DIFF
--- a/Formula/p/pixtuoid.rb
+++ b/Formula/p/pixtuoid.rb
@@ -1,0 +1,33 @@
+class Pixtuoid < Formula
+  desc "Terminal pixel-art office for AI coding agents"
+  homepage "https://github.com/IvanWng97/pixtuoid"
+  url "https://github.com/IvanWng97/pixtuoid/archive/refs/tags/v0.15.0.tar.gz"
+  sha256 "0785360dfd4133b910df0e6dab4d2e35df9c6c975cd925ce2bd2bd414ed7505d"
+  license "MIT"
+  head "https://github.com/IvanWng97/pixtuoid.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  def install
+    # Drop upstream's x86_64 Linux lld linker pin
+    rm ".cargo/config.toml"
+
+    system "cargo", "install", *std_cargo_args(path: "crates/pixtuoid")
+    system "cargo", "install", *std_cargo_args(path: "crates/pixtuoid-hook")
+
+    (man1/"pixtuoid.1").write Utils.safe_popen_read(bin/"pixtuoid", "man")
+    generate_completions_from_executable(bin/"pixtuoid", "completions")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/pixtuoid --version")
+
+    system bin/"pixtuoid", "init-pack", testpath/"pack"
+    assert_match "OK: pack \"skeleton\"", shell_output("#{bin}/pixtuoid validate-pack #{testpath}/pack")
+
+    require "json"
+    connected = JSON.parse(shell_output("#{bin}/pixtuoid connect claude-code --json"))
+    assert_equal [{ "id" => "claude-code", "outcome" => "connected" }], connected
+    assert_match "pixtuoid-hook", (testpath/".claude/settings.json").read
+  end
+end

--- a/Formula/p/pixtuoid.rb
+++ b/Formula/p/pixtuoid.rb
@@ -6,6 +6,15 @@ class Pixtuoid < Formula
   license "MIT"
   head "https://github.com/IvanWng97/pixtuoid.git", branch: "main"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "01e713be6a99b904d1d7260f024e457845697b913d05f6dcc532aa9ada1d0a85"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "91fceebb6d07558e02d03cace254d46400cf04c785b5c8fbfc2415785c0ed9ad"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "e08a1a22a12af18657bdec7fa4709062974589f816a697542aa8180fade737bc"
+    sha256 cellar: :any_skip_relocation, sonoma:        "559c1dfb45c8c290efebe2f7bb4ab5e6dcdf44933c98b858af1c894a475f4280"
+    sha256 cellar: :any,                 arm64_linux:   "af50c8ed57d23abf95689b483c8dbe76b41c73a604d4490d00741fd36c8d3fad"
+    sha256 cellar: :any,                 x86_64_linux:  "86bd764227ee420cb396a548992717c130c78ae3fa62dbd909e4a1a536ed2dc7"
+  end
+
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
Adds `pixtuoid` — a terminal-native pixel-art "office" that visualizes AI coding-agent CLI sessions (Claude Code, Codex, and others) as animated sprites.

- Homepage / repo: https://github.com/IvanWng97/pixtuoid
- License: MIT
- Builds from source with `cargo` (workspace; installs two binaries, `pixtuoid` and the `pixtuoid-hook` shim).

Verified locally on macOS (Apple Silicon):
- `brew install --build-from-source pixtuoid` ✓
- `brew test pixtuoid` ✓
- `brew audit --new --strict --online pixtuoid` ✓
- `brew audit --strict pixtuoid` ✓

Disclosure: I'm the project author (self-submission). The repo is MIT-licensed, >30 days old, and at ~300 stars (clears the 3× self-submission notability threshold).

Heads-up for the Linux bottle: the `pixtuoid` binary links `winit`/`softbuffer` for an optional desktop-window mode. On macOS these use native frameworks (no extra deps). On Linux they pull X11/Wayland — happy to add the appropriate `depends_on` under `on_linux` if BrewTestBot's Linux build needs it.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
