### PR TITLE
prrte 3.0.14 (new formula); open-mpi: split out `prrte`

### DIFF
--- a/Formula/o/open-mpi.rb
+++ b/Formula/o/open-mpi.rb
@@ -3,7 +3,10 @@ class OpenMpi < Formula
   homepage "https://www.open-mpi.org/"
   url "https://download.open-mpi.org/release/open-mpi/v5.0/openmpi-5.0.9.tar.bz2"
   sha256 "dfb72762531170847af3e4a0f21d77d7b23cf36f67ce7ce9033659273677d80b"
-  license "BSD-3-Clause"
+  license all_of: [
+    "BSD-3-Clause-Open-MPI",
+    "mpich2", # opal/datatype/opal_datatype_pack_unpack_predefined.h
+  ]
   compatibility_version 1
 
   livecheck do
@@ -27,12 +30,16 @@ class OpenMpi < Formula
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build
+
+    uses_from_macos "flex" => :build
+    uses_from_macos "python" => :build
   end
 
   depends_on "gcc" # for gfortran
   depends_on "hwloc"
   depends_on "libevent"
   depends_on "pmix"
+  depends_on "prrte"
 
   conflicts_with "mpich", because: "both install MPI compiler wrappers"
 
@@ -43,7 +50,7 @@ class OpenMpi < Formula
     ENV["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version if OS.mac?
 
     # Remove bundled copies of libraries that shouldn't be used
-    unbundled_packages = %w[hwloc libevent openpmix].join(",")
+    unbundled_packages = %w[hwloc libevent openpmix prrte].join(",")
     rm_r Dir["3rd-party/{#{unbundled_packages}}*"]
 
     # Avoid references to the Homebrew shims directory
@@ -51,11 +58,8 @@ class OpenMpi < Formula
       ompi/tools/ompi_info/param.c
       oshmem/tools/oshmem_info/param.c
     ]
-    cxx = OS.linux? ? "g++" : ENV.cxx
-    cc = OS.linux? ? "gcc" : ENV.cc
-    inreplace inreplace_files, "OMPI_CXX_ABSOLUTE", "\"#{cxx}\""
-    inreplace inreplace_files, "OPAL_CC_ABSOLUTE", "\"#{cc}\""
-    inreplace "3rd-party/prrte/src/tools/prte_info/param.c", "PRTE_CC_ABSOLUTE", "\"#{cc}\""
+    inreplace inreplace_files, "OMPI_CXX_ABSOLUTE", "\"#{ENV.cxx}\""
+    inreplace inreplace_files, "OPAL_CC_ABSOLUTE", "\"#{ENV.cc}\""
 
     args = %W[
       --disable-silent-rules
@@ -65,6 +69,7 @@ class OpenMpi < Formula
       --with-hwloc=#{formula_opt_prefix("hwloc")}
       --with-libevent=#{formula_opt_prefix("libevent")}
       --with-pmix=#{formula_opt_prefix("pmix")}
+      --with-prrte=#{formula_opt_prefix("prrte")}
       --with-sge
     ]
 
@@ -84,16 +89,6 @@ class OpenMpi < Formula
 
     # Avoid references to cellar paths.
     inreplace (lib/"pkgconfig").glob("*.pc"), prefix, opt_prefix, audit_result: false
-
-    # Avoid conflict with `putty` by renaming pterm to prte-term which matches
-    # upstream change[^1]. In future release, we may want to split out `prrte`
-    # to a separate formula and pass `--without-legacy-names`[^2].
-    #
-    # [^1]: https://github.com/openpmix/prrte/issues/1836#issuecomment-2564882033
-    # [^2]: https://github.com/openpmix/prrte/blob/master/config/prte_configure_options.m4#L390-L393
-    odie "Update configure for PRRTE or split to separate formula as prte-term exists" if (bin/"prte-term").exist?
-    bin.install bin/"pterm" => "prte-term"
-    man1.install man1/"pterm.1" => "prte-term.1"
   end
 
   test do

--- a/Formula/o/open-mpi.rb
+++ b/Formula/o/open-mpi.rb
@@ -15,13 +15,13 @@ class OpenMpi < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 arm64_tahoe:   "cd28d2c171ababacf625797283aa0bf5e8320afb6153457a6f90388c4f1d4473"
-    sha256 arm64_sequoia: "eeed54525cd950a5a5d008b7511277e20c3a50eb762f45d160fd6c9de8c835d3"
-    sha256 arm64_sonoma:  "ddbff35130a0e77b5f8f5f4c503e929a510ce1c2949f6efa5a262f2fdb224526"
-    sha256 sonoma:        "77763194eeb86e1c20cc2fc7256bfe9c0b16eb8451c180b5957ddb7c2faee37c"
-    sha256 arm64_linux:   "fdde5d8440a00a052b04cd9925cbda0a3df436e9a15dad8e57e851656a3da32f"
-    sha256 x86_64_linux:  "05ac59d4efcfb8b0b77bdab7daf261c7639f62e9c48caa7c05d634457b3c9b99"
+    rebuild 2
+    sha256 arm64_tahoe:   "e0f21b4be8bee1c97e7f9f6e4ee1cfd57fed5bafa26715c87750f1dac351577e"
+    sha256 arm64_sequoia: "6389bdcd527f5e81d4ced441ba47b87df173e35ec68366d0f952d2d4f6e8dc4b"
+    sha256 arm64_sonoma:  "d6c225e34bf09107177a161d44b43e7db7e4c8caf48dfb2add8a7949a381d8c0"
+    sha256 sonoma:        "99c85c3753ca360b2584267085b34335d24c708dbc5f1dc6453eb0787f84b6d6"
+    sha256 arm64_linux:   "afcb084b7f8155f0ef6ddaa2d413e9847118afbaecfeab0fc9d6f3fc07081b02"
+    sha256 x86_64_linux:  "78a948af66d16c15e06cec5dca890dcc5fbd83cf6b72549227eedc3f9f11e5c3"
   end
 
   head do

--- a/Formula/p/prrte.rb
+++ b/Formula/p/prrte.rb
@@ -1,0 +1,108 @@
+class Prrte < Formula
+  desc "PMIx Reference RunTime Environment"
+  homepage "https://pmix.org/"
+  license "BSD-3-Clause-Open-MPI"
+
+  stable do
+    url "https://github.com/openpmix/prrte/releases/download/v3.0.14/prrte-3.0.14.tar.bz2"
+    sha256 "c3d8e8f79d7498dd18bb0e3fd5a2b761922c3e1e67b94a23d3ae6c4b6f8e8d0e"
+
+    # Fix -flat_namespace being used on Big Sur and later.
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/homebrew-core/1cf441a0/Patches/libtool/configure-big_sur.diff"
+      sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+    end
+  end
+
+  head do
+    url "https://github.com/openpmix/prrte.git", branch: "master"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+
+    uses_from_macos "flex" => :build
+    uses_from_macos "python" => :build
+  end
+
+  depends_on "hwloc"
+  depends_on "libevent"
+  depends_on "pmix"
+
+  uses_from_macos "perl" => :build
+
+  # These used to be bundled with open-mpi
+  link_overwrite "bin/pcc", "bin/prte*", "bin/prun", "include/prte*", "lib/libprrte.*"
+  link_overwrite "share/man/man1/prte*.1", "share/man/man1/prun.1",
+                 "share/man/man5/prte.5", "share/doc/prrte/", "share/prte/"
+
+  def install
+    # Avoid references to the Homebrew shims directory
+    inreplace "src/tools/prte_info/param.c", "PRTE_CC_ABSOLUTE", "\"#{ENV.cc}\""
+
+    args = %W[
+      --disable-silent-rules
+      --enable-ipv6
+      --sysconfdir=#{etc}
+      --with-hwloc=#{formula_opt_prefix("hwloc")}
+      --with-libevent=#{formula_opt_prefix("libevent")}
+      --with-pmix=#{formula_opt_prefix("pmix")}
+      --with-sge
+      --without-legacy-tools
+    ]
+
+    system "./autogen.pl", "--force" if build.head?
+    system "./configure", *args, *std_configure_args
+    system "make", "install"
+
+    # Avoid conflict with `putty` by renaming pterm to prte-term which matches upstream:
+    # ref: https://github.com/openpmix/prrte/issues/1836#issuecomment-2564882033
+    odie "Update configure for PRRTE or split to separate formula as prte-term exists" if (bin/"prte-term").exist?
+    bin.install bin/"pterm" => "prte-term"
+    man1.install man1/"pterm.1" => "prte-term.1"
+  end
+
+  test do
+    # Based on https://github.com/openpmix/prrte/blob/master/test/attachtest/app.c
+    (testpath/"test.c").write <<~'C'
+      #include <pmix.h>
+      #include <stdio.h>
+      #include <stdlib.h>
+
+      int main(int argc, char **argv)
+      {
+        int pause = 0;
+        if (argc > 1) {
+            pause = atoi(argv[1]);
+        }
+
+        pmix_proc_t proc;
+        pmix_status_t rc = PMIX_ERROR;
+
+        rc = PMIx_Init(&proc, NULL, 0);
+        if (rc != PMIX_SUCCESS) {
+          fprintf(stderr, "PMIx_Init failed: %s\n", PMIx_Error_string(rc));
+          return EXIT_FAILURE;
+        }
+
+        printf("Hello\n");
+
+        sleep(pause);
+
+        printf("Bye\n");
+
+        rc = PMIx_Finalize(NULL, 0);
+        if (rc != PMIX_SUCCESS) {
+          fprintf(stderr, "PMIx_Finalize failed: %s\n", PMIx_Error_string(rc));
+          return EXIT_FAILURE;
+        }
+        return EXIT_SUCCESS;
+      }
+    C
+
+    system bin/"pcc", "test.c", "-o", "test"
+    assert_equal "Hello\nHello\nBye\nBye\n", shell_output("#{bin}/prterun -n 2 ./test 1")
+
+    assert_match "PRTE: #{version}", shell_output("#{bin}/prte_info")
+  end
+end

--- a/Formula/p/prrte.rb
+++ b/Formula/p/prrte.rb
@@ -14,6 +14,15 @@ class Prrte < Formula
     end
   end
 
+  bottle do
+    sha256 arm64_tahoe:   "0f71161c5123695aa84865e17062bb6b9b86d53e4995b315bc4bd8b221d0dc27"
+    sha256 arm64_sequoia: "6a59e04555bb0c6a290cae7cbe9c16492a800daebe02514eed7b104f32ab0267"
+    sha256 arm64_sonoma:  "daae27ddb909f19f41fcb0bc555f24fea1a3b809847cc54951d6b3308315df1e"
+    sha256 sonoma:        "93480f0e4ab72b3d3079cbb0adb1ecd78c73fdbb62800a7cdedc7eb9319177bd"
+    sha256 arm64_linux:   "f47049dbf771197b833d0461f16dd33f4b61dc05f8c0cc976d73e3dfaaef3dc1"
+    sha256 x86_64_linux:  "12e343ddb549456626718523d6680a72ee23b46b6979d55d10d0ce057ca432bb"
+  end
+
   head do
     url "https://github.com/openpmix/prrte.git", branch: "master"
 


### PR DESCRIPTION
`CI-skip-new-formula` for `-flat_namespace` patch.

4.x requires also updating PMIX. Can handle that later on.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
