### PR TITLE
Pass `--privileged` to Linux containers on dispatch jobs

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -85,7 +85,7 @@ jobs:
                   runner:    s,
                   container: {
                     image:   "ghcr.io/homebrew/brew:main",
-                    options: "--user=linuxbrew -e GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED"
+                    options: "--user=linuxbrew --privileged"
                   },
                   workdir:   "/github/home",
                   cleanup:   false

--- a/cmd/determine-rebottle-runners.rb
+++ b/cmd/determine-rebottle-runners.rb
@@ -33,7 +33,7 @@ module Homebrew
           runner:    linux_runner,
           container: {
             image:   "ghcr.io/homebrew/brew:main",
-            options: "--user=linuxbrew -e GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED",
+            options: "--user=linuxbrew --privileged",
           },
           workdir:   "/github/home",
         }


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Our `dispatch-*` workflows are currently broken because we try to use
the `bwrap` sandbox in them but the container lacks privileges. See
Homebrew/brew#22907.

Also, remove `GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED`, as this is no longer
needed. See Homebrew/brew#22995.
