### PR TITLE
go-size-analyzer: build with `pnpm@10`

### DIFF
--- a/Formula/g/go-size-analyzer.rb
+++ b/Formula/g/go-size-analyzer.rb
@@ -22,12 +22,18 @@ class GoSizeAnalyzer < Formula
 
   depends_on "go" => [:build, :test]
   depends_on "node" => :build
-  depends_on "pnpm" => :build
+  depends_on "pnpm@10" => :build # frozen build (default on CI) needs upstream changes for pnpm 11
 
   conflicts_with "gwenhywfar", because: "both install `gsa` binaries"
 
   def install
-    system "pnpm", "--dir", "ui", "install"
+    # Prevent pnpm from downloading another copy due to `packageManager` feature
+    odie "Switch to `pnpm with current`!" if deps.map(&:name).exclude?("pnpm@10")
+    (buildpath/"ui/pnpm-workspace.yaml").write <<~YAML
+      managePackageManagerVersions: false
+    YAML
+
+    system "pnpm", "--dir", "ui", "install", "--frozen-lockfile"
     system "pnpm", "--dir", "ui", "build:ui"
 
     mv "ui/dist/webui/index.html", "internal/webui/index.html"


### PR DESCRIPTION
When CI environment variable is set (like GitHub actions), frozen lockfile is automatically enabled. The flag is only to keep consistent behavior when locally building too.

We could use pnpm 11 by manually disabling lockfile, but doesn't seem ideal. For now can keep using pnpm 10. pnpm 12 is still in alpha so still have some time until pnpm 10 is unmaintained.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
