### PR TITLE
delly 2.3.1 (new formula)

### DIFF
--- a/Formula/d/delly.rb
+++ b/Formula/d/delly.rb
@@ -6,6 +6,15 @@ class Delly < Formula
   license "BSD-3-Clause"
   head "https://github.com/dellytools/delly.git", branch: "main"
 
+  bottle do
+    sha256 cellar: :any, arm64_tahoe:   "4d305d4bafc55fb97920c21950004f8e40ca4f43ab73cdbd4028e7594ed8ff03"
+    sha256 cellar: :any, arm64_sequoia: "63fc590a4872b683b417e33e9031d4f74377513563809e598018a3b431939da3"
+    sha256 cellar: :any, arm64_sonoma:  "5179b7118b48e17f4a2d02a0138a6ee450ee6382dcb65bdd50517901a59be6dd"
+    sha256 cellar: :any, sonoma:        "834c274742d7ec449cf8a1bdd2c9f1d64312d83cc25beca0d1cee94db55e5f2f"
+    sha256 cellar: :any, arm64_linux:   "0671ac324c98977b4270ef18c30ae460fad728f4677a65f006ada28e5327a530"
+    sha256 cellar: :any, x86_64_linux:  "de3341eb6d9b7b958fd4c635a7984e546aa85ef4753496798792e3923c8c41c0"
+  end
+
   depends_on "boost"
   depends_on "htslib"
   depends_on "xz"

--- a/Formula/d/delly.rb
+++ b/Formula/d/delly.rb
@@ -1,0 +1,31 @@
+class Delly < Formula
+  desc "Structural variant discovery by paired-end and split-read analysis"
+  homepage "https://github.com/dellytools/delly"
+  url "https://github.com/dellytools/delly/archive/refs/tags/v2.3.1.tar.gz"
+  sha256 "4e2568b16039d40399f58e7cffc851bfdb17ae5eccbc0c2e1768502c0895e42e"
+  license "BSD-3-Clause"
+  head "https://github.com/dellytools/delly.git", branch: "main"
+
+  depends_on "boost"
+  depends_on "htslib"
+  depends_on "xz"
+
+  uses_from_macos "bzip2"
+  uses_from_macos "zlib"
+
+  def install
+    system "make", "src/delly",
+           "HTSLIBINCDIR=#{formula_opt_include("htslib")}",
+           "HTSLIBLIBDIR=#{formula_opt_lib("htslib")}",
+           "BOOSTINCDIR=#{formula_opt_include("boost")}",
+           "BOOSTLIBDIR=#{formula_opt_lib("boost")}"
+    bin.install "src/delly"
+    pkgshare.install %w[example R scripts]
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/delly --version 2>&1")
+    system bin/"delly", "lr", "-g", pkgshare/"example/ref.fa", "-o", testpath/"lr.bcf", pkgshare/"example/lr.bam"
+    assert_path_exists testpath/"lr.bcf"
+  end
+end


### PR DESCRIPTION
Migrated from the `brewsci/bio` tap. Adds `delly`, structural variant discovery by paired-end and split-read analysis (dellytools/delly). Builds against Homebrew `htslib`/`boost` rather than bundled submodules.

(Split out from #291887 as requested, into one PR per formula.)

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Claude Code was used to prepare this formula from the `brewsci/bio` tap. It was
manually verified on macOS arm64: passes `brew audit --new --strict --online`,
builds with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source`,
and passes `brew test`. License, source URL and checksum were checked upstream.
