### PR TITLE
metabase: remove broken HEAD build

### DIFF
--- a/Formula/m/metabase.rb
+++ b/Formula/m/metabase.rb
@@ -9,7 +9,7 @@ class Metabase < Formula
   # latest OSS jar file. We check the "latest" GitHub release, as the release
   # body text contains a versioned link to the OSS jar file.
   livecheck do
-    url :head
+    url "https://github.com/metabase/metabase.git"
     strategy :github_latest
   end
 
@@ -17,24 +17,10 @@ class Metabase < Formula
     sha256 cellar: :any_skip_relocation, all: "69b8f85c481e4eb236b57badd807d4f462375433cca8890ee3f266724699d844"
   end
 
-  head do
-    url "https://github.com/metabase/metabase.git", branch: "master"
-
-    depends_on "leiningen" => :build
-    depends_on "node" => :build
-    depends_on "yarn" => :build
-  end
-
   depends_on "openjdk"
 
   def install
-    if build.head?
-      system "./bin/build"
-      libexec.install "target/uberjar/metabase.jar"
-    else
-      libexec.install "metabase.jar"
-    end
-
+    libexec.install "metabase.jar"
     bin.write_jar_script libexec/"metabase.jar", "metabase"
   end
 


### PR DESCRIPTION
It's been broken for years (build script was renamed to build.sh in 2023).

Did try fixing build but it modifies some environment variables in a way that breaks superenv.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
