### PR TITLE
dbx-cli: add livecheck block

### DIFF
--- a/Formula/d/dbx-cli.rb
+++ b/Formula/d/dbx-cli.rb
@@ -14,6 +14,11 @@ class DbxCli < Formula
     sha256 cellar: :any, x86_64_linux:  "d7e2687ee017c2f4cccced2c50c194806a504783b589adb6bc5cd1eb572812bb"
   end
 
+  livecheck do
+    url "https://registry.npmjs.org/@dbx-app/cli/latest"
+    regex(/"version":"(\d+(?:\.\d+)+)"/i)
+  end
+
   depends_on "node"
 
   on_linux do


### PR DESCRIPTION
This adds a `livecheck` block to the `dbx-cli` formula so that Homebrew's auto-bump bot can detect new releases automatically.