### PR TITLE
diffoscope: restore pypi_packages

### DIFF
--- a/Formula/d/diffoscope.rb
+++ b/Formula/d/diffoscope.rb
@@ -20,8 +20,7 @@ class Diffoscope < Formula
   depends_on "libmagic" => :no_linkage
   depends_on "python@3.14"
 
-  # pypi_packages package_name: "diffoscope[cmdline]"
-  pypi_packages extra_packages: %w[argcomplete progressbar]
+  pypi_packages package_name: "diffoscope[cmdline]"
 
   resource "argcomplete" do
     url "https://files.pythonhosted.org/packages/95/c0/c8e94135e66fabf89a120d9b4b123fe6993506beca6c1938a74c24cfa5fd/argcomplete-3.7.0.tar.gz"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

This was a workaround from https://github.com/Homebrew/homebrew-core/commit/c3e4c627e6e375c93d782ef7ab6e2eba25da7b7e that we forgot to restore