### PR TITLE
goredo: deprecate, moved to new URL

### DIFF
--- a/Formula/g/goredo.rb
+++ b/Formula/g/goredo.rb
@@ -1,12 +1,12 @@
 class Goredo < Formula
   desc "Go implementation of djb's redo, a Makefile replacement that sucks less"
-  homepage "https://goredo.dabase.com/"
-  url "https://goredo.dabase.com/download/goredo-2.9.1.tar.zst"
+  homepage "http://www.goredo.stargrave.org/"
+  url "http://www.goredo.stargrave.org/download/goredo-2.9.1.tar.zst"
   sha256 "dc668707f17b80a62e963e14c05b266f9445e6c88ed137d4108fa8b3833557ad"
   license "GPL-3.0-only"
 
   livecheck do
-    url "https://goredo.dabase.com/NEWS.html"
+    url "http://www.goredo.stargrave.org/NEWS.html"
     regex(/v?(\d+(?:\.\d+)+)/i)
   end
 
@@ -18,6 +18,8 @@ class Goredo < Formula
     sha256 cellar: :any_skip_relocation, arm64_linux:   "0951d98cb61b0d9da7152f5209c06100b17a9d6677b8647444ecdd15ff481f2b"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "eaed3d7c4a251b26f67767ba92951a43ed1f89f5414fb25b9ba781d5c96cb5bb"
   end
+
+  deprecate! date: "2026-07-02", because: "is not available via HTTPS"
 
   depends_on "go" => :build
 


### PR DESCRIPTION
[`https://goredo.dabase.com/`](https://goredo.dabase.com/) became non functional, moved to new host [`http://www.goredo.stargrave.org/`](http://www.goredo.stargrave.org/), but again no longer available on https, [requiring](https://github.com/Homebrew/homebrew-core/actions/runs/28565474492/job/84691765333?pr=290944#step:5:29) deprecation (`FormulaAudit/HttpUrls: Formulae in homebrew/core should not use http:// URLs.`).

Ref:
* http://www.goredo.stargrave.org/NEWS.html
* https://github.com/Homebrew/homebrew-core/pull/268694
* https://github.com/Homebrew/homebrew-core/pull/288803

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
