### PR TITLE
libyojimbo 1.6.3 (new formula)

### DIFF
--- a/Formula/lib/libyojimbo.rb
+++ b/Formula/lib/libyojimbo.rb
@@ -1,0 +1,39 @@
+class Libyojimbo < Formula
+  desc "Secure client/server network protocol library for multiplayer games"
+  homepage "https://github.com/mas-bandwidth/yojimbo"
+  url "https://github.com/mas-bandwidth/yojimbo/archive/refs/tags/v1.6.3.tar.gz"
+  sha256 "1348929e786afb117a536370e1ff400ce07fdd01e2887abca3cce1dcc392b077"
+  license "BSD-3-Clause"
+
+  depends_on "cmake" => :build
+  depends_on "libsodium"
+  depends_on "netcode"
+  depends_on "reliable"
+  depends_on "serialize"
+
+  def install
+    system "cmake", "-S", ".", "-B", "build",
+                    "-DYOJIMBO_SYSTEM_DEPS=ON",
+                    "-DYOJIMBO_BUILD_TESTS=OFF",
+                    "-DBUILD_SHARED_LIBS=ON",
+                    *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~CPP
+      #include <yojimbo.h>
+
+      int main() {
+        if (!InitializeYojimbo()) {
+          return 1;
+        }
+        ShutdownYojimbo();
+        return 0;
+      }
+    CPP
+    system ENV.cxx, "test.cpp", "-std=c++11", "-I#{include}", "-L#{lib}", "-lyojimbo", "-o", "test"
+    system "./test"
+  end
+end

--- a/Formula/lib/libyojimbo.rb
+++ b/Formula/lib/libyojimbo.rb
@@ -5,6 +5,15 @@ class Libyojimbo < Formula
   sha256 "1348929e786afb117a536370e1ff400ce07fdd01e2887abca3cce1dcc392b077"
   license "BSD-3-Clause"
 
+  bottle do
+    sha256 cellar: :any, arm64_tahoe:   "dbc2f1935619c52784b0ced227711b77bf8943fcf31c29719ddc796e5864f7b8"
+    sha256 cellar: :any, arm64_sequoia: "6d52f5d44be0ccfe7e4421f42aa0e73fec1b4d4cd8635bdb096afdd6aa85f75d"
+    sha256 cellar: :any, arm64_sonoma:  "ce751cbdeaaaf37f99c49f92c2adef98725aa365539761445e33671de58c34e1"
+    sha256 cellar: :any, sonoma:        "52b1f62480ad94d64da600866e82ab010a0a3671f650d415034db2e6c7c23fb4"
+    sha256 cellar: :any, arm64_linux:   "f610ea2b77278c60f50094958841b7ae1919e3091d5a8224c835931d1686acec"
+    sha256 cellar: :any, x86_64_linux:  "939c020908bf1fd6908c3cb83a0f4b88f66fb0a4d870229f3efeb917f637d474"
+  end
+
   depends_on "cmake" => :build
   depends_on "libsodium"
   depends_on "netcode"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Claude (Anthropic) drafted this formula on behalf of the upstream author (mas-bandwidth,
maintainer of yojimbo, reliable, netcode, and serialize) and validated it locally before
opening this PR: `brew audit --new --formula` clean, `brew style` clean,
`brew install --build-from-source` succeeds against the real published v1.6.2 release
tarball, and `brew test` passes (compiles and links a minimal program against the
installed library, calling `InitializeYojimbo()`/`ShutdownYojimbo()`). The upstream
author reviewed and approved submission.

-----

## About this formula

`libyojimbo` packages [yojimbo](https://github.com/mas-bandwidth/yojimbo), a secure
client/server network protocol library for multiplayer games by the same author as the
already-merged `netcode`, `reliable`, and `serialize` formulas, which it depends on. It
builds against those installed formulas via `-DYOJIMBO_SYSTEM_DEPS=ON` rather than
vendoring copies of them.

Named `libyojimbo` rather than `yojimbo` because the `yojimbo` token is already taken by
the `homebrew-cask` token for Bare Bones Software's macOS app of the same name
(https://www.barebones.com/products/yojimbo/), and Homebrew requires formula/cask tokens
to be globally unique.
