### PR TITLE
happy-coder: deprecate as newer versions have non-FOSS dependency

### DIFF
--- a/Formula/h/happy-coder.rb
+++ b/Formula/h/happy-coder.rb
@@ -7,8 +7,7 @@ class HappyCoder < Formula
   head "https://github.com/slopus/happy-cli.git", branch: "main"
 
   livecheck do
-    url :stable
-    strategy :github_latest
+    skip "Newer versions use non-FOSS @anthropic-ai/claude-agent-sdk"
   end
 
   bottle do
@@ -19,6 +18,11 @@ class HappyCoder < Formula
     sha256 cellar: :any_skip_relocation, arm64_linux:   "bb9de9d2959ccac07a1d8ec38ea92c54cb850cb98b5da6e038ebaf077a475d17"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "bb9de9d2959ccac07a1d8ec38ea92c54cb850cb98b5da6e038ebaf077a475d17"
   end
+
+  # As of 1.1.5, happy has a required dependency on non-FOSS @anthropic-ai/claude-agent-sdk
+  # Ref: https://github.com/slopus/happy/commit/aa0014e501fb7263ab4f80a2447e65a0d5079f5a
+  deprecate! date: "2026-07-11", because: "uses non-FOSS @anthropic-ai/claude-agent-sdk since 1.1.5"
+  disable! date: "2027-07-11", because: "uses non-FOSS @anthropic-ai/claude-agent-sdk since 1.1.5"
 
   depends_on "yarn" => :build
   depends_on "difftastic"


### PR DESCRIPTION
In new repo, dependency on non-FOSS `@anthropic-ai/claude-agent-sdk` was added:
- https://github.com/slopus/happy/commit/aa0014e501fb7263ab4f80a2447e65a0d5079f5a

Old repo is now archived and since we cannot switch to new repo, this will be deprecated.
- https://github.com/slopus/happy-cli

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
