### PR TITLE
trim-galore 2.3.0 (new formula)

### DIFF
--- a/Formula/t/trim-galore.rb
+++ b/Formula/t/trim-galore.rb
@@ -1,0 +1,23 @@
+class TrimGalore < Formula
+  desc "Wrapper around Cutadapt and FastQC for quality and adapter trimming"
+  homepage "https://github.com/FelixKrueger/TrimGalore"
+  url "https://github.com/FelixKrueger/TrimGalore/archive/refs/tags/v2.3.0.tar.gz"
+  sha256 "6dd4d99c10a2d1e740d8e49ee870b1f9a7ccb8ee94c0bc5183d2ae507492aab0"
+  license "GPL-3.0-only"
+  head "https://github.com/FelixKrueger/TrimGalore.git", branch: "master"
+
+  depends_on "rust" => :build
+  depends_on "cutadapt"
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/trim_galore --version")
+
+    (testpath/"reads.fq").write "@r1\n#{"A" * 30}AGATCGGAAGAGC\n+\n#{"I" * 43}\n"
+    system bin/"trim_galore", "--dont_gzip", testpath/"reads.fq"
+    assert_path_exists testpath/"reads_trimmed.fq"
+  end
+end


### PR DESCRIPTION
[Trim Galore](https://github.com/FelixKrueger/TrimGalore) 2.3.0 — a wrapper
around Cutadapt (and optionally FastQC) for consistent quality and adapter
trimming, with automatic adapter detection and RRBS/bisulfite-aware modes.

Note: 2.x is the new Rust rewrite of Trim Galore (single `trim_galore` binary,
built via `cargo`). It still drives `cutadapt` as the trimming engine, so
`cutadapt` is declared as a runtime dependency.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Drafted with AI assistance (Claude Code). Manually verified on macOS arm64: `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source trim-galore`, `brew test trim-galore` (trims a synthetic read carrying the Illumina adapter and checks the trimmed output), and `brew audit --new --strict --online trim-galore` all pass. Confirmed upstream that 2.x drives `cutadapt` at runtime, hence the dependency.

-----
