### PR TITLE
percona-toolkit: update checksum for 3.7.1 release

### DIFF
--- a/Formula/p/percona-toolkit.rb
+++ b/Formula/p/percona-toolkit.rb
@@ -6,7 +6,7 @@ class PerconaToolkit < Formula
 
   stable do
     url "https://downloads.percona.com/downloads/percona-toolkit/3.7.1/source/tarball/percona-toolkit-3.7.1.tar.gz"
-    sha256 "d5abd944905e75800e29176aff7fdeb7062da212511e82c265be50ac03b4c19b"
+    sha256 "ee997edf4f5c9f530032cf36b09ca08c1cd43db64b94e3f21f60cca878c0c730"
 
     # Fix Makefile.PL to also install go tools
     patch do


### PR DESCRIPTION
Ref (chronological):
* https://docs.percona.com/percona-toolkit/release_notes.html#v3-7-1-released-2025-12-17
* https://github.com/percona/percona-toolkit/releases/tag/v3.7.1
* https://github.com/Homebrew/homebrew-core/pull/259356
* https://github.com/Homebrew/homebrew-core/pull/263460 (https://github.com/percona/percona-toolkit/pull/1052)
* https://docs.percona.com/percona-toolkit/release_notes.html#v3-7-1-3-released-2026-04-17
* https://github.com/Homebrew/homebrew-core/pull/288803

https://github.com/percona/percona-toolkit/blob/3.x/Changelog

Side quest: No separate tag / release 3.7.1-3?

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
