### PR TITLE
fish: remove postinstall

### DIFF
--- a/Formula/f/fish.rb
+++ b/Formula/f/fish.rb
@@ -15,12 +15,13 @@ class Fish < Formula
   pour_bottle? only_if: :default_prefix
 
   bottle do
-    sha256 cellar: :any, arm64_tahoe:   "997643016a4e08dff753dd1e0e3ff309ddaa97cb275d6b0a3a58b6481fe81ae7"
-    sha256 cellar: :any, arm64_sequoia: "42eb74c806fcd8bc9063cc4062cb33d252332cd6e5b0e38cc9e4a5282700c8d1"
-    sha256 cellar: :any, arm64_sonoma:  "29df45ceb1e4661b944e4ac0cc4ee75e6e6fcf133abd06f9ce490cdd81b9390b"
-    sha256 cellar: :any, sonoma:        "86fd899be4526711c7390fa832728506da964bdaf00ce3399f46ff40a757e368"
-    sha256 cellar: :any, arm64_linux:   "220dd080c81fedb2bc9f96a41784c64be645035dcb6ea481c7849845eba931fa"
-    sha256 cellar: :any, x86_64_linux:  "9585d0abfcb0476a1620bc79b74894e4509435267b6d903c23265bff293cbb98"
+    rebuild 1
+    sha256 cellar: :any, arm64_tahoe:   "f7a1e3e1aade3b50016d0c9ab2b7217bad0b74e6710eb564eb8f99f42d89b540"
+    sha256 cellar: :any, arm64_sequoia: "f7b956b27431b856cdbbe093e6316d77702a7b807ee19518e6074b702e4ad950"
+    sha256 cellar: :any, arm64_sonoma:  "cf6cfae838dacdd0ae79e9b0d03f988c4ce7ed1d5a7c00d35f65e914c8958f38"
+    sha256 cellar: :any, sonoma:        "42a04063c4c04b49141a82eef31750238a5b6d40e833db00c88a9442441a6cca"
+    sha256 cellar: :any, arm64_linux:   "759ba573dd3a5687c1da187c939d13f036fb97380fab82cbde7ccaf3780114d1"
+    sha256 cellar: :any, x86_64_linux:  "8143f64d4019bc79b38d5ea089f7bbbd6ac6b7e657eb1b79ed20a19362ccde59"
   end
 
   depends_on "cmake" => :build

--- a/Formula/f/fish.rb
+++ b/Formula/f/fish.rb
@@ -39,12 +39,6 @@ class Fish < Formula
     system "cmake", "--install", "build"
   end
 
-  def post_install
-    (pkgshare/"vendor_functions.d").mkpath
-    (pkgshare/"vendor_completions.d").mkpath
-    (pkgshare/"vendor_conf.d").mkpath
-  end
-
   test do
     system bin/"fish", "-c", "echo"
     output = shell_output("#{bin}/fish -c 'set --show fish_function_path'")


### PR DESCRIPTION
Can't see reason why cellar directories were created in postinstall when configure was set to use homebrew prefix directories: https://github.com/Homebrew/homebrew-core/commit/d32bcc2757ea017b60168a07c12ea474e03b84f5

Removing to simplify formula. Can consider .keepme file or post_install_steps if there is a scenario these are still needed.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
