### PR TITLE
netcode 1.3.3 (new formula)

### DIFF
--- a/Formula/n/netcode.rb
+++ b/Formula/n/netcode.rb
@@ -5,6 +5,15 @@ class Netcode < Formula
   sha256 "b21995f192fcc0252cccfa2a584dfab3509172741e9a1eeb58baf514b9747c92"
   license "BSD-3-Clause"
 
+  bottle do
+    sha256 cellar: :any, arm64_tahoe:   "aed81be23962b53043461b6f2b6b3fe515a2ec20f194cc59ce9d36264ba08903"
+    sha256 cellar: :any, arm64_sequoia: "4065f5751057dcae095e789f77721a01e549a3bbae60ee01165b9f0c52e45328"
+    sha256 cellar: :any, arm64_sonoma:  "4c5644518debf9f6a9bfbec99d1f5cb8ef52b581f04dc11e4f8c702133c152bd"
+    sha256 cellar: :any, sonoma:        "f3c741f2857c0c27cfa9f7172dd13c6a048026a1076fe32ff4c5759bcc888275"
+    sha256 cellar: :any, arm64_linux:   "db5ce47fec191187ad10e8fb5ca92a4915bc4ea318aed6972ec0088b93a85039"
+    sha256 cellar: :any, x86_64_linux:  "f8ade1334eda200e29ec02c4a352b7e98ed12f3936b4d572070c57ce48b4207f"
+  end
+
   depends_on "cmake" => :build
   depends_on "libsodium"
 

--- a/Formula/n/netcode.rb
+++ b/Formula/n/netcode.rb
@@ -1,0 +1,43 @@
+class Netcode < Formula
+  desc "Secure client/server protocol for multiplayer games built on top of UDP"
+  homepage "https://github.com/mas-bandwidth/netcode"
+  url "https://github.com/mas-bandwidth/netcode/archive/refs/tags/v1.3.3.tar.gz"
+  sha256 "b21995f192fcc0252cccfa2a584dfab3509172741e9a1eeb58baf514b9747c92"
+  license "BSD-3-Clause"
+
+  depends_on "cmake" => :build
+  depends_on "libsodium"
+
+  def install
+    system "cmake", "-S", ".", "-B", "build",
+                    "-DNETCODE_SYSTEM_SODIUM=ON",
+                    "-DBUILD_SHARED_LIBS=ON",
+                    *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <netcode.h>
+
+      int main(void) {
+        if (netcode_init() != NETCODE_OK) return 1;
+        struct netcode_address_t address;
+        if (netcode_parse_address("127.0.0.1:40000", &address) != NETCODE_OK) return 1;
+        if (address.port != 40000) return 1;
+        struct netcode_server_config_t config;
+        netcode_default_server_config(&config);
+        struct netcode_server_t *server = netcode_server_create("127.0.0.1:40000", &config, 0.0);
+        if (!server) return 1;
+        netcode_server_start(server, 16);
+        if (!netcode_server_running(server)) return 1;
+        netcode_server_destroy(server);
+        netcode_term();
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lnetcode", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

The formula and the upstream system-libsodium build option (added in v1.3.1) were written with Claude Code, directed by me (I am the author and maintainer of netcode). Manual verification, re-run after bumping this PR to v1.3.3: the formula was built from source with brew on macOS (arm64) against Homebrew's libsodium, `brew test netcode` passes, and `brew audit --strict --online --new netcode` passes. The upstream project's own CI — build + test suite + fuzzing + ASan/UBSan on macOS, Linux and Windows, including a dedicated system-libsodium leg matching this formula's configuration — is green for the v1.3.3 tag.

-----

**netcode** is a secure client/server connection protocol for multiplayer games built on top of UDP: encrypted, signed packets with connect-token authentication against a game backend. BSD-3-Clause, C99, actively maintained since 2017 by [Glenn Fiedler](https://github.com/gafferongames) (mas-bandwidth). ~2.6k stars / 200 forks, with independent protocol implementations in C#, Go, Rust, and TypeScript built against its published standard.

The formula builds the shared library against Homebrew's libsodium (`-DNETCODE_SYSTEM_SODIUM=ON`, added upstream in v1.3.1 specifically to support packaging) and installs `netcode.h` + `libnetcode`. The test block compiles and runs a real consumer program that initializes the library, parses an address, and creates and starts a server.
