### PR TITLE
gcc: link with -headerpad_max_install_names on older gcc

### DIFF
--- a/Formula/g/gcc@13.rb
+++ b/Formula/g/gcc@13.rb
@@ -85,7 +85,10 @@ class GccAT13 < Formula
       # Avoid this semi-random failure:
       # "Error: Failed changing install name"
       # "Updated load commands do not fit in the header"
-      make_args = %w[BOOT_LDFLAGS=-Wl,-headerpad_max_install_names]
+      make_args = %w[
+        BOOT_LDFLAGS=-Wl,-headerpad_max_install_names
+        LDFLAGS_FOR_TARGET=-Wl,-headerpad_max_install_names
+      ]
     else
       # Fix Linux error: gnu/stubs-32.h: No such file or directory.
       args << "--disable-multilib"

--- a/Formula/g/gcc@14.rb
+++ b/Formula/g/gcc@14.rb
@@ -99,7 +99,10 @@ class GccAT14 < Formula
       # Avoid this semi-random failure:
       # "Error: Failed changing install name"
       # "Updated load commands do not fit in the header"
-      make_args = %w[BOOT_LDFLAGS=-Wl,-headerpad_max_install_names]
+      make_args = %w[
+        BOOT_LDFLAGS=-Wl,-headerpad_max_install_names
+        LDFLAGS_FOR_TARGET=-Wl,-headerpad_max_install_names
+      ]
     else
       # Fix Linux error: gnu/stubs-32.h: No such file or directory.
       args << "--disable-multilib"

--- a/Formula/g/gcc@15.rb
+++ b/Formula/g/gcc@15.rb
@@ -99,7 +99,10 @@ class GccAT15 < Formula
       # Avoid this semi-random failure:
       # "Error: Failed changing install name"
       # "Updated load commands do not fit in the header"
-      make_args = %w[BOOT_LDFLAGS=-Wl,-headerpad_max_install_names]
+      make_args = %w[
+        BOOT_LDFLAGS=-Wl,-headerpad_max_install_names
+        LDFLAGS_FOR_TARGET=-Wl,-headerpad_max_install_names
+      ]
     else
       # Fix Linux error: gnu/stubs-32.h: No such file or directory.
       args << "--disable-multilib"


### PR DESCRIPTION

This is a backport of #266996 by @RazerM for `gcc@15`, `gcc@14` and `gcc@13` as those also had the same `make_args` that `gcc@16` does. Without it you get:

```
✔︎ Formula gcc@15 (15.3.0)                                                                                                                                         Verified    101.3MB/101.3MB
==> Patching
==> ../configure --prefix=/Users/mathomp4/.homebrew/brew/opt/gcc@15 --libdir=/Users/mathomp4/.homebrew/brew/opt/gcc@15/lib/gcc/15 --disable-nls --enable-checking=release --with-gcc-major-ve
==> gmake BOOT_LDFLAGS=-Wl,-headerpad_max_install_names
==> gmake install DESTDIR=/private/tmp/gccA15-20260622-15280-jeaqwj/gcc-15.3.0/build/../instdir
Error: Failed changing dylib ID of /Users/mathomp4/.homebrew/brew/Cellar/gcc@15/15.3.0/lib/gcc/15/libatomic.1.dylib
  from @rpath/libatomic.1.dylib
    to /Users/mathomp4/.homebrew/brew/opt/gcc@15/lib/gcc/15/libatomic.1.dylib
Error: Failed to fix install linkage
Updated load commands do not fit in the header of /Users/mathomp4/.homebrew/brew/Cellar/gcc@15/15.3.0/lib/gcc/15/libatomic.1.dylib. /Users/mathomp4/.homebrew/brew/Cellar/gcc@15/15.3.0/lib/gcc/15/libatomic.1.dylib needs to be relinked, possibly with -headerpad or -headerpad_max_install_names
The formula built, but you may encounter issues using it or linking other
formulae against it.
```

I didn't update 12 or older since they didn't seem to have `make_args` and I'm not smart enough to figure out how to update those. (Plus, I don't use gcc 12 or older anymore in my work.)

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
