### PR TITLE
workflows/triage: temporarily stop using CI-linux-self-hosted-deps

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -424,10 +424,9 @@ jobs:
               keep_if_no_match: true
               allow_any_match: true
 
-            - label: CI-linux-self-hosted-deps
+            - label: CI-no-fail-fast-deps
               path: "Formula/.+/(\
                 glib|\
-                libva|\
                 libxml2|\
                 mesa|\
                 openssl@3|\


### PR DESCRIPTION
At least until we actually have a runner available. Instead use `CI-no-fail-fast-deps` to avoid run failing on timeout so we get partial coverage of Linux dependents (particularly important for stuff like Mesa which is heavily used on Linux)

Also, once we get shards into a more stable state, should try to replace self-hosted with parallel runners.

Removing `libva` as we now skip recursive dependents so only 4 formulae

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
