### PR TITLE
lidwatch 0.1.0 (new formula)

### DIFF
--- a/Formula/l/lidwatch.rb
+++ b/Formula/l/lidwatch.rb
@@ -1,0 +1,27 @@
+class Lidwatch < Formula
+  desc "Sleeps a MacBook when its lid closes while docked"
+  homepage "https://github.com/KristijanKocev/noclamshell/tree/master/LidWatch"
+  url "https://github.com/KristijanKocev/noclamshell/archive/refs/tags/v0.1.0.tar.gz"
+  sha256 "54f4dd255055f62c7c89e025e06c222c7ff984e158e1ef72e0332653c8e13a76"
+  license "MIT"
+
+  depends_on :macos
+
+  def install
+    cd "LidWatch" do
+      system "swift", "build", "--disable-sandbox", "-c", "release"
+      bin.install ".build/release/LidWatch"
+    end
+  end
+
+  service do
+    run opt_bin/"LidWatch"
+    keep_alive true
+    log_path var/"log/lidwatch.log"
+    error_log_path var/"log/lidwatch.error.log"
+  end
+
+  test do
+    assert_predicate bin/"LidWatch", :executable?
+  end
+end


### PR DESCRIPTION
LidWatch is a native macOS service that sleeps a MacBook when its lid closes
while AC power and an external display are connected.

The formula builds the Swift package from source and provides a Homebrew
service definition.

Validated with:

- `brew audit --new lidwatch`
- `brew style Formula/l/lidwatch.rb`
- `brew install --build-from-source KristijanKocev/tap/lidwatch`
- `brew test KristijanKocev/tap/lidwatch`
- `brew services start/stop lidwatch`
