### PR TITLE
pypy3.10: deprecate

### DIFF
--- a/Formula/p/pypy3.10.rb
+++ b/Formula/p/pypy3.10.rb
@@ -7,11 +7,6 @@ class Pypy310 < Formula
   revision 1
   head "https://github.com/pypy/pypy.git", branch: "main"
 
-  livecheck do
-    url "https://downloads.python.org/pypy/"
-    regex(/href=.*?pypy3\.10[._-]v?(\d+(?:\.\d+)+)-src\.t/i)
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "de425a276a64d92a0e2d69d589753d119733d0e3cc18aa985ae329aaf1bfa910"
     sha256 cellar: :any,                 arm64_sequoia: "311b947a1528ae90983edc2176864a00865fb678c13c2286efe24075463a1796"
@@ -22,6 +17,10 @@ class Pypy310 < Formula
     sha256 cellar: :any_skip_relocation, arm64_linux:   "6c838f8f2bde36ec834a8d390cd441e75aec83b1cc21126e8e974e05024a5d09"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "c4032a756625270ffb7945d97b0116ac7e9acb1e5731eab7590241874f2fb12d"
   end
+
+  # PyPy 3.10 was dropped in 7.3.20 and source tarballs have been removed
+  deprecate! date: "2026-06-22", because: :does_not_build
+  disable! date: "2027-06-22", because: :does_not_build
 
   depends_on "pkgconf" => :build
   depends_on "pypy" => :build


### PR DESCRIPTION
We can try getting pypy3.11 out before this is removed, but either way pypy3.10 is officially unsupported for over a year now.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
