### PR TITLE
betterglobekey 4.0.1 (new formula)

### DIFF
--- a/Formula/b/betterglobekey.rb
+++ b/Formula/b/betterglobekey.rb
@@ -1,0 +1,28 @@
+class Betterglobekey < Formula
+  desc "Reworked Globe key for faster input source switching"
+  homepage "https://github.com/Serpentiel/betterglobekey"
+  url "https://github.com/Serpentiel/betterglobekey/archive/refs/tags/v4.0.1.tar.gz"
+  sha256 "7afa2128bbd2fb2a7c33f4a9b6c2ddfe26a370017d9eb8a0dee904c49f7e915d"
+  license "MIT"
+  head "https://github.com/Serpentiel/betterglobekey.git", branch: "main"
+
+  depends_on "go" => :build
+  depends_on :macos
+
+  def install
+    system "go", "build", *std_go_args(ldflags: "-X main.version=#{version}")
+    generate_completions_from_executable(bin/"betterglobekey", "completion")
+  end
+
+  service do
+    run opt_bin/"betterglobekey"
+    keep_alive true
+    log_path var/"log/betterglobekey.log"
+    error_log_path var/"log/betterglobekey.log"
+  end
+
+  test do
+    list = shell_output("#{bin}/betterglobekey list")
+    assert_match(/^com\.apple\.keylayout\./, list)
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

AI-assisted contribution by Antigravity AI version 3.5 of 100% of the work. Validation steps done by USER.

Built and tested locally on macOS running arm64

This PR adds a new formula `betterglobekey` version `4.0.1`.
