### PR TITLE
ollama: update llama-server test output

### DIFF
--- a/Formula/o/ollama.rb
+++ b/Formula/o/ollama.rb
@@ -2,8 +2,8 @@ class Ollama < Formula
   desc "Create, run, and share large language models (LLMs)"
   homepage "https://ollama.com/"
   url "https://github.com/ollama/ollama.git",
-      tag:      "v0.30.11",
-      revision: "d26a58557d83aa8892bdfa79b3550f5ee969cd1c"
+      tag:      "v0.31.1",
+      revision: "710292ff4f191d8da9f6a4230804fbc693338d4a"
   license "MIT"
   head "https://github.com/ollama/ollama.git", branch: "main"
 
@@ -47,8 +47,8 @@ class Ollama < Formula
   # Pinned dependency required by llama-server
   resource "llama.cpp" do
     url "https://github.com/ggml-org/llama.cpp.git",
-        tag:      "b9781",
-        revision: "51eae8cfcac4fb403bcf91d1fb524fec0974f510"
+        tag:      "b9840",
+        revision: "8c146a8366304c871efc26057cc90370ccf58dad"
 
     livecheck do
       url "https://raw.githubusercontent.com/ollama/ollama/refs/tags/v#{LATEST_VERSION}/LLAMA_CPP_VERSION"

--- a/Formula/o/ollama.rb
+++ b/Formula/o/ollama.rb
@@ -154,7 +154,7 @@ class Ollama < Formula
     r, _w, pid = PTY.spawn(libexec/"lib/ollama/llama-server")
     begin
       timeout = Time.now + 20
-      until output.include?("starting router server")
+      until output.include?("starting server in router mode")
         raise "timed out waiting for llama-server to start\n#{output}" if Time.now > timeout
 
         begin
@@ -166,7 +166,7 @@ class Ollama < Formula
         end
       end
 
-      assert_match "starting router server", output
+      assert_match "starting server in router mode", output
     ensure
       Process.kill "TERM", pid
       Process.wait pid


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI was used to inspect the failing CI logs for Homebrew/homebrew-core#290701 and compare the pinned llama.cpp versions. The change updates the formula test to match the llama-server router startup log in the llama.cpp revision pinned by ollama 0.31.1.

Manual verification performed:
- Confirmed the failing CI log contains `starting server in router mode. models will be automatically loaded on-demand`.
- Confirmed llama.cpp changed the previous `starting router server...` log in ggml-org/llama.cpp@27c8bb4f63ad9f20bf5901067810a4be5ffe20c4.
- Ran `brew ruby -- -c Formula/o/ollama.rb`.
- Matched the updated string against the failing CI output.

-----