### PR TITLE
cmus: remove mp4v2 support as incompatible license

### DIFF
--- a/Formula/c/cmus.rb
+++ b/Formula/c/cmus.rb
@@ -32,13 +32,13 @@ class Cmus < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 arm64_tahoe:   "51b42ebc31527eea5562974b745eb1c961436282882ffed5a183e043a997987d"
-    sha256 arm64_sequoia: "9878efe2232228b9e5e67a588ebd22867bb0b13fb9d7155bb1c697d2ecaf0376"
-    sha256 arm64_sonoma:  "c13b26723f0d2547bb8fcc31d8437c738c437f01f4245b281e294e0c3928d7f7"
-    sha256 sonoma:        "09934b3459b7b8d617aa3f46f6a7012d245d92d85d70a3c46fd22f80d8dff083"
-    sha256 arm64_linux:   "5ac1322da5e1d6ab4dd872e5a50dfc938628f9d6e57d2454c8e6435c4eb004cf"
-    sha256 x86_64_linux:  "47bdd3c67a317fd239b8af7b6e0a177e16ba1047c729e30af4dfb4b6598ed878"
+    rebuild 2
+    sha256 arm64_tahoe:   "00ca0987ecc6c79c9b380a96ca9ad3d261567ce97903554ab0367530a39d59bf"
+    sha256 arm64_sequoia: "5301455c054375b174fc71cf627383fe7c612d27ac65cdbf9eaf6fd4f3a86343"
+    sha256 arm64_sonoma:  "18859fcf9d5693580cb8124027b64a29e6f8820be0d95a9f116e5b87982a7bb5"
+    sha256 sonoma:        "e7a5d77b9e0c334f4c5309fb10a163eb80ed8a01dd3f5224c98339cf55bc1bee"
+    sha256 arm64_linux:   "2205b91cc172119113461b5a6cbc82d2bcaa557ae484042e9b15acec432b3197"
+    sha256 x86_64_linux:  "9af11bfb0fd581b8ccad7ae05a6e1cf30a63b8858167cc25f0859c25917a79e5"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/c/cmus.rb
+++ b/Formula/c/cmus.rb
@@ -48,7 +48,6 @@ class Cmus < Formula
   depends_on "libao" # See https://github.com/cmus/cmus/issues/1130
   depends_on "libvorbis"
   depends_on "mad"
-  depends_on "mp4v2"
   depends_on "ncurses"
   depends_on "opusfile"
 
@@ -58,6 +57,11 @@ class Cmus < Formula
   end
 
   def install
+    # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=765634#10
+    # https://www.gnu.org/licenses/license-list.html#MPL
+    # https://www.mozilla.org/en-US/MPL/1.1/FAQ/
+    odie "mp4v2 is licensed under MPL-1.1 which is incompatible with GPL!" if deps.map(&:name).include?("mp4v2")
+
     args = [
       "prefix=#{prefix}",
       "mandir=#{man}",


### PR DESCRIPTION
Same as Debian decision at https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=765634#10

Legal incompatibility is documented by both sides:
* GNU: https://www.gnu.org/licenses/license-list.html#MPL
* Mozilla: https://www.mozilla.org/en-US/MPL/1.1/FAQ/

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
