### PR TITLE
rustup: remove formatting from caveat for formulae.brew.sh

### DIFF
--- a/Formula/r/rustup.rb
+++ b/Formula/r/rustup.rb
@@ -72,7 +72,7 @@ class Rustup < Formula
   def caveats
     <<~EOS
       To use rustup, ensure you have "$(brew --prefix rustup)/bin" in your $PATH:
-        #{Formatter.url("https://rust-lang.github.io/rustup/installation/already-installed-rust.html")}
+        https://rust-lang.github.io/rustup/installation/already-installed-rust.html
 
       This formula no longer provides `rustup-init`.
     EOS


### PR DESCRIPTION
Otherwise ANSI codes show up at https://formulae.brew.sh/formula/rustup#default
```
To use rustup, ensure you have "$(brew --prefix rustup)/bin" in your $PATH:
    [4mhttps://rust-lang.github.io/rustup/installation/already-installed-rust.html[24m

This formula no longer provides `rustup-init`.
```

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
