### PR TITLE
git: enable Rust build support

### DIFF
--- a/Formula/g/git.rb
+++ b/Formula/g/git.rb
@@ -29,6 +29,7 @@ class Git < Formula
 
   depends_on "gettext" => :build
   depends_on "pkgconf" => :build
+  depends_on "rust" => :build
   depends_on "pcre2"
 
   uses_from_macos "curl"
@@ -106,6 +107,13 @@ class Git < Formula
     # to avoid a dependency on tcl-tk and to avoid using the broken system
     # tcl-tk (see https://github.com/Homebrew/homebrew-core/issues/36390)
     # This is done by setting the NO_TCLTK make variable.
+    #
+    # Rust support is enabled by default upstream since Git 2.55 (the
+    # `WITH_RUST` Makefile knob was renamed to `NO_RUST`, i.e. opt-out).
+    # We build the memory-safe Rust subsystems (contrib/libgit-sys, gitcore:
+    # varint/csum_file/hash/loose) rather than passing `NO_RUST=1`, so that
+    # the Homebrew bottle matches upstream defaults and is ready for Git 3.0,
+    # where Rust becomes mandatory. See `rust => :build` above.
     args = %W[
       prefix=#{prefix}
       sysconfdir=#{etc}
@@ -113,7 +121,6 @@ class Git < Formula
       CFLAGS=#{ENV.cflags}
       LDFLAGS=#{ENV.ldflags}
       NO_TCLTK=1
-      NO_RUST=1
     ]
 
     args += if OS.mac?
@@ -231,6 +238,12 @@ class Git < Formula
     # If this assertion fails, please fix the `inreplace` instead of removing this test.
     # The failure of this test means that `git` will generate broken launchctl plist files.
     refute_match HOMEBREW_CELLAR.to_s, shell_output("#{bin}/git --exec-path")
+
+    # Ensure the Rust subsystems were actually compiled in (upstream default
+    # since Git 2.55). A Rust-enabled build reports `rust: enabled` here, while
+    # a `NO_RUST=1` build omits the line. This guards against silently
+    # regressing back to the legacy C-only configuration.
+    assert_match "rust: enabled", shell_output("#{bin}/git version --build-options")
 
     return unless OS.mac?
 


### PR DESCRIPTION
Enable upstream's default Rust build for `git` and stop passing `NO_RUST=1`.

Since Git 2.55 the build system enables Rust by default (the `WITH_RUST` knob was
renamed to `NO_RUST`, i.e. opt-out); Git 3.0 will make Rust mandatory and remove
the opt-out. The Homebrew bottle currently reports `rust: disabled`, diverging
from the upstream default.

**User-facing disparity (not just "Rust for Rust's sake"):** with `NO_RUST=1`,
hash-algorithm interoperability paths that are implemented in the Rust `gitcore`
crate are unavailable, and exercising them fails at runtime with `requires Rust`
(e.g. object-format compatibility between SHA-1 and SHA-256 via
`extensions.compatObjectFormat`). Enabling Rust restores these features. See
#290964 for the reproduction and `git version --build-options` evidence
(`rust: disabled` on the bottle vs `rust: enabled` on a default upstream build).

Changes to `Formula/g/git.rb`: add `depends_on "rust" => :build`, drop
`NO_RUST=1`, and assert `rust: enabled` in the formula test.

Closes #290964.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI assistance was used to research the upstream Rust migration, draft the formula
change, and prepare this PR. Manual verification performed: (1) confirmed the
change against the upstream `v2.55.0` `Makefile`, `meson_options.txt`, and
`Documentation/BreakingChanges.adoc`; (2) built `git 2.55.0` from source with
Rust enabled (rustc/cargo 1.96.0) — it links `target/release/libgitcore.a` and
`git version --build-options` reports `rust: enabled`; (3) reproduced the
`rust: disabled` state on the current Homebrew bottle; (4) `ruby -c` syntax-checked
the formula. Local `brew install --build-from-source` / `brew test` / `brew audit`
on a runner remain to be completed by CI.
