### PR TITLE
auto-editor: enable whisper support

### DIFF
--- a/Formula/a/auto-editor.rb
+++ b/Formula/a/auto-editor.rb
@@ -4,6 +4,7 @@ class AutoEditor < Formula
   url "https://github.com/WyattBlue/auto-editor/archive/refs/tags/31.1.2.tar.gz"
   sha256 "155b594c15c4c0f6ccb822ae2c70089541fb7c516924610ef8fd9c8748416bd1"
   license "Unlicense"
+  revision 1
   head "https://github.com/WyattBlue/auto-editor.git", branch: "master"
 
   bottle do
@@ -18,6 +19,8 @@ class AutoEditor < Formula
   depends_on "nim" => :build
   depends_on "pkgconf" => :build
   depends_on "ffmpeg"
+  depends_on "ggml"
+  depends_on "whisper-cpp"
 
   def install
     system "nimble", "brewmake"
@@ -31,5 +34,9 @@ class AutoEditor < Formula
     system "ffmpeg", "-filter_complex", "testsrc=rate=1:duration=5", mp4in
     system bin/"auto-editor", mp4in, "--edit", "none"
     assert_match(/Duration: 00:00:05\.00,.*Video: h264/m, shell_output("ffprobe -hide_banner #{mp4out} 2>&1"))
+
+    whisper = Formula["whisper-cpp"]
+    system bin/"auto-editor", "whisper", whisper.pkgshare/"jfk.wav",
+      whisper.pkgshare/"for-tests-ggml-tiny.bin"
   end
 end

--- a/Formula/a/auto-editor.rb
+++ b/Formula/a/auto-editor.rb
@@ -8,12 +8,12 @@ class AutoEditor < Formula
   head "https://github.com/WyattBlue/auto-editor.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any, arm64_tahoe:   "be3873cf3d572a3098732636e3d40db1f11937bb6f7de1aca920e1c253aeb91f"
-    sha256 cellar: :any, arm64_sequoia: "58482b8ed78e53fae96a1204edd4bf44105db68ac22415d7ba83b6c9968d84a7"
-    sha256 cellar: :any, arm64_sonoma:  "2f8cda0cb62484bd0e21e2670d8266ff281e5fa7c27f1dd7272d47ae7d2ea794"
-    sha256 cellar: :any, sonoma:        "addb9575ec43d8aa9bb82e1e271ba633ecdd1e1d7c28b04931524732a022eae6"
-    sha256 cellar: :any, arm64_linux:   "2345460b218d43c1b847cd347ad0a3827c1ac2f84799a01131a9f1c5f8f04944"
-    sha256 cellar: :any, x86_64_linux:  "4885e982367ef0c16e74da1eabba8c4695ce0d6eea395a4bb099efc66b72db2b"
+    sha256 cellar: :any, arm64_tahoe:   "958c8e14f0f72660553d9f49472b4ea3b7133b3b053c15071d87e1ab95798e70"
+    sha256 cellar: :any, arm64_sequoia: "507568c03b15a5d601f94205da6ab9c7e38fcf8001ec744b5f10a977ea3f57d5"
+    sha256 cellar: :any, arm64_sonoma:  "f2d22a3b077034be11c177db6293f6aef6d3d2340d9ee370afed19aea97b891b"
+    sha256 cellar: :any, sonoma:        "2c3ba1e2ef60151991601ab8ebb93217266d21e3f78f2a85058e8e7961852786"
+    sha256 cellar: :any, arm64_linux:   "63fe1559ebfcb6e5be359dce9dd7c440adfd7de38ad1e2d6bff7a095bfd52d53"
+    sha256 cellar: :any, x86_64_linux:  "1abee32c564e15b89a3295803e135579c76f319dea5b7b8df9d53bb3db24f2e3"
   end
 
   depends_on "nim" => :build


### PR DESCRIPTION
auto-editor's build auto-detects whisper via pkg-config, so depending on whisper-cpp (and ggml, which it links directly) turns on the `auto-editor whisper` transcription subcommand. Revision bump so bottles are rebuilt with the new linkage.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Used fable to do almost everything. However frankly I shouldn't have to have done anything in the first place since this change was directly called out in the first line of the ae changelog. 

-----
