### PR TITLE
openssl@4: use brew perl on Linux to minimize issues across distros

### DIFF
--- a/Formula/o/openssl@4.rb
+++ b/Formula/o/openssl@4.rb
@@ -25,25 +25,7 @@ class OpensslAT4 < Formula
 
   depends_on "ca-certificates" => :no_linkage
 
-  on_linux do
-    resource "Test::Harness" do
-      url "https://cpan.metacpan.org/authors/id/L/LE/LEONT/Test-Harness-3.52.tar.gz"
-      mirror "http://cpan.metacpan.org/authors/id/L/LE/LEONT/Test-Harness-3.52.tar.gz"
-      sha256 "8fe65cfc0261ed3c8a4395f0524286f5719669fe305f9b03b16cf3684d62cd70"
-    end
-
-    resource "Test::More" do
-      url "https://cpan.metacpan.org/authors/id/E/EX/EXODIST/Test-Simple-1.302220.tar.gz"
-      mirror "http://cpan.metacpan.org/authors/id/E/EX/EXODIST/Test-Simple-1.302220.tar.gz"
-      sha256 "bbca30d9fb64a67a28ccd9086cdc08cdb6046423fa032d9101f978d7ccd46cf9"
-    end
-
-    resource "ExtUtils::MakeMaker" do
-      url "https://cpan.metacpan.org/authors/id/B/BI/BINGOS/ExtUtils-MakeMaker-7.78.tar.gz"
-      mirror "http://cpan.metacpan.org/authors/id/B/BI/BINGOS/ExtUtils-MakeMaker-7.78.tar.gz"
-      sha256 "43b33c20f8d82dba7cc48f8cd702f8fc9811e9d07880886dfd31b7077bd4a3a6"
-    end
-  end
+  uses_from_macos "perl" => :build
 
   # Backport commits to avoid test intermittent failures
   patch do
@@ -56,24 +38,6 @@ class OpensslAT4 < Formula
   end
 
   def install
-    if OS.linux?
-      ENV.prepend_create_path "PERL5LIB", buildpath/"lib/perl5"
-      ENV.prepend_path "PATH", buildpath/"bin"
-
-      %w[ExtUtils::MakeMaker Test::Harness Test::More].each do |r|
-        resource(r).stage do
-          system "perl", "Makefile.PL", "INSTALL_BASE=#{buildpath}"
-          system "make", "PERL5LIB=#{ENV["PERL5LIB"]}", "CC=#{ENV.cc}"
-          system "make", "install"
-        end
-      end
-    end
-
-    # This ensures where Homebrew's Perl is needed the Cellar path isn't
-    # hardcoded into OpenSSL's scripts, causing them to break every Perl update.
-    # Whilst our env points to opt_bin, by default OpenSSL resolves the symlink.
-    ENV["PERL"] = formula_opt_bin("perl")/"perl" if which("perl") == formula_opt_bin("perl")/"perl"
-
     configure_args = %W[
       --prefix=#{prefix}
       --openssldir=#{pkgetc}


### PR DESCRIPTION
Experimenting here to avoid some Perl installation differences across Linux distros. 

Main disadvantage is `perl` and its dependency `gdbm` are non-relocatable so users on non-standard prefix would need to also build those from source. `gdbm` can be relocatable if NLS was disabled (as seen by relocatable macOS bottles). `perl` however explicitly rejects relocatable support when shared library is enabled.

Brew perl is new enough to have all core modules (including Test::More and Test::Harness):
- https://github.com/openssl/openssl/blob/master/NOTES-PERL.md#required-perl-modules

We can avoid `ENV["PERL"]`. It is used to create shebang but can instead use `#!/usr/bin/env perl` default.
```console
~/.linuxbrew/etc/openssl@4$ grep -R perl
misc/CA.pl:#!/usr/bin/env perl
misc/tsget:#!/usr/bin/env perl
misc/tsget.pl:#!/usr/bin/env perl
```

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
