### PR TITLE
scala@2.*: remove mirror

### DIFF
--- a/Formula/s/scala@2.12.rb
+++ b/Formula/s/scala@2.12.rb
@@ -2,7 +2,6 @@ class ScalaAT212 < Formula
   desc "JVM-based programming language"
   homepage "https://www.scala-lang.org/"
   url "https://github.com/scala/scala/releases/download/v2.12.21/scala-2.12.21.tgz"
-  mirror "https://www.scala-lang.org/files/archive/scala-2.12.21.tgz"
   sha256 "13bad6399f433ae244e98834aa79f393cb43b46b94ec34662d50d678cb4009ea"
   license "Apache-2.0"
 

--- a/Formula/s/scala@2.13.rb
+++ b/Formula/s/scala@2.13.rb
@@ -2,7 +2,6 @@ class ScalaAT213 < Formula
   desc "JVM-based programming language"
   homepage "https://www.scala-lang.org/"
   url "https://github.com/scala/scala/releases/download/v2.13.18/scala-2.13.18.tgz"
-  mirror "https://www.scala-lang.org/files/archive/scala-2.13.18.tgz"
   sha256 "1834d09fd5c78ec77e9a933ab76c724280a8ec9595a332a6112823787a9ac3e6"
   license "Apache-2.0"
 


### PR DESCRIPTION
Now that main download url is on GitHub (as seen from urls at https://scala-lang.org/download/2.12.21.html), we can drop mirrors. They were needed when main downloads were from homepage.



-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
