### PR TITLE
lunzip lzip lziprecover: use mirrored url

### DIFF
--- a/Formula/l/lunzip.rb
+++ b/Formula/l/lunzip.rb
@@ -1,7 +1,8 @@
 class Lunzip < Formula
   desc "Decompressor for lzip files"
   homepage "https://www.nongnu.org/lzip/lunzip.html"
-  url "https://download-mirror.savannah.gnu.org/releases/lzip/lunzip/lunzip-1.16.tar.gz"
+  url "https://download.savannah.nongnu.org/releases/lzip/lunzip/lunzip-1.16.tar.gz"
+  mirror "https://download-mirror.savannah.gnu.org/releases/lzip/lunzip/lunzip-1.16.tar.gz"
   sha256 "f13809a1aeaf953f32b07f822c3804bfb11056c08d465b93750b4e45190becda"
   license "GPL-2.0-or-later"
 

--- a/Formula/l/lzip.rb
+++ b/Formula/l/lzip.rb
@@ -1,7 +1,8 @@
 class Lzip < Formula
   desc "LZMA-based compression program similar to gzip or bzip2"
   homepage "https://www.nongnu.org/lzip/"
-  url "https://download-mirror.savannah.gnu.org/releases/lzip/lzip-1.26.tar.gz"
+  url "https://download.savannah.nongnu.org/releases/lzip/lzip-1.26.tar.gz"
+  mirror "https://download-mirror.savannah.gnu.org/releases/lzip/lzip-1.26.tar.gz"
   sha256 "641cf30961525cbe3b340cc883436c8854e9f5032f459f444de4782b621e6572"
   license "GPL-2.0-or-later"
   compatibility_version 1

--- a/Formula/l/lziprecover.rb
+++ b/Formula/l/lziprecover.rb
@@ -1,7 +1,8 @@
 class Lziprecover < Formula
   desc "Data recovery tool and decompressor for files in the lzip compressed data format"
   homepage "https://www.nongnu.org/lzip/lziprecover.html"
-  url "https://download-mirror.savannah.gnu.org/releases/lzip/lziprecover/lziprecover-1.26.tar.gz"
+  url "https://download.savannah.nongnu.org/releases/lzip/lziprecover/lziprecover-1.26.tar.gz"
+  mirror "https://download-mirror.savannah.gnu.org/releases/lzip/lziprecover/lziprecover-1.26.tar.gz"
   sha256 "e234005a756d5649f41686116d3e548736d4a77e5a5ec37b943ca6650787801d"
   license "GPL-2.0-or-later"
 


### PR DESCRIPTION
Avoid putting load on a single server and instead use the recommended mirrored url. Similar to other "gnu.org"/"nongnu.org" formulae

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
