### PR TITLE
nvi: annotate CVE-2015-2305 resolved by Debian regex patch

### DIFF
--- a/Formula/n/nvi.rb
+++ b/Formula/n/nvi.rb
@@ -65,6 +65,9 @@ class Nvi < Formula
   patch do
     url "https://deb.debian.org/debian/pool/main/n/nvi/nvi_1.81.6-17.debian.tar.xz"
     sha256 "4f81fa274e71093d212ca981dc510e9bf2f1d4716f3c447ec2402607aa394bca"
+    type :backport
+    # 31regex_heap_overflow.patch fixes the Henry Spencer regex overflow, see https://bugs.debian.org/778412
+    resolves "CVE-2015-2305"
     apply "patches/03db4.patch",
           "patches/19include_term_h.patch",
           "patches/20glibc_has_grantpt.patch",


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Syntax-only change adding `resolves "CVE-2015-2305"` to the Debian patchset block. The applied `patches/31regex_heap_overflow.patch` is the Henry Spencer regex integer-overflow fix; see the patch's DEP-3 header, https://bugs.debian.org/778412 and https://security-tracker.debian.org/tracker/CVE-2015-2305 (nvi listed). `brew style` passes; build/test/audit boxes left unticked since this doesn't touch the build.

Part of the `resolves` backfill tracked in Homebrew/homebrew-brew-vulns#95. No bottle change needed. The formula is deprecated but still installable until 2027-05-21.

AI assistance: Claude Code identified the candidate by reading DEP-3 headers across formulae that apply `debian.tar.xz` patchsets, and cross-referenced the Debian bug and security tracker. I verified the CVE description matches the patch (regcomp 32-bit overflow guard in the bundled Spencer regex) and that the syntax matches existing annotated formulae like `libquicktime`.
