### PR TITLE
daemontools: use post_install_steps

### DIFF
--- a/Formula/d/daemontools.rb
+++ b/Formula/d/daemontools.rb
@@ -12,15 +12,13 @@ class Daemontools < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "4d2dc1ed742ae4b8ab911aef610c8315ea79b9dce79a4a9d21028f413352bd6c"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "1caba2a88c37b416bf48c950f376693b1412a06f54bc62c815a6e8679f30b41d"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "4079bdac80d383b3423b5daf190a2abc5583db2d5e33939ccd0e3c637ab57033"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "414c519a3f46d28c74e28d95f882b68dae09dcd9604b8f207c93539d4af34cd3"
-    sha256 cellar: :any_skip_relocation, sonoma:        "b2fbc29b09bf37004b7a31ff2a7f57bd705e757cef0b1970b2b9723f624bc8d9"
-    sha256 cellar: :any_skip_relocation, ventura:       "813c64aa076209409ab420484007a7d43e7bfa86ce26842829d8800501e9b138"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "78eeabb0f8b6f6d678f97dfcf0a84e51c1b0f667e5fba8c6a1ef4707f85a91ce"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2f527c08fac6754686403613d81fe344434ead8477130d596ffa05862b4962fe"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "da992fd278ff1a26880a1a254f7a54e2440ef886c565bef4d52335a53a0efe99"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "d5272511ffc8ff84d1a6a86ff7a4b643530c9d1feab3cfca5b70cea23e7855ba"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "7e6c9db0f8c6137035c15da9445fbdac2dfd0475eb3ae3bb563237affe0f6867"
+    sha256 cellar: :any_skip_relocation, sonoma:        "9181744087c4ab10deb008bfd08bb892ba7c00dd6cfa092be93c8fb37018c659"
+    sha256 cellar: :any,                 arm64_linux:   "2b086e3eb960e1f213b829504158a83246c196cbbad30e548d0bdd396ef8292b"
+    sha256 cellar: :any,                 x86_64_linux:  "ec457300fd92eaf1f7f3fad1e5a7904b9f02665b85d78b5e4628d176bc0a4008"
   end
 
   resource "man" do

--- a/Formula/d/daemontools.rb
+++ b/Formula/d/daemontools.rb
@@ -60,13 +60,8 @@ class Daemontools < Formula
     end
   end
 
-  def post_install
-    (etc/"service").mkpath
-
-    Pathname.glob("/service/*") do |original|
-      target = "#{etc}/service/#{original.basename}"
-      ln_s original, target unless File.exist?(target)
-    end
+  post_install_steps do
+    mkdir_p "service", base: :etc
   end
 
   def caveats


### PR DESCRIPTION
Can remove old migration logic. Old path stopped working in 10.15.
- https://github.com/Homebrew/homebrew-core/commit/e2bdb91e0504c8e52a272d2c8860109e93e9d150

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
