### PR TITLE
formulae: use `zlib-ng-compat`

### DIFF
--- a/Formula/c/committed.rb
+++ b/Formula/c/committed.rb
@@ -18,7 +18,7 @@ class Committed < Formula
   depends_on "rust" => :build
 
   on_linux do
-    depends_on "zlib"
+    depends_on "zlib-ng-compat"
   end
 
   def install

--- a/Formula/c/committed.rb
+++ b/Formula/c/committed.rb
@@ -7,12 +7,13 @@ class Committed < Formula
   head "https://github.com/crate-ci/committed.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "b0ba1b869ec35634f88a7be9be9681495649044c783de5a8919aafe3ccc08545"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "69d0840a3cd73a541795542ce7cdc7ebc068d3988f04f100e52a4a6726c13d8e"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "943b0bd708823ed8a4111ac9b6279493d975f9490b4468f01699920f8e971302"
-    sha256 cellar: :any_skip_relocation, sonoma:        "ff58466048d4e980b120aa381e8fafca7fc15f4317c088b2dd9e8f10922442dc"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "d629fdb8f4e20bdf7577b37ba53dea36fe7702c0db4c0682ad09f5cf939d4238"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "289b4fffa6f5339cd7e6e6a0e9c04bce7b82e762acbf244646468630e4140088"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "3d7c4964ba5f02e337add48870263525ab618dda39c5e69d8e51dc03320771d5"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "f4aced867d8d33a939457f3e171800d2fc996e558da920956c0ff8088d7154eb"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "ef02f7b8ab4411a9fb0ed02e74abc573aa596043dce6bd30564df80157f9eff4"
+    sha256 cellar: :any_skip_relocation, sonoma:        "452aca8c27ab273d9acffc134b3b2bf8e059fc7918cd9d9e3ad8af951a8668fe"
+    sha256 cellar: :any,                 arm64_linux:   "06366f236d9d86d4370a9cf65c58a74aa8499a34ac5e09e676e50621aa59d525"
+    sha256 cellar: :any,                 x86_64_linux:  "f1846d0480f02007eabe6bcf1fb99f37e00d0fe526b724a3baf52976d2306a06"
   end
 
   depends_on "rust" => :build

--- a/Formula/g/gemmi.rb
+++ b/Formula/g/gemmi.rb
@@ -6,12 +6,13 @@ class Gemmi < Formula
   license "MPL-2.0"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "dc264245afab6fce73a2db3e1378f9c0e98e2be858253b88b4063466d81eeace"
-    sha256 cellar: :any,                 arm64_sequoia: "b8d9d0dd70cb7374e621ab9aa1cc044488ca8c509141ecf6efcafd86bb7c2acc"
-    sha256 cellar: :any,                 arm64_sonoma:  "2bdf40108f7d6d537fd8349c1cbe7b0036bd17c03ec37e6d19a36fe47576a511"
-    sha256 cellar: :any,                 sonoma:        "6ae5ee326e72a0301a9dc2a97a15a1adffad9a1237e62900e160be0441b676b9"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "0053ca84fe45cc033fe5cb30c7faaf6e5f4aca3c2cd4abca47fa89421de22ebe"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "11db7111cbf9f79e4b050d114543fd536d282ca1eb6d4d19fa69cedd1f87944c"
+    rebuild 1
+    sha256 cellar: :any, arm64_tahoe:   "3dc2a4467fa0ed0928090f9cd53ef636ef03dd68902a1922d298e09b992f6c4a"
+    sha256 cellar: :any, arm64_sequoia: "2077899d6278a7f1ca8ccb53baafdf1b99eb9b236ac8564ac2c4920043941f55"
+    sha256 cellar: :any, arm64_sonoma:  "a2c1dbcb81cbed37589504edb8e0191e12493a2f1f0780b988aba084623c39d4"
+    sha256 cellar: :any, sonoma:        "f73c874975cd7286f5cc420129ad7db5996e8aee21fd7b8efb3a336ab04c1dba"
+    sha256 cellar: :any, arm64_linux:   "7c00d4a2c478413c35c00072b362568ffe153089e8ba2f60a7ecf69ccf4336ab"
+    sha256 cellar: :any, x86_64_linux:  "9ffa4d84b28bb74552a6b0ed7eef9b26cad33b46b403a8cded4a7e927e1e8b64"
   end
 
   depends_on "cmake" => :build

--- a/Formula/g/gemmi.rb
+++ b/Formula/g/gemmi.rb
@@ -16,7 +16,9 @@ class Gemmi < Formula
 
   depends_on "cmake" => :build
 
-  uses_from_macos "zlib"
+  on_linux do
+    depends_on "zlib-ng-compat"
+  end
 
   def install
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args

--- a/Formula/i/iqtree3.rb
+++ b/Formula/i/iqtree3.rb
@@ -6,12 +6,13 @@ class Iqtree3 < Formula
   license "GPL-2.0-or-later"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "fb5bab78cec04ce9c1ef1937fc7f3b7270e2884a705adc76c2b82b824aee4ac5"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "97a3ccb3cf2246ede9938bee894ac5d6eb23961e1a90dcbf0630135a4ec05063"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "003bc18dc66b43701ac5f41f12095094ce1ed2e145c26ff443cd868675ff069f"
-    sha256 cellar: :any_skip_relocation, sonoma:        "c1c5810ba0468d089f62f4b96b4f01a0ba9d9b3a2fb8f62f5855aaf712973169"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "5ddfc94e068ec16c99a267d70e371e61ee8e89a58d0e3e02d07fbe154ccfdbad"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f4b3e39d526332c45b3e11b1540e39d45fba9af976f98faa3b8c156e020e69e4"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "ae6440023e30272346d61eb64544cad03cdcd28ce5534881ea57e68741d9804a"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "7be3601ecc0577748794a0cedc0f2bcb559c6c58f30b4b2d9d71ddf708b390fc"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "1aa9e27195328385963ee3820070cd3fe336c96f53e2e3db1f89ae23de05ed05"
+    sha256 cellar: :any_skip_relocation, sonoma:        "c87a0732f7b3d034580a7c12ca67a4adbe3e783ddf46468d229e7e800123abb4"
+    sha256 cellar: :any,                 arm64_linux:   "5c93f778819bb6cbad85f83b54597776ee4f70ced9053cb6554f6faf78f08f1b"
+    sha256 cellar: :any,                 x86_64_linux:  "aed8a1b92653deafe99be38cef420dd6fcb6388f5cc07a99cf1e637ee750ac2e"
   end
 
   depends_on "boost" => :build

--- a/Formula/i/iqtree3.rb
+++ b/Formula/i/iqtree3.rb
@@ -18,7 +18,9 @@ class Iqtree3 < Formula
   depends_on "cmake" => :build
   depends_on "eigen" => :build
 
-  uses_from_macos "zlib"
+  on_linux do
+    depends_on "zlib-ng-compat"
+  end
 
   resource "lsd2" do
     url "https://github.com/tothuhien/lsd2.git",

--- a/Formula/lib/libkiwix.rb
+++ b/Formula/lib/libkiwix.rb
@@ -6,12 +6,13 @@ class Libkiwix < Formula
   license "GPL-3.0-or-later"
 
   bottle do
-    sha256 cellar: :any, arm64_tahoe:   "2a779996b714c51dc1df5aa842d20211e71477b04e3e7163f496967c61c65d4f"
-    sha256 cellar: :any, arm64_sequoia: "f365ae439494f7c27d998ba4e875865bfe90e916c53ece33ff3b772aae685eac"
-    sha256 cellar: :any, arm64_sonoma:  "5748766af7090d35b313fe2fb417d119af58d82c2f60c0d3f52189e1ce250a59"
-    sha256 cellar: :any, sonoma:        "3cc3db2a4700a01f92c713ff9a3fd51d65ba2651847e1d73c79e4179a536b970"
-    sha256               arm64_linux:   "10e8b84fae2fbbd98bf4edb3c26c2b2648fc208b4ba8a01bb8b94fcfb0638ddc"
-    sha256               x86_64_linux:  "cc58c24a8642d767352e224a8db4f00136467fd909d7a46600147d916c6df7a7"
+    rebuild 1
+    sha256 cellar: :any, arm64_tahoe:   "1a163b339857896a25e7ca137ea5b89b9e694b373504ff96e4c0ce54571cb415"
+    sha256 cellar: :any, arm64_sequoia: "39923d9fa6b7814243a0f16bde23b4748f8a22d6700b1b3e60a522e603bd2a53"
+    sha256 cellar: :any, arm64_sonoma:  "f1459f38b2a666ee732745d1b3f721387effe6eabac795d9032787268f29255a"
+    sha256 cellar: :any, sonoma:        "36b65cfdc8f4a14eec5306166e155ad619ae44daa3fe82d55294978fd7e0b221"
+    sha256               arm64_linux:   "7136c54709fc11a9c35aa4ad5ca1935eb99decbb4cbc534ab09ce9a9d0935378"
+    sha256               x86_64_linux:  "6757a377743d2dd7fc5a7a51872dad662f04e2448d5ad313a2e46bf883f44024"
   end
 
   depends_on "meson" => :build

--- a/Formula/lib/libkiwix.rb
+++ b/Formula/lib/libkiwix.rb
@@ -26,7 +26,10 @@ class Libkiwix < Formula
 
   uses_from_macos "python" => :build
   uses_from_macos "curl"
-  uses_from_macos "zlib"
+
+  on_linux do
+    depends_on "zlib-ng-compat"
+  end
 
   # TODO: separate as a new formula once upstream release a new tag
   resource "mustache" do

--- a/Formula/o/oarfish.rb
+++ b/Formula/o/oarfish.rb
@@ -6,12 +6,13 @@ class Oarfish < Formula
   license "BSD-3-Clause"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "97b191385b9c87a080f4114487766148bd881481e9385771c86d48225160bd3e"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "ab18a2ca9ce121fc380b4b0aa577b3694c6841a8ba5afb5cdbb848e86514c1d6"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "a0fb702c0ff0a6f5925860f37f6cb8d6ff98aa81d8ce4e16d32b59e9aa09d547"
-    sha256 cellar: :any_skip_relocation, sonoma:        "9df4db569d3a4e1ac35af390c4b7f34fdf20ff424637757522657970d5233440"
-    sha256 cellar: :any,                 arm64_linux:   "7636627e3e9dfc3e6a6fe5ef86c405fcab5bc0b6bfdab55afcb721ccebc0ede8"
-    sha256 cellar: :any,                 x86_64_linux:  "6c12bfb6d937fdd394f97fe00e4aedba33ddf6ee3854870667e29df98cf61f5c"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "d5ce9664be4d5ae8fcf8e7d4c0b35cedbf3e8da5023b1b1005c50840d47b24f6"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "3adb87ebc03995dd9df4c731f4b36058ef08fd2b3e7eb51e25680bcb8a782b39"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "fde6f151d919ee41b3bdf46fb2a1b610b763d264a9e028446a133a55be6b4dd7"
+    sha256 cellar: :any_skip_relocation, sonoma:        "a73f608ab6699602d615e4e70e5d1203548ec53a97876889307ee610944c7094"
+    sha256 cellar: :any,                 arm64_linux:   "f8941d5ae8df1e577b50d16f76d60478d3c1860fadae6937a8845d3b0b4ef948"
+    sha256 cellar: :any,                 x86_64_linux:  "d18673039270574205c4d5cccb044877c97b9e927c3ac8a3572f2c08b2b966a8"
   end
 
   depends_on "rust" => :build

--- a/Formula/o/oarfish.rb
+++ b/Formula/o/oarfish.rb
@@ -17,7 +17,10 @@ class Oarfish < Formula
   depends_on "rust" => :build
 
   uses_from_macos "bzip2"
-  uses_from_macos "zlib"
+
+  on_linux do
+    depends_on "zlib-ng-compat"
+  end
 
   def install
     system "cargo", "install", *std_cargo_args

--- a/Formula/r/rustnet.rb
+++ b/Formula/r/rustnet.rb
@@ -7,12 +7,13 @@ class Rustnet < Formula
   head "https://github.com/domcyrus/rustnet.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "60b390d45e6fecd6435a0b7b4fe7f718e66ea4cef1b9c81a00059dd5d17f9cb7"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "1b15eca38ca0b3c1c3cc7800f4cbd039831b0616b6e70fdca01cb3c9ca49a9a1"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "1c8324446d3068637c38b9a03526fd58f6b2ffa6b2af7663922d43321e014036"
-    sha256 cellar: :any_skip_relocation, sonoma:        "61613d5a0ccb18b3914ee78aed28f6b46a1b0672f3e33e02a7cd1a6976809e3f"
-    sha256 cellar: :any,                 arm64_linux:   "9408c55b36cc65b45e883f55e4b7639c7e18f3f5f836cbc1988631ccfe5864a0"
-    sha256 cellar: :any,                 x86_64_linux:  "822fcca6989c718a580c3e32b98ca2afd0116604ff1ab2c9e3ceb9199a018e90"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "28ca4ad2fba70115eb1bec9838f723e6c8d8aec356809a8fbe20c61f1fefa28d"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "5e78b87995797d057c7fa48bd47b5d59d27a70441088aae8a8ba2ca81db1236e"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "78918b44799c98314278a85e3fae4fb139925efea11e5a62b6be975c2ae7b952"
+    sha256 cellar: :any_skip_relocation, sonoma:        "a74daab23db480e2de9aedf36cede91355e32aa1acd50ba29a72c7dd2dff8280"
+    sha256 cellar: :any,                 arm64_linux:   "c88dff5f29905a343ed524e08ce9e8f2b231559fd509792efbff59de3a92121c"
+    sha256 cellar: :any,                 x86_64_linux:  "8cb1d7cb93b04c8384dbfaaf487358ec4b79421ee114c268bae183fb9f67c137"
   end
 
   depends_on "rust" => :build

--- a/Formula/r/rustnet.rb
+++ b/Formula/r/rustnet.rb
@@ -18,12 +18,12 @@ class Rustnet < Formula
   depends_on "rust" => :build
 
   uses_from_macos "libpcap"
-  uses_from_macos "zlib"
 
   on_linux do
     depends_on "llvm" => :build
     depends_on "pkgconf" => :build
     depends_on "elfutils"
+    depends_on "zlib-ng-compat"
   end
 
   def install

--- a/Formula/s/smlnj.rb
+++ b/Formula/s/smlnj.rb
@@ -12,12 +12,13 @@ class Smlnj < Formula
   end
 
   bottle do
-    sha256 arm64_tahoe:   "93b1219027b0abcf80a71243e1607c50fc2a5849a734ae89190ce43d1168f5f6"
-    sha256 arm64_sequoia: "bb5a27da68e44310858f4df611cdc5f125c8da814d06c188191349ae0aafc113"
-    sha256 arm64_sonoma:  "13b5078c334318acab15ea2b2fd17ead939552f7a5e0c620d696f90feb42cf96"
-    sha256 sonoma:        "d6da8b8a343b1582f652980f6a08410d2f0f4e9ff0e6dd30ec32c2072347d3cc"
-    sha256 arm64_linux:   "141e547aa173e6a4c24667d29daa04547b2fefd2eaeeec702e3eb472036acb9a"
-    sha256 x86_64_linux:  "213f6ba81cdecb49d155373e72106177a625bb2310419df123e7292791dd06bf"
+    rebuild 1
+    sha256 arm64_tahoe:   "c7e181578cf2fc684e4894f40ca0537b6e1bf14eea5e6d024bf54e531f2848b5"
+    sha256 arm64_sequoia: "602e9365b6d5395cc83f40be0a26fb456a7d472deeef23a650f0f88cc466cb29"
+    sha256 arm64_sonoma:  "955e5427747a25e5faeddd7ad6fbc67ac15e09aaf5a037c76e8b40f24f5e4ecc"
+    sha256 sonoma:        "292a91c62f8b2d3c71564c27aea673e5a4158f76114cfad31aab3de2c2a6ba2b"
+    sha256 arm64_linux:   "e630cd54b1d783b275fcfca53f70755fd3bf3e7425832c67ed69f9b94c8bb6ff"
+    sha256 x86_64_linux:  "b9fdf377406f5c744d1b9d61909b4d47c427c307c7a1dcb68f0c91520790fc47"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/s/smlnj.rb
+++ b/Formula/s/smlnj.rb
@@ -24,7 +24,9 @@ class Smlnj < Formula
   depends_on "cmake" => :build
   depends_on "python@3.14" => :build
 
-  uses_from_macos "zlib"
+  on_linux do
+    depends_on "zlib-ng-compat"
+  end
 
   resource "bootarchive" do
     on_arm do

--- a/Formula/s/spoa.rb
+++ b/Formula/s/spoa.rb
@@ -6,12 +6,13 @@ class Spoa < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "ad55584bc1d671174019fc33fba25846d45695b1495a8a58e4f569df3f51e4a7"
-    sha256 cellar: :any,                 arm64_sequoia: "e78b56f6b7ccd0c550496370806409371af5aa0e247b19fb6a19766dc8588b98"
-    sha256 cellar: :any,                 arm64_sonoma:  "a233dfaffda20031385fff9037eed19790d91745b7a158c251924de0710eac83"
-    sha256 cellar: :any,                 sonoma:        "6e5926cd309fa1eeac6595bc1bedad2d27a1b9073c263829509cd9a598b286b3"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "13f431aa4da78f6726cf32c9d188b5bde27f7120d54db94763cb5f1f7aef29fd"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d45598cf9672ff7d9daa64cdb07d315980580e21fddb16100b4de4c8c2b849c9"
+    rebuild 1
+    sha256 cellar: :any, arm64_tahoe:   "c9fccbc0014b8c1f495ddc9073dd51f69d0a10aefc46e10b166311c1e4724d60"
+    sha256 cellar: :any, arm64_sequoia: "44cbe5908a4d582d75edf115868fadb1247b1f6111ca0f2974e50a1e74b5f440"
+    sha256 cellar: :any, arm64_sonoma:  "749823a0c1e16ab05d1d916d45bfb74f9abda75bee68c6d6ae65955efb76bedb"
+    sha256 cellar: :any, sonoma:        "f5773e569d8b1bb47043cff37f3dcde4d11e5142a28a7ffd8b8465d77e410583"
+    sha256 cellar: :any, arm64_linux:   "caf94661a23225cae4a559cdd3867f368e62b5eb44af4fc05d256284cb05d0ef"
+    sha256 cellar: :any, x86_64_linux:  "1185760cad8547073d91443bbe6965ac39a88fe8d9b04e6098d6d170d36809bd"
   end
 
   depends_on "cmake" => :build

--- a/Formula/s/spoa.rb
+++ b/Formula/s/spoa.rb
@@ -16,7 +16,9 @@ class Spoa < Formula
 
   depends_on "cmake" => :build
 
-  uses_from_macos "zlib"
+  on_linux do
+    depends_on "zlib-ng-compat"
+  end
 
   def install
     args = %w[

--- a/Formula/v/vcflib.rb
+++ b/Formula/v/vcflib.rb
@@ -23,10 +23,13 @@ class Vcflib < Formula
   depends_on "xz"
 
   uses_from_macos "bzip2"
-  uses_from_macos "zlib"
 
   on_macos do
     depends_on "libomp"
+  end
+
+  on_linux do
+    depends_on "zlib-ng-compat"
   end
 
   def install

--- a/Formula/v/vcflib.rb
+++ b/Formula/v/vcflib.rb
@@ -6,12 +6,13 @@ class Vcflib < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "dae474cbc0c7e6df472e8a8b7d903fcc326706e985391a533a92eecdcab56dc5"
-    sha256 cellar: :any,                 arm64_sequoia: "ef9292a2426c8dde700d72dbef0a8c90b64aca16e13408dcebff8153381563f7"
-    sha256 cellar: :any,                 arm64_sonoma:  "f20a7074ff10f55f5f61b7c1c7664c695716ab9e423580b0ec58c9b909c88408"
-    sha256 cellar: :any,                 sonoma:        "3e65b889529b3887e5ee65f67aca8cf7321bd151635af66767f0a1eb2a9ff009"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "593cc2e3478b480c04250f7396747e8d4a3e3dff01ac220a592b6cf3d4aaa03b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b270eec4b3a5cecdcef38f0f2fd32bf813d46753eeacbbb5471688b3855645e4"
+    rebuild 1
+    sha256 cellar: :any, arm64_tahoe:   "837e94d79bd6b94f62aa5da9ada2695c30421933fbbf121bff6d3bc32bfe8ac0"
+    sha256 cellar: :any, arm64_sequoia: "ce48bd31457f57bbdc44ccca1bcc198a7002d7a91069fb352c980318d19241ef"
+    sha256 cellar: :any, arm64_sonoma:  "0bbc25128abb0a232e460042373b9d8ac516c6f47dae1d5107d66c591b4b0de7"
+    sha256 cellar: :any, sonoma:        "572645a1d26f3f0de4c7dd2a704fec02a70b53bc9f209c9147d9b0f3951ddd4f"
+    sha256 cellar: :any, arm64_linux:   "9151d202f36c0f4ec53c44ae264a7f5a0466aff4a7c477c70d5ac32e03de2c02"
+    sha256 cellar: :any, x86_64_linux:  "3262faae8a544bd217c646635d6309e2555612aeec51fdc6ebb77f07cacdde69"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
Fix incorrect usage of `zlib` introduced in new formulae

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
