### PR TITLE
curl: enable libpsl

### DIFF
--- a/Formula/c/curl.rb
+++ b/Formula/c/curl.rb
@@ -16,12 +16,13 @@ class Curl < Formula
   end
 
   bottle do
-    sha256 cellar: :any, arm64_tahoe:   "8451a7abc6219aaea2f314e8453a8e4eaf02ebe0e8ba3b4af6f914c63314516f"
-    sha256 cellar: :any, arm64_sequoia: "1ee3b96f6648de2833b2643c50b0e48086275c62efbb139c41957fa63dc110e2"
-    sha256 cellar: :any, arm64_sonoma:  "188121382f5f8343752ae1b32a3d7845680786130ce57acb2dfa160f8f1d3f39"
-    sha256 cellar: :any, sonoma:        "bceca1c71bec909951651593a8ffa2b4c89c48e4a9fc72d2f79b399f279ae6a8"
-    sha256 cellar: :any, arm64_linux:   "029fa8f4e8e831792e5919e02770f875498dc911602ffba5b9f1a61d84ad85ab"
-    sha256 cellar: :any, x86_64_linux:  "9589fd42a20cfe50957e63a6fb159f507e0172474f6f415a159908a4d845fc17"
+    rebuild 1
+    sha256 cellar: :any, arm64_tahoe:   "7ceececba7b3be416aa9bdadd3ee68ab964c322d3df4890ae8761bf4c5e0ce50"
+    sha256 cellar: :any, arm64_sequoia: "432965ded4ed87b8ac7bc844f1d624b6ff6ce76d6985b76c8db76c9fede80d2a"
+    sha256 cellar: :any, arm64_sonoma:  "8f4561cbcbb9f858431c52a3f2d48e7f70e65e0c8b6eb1227735c08eb7d96aa8"
+    sha256 cellar: :any, sonoma:        "37bacf782cce6caef087200f41b4b632dd96c346818f1067f0fb98a1d4d8362d"
+    sha256 cellar: :any, arm64_linux:   "33f3d4388cc2c8c8a2703b54dfd3f9988af1bb5d3c4e9ba9b4167891108d2333"
+    sha256 cellar: :any, x86_64_linux:  "c17375ac0e06bc2dca81fb57b56002c52db22171d66438ae3a1db874dbac4793"
   end
 
   head do

--- a/Formula/c/curl.rb
+++ b/Formula/c/curl.rb
@@ -39,6 +39,7 @@ class Curl < Formula
   depends_on "libnghttp2"
   depends_on "libnghttp3"
   depends_on "libngtcp2"
+  depends_on "libpsl"
   depends_on "libssh2"
   depends_on "openssl@3"
   depends_on "zstd"
@@ -76,7 +77,7 @@ class Curl < Formula
       --with-libssh2
       --with-nghttp3
       --with-ngtcp2
-      --without-libpsl
+      --with-libpsl
       --with-zsh-functions-dir=#{zsh_completion}
       --with-fish-functions-dir=#{fish_completion}
     ]
@@ -120,7 +121,7 @@ class Curl < Formula
 
     # Check dependencies linked correctly
     curl_features = shell_output("#{bin}/curl-config --features").split("\n")
-    %w[brotli GSS-API HTTP2 HTTP3 IDN libz SSL zstd].each do |feature|
+    %w[brotli GSS-API HTTP2 HTTP3 IDN libz PSL SSL zstd].each do |feature|
       assert_includes curl_features, feature
     end
     curl_protocols = shell_output("#{bin}/curl-config --protocols").split("\n")


### PR DESCRIPTION
Build with libpsl to turn on Public Suffix List checks, so cookies can't be set for broad public suffixes like `.co.uk`; this blocks "supercookies" that would otherwise be shared across unrelated sites under the same suffix.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
