### PR TITLE
llvm@17: skip parts of test on newer CLT

### DIFF
--- a/Formula/l/llvm@17.rb
+++ b/Formula/l/llvm@17.rb
@@ -49,6 +49,14 @@ class LlvmAT17 < Formula
     file "Patches/llvm/17.x-arm64-opt.patch"
   end
 
+  # Backport commit for newer macOS CLT
+  patch do
+    on_tahoe :or_newer do
+      url "https://github.com/llvm/llvm-project/commit/a8016e296e6ec161897e7421c5efbc25a6aa3a9f.patch?full_index=1"
+      sha256 "17ef118c305a3fbe9b7143134f998351e92f6c7f24b62447abacbc0731c8b9b1"
+    end
+  end
+
   def python3
     "python3.14"
   end
@@ -277,8 +285,8 @@ class LlvmAT17 < Formula
 
     # These tests should ignore the usual SDK includes
     with_env(CPATH: nil) do
-      # Testing Command Line Tools
-      if OS.mac? && MacOS::CLT.installed?
+      # Testing Command Line Tools; skipped on CLT 26.4+ due to __builtin_clzg added in LLVM 19+
+      if OS.mac? && MacOS::CLT.installed? && MacOS::CLT.version < "26.4"
         toolchain_path = "/Library/Developer/CommandLineTools"
         cpp_base = (MacOS.version >= :big_sur) ? MacOS::CLT.sdk_path : toolchain_path
         system bin/"clang++", "-v",
@@ -293,8 +301,8 @@ class LlvmAT17 < Formula
         assert_equal "Hello World!", shell_output("./testCLT").chomp
       end
 
-      # Testing Xcode
-      if OS.mac? && MacOS::Xcode.installed?
+      # Testing Xcode; skipped on Xcode 26.4+ due to __builtin_clzg added in LLVM 19+
+      if OS.mac? && MacOS::Xcode.installed? && MacOS::Xcode.version < "26.4"
         cpp_base = (MacOS::Xcode.version >= "12.5") ? MacOS::Xcode.sdk_path : MacOS::Xcode.toolchain_path
         system bin/"clang++", "-v",
                "-isysroot", MacOS::Xcode.sdk_path,


### PR DESCRIPTION
Similar issues to LLVM 16. Likely not worth trying to fix as unmaintained LLVM version we mainly keep around for old macOS.

May also need to skip build.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
