### PR TITLE
commit-gh-cli 2.0.26 (new formula)

### DIFF
--- a/Formula/c/commit-gh-cli.rb
+++ b/Formula/c/commit-gh-cli.rb
@@ -1,0 +1,18 @@
+class CommitGhCli < Formula
+  desc "Secure Git commits, releases, and repository security hardening"
+  homepage "https://github.com/raymonepping/homebrew-commit-gh-cli"
+  url "https://github.com/raymonepping/homebrew-commit-gh-cli/archive/refs/tags/v2.0.26.tar.gz"
+  sha256 "1dcd65b37e01388d2621ff90b94b0e48649ae249ea2a2983cab6caa915be56a5"
+  license "MIT"
+
+  depends_on "bash"
+
+  def install
+    bin.install "bin/commit_gh"
+    doc.install "README.md"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/commit_gh --version")
+  end
+end


### PR DESCRIPTION
`commit_gh` is a Bash CLI that wraps `git` and `gh` to enforce a secure, opinionated commit and release workflow. It provides pre-commit secret scanning (gitleaks), repository scaffolding (`--harden`), security auditing (`--audit`), and automated semantic versioning with GitHub release creation (`--release`). Ships with a man page and shell completions for zsh, bash, and fish.

Published article: [How One Small Mistake Changed the Way I Build Every GitHub Repository](https://medium.com/@raymonepping/how-one-small-mistake-changed-the-way-i-build-every-github-repository-4b476e753360)

Available via tap: `brew install raymonepping/commit-gh-cli/commit-gh-cli`

---

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open pull requests for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source commit-gh-cli`?
- [x] Is your test running fine `brew test commit-gh-cli`?
- [x] Does your build pass `brew audit --new commit-gh-cli`?
- [x] AI was used to generate or assist with generating this PR. Claude (claude.ai) assisted with writing the formula, man page, shell completions, and PR description. The tap formula (`raymonepping/commit-gh-cli`) was manually verified: `brew install`, `brew test`, and `brew audit --new` all pass. The sha256 was verified against the released tarball. The binary, man page, and completions were confirmed to install and work correctly after `brew upgrade`.