### PR TITLE
vite-plus 0.2.2 (fix resource revisions)

### DIFF
--- a/Formula/v/vite-plus.rb
+++ b/Formula/v/vite-plus.rb
@@ -1,0 +1,81 @@
+class VitePlus < Formula
+  desc "Unified toolchain and entry point for web development"
+  homepage "https://viteplus.dev"
+  url "https://github.com/voidzero-dev/vite-plus/archive/refs/tags/v0.2.3.tar.gz"
+  sha256 "8d21fd9ff529017988eb834bf23014af329a2a4bbd009c6cd1384d864701e765"
+  license "MIT"
+  head "https://github.com/voidzero-dev/vite-plus.git", branch: "main"
+
+  depends_on "cmake" => :build
+  depends_on "just" => :build
+  depends_on "pnpm" => :build
+  depends_on "rust" => :build
+  depends_on "node"
+
+  resource "rolldown" do
+    url "https://github.com/rolldown/rolldown.git",
+        revision: "6cbd2330dc5ca973b90444973ee04c2dc7ee2f2d"
+    version "6cbd2330dc5ca973b90444973ee04c2dc7ee2f2d"
+
+    livecheck do
+      url "https://raw.githubusercontent.com/voidzero-dev/vite-plus/refs/tags/v#{LATEST_VERSION}/packages/tools/.upstream-versions.json"
+      strategy :json do |json|
+        json.dig("rolldown", "hash")
+      end
+    end
+  end
+
+  resource "vite" do
+    url "https://github.com/vitejs/vite.git",
+        revision: "578ffb80d46940f3b99cd96ed609f8b3a0ac5ede"
+    version "578ffb80d46940f3b99cd96ed609f8b3a0ac5ede"
+
+    livecheck do
+      url "https://raw.githubusercontent.com/voidzero-dev/vite-plus/refs/tags/v#{LATEST_VERSION}/packages/tools/.upstream-versions.json"
+      strategy :json do |json|
+        json.dig("vite", "hash")
+      end
+    end
+  end
+
+  def install
+    resource("rolldown").stage buildpath/"rolldown"
+    resource("vite").stage buildpath/"vite"
+
+    ENV["NPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS"] = "false"
+
+    # fspy requires nightly Cargo's `-Z bindeps`.
+    # Use a stable-Rust stub to keep the CLI buildable without nightly.
+    ENV["RUSTC_BOOTSTRAP"] = "1"
+
+    system "just", "build"
+    system "cargo", "install", *std_cargo_args(path: "crates/vite_global_cli")
+
+    system "pnpm", "--filter=vite-plus", "deploy", "--prod", "--legacy", "--no-optional",
+           prefix/"node_modules/vite-plus"
+    node_modules = prefix/"node_modules/vite-plus/node_modules"
+    rm_r node_modules.glob(".pnpm/*/node_modules/*/prebuilds/{darwin,ios}-x64*")
+    rm_r node_modules.glob(".pnpm/fsevents@*/node_modules/fsevents")
+
+    # Symlink vp to vpr and vpx. These are detected at runtime by argv[0]
+    bin.install_symlink bin/"vp" => "vpr"
+    bin.install_symlink bin/"vp" => "vpx"
+
+    # Generate shell completions, vp uses clap but with a custom env var so we can't use our helper
+    (bash_completion/"vp").write Utils.safe_popen_read({ "VP_COMPLETE" => "bash" }, bin/"vp")
+    (fish_completion/"vp.fish").write Utils.safe_popen_read({ "VP_COMPLETE" => "fish" }, bin/"vp")
+    (zsh_completion/"_vp").write Utils.safe_popen_read({ "VP_COMPLETE" => "zsh" }, bin/"vp")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/vp --version")
+
+    system bin/"vp", "create", "vite:application", "--no-interactive", "--directory", "test-app"
+    assert_path_exists testpath/"test-app/package.json"
+
+    cd testpath/"test-app" do
+      output = shell_output("#{bin}/vp fmt")
+      assert_match "Finished", output
+    end
+  end
+end


### PR DESCRIPTION
-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. Identified root cause (resource hashes in formula don't match vite-plus .upstream-versions.json) and prepared the fix. Hash values verified against https://github.com/voidzero-dev/vite-plus/blob/v0.2.2/packages/tools/.upstream-versions.json

-----