### PR TITLE
xinit: use stable opt_libexec paths in services

### DIFF
--- a/Formula/x/xinit.rb
+++ b/Formula/x/xinit.rb
@@ -27,9 +27,8 @@ class Xinit < Formula
   depends_on "xterm"
 
   on_macos do
-    depends_on "lndir" => :build
-    depends_on "mkfontscale" => :build
-
+    depends_on "lndir"
+    depends_on "mkfontscale"
     depends_on "quartz-wm"
 
     resource "xquartz" do
@@ -87,7 +86,8 @@ class Xinit < Formula
     ]
 
     system "./configure", *configure_args, *std_configure_args
-    system "make", "RAWCPP=tradcpp"
+    system "make", "RAWCPP=tradcpp",
+                   "libexecdir=#{opt_libexec}"
     system "make", "XINITDIR=#{prefix}/etc/X11/xinit",
                    "sysconfdir=#{prefix}/etc",
                    "bindir=#{bin}", "install"

--- a/Formula/x/xinit.rb
+++ b/Formula/x/xinit.rb
@@ -6,14 +6,13 @@ class Xinit < Formula
   license all_of: ["MIT", "APSL-2.0"]
 
   bottle do
-    sha256 arm64_tahoe:   "dd3c7693b0185d79555d1f91e559612ad865688fe779f1c4986f86493058ba6b"
-    sha256 arm64_sequoia: "f032d2ee9b34ba1ee42d99701266d51e3dcbdcb30d66883ec8f05033894356bb"
-    sha256 arm64_sonoma:  "12231945f0af6967b64ea1e6f992caedcc760a7ed13d142590dab52ae7fc3e96"
-    sha256 arm64_ventura: "6f5350a1fceed943594b743212e2ae40e37559e1daa82c31e617311a706ee25a"
-    sha256 sonoma:        "14ad40b8e7143eb60fd252ecadaa4012428a33d9572920fc7e4968ac52904d38"
-    sha256 ventura:       "caf7be003b70bc8a6a0a2c0fd64df3b6f1479ecb437ecbb00b4675660bf15319"
-    sha256 arm64_linux:   "5afccb26823574faa9cc8e322ffa73ba0f5466862dd88ca5a8a4c828ab0d95cc"
-    sha256 x86_64_linux:  "8b8186133c32e00a1411809fa7b2569bffacaa9fd2ddbd575605abd3555c6316"
+    rebuild 1
+    sha256               arm64_tahoe:   "3ce6a5600a9a88b1d4018a6ecf88b437563538938ae559129713425112cb032f"
+    sha256               arm64_sequoia: "5727dd128f946d0e16660e2db86ee1ad79cc3d97340bdc9869d867cc077641ff"
+    sha256               arm64_sonoma:  "a992bd591fb51755561d3db0d9b6adf43c69bfc4357c8e9910958d4e89897e95"
+    sha256 cellar: :any, sonoma:        "d18f2e51c72eb9fc51c0de81a4856aeaabba640f3c8acc510ac474de427ebc2d"
+    sha256               arm64_linux:   "8b1f7924f2e2cab4fb2f3282cece3eeb75106105b3f9d84ccaa851dd9b1582a2"
+    sha256               x86_64_linux:  "bfb05c8b3ce100f8a796ebe2d4ea33bcefa72b0c226eacc710f412bc87d9a66e"
   end
 
   depends_on "pkgconf" => :build


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Hand coded.

-----
Prior to this PR, `homebrew.mxcl.startx.plist` and `homebrew.mxcl.privileged_startx.plist` hardcode the versioned Cellar paths, like the following:
```
<array>
	<string>/opt/homebrew/Cellar/xinit/1.4.4/libexec/privileged_startx</string>
	<string>-d</string>
	<string>/opt/homebrew/etc/X11/xinit/privileged_startx.d</string>
</array>
```
This causes the services to break after `xinit` updates, and is inconsistent with other services like `nginx` that use `$HOMEBREW_PREFIX/opt` instead of the Cellar path. This PR changes that so a stable $HOMEBREW_PREFIX/opt/xinit/libexec` path is used instead, like the following:
```
<array>
	<string>/opt/homebrew/opt/xinit/libexec/privileged_startx</string>
	<string>-d</string>
	<string>/opt/homebrew/etc/X11/xinit/privileged_startx.d</string>
</array>
```
This makes `xinit` consistent with other formulae that use services, and allows the service to persist after an `xinit` update. During testing, I also noticed the following error when running `startx`, so I moved the `lndir` and `mkfontscale` dependencies from build to runtime. This change matches the XQuartz pkg, as well as `xinit` in macports.
```
/opt/homebrew/bin/font_cache: line 147: /opt/homebrew/bin/lndir: No such file or directory
```
Note that there is currently an issue where `brew services start xinit` fails for both the privileged and non-privileged services, but that likely has to be fixed in Homebrew/brew instead.

```
> brew services start xinit
Usage: brew [sudo] brew services start (formula|--all) [--file=]:
    Start the service formula immediately and register it to launch at login
(or boot).

  -d, --debug                      Display any debugging information.
  -q, --quiet                      Make some output more quiet.
  -v, --verbose                    Make some output more verbose.
  -h, --help                       Show this message.
      --sudo-service-user          When run as root on macOS, run the service(s)
                                   as this user.
      --file                       Use the service file from this location to
                                   start the service.
      --all                        Start all services and register them to
                                   launch at login (or boot).

Error: Invalid usage: Formula `xinit` has not implemented #plist, #service or provided a locatable service file.
```
```
> sudo brew services start xinit --file=/opt/homebrew/opt/xinit/homebrew.mxcl.privileged_startx.plist
Usage: brew [sudo] brew services start (formula|--all) [--file=]:
    Start the service formula immediately and register it to launch at login
(or boot).

  -d, --debug                      Display any debugging information.
  -q, --quiet                      Make some output more quiet.
  -v, --verbose                    Make some output more verbose.
  -h, --help                       Show this message.
      --sudo-service-user          When run as root on macOS, run the service(s)
                                   as this user.
      --file                       Use the service file from this location to
                                   start the service.
      --all                        Start all services and register them to
                                   launch at login (or boot).

Error: Invalid usage: Formula `xinit` has not implemented #plist, #service or provided a locatable service file.
```