### PR TITLE
node: disable broken SEA, caveat to make intentional

### DIFF
--- a/Formula/c/c-ares.rb
+++ b/Formula/c/c-ares.rb
@@ -22,12 +22,13 @@ class CAres < Formula
   end
 
   bottle do
-    sha256 cellar: :any, arm64_tahoe:   "9de9c5a3a303af0a89d4508b5c0eb07d30e8c084f003fcf89e777769c28c66db"
-    sha256 cellar: :any, arm64_sequoia: "4f9370924b6868bcb8f840133d22e476bd7098a6d80c1913b469fb0999dfd070"
-    sha256 cellar: :any, arm64_sonoma:  "c1525a2aea970f1f367a317fa412c2ba33d3c1634ccfea4901fcc7bb396982fc"
-    sha256 cellar: :any, sonoma:        "bf5170e7d181149e2ca5fec4dacb590a27750af163b701f8d3a184ce7423e052"
-    sha256 cellar: :any, arm64_linux:   "82f0cf8f8880f9d00b1988160eab469bebbe7d57826b9fc7d65946d1c8fde5eb"
-    sha256 cellar: :any, x86_64_linux:  "fd7cff6647754ab3ff999bd60927958f0fd02067193c82f4c26191e37130ca3f"
+    rebuild 1
+    sha256 cellar: :any, arm64_tahoe:   "31d95f39faa99ae238ac17ba33076318c51ff3153bc1f43f8d5c4c4de0e7bc6c"
+    sha256 cellar: :any, arm64_sequoia: "a16212e728de407ad8a6f24e2a2e77e08b2f48226fb4e8dfeb2128063f73726d"
+    sha256 cellar: :any, arm64_sonoma:  "10c36b85a92ba1008bacf09cf4bdb00567043d7f5ef5be466b656a582c6cd2e4"
+    sha256 cellar: :any, sonoma:        "6b6404874116de97753bb8b26754f6c315813ca6df8bd41a0561f1897d9843ef"
+    sha256 cellar: :any, arm64_linux:   "59e40c36c93af012ea29a8598438a91178f8a291f1e637f8758b6e74a5709d2b"
+    sha256 cellar: :any, x86_64_linux:  "47796f02038044993a377c04fb2a5081cbe612e20a59963c6b4da07d9f056127"
   end
 
   depends_on "cmake" => :build

--- a/Formula/c/c-ares.rb
+++ b/Formula/c/c-ares.rb
@@ -1,11 +1,20 @@
 class CAres < Formula
   desc "Asynchronous DNS library"
   homepage "https://c-ares.org/"
-  url "https://github.com/c-ares/c-ares/releases/download/v1.34.7/c-ares-1.34.7.tar.gz"
-  sha256 "556f781dd188ad932dc8263fee0ad3aaba675b4cd8e54d86908681b43ce3e327"
   license "MIT"
   compatibility_version 1
   head "https://github.com/c-ares/c-ares.git", branch: "main"
+
+  stable do
+    url "https://github.com/c-ares/c-ares/releases/download/v1.34.7/c-ares-1.34.7.tar.gz"
+    sha256 "556f781dd188ad932dc8263fee0ad3aaba675b4cd8e54d86908681b43ce3e327"
+
+    # Backport commit to revert API/ABI break
+    patch do
+      url "https://github.com/c-ares/c-ares/commit/636f85326908a521f232c7e7acb6c3484582391d.patch?full_index=1"
+      sha256 "edc660df5ef02a47b4b8e0f14dad5f24faceeaf2e387cfa6a50336ebc28febe9"
+    end
+  end
 
   livecheck do
     url :homepage

--- a/Formula/n/node.rb
+++ b/Formula/n/node.rb
@@ -84,13 +84,6 @@ class Node < Formula
   deny_network_access! [:build, :postinstall]
 
   def install
-    # Backport fix for bundled LIEF's bundled spdlog's bundled fmt.
-    # Should be fixed when new LIEF version with following commit is released and used by node:
-    # https://github.com/lief-project/LIEF/commit/710637216b1f6f19569002d62e43fca201b9d91c
-    inreplace "deps/LIEF/third-party/spdlog/include/spdlog/fmt/bundled/format.h",
-              "#ifndef FMT_MODULE\n#  include <cmath>",
-              "#ifndef FMT_MODULE\n#  include <stdlib.h>\n#  include <cmath>"
-
     # make sure subprocesses spawned by make are using our Python 3
     ENV["PYTHON"] = which("python3.14")
 
@@ -99,12 +92,14 @@ class Node < Formula
 
     # Never install the bundled "npm", always prefer our
     # installation from tarball for better packaging control.
+    # Disable SEA as incompatible with --shared, https://github.com/nodejs/node/issues/63126
     args = %W[
       --prefix=#{prefix}
       --without-npm
       --with-intl=system-icu
       --shared
       --openssl-use-def-ca-store
+      --disable-single-executable-application
     ]
     args << "--tag=head" if build.head?
 
@@ -144,7 +139,7 @@ class Node < Formula
     # - `--shared-gtest` is only used for building the test suite, which we don't run here.
     # - `--shared-simdutf` seems to result in build failures.
     # - `--shared-temporal_capi` is only used when building with `--v8-enable-temporal-support`
-    # - `--shared-lief` is not available as dependency in Homebrew.
+    # - `--shared-lief` is only used for disabled SEA feature
     ignored_shared_flags = %w[
       gtest
       simdutf
@@ -230,6 +225,15 @@ class Node < Formula
     end
 
     (node_modules/"npm/npmrc").atomic_write("prefix = #{HOMEBREW_PREFIX}\n")
+  end
+
+  # Explain why some features enabled in upstream binaries are disabled in Homebrew.
+  # These require fixes upstream for Homebrew to consider enabling them. Do not open issues.
+  def caveats
+    <<~EOS
+      Single Executable Application is disabled as it doesn't work with shared libnode.
+      Temporal support is disabled as it doesn't work with shared ICU library.
+    EOS
   end
 
   test do

--- a/Formula/n/node.rb
+++ b/Formula/n/node.rb
@@ -13,12 +13,13 @@ class Node < Formula
   end
 
   bottle do
-    sha256 arm64_tahoe:   "bbac60159fbed617a409fc241113a7d4824e115c6193df2661c9be6b6ed3f59f"
-    sha256 arm64_sequoia: "99cef8119eebd10eeedd277f9abd5ef22e1dabb7ee497c99fa4409c201ac9f4d"
-    sha256 arm64_sonoma:  "c8797fda23595d84fa8a8e68cedd62c63c5ff50228ac8a9fa3f6528da83a9e65"
-    sha256 sonoma:        "49a0dba0e9620845c2fb4a4eaec604ac90d013773e4e02945eca9e167d7e3be9"
-    sha256 arm64_linux:   "3cf5b744223b997a37f12a87a5cdaf09308c0575ffe245af1b1ebb9cdfb80f28"
-    sha256 x86_64_linux:  "4553aa69ff2ed12259d799b995fce3922861cf181db9c7ab51a868fe3fcefcef"
+    rebuild 1
+    sha256 arm64_tahoe:   "2343b568993c76af25f49e1f41e60017dec641fca567983d80f38a5469203055"
+    sha256 arm64_sequoia: "1506cbc290e13886da8028d502673770ed2e011d055cf1d8f72d0a552c404476"
+    sha256 arm64_sonoma:  "f04911fa7702d76b83f3280102e99025d96509f6795ffa5368bd1f09ef637001"
+    sha256 sonoma:        "727f75f06f070b260b31b757c55e76f0cf6f9ec9850ffab25c7bd20b161f129a"
+    sha256 arm64_linux:   "0a2637699f4378643e9c3e09dd6887a116ad3f4529641d3304be84e5fc8d3420"
+    sha256 x86_64_linux:  "91c4484fc229a208e1704a2ed28f8df98505ce5c766ad24020c26609d94a731f"
   end
 
   depends_on "pkgconf" => :build


### PR DESCRIPTION
SEA uses LIEF to search for a particular marker inside the `node` binary. When built with `--shared` (libnode.147.{so,dylib}), this is located in the library thus leading to broken support.

Original message is vague:
`Error: sentinel NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2 not found`

while disabling it directly states this to user and avoids compiling broken features:
`node: Single executable application is disabled.`

Can be reproduced on macOS and Linux following:
- https://nodejs.org/api/single-executable-applications.html#single-executable-applications

---

Let's also use caveat to explain this is an intentional decision. Upstream has already gotten an issue on this:
- `https://github.com/nodejs/node/issues/63126`

Similarly add caveat why temporal is disabled given we had 2 issues for this:
- `https://github.com/Homebrew/homebrew-core/issues/287072`
- `https://github.com/Homebrew/homebrew-core/issues/281625`

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
