### PR TITLE
zsign 1.0.8

### DIFF
--- a/Formula/z/zsign.rb
+++ b/Formula/z/zsign.rb
@@ -7,12 +7,12 @@ class Zsign < Formula
   head "https://github.com/zhlynn/zsign.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any, arm64_tahoe:   "6eaf659241a2a0f56398f68db82ffd856897f1acb9bf7cf09171c51b45b9ec25"
-    sha256 cellar: :any, arm64_sequoia: "a4d296b7442a976a83e798a08611bdc3e8879dcbf02141c6583920ed1fa7a511"
-    sha256 cellar: :any, arm64_sonoma:  "4f5f564cdf08f2a6844da216ad5fc25a908f740e2c3f746b15edec41b63153c8"
-    sha256 cellar: :any, sonoma:        "849db49f21a50fe77f5a0173f7acde25c39b750a7639816a7e149b05bd98eb65"
-    sha256 cellar: :any, arm64_linux:   "dd14f2972b65c373632721fb07c3f28e1b1b69e5a0007b4f00025b3d6fc9f897"
-    sha256 cellar: :any, x86_64_linux:  "c1ba504d892b70bd48bf67b86f89b813361785e209e5fa4870fafd3367801e07"
+    sha256 cellar: :any, arm64_tahoe:   "00c80077eb2bcbdbf91412c3eaa0c019a6d293f65a4eb62b025dc3e84850a6c1"
+    sha256 cellar: :any, arm64_sequoia: "f8029400a71952ff80da2b0b7e14a70b0c358be2309d6d94bbe5351bb3ca07d0"
+    sha256 cellar: :any, arm64_sonoma:  "71b77283f2fa25241b29ed68c8d0efcf48f97ef0e7b194e5ff8aa3091f02cea0"
+    sha256 cellar: :any, sonoma:        "5b828ce52185582c53bd8633bae88666240ab939862cee349315572a4b65b314"
+    sha256 cellar: :any, arm64_linux:   "335fc3c72c8a06c93a1158888dc75bb5ccc76635f8385efb351633abe487b054"
+    sha256 cellar: :any, x86_64_linux:  "bf58bfee32de6440ddde2470617779977e308c3e33ed9a4fd7a7938cd11d1d5f"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/z/zsign.rb
+++ b/Formula/z/zsign.rb
@@ -1,8 +1,8 @@
 class Zsign < Formula
   desc "Cross-platform codesigning tool for iOS apps"
   homepage "https://github.com/zhlynn/zsign"
-  url "https://github.com/zhlynn/zsign/archive/refs/tags/v1.0.5.tar.gz"
-  sha256 "84cc3458da2366f88cb87da87ddeed9c0a903c716d2a891aa09cc14e0a74b7ac"
+  url "https://github.com/zhlynn/zsign/archive/refs/tags/v1.0.8.tar.gz"
+  sha256 "f1cc0d4ffdf4eba3f2848ded3c81a1d37b614f6a5219b3aa444f4e222bcbcff4"
   license "MIT"
   head "https://github.com/zhlynn/zsign.git", branch: "master"
 
@@ -19,16 +19,9 @@ class Zsign < Formula
   depends_on "minizip-ng"
   depends_on "openssl@4"
 
-  # Build against OpenSSL 4's const-correct X509/ASN1 accessors.
-  # PR ref: https://github.com/zhlynn/zsign/pull/400
-  patch do
-    url "https://github.com/zhlynn/zsign/commit/c39607e4231bceffc0e4d7c1dc257ef67dd3c5b7.patch?full_index=1"
-    sha256 "dda8e0a6308cbeb8190f349ffb8009e887c9c1053b2a30d1bcb78ee3d6e57d8c"
-  end
-
   def install
     build_dir = OS.mac? ? "build/macos" : "build/linux"
-    system "make", "-C", build_dir, "CXX=#{ENV.cxx}"
+    system "make", "-C", build_dir, "CXX=#{ENV.cxx}", "VERSION=#{version}", "SYSTEM_MINIZIP=ng"
     bin.install "bin/zsign"
   end
 


### PR DESCRIPTION
-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI usage: Claude Code edited the formula and drafted this PR description. Manual verification of the changes: built locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source zsign`; ran `brew test zsign`, `brew style zsign`, and `brew audit --strict --online zsign` (all pass); checked `brew linkage zsign` — the binary links `minizip-ng` and `openssl@4` from Homebrew plus system libraries only; verified `zsign -v` reports `1.0.8`; performed a real Mach-O/IPA signing run with the upstream test credentials (`Signed OK`).

-----

Version bump 1.0.5 → 1.0.8 ([release](https://github.com/zhlynn/zsign/releases/tag/v1.0.8)). I am the upstream maintainer.

- **Link Homebrew's `minizip-ng` instead of the vendored minizip**: the 1.0.5 formula declared `minizip-ng` but the binary never actually linked it (minizip sources were vendored upstream in v1.0.5, zhlynn/zsign@b1948cd). Per the [unbundling policy](https://docs.brew.sh/Acceptable-Formulae#stuff-that-requires-vendored-versions-of-homebrew-formulae) and review feedback, zsign v1.0.8 adds `SYSTEM_MINIZIP=1|ng` make options (zhlynn/zsign@1faa35c, zhlynn/zsign@09486af) that link system minizip or minizip-ng (via its minizip compat layer) instead of compiling the vendored copies — the formula builds with `SYSTEM_MINIZIP=ng`, so the binary links Homebrew's `minizip-ng` as originally packaged.
- **Drop the OpenSSL 4 compatibility patch**: zhlynn/zsign@c39607e (PR zhlynn/zsign#400) is included in the tag.
- **Pass `VERSION` to make**: tarball builds have no git metadata, so `zsign -v` previously reported `0.0.0-dev`; it now reports the formula version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
