### PR TITLE
z3: fails with old clang

### DIFF
--- a/Formula/z/z3.rb
+++ b/Formula/z/z3.rb
@@ -27,6 +27,13 @@ class Z3 < Formula
   # which does not need Python.
   depends_on "python@3.14" => [:build, :test]
 
+  # The following macOS conditional should be the inverse of LLVM's Z3 conditional
+  on_ventura :or_older do
+    fails_with :clang do
+      cause "Requires C++20 std::format, https://developer.apple.com/xcode/cpp/#c++20"
+    end
+  end
+
   fails_with :gcc do
     version "12"
     cause "Requires C++20 std::format, https://gcc.gnu.org/gcc-13/changes.html#libstdcxx"


### PR DESCRIPTION
It is possible that some Sonoma on old Xcode could fail, but ignoring those as it will create a dependency loop.

Also, for now, not including LLVM dependency. We only really need it for Tier 1 bottling to guarantee compiler is installed in CI. When user is source-building, Homebrew will report failure due to lack of compiler and user can manually install LLVM similar to how we handle Linux.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
