### PR TITLE
wordnet: deprecate

### DIFF
--- a/Formula/w/wordnet.rb
+++ b/Formula/w/wordnet.rb
@@ -5,14 +5,8 @@ class Wordnet < Formula
   # Version 3.1 is version 3.0 with the 3.1 dictionary.
   version "3.1"
   sha256 "6c492d0c7b4a40e7674d088191d3aa11f373bb1da60762e098b8ee2dda96ef22"
-  license :cannot_represent
+  license "WordNet"
   revision 2
-
-  # From homepage: "Princeton WordNet is no longer developed, though the
-  # database and all tools are freely available on the download page."
-  livecheck do
-    skip "No longer developed or maintained"
-  end
 
   bottle do
     sha256                               arm64_tahoe:   "c76614f1a228d94b2470a7b931ae833377ae13d1214cff36d6a93b5fb7da4ae5"
@@ -24,6 +18,13 @@ class Wordnet < Formula
     sha256                               arm64_linux:   "3a67f8e72a2b2c2b3119386adefe9ccf353c45bb05598aef4970be2bbe64da1d"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "b5090e0ee1251e6d13e6c77024a0d1f18e0b6d563a4ced176d3c2cd1fffb52b7"
   end
+
+  # From homepage: "Princeton WordNet is no longer developed, though the
+  # database and all tools are freely available on the download page."
+  #
+  # Also needs unmaintained TCL/Tk 8
+  deprecate! date: "2026-06-22", because: :unmaintained
+  disable! date: "2027-06-22", because: :unmaintained
 
   depends_on "tcl-tk@8"
 


### PR DESCRIPTION
WordNet is officially unmaintained. 

Also, TCL 8 is likely EOL now - https://github.com/tcltk/tcl/releases/tag/core-8-6-18
> We intend these to be the final releases of Tcl 8.6 and Tk 8.6

Unpopular, unmaintained dependents can likely be deprecated.

Will need to figure out plan for commonly used but unmaintained stuff like `expect` (e.g. may need to use Debian patch series).

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
