### PR TITLE
podman: use applehv as default machine provider on macOS

### DIFF
--- a/Formula/p/podman.rb
+++ b/Formula/p/podman.rb
@@ -19,11 +19,11 @@ class Podman < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "69eb130ad2a542abd89792fab936f026ff8884cce70bb8559df5ee0c97a295c6"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "402e4dbcdcd31fe17b5c8564ba7c09d7edfc91d33aef86ef364b75f4e3bcc891"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "86297927eac85ab4f0439eda7c83fa510c62bdc7b39807dbe5c4a4fab137639f"
-    sha256                               arm64_linux:   "203de22b766887b1e4e0fa1f9a1185849d7e640e6ded5458dffbad15f3325da6"
-    sha256                               x86_64_linux:  "e47e2c781d2307976e4517709db48bb409324819a01dc5678d268e9026649c63"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "598ca0c63fe924058efc11cdb3574ec3ff33a9ba3835f2ec05352046e9fe3d0b"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "ddb0c05ed08c186ec9d27c3765a5ad7a04e5293edfb91ac2f01724a39c208014"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "cb4d0622599c00bc9d6151d6c0e962b422247d09ca0b8c5780bb9f14148875b5"
+    sha256                               arm64_linux:   "5b7854662b116a666d63185227962995d161aed3dce41ae0e9420c3c2e2b6f05"
+    sha256                               x86_64_linux:  "ce7ce8f97c5a5055c2e0e95000585589bb029d8a23e3b79d56422a6037458f64"
   end
 
   depends_on "go" => :build

--- a/Formula/p/podman.rb
+++ b/Formula/p/podman.rb
@@ -4,6 +4,7 @@ class Podman < Formula
   url "https://github.com/podman-container-tools/podman/archive/refs/tags/v6.0.1.tar.gz"
   sha256 "4829d7c1423523a6a4d5537dea7968ae7f6c22ed7f1d5f416638fd81c83caa47"
   license all_of: ["Apache-2.0", "GPL-3.0-or-later"]
+  revision 1
   compatibility_version 1
   head "https://github.com/podman-container-tools/podman.git", branch: "main"
 
@@ -90,6 +91,17 @@ class Podman < Formula
       url "https://github.com/containers/aardvark-dns/archive/refs/tags/v2.0.0.tar.gz"
       sha256 "d3f5d6b3be3c2d80e8257fb9467e34ff104f299474427979454034dca6dc88cc"
     end
+  end
+
+  # Starting in podman 6.0.0, libkrun (via krunkit) is the default machine
+  # driver on macOS. krunkit is not yet available in homebrew-core, so continue
+  # using the previous default driver applehv.
+  #
+  # See https://github.com/Homebrew/homebrew-core/issues/291552
+  # Remove once krunkit is available in homebrew-core.
+  patch do
+    file "Patches/podman/revert-libkrun-default.patch"
+    type :unofficial
   end
 
   def install
@@ -210,6 +222,12 @@ class Podman < Formula
       # See https://github.com/Homebrew/homebrew-core/pull/166471
       out = shell_output("#{bin}/podman-remote machine init homebrew-testvm")
       assert_match "Machine init complete", out
+
+      # Remove once krunkit is available and we follow the upstream behavior of using it
+      # by default
+      cfg_output = shell_output("#{bin}/podman-remote machine inspect homebrew-testvm --format {{.ConfigDir.Path}}")
+      assert_equal (testpath/".config/containers/podman/machine/applehv").to_s, cfg_output.chomp
+
       system bin/"podman-remote", "machine", "rm", "-f", "homebrew-testvm"
     else
       assert_equal %w[podman podman-remote podmansh]

--- a/Patches/podman/revert-libkrun-default.patch
+++ b/Patches/podman/revert-libkrun-default.patch
@@ -1,0 +1,157 @@
+commit c0102ee00dc3a6dad5a7baf0cb25e656a6c24197
+Author: Caleb Xu <calebcenter@live.com>
+Date:   Thu Jul 9 14:27:09 2026 -0400
+
+    Revert "Merge pull request #27546 from jakecorrenti/libkrun-as-default"
+    
+    This reverts commit 18aa7849884ff61c423b5c7eb6aa850c98f6ea11, reversing
+    changes made to 7cd9b81b43947828f5bbeb0728a11d0a1a01fffc. It also
+    restores imports/guards as needed for the codebase to build cleanly
+    after the revert.
+
+diff --git a/pkg/machine/e2e/README.md b/pkg/machine/e2e/README.md
+index 07deb700e1..72a1c8bd95 100644
+--- a/pkg/machine/e2e/README.md
++++ b/pkg/machine/e2e/README.md
+@@ -67,7 +67,7 @@ above.
+ ## MacOS
+ 
+ Macs now support two different machine providers: `applehv` and `libkrun`. The
+-`libkrun` provider is the default.
++`applehv` provider is the default.
+ 
+ Note: On macOS, an error will occur if the path length of `$TMPDIR` is longer
+ than 22 characters. Please set the appropriate path to `$TMPDIR`. Also, if
+@@ -77,11 +77,11 @@ than 22 characters. Please set the appropriate path to `$TMPDIR`. Also, if
+ 
+ 1. `brew install vfkit`
+ 1. `make podman-remote`
+-1. `export CONTAINERS_MACHINE_PROVIDER="applehv"`
+ 1. `make localmachine`
+ 
+ ### [Libkrun](https://github.com/containers/libkrun)
+ 
+ 1. `brew install krunkit`
+ 1. `make podman-remote`
++1. `export CONTAINERS_MACHINE_PROVIDER="libkrun"`
+ 1. `make localmachine`
+diff --git a/pkg/machine/provider/platform_darwin.go b/pkg/machine/provider/platform_darwin.go
+index 88ee2d057a..a843896ccd 100644
+--- a/pkg/machine/provider/platform_darwin.go
++++ b/pkg/machine/provider/platform_darwin.go
+@@ -2,9 +2,11 @@ package provider
+ 
+ import (
+ 	"bytes"
++	"errors"
+ 	"fmt"
+ 	"os"
+ 	"os/exec"
++	"runtime"
+ 	"strings"
+ 
+ 	"github.com/blang/semver/v4"
+@@ -25,7 +27,7 @@ func Get() (vmconfigs.VMProvider, error) {
+ 	if providerOverride, found := os.LookupEnv("CONTAINERS_MACHINE_PROVIDER"); found {
+ 		provider = providerOverride
+ 	}
+-	resolvedVMType, err := define.ParseVMType(provider, define.LibKrun)
++	resolvedVMType, err := define.ParseVMType(provider, define.AppleHvVirt)
+ 	if err != nil {
+ 		return nil, err
+ 	}
+@@ -41,6 +43,9 @@ func GetByVMType(resolvedVMType define.VMType) (vmconfigs.VMProvider, error) {
+ 	case define.AppleHvVirt:
+ 		return new(applehv.AppleHVStubber), nil
+ 	case define.LibKrun:
++		if runtime.GOARCH == "amd64" {
++			return nil, errors.New("libkrun is not supported on Intel based machines. Please revert to the applehv provider")
++		}
+ 		return new(libkrun.LibKrunStubber), nil
+ 	default:
+ 	}
+@@ -48,12 +53,20 @@ func GetByVMType(resolvedVMType define.VMType) (vmconfigs.VMProvider, error) {
+ }
+ 
+ func GetAll() []vmconfigs.VMProvider {
+-	return []vmconfigs.VMProvider{new(libkrun.LibKrunStubber), new(applehv.AppleHVStubber)}
++	configs := []vmconfigs.VMProvider{new(applehv.AppleHVStubber)}
++	if runtime.GOARCH == "arm64" {
++		configs = append(configs, new(libkrun.LibKrunStubber))
++	}
++	return configs
+ }
+ 
+ // SupportedProviders returns the providers that are supported on the host operating system
+ func SupportedProviders() []define.VMType {
+-	return []define.VMType{define.AppleHvVirt, define.LibKrun}
++	supported := []define.VMType{define.AppleHvVirt}
++	if runtime.GOARCH == "arm64" {
++		return append(supported, define.LibKrun)
++	}
++	return supported
+ }
+ 
+ func IsInstalled(provider define.VMType) (bool, error) {
+@@ -101,6 +114,10 @@ func appleHvInstalled() (bool, error) {
+ }
+ 
+ func libKrunInstalled() (bool, error) {
++	if runtime.GOARCH != "arm64" {
++		return false, nil
++	}
++
+ 	// need to verify that krunkit, virglrenderer, and libkrun-efi are installed
+ 	cfg, err := config.Default()
+ 	if err != nil {
+diff --git a/pkg/machine/provider/platform_test.go b/pkg/machine/provider/platform_test.go
+index 135527f912..f5bc89df52 100644
+--- a/pkg/machine/provider/platform_test.go
++++ b/pkg/machine/provider/platform_test.go
+@@ -11,7 +11,11 @@ import (
+ func TestSupportedProviders(t *testing.T) {
+ 	switch runtime.GOOS {
+ 	case "darwin":
+-		assert.Equal(t, []define.VMType{define.AppleHvVirt, define.LibKrun}, SupportedProviders())
++		if runtime.GOARCH == "arm64" {
++			assert.Equal(t, []define.VMType{define.AppleHvVirt, define.LibKrun}, SupportedProviders())
++		} else {
++			assert.Equal(t, []define.VMType{define.AppleHvVirt}, SupportedProviders())
++		}
+ 	case "windows":
+ 		assert.ElementsMatch(t, []define.VMType{define.WSLVirt, define.HyperVVirt}, SupportedProviders())
+ 	case "linux":
+@@ -24,7 +28,8 @@ func TestInstalledProviders(t *testing.T) {
+ 	assert.NoError(t, err)
+ 	switch runtime.GOOS {
+ 	case "darwin":
+-		assert.Equal(t, []define.VMType{define.LibKrun, define.AppleHvVirt}, installed)
++		// TODO: need to verify if an arm64 machine reports {applehv, libkrun}
++		assert.Equal(t, []define.VMType{define.AppleHvVirt}, installed)
+ 	case "windows":
+ 		provider, err := Get()
+ 		assert.NoError(t, err)
+@@ -55,8 +60,9 @@ func TestBadSupportedProviders(t *testing.T) {
+ 	switch runtime.GOOS {
+ 	case "darwin":
+ 		assert.NotEqual(t, []define.VMType{define.QemuVirt}, SupportedProviders())
+-		assert.NotEqual(t, []define.VMType{define.WSLVirt, define.HyperVVirt}, SupportedProviders())
+-		assert.NotEqual(t, []define.VMType{define.AppleHvVirt}, SupportedProviders())
++		if runtime.GOARCH != "arm64" {
++			assert.NotEqual(t, []define.VMType{define.AppleHvVirt, define.LibKrun}, SupportedProviders())
++		}
+ 	case "windows":
+ 		assert.NotEqual(t, []define.VMType{define.QemuVirt}, SupportedProviders())
+ 	case "linux":
+@@ -70,8 +76,9 @@ func TestBadInstalledProviders(t *testing.T) {
+ 	switch runtime.GOOS {
+ 	case "darwin":
+ 		assert.NotEqual(t, []define.VMType{define.QemuVirt}, installed)
+-		assert.NotEqual(t, []define.VMType{define.AppleHvVirt}, installed)
+-		assert.NotEqual(t, []define.VMType{define.WSLVirt, define.HyperVVirt}, installed)
++		if runtime.GOARCH != "arm64" {
++			assert.NotEqual(t, []define.VMType{define.AppleHvVirt, define.LibKrun}, installed)
++		}
+ 	case "windows":
+ 		assert.NotContains(t, installed, define.QemuVirt)
+ 	case "linux":


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Users can still use `libkrun`-based machines by installing `krunkit` from the third party tap maintained by the `libkrun` team, and then running `podman machine init` with the `--provider libkrun` flag. Note that this default only takes effect when creating a new machine; any existing machines continue using the driver with which they were created.