### PR TITLE
advai-cli 1.0.4 (new formula)

### DIFF
--- a/Formula/a/advai-cli.rb
+++ b/Formula/a/advai-cli.rb
@@ -1,0 +1,30 @@
+class AdvaiCli < Formula
+  include Language::Python::Virtualenv
+
+  desc "CLI for managing AdvAI skills and external CLIs"
+  homepage "https://github.com/Advai-X/advai-x-cli"
+  url "https://files.pythonhosted.org/packages/4d/b0/69f7d9356ad4692ba588ccbc4976e9c9757d81c1d680cc9b7ae4d93914db/advai_cli-1.0.4.tar.gz"
+  sha256 "81ac57e7eae6d964df174c55d89071309fd0b2fe551c2ed6e53197f3e65b977d"
+  license "MIT"
+
+  depends_on "python@3.14"
+
+  resource "click" do
+    url "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz"
+    sha256 "918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96"
+  end
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    (testpath/"home").mkpath
+    ENV["HOME"] = testpath/"home"
+
+    assert_match version.to_s, shell_output("#{bin}/advai --version")
+    system bin/"advai", "skill", "install", "demo-skill"
+    assert_match "demo-skill", shell_output("#{bin}/advai skill list")
+    assert_match "demo-skill", shell_output("#{bin}/advai skill info demo-skill")
+  end
+end


### PR DESCRIPTION
-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI helped draft the formula, prepare the PR text, and align the Python packaging flow with Homebrew's `Language::Python::Virtualenv` conventions.

Manual verification performed:
- `brew style Formula/a/advai-cli.rb`
- local source build and packaging validation for the upstream project
- local CLI smoke testing for `advai skill install`, `advai skill list`, `advai skill info`, and `advai skill uninstall`
- local `brew install --build-from-source advai-cli`

Additional context:
- `advai-cli` is a command-line tool for managing AdvAI skills and working with external CLIs through a single `advai` entrypoint.
- Upstream repository: https://github.com/Advai-X/advai-x-cli
- PyPI release: https://pypi.org/project/advai-cli/
- The formula packages a Python application from the PyPI source tarball using `Language::Python::Virtualenv`.
