### PR TITLE
libjwt: add rpath, remove gnutls dependency

### DIFF
--- a/Formula/lib/libjwt.rb
+++ b/Formula/lib/libjwt.rb
@@ -22,12 +22,15 @@ class Libjwt < Formula
 
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
-  depends_on "gnutls"
   depends_on "jansson"
   depends_on "openssl@3"
 
   def install
-    system "cmake", "-S", ".", "-B", "build", "-DWITH_TESTS=OFF", *std_cmake_args
+    args = %W[
+      -DCMAKE_INSTALL_RPATH=#{rpath}
+      -DWITH_TESTS=OFF
+    ]
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
   end

--- a/Formula/lib/libjwt.rb
+++ b/Formula/lib/libjwt.rb
@@ -12,12 +12,13 @@ class Libjwt < Formula
   end
 
   bottle do
-    sha256 cellar: :any, arm64_tahoe:   "b586af46bba3526ae59669856ec8d782681169a5f068ec2a07347280a477aa3e"
-    sha256 cellar: :any, arm64_sequoia: "023b65d38408089268a44c4326aadd68f5973a76d9c068e9c15627d32d588699"
-    sha256 cellar: :any, arm64_sonoma:  "48f1635bc477be3196b72cc1774277450a624836937f891a07e84fb73acc7d72"
-    sha256 cellar: :any, sonoma:        "e476cba0594dd05358eaab4e1013bfc14324640aafe9434d057203d894381c33"
-    sha256 cellar: :any, arm64_linux:   "3049cfd013f9bd7e554d4d4e339e155caa6bd4abf4daa48c1b3a9c6cb77c8012"
-    sha256 cellar: :any, x86_64_linux:  "9c4716bccba03602ab2d9a22f4c93d80c6b4794147e20ae31b40e4a690531cbd"
+    rebuild 1
+    sha256 cellar: :any, arm64_tahoe:   "61773960bcdf648e9ca898014d174d06892a040c24af12c257fb5069cf2ffa13"
+    sha256 cellar: :any, arm64_sequoia: "16500fd9d18377e8abdb79126639f58a9a85098e8960710717aa14204f8e8143"
+    sha256 cellar: :any, arm64_sonoma:  "36b4976416aa72340a3713494eb505a5734bfa002057c00216eadac413ecd52a"
+    sha256 cellar: :any, sonoma:        "3bca716a62e7011009c45c2d3b1ef0b737e2060d1989c164237bc6c56bad56a3"
+    sha256 cellar: :any, arm64_linux:   "282bb91e8bb37caf6c2e99aaf1a79c8163e7459fe97b839e25716edb43cc2dc9"
+    sha256 cellar: :any, x86_64_linux:  "71911a4882b10f56d58dc36f820be5ad41c50e7ce3a2cf7cf82341a5dde8804f"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
We added gnutls in v2 when build failed without it, but now it is optional so can restore minimal dependency tree.

RPATH is needed on macOS for installed executables.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
