### PR TITLE
xorg-server: register X11.app in macOS Launch Services

### DIFF
--- a/Formula/x/xorg-server.rb
+++ b/Formula/x/xorg-server.rb
@@ -111,6 +111,17 @@ class XorgServer < Formula
     end
   end
 
+  def post_install
+    return unless OS.mac?
+
+    app = opt_libexec/"X11.app"
+    lsregister = Pathname(
+      "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister",
+    )
+
+    system lsregister, "-f", app if app.directory? && lsregister.executable?
+  end
+
   def caveats
     <<~EOS
       To launch X server, it is recommend to install xinit,


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Assisted by GPT-5.5 Pro Extended in ChatGPT, manually verified.

-----

Currently, `startx` is non-functional after a fresh run of `brew install xinit xorg-server`, and throws the following error.

```
xinit: giving up
xinit: unable to connect to X server: Connection refused
xinit: server error
```

Opening `/opt/homebrew/opt/xorg-server/libexec/X11.app` once from Finder fixes the issue persistently, including after quitting `X11.app` and after a reboot. This PR makes that registration explicit instead of relying on a manual first launch.

## Rationale

Homebrew’s `xorg-server` formula installs the macOS app bundle under Homebrew’s prefix, currently under `libexec`, rather than in a standard application location such as `/Applications`.

Upstream XQuartz startup code expects the app bundle to be discoverable through Launch Services. The `Xquartz` stub constructs the bundle identifier as `BUNDLE_ID_PREFIX ".X11"` and calls `LSFindApplicationForInfo(...)` to locate `X11.app`. If the lookup succeeds, it launches the app with `LSOpenApplication(...)`. If Launch Services does not know about the app bundle yet, this path can fail even though the bundle exists on disk.

## Implementation

This uses Apple’s Launch Services registration tool `/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister` to force-register the installed app bundle. I put this in `xorg-server` rather than `xinit` because `xorg-server` owns and installs the `X11.app` bundle.

## Testing

1. First verify that `X11.app` is not already registered in Launch Services
```sh
/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -dump \
  | grep -A8 -B8 'homebrew.mxcl.X11'
```
If it is, then manually unregister it with `/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -f -u /opt/homebrew/Cellar/xorg-server/21.1.23/libexec/X11.app`

2. (Re)install `xinit xorg-server`, and then immediately run `startx`. Starting the `xinit` launchd services are unnecessary. See that `X11.app` does not launch and observe the aforementioned `xinit: server error` messages.

3. Reinstall `xorg-server` from this PR, and then immediately run `startx` again. See how `X11.app` successfully launches, and how it is present in `lsregister -dump`.

## References

* XQuartz startup stub using `LSFindApplicationForInfo` / `LSOpenApplication`: https://github.com/XQuartz/xorg-server/blob/master/hw/xquartz/mach-startup/stub.c