### PR TITLE
formulae: move maximum_macos under on_macos

### DIFF
--- a/Formula/f/fdclone.rb
+++ b/Formula/f/fdclone.rb
@@ -25,10 +25,13 @@ class Fdclone < Formula
   deprecate! date: "2026-01-05", because: :repo_removed
   disable! date: "2027-01-05", because: :repo_removed
 
-  depends_on maximum_macos: [:sonoma, :build]
   depends_on "nkf" => :build
 
   uses_from_macos "ncurses"
+
+  on_macos do
+    depends_on maximum_macos: [:sonoma, :build]
+  end
 
   conflicts_with "fd", because: "both install `fd` binaries"
 

--- a/Formula/g/gcc@10.rb
+++ b/Formula/g/gcc@10.rb
@@ -23,13 +23,13 @@ class GccAT10 < Formula
   # out of the box on Xcode-only systems due to an incorrect sysroot.
   pour_bottle? only_if: :clt_installed
 
-  depends_on maximum_macos: [:ventura, :build]
   depends_on "gmp"
   depends_on "isl"
   depends_on "libmpc"
   depends_on "mpfr"
 
   on_macos do
+    depends_on maximum_macos: [:ventura, :build]
     depends_on arch: :x86_64
     # Align dates to remove Intel macOS support with brew
     # https://docs.brew.sh/Support-Tiers#future-macos-support

--- a/Formula/g/gcc@11.rb
+++ b/Formula/g/gcc@11.rb
@@ -27,12 +27,15 @@ class GccAT11 < Formula
   # out of the box on Xcode-only systems due to an incorrect sysroot.
   pour_bottle? only_if: :clt_installed
 
-  depends_on maximum_macos: [:ventura, :build] # Xcode < 16
   depends_on "gmp"
   depends_on "isl"
   depends_on "libmpc"
   depends_on "mpfr"
   depends_on "zstd"
+
+  on_macos do
+    depends_on maximum_macos: [:ventura, :build] # Xcode < 16
+  end
 
   on_linux do
     depends_on "binutils"

--- a/Formula/g/gcc@9.rb
+++ b/Formula/g/gcc@9.rb
@@ -23,13 +23,13 @@ class GccAT9 < Formula
   # out of the box on Xcode-only systems due to an incorrect sysroot.
   pour_bottle? only_if: :clt_installed
 
-  depends_on maximum_macos: [:monterey, :build]
   depends_on "gmp"
   depends_on "isl"
   depends_on "libmpc"
   depends_on "mpfr"
 
   on_macos do
+    depends_on maximum_macos: [:monterey, :build]
     depends_on arch: :x86_64
     # Align dates to remove Intel macOS support with brew
     # https://docs.brew.sh/Support-Tiers#future-macos-support

--- a/Formula/g/ghc@9.2.rb
+++ b/Formula/g/ghc@9.2.rb
@@ -30,13 +30,16 @@ class GhcAT92 < Formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
-  depends_on maximum_macos: [:sonoma, :build]
   depends_on "python@3.12" => :build
   depends_on "sphinx-doc" => :build
 
   uses_from_macos "m4" => :build
   uses_from_macos "xz" => :build
   uses_from_macos "ncurses"
+
+  on_macos do
+    depends_on maximum_macos: [:sonoma, :build]
+  end
 
   on_linux do
     depends_on "gmp" => :build

--- a/Formula/g/ghc@9.4.rb
+++ b/Formula/g/ghc@9.4.rb
@@ -30,13 +30,16 @@ class GhcAT94 < Formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
-  depends_on maximum_macos: [:sonoma, :build]
   depends_on "python@3.12" => :build
   depends_on "sphinx-doc" => :build
 
   uses_from_macos "m4" => :build
   uses_from_macos "xz" => :build
   uses_from_macos "ncurses"
+
+  on_macos do
+    depends_on maximum_macos: [:sonoma, :build]
+  end
 
   # Build uses sed -r option, which is not available in Catalina shipped sed.
   on_catalina do

--- a/Formula/l/llvm@14.rb
+++ b/Formula/l/llvm@14.rb
@@ -31,14 +31,17 @@ class LlvmAT14 < Formula
   # We intentionally use Make instead of Ninja.
   # See: Homebrew/homebrew-core/issues/35513
   depends_on "cmake" => :build
-  # sanitizer_mac.cpp:621:15: error: constexpr function never produces a constant expression [-Winvalid-constexpr]
-  # constexpr u16 GetOSMajorKernelOffset() {
-  depends_on maximum_macos: [:ventura, :build]
   depends_on "python@3.12" => [:build, :test]
 
   uses_from_macos "libedit"
   uses_from_macos "libffi"
   uses_from_macos "ncurses"
+
+  on_macos do
+    # sanitizer_mac.cpp:621:15: error: constexpr function never produces a constant expression [-Winvalid-constexpr]
+    # constexpr u16 GetOSMajorKernelOffset() {
+    depends_on maximum_macos: [:ventura, :build]
+  end
 
   on_linux do
     depends_on "pkgconf" => :build

--- a/Formula/l/llvm@15.rb
+++ b/Formula/l/llvm@15.rb
@@ -31,15 +31,18 @@ class LlvmAT15 < Formula
   # We intentionally use Make instead of Ninja.
   # See: Homebrew/homebrew-core/issues/35513
   depends_on "cmake" => :build
-  # sanitizer_mac.cpp:630:15: error: constexpr function never produces a constant expression [-Winvalid-constexpr]
-  # constexpr u16 GetOSMajorKernelOffset() {
-  depends_on maximum_macos: [:ventura, :build]
   depends_on "python@3.12" => [:build, :test]
   depends_on "zstd"
 
   uses_from_macos "libedit"
   uses_from_macos "libffi"
   uses_from_macos "ncurses"
+
+  on_macos do
+    # sanitizer_mac.cpp:630:15: error: constexpr function never produces a constant expression [-Winvalid-constexpr]
+    # constexpr u16 GetOSMajorKernelOffset() {
+    depends_on maximum_macos: [:ventura, :build]
+  end
 
   on_linux do
     depends_on "pkgconf" => :build

--- a/Formula/l/llvm@16.rb
+++ b/Formula/l/llvm@16.rb
@@ -31,9 +31,6 @@ class LlvmAT16 < Formula
 
   # https://llvm.org/docs/GettingStarted.html#requirement
   depends_on "cmake" => :build
-  # Fails to build with Xcode/CLT 26.4+. Also parts of test fail.
-  # sancov.cpp:521:42: error: chosen constructor is explicit in copy-initialization
-  depends_on maximum_macos: [:sequoia, :build]
   depends_on "ninja" => :build
   depends_on "swig" => :build
   depends_on "python@3.12"
@@ -43,6 +40,12 @@ class LlvmAT16 < Formula
   uses_from_macos "libedit"
   uses_from_macos "libffi"
   uses_from_macos "ncurses"
+
+  on_macos do
+    # Fails to build with Xcode/CLT 26.4+. Also parts of test fail.
+    # sancov.cpp:521:42: error: chosen constructor is explicit in copy-initialization
+    depends_on maximum_macos: [:sequoia, :build]
+  end
 
   on_sequoia do
     depends_on xcode: ["16.4", :build]

--- a/Formula/t/tcc.rb
+++ b/Formula/t/tcc.rb
@@ -10,9 +10,12 @@ class Tcc < Formula
     sha256 "de23af78fca90ce32dff2dd45b3432b2334740bb9bb7b05bf60fdbfc396ceb9c"
 
     depends_on arch: :x86_64
-    # Big Sur and later are not supported
-    # http://savannah.nongnu.org/bugs/?59640
-    depends_on maximum_macos: :catalina
+
+    on_macos do
+      # Big Sur and later are not supported
+      # http://savannah.nongnu.org/bugs/?59640
+      depends_on maximum_macos: :catalina
+    end
   end
 
   livecheck do


### PR DESCRIPTION
To avoid some discrepancy during SimulateSystem, e.g.

Before on macOS:
```console
❯ brew ruby -e 'Homebrew::SimulateSystem.with(os: :linux) { pp Formula["llvm@16"].requirements }'
Set[#<MacOSRequirement: version<="15" [:build]>]
```

While on Linux:
```console
$ brew ruby -e 'Homebrew::SimulateSystem.with(os: :linux) { pp Formula["llvm@16"].requirements }'
Set[]
```

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
