### PR TITLE
v2ray: resource update

### DIFF
--- a/Formula/v/v2ray.rb
+++ b/Formula/v/v2ray.rb
@@ -12,12 +12,13 @@ class V2ray < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "c4057e6a42f779e50ccb6f455a1c12a5652cedc676330a3ffb6736a00fa0b7f2"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "c4057e6a42f779e50ccb6f455a1c12a5652cedc676330a3ffb6736a00fa0b7f2"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "c4057e6a42f779e50ccb6f455a1c12a5652cedc676330a3ffb6736a00fa0b7f2"
-    sha256 cellar: :any_skip_relocation, sonoma:        "c9ab402aeda9cdf3aaa9a380cbf525ea88b7a6c934cfc3ebfcbd07198f0a31bb"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "bfe250fa902c1cab0a47970f6748f8e5f0118dba5a924170a77138ecb4cd90f8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "ac4e9bae4f2451dcb844a6a10d936c7e017acc05ff7591fc45db54ef14838e19"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "c174faed11802c0fe249ca65c4a700ac4578506ba113ccde5b48749543f2bcb9"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "c174faed11802c0fe249ca65c4a700ac4578506ba113ccde5b48749543f2bcb9"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "c174faed11802c0fe249ca65c4a700ac4578506ba113ccde5b48749543f2bcb9"
+    sha256 cellar: :any_skip_relocation, sonoma:        "07a19f492efd8c14cf9cc37d866089976ec399669ba7ebb19a3f774937a82649"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "1a4276f4aac894ae4e657e344435ac7f3b111da78cfe954051bc44e512592e13"
+    sha256 cellar: :any,                 x86_64_linux:  "77ce611cbc275ca0dae984f54173cc352dff0667e99115b5b4b83f2a9a65ae82"
   end
 
   depends_on "go" => :build

--- a/Formula/v/v2ray.rb
+++ b/Formula/v/v2ray.rb
@@ -23,18 +23,18 @@ class V2ray < Formula
   depends_on "go" => :build
 
   resource "geoip" do
-    url "https://github.com/v2fly/geoip/releases/download/202605120112/geoip.dat"
-    sha256 "e9002979e0df72bce1c8751ff70725386594c551db684b7a232935b8b2bb8aa2"
+    url "https://github.com/v2fly/geoip/releases/download/202607020247/geoip.dat"
+    sha256 "b71d1999439dde2de2d2b6844a2befa50c50211ff739785c005ca7c230a17d6a"
   end
 
   resource "geoip-only-cn-private" do
-    url "https://github.com/v2fly/geoip/releases/download/202605120112/geoip-only-cn-private.dat"
-    sha256 "b11bf44231eefce4a03f576c6243ed3d589f9ef4d88bf5286ba74698ff6d181b"
+    url "https://github.com/v2fly/geoip/releases/download/202607020247/geoip-only-cn-private.dat"
+    sha256 "dff2733e43dbbdae88b2a59f908572eb5d9267d4afdb4c456a17f4a49d36747f"
   end
 
   resource "geosite" do
-    url "https://github.com/v2fly/domain-list-community/releases/download/20260516132422/dlc.dat"
-    sha256 "c4992857ce23464697b498cee60c0d392ce69ba1b48df3e4cc99e4011b86345c"
+    url "https://github.com/v2fly/domain-list-community/releases/download/20260702133809/dlc.dat"
+    sha256 "f2ec0b9dc07c03af30d61f84d0d07210235fcc226a9c2b6682717bada6e58c12"
   end
 
   def install


### PR DESCRIPTION
domain-list-community release 20260516132422 is no longer available

Ref:
* https://github.com/v2fly/domain-list-community/releases/20260516132422
* https://github.com/v2fly/domain-list-community/releases
* https://github.com/Homebrew/homebrew-core/pull/288803

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
