### PR TITLE
gocr: deprecate

### DIFF
--- a/Formula/g/gocr.rb
+++ b/Formula/g/gocr.rb
@@ -6,11 +6,6 @@ class Gocr < Formula
   license "GPL-2.0-or-later"
   revision 2
 
-  livecheck do
-    url "https://wasd.urz.uni-magdeburg.de/jschulen/ocr/download.html"
-    regex(%r{href=(?:["']?|.*?/)gocr[._-]v?(\d+(?:\.\d+)+)\.t}i)
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "22d93d120980d188dbee305cbec8c1d22aab0a9def0580ff3ecaeaa44fe488e7"
     sha256 cellar: :any,                 arm64_sequoia:  "f38bbed5dfe8ae2150cab6f508e71dc9402d9f05c3c72273f3c9270dd42ff6fa"
@@ -26,6 +21,10 @@ class Gocr < Formula
     sha256 cellar: :any_skip_relocation, arm64_linux:    "4012b5d2e3c64d8bffa02852c25348f57cee8475aa726d7e14384e248a08e349"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "614341527ffeeb9e65ea13c95c230569bd68316f11b6e4c3d5bbc4c46757faa8"
   end
+
+  # Upstream homepage is gone
+  deprecate! date: "2026-06-22", because: :repo_removed
+  disable! date: "2027-06-22", because: :repo_removed
 
   depends_on "jpeg-turbo"
   depends_on "netpbm"


### PR DESCRIPTION
Upstream is gone
160 downloads in the last year, which is pretty low

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
