### PR TITLE
bismark 3.0.0 (new formula)

### DIFF
--- a/Formula/b/bismark.rb
+++ b/Formula/b/bismark.rb
@@ -6,6 +6,15 @@ class Bismark < Formula
   license "GPL-3.0-only"
   head "https://github.com/FelixKrueger/Bismark.git", branch: "master"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "518b6eab8123951f73fa55bca7e44a5b2999236150b8242b5ebf0add60e24ca5"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "10af470234099771470b3985d418dceabd3162b18d935e5852b6223940bfb7ce"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "c5836eea519b2d4da5fa8f0bb2dc7ed9ac67174bcafd9ece56d315cc22ae717c"
+    sha256 cellar: :any_skip_relocation, sonoma:        "d5a1a3df7c383ad62b3ae2ae43d482766aaf9eacee98c8a9542608648bdaf43c"
+    sha256 cellar: :any,                 arm64_linux:   "afd805509f3fa7645e3a8fcbd7fce042253a6574b33386ea4936c62be7f12cac"
+    sha256 cellar: :any,                 x86_64_linux:  "6762ba9438e00ee612a3dc7481f086df6fff564026caf54f83776192e0efc394"
+  end
+
   depends_on "rust" => :build
   depends_on "bowtie2"
   depends_on "minimap2"

--- a/Formula/b/bismark.rb
+++ b/Formula/b/bismark.rb
@@ -1,0 +1,24 @@
+class Bismark < Formula
+  desc "Bisulfite read mapper and methylation caller"
+  homepage "https://github.com/FelixKrueger/Bismark"
+  url "https://github.com/FelixKrueger/Bismark/archive/refs/tags/bismark-rust-v3.0.0.tar.gz"
+  sha256 "da04c2dccd234877d61bc217afa39474eba4aca56f34fc3752ef3bc891c11636"
+  license "GPL-3.0-only"
+  head "https://github.com/FelixKrueger/Bismark.git", branch: "master"
+
+  depends_on "rust" => :build
+  depends_on "bowtie2"
+  depends_on "minimap2"
+
+  def install
+    system "cargo", "install", *std_cargo_args(path: "rust/bismark")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/bismark --version")
+
+    (testpath/"genome/chr.fa").write ">chr\n#{"ACGTACACGTGTACGT" * 40}\n"
+    system bin/"bismark_genome_preparation", testpath/"genome"
+    assert_path_exists testpath/"genome/Bisulfite_Genome"
+  end
+end


### PR DESCRIPTION
Bismark 3.0.0 — the new Rust rewrite of the Bismark bisulfite-sequencing suite
(the `bismark` aligner, `deduplicate_bismark`, `bismark_methylation_extractor`,
`coverage2cytosine`, etc.), shipped as a single multicall binary that also
installs the classic tool names. BAM/SAM/CRAM I/O is pure-Rust via `noodles`
(no `htslib`/`samtools`). Runtime aligners: `bowtie2` (default) and `minimap2`;
HISAT2 is also supported and I'll add `hisat2` here once it lands in core.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

The formula was drafted with AI assistance (Claude Code). I manually verified the result on macOS arm64: `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source bismark`, `brew test bismark`, `brew audit --new --strict --online bismark`, and `brew style bismark` all pass; I confirmed the installed binaries and reported version, and checked the upstream repo (Cargo workspace layout, GPL-3.0-only license, and the aligner backends it invokes at runtime) to set the correct `depends_on`.

-----
