### PR TITLE
sha2: deprecate

### DIFF
--- a/Formula/s/sha2.rb
+++ b/Formula/s/sha2.rb
@@ -5,11 +5,6 @@ class Sha2 < Formula
   sha256 "67bc662955c6ca2fa6a0ce372c4794ec3d0cd2c1e50b124e7a75af7e23dd1d0c"
   license "BSD-3-Clause"
 
-  livecheck do
-    url :homepage
-    regex(/href=.*?sha2[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     rebuild 4
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "55b0e8d020c0e19723dac33bf78a7766ad2a9bc1fbf0ae532909fed61f9c5685"
@@ -26,6 +21,10 @@ class Sha2 < Formula
     sha256 cellar: :any_skip_relocation, arm64_linux:    "82d260e0a84cc48d8442d041c3da6305a586be869936e999a80abb4f58548849"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "027526015a81f4aec75269a3c104a0fab290359471f228d87f0922a788eedee0"
   end
+
+  # Upstream homepage is gone
+  deprecate! date: "2026-06-22", because: :repo_removed
+  disable! date: "2027-06-22", because: :repo_removed
 
   def install
     # Xcode 12 made -Wimplicit-function-declaration an error by default so we need to


### PR DESCRIPTION
Upstream is gone
250 installs over the last year: this is not enough, so let's deprecate this formula

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
