### PR TITLE
muscle 5.3 (new formula)

### DIFF
--- a/Formula/m/muscle.rb
+++ b/Formula/m/muscle.rb
@@ -1,0 +1,54 @@
+class Muscle < Formula
+  desc "Multiple sequence alignment program"
+  homepage "https://drive5.com/muscle/"
+  url "https://github.com/rcedgar/muscle/archive/refs/tags/v5.3.tar.gz"
+  sha256 "74b22a94e630b16015c2bd9ae83aa2be2c2048d3e41f560b2d4a954725c81968"
+  license "GPL-3.0-only"
+  head "https://github.com/rcedgar/muscle.git", branch: "main"
+
+  depends_on "python@3.14" => :build
+
+  on_macos do
+    depends_on "llvm" => :build if DevelopmentTools.clang_build_version <= 1699
+    depends_on "libomp"
+  end
+
+  on_linux do
+    depends_on "gcc"
+  end
+
+  fails_with :clang do
+    build 1699
+    cause "Requires C++20"
+  end
+
+  # Upstream's build scripts (src/build_osx.bash, src/build_linux.bash) download
+  # this helper to build the Visual Studio project on POSIX systems; vendor it
+  # pinned to the same commit those scripts use.
+  resource "vcxproj_make" do
+    url "https://raw.githubusercontent.com/rcedgar/vcxproj_make/806d016/vcxproj_make.py"
+    sha256 "902735703004c47705ffa389329378f237fecb154945b489edf6abe260c6694f"
+  end
+
+  def install
+    resource("vcxproj_make").stage buildpath/"src"
+    cd "src" do
+      if OS.mac?
+        ENV["CPPFLAGS"] = "-Xpreprocessor -I#{formula_opt_include("libomp")}"
+        ENV["LDFLAGS"] = "-L#{formula_opt_lib("libomp")} -lomp"
+      else
+        inreplace "vcxproj_make.py", "-static", ""
+      end
+      system formula_opt_bin("python@3.14")/"python3.14", "vcxproj_make.py",
+             "--openmp", "--cppcompiler", ENV.cxx, "--ccompiler", ENV.cc
+    end
+    bin.install "bin/muscle"
+    pkgshare.install "test_data"
+  end
+
+  test do
+    assert_match "muscle", shell_output("#{bin}/muscle -version")
+    system bin/"muscle", "-super5", pkgshare/"test_data/fa/BB11001", "-output", "out.fna"
+    assert_path_exists testpath/"out.fna"
+  end
+end


### PR DESCRIPTION
[MUSCLE](https://drive5.com/muscle/) 5.3 — widely used multiple sequence
alignment program (Edgar).

Build note: upstream ships only Visual Studio project files plus
`src/build_osx.bash` / `src/build_linux.bash`, which download `vcxproj_make.py`
to build on POSIX. To avoid a network fetch during the build, that helper is
vendored as a checksummed `resource`, pinned to the exact commit (`806d016`)
those upstream scripts reference. MUSCLE 5 requires C++20 (hence the clang
version guard / `llvm` build dep on older macOS) and uses OpenMP (`libomp`).

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Drafted with AI assistance (Claude Code). Manually verified on macOS arm64: `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source muscle`, `brew test muscle` (runs a `-super5` alignment on bundled test data), and `brew audit --new --strict --online muscle` all pass. I checked upstream that the vendored `vcxproj_make.py` matches the commit referenced by MUSCLE's own build scripts.

-----
