### PR TITLE
rancher-machine 0.15.0-rancher144 (new formula)

### DIFF
--- a/Formula/d/docker-machine-driver-vultr.rb
+++ b/Formula/d/docker-machine-driver-vultr.rb
@@ -7,12 +7,13 @@ class DockerMachineDriverVultr < Formula
   head "https://github.com/vultr/docker-machine-driver-vultr.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "3dda2f729047493afd3de8c833bad9a0d2a92ac9cda6756c6518e30ee7f3b865"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "3dda2f729047493afd3de8c833bad9a0d2a92ac9cda6756c6518e30ee7f3b865"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "3dda2f729047493afd3de8c833bad9a0d2a92ac9cda6756c6518e30ee7f3b865"
-    sha256 cellar: :any_skip_relocation, sonoma:        "606c6391582f3353b25bf1c2cb58e7c5a0388c9df9aee77445e1b6e5e959261a"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "fcbda52b4860cc84ddfefa6b21e9b5a9284324cc5e2c9451bf7ca7eb9747fe1c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "fc02dec3304a23cbda77067ae6a1bc315265468eb40cf015ee74e8c04954a03a"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "8a2113c1e6022f95fd189b597885b1dbd321584adcb48558d5918d8b8c3b82d0"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "8a2113c1e6022f95fd189b597885b1dbd321584adcb48558d5918d8b8c3b82d0"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "8a2113c1e6022f95fd189b597885b1dbd321584adcb48558d5918d8b8c3b82d0"
+    sha256 cellar: :any_skip_relocation, sonoma:        "803bc1f9822027a2f45a6a2713a13f9eca07b17fa4e6b8902f665cd30b388555"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "15d423cb1c6f861f95de022a8df429df7abc0e9684601c03f068eef9b062c72c"
+    sha256 cellar: :any,                 x86_64_linux:  "0a716e6a759a224d1d94a60b87a7565f7bce54a671f7420170a5dd095739e263"
   end
 
   depends_on "go" => :build

--- a/Formula/d/docker-machine-driver-vultr.rb
+++ b/Formula/d/docker-machine-driver-vultr.rb
@@ -16,7 +16,7 @@ class DockerMachineDriverVultr < Formula
   end
 
   depends_on "go" => :build
-  depends_on "docker-machine"
+  depends_on "rancher-machine"
 
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w"), "./machine"
@@ -24,6 +24,6 @@ class DockerMachineDriverVultr < Formula
 
   test do
     assert_match "--vultr-api-key",
-      shell_output("#{Formula["docker-machine"].bin}/docker-machine create --driver vultr -h")
+      shell_output("#{Formula["rancher-machine"].bin}/rancher-machine create --driver vultr -h")
   end
 end

--- a/Formula/r/rancher-machine.rb
+++ b/Formula/r/rancher-machine.rb
@@ -1,0 +1,38 @@
+class RancherMachine < Formula
+  desc "Machine management for a container-centric world"
+  homepage "https://github.com/rancher/machine"
+  url "https://github.com/rancher/machine/archive/refs/tags/v0.15.0-rancher144.tar.gz"
+  version "0.15.0-rancher144"
+  sha256 "b7508aa1d0cd995690abf65813cff76ae3b64b2735731b0ae9e817f551a7bc7d"
+  license "Apache-2.0"
+  head "https://github.com/rancher/machine.git", branch: "master"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+-rancher\d+)$/i)
+  end
+
+  depends_on "go" => :build
+
+  def install
+    commit = build.head? ? Utils.git_short_head : tap.user
+    ldflags = %W[
+      -w -s
+      -X github.com/rancher/machine/version.Version=#{version}
+      -X github.com/rancher/machine/version.GitCommit=#{commit}
+    ]
+    system "go", "build", *std_go_args(ldflags:), "./cmd/rancher-machine"
+  end
+
+  service do
+    run [opt_bin/"rancher-machine", "start", "default"]
+    environment_variables PATH: std_service_path_env
+    run_type :immediate
+    working_dir HOMEBREW_PREFIX
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/rancher-machine --version")
+    assert_match "VBoxManage --version", shell_output("#{bin}/rancher-machine create test", 3)
+  end
+end

--- a/Formula/r/rancher-machine.rb
+++ b/Formula/r/rancher-machine.rb
@@ -12,6 +12,15 @@ class RancherMachine < Formula
     regex(/^v?(\d+(?:\.\d+)+-rancher\d+)$/i)
   end
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "f76435c3175d95ee4eed404bba73573efcb09122763b97798504d47f2be007b2"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "f76435c3175d95ee4eed404bba73573efcb09122763b97798504d47f2be007b2"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "f76435c3175d95ee4eed404bba73573efcb09122763b97798504d47f2be007b2"
+    sha256 cellar: :any_skip_relocation, sonoma:        "0b0b818dbf72e003f90662cb1efae84f0321cfb13298ef2edab61b812ab4095e"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "337753acf3898437de9c42ef83126aeb3e665efe1a4caffe9a9e7f160eb50885"
+    sha256 cellar: :any,                 x86_64_linux:  "9ae2d72bdfd7988b492ad848604410786d03c882912b0385aea951d27c522f1c"
+  end
+
   depends_on "go" => :build
 
   def install


### PR DESCRIPTION
Fork of `docker-machine` maintained by Rancher with sufficient notability. Our `docker-machine` is currently a fork maintained by GitLab but GitLab has deprecated it and will drop support in May 2027.

The remaining maintained driver is https://github.com/vultr/docker-machine-driver-vultr  and they specifically use `rancher-machine` - https://github.com/vultr/docker-machine-driver-vultr#install-as-a-docker-machine-driver
> It is recommended to install rancher-machine instead. See the official repository: https://github.com/rancher/machine.

Will be deprecating `docker-machine` afterward:
- https://github.com/Homebrew/homebrew-core/pull/290713

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
