### PR TITLE
zlib: remove HTTP mirrors, use official GitHub for mirror

### DIFF
--- a/Formula/z/zlib.rb
+++ b/Formula/z/zlib.rb
@@ -2,9 +2,7 @@ class Zlib < Formula
   desc "General-purpose lossless data-compression library"
   homepage "https://zlib.net/"
   url "https://zlib.net/zlib-1.3.2.tar.gz"
-  mirror "https://downloads.sourceforge.net/project/libpng/zlib/1.3.2/zlib-1.3.2.tar.gz"
-  mirror "http://fresh-center.net/linux/misc/zlib-1.3.2.tar.gz"
-  mirror "http://fresh-center.net/linux/misc/legacy/zlib-1.3.2.tar.gz"
+  mirror "https://github.com/madler/zlib/releases/download/v1.3.2/zlib-1.3.2.tar.gz"
   sha256 "bb329a0a2cd0274d05519d61c667c062e06990d72e125ee2dfa8de64f0119d16"
   license "Zlib"
   head "https://github.com/madler/zlib.git", branch: "develop"
@@ -41,7 +39,6 @@ class Zlib < Formula
     # https://zlib.net/zlib_how.html
     resource "zpipe.c" do
       url "https://raw.githubusercontent.com/madler/zlib/3f5d21e8f573a549ffc200e17dd95321db454aa1/examples/zpipe.c"
-      mirror "http://zlib.net/zpipe.c"
       sha256 "e79717cefd20043fb78d730fd3b9d9cdf8f4642307fc001879dc82ddb468509f"
     end
 


### PR DESCRIPTION
No longer part of curl dependency tree so HTTP mirrors are not needed. Also SourceForge mirror doesn't work so use main GitHub which should be maintained by upstream

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
