### PR TITLE
serialize 1.4.3 (new formula)

### DIFF
--- a/Formula/s/serialize.rb
+++ b/Formula/s/serialize.rb
@@ -5,6 +5,10 @@ class Serialize < Formula
   sha256 "4be561172300962ccb340ae7f7904882700ee79a20a698979cce5097310eeaae"
   license "BSD-3-Clause"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, all: "7a47608fb4576b7434e60874d7649ff94a71793a3219e6e6bc1cd4ea0fd2a4e1"
+  end
+
   depends_on "cmake" => :build
 
   def install

--- a/Formula/s/serialize.rb
+++ b/Formula/s/serialize.rb
@@ -1,0 +1,35 @@
+class Serialize < Formula
+  desc "Single-header bitpacking serializer for C++ aimed at game networking"
+  homepage "https://github.com/mas-bandwidth/serialize"
+  url "https://github.com/mas-bandwidth/serialize/archive/refs/tags/v1.4.3.tar.gz"
+  sha256 "4be561172300962ccb340ae7f7904882700ee79a20a698979cce5097310eeaae"
+  license "BSD-3-Clause"
+
+  depends_on "cmake" => :build
+
+  def install
+    system "cmake", "-S", ".", "-B", "build", "-DSERIALIZE_BUILD_TESTS=OFF", *std_cmake_args
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~CPP
+      #include <serialize.h>
+      int main()
+      {
+          uint8_t buffer[64];
+          memset( buffer, 0, sizeof( buffer ) );
+          serialize::WriteStream writer( buffer, 64 );
+          uint32_t written = 12345;
+          writer.SerializeBits( written, 14 );
+          writer.Flush();
+          serialize::ReadStream reader( buffer, writer.GetBytesProcessed() );
+          uint32_t value = 0;
+          reader.SerializeBits( value, 14 );
+          return value == 12345 ? 0 : 1;
+      }
+    CPP
+    system ENV.cxx, "test.cpp", "-I#{include}", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

The formula was written with Claude Code, directed by me (I am the author and maintainer of serialize). Manual verification, re-run after bumping this PR to v1.4.3: the formula was built from source with brew on macOS (arm64), `brew test serialize` passes (it compiles and runs a consumer program that round-trips bitpacked data through the installed header), and `brew audit --strict --online --new serialize` passes. Upstream CI for the v1.4.3 tag is green, including the golden test that pins the wire format across little- and big-endian platforms and the continuous fuzzing run.

-----

**serialize** is a single-header, header-only bitpacking serializer for C++ aimed at game networking, from Más Bandwidth / Glenn Fiedler. BSD-3-Clause. The wire format is pinned by a golden test across little- and big-endian platforms, and the library is fuzzed continuously (60s smoke on every push, 1-hour nightly run).

The main motivation for this submission is to support vendoring `serialize` as a dependency of [yojimbo](https://github.com/mas-bandwidth/yojimbo) in homebrew-core. yojimbo is a much older, widely-used, well-starred (10+ years) UDP game networking library that itself depends on serialize.h for its packet serialization. Rather than vendoring serialize.h manually inside a future yojimbo formula, having `serialize` available as its own formula lets a yojimbo formula simply `depends_on "serialize"` and reference it cleanly.
