### PR TITLE
exiftool: temporary SourceForge urls, add HEAD

### DIFF
--- a/Formula/e/exiftool.rb
+++ b/Formula/e/exiftool.rb
@@ -2,15 +2,18 @@ class Exiftool < Formula
   desc "Perl lib for reading and writing EXIF metadata"
   homepage "https://exiftool.org"
   # Ensure release is tagged production before submitting.
-  # https://exiftool.org/history.html
-  url "https://exiftool.org/Image-ExifTool-13.55.tar.gz"
+  # https://exiftool.sourceforge.net/history.html
+  # TODO: Upstream temporarily uses SourceForge due to issues with DreamHost. Check if they resolve this
+  url "https://downloads.sourceforge.net/project/exiftool/Image-ExifTool-13.55.tar.gz"
+  mirror "https://exiftool.org/Image-ExifTool-13.55.tar.gz"
   mirror "https://cpan.metacpan.org/authors/id/E/EX/EXIFTOOL/Image-ExifTool-13.55.tar.gz"
   sha256 "5f4c81d34ad406538c2871ad72dbfceb5d9b412b2f16cbbeb4d712d270846667"
   license any_of: ["Artistic-1.0-Perl", "GPL-1.0-or-later"]
   compatibility_version 1
+  head "https://git.code.sf.net/p/exiftool/code.git", branch: "master"
 
   livecheck do
-    url "https://exiftool.org/history.html"
+    url "https://exiftool.sourceforge.net/history.html"
     regex(/production release is.*?href=.*?Image[._-]ExifTool[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
https://exiftool.org/
> NOTE: The crappy DreamHost server can't handle the traffic of the ExifTool web pages, and because of this the unsupportive DreamHost team has disabled the ExifTool web site. This page is a temporary stop-gap. Please go to [the ExifTool page on SourceForge](https://exiftool.sourceforge.net/) for ExifTool documentation, downloads and support until this issue is resolved.

So updating to official temporary URLs until upstream can resolve issue.

Also add official GitHub to allow development builds via HEAD. GitHub url is from https://exiftool.org/#links

> * [ExifTool source code on GitHub](https://github.com/exiftool/exiftool)

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
