### PR TITLE
postgresql@17: revert use init_data_dir

### DIFF
--- a/Formula/p/postgresql@17.rb
+++ b/Formula/p/postgresql@17.rb
@@ -114,13 +114,10 @@ class PostgresqlAT17 < Formula
     inreplace makefile, "-install_name '#{lib}/postgresql/", "-install_name '$(libdir)/"
   end
 
-  post_install_steps do
-    mkdir_p "log"
-    # Don't initialize database, it clashes when testing other PostgreSQL versions.
-    init_data_dir "postgresql@17", using: :postgresql_initdb
-  end
-
   def post_install
+    (var/"log").mkpath
+    postgresql_datadir.mkpath
+
     # Manually link files from keg to non-conflicting versioned directories in HOMEBREW_PREFIX.
     %w[include lib share].each do |dir|
       dst_dir = HOMEBREW_PREFIX/dir/name
@@ -143,6 +140,11 @@ class PostgresqlAT17 < Formula
 
     # Also link versioned executables
     bin.each_child { |f| (HOMEBREW_PREFIX/"bin").install_symlink f => "#{f.basename}-#{version.major}" }
+
+    # Don't initialize database, it clashes when testing other PostgreSQL versions.
+    return if ENV["HOMEBREW_GITHUB_ACTIONS"]
+
+    system bin/"initdb", "--locale=en_US.UTF-8", "-E", "UTF-8", postgresql_datadir unless pg_version_exists?
   end
 
   def postgresql_datadir
@@ -151,6 +153,10 @@ class PostgresqlAT17 < Formula
 
   def postgresql_log_path
     var/"log/#{name}.log"
+  end
+
+  def pg_version_exists?
+    (postgresql_datadir/"PG_VERSION").exist?
   end
 
   def caveats


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Workaround for #291537. Fixing this properly needs a fix in `brew` and
another release, so let's revert it first until then.

This reverts commit b78fc98cb83132c9e1e0a53fa48d6270199405b1.
