### PR TITLE
tilt: use corepack to build

### DIFF
--- a/Formula/t/tilt.rb
+++ b/Formula/t/tilt.rb
@@ -18,14 +18,15 @@ class Tilt < Formula
     sha256 cellar: :any,                 x86_64_linux:  "f3e5ba16c7e060fa5af2cd7479a46aeea5caa0594a5ec9cbefb1a3cadfb9be0e"
   end
 
+  depends_on "corepack" => :build # for newer yarn
   depends_on "go" => :build
   depends_on "node" => :build
-  depends_on "yarn" => :build
 
   def install
+    ENV["COREPACK_ENABLE_DOWNLOAD_PROMPT"] = "0"
+
     # bundling the frontend assets first will allow them to be embedded into
     # the final build
-    system "yarn", "config", "set", "ignore-engines", "true" # allow our newer node
     system "make", "build-js"
 
     ENV["CGO_ENABLED"] = "1"


### PR DESCRIPTION
For tilt, yarn 1.x will end up downloading yarn 4.x anyways, so may as well use corepack to do the same thing and avoid an unmaintained dependency.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
