### PR TITLE
workflows: skip recursive dependents by default

### DIFF
--- a/.github/workflows/scripts/check-labels.js
+++ b/.github/workflows/scripts/check-labels.js
@@ -105,13 +105,6 @@ module.exports = async ({github, context, core}, formulae_detect, dependent_test
       console.log('No CI-build-dependents-from-source label found. Not passing --build-dependents-from-source to brew test-bot.')
     }
 
-    if (label_names.includes('CI-skip-recursive-dependents')) {
-      console.log('CI-skip-recursive-dependents label found. Passing --skip-recursive-dependents to brew test-bot.')
-      test_bot_dependents_args.push('--skip-recursive-dependents')
-    } else {
-      console.log('No CI-skip-recursive-dependents label found. Not passing --skip-recursive-dependents to brew test-bot.')
-    }
-
     if (label_names.includes('CI-skip-livecheck')) {
       console.log('CI-skip-livecheck label found. Passing --skip-livecheck to brew test-bot.')
       test_bot_formulae_args.push('--skip-livecheck')

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -410,26 +410,6 @@ jobs:
               keep_if_no_match: true
               allow_any_match: true
 
-            - label: CI-skip-recursive-dependents
-              path: "Formula/.+/(\
-                alsa-lib|\
-                ca-certificates|\
-                certifi|\
-                cmake|\
-                curl|\
-                gettext|\
-                glib|\
-                harfbuzz|\
-                libcap|\
-                openssl@3|\
-                rust|\
-                sqlite|\
-                systemd|\
-                wayland-protocols\
-                ).rb"
-              keep_if_no_match: true
-              allow_any_match: true
-
             - label: CI-linux-self-hosted
               path: "Formula/.+/(\
                 dart-sdk|\


### PR DESCRIPTION
Opening this as potential idea we have proposed before but never followed up on. We did make indirect linkage mandatory now.

Maybe languages like Python could still be incomplete. Though we don't have that many dependency trees:
* `cryptography --> cffi --> pycparser`
* `scipy --> numpy`
* `pygobject3 -> py3cairo`

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
