### PR TITLE
autobrr: use brew pnpm rather than downloaded copy

### DIFF
--- a/Formula/a/autobrr.rb
+++ b/Formula/a/autobrr.rb
@@ -20,8 +20,8 @@ class Autobrr < Formula
   depends_on "pnpm" => :build
 
   def install
-    system "pnpm", "install", "--dir", "web"
-    system "pnpm", "--dir", "web", "run", "build"
+    system "pnpm", "with", "current", "--dir", "web", "install"
+    system "pnpm", "with", "current", "--dir", "web", "run", "build"
 
     ldflags = "-s -w -X main.version=#{version} -X main.commit=#{tap.user}"
 


### PR DESCRIPTION
Alternatively could set `pmOnFail: ignore` configuration or equivalent environment variable.

However, given configuration has changed before (previously `managePackageManagerVersions: false`), the explicit command seems more likely to avoid accidentally bypassing old configs.

Ref: https://pnpm.io/cli/with

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
