### PR TITLE
ecl: search for installed extensions in lib/ecl-<version>

### DIFF
--- a/Formula/e/ecl.rb
+++ b/Formula/e/ecl.rb
@@ -39,6 +39,12 @@ class Ecl < Formula
     end
   end
 
+  patch do
+    url "https://gitlab.com/embeddable-common-lisp/ecl/-/commit/59de50b52380132d44bfa05f573544cba0a8c65f.diff"
+    sha256 "553982804178fbcc3111474e8ca5319c689141e74c151f3feb6fec78f93ae640"
+    type :backport
+  end
+
   def install
     ENV.deparallelize
 
@@ -53,7 +59,9 @@ class Ecl < Formula
                           "--with-gmp-prefix=#{formula_opt_prefix("gmp")}",
                           "--with-libffi-prefix=#{libffi_prefix}",
                           "--with-libgc-prefix=#{formula_opt_prefix("bdw-gc")}",
+                          "--with-extra-files=#{buildpath}/src/util/side-modules.lsp",
                           *std_configure_args
+    ENV["ECL_SIDE_MODULES_PATH"] = "#{HOMEBREW_PREFIX}/lib/ecl-#{version}"
     system "make"
     system "make", "install"
   end

--- a/Formula/e/ecl.rb
+++ b/Formula/e/ecl.rb
@@ -12,13 +12,13 @@ class Ecl < Formula
   end
 
   bottle do
-    rebuild 2
-    sha256 arm64_tahoe:   "0f7e05aeec7f7aafd866af99e623694c15a84a3def12477da3f619a4502766b2"
-    sha256 arm64_sequoia: "1865df5c96476b9feb55a61c358e8c52d8fbf41d977eae8b9515893f5a23222f"
-    sha256 arm64_sonoma:  "b816ed156a7176b2c546eba281326dd830090b62143414dc404bf78a18cf4b49"
-    sha256 sonoma:        "10ad3c74b525e7bcfffb2a2463f0e8a7590f638412ae61f79a25fa4a0e5fd572"
-    sha256 arm64_linux:   "722ddbc762366d2a8afb36509b663346bc7b06dec34faa7fb3667ee1e520ffd9"
-    sha256 x86_64_linux:  "c43ff030cb6b7b4ad38f3be3586d9371ec0442980e9e35de2db8ac033048f4d8"
+    rebuild 3
+    sha256 arm64_tahoe:   "79f4778027f26a5ed162a672840d50acd347aeaa73ebb94d66cbd072f048e060"
+    sha256 arm64_sequoia: "dbc7411cb1d7d85e211fbfcb1ac245fb077312b194394ef5b7879a389a3a4d3b"
+    sha256 arm64_sonoma:  "29b32f9bf4fc09206f8e3b08ded8b0bdb08167963a80ff3330077db4a8a2d952"
+    sha256 sonoma:        "b8f6d1d2b0eedb0cb27e8adc1847bcd0e27c32e59e22a0e5b1807b205bdd4c9d"
+    sha256 arm64_linux:   "583cab74ee2c1a7b85a1c10b67228e39d66447cc160c6d8c38867ba31f5608b5"
+    sha256 x86_64_linux:  "6ffe0230d65fc695a539c69fc98d11edd4e71425bba8f9db50ff3aa64f530fff"
   end
 
   depends_on "texinfo" => :build # Apple's is too old


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

By default, ecl only searches for installed 3rd-party extensions (via Common Lisp `(require :foobar42)` calls) in its own Cellar. Given Homebrew's restriction on installing anything in the Cellar of another package, this makes extension discovery impossible.
This patch registers a method which tells ecl to search for 3rd party extensions in `HOMEBREW_PREFIX/lib/ecl-<version>`;
this allows other formulae to install extensions discoverable by ecl.

Developed in cooperation with ecl upstream (@dkochmanski) on https://gitlab.com/embeddable-common-lisp/ecl/-/work_items/846 

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
