### PR TITLE
go-critic: build as go-critic, symlink gocritic

### DIFF
--- a/Formula/g/go-critic.rb
+++ b/Formula/g/go-critic.rb
@@ -25,10 +25,14 @@ class GoCritic < Formula
   def install
     ldflags = "-s -w"
     ldflags += " -X main.Version=v#{version}" if build.stable?
-    system "go", "build", *std_go_args(ldflags:, output: bin/"gocritic"), "./cmd/gocritic"
+    system "go", "build", *std_go_args(ldflags:), "./cmd/go-critic"
+    bin.install_symlink bin/"go-critic" => "gocritic"
   end
 
   test do
+    assert_predicate bin/"gocritic", :symlink?
+    assert_equal "go-critic", (bin/"gocritic").readlink.to_s
+
     (testpath/"main.go").write <<~GO
       package main
 
@@ -42,7 +46,10 @@ class GoCritic < Formula
       }
     GO
 
-    output = shell_output("#{bin}/gocritic check main.go 2>&1", 1)
-    assert_match "sloppyLen: len(str) <= 0 can be len(str) == 0", output
+    output_go_critic = shell_output("#{bin}/go-critic check main.go 2>&1", 1)
+    assert_match "sloppyLen: len(str) <= 0 can be len(str) == 0", output_go_critic
+
+    output_gocritic = shell_output("#{bin}/gocritic check main.go 2>&1", 1)
+    assert_match "sloppyLen: len(str) <= 0 can be len(str) == 0", output_gocritic
   end
 end


### PR DESCRIPTION
The go-critic project renamed their official binary from 'gocritic' to 'go-critic' as part of the v0.14.0 release on Oct 14, 2025:
- RELEASE: https://github.com/go-critic/go-critic/releases/tag/v0.14.0

To reflect the change, we update the recipe's target output binary to the new name.

As many community members still appear to be referencing the old name, we also symlink it for compatibility.

* Migrate the Go build command to compile from `./cmd/go-critic` instead of `./cmd/gocritic`
* Output the compiled binary as `go-critic`
* Add a `gocritic` compatibility symlink
* Update the test block to verify both binary and symlink behavior

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

I used `antigravity-cli` to help find existing patterns for renaming the primary binary name, sym-linking the previous name, updating the recipe post-install tests, running through the cookbook for testing / validating the recipe changes, and ideating on the commit message.

All changes were personally reviewed and reflect the outcome I was aiming for.

-----
