### PR TITLE
bbrew 2.3.0 (new formula)

### DIFF
--- a/Formula/b/bbrew.rb
+++ b/Formula/b/bbrew.rb
@@ -6,6 +6,15 @@ class Bbrew < Formula
   license "MIT"
   head "https://github.com/Valkyrie00/bold-brew.git", branch: "main"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "51687e72efa1e34857d074f63c46c2acd77cf3343ea8ec3a7e5b721b3f96d183"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "51687e72efa1e34857d074f63c46c2acd77cf3343ea8ec3a7e5b721b3f96d183"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "51687e72efa1e34857d074f63c46c2acd77cf3343ea8ec3a7e5b721b3f96d183"
+    sha256 cellar: :any_skip_relocation, sonoma:        "49fae21e7e2347e62bd5cf627fe134f36e80642fd95f823b5eeac33a534da7e7"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "dfda2386161a27d17235c359279aa6ac5349221cacf18a781638a555548bbb54"
+    sha256 cellar: :any,                 x86_64_linux:  "bc3cf853eefedb10a357db3314b9610ae964c127eebb7c6ac9e2d3326b2b416f"
+  end
+
   depends_on "go" => :build
 
   def install

--- a/Formula/b/bbrew.rb
+++ b/Formula/b/bbrew.rb
@@ -1,0 +1,31 @@
+class Bbrew < Formula
+  desc "TUI for managing Homebrew, Flatpak, and Mac App Store packages"
+  homepage "https://bold-brew.com"
+  url "https://github.com/Valkyrie00/bold-brew/archive/refs/tags/v2.3.0.tar.gz"
+  sha256 "ddf3d5e69da599fe6cb9660c50895b3572f31abb511d25e5d39547e9e7e95ae0"
+  license "MIT"
+  head "https://github.com/Valkyrie00/bold-brew.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = "-s -w -X bbrew/internal/services.AppVersion=#{version}"
+    system "go", "build", *std_go_args(ldflags:), "./cmd/bbrew"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/bbrew -v")
+
+    output = shell_output("#{bin}/bbrew -f #{testpath}/nonexistent.Brewfile 2>&1", 1)
+    assert_match "brewfile not found", output
+
+    ENV["TERM"] = "xterm"
+    require "pty"
+    PTY.spawn(bin/"bbrew") do |r, _w, pid|
+      r.winsize = [80, 43]
+      sleep 7
+      Process.kill "TERM", pid
+      assert_match "Bold Brew", r.read_nonblock(512)
+    end
+  end
+end


### PR DESCRIPTION
Bold Brew (bbrew) is a TUI for Homebrew, Flatpak, and Mac App Store, written in Go.
It lets you browse, search, filter, sort, and manage formulae and casks, with vulnerability scanning, Brewfile export, and multi-source support.
- **Homepage:** https://bold-brew.com
- **GitHub:** https://github.com/Valkyrie00/bold-brew
- **License:** MIT
- **Notability:** 368★ (above the 225★ self-submission threshold);
- official Homebrew TUI for Project [Bluefin](https://docs.projectbluefin.io/blog/bold-brew/) and Universal Blue (tens of thousands of users)

Currently only available via a custom tap (`Valkyrie00/bbrew`); this adds it to homebrew-core.

The test asserts the version flag outputs correctly.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
