### PR TITLE
tor: update url, drop dead mirror

### DIFF
--- a/Formula/t/tor.rb
+++ b/Formula/t/tor.rb
@@ -1,8 +1,7 @@
 class Tor < Formula
   desc "Anonymizing overlay network for TCP"
   homepage "https://www.torproject.org/"
-  url "https://www.torproject.org/dist/tor-0.4.9.11.tar.gz"
-  mirror "https://www.torservers.net/mirrors/torproject.org/dist/tor-0.4.9.11.tar.gz"
+  url "https://dist.torproject.org/tor-0.4.9.11.tar.gz"
   mirror "https://fossies.org/linux/misc/tor-0.4.9.11.tar.gz"
   sha256 "2e6c1720118c812acf0079fd47cf91b6bfaba5d766c321c4d3d2a28d6a11a8ed"
   # Complete list of licenses:


### PR DESCRIPTION
Redirected url is the one that is listed on homepage so updating to match - https://www.torproject.org/download/tor/
> [Download](https://dist.torproject.org/tor-0.4.9.11.tar.gz) ([checksum](https://dist.torproject.org/tor-0.4.9.11.tar.gz.sha256sum) | [sig](https://dist.torproject.org/tor-0.4.9.11.tar.gz.sha256sum.asc))

First mirror looks broken. Doesn't work with any of last releases so should drop.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
