### PR TITLE
bbrew 2.3.0 (new formula)

### DIFF
--- a/Formula/b/bbrew.rb
+++ b/Formula/b/bbrew.rb
@@ -1,0 +1,19 @@
+class Bbrew < Formula
+  desc "TUI for managing Homebrew, Flatpak, and Mac App Store packages"
+  homepage "https://bold-brew.com"
+  url "https://github.com/Valkyrie00/bold-brew/archive/refs/tags/v2.3.0.tar.gz"
+  sha256 "ddf3d5e69da599fe6cb9660c50895b3572f31abb511d25e5d39547e9e7e95ae0"
+  license "MIT"
+  head "https://github.com/Valkyrie00/bold-brew.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = "-s -w -X bbrew/internal/services.AppVersion=#{version}"
+    system "go", "build", *std_go_args(ldflags:), "./cmd/bbrew"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/bbrew -v")
+  end
+end


### PR DESCRIPTION
Bold Brew (bbrew) is a TUI for Homebrew, Flatpak, and Mac App Store, written in Go.
It lets you browse, search, filter, sort, and manage formulae and casks, with vulnerability scanning, Brewfile export, and multi-source support.
- **Homepage:** https://bold-brew.com
- **GitHub:** https://github.com/Valkyrie00/bold-brew
- **License:** MIT
- **Notability:** 368★ (above the 225★ self-submission threshold);
- official Homebrew TUI for Project [Bluefin](https://docs.projectbluefin.io/blog/bold-brew/) and Universal Blue (tens of thousands of users)

Currently only available via a custom tap (`Valkyrie00/bbrew`); this adds it to homebrew-core.

The test asserts the version flag outputs correctly.

---
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source bbrew`?
- [x] Is your test running fine `brew test bbrew`?
- [x] Does your build pass `brew audit --strict bbrew` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source bbrew`)? If this is a new formula, does it pass `brew audit --new bbrew`?
