### PR TITLE
fontconfig: remove macOS-specific hardcoded values on Linux

### DIFF
--- a/Formula/f/fontconfig.rb
+++ b/Formula/f/fontconfig.rb
@@ -19,12 +19,13 @@ class Fontconfig < Formula
   end
 
   bottle do
-    sha256 arm64_tahoe:   "3e5fe5ced46e677b036a434f33bfad015b26ec599896e13431f90880fefc2db2"
-    sha256 arm64_sequoia: "1538844d9dcd7ace123b4c55220506782726cb6803ad96a132a30e85720b3699"
-    sha256 arm64_sonoma:  "f4854307ce84898d35564e9a7027cd200973736c74bc9b783a8b34cc1fffd821"
-    sha256 sonoma:        "30bdb67e3e52cdd396a19668313a580850ae94ca1a6fb355d2320cd803dd1be6"
-    sha256 arm64_linux:   "b78fd19a27aa988fb4b22f5381ed0a0a75010708a636a1a5c5e110d5009e212e"
-    sha256 x86_64_linux:  "1006f26b98bfe4b9c032e8b93842ce5ef8b0342b7582915b5aafcb17e53a3518"
+    rebuild 1
+    sha256 arm64_tahoe:   "dcaf4b8c5a308651cc39a24ab097b59530113fe98bcc302bb5bd1cbe6a2e0d85"
+    sha256 arm64_sequoia: "dffd1a8e1eaf113055c22c1ae031341e6db31a417b3043374fe568691df3578e"
+    sha256 arm64_sonoma:  "3492485e918c890cd828d19c06cfda7c8825b3705cca4d4810f4d54f329296a5"
+    sha256 sonoma:        "9550776a54e32d8340966173a5d30d337a9f9984030bbdf7233eed792ad5d69c"
+    sha256 arm64_linux:   "a390144d5d2e743d112ddace5726e6592c2c1c6f2fa868a5d371fc5596f5fdd2"
+    sha256 x86_64_linux:  "b7e8a3cfa84aea47242a94fc4e44aaf1a35c926b761daa836428f936f468e1bd"
   end
 
   depends_on "gettext" => :build

--- a/Formula/f/fontconfig.rb
+++ b/Formula/f/fontconfig.rb
@@ -42,14 +42,6 @@ class Fontconfig < Formula
   end
 
   def install
-    font_dirs = %w[
-      /System/Library/Fonts
-      /Library/Fonts
-      ~/Library/Fonts
-    ]
-
-    font_dirs << Dir["/System/Library/Assets{,V2}/com_apple_MobileAsset_Font*"].max if OS.mac?
-
     args = %W[
       --default-library=both
       --localstatedir=#{var}
@@ -58,9 +50,22 @@ class Fontconfig < Formula
       -Dtests=disabled
       -Dtools=enabled
       -Dcache-build=disabled
-      -Ddefault-fonts-dirs=#{font_dirs}
       -Dadditional-fonts-dirs=no
     ]
+
+    # Cannot use default dirs on macOS due to fc-cache recursing unnecessary directories
+    # Issue ref: https://gitlab.freedesktop.org/fontconfig/fontconfig/-/work_items/547
+    if OS.mac?
+      font_dirs = %w[
+        /System/Library/Fonts
+        /Library/Fonts
+        ~/Library/Fonts
+      ]
+      font_dirs << Dir["/System/Library/Assets{,V2}/com_apple_MobileAsset_Font*"].max
+
+      args << "-Ddefault-fonts-dirs=#{font_dirs}"
+    end
+
     system "meson", "setup", "build", *args, *std_meson_args
     system "meson", "compile", "-C", "build", "--verbose"
     system "meson", "install", "-C", "build"


### PR DESCRIPTION
This creates a broken configuration file on Linux. Also, upstream has improved macOS font handling so default values are likely better https://gitlab.freedesktop.org/fontconfig/fontconfig/-/commit/776a4f1c1e4e08fced54f222a46f1299d0506511


-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
