### PR TITLE
vamp-plugin-sdk: update urls to official GitHub

### DIFF
--- a/Formula/v/vamp-plugin-sdk.rb
+++ b/Formula/v/vamp-plugin-sdk.rb
@@ -1,21 +1,23 @@
 class VampPluginSdk < Formula
   desc "Audio processing plugin system sdk"
   homepage "https://www.vamp-plugins.org/"
-  # curl fails to fetch upstream source, using Debian's instead
-  url "https://deb.debian.org/debian/pool/main/v/vamp-plugin-sdk/vamp-plugin-sdk_2.10.0.orig.tar.gz"
-  mirror "https://code.soundsoftware.ac.uk/attachments/download/2691/vamp-plugin-sdk-2.10.0.tar.gz"
+  url "https://github.com/vamp-plugins/vamp-plugin-sdk/releases/download/vamp-plugin-sdk-v2.10/vamp-plugin-sdk-2.10.0.tar.gz"
   sha256 "aeaf3762a44b148cebb10cde82f577317ffc9df2720e5445c3df85f3739ff75f"
   license all_of: ["X11", "BSD-3-Clause"]
   revision 1
-  head "https://code.soundsoftware.ac.uk/hg/vamp-plugin-sdk", using: :hg
+  head "https://github.com/vamp-plugins/vamp-plugin-sdk.git", branch: "master"
 
-  # code.soundsoftware.ac.uk has SSL certificate verification issues, so we're
-  # using Debian in the interim time. If/when the `stable` URL returns to
-  # code.soundsoftware.ac.uk, the previous `livecheck` block should be
-  # reinstated: https://github.com/Homebrew/homebrew-core/pull/75104
   livecheck do
-    url "https://deb.debian.org/debian/pool/main/v/vamp-plugin-sdk/"
-    regex(/href=.*?vamp-plugin-sdk[._-]v?(\d+(?:\.\d+)+)\.orig\.t/i)
+    url :stable
+    regex(/^vamp-plugin-sdk[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["name"]&.match(regex)
+        next if match.blank?
+
+        match[1]
+      end
+    end
   end
 
   bottle do


### PR DESCRIPTION
Upstream switched to GitHub at some point - https://www.vamp-plugins.org/develop.html
> The main SDK (development headers, source code, example code):
[As a gzipped tar file](https://github.com/vamp-plugins/vamp-plugin-sdk/releases/download/vamp-plugin-sdk-v2.10/vamp-plugin-sdk-2.10.0.tar.gz) or [as a ZIP file](https://github.com/vamp-plugins/vamp-plugin-sdk/releases/download/vamp-plugin-sdk-v2.10/vamp-plugin-sdk-2.10.0.zip).

Tags do not have full version number so need livecheck

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
