### PR TITLE
kuzco: deprecate

### DIFF
--- a/Formula/k/kuzco.rb
+++ b/Formula/k/kuzco.rb
@@ -17,6 +17,10 @@ class Kuzco < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "e2c0c1cf10c9a3a8c0ffa27c4cc977738f6c55b08fd0c5da5def1276c1a449a7"
   end
 
+  # upstream repository is removed (or made private)
+  deprecate! date: "2026-07-03", because: :repo_removed
+  disable! date: "2027-07-03", because: :repo_removed
+
   depends_on "go" => :build
   depends_on "opentofu" => :test
 


### PR DESCRIPTION
Upstream repository is no longer (publicly) available.

Ref
* https://github.com/RoseSecurity/Kuzco
* https://github.com/Homebrew/homebrew-core/pull/288803


-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
