### PR TITLE
omlx 0.4.4 (new formula)

### DIFF
--- a/Formula/o/omlx.rb
+++ b/Formula/o/omlx.rb
@@ -1,0 +1,73 @@
+class Omlx < Formula
+  desc "LLM inference server optimized for Apple Silicon"
+  homepage "https://omlx.ai"
+  url "https://github.com/jundot/omlx/archive/refs/tags/v0.4.4.tar.gz"
+  sha256 "ff06063b215cd9f9ea6d311069f13f0523164cbb9eb2d05e29ef5b48d4dcbf48"
+  license "Apache-2.0"
+
+  head "https://github.com/jundot/omlx.git", branch: "main"
+
+  depends_on "rust" => :build
+  depends_on arch: :arm64
+  depends_on macos: :tahoe
+  depends_on maximum_macos: :tahoe
+  depends_on "python@3.14"
+
+  def python3
+    "python3.14"
+  end
+
+  def install
+    system python3, "-m", "venv", libexec
+
+    inreplace "pyproject.toml", '"transformers>=5.7.0"', '"transformers==5.9.0"'
+    inreplace "pyproject.toml", '"markitdown[pdf,docx,pptx]==0.1.6"', '"markitdown==0.1.6"'
+
+    system libexec/"bin/pip", "install",
+           "--no-binary", "cohere_melody,tiktoken",
+           buildpath
+
+    site_packages = libexec/"lib/#{python3}/site-packages"
+    paths_to_remove = %w[
+      _sounddevice.py
+      _sounddevice_data
+      cv2
+      lxml
+      lxml-6.1.1.dist-info
+      mlx_audio
+      mlx_audio-0.4.4.dist-info
+      opencv_python-5.0.0.93.dist-info
+      pptx
+      python_pptx-1.0.2.dist-info
+      sounddevice.py
+      sounddevice-0.5.5.dist-info
+    ].map { |path| site_packages/path }
+    rm_r paths_to_remove.select(&:exist?)
+    rm Dir[site_packages/"*_mypyc*.so"]
+    rm Dir[site_packages/"charset_normalizer/*.so"]
+    rm_r site_packages/"google/_upb" if (site_packages/"google/_upb").exist?
+
+    bin.install_symlink libexec/"bin/omlx"
+  end
+
+  service do
+    run [opt_bin/"omlx", "serve"]
+    keep_alive true
+    working_dir var
+    log_path var/"log/omlx.log"
+    error_log_path var/"log/omlx.log"
+    environment_variables PATH: std_service_path_env
+  end
+
+  test do
+    port = free_port
+    pid = spawn bin/"omlx", "serve", "--host", "127.0.0.1", "--port", port.to_s
+    begin
+      output = JSON.parse(shell_output("curl --silent --retry 5 --retry-connrefused http://127.0.0.1:#{port}/health"))
+      assert_equal "healthy", output["status"]
+    ensure
+      Process.kill "TERM", pid
+      Process.wait pid
+    end
+  end
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI assistance was used to draft the formula and run local checks. I manually verified the formula diff and checked that no duplicate open or closed Homebrew Core PRs/issues for `omlx` were found.

Verified:

- `brew style omlx`
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew audit --new --strict --os tahoe --arch arm omlx`

Not claimed as verified:

- macOS Tahoe ARM source build
- macOS Tahoe ARM `brew test omlx`

The formula intentionally targets Apple Silicon on macOS Tahoe only and caps support with `depends_on maximum_macos: :tahoe`; local macOS 27 output is not used as release evidence.

-----
