### PR TITLE
hbase: drop native lzo support as needs unmaintained resource

### DIFF
--- a/Formula/h/hbase.rb
+++ b/Formula/h/hbase.rb
@@ -7,12 +7,13 @@ class Hbase < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 arm64_tahoe:   "8fe2578bdd1fb4288530b15721d72679a44c1f535a2ceaf7d85a8a5dd25aa0d0"
-    sha256 arm64_sequoia: "ec96d394f1a20747f38c0e874c0ac72fe012614b6f3ebbd46a7093d322ad3bc9"
-    sha256 arm64_sonoma:  "89d8151ecf120d5228473ea835540c50b4dac5abd2a996346eff9d0a4c78ea97"
-    sha256 sonoma:        "6cad68272975fe6ea1bfa854c430e3b1201cb115c9a9717b8b6759bea661d9bc"
-    sha256 arm64_linux:   "08dbb999a86cfaa7662a3fa990434f862e59a38ebf7e5a643a06540e9ed1df58"
-    sha256 x86_64_linux:  "a459a717fb035af4541cfea2ee9acda0d06076ff03e475e166497120030c4638"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "16c927027587377823e7cb562023adaee6421874fb6e131e22290e6f3d8f42f3"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "16c927027587377823e7cb562023adaee6421874fb6e131e22290e6f3d8f42f3"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "16c927027587377823e7cb562023adaee6421874fb6e131e22290e6f3d8f42f3"
+    sha256 cellar: :any_skip_relocation, sonoma:        "5e45a3415796d599b63537f18a32bf2e55a104ca4af8cdbcf5c8e904c820647d"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "3fa790a5b8c6e12b4c882a392dcdcf49eba5ab4940f0ffc40b03e11f78bd2470"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3fa790a5b8c6e12b4c882a392dcdcf49eba5ab4940f0ffc40b03e11f78bd2470"
   end
 
   depends_on "ant" => :build

--- a/Formula/h/hbase.rb
+++ b/Formula/h/hbase.rb
@@ -4,8 +4,7 @@ class Hbase < Formula
   url "https://www.apache.org/dyn/closer.lua?path=hbase/2.6.6/hbase-2.6.6-bin.tar.gz"
   mirror "https://archive.apache.org/dist/hbase/2.6.6/hbase-2.6.6-bin.tar.gz"
   sha256 "cbcfbfed6411cf898961133c228dcdb4beeb155a611e503ccb212e6f08abec00"
-  # We bundle hadoop-lzo which is GPL-3.0-or-later
-  license all_of: ["Apache-2.0", "GPL-3.0-or-later"]
+  license "Apache-2.0"
 
   bottle do
     sha256 arm64_tahoe:   "8fe2578bdd1fb4288530b15721d72679a44c1f535a2ceaf7d85a8a5dd25aa0d0"
@@ -17,30 +16,12 @@ class Hbase < Formula
   end
 
   depends_on "ant" => :build
-  depends_on "lzo"
   depends_on "openjdk@17"
 
   on_linux do
     on_arm do
       # Added automake as a build dependency to update config files for ARM support.
       depends_on "automake" => :build
-    end
-  end
-
-  resource "hadoop-lzo" do
-    url "https://github.com/cloudera/hadoop-lzo/archive/refs/tags/0.4.14.tar.gz"
-    sha256 "aa8ddbb8b3f9e1c4b8cc3523486acdb7841cd97c002a9f2959c5b320c7bb0e6c"
-
-    patch do
-      url "https://raw.githubusercontent.com/Homebrew/homebrew-core/1cf441a0/Patches/hbase/build.xml.patch"
-      sha256 "d1d65330a4367db3e17ee4f4045641b335ed42449d9e6e42cc687e2a2e3fa5bc"
-    end
-
-    # Fix -flat_namespace being used on Big Sur and later.
-    patch do
-      url "https://raw.githubusercontent.com/Homebrew/homebrew-core/1cf441a0/Patches/libtool/configure-pre-0.4.2.418-big_sur.diff"
-      sha256 "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923"
-      directory "src/native"
     end
   end
 
@@ -53,32 +34,6 @@ class Hbase < Formula
     # too special-purpose to be permanently available via PATH.
     %w[hbase start-hbase.sh stop-hbase.sh].each do |script|
       (bin/script).write_env_script libexec/"bin"/script, Language::Java.overridable_java_home_env("17")
-    end
-
-    resource("hadoop-lzo").stage do
-      if OS.linux? && Hardware::CPU.arm?
-        # Workaround for ancient config files not recognizing aarch64 macos.
-        automake_dir = Formula["automake"].share/"automake-#{Formula["automake"].version.major_minor}"
-        %w[config.guess config.sub].each { |fn| cp automake_dir/fn, "src/native/config/#{fn}" }
-      end
-
-      # Help configure to find liblzo on Linux.
-      unless OS.mac?
-        inreplace "src/native/configure",
-        "#define HADOOP_LZO_LIBRARY ${ac_cv_libname_lzo2}",
-        "#define HADOOP_LZO_LIBRARY \"#{formula_opt_lib("lzo")/shared_library("liblzo2")}\""
-      end
-
-      # Fixed upstream: https://github.com/cloudera/hadoop-lzo/blob/HEAD/build.xml#L235
-      ENV["CLASSPATH"] = Dir["#{libexec}/lib/hadoop-common-*.jar"].first
-      # Workaround for Xcode 14.3.
-      ENV.append_to_cflags "-m64" if Hardware::CPU.intel?
-      ENV.append_to_cflags "-Wno-implicit-function-declaration"
-      ENV["CPPFLAGS"] = "-I#{Formula["openjdk@17"].include}"
-
-      system "ant", "compile-native", "tar"
-      (libexec/"lib").install Dir["build/hadoop-lzo-*/hadoop-lzo-*.jar"]
-      (libexec/"lib/native").install Dir["build/hadoop-lzo-*/lib/native/*"]
     end
 
     inreplace libexec/"conf/hbase-env.sh" do |s|


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

The Cloudera resource is from 2011 but repo isn't maintained and we are patching it. There is a continuation in Twitter repo https://github.com/twitter/hadoop-lzo/tags but last release is 2016.

HBase does include a pure-Java LZO option so functionality is there (it may not be as performant, but it is maintained and avoids GPL-ing our HBase bottle):
- https://github.com/apache/hbase/blob/rel/2.6.6/hbase-compression/hbase-compression-aircompressor/src/main/java/org/apache/hadoop/hbase/io/compress/aircompressor/LzoCodec.java