### PR TITLE
libdnet: remove autoreconf

### DIFF
--- a/Formula/lib/libdnet.rb
+++ b/Formula/lib/libdnet.rb
@@ -20,17 +20,10 @@ class Libdnet < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "b272ad6743af2c89e44ecfa3514d0295f3dc3f1a97ce87796983a27de30411a7"
   end
 
-  depends_on "autoconf" => :build
-  depends_on "automake" => :build
-  depends_on "libtool" => :build
   depends_on "pkgconf" => :build
 
   def install
-    # autoreconf to get '.dylib' extension on shared lib
-    ENV.append_path "ACLOCAL_PATH", "config"
-    system "autoreconf", "--force", "--install", "--verbose"
-
-    system "./configure", "--mandir=#{man}", "--disable-check", *std_configure_args
+    system "./configure", "--disable-check", *std_configure_args
     system "make", "install"
   end
 


### PR DESCRIPTION
Doesn't seem to be needed anymore

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
