### PR TITLE
zsh: don't use --enable-cap on macos

### DIFF
--- a/Formula/z/zsh.rb
+++ b/Formula/z/zsh.rb
@@ -62,7 +62,7 @@ class Zsh < Formula
            "--enable-site-fndir=#{HOMEBREW_PREFIX}/share/zsh/site-functions",
            "--enable-site-scriptdir=#{HOMEBREW_PREFIX}/share/zsh/site-scripts",
            "--enable-runhelpdir=#{pkgshare}/help",
-           "--enable-cap",
+           *("--enable-cap" if OS.linux?),
            "--enable-maildir-support",
            "--enable-multibyte",
            "--enable-pcre",

--- a/Formula/z/zsh.rb
+++ b/Formula/z/zsh.rb
@@ -56,21 +56,24 @@ class Zsh < Formula
 
     system "Util/preconfig" if build.head?
 
-    system "./configure", "--prefix=#{prefix}",
-           "--enable-fndir=#{pkgshare}/functions",
-           "--enable-scriptdir=#{pkgshare}/scripts",
-           "--enable-site-fndir=#{HOMEBREW_PREFIX}/share/zsh/site-functions",
-           "--enable-site-scriptdir=#{HOMEBREW_PREFIX}/share/zsh/site-scripts",
-           "--enable-runhelpdir=#{pkgshare}/help",
-           *("--enable-cap" if OS.linux?),
-           "--enable-maildir-support",
-           "--enable-multibyte",
-           "--enable-pcre",
-           "--enable-zsh-secure-free",
-           "--enable-unicode9",
-           "--enable-etcdir=/etc",
-           "--with-tcsetpgrp",
-           "DL_EXT=bundle"
+    args = %W[
+      --enable-fndir=#{pkgshare}/functions
+      --enable-scriptdir=#{pkgshare}/scripts
+      --enable-site-fndir=#{HOMEBREW_PREFIX}/share/zsh/site-functions
+      --enable-site-scriptdir=#{HOMEBREW_PREFIX}/share/zsh/site-scripts
+      --enable-runhelpdir=#{pkgshare}/help
+      --enable-maildir-support
+      --enable-multibyte
+      --enable-pcre
+      --enable-zsh-secure-free
+      --enable-unicode9
+      --enable-etcdir=/etc
+      --with-tcsetpgrp
+    ]
+
+    args << "--enable-cap" if OS.linux?
+
+    system "./configure", *args, *std_configure_args, "DL_EXT=bundle"
 
     # Do not version installation directories.
     inreplace ["Makefile", "Src/Makefile"],


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

previously, if zsh was built with --enable-cap on a system that doesn't actually support capabilities, such as macos, it produced a stub module with built-ins that do nothing

as of https://github.com/zsh-users/zsh/commit/1426a4dfdc2eccbc, this is no longer the case -- it now causes the build to fail

the solution is to omit this option on macos

currently this only affects HEAD builds