### PR TITLE
pkgconf: skip 90+ patch versions

### DIFF
--- a/Formula/p/pkgconf.rb
+++ b/Formula/p/pkgconf.rb
@@ -10,7 +10,7 @@ class Pkgconf < Formula
 
   livecheck do
     url "https://distfiles.ariadne.space/pkgconf/"
-    regex(/href=.*?pkgconf[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?pkgconf[._-]v?(\d+\.\d+(?:\.[1-8]?\d(?:\.\d+)*)?)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
Current 2.9.90+ seem to be back-to-back RCs for upcoming 3.0.

Otherwise, would be strange to jump from 2.5.1 -> 2.9.90. And commit message at https://github.com/pkgconf/pkgconf/commit/cdbf0a9291112f4f422beb4c969dc28225b1b66f
```
man: update manual page dates to reflect 2.9.90 (3.0 rc1)
```

90+ patch is a pretty common alternative to `<version>-{alpha,beta,rc}#` style of prereleases. Used by a number of GNOME projects and adopted by various others.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
