### PR TITLE
avanor: replace gist with local patch file

### DIFF
--- a/Formula/a/avanor.rb
+++ b/Formula/a/avanor.rb
@@ -25,8 +25,8 @@ class Avanor < Formula
 
   # Upstream fix for clang: https://sourceforge.net/p/avanor/code/133/
   patch :p0 do
-    url "https://gist.githubusercontent.com/mistydemeo/64f47233ee64d55cb7d5/raw/c1847d7e3a134e6109ad30ce1968919dd962e727/avanor-clang.diff"
-    sha256 "2d24ce7b71eb7b20485d841aabffa55b25b9074f9a5dd83aee33b7695ba9d75c"
+    file "Patches/avanor/r133.diff"
+    type :cherry_pick # from 0.5 branch
   end
 
   def install

--- a/Patches/avanor/r133.diff
+++ b/Patches/avanor/r133.diff
@@ -1,0 +1,38 @@
+Index: game/location.h
+===================================================================
+--- game/location.h	(revision 132)
++++ game/location.h	(revision 133)
+@@ -105,7 +105,6 @@
+ 	PAL_EXTINCT_VOLCANO
+ };
+ 
+-enum STDMAP;
+ struct PALETTE_MAP
+ {
+ 	char this_view;
+Index: game/cave.cpp
+===================================================================
+--- game/cave.cpp	(revision 132)
++++ game/cave.cpp	(revision 133)
+@@ -192,7 +192,8 @@
+ 		}
+ 	
+ 	}
+-	r.Setup(&XRect(x, y, x + l, y + h));
++	XRect tmp(x, y, x + l, y + h);
++	r.Setup(&tmp);
+ }
+ 
+ int XCave::Compare(XObject * o)
+Index: creature/creature.h
+===================================================================
+--- creature/creature.h	(revision 132)
++++ creature/creature.h	(revision 133)
+@@ -99,7 +99,6 @@
+ class XPotion;
+ class XBook;
+ class XScroll;
+-enum MAGIC_SCHOOL;
+ 
+ struct ACTION_DATA
+ {


### PR DESCRIPTION
Output of `svn diff -c 133` on branch. Identical to gist but better to directly maintain unofficial patches in repo.

Using `:cherry_pick` as change never made it to trunk.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
