### PR TITLE
gobackup: replace yarn with npm

### DIFF
--- a/Formula/g/gobackup.rb
+++ b/Formula/g/gobackup.rb
@@ -19,14 +19,13 @@ class Gobackup < Formula
 
   depends_on "go" => :build
   depends_on "node" => :build
-  depends_on "yarn" => :build
 
   def install
     revision = build.head? ? version.commit : version
 
     chdir "web" do
-      system "yarn", "install"
-      system "yarn", "build"
+      system "npm", "install", *std_npm_args(prefix: false)
+      system "npm", "run", "build"
     end
     system "go", "build", *std_go_args(ldflags: "-s -w -X main.version=#{revision}")
   end


### PR DESCRIPTION
No specific yarn commands needed so can build with npm instead.

Our yarn formula is for unmaintained 1.x series. Whether we can upgrade to 4.x is questionable (upstream makes it difficult to do this and wants users to use corepack as shim instead).

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
