### PR TITLE
terramaid: deprecate

### DIFF
--- a/Formula/t/terramaid.rb
+++ b/Formula/t/terramaid.rb
@@ -17,6 +17,10 @@ class Terramaid < Formula
     sha256 cellar: :any,                 x86_64_linux:  "c1146e76edb44538f2252fbb80fd13ff11c6f700f6cc5e88337f27cb3a0d7bce"
   end
 
+  # https://github.com/RoseSecurity/Terramaid/issues/565
+  deprecate! date: "2026-07-04", because: :checksum_mismatch
+  disable! date: "2027-07-04", because: :deprecated_upstream
+
   depends_on "go" => [:build, :test]
   depends_on "opentofu" => :test
 


### PR DESCRIPTION
Ref:
* https://github.com/RoseSecurity/Terramaid/issues/565#issuecomment-4879528613
* Closes https://github.com/Homebrew/homebrew-core/pull/290269
* https://github.com/Homebrew/homebrew-core/pull/288803

I don't think we have a replacement formula (for Hashicorp licensing reasons) that would (once released) include:
* https://github.com/hashicorp/terraform/pull/38719

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
