### PR TITLE
gcc@15: link with -headerpad_max_install_names

### DIFF
--- a/Formula/g/gcc@15.rb
+++ b/Formula/g/gcc@15.rb
@@ -99,7 +99,10 @@ class GccAT15 < Formula
       # Avoid this semi-random failure:
       # "Error: Failed changing install name"
       # "Updated load commands do not fit in the header"
-      make_args = %w[BOOT_LDFLAGS=-Wl,-headerpad_max_install_names]
+      make_args = %w[
+        BOOT_LDFLAGS=-Wl,-headerpad_max_install_names
+        LDFLAGS_FOR_TARGET=-Wl,-headerpad_max_install_names
+      ]
     else
       # Fix Linux error: gnu/stubs-32.h: No such file or directory.
       args << "--disable-multilib"


### PR DESCRIPTION
-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source gcc@15`?
- [x] Is your test running fine `brew test gcc@15`?
- [x] Does your build pass `brew audit --strict gcc@15` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source gcc@15`)?

-----

- [x] AI was used to generate or assist with generating this PR. AI (OpenCode/claude-sonnet-4.6) was used to split the original PR #289297 into three separate single-formula PRs by creating individual branches and commits. The formula change itself (adding `LDFLAGS_FOR_TARGET=-Wl,-headerpad_max_install_names` to `make_args`) was authored by the human contributor and validated locally prior to the original PR. The AI only performed the mechanical git branch/commit splitting. Build, test, and audit were performed by the human on the original branch.

-----

Backport of #266996 by @RazerM for `gcc@15`.

Without this fix, installing `gcc@15` from source on macOS fails with:

```
Error: Failed changing dylib ID of .../libatomic.1.dylib
Updated load commands do not fit in the header
```

Adds `LDFLAGS_FOR_TARGET=-Wl,-headerpad_max_install_names` alongside the existing `BOOT_LDFLAGS` flag so that target libraries also get the extra header padding.

Splits out from #289297.