### PR TITLE
libultrahdr: enable XMP gain-map metadata

### DIFF
--- a/Formula/lib/libultrahdr.rb
+++ b/Formula/lib/libultrahdr.rb
@@ -4,6 +4,7 @@ class Libultrahdr < Formula
   url "https://github.com/google/libultrahdr/archive/refs/tags/v1.4.0.tar.gz"
   sha256 "e7e1252e2c44d8ed6b99ee0f67a3caf2d8a61c43834b13b1c3cd485574c03ab9"
   license "Apache-2.0"
+  revision 1
   compatibility_version 1
 
   bottle do
@@ -22,7 +23,11 @@ class Libultrahdr < Formula
   depends_on "jpeg-turbo"
 
   def install
-    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    # Dual-encode the gain map: write the Adobe hdrgm XMP metadata in addition
+    # to the default ISO 21496-1 box. ISO-only output is not decodable by Apple
+    # ImageIO (Preview, Photos, Quick Look, Safari); the XMP plus ISO combination
+    # is what Android 15 and Apple's own camera write, and it renders on all of them.
+    system "cmake", "-S", ".", "-B", "build", "-DUHDR_WRITE_XMP=ON", *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
   end


### PR DESCRIPTION
Build `libultrahdr` with `-DUHDR_WRITE_XMP=ON` so the encoder dual-writes the Adobe `hdrgm` XMP gain-map metadata alongside the default ISO 21496-1 box, and bump `revision`.

### Why

libultrahdr's upstream default is `UHDR_WRITE_XMP=OFF` / `UHDR_WRITE_ISO=ON` (see the project's `CMakeLists.txt`; this was made build-time configurable in google/libultrahdr#329). The current bottle therefore produces **ISO-21496-1-only** UltraHDR JPEGs whose gain-map sub-image carries a ~30 KB LUT-based Lab/CICP ICC profile, and on macOS that combination is not consumable by Apple's ImageIO:

- `CGImageSourceCreateImageAtIndex` returns nil and `qlmanage` (Finder/QuickLook) **hangs**: Preview, Photos, Quick Look and Safari fail to open the file at all (not just fail to render HDR).
- Every gain-map JPEG that Apple actually reads (Apple's own camera, Android 15) avoids this.

Building with `UHDR_WRITE_XMP=ON` fixes it. In `lib/src/jpegr.cpp` `compressGainMap` the ~30 KB gain-map ICC is written only in the `!kWriteXmpMetadata` branch, so enabling XMP both drops that Apple-incompatible aux ICC and adds the `hdrgm` XMP, in one switch, with no source patch.

### Verification

I built v1.4.0 both ways from source and encoded the same PQ Rec2020 input, then probed with macOS ImageIO / Core Image and QuickLook:

| build | ImageIO decode | QuickLook (`qlmanage`) | headroom (true HDR) |
|---|---|---|---|
| default (XMP off, ISO only) | nil (won't open) | hangs | n/a |
| `-DUHDR_WRITE_XMP=ON` | decodes 1024x512 | thumbnail OK | 49.26 = **5.62 stops** above SDR white, ISO gain-map aux present |

Chrome / Android render the file in both builds; this change additionally makes it open and render HDR in Apple's pipeline. No new dependencies (XMP/ISO writing is built into the library, gated only at compile time). This benefits every libultrahdr consumer on the bottle (e.g. GIMP, darktable's UltraHDR export), not just one app.

### Note on mechanism / upstream

`UHDR_WRITE_XMP` is the only formula-level lever that yields Apple-readable output today, but the reason it works is the aux-ICC omission described above; the `hdrgm` XMP itself is somewhat deprecated upstream and adds ~2 KB per image. A cleaner long-term fix would decouple the aux-ICC emission from the XMP flag in libultrahdr itself; I have raised that with evidence at google/libultrahdr#365. Until then, enabling XMP is the simplest formula change that makes the bottle's output open and render HDR on macOS while staying Chrome/Android-compatible. Happy to adjust if maintainers prefer to wait for an upstream decoupling instead.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open pull requests for the same change?
- [x] Have you run `brew style` on the formula (passes with no offenses)?
- [ ] `brew install --build-from-source`: verified by building libultrahdr v1.4.0 from source with `-DUHDR_WRITE_XMP=ON` directly (cmake) and confirming output, rather than via `brew install`, to avoid relinking the installed bottle that other local software depends on. Leaving the full bottle build to CI.