### PR TITLE
httrack 3.49.12

### DIFF
--- a/Formula/h/httrack.rb
+++ b/Formula/h/httrack.rb
@@ -1,17 +1,9 @@
 class Httrack < Formula
   desc "Website copier/offline browser"
   homepage "https://www.httrack.com/"
-  # Always use mirror.httrack.com when you link to a new version of HTTrack, as
-  # link to download.httrack.com will break on next HTTrack update.
-  url "https://mirror.httrack.com/historical/httrack-3.49.2.tar.gz"
-  sha256 "3477a0e5568e241c63c9899accbfcdb6aadef2812fcce0173688567b4c7d4025"
+  url "https://github.com/xroche/httrack/releases/download/3.49.12/httrack-3.49.12.tar.gz"
+  sha256 "2f4362802e2b42a0f6caf5db37a53decf962e2dc876ef2c2507d1a53db270bc4"
   license "GPL-3.0-or-later" => { with: "openvpn-openssl-exception" }
-  revision 2
-
-  livecheck do
-    url "https://mirror.httrack.com/historical/"
-    regex(/href=.*?httrack[._-]v?(\d+(?:\.\d+)+)\./i)
-  end
 
   bottle do
     sha256 arm64_tahoe:   "b32f52b8a3d7c29bc4ef8786a5d7442b989d007c92ed205bd8e2fce3d7d9e7c3"
@@ -26,11 +18,6 @@ class Httrack < Formula
 
   on_linux do
     depends_on "zlib-ng-compat"
-  end
-
-  # Fix -flat_namespace being used on Big Sur and later.
-  patch do
-    file "Patches/libtool/configure-pre-0.4.2.418-big_sur.diff"
   end
 
   def install

--- a/Formula/h/httrack.rb
+++ b/Formula/h/httrack.rb
@@ -6,12 +6,12 @@ class Httrack < Formula
   license "GPL-3.0-or-later" => { with: "openvpn-openssl-exception" }
 
   bottle do
-    sha256 arm64_tahoe:   "b32f52b8a3d7c29bc4ef8786a5d7442b989d007c92ed205bd8e2fce3d7d9e7c3"
-    sha256 arm64_sequoia: "c490f41b189c3f0627d2430c16657c2789ef61fe533d90ed72ab5c5e0869fd9e"
-    sha256 arm64_sonoma:  "896935f765df6afd7676c0b3e582ae66ce4052a097b20e78200aadef15be4268"
-    sha256 sonoma:        "58af4297d8cdebb0c20de947610b3f473f5081ac81fbd75a253c27c570362c2c"
-    sha256 arm64_linux:   "548edf68271f1856edf0f9c34153043ece5575d8b97f1e3373cbabde82f93cff"
-    sha256 x86_64_linux:  "4425d23c7e0fc3fbae36a0201b1519e4fb2ad3f6789caa4cf1b58b43e8c826cc"
+    sha256 arm64_tahoe:   "9cb654b11a2258521a5f8d800009679b684ebad1cef145d0596241148c48de43"
+    sha256 arm64_sequoia: "ba56ca44d6a62c77e3615cbe0f750ffbfa219270d60dc273a604fcbbabf2a9de"
+    sha256 arm64_sonoma:  "99f126964746a41898761ee4caafd3680df3380d6b44a154d29cc907e74708d1"
+    sha256 sonoma:        "80886fe6a1772e33fa2a6d44c5bc89598f29b33775b3d5a5e4c2c2fc831b8d59"
+    sha256 arm64_linux:   "6e3b4bfa9051210875017cd676b50844af849d0c2c6c5a24a899c824f15c1495"
+    sha256 x86_64_linux:  "d4408502cd74d107d92ff5ff00ce2da0056ab521a825b8558d4f5f5f35eca80b"
   end
 
   depends_on "openssl@4"


### PR DESCRIPTION
Bumps httrack 3.49.2 to 3.49.12 and moves the source to GitHub Releases.

The formula was stuck because livecheck watched `mirror.httrack.com/historical/`, which froze at 3.49.2. Upstream now ships the signed `make dist` tarball as a GitHub Release. Pointing `url` there lets livecheck's default Git-tags strategy track the `3.49.x` tags, so it stays current without the mirror; the `livecheck` block and `revision` are dropped with it.

It also drops the `Patches/libtool/configure-pre-0.4.2.418-big_sur.diff` reference: 3.49.12's regenerated `configure` already uses `dynamic_lookup` on modern macOS, so the patch no longer applies. The shared patch file stays for the other formulae that use it.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

Local build/test/audit not run: the only Homebrew I have here is a container too old to build a current formula, though `brew style` passes. Those boxes rely on BrewTestBot, which builds green on Linux x86_64/arm64 and macOS 14/15/26.

-----

- [x] AI was used to generate or assist with generating this PR.

Prepared with Claude Code (Anthropic Claude), which edited the version, url, and sha256 and removed the `livecheck` block, the `revision`, and the obsolete patch reference. As httrack's upstream maintainer I reviewed the full diff and verified the release asset's SHA-256 against the checksum I published for 3.49.12. I will address review feedback directly.
