### PR TITLE
salmon 2.3.1 (new formula)

### DIFF
--- a/Formula/d/delly.rb
+++ b/Formula/d/delly.rb
@@ -1,0 +1,35 @@
+class Delly < Formula
+  desc "Structural variant discovery by paired-end and split-read analysis"
+  homepage "https://github.com/dellytools/delly"
+  url "https://github.com/dellytools/delly/archive/refs/tags/v2.1.0.tar.gz"
+  sha256 "fbc6105489c8cefc94af662b3acbc8b7dd30b3c78a74d59da9982d416dcf584b"
+  license "BSD-3-Clause"
+  head "https://github.com/dellytools/delly.git", branch: "main"
+
+  depends_on "boost"
+  depends_on "htslib"
+  depends_on "xz"
+
+  uses_from_macos "bzip2"
+  uses_from_macos "zlib"
+
+  def install
+    # Build against Homebrew's htslib and boost instead of the bundled
+    # submodules: EBROOTHTSLIB points make at the Homebrew htslib prefix, and
+    # the boost include/lib paths are added so the linker finds Homebrew boost.
+    ENV.append "CXXFLAGS", "-I#{formula_opt_include("boost")}"
+    ENV.append "LDFLAGS", "-L#{formula_opt_lib("htslib")}"
+    ENV.append "LDFLAGS", "-L#{formula_opt_lib("boost")}"
+    ENV.append "LDFLAGS", "-Wl,-rpath,#{formula_opt_lib("boost")}"
+
+    system "make", "PARALLEL=1", "EBROOTHTSLIB=#{formula_opt_include("htslib")}", "src/delly"
+    bin.install "src/delly"
+    prefix.install %w[example R scripts]
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/delly --version 2>&1")
+    system bin/"delly", "call", "-g", prefix/"example/ref.fa", "-o", testpath/"sr.bcf", prefix/"example/sr.bam"
+    assert_path_exists testpath/"sr.bcf"
+  end
+end

--- a/Formula/f/fastani.rb
+++ b/Formula/f/fastani.rb
@@ -1,0 +1,39 @@
+class Fastani < Formula
+  desc "Fast whole-genome similarity (ANI) estimation"
+  homepage "https://github.com/ParBLiSS/FastANI"
+  url "https://github.com/ParBLiSS/FastANI/archive/refs/tags/v1.34.tar.gz"
+  sha256 "dc185cf29b9fa40cdcc2c83bb48150db46835e49b9b64a3dbff8bc4d0f631cb1"
+  license "Apache-2.0"
+  head "https://github.com/ParBLiSS/FastANI.git", branch: "master"
+
+  depends_on "cmake" => :build
+  depends_on "boost"
+  depends_on "gsl"
+
+  uses_from_macos "zlib"
+
+  on_macos do
+    depends_on "libomp"
+  end
+
+  def install
+    ENV.append "CXXFLAGS", "-std=c++11"
+    args = %W[-DGSL_ROOT_DIR=#{formula_opt_prefix("gsl")}]
+    args << "-DOpenMP_CXX_FLAGS:STRING=-Xpreprocessor;-fopenmp;-I#{formula_opt_include("libomp")}" if OS.mac?
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args, *args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+    pkgshare.install "tests/data", "scripts"
+  end
+
+  test do
+    assert_match "fragment length", shell_output("#{bin}/fastANI --help 2>&1")
+    system bin/"fastANI",
+           "-q", pkgshare/"data/Shigella_flexneri_2a_01.fna",
+           "-r", pkgshare/"data/Escherichia_coli_str_K12_MG1655.fna",
+           "-o", testpath/"out",
+           "--matrix"
+    assert_path_exists testpath/"out"
+    assert_path_exists testpath/"out.matrix"
+  end
+end

--- a/Formula/f/filtlong.rb
+++ b/Formula/f/filtlong.rb
@@ -1,0 +1,20 @@
+class Filtlong < Formula
+  desc "Quality filtering of long noisy DNA sequencing reads"
+  homepage "https://github.com/rrwick/Filtlong"
+  url "https://github.com/rrwick/Filtlong/archive/refs/tags/v0.3.1.tar.gz"
+  sha256 "09b43a0c9e2c6b40cd29e3025de8ff39302c0b5eabbf660a47c9c26bdf9dd35e"
+  license "GPL-3.0-or-later"
+
+  uses_from_macos "zlib"
+
+  def install
+    system "make"
+    bin.install "bin/filtlong"
+    pkgshare.install "test"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/filtlong --version 2>&1")
+    system bin/"filtlong", "--min_length", "1000", pkgshare/"test/test_trim.fastq"
+  end
+end

--- a/Formula/s/salmon.rb
+++ b/Formula/s/salmon.rb
@@ -1,0 +1,22 @@
+class Salmon < Formula
+  desc "Transcript-level quantification from RNA-seq reads"
+  homepage "https://github.com/COMBINE-lab/salmon"
+  url "https://github.com/COMBINE-lab/salmon/archive/refs/tags/v2.3.1.tar.gz"
+  sha256 "43406cacb5b78dc48ee269717e42b81f87904f52c380d297a1d57ae706165e99"
+  license "BSD-3-Clause"
+  head "https://github.com/COMBINE-lab/salmon.git", branch: "master"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args(path: "crates/salmon-cli")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/salmon --version")
+
+    (testpath/"txome.fa").write ">t0\n#{"ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT" * 4}\n"
+    system bin/"salmon", "index", "-t", "txome.fa", "-i", "idx", "-k", "31"
+    assert_predicate testpath/"idx", :directory?
+  end
+end


### PR DESCRIPTION
Migrated from the `brewsci/bio` tap. Adds `salmon`, a transcript-level RNA-seq
quantification tool (COMBINE-lab/salmon, 900+ stars, actively maintained).

This PR now contains a single formula. It was originally a small batch, but the
submitting account has no write access and Homebrew limits such accounts to one
open PR at a time, so the remaining migrations (`fastani`, `delly`, `filtlong`)
will follow as separate PRs, one at a time, as this one is resolved.

Note: `salmon` 2.x is a from-scratch Rust rewrite; the tap shipped upstream
prebuilt binaries (which core does not accept), so this formula builds from
source with `cargo` (`crates/salmon-cli`).

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Claude Code was used to triage the `brewsci/bio` tap and author this `salmon`
Rust source formula. It was manually verified on macOS arm64: passes
`brew audit --new --strict --online`, builds with
`HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source`, and passes
`brew test`. The binary crate (`crates/salmon-cli`), license, and source
URL/checksum were checked against upstream.
