### PR TITLE
gastown: pick free port for test

### DIFF
--- a/Formula/g/gastown.rb
+++ b/Formula/g/gastown.rb
@@ -41,7 +41,7 @@ class Gastown < Formula
     system "dolt", "config", "--global", "--add", "user.name", "BrewTestBot"
     system "dolt", "config", "--global", "--add", "user.email", "BrewTestBot@test.com"
 
-    system bin/"gt", "install"
+    system bin/"gt", "install", "--dolt-port", free_port.to_s
     assert_path_exists testpath/"mayor"
   end
 end


### PR DESCRIPTION

https://github.com/Homebrew/homebrew-core/actions/runs/27825740996/job/82353326998?pr=288803#step:3:11779
```
  ==> /opt/homebrew/Cellar/gastown/1.1.0/bin/gt install
  Error: Dolt port 3307 is already in use
  Port is held by PID 24998
  
  Another Gas Town instance is using this port. Specify a free port:
  
    gt install --dolt-port 3308

```

Ref:
* https://github.com/Homebrew/homebrew-core/pull/288803

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
