### PR TITLE
trim-galore 2.3.0 (new formula)

### DIFF
--- a/Formula/t/trim-galore.rb
+++ b/Formula/t/trim-galore.rb
@@ -6,6 +6,15 @@ class TrimGalore < Formula
   license "GPL-3.0-only"
   head "https://github.com/FelixKrueger/TrimGalore.git", branch: "master"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "21715e4c80f487a2e3e4ad673e12cdfa872bde5685597b6790e062be97a275ed"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "4be9dd3a0cba6a7671eb0e3cbc426e30e621c3754831bcdbf25dfcafed47e9df"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "981fa7a134a77f9ed8af9e91eaf7dfe6e37536a2bea3eb1baab6345fa55b331f"
+    sha256 cellar: :any_skip_relocation, sonoma:        "c2475710430a340a61d03036f9b626226e3e2cd7f9a6544fc2ddbfe404488f19"
+    sha256 cellar: :any,                 arm64_linux:   "95e72c2c77cb70c6348c5f5b4ff4053fb9a455ad61ac3ed42e5ea42789cfebdd"
+    sha256 cellar: :any,                 x86_64_linux:  "5b67d87bfc3fd3e780117d9c7aa98485a02f0c39d99f3c0ce1df3df2957efa05"
+  end
+
   depends_on "rust" => :build
 
   on_linux do

--- a/Formula/t/trim-galore.rb
+++ b/Formula/t/trim-galore.rb
@@ -1,0 +1,26 @@
+class TrimGalore < Formula
+  desc "Quality and adapter trimming for FastQ sequencing reads"
+  homepage "https://github.com/FelixKrueger/TrimGalore"
+  url "https://github.com/FelixKrueger/TrimGalore/archive/refs/tags/v2.3.0.tar.gz"
+  sha256 "6dd4d99c10a2d1e740d8e49ee870b1f9a7ccb8ee94c0bc5183d2ae507492aab0"
+  license "GPL-3.0-only"
+  head "https://github.com/FelixKrueger/TrimGalore.git", branch: "master"
+
+  depends_on "rust" => :build
+
+  on_linux do
+    depends_on "zlib-ng-compat"
+  end
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/trim_galore --version")
+
+    (testpath/"reads.fq").write "@r1\n#{"A" * 30}AGATCGGAAGAGC\n+\n#{"I" * 43}\n"
+    system bin/"trim_galore", "--dont_gzip", testpath/"reads.fq"
+    assert_path_exists testpath/"reads_trimmed.fq"
+  end
+end


### PR DESCRIPTION
**Trim Galore 2.3.0** — quality and adapter trimming for FastQ sequencing reads.

v2 is a self-contained Rust rewrite of Trim Galore: a single binary with **no
runtime dependencies**, designed as a drop-in replacement for the v0.6.x Perl
scripts (same CLI, same output filenames, same report format). It does its own
adapter auto-detection (Illumina / Nextera / small-RNA / BGI-DNBSEQ), Phred
quality trimming, poly-G (2-colour) and poly-A trimming, paired-end and RRBS
handling, and MultiQC-compatible reports. FastQC reporting is built in via a
bundled `fastqc-rust` library, so it needs neither `cutadapt`, an external
`fastqc`, nor a Java runtime. Migration notes: https://www.trimgalore.com/reference/migration/

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Drafted with AI assistance (Claude Code). Manually verified on macOS arm64: `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source trim-galore`, `brew test trim-galore` (trims a synthetic read carrying the Illumina adapter), and `brew audit --new --strict --online trim-galore` all pass. I confirmed against the source that v2.0 spawns no external processes (no `cutadapt`/`fastqc` subprocess), so the formula has no runtime dependencies beyond the Rust build toolchain.

-----
