### PR TITLE
sproxy: deprecate

### DIFF
--- a/Formula/s/sproxy.rb
+++ b/Formula/s/sproxy.rb
@@ -21,6 +21,9 @@ class Sproxy < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "0bf77197199267e3b521e88729b49abcc2341fc460cf017ce16d63473d6cbf63"
   end
 
+  deprecate! date: "2026-07-09", because: :repo_removed
+  disable! date: "2027-01-09", because: :repo_removed
+
   # Only needed due to the change to "Makefile.am"
   depends_on "autoconf" => :build
   depends_on "automake" => :build


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Couldn't find homepage and also author remove the repo. The only remaining is source tarball but it is about 11 years ago. I think this can be deprecate now.