### PR TITLE
mole 1.45.0

### DIFF
--- a/Formula/m/mole.rb
+++ b/Formula/m/mole.rb
@@ -1,8 +1,8 @@
 class Mole < Formula
   desc "Deep clean and optimize your Mac"
   homepage "https://mole.fit"
-  url "https://github.com/tw93/Mole/archive/refs/tags/V1.44.1.tar.gz"
-  sha256 "fa5abe50f190de58bba273352928fbae80a7214d0711937d27914edf7af2da1e"
+  url "https://github.com/tw93/Mole/archive/refs/tags/V1.45.0.tar.gz"
+  sha256 "2896681e5e1482a2e8ce17f0bca0ddbf456b7b64ff31d8d25757adf55b854b33"
   license "GPL-3.0-or-later"
   head "https://github.com/tw93/Mole.git", branch: "main"
 

--- a/Formula/m/mole.rb
+++ b/Formula/m/mole.rb
@@ -15,10 +15,10 @@ class Mole < Formula
   no_autobump! because: :bumped_by_upstream
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "2d7de7e43617358d520188981af3dadd17a0bc8379143647b58ebb4dc8009e54"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "9eae9fcaca512ce232eb0b43eaa8aa003d64e54ef7eaa5a58b54233442b1ff6d"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "619a840adb0551ff8876f1eb2cf31893506fd5059f70905191a397f321688d4a"
-    sha256 cellar: :any_skip_relocation, sonoma:        "2f3dcf2278e7af81ebc09c96c453c426860e947214bb3f4f27e742768ceffcd0"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "3dcde32a92873490566661149d543cff0219368c4dcafc2e4e9b4ff54388626a"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "dba2e98b4ad3939e2d54cb1cc467ea28a4f36440ef412a6112eda9ff5812dc41"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "94baf80c6f661be67189f2d716bbac3f11331fbdd2453d84467bc64dd044107d"
+    sha256 cellar: :any_skip_relocation, sonoma:        "307c5ddd824da8c0f8da0a076b28a661aca27e0ff34bd86961d9535aabc96527"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
Release notes: https://github.com/tw93/Mole/releases/tag/V1.45.0

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

The formula diff passed Homebrew Core CI on macOS 14, 15, and 26 arm64, plus macOS 14 x86_64. Local build and audit were not run.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI assisted with diagnosing and repairing the release automation after this PR was closed for an outdated body. The maintainer verified the formula diff, release assets, checksums, Core CI results, and current open PR list.

-----