### PR TITLE
webfont 12.4.1 (new formula)

### DIFF
--- a/Formula/w/webfont.rb
+++ b/Formula/w/webfont.rb
@@ -5,6 +5,10 @@ class Webfont < Formula
   sha256 "cc22a60186c0ec0d7367945bff513318ad736bb39b3705d4b00b70c18584eb28"
   license "MIT"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, all: "44510bb76e1f5bb276f70c0749afe263feb88bdad4ae7a9656ce189dde9faa5b"
+  end
+
   depends_on "node"
 
   def install

--- a/Formula/w/webfont.rb
+++ b/Formula/w/webfont.rb
@@ -1,0 +1,24 @@
+class Webfont < Formula
+  desc "Generator of fonts from SVG icons, with TTF encoding and WOFF/WOFF2 decoding"
+  homepage "https://webfont.js.org/"
+  url "https://registry.npmjs.org/webfont/-/webfont-12.4.1.tgz"
+  sha256 "cc22a60186c0ec0d7367945bff513318ad736bb39b3705d4b00b70c18584eb28"
+  license "MIT"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink libexec.glob("bin/*")
+  end
+
+  test do
+    (testpath/"icon.svg").write <<~SVG
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path d="M2 2h12v12H2z"/></svg>
+    SVG
+
+    system bin/"webfont", testpath/"icon.svg", "-d", testpath, "-f", "woff2"
+    assert_path_exists testpath/"webfont.woff2"
+    assert_match version.to_s, shell_output("#{bin}/webfont --version")
+  end
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven't performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Cursor (AI) assisted with drafting the formula from upstream [`HomebrewFormula/webfont.rb`](https://github.com/itgalaxy/webfont/blob/master/HomebrewFormula/webfont.rb) in [itgalaxy/webfont](https://github.com/itgalaxy/webfont). I manually verified on macOS (Apple Silicon): `brew style`, `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source` via a local tap with the same formula content, `brew test webfont`, and `brew audit --strict --new webfont` (all exit 0; installed version 12.4.1). Homebrew CI (`brew test-bot`) also passed on this PR. Upstream tracking: https://github.com/itgalaxy/webfont/issues/785

-----