### PR TITLE
nail 1.9.0 (new formula)

### DIFF
--- a/Formula/n/nail.rb
+++ b/Formula/n/nail.rb
@@ -1,0 +1,24 @@
+class Nail < Formula
+  desc "CLI for exploring, filtering, and transforming Parquet, CSV, and Excel files"
+  homepage "https://github.com/Vitruves/nail-parquet"
+  url "https://github.com/Vitruves/nail-parquet/archive/refs/tags/v1.9.0.tar.gz"
+  sha256 "2fe3d96f3e88e58c3ba7e065e17be3bcaa7ac5fb037d6ae8a50d704541cdbb65"
+  license "MIT"
+  head "https://github.com/Vitruves/nail-parquet.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    (testpath/"data.csv").write <<~EOS
+      id,name,value
+      1,alpha,10
+      2,beta,20
+    EOS
+    output = shell_output("#{bin}/nail head #{testpath}/data.csv")
+    assert_match "alpha", output
+  end
+end


### PR DESCRIPTION
Adds `nail` — a CLI for exploring, filtering, and transforming Parquet, CSV, JSON, and Excel files, built on Apache Arrow + DataFusion. The crate is published as `nail-parquet`; the executable is `nail`.

- Repository: https://github.com/Vitruves/nail-parquet
- crates.io: https://crates.io/crates/nail-parquet
- License: MIT

### Notability / usage
- 7,600+ downloads on crates.io
- 93 GitHub stars
- Actively maintained: 63 commits, regular tagged releases (latest v1.9.0)
- CI green on tagged releases

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. The formula and this PR description were drafted with assistance from Claude (Anthropic). All changes were manually verified locally against a scratch tap: `brew audit --new --strict --online` passes with no warnings, `brew install --build-from-source` succeeds, and `brew test` passes.

-----
