### PR TITLE
neonctl: use esbuild formula

### DIFF
--- a/Formula/n/neonctl.rb
+++ b/Formula/n/neonctl.rb
@@ -4,6 +4,7 @@ class Neonctl < Formula
   url "https://registry.npmjs.org/neonctl/-/neonctl-2.29.2.tgz"
   sha256 "2c368d4fa69d5ced561243eeb5f67947dfb46310aad23c806316eea59e5c6cd9"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "cac783259d1e498a3aa6b124153713d4f68b77b023bcb783cc98d0a3aa5f7c4c"
@@ -14,6 +15,7 @@ class Neonctl < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "55663cf10e522379573524763b5076a9163961bb564f192e88263c24fb973177"
   end
 
+  depends_on "esbuild" # replaces the bundled copy
   depends_on "node"
 
   def install
@@ -24,16 +26,56 @@ class Neonctl < Formula
       generate_completions_from_executable(bin/cmd, "completion", shells: [:bash, :zsh])
     end
 
+    node_modules = libexec/"lib/node_modules/neonctl/node_modules"
+
     # Remove incompatible pre-built binaries
     os = OS.kernel_name.downcase
     arch = Hardware::CPU.intel? ? "x64" : Hardware::CPU.arch.to_s
-    node_modules = libexec/"lib/node_modules/neonctl/node_modules"
     node_modules.glob("{bare-fs,bare-os,bare-url}/prebuilds/*")
                 .each { |dir| rm_r(dir) if dir.basename.to_s != "#{os}-#{arch}" }
+
+    # Remove bundled esbuild to use the `esbuild` formula from PATH; delete the
+    # whole module so neonctl falls back to PATH. Symlinks first to avoid dangling.
+    node_modules.glob("**/.bin/esbuild").each { |bin| rm(bin) }
+    node_modules.glob("**/{esbuild,@esbuild}").select(&:directory?).each { |dir| rm_r(dir) }
   end
 
   test do
     output = shell_output("#{bin}/neonctl --api-key DOES-NOT-EXIST projects create 2>&1", 1)
     assert_match("Authentication failed", output)
+
+    # `neonctl dev` bundles the function with esbuild and serves it, exercising
+    # the `esbuild` dependency. Keep the source in its own dir: `dev` watches the
+    # source's directory and restarts on any change, so the log must live outside it.
+    (testpath/"neon").mkpath
+    (testpath/"neon/index.ts").write <<~TS
+      export default async () => new Response("Hello, Homebrew!");
+    TS
+    port = free_port
+    log = testpath/"dev.log"
+    pid = spawn bin/"neonctl", "dev", "--source", testpath/"neon/index.ts", "--port", port.to_s,
+                "--config-dir", testpath/"config", "--analytics", "false",
+                out: log.to_s, err: log.to_s
+    begin
+      Timeout.timeout(60) do
+        loop do
+          contents = log.read if log.exist?
+          break if contents&.include?("localhost:#{port}")
+
+          refute_match "bundle failed", contents.to_s
+          sleep 0.5
+        end
+      end
+      assert_match "Hello, Homebrew!",
+                   shell_output("curl --silent --retry 5 --retry-connrefused --retry-all-errors " \
+                                "127.0.0.1:#{port}/")
+    ensure
+      begin
+        Process.kill("TERM", pid)
+        Process.wait(pid)
+      rescue Errno::ESRCH, Errno::ECHILD
+        nil
+      end
+    end
   end
 end

--- a/Formula/n/neonctl.rb
+++ b/Formula/n/neonctl.rb
@@ -7,12 +7,7 @@ class Neonctl < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "cac783259d1e498a3aa6b124153713d4f68b77b023bcb783cc98d0a3aa5f7c4c"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "cac783259d1e498a3aa6b124153713d4f68b77b023bcb783cc98d0a3aa5f7c4c"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "cac783259d1e498a3aa6b124153713d4f68b77b023bcb783cc98d0a3aa5f7c4c"
-    sha256 cellar: :any_skip_relocation, sonoma:        "0b49acb8fb717eb7dabb76bdd91d0ec61b52f33228dc28222f24842048bc5d7e"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "3c1b65b8542940bebb4a651c18e7d3e05dd814cee2babb709c9d87fa849a6efd"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "55663cf10e522379573524763b5076a9163961bb564f192e88263c24fb973177"
+    sha256 cellar: :any_skip_relocation, all: "0794d1dc4428f18c86da36b71365eefdece31f289cafcc2ab32db4d1765a8f10"
   end
 
   depends_on "esbuild" # replaces the bundled copy


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

AI-assisted contribution by Claude Opus 4.8 of ~90% of the work; style/audit/test validation run by AI and reviewed by the author.

Built and tested locally on macOS Tahoe 26.5.1 running arm64.

Depend on the `esbuild` formula and strip neonctl's two bundled esbuild copies (~20MB), resolved from `PATH` at runtime; install 55MB → 35MB.
