### PR TITLE
docker-machine: deprecate

### DIFF
--- a/Formula/d/docker-machine-driver-vmware.rb
+++ b/Formula/d/docker-machine-driver-vmware.rb
@@ -24,6 +24,14 @@ class DockerMachineDriverVmware < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "c2699119a539f3b9b7c86f900d5510d5b4cdb952ebdc60b7f5c12bf80f5d4932"
   end
 
+  # After Docker ended support for original docker-machine[^1], we have used
+  # GitLab-maintained fork. However, the fork is now officially deprecated[^2]
+  # and scheduled for removal in GitLab 20.0 (May 2027)
+  #
+  # [^1]: https://docs.docker.com/retired/#docker-machine
+  # [^2]: https://docs.gitlab.com/runner/executors/docker_machine/
+  disable! date: "2027-06-30", because: :deprecated_upstream
+
   depends_on "go" => :build
   depends_on "docker-machine"
 

--- a/Formula/d/docker-machine.rb
+++ b/Formula/d/docker-machine.rb
@@ -17,6 +17,14 @@ class DockerMachine < Formula
     sha256 cellar: :any,                 x86_64_linux:  "3f01b0ef020ee62c2d6b0517e7868a3e32074cac944bdb60a3f9431bbba3a5c0"
   end
 
+  # After Docker ended support for original docker-machine[^1], we have used
+  # GitLab-maintained fork. However, the fork is now officially deprecated[^2]
+  # and scheduled for removal in GitLab 20.0 (May 2027)
+  #
+  # [^1]: https://docs.docker.com/retired/#docker-machine
+  # [^2]: https://docs.gitlab.com/runner/executors/docker_machine/
+  disable! date: "2027-06-30", because: :deprecated_upstream
+
   depends_on "go" => :build
 
   def install


### PR DESCRIPTION
After Docker ended support for original docker-machine[^1], we have used GitLab-maintained fork. However, the fork is now officially deprecated[^2] and scheduled for removal in GitLab 20.0 (May 2027)

[^1]: https://docs.docker.com/retired/#docker-machine
[^2]: https://docs.gitlab.com/runner/executors/docker_machine/

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
