### PR TITLE
ruby@3.*: remove postinstall, update for unversioned CC

### DIFF
--- a/Formula/r/ruby@3.2.rb
+++ b/Formula/r/ruby@3.2.rb
@@ -124,19 +124,6 @@ class RubyAT32 < Formula
     # A newer version of ruby-mode.el is shipped with Emacs
     elisp.install Dir["misc/*.el"].reject { |f| f == "misc/ruby-mode.el" }
 
-    if OS.linux?
-      arch = Utils.safe_popen_read(
-        bin/"ruby", "-rrbconfig", "-e", 'print RbConfig::CONFIG["arch"]'
-      ).chomp
-      # Don't restrict to a specific GCC compiler binary we used (e.g. gcc-5).
-      inreplace lib/"ruby/#{api_version}/#{arch}/rbconfig.rb" do |s|
-        s.gsub! ENV.cxx, "c++"
-        s.gsub! ENV.cc, "cc"
-        # Change e.g. `CONFIG["AR"] = "gcc-ar-11"` to `CONFIG["AR"] = "ar"`
-        s.gsub!(/(CONFIG\[".+"\] = )"(?:gcc|g\+\+)-(.*)-\d+"/, '\\1"\\2"')
-      end
-    end
-
     # This is easier than trying to keep both current & versioned Ruby
     # formulae repeatedly updated with Rubygem patches.
     resource("rubygems").stage do
@@ -168,17 +155,6 @@ class RubyAT32 < Formula
     # instead of in the Cellar, making gems last across reinstalls
     config_file = lib/"ruby/#{api_version}/rubygems/defaults/operating_system.rb"
     config_file.write rubygems_config
-  end
-
-  def post_install
-    # Since Gem ships Bundle we want to provide that full/expected installation
-    # but to do so we need to handle the case where someone has previously
-    # installed bundle manually via `gem install`.
-    rm(%W[
-      #{rubygems_bindir}/bundle
-      #{rubygems_bindir}/bundler
-    ].select { |file| File.exist?(file) })
-    rm_r(Dir[HOMEBREW_PREFIX/"lib/ruby/gems/#{api_version}/gems/bundler-*"])
   end
 
   def rubygems_config

--- a/Formula/r/ruby@3.2.rb
+++ b/Formula/r/ruby@3.2.rb
@@ -11,12 +11,13 @@ class RubyAT32 < Formula
   end
 
   bottle do
-    sha256 arm64_tahoe:   "0bc621bf324437da905f23b37e733cfae3ac30850acb48a686bbccbce80d6397"
-    sha256 arm64_sequoia: "24b804e45abe9e2cfb5613c865beaf5400b71196aa223e66d6b5187169a64e02"
-    sha256 arm64_sonoma:  "e47043673f7dc1ff296ab4365634ebdbf986e124081f640ebf78bd452ce01ca9"
-    sha256 sonoma:        "1449eb77d22ecd69f3b9c413febb4810fbdcc194b81907b192e12069feb88327"
-    sha256 arm64_linux:   "4ef4f1cded7bec72ae2adde477272a22f7e226f568af3d691989a7dc6392afbf"
-    sha256 x86_64_linux:  "18b1316026bdb309ace0ab989c349afe01692f466cdb03dd01422da636575eed"
+    rebuild 1
+    sha256 arm64_tahoe:   "779e20d3ac0ef4c7ecc61a230193845ffa45d4c073731558dc1c1474c4893b21"
+    sha256 arm64_sequoia: "f717713eb2b6b7717cc943d7382e2a74e08dc7245eaaa8a675a1dd56708e9a36"
+    sha256 arm64_sonoma:  "affa0aa007084a41f3d5cacdd970c80c8416ad2603a221e7c465405dd2015570"
+    sha256 sonoma:        "869bd98a5ffdbfa780402bc6d820b2721042e48819ac23eeded11e51e1a9112d"
+    sha256 arm64_linux:   "f9e53461b33d9fdb69bc720b9151efc16e56ba692459e2fefa4123e5dae5b0b1"
+    sha256 x86_64_linux:  "a2ddc76f58672ddbbf3a5f6a4c61649e3aefca1e2268998e4718b5088af700c1"
   end
 
   keg_only :versioned_formula

--- a/Formula/r/ruby@3.3.rb
+++ b/Formula/r/ruby@3.3.rb
@@ -101,19 +101,6 @@ class RubyAT33 < Formula
     # A newer version of ruby-mode.el is shipped with Emacs
     elisp.install Dir["misc/*.el"].reject { |f| f == "misc/ruby-mode.el" }
 
-    if OS.linux?
-      arch = Utils.safe_popen_read(
-        bin/"ruby", "-rrbconfig", "-e", 'print RbConfig::CONFIG["arch"]'
-      ).chomp
-      # Don't restrict to a specific GCC compiler binary we used (e.g. gcc-5).
-      inreplace lib/"ruby/#{api_version}/#{arch}/rbconfig.rb" do |s|
-        s.gsub! ENV.cxx, "c++"
-        s.gsub! ENV.cc, "cc"
-        # Change e.g. `CONFIG["AR"] = "gcc-ar-11"` to `CONFIG["AR"] = "ar"`
-        s.gsub!(/(CONFIG\[".+"\] = )"(?:gcc|g\+\+)-(.*)-\d+"/, '\\1"\\2"')
-      end
-    end
-
     # This is easier than trying to keep both current & versioned Ruby
     # formulae repeatedly updated with Rubygem patches.
     resource("rubygems").stage do
@@ -145,17 +132,6 @@ class RubyAT33 < Formula
     # instead of in the Cellar, making gems last across reinstalls
     config_file = lib/"ruby/#{api_version}/rubygems/defaults/operating_system.rb"
     config_file.write rubygems_config
-  end
-
-  def post_install
-    # Since Gem ships Bundle we want to provide that full/expected installation
-    # but to do so we need to handle the case where someone has previously
-    # installed bundle manually via `gem install`.
-    rm(%W[
-      #{rubygems_bindir}/bundle
-      #{rubygems_bindir}/bundler
-    ].select { |file| File.exist?(file) })
-    rm_r(Dir[HOMEBREW_PREFIX/"lib/ruby/gems/#{api_version}/gems/bundler-*"])
   end
 
   def rubygems_config

--- a/Formula/r/ruby@3.3.rb
+++ b/Formula/r/ruby@3.3.rb
@@ -11,12 +11,13 @@ class RubyAT33 < Formula
   end
 
   bottle do
-    sha256 arm64_tahoe:   "5a7ed215d0f36ef6eace83824aa82bc8338719efecff5d844477cb67a6983f83"
-    sha256 arm64_sequoia: "5ac78d6da4430380e2fbb13014d36ece144c5cda1f0a76f525dc45cbc07ff588"
-    sha256 arm64_sonoma:  "354ea0e876c66fc0a31486fd3780fe7dcd0865c776210b14ed09f9d9a1476482"
-    sha256 sonoma:        "077f5a0f18025a1010d556436aec97f37aad2eb669a0f88ff08bf2a9423743df"
-    sha256 arm64_linux:   "4bd9d79381ac0897e830ea3eeb07128e7d996f9ea3cdee55d8fc8e82dbf5a282"
-    sha256 x86_64_linux:  "ba673a5b6e384874269a80aab923a083b9d9da42b4119dd452f5b433a831abf0"
+    rebuild 1
+    sha256 arm64_tahoe:   "29fddd4ba44cfbfb98a6965c050a5bd3578488febd70c527bfd92550eecd5a9b"
+    sha256 arm64_sequoia: "e5e5dbabf1091f08407dc0e102c19f9c637df37a3edd3a20643d63c372e8eb3a"
+    sha256 arm64_sonoma:  "a2f1c35482f9caf6709679ebb73ac1fa7df34758c05c93e79d66caed08c10fba"
+    sha256 sonoma:        "a959421b817b06bf368694e8f0d76f6790f121f7d397c70c691673e8c8c031d9"
+    sha256 arm64_linux:   "dc709a92c5c72e53347ca83958f9d20c0abaa1cdf13821886247d4e21d271eb4"
+    sha256 x86_64_linux:  "c86eb244296bd19c8ad0fe84f3316ed87b7ad7b2f5b4fcf165728fcc9731ae17"
   end
 
   keg_only :versioned_formula

--- a/Formula/r/ruby@3.4.rb
+++ b/Formula/r/ruby@3.4.rb
@@ -11,12 +11,13 @@ class RubyAT34 < Formula
   end
 
   bottle do
-    sha256 arm64_tahoe:   "21560c8b90c0385208126b3506b220e78c268c6d16905e8a8ef14f24a533f401"
-    sha256 arm64_sequoia: "fe4e389464cfff111efeb4a0453b2a8cc7714edd552cfcd7fa8201acfad9ba7b"
-    sha256 arm64_sonoma:  "1f088487dbb89117b80b9c64c5ab12919e306894ba01d34f2f088c8c5855a2e4"
-    sha256 sonoma:        "aa6fc6c9596463be65b116e0bf870e32592b9427a45b5c0d714c28cfff1ffe05"
-    sha256 arm64_linux:   "b12568a41fb681a77bf2978de4e6b0db799eefe2a12c7929d7d0d0c9ba637331"
-    sha256 x86_64_linux:  "fd5d5c10fc2ff8c580c1b1e9f20240af1a6a0fd135343aacf023fd38b412d171"
+    rebuild 1
+    sha256 arm64_tahoe:   "65bef4e095e90fe491394673e5ba08107e3719621f09a271cd791699ae62d70c"
+    sha256 arm64_sequoia: "b7e8376697932898b02f941e817807578b1a7390da11d4d0384adf2d1bed2fee"
+    sha256 arm64_sonoma:  "ffd35b48a286ec986c9a9f0a05205c438b6d4447556174089d47e641f6f9ce22"
+    sha256 sonoma:        "a2357c44241be30cd28a4c33833fcd1b6ae209c7a3b74a4adbe6bd97e664ff1e"
+    sha256 arm64_linux:   "4e820ed2b0c652229a52333be8557f422ce4898f38e66cff1e842a339ef64178"
+    sha256 x86_64_linux:  "aaceb4ae9d15d102bc8197e50008c260680ae97ccc394e59e90d3911bdada33d"
   end
 
   keg_only :versioned_formula

--- a/Formula/r/ruby@3.4.rb
+++ b/Formula/r/ruby@3.4.rb
@@ -109,19 +109,6 @@ class RubyAT34 < Formula
     # A newer version of ruby-mode.el is shipped with Emacs
     elisp.install Dir["misc/*.el"].reject { |f| f == "misc/ruby-mode.el" }
 
-    if OS.linux?
-      arch = Utils.safe_popen_read(
-        bin/"ruby", "-rrbconfig", "-e", 'print RbConfig::CONFIG["arch"]'
-      ).chomp
-      # Don't restrict to a specific GCC compiler binary we used (e.g. gcc-5).
-      inreplace lib/"ruby/#{api_version}/#{arch}/rbconfig.rb" do |s|
-        s.gsub! ENV.cxx, "c++"
-        s.gsub! ENV.cc, "cc"
-        # Change e.g. `CONFIG["AR"] = "gcc-ar-11"` to `CONFIG["AR"] = "ar"`
-        s.gsub!(/(CONFIG\[".+"\] = )"(?:gcc|g\+\+)-(.*)-\d+"/, '\\1"\\2"')
-      end
-    end
-
     resource("rubygems").stage do
       ENV.prepend_path "PATH", bin
 
@@ -151,17 +138,6 @@ class RubyAT34 < Formula
     # instead of in the Cellar, making gems last across reinstalls
     config_file = lib/"ruby/#{api_version}/rubygems/defaults/operating_system.rb"
     config_file.write rubygems_config
-  end
-
-  def post_install
-    # Since Gem ships Bundle we want to provide that full/expected installation
-    # but to do so we need to handle the case where someone has previously
-    # installed bundle manually via `gem install`.
-    rm(%W[
-      #{rubygems_bindir}/bundle
-      #{rubygems_bindir}/bundler
-    ].select { |file| File.exist?(file) })
-    rm_r(Dir[HOMEBREW_PREFIX/"lib/ruby/gems/#{api_version}/gems/bundler-*"])
   end
 
   def rubygems_config


### PR DESCRIPTION
This was introduced in Ruby 2.5.0 to switch users over to included version. I think it's been long enough that we can assume a user who ran `gem install` did it intentionally and can fix it themself.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
