### PR TITLE
dvdrtools: deprecate

### DIFF
--- a/Formula/d/dvdrtools.rb
+++ b/Formula/d/dvdrtools.rb
@@ -5,11 +5,6 @@ class Dvdrtools < Formula
   sha256 "053d0f277f69b183f9c8e8c8b09b94d5bb4a1de6d9b122c0e6c00cc6593dfb46"
   license "GPL-2.0-or-later"
 
-  livecheck do
-    url "https://download.savannah.gnu.org/releases/dvdrtools/"
-    regex(/href=.*?dvdrtools[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:    "d9ce7dd044c0b813f15a0a53332e50bd2f4b85fca18f7bb9951796f061abdb24"
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "57b79ee1791a3cbd816e11cbb178cf961f4fc0b5b71324233ea6c68a6c420db1"
@@ -26,8 +21,12 @@ class Dvdrtools < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "b0ded8f875ea08da1c4ac07675a925b475414f03e03071b6e4445ec690494d88"
   end
 
-  conflicts_with "cdrtools",
-    because: "both cdrtools and dvdrtools install binaries by the same name"
+  # Unmaintained fork of cdrtools that requires patches to build
+  # Last release on 2005-02-05. cdrtools added support for DVD in 2006.
+  deprecate! date: "2026-06-30", because: :unmaintained
+  disable! date: "2027-06-30", because: :unmaintained
+
+  conflicts_with "cdrtools", because: "both cdrtools and dvdrtools install binaries by the same name"
 
   # Below three patches via MacPorts.
   patch :p0 do


### PR DESCRIPTION
Unmaintained fork. Release we are using is from 2005. There was another release in 2006 but uploaded to dead site.

Outside of Homebrew, only MacPorts includes this:
- https://repology.org/project/dvdrtools/versions

`cdrtools` also added support for DVD in open-source version around 2006. Although the current `cdrtools` source is not active as maintainer passed away, there are at least 2 maintained forks we can consider:
- Debian `cdrkit` which is based on older GPL-licensed code to avoid license incompatibility combining CDDL with GPL
- Codeberg fork `schilytools`. We already use this for `star` and `smake` so maybe can be acceptable to use. However, it is unlikely to meet our documented fork clause as Linux distros switched to Debian fork. Would need to be willing to consider BSD/macOS repositories, e.g. pkgsrc, FreeBSD, MacPorts.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
