### PR TITLE
mole 1.44.1

### DIFF
--- a/Formula/m/mole.rb
+++ b/Formula/m/mole.rb
@@ -1,8 +1,8 @@
 class Mole < Formula
   desc "Deep clean and optimize your Mac"
   homepage "https://mole.fit"
-  url "https://github.com/tw93/Mole/archive/refs/tags/V1.44.0.tar.gz"
-  sha256 "a3934d8cff7b292c173eb949dee094a464d924f9d69ede678975dbb8145c8fbe"
+  url "https://github.com/tw93/Mole/archive/refs/tags/V1.44.1.tar.gz"
+  sha256 "fa5abe50f190de58bba273352928fbae80a7214d0711937d27914edf7af2da1e"
   license "GPL-3.0-or-later"
   head "https://github.com/tw93/Mole.git", branch: "main"
 

--- a/Formula/m/mole.rb
+++ b/Formula/m/mole.rb
@@ -15,10 +15,10 @@ class Mole < Formula
   no_autobump! because: :bumped_by_upstream
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "ec19f657cd2e96ba257b8d4c30868484d024761e51868e330ac97850cc57df3b"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "4d66e1c0303a7aeddf251cf6d9104c819f65f5d53899bbd84c3a151118986c38"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "80419b68d56b88c712b31d7aa09f99bec017e1e2de5ef49a96300d3d955d5048"
-    sha256 cellar: :any_skip_relocation, sonoma:        "bf2173136e5f7d48f24049b1d41784672a78c43cc68959ccc472c63b9ec20a69"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "2d7de7e43617358d520188981af3dadd17a0bc8379143647b58ebb4dc8009e54"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "9eae9fcaca512ce232eb0b43eaa8aa003d64e54ef7eaa5a58b54233442b1ff6d"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "619a840adb0551ff8876f1eb2cf31893506fd5059f70905191a397f321688d4a"
+    sha256 cellar: :any_skip_relocation, sonoma:        "2f3dcf2278e7af81ebc09c96c453c426860e947214bb3f4f27e742768ceffcd0"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
Release notes: https://github.com/tw93/Mole/releases/tag/V1.44.1

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

Local build/test/audit were not completed because Homebrew stalled while tapping `homebrew/core` before entering this formula. The release workflow verified the updated formula generation, the personal tap formula has been updated, and the GitHub release assets were downloaded and verified against `SHA256SUMS`.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI helped with the release checklist, release-note drafting, and verification readback. The formula diff was generated by the release workflow. Manual verification included reading the generated formula, checking that no other open `mole` PR existed, downloading the published `V1.44.1` release assets, verifying them against `SHA256SUMS`, and confirming the archive entries.

-----
