### PR TITLE
difi 0.2.8 (new formula)

### DIFF
--- a/Formula/difi.rb
+++ b/Formula/difi.rb
@@ -1,0 +1,33 @@
+class Difi < Formula
+  desc "Pixel-perfect terminal diff viewer"
+  homepage "https://github.com/xguot/difi"
+  url "https://github.com/xguot/difi/archive/refs/tags/v0.2.8.tar.gz"
+  sha256 "3d5955f1ed2d8cf9162719b3399dd4b7ae2a888322484ee921ea0add3f0f94d7"
+  license "MIT"
+  head "https://github.com/xguot/difi.git", branch: "main"
+
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args(ldflags: "-s -w -X main.version=#{version}"), "./cmd/difi"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/difi --version")
+
+    system "git", "init"
+    system "git", "config", "user.email", "test@example.com"
+    system "git", "config", "user.name", "Test"
+
+    (testpath/"file.txt").write("one")
+    system "git", "add", "file.txt"
+    system "git", "commit", "-m", "init"
+
+    File.write(testpath/"file.txt", "two")
+    system "git", "commit", "-am", "change"
+
+    output = shell_output("#{bin}/difi --plain HEAD~1")
+    assert_match "file.txt", output
+  end
+end


### PR DESCRIPTION
Update homepage and source from oug-t/difi to xguot/difi. Bump to 0.2.8.