### PR TITLE
opencc: add test for jieba plugin

### DIFF
--- a/Formula/o/opencc.rb
+++ b/Formula/o/opencc.rb
@@ -37,5 +37,14 @@ class Opencc < Formula
     output = pipe_output(bin/"opencc", input)
     output = output.force_encoding("UTF-8") if output.respond_to?(:force_encoding)
     assert_match "中國鼠標軟件打印機", output
+
+    # The jieba segmentation plugin is only built by default on macOS
+    return unless OS.mac?
+
+    assert_path_exists lib/"opencc/plugins"/shared_library("libopencc-jieba")
+    input = "城堡里的士兵"
+    output = pipe_output("#{bin}/opencc -c s2twp_jieba.json", input)
+    output = output.force_encoding("UTF-8") if output.respond_to?(:force_encoding)
+    assert_match "城堡裡的士兵", output
   end
 end


### PR DESCRIPTION
<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI-assisted contribution by Claude Code (Fable 5) for most of the work. Build, test, and audit validation done by AI; final diff reviewed by the user.

Built and tested locally on macOS 26 (Tahoe) running arm64.

Since OpenCC 1.4.1 the jieba segmentation plugin is built by default on macOS top-level builds, so the formula no longer needs `-DBUILD_OPENCC_JIEBA_PLUGIN=ON` (previous scope of this PR). This PR now only adds a test verifying the plugin: `libopencc-jieba` exists and `s2twp_jieba.json` conversion works (城堡里的士兵 → 城堡裡的士兵). The plugin is not built by default on Linux, so the new test is macOS-only.

Validation performed (by AI, on this exact revision):
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew reinstall --build-from-source opencc`
- `brew test opencc` (both existing and new assertions pass)
- `brew audit --strict opencc` and `brew style` — clean
