### PR TITLE
pypy3.10: move up disable date

### DIFF
--- a/Formula/p/pypy3.10.rb
+++ b/Formula/p/pypy3.10.rb
@@ -20,7 +20,7 @@ class Pypy310 < Formula
 
   # PyPy 3.10 was dropped in 7.3.20 and source tarballs have been removed
   deprecate! date: "2026-06-22", because: :does_not_build
-  disable! date: "2027-06-22", because: :does_not_build
+  disable! date: "2026-09-22", because: :does_not_build
 
   depends_on "pkgconf" => :build
   depends_on "pypy" => :build


### PR DESCRIPTION
One of formulae with postinstall we won't be able to replace and won't build on any OS. Doesn't meet "popularity" metric for minimum 6 months moving up date.

Also code is based on Python 3.10.14 so 6 security patch releases out of date. 

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
