### PR TITLE
php@8.2: switch to available mirror

### DIFF
--- a/Formula/p/php@8.2.rb
+++ b/Formula/p/php@8.2.rb
@@ -3,7 +3,7 @@ class PhpAT82 < Formula
   homepage "https://www.php.net/"
   # Should only be updated if the new version is announced on the homepage, https://www.php.net/
   url "https://www.php.net/distributions/php-8.2.31.tar.xz"
-  mirror "https://fossies.org/linux/www/php-8.2.31.tar.xz"
+  mirror "https://ftp.osuosl.org/pub/php/php-8.2.31.tar.xz"
   sha256 "95eae411d594fe6f6e5678b76645dc13ae47d3c0a5325c1d969b58dea56ee45a"
   license all_of: [
     "PHP-3.01",


### PR DESCRIPTION
Fossies only has last 3 minor versions. OSUOSL is common mirror we use (with credibility given it is main host of all Xiph formulae, download server for Mutt, etc) and has older versions of PHP.

If needed, can add Mirror Service too/instead:
- https://www.mirrorservice.org/sites/www.php.net/distributions/php-8.2.31.tar.xz

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
