### PR TITLE
ghcup: update workaround, drop unsupported flag

### DIFF
--- a/Formula/g/ghcup.rb
+++ b/Formula/g/ghcup.rb
@@ -35,12 +35,11 @@ class Ghcup < Formula
   end
 
   def install
-    # Workaround to build aeson with GHC 9.14, https://github.com/haskell/aeson/issues/1155
-    args = ["--allow-newer=base,containers,template-haskell"]
+    # Workaround to build with GHC 9.14 until serialise > 0.2.6.1 and dhall > 1.42.3 are released
+    args = ["--allow-newer=base,template-haskell"]
 
     system "cabal", "v2-update"
-    # `+disable-upgrade` disables the self-upgrade feature.
-    system "cabal", "v2-install", *args, *std_cabal_v2_args, "--flags=+disable-upgrade"
+    system "cabal", "v2-install", *args, *std_cabal_v2_args
 
     bash_completion.install "scripts/shell-completions/bash" => "ghcup"
     fish_completion.install "scripts/shell-completions/fish" => "ghcup.fish"


### PR DESCRIPTION
`disable-upgrade` was removed back in 0.1.19.0[^1] so is unused

[^1]: https://github.com/haskell/ghcup-hs/commit/b036c9861fb1f39d3bb06f88aa1ae22f3799c29c

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
