### PR TITLE
bismark 0.25.1 (new formula)

### DIFF
--- a/Formula/b/bismark.rb
+++ b/Formula/b/bismark.rb
@@ -1,0 +1,44 @@
+class Bismark < Formula
+  desc "Bisulfite read mapper and methylation caller"
+  homepage "https://github.com/FelixKrueger/Bismark"
+  url "https://github.com/FelixKrueger/Bismark/archive/refs/tags/v0.25.1.tar.gz"
+  sha256 "b7e69f8e4893059f73863a8d2835245e70132715fdf49163b453bb7c0a8de61d"
+  license "GPL-3.0-or-later"
+
+  depends_on "bowtie2"
+  depends_on "minimap2"
+  depends_on "samtools"
+
+  uses_from_macos "perl"
+
+  def install
+    # Scripts locate sibling tools and templates via FindBin's $RealBin (which
+    # resolves symlinks), so install everything into libexec and symlink the
+    # user-facing executables. The plotly/ directory holds report templates.
+    scripts = %w[
+      bismark bismark_genome_preparation bismark_methylation_extractor
+      deduplicate_bismark bismark2bedGraph coverage2cytosine bismark2report
+      bismark2summary bam2nuc filter_non_conversion NOMe_filtering
+      methylation_consistency
+    ]
+    libexec.install scripts, "plotly"
+    scripts.each { |s| bin.install_symlink libexec/s }
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/bismark --version")
+
+    seq = "GAGCTCAAGCTTGGATCCGTCGACCTGCAGGCATGCAAGCTTGAGTATTCTATAGTGTCAC" * 10
+    (testpath/"genome/genome.fa").write ">chr1\n#{seq}\n"
+    system bin/"bismark_genome_preparation", testpath/"genome"
+
+    (testpath/"reads.fastq").write <<~EOS
+      @r1
+      GAGTTTAAGTTTGGATTTGTCGATTTGTAGGTATGTAAGTTTGAGTATTTTATAGTGTTAT
+      +
+      IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII
+    EOS
+    system bin/"bismark", "--genome", testpath/"genome", testpath/"reads.fastq", "-o", testpath
+    assert_path_exists testpath/"reads_bismark_bt2.bam"
+  end
+end


### PR DESCRIPTION
Migrated from the `brewsci/bio` tap. Adds `bismark`, a bisulfite read mapper and
methylation caller (FelixKrueger/Bismark, 450+ stars, actively maintained).

Note: the tap formula also declared `hisat2` as a dependency, but hisat2 is not
yet in homebrew-core. hisat2 is only an optional alternative aligner (Bismark
defaults to `bowtie2`, which is what the test exercises), so it is omitted here.
I'm submitting `hisat2` as a separate PR; it can be added back as a dependency
once that lands.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Claude Code was used to prepare this formula from the `brewsci/bio` tap and drop
the unavailable `hisat2` dependency. Verified on macOS arm64: passes
`brew audit --new --strict --online`, builds with
`HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source`, and passes
`brew test` (bowtie2 alignment path). License, source URL and checksum checked upstream.
