### PR TITLE
writersproof-cli 1.5.2 (new formula)

### DIFF
--- a/Formula/w/writersproof-cli.rb
+++ b/Formula/w/writersproof-cli.rb
@@ -1,0 +1,31 @@
+class WritersproofCli < Formula
+  desc "Cryptographic authorship witnessing CLI for writers and creators"
+  homepage "https://writersproof.com"
+  url "https://github.com/writerslogic/writersproof-cli/archive/refs/tags/v1.5.2.tar.gz"
+  sha256 "b9700174bf5232369b5e48d1ca54dbb2d855b87bce90092d6dc8fcdf4c9df3a4"
+  license "AGPL-3.0-only"
+  head "https://github.com/writerslogic/writersproof-cli.git", branch: "main"
+
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "TODO"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "TODO"
+    sha256 cellar: :any_skip_relocation, sequoia:       "TODO"
+    sha256 cellar: :any_skip_relocation, sonoma:        "TODO"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "TODO"
+  end
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install",
+      "--locked",
+      "--root", prefix,
+      "--path", "apps/cpoe_cli",
+      "--features", "default"
+    bin.install "bin/writersproof-cli"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/writersproof-cli --version")
+  end
+end


### PR DESCRIPTION
-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source writersproof-cli`?
- [ ] Is your test running fine `brew test writersproof-cli`?
- [ ] Does your build pass `brew audit --strict writersproof-cli` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source writersproof-cli`)? If this is a new formula, does it pass `brew audit --new writersproof-cli`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----