### PR TITLE
gettext: add dependencies to fix `spit` binary

### DIFF
--- a/Formula/g/gettext.rb
+++ b/Formula/g/gettext.rb
@@ -20,8 +20,10 @@ class Gettext < Formula
     sha256 x86_64_linux:  "ed30be09f5f328a974e51e34966a502496e0623c7ecde0faf7559143cbd02255"
   end
 
+  depends_on "json-c" # for spit
   depends_on "libunistring"
 
+  uses_from_macos "curl" # for spit
   uses_from_macos "libxml2"
   uses_from_macos "ncurses"
 
@@ -70,5 +72,6 @@ class Gettext < Formula
 
   test do
     system bin/"gettext", "test"
+    assert_match "spit: missing --model option\n", shell_output("#{bin}/spit 2>&1", 1)
   end
 end

--- a/Formula/g/gettext.rb
+++ b/Formula/g/gettext.rb
@@ -12,12 +12,13 @@ class Gettext < Formula
   compatibility_version 1
 
   bottle do
-    sha256 arm64_tahoe:   "1f98400343132c8e469ed475157f8f4d0f516ea86bd4600552e8b75ab638fcf9"
-    sha256 arm64_sequoia: "982f3a3cc24df4f552efc1b6ed6303d2920b2d5b1c1975fe3d9bd7418b8fa532"
-    sha256 arm64_sonoma:  "f9ea4eed738746ea4150a4f83e8dd11ca21ca3de5bb113995c25eec409bb5749"
-    sha256 sonoma:        "2cc112cce103be3beb13cc8ba67f521d4e972c4082fd69868d34920d63120c09"
-    sha256 arm64_linux:   "0d24ef468ab6683610fb866973cbdf899165be653b42c68689b70743be5ce695"
-    sha256 x86_64_linux:  "ed30be09f5f328a974e51e34966a502496e0623c7ecde0faf7559143cbd02255"
+    rebuild 1
+    sha256 arm64_tahoe:   "2b713227e438f51d025d76df24cfa45a2b813b61718df7bb91a6cedb1091037b"
+    sha256 arm64_sequoia: "dde3cd0db0d7549fadf762b901f8c548dae99e3c592a6e6d41f60e1436253e5e"
+    sha256 arm64_sonoma:  "d11a97db1d735fb9860a9637e72b2765ef93536851d36c8f0b5cbbc22b539c5a"
+    sha256 sonoma:        "e0072004be0db53c5f501d6ab2b78b9219067243f8989c40604720751dd6bdc4"
+    sha256 arm64_linux:   "a436430dfcd915d3c9cd7888f6b4f82f7d02d1d9556f48bef218704df482879e"
+    sha256 x86_64_linux:  "2dcf2f53d79cf6beb5c0df6f880c2cb7d21890be81533b3f74fc628d7f435cac"
   end
 
   depends_on "json-c" # for spit


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

`spit` binary is currently broken since it falls back to a python script without the necessary dependencies (see https://github.com/Homebrew/homebrew-core/issues/289785). By adding `curl` on macos and `json-c` dependencies it builds the C implementation of `spit`. 

Related discussion: https://github.com/orgs/Homebrew/discussions/6693

An alternative would be to remove the tools building in `gettext` and create a specific `gettext-tools` formula. This would impact the 429 dependents formulae so I didn't go that route for now.