### PR TITLE
check-bottle-modification: only comment on real detection

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -105,7 +105,7 @@ jobs:
         run: brew check-bottle-modification "${PR}"
 
       - name: Post comment
-        if: failure() && steps.bottle-block.conclusion == 'failure'
+        if: failure() && steps.bottle-block.outputs.bottle_modified == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BODY: |-

--- a/cmd/check-bottle-modification.rb
+++ b/cmd/check-bottle-modification.rb
@@ -59,7 +59,13 @@ module Homebrew
         pr = args.named.first.to_i
         commits = get_pull_request_commits(pr)
 
-        odie "PR##{pr} modifies the bottle block" if commits.any? { |sha| commit_modifies_bottle_block?(sha) }
+        return unless commits.any? { |sha| commit_modifies_bottle_block?(sha) }
+
+        if (github_output = ENV.fetch("GITHUB_OUTPUT", nil))
+          File.write(github_output, "bottle_modified=true\n", mode: "a")
+        end
+
+        odie "PR##{pr} modifies the bottle block"
       end
     end
   end


### PR DESCRIPTION
The triage workflow's check-bottle-block job posted the "do not modify the bottle block" comment on any failure of brew check-bottle-modification, including transient GitHub API errors (Failed to parse JSON response). That caused false-positive comments on unrelated PRs such as mirror removals (e.g. [#290238](https://github.com/Homebrew/homebrew-core/issues/290238), [#290233](https://github.com/Homebrew/homebrew-core/issues/290233)). This sets a bottle_modified step output only when a commit genuinely modifies the bottle block, and gates the comment on that output instead of on step failure.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Done by✋🏻

-----
