### PR TITLE
reop: deprecate, use alternative urls

### DIFF
--- a/Formula/r/reop.rb
+++ b/Formula/r/reop.rb
@@ -1,15 +1,11 @@
 class Reop < Formula
   desc "Encrypted keypair management"
-  homepage "https://flak.tedunangst.com/post/reop"
-  url "https://flak.tedunangst.com/files/reop-2.1.1.tgz"
-  mirror "https://bo.mirror.garr.it/OpenBSD/distfiles/reop-2.1.1.tgz"
+  homepage "https://web.archive.org/web/20251224210131/https://flak.tedunangst.com/post/reop"
+  url "https://pkg.freebsd.org/ports-distfiles/reop-2.1.1.tgz"
+  mirror "https://ftp.openbsd.org/pub/OpenBSD/distfiles/reop-2.1.1.tgz"
   sha256 "fa8ae058c51efec5bde39fab15b4275e6394d9ab1dd2190ffdba3cf9983fdcac"
   license "ISC"
   revision 1
-
-  livecheck do
-    skip "No longer developed"
-  end
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "95b75472fc27e78edb5a78cfce5ee11eab88c09ba2b3344d50f55189c055c038"
@@ -23,6 +19,9 @@ class Reop < Formula
     sha256 cellar: :any_skip_relocation, arm64_linux:    "566db99533e99f809e5fe5dac5f9f671c2612139c0e51099c0b328cbdb7f2f9b"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "39a6b6aaa92dc34131e9ecf9c22a8ef890b8d662960a5dba258bb58f87d71516"
   end
+
+  deprecate! date: "2026-06-27", because: :unmaintained
+  disable! date: "2026-09-27", because: :unmaintained
 
   depends_on "libsodium"
 


### PR DESCRIPTION
Both site and mirror were dead.

Switching urls to main FreeBSD and OpenBSD domains to allow building until we remove. Low installs so going with 3 month deprecation.
> install: 0 (30 days), 3 (90 days), 10 (365 days)

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
