### PR TITLE
mash 2.3 (new formula)

### DIFF
--- a/Formula/m/mash.rb
+++ b/Formula/m/mash.rb
@@ -1,0 +1,44 @@
+class Mash < Formula
+  desc "Fast genome distance estimation using MinHash"
+  homepage "https://github.com/marbl/Mash"
+  url "https://github.com/marbl/Mash/archive/refs/tags/v2.3.tar.gz"
+  sha256 "f96cf7305e010012c3debed966ac83ceecac0351dbbfeaa6cd7ad7f068d87fe1"
+  license "BSD-3-Clause"
+  head "https://github.com/marbl/Mash.git", branch: "master"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "pkgconf" => :build
+  depends_on "capnp"
+  depends_on "gsl"
+
+  on_linux do
+    depends_on "zlib-ng-compat"
+  end
+
+  def install
+    # Newer compilers need explicit <cstdint>/<limits> includes, and the
+    # bundled build pins -std=c++14 while the current Cap'n Proto requires C++17.
+    ENV.append "CXXFLAGS", "-include cstdint -include limits"
+    inreplace ["Makefile.in", "configure.ac"], "-std=c++14", "-std=c++17"
+    # Drop the glibc-symbol-pinning memcpy wrapper: it forces memcpy@GLIBC_2.2.5,
+    # which the Homebrew toolchain does not provide (Homebrew targets its own glibc).
+    inreplace "Makefile.in", " -include src/mash/memcpyLink.h -Wl,--wrap=memcpy", ""
+    inreplace "Makefile.in", "-include src/mash/memcpyLink.h", ""
+    system "./bootstrap.sh"
+    system "./configure", *std_configure_args,
+                          "--with-capnp=#{formula_opt_prefix("capnp")}",
+                          "--with-gsl=#{formula_opt_prefix("gsl")}"
+    system "make"
+    bin.install "mash"
+    doc.install Dir["doc/sphinx/*"]
+    pkgshare.install "data"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/mash --version 2>&1")
+    system bin/"mash", "sketch", "-o", "test", pkgshare/"data/genome1.fna"
+    assert_match "Sketches:", shell_output("#{bin}/mash info test.msh")
+  end
+end


### PR DESCRIPTION
[Mash](https://github.com/marbl/Mash) 2.3 — fast genome and metagenome distance
estimation using the MinHash algorithm; a standard tool for sequence sketching
and rapid all-vs-all comparison.

License is declared as `BSD-3-Clause` (the LICENSE.txt is the verbatim 3-clause
BSD text with a BNBI copyright header; GitHub reports it as NOASSERTION only
because of that header).

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Drafted with AI assistance (Claude Code). Manually verified on macOS arm64: `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source mash`, `brew test mash` (sketch + info round-trip), and `brew audit --new --strict --online mash` all pass. I confirmed the LICENSE.txt matches BSD-3-Clause verbatim before declaring the license.

-----
