### PR TITLE
mas: fix wrapper jq path on macOS <15

### DIFF
--- a/Formula/m/mas.rb
+++ b/Formula/m/mas.rb
@@ -30,13 +30,13 @@ class Mas < Formula
 
   def install
     ENV["MAS_DIRTY_INDICATOR"] = ""
+    # /usr/bin/jq only exists on Sequoia+; use the Homebrew dep otherwise.
+    on_sonoma :or_older do
+      inreplace "Scripts/mas", "/usr/bin/jq", Formula["jq"].opt_bin/"jq"
+    end
     system "Scripts/build", "homebrew/core/mas", "--disable-sandbox", "-c", "release"
     (libexec/"bin").install ".build/release/mas"
     bin.install "Scripts/mas"
-    on_sonoma :or_older do
-      # /usr/bin/jq only exists on Sequoia+; use the Homebrew dep otherwise.
-      inreplace bin/"mas", "/usr/bin/jq", Formula["jq"].opt_bin/"jq"
-    end
     system "swift", "package", "--disable-sandbox", "generate-manual"
     man1.install ".build/plugins/GenerateManual/outputs/mas/mas.1"
     bash_completion.install "contrib/completion/mas.bash" => "mas"

--- a/Formula/m/mas.rb
+++ b/Formula/m/mas.rb
@@ -33,6 +33,10 @@ class Mas < Formula
     system "Scripts/build", "homebrew/core/mas", "--disable-sandbox", "-c", "release"
     (libexec/"bin").install ".build/release/mas"
     bin.install "Scripts/mas"
+    on_sonoma :or_older do
+      # /usr/bin/jq only exists on Sequoia+; use the Homebrew dep otherwise.
+      inreplace bin/"mas", "/usr/bin/jq", Formula["jq"].opt_bin/"jq"
+    end
     system "swift", "package", "--disable-sandbox", "generate-manual"
     man1.install ".build/plugins/GenerateManual/outputs/mas/mas.1"
     bash_completion.install "contrib/completion/mas.bash" => "mas"


### PR DESCRIPTION
-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Claude Code assisted with drafting the formula patch and this PR body. Manual verification I performed:

- Read the mas 7.0.0 wrapper (`Scripts/mas` in [mas-cli/mas@v7.0.0](https://github.com/mas-cli/mas/blob/v7.0.0/Scripts/mas)) and confirmed the `/usr/bin/jq` hardcode plus the `path_or_simple_command` fallback.
- Confirmed `/opt/homebrew/bin/brew:292` resets `PATH="/usr/bin:/bin:/usr/sbin:/sbin"` before `exec /usr/bin/env -i ...`, so subprocesses inherit that restricted PATH.
- Confirmed `/usr/bin/jq` does not exist on my macOS 14 Sonoma system; jq is only at `/opt/homebrew/bin/jq`.
- Confirmed the reproduction: `env -i PATH=/usr/bin:/bin:/usr/sbin:/sbin mas list` (with mas 7.0.0) silently emits no output.
- Verified the `on_sonoma :or_older` DSL is idiomatic here by matching the existing `on_sequoia :or_newer` block already present in this formula.

Local `brew install --build-from-source` / `brew test` / `brew audit` boxes are unchecked because I currently have a workaround-pinned mas 6.0.1 installed and haven't displaced it yet — happy to rerun and check them if maintainers prefer.

-----

mas 7.0.0 ships a zsh wrapper (`Scripts/mas`) that hardcodes `/usr/bin/jq`. On macOS <15 Sequoia, `/usr/bin/jq` does not exist and the wrapper falls back to bare `jq`, which is only findable if jq is on `$PATH`.

Homebrew's `bin/brew` resets `PATH` to `/usr/bin:/bin:/usr/sbin:/sbin` before exec-ing subprocesses. So on macOS 14 Sonoma with mas installed via Homebrew, any invocation of `mas list` via `brew` (notably `brew bundle dump`) fails silently: jq is unfindable, no apps are enumerated, and `brew bundle dump` drops all `mas "..."` entries from the Brewfile.

This patch `inreplace`s the hardcoded `/usr/bin/jq` in the wrapper with `Formula["jq"].opt_bin/"jq"` on macOS <15 (where jq is already a Homebrew dep via `uses_from_macos "jq", since: :sequoia`). Sequoia+ is unaffected.

Upstream mas-cli issue: https://github.com/mas-cli/mas/issues/1274
