### PR TITLE
subread 2.1.1 (new formula)

### DIFF
--- a/Formula/s/subread.rb
+++ b/Formula/s/subread.rb
@@ -1,0 +1,41 @@
+class Subread < Formula
+  desc "High-performance read alignment, quantification and mutation discovery"
+  homepage "https://subread.sourceforge.net/"
+  url "https://downloads.sourceforge.net/project/subread/subread-2.1.1/subread-2.1.1-source.tar.gz"
+  sha256 "6392d7c66831cdd767e58251892a79a51b6fab8ed0ba9671ad5e85ff1ab01eaa"
+  license "GPL-3.0-or-later"
+
+  on_linux do
+    depends_on "zlib-ng-compat"
+  end
+
+  def install
+    cd "src" do
+      if OS.mac?
+        # The bundled Makefile hardcodes x86 SIMD flags that clang rejects on arm64.
+        inreplace "Makefile.MacOS", " -mmmx -msse -msse2 -msse3", "" if Hardware::CPU.arm?
+        system "make", "-f", "Makefile.MacOS"
+      else
+        inreplace "Makefile.Linux", "-mtune=core2", "" if Hardware::CPU.arm?
+        system "make", "-f", "Makefile.Linux"
+      end
+    end
+    bin.install Dir["bin/sub*"]
+    bin.install "bin/exactSNP", "bin/featureCounts"
+    bin.install Dir["bin/utilities/*"]
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/featureCounts -v 2>&1")
+
+    (testpath/"genes.saf").write "GeneID\tChr\tStart\tEnd\tStrand\ng1\tchr1\t1\t100\t+\n"
+    (testpath/"reads.sam").write <<~SAM
+      @HD\tVN:1.0\tSO:unsorted
+      @SQ\tSN:chr1\tLN:1000
+      r1\t0\tchr1\t10\t40\t50M\t*\t0\t0\t#{"A" * 50}\t#{"I" * 50}
+    SAM
+    system bin/"featureCounts", "-F", "SAF", "-a", "genes.saf", "-o", "counts.txt", "reads.sam"
+    # The single read overlaps gene g1, so its assigned-read count is 1.
+    assert_match(/^g1\t.*\t1$/, (testpath/"counts.txt").read)
+  end
+end


### PR DESCRIPTION
[subread](https://subread.sourceforge.net/) 2.1.1 — high-performance read
alignment, quantification and mutation discovery (includes `featureCounts`,
`subread-align`, `exactSNP`, etc.), widely used for RNA-seq read summarization.

The bundled Makefiles hardcode x86 tuning/SIMD flags (`-mtune=core2` on Linux,
`-mmmx -msse -msse2 -msse3` on macOS); the source uses no x86 intrinsics, so
these are stripped on arm64 to build natively there.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Drafted with AI assistance (Claude Code). Manually verified on macOS arm64: `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source subread`, `brew test subread`, and `brew audit --new --strict --online subread` all pass; confirmed `featureCounts -v` reports 2.1.1. I checked upstream that no x86 intrinsics are used (only compiler flags), so stripping them on arm64 is safe; the license (GPL-3.0-or-later) was confirmed from the source headers.

-----
