### PR TITLE
gcc@13-16: replace deprecated sdk_path_if_needed with sdk_path

### DIFF
--- a/Formula/g/gcc.rb
+++ b/Formula/g/gcc.rb
@@ -108,7 +108,7 @@ class Gcc < Formula
       args << "--build=#{cpu}-apple-darwin#{OS.kernel_version.major}"
 
       # System headers may not be in /usr/include
-      sdk = MacOS.sdk_path_if_needed
+      sdk = MacOS.sdk_path
       args << "--with-sysroot=#{sdk}" if sdk
 
       # Avoid this semi-random failure:

--- a/Formula/g/gcc@13.rb
+++ b/Formula/g/gcc@13.rb
@@ -79,7 +79,7 @@ class GccAT13 < Formula
       args << "--build=#{cpu}-apple-darwin#{OS.kernel_version.major}"
 
       # System headers may not be in /usr/include
-      sdk = MacOS.sdk_path_if_needed
+      sdk = MacOS.sdk_path
       args << "--with-sysroot=#{sdk}" if sdk
 
       # Avoid this semi-random failure:

--- a/Formula/g/gcc@14.rb
+++ b/Formula/g/gcc@14.rb
@@ -93,7 +93,7 @@ class GccAT14 < Formula
       args << "--build=#{cpu}-apple-darwin#{OS.kernel_version.major}"
 
       # System headers may not be in /usr/include
-      sdk = MacOS.sdk_path_if_needed
+      sdk = MacOS.sdk_path
       args << "--with-sysroot=#{sdk}" if sdk
 
       # Avoid this semi-random failure:

--- a/Formula/g/gcc@15.rb
+++ b/Formula/g/gcc@15.rb
@@ -93,7 +93,7 @@ class GccAT15 < Formula
       args << "--build=#{cpu}-apple-darwin#{OS.kernel_version.major}"
 
       # System headers may not be in /usr/include
-      sdk = MacOS.sdk_path_if_needed
+      sdk = MacOS.sdk_path
       args << "--with-sysroot=#{sdk}" if sdk
 
       # Avoid this semi-random failure:


### PR DESCRIPTION
@cho-m fixed the other gcc formulae the same way in https://github.com/Homebrew/homebrew-core/pull/289332

They said:

> Other GCC are handled in existing PRs

but I can't find any other PRs that cover this (maybe they got closed)?

---

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

- [ ] AI was used to generate or assist with generating this PR. _Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes_.

---