### PR TITLE
cython: remove `keg_only`, use venv

### DIFF
--- a/Formula/c/cython.rb
+++ b/Formula/c/cython.rb
@@ -1,9 +1,12 @@
 class Cython < Formula
+  include Language::Python::Virtualenv
+
   desc "Compiler for writing C extensions for the Python language"
   homepage "https://cython.org/"
   url "https://files.pythonhosted.org/packages/b6/6b/80101e02ebacaf9232ecf32bf6a788d36b27d820ee02434746252569ef98/cython-3.2.8.tar.gz"
   sha256 "f4f23a56b25221a06f91817fe8f3114ab8b48a4fac73187dbb64bc2c4a87961f"
   license "Apache-2.0"
+  head "https://github.com/cython/cython.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "be70819a19262dac44cf976ab33523a774cf17cd87835ebb79fd7aa725ec625e"
@@ -14,40 +17,25 @@ class Cython < Formula
     sha256 cellar: :any,                 x86_64_linux:  "da644e004b46422958b2fcc2fbcce737d0f6c3193895e73ebe3a3ed565615d65"
   end
 
-  keg_only <<~EOS
-    this formula is mainly used internally by other formulae.
-    Users are advised to use `pip` to install cython
-  EOS
-
-  depends_on "python-setuptools" => [:build, :test]
   depends_on "python@3.14"
 
-  def python3
-    "python3.14"
+  # https://github.com/cython/cython/issues/5976
+  pypi_packages extra_packages: "setuptools"
+
+  resource "setuptools" do
+    url "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz"
+    sha256 "025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef"
   end
 
   def install
-    ENV.prepend_create_path "PYTHONPATH", libexec/Language::Python.site_packages(python3)
-    system python3, "-m", "pip", "install", *std_pip_args(prefix: libexec), "."
-
-    bin.install (libexec/"bin").children
-    bin.env_script_all_files(libexec/"bin", PYTHONPATH: ENV["PYTHONPATH"])
+    virtualenv_install_with_resources
   end
 
   test do
-    ENV.prepend_path "PYTHONPATH", libexec/Language::Python.site_packages(python3)
-
     phrase = "You are using Homebrew"
-    (testpath/"package_manager.pyx").write "print '#{phrase}'"
-    (testpath/"setup.py").write <<~PYTHON
-      from distutils.core import setup
-      from Cython.Build import cythonize
+    (testpath/"example.pyx").write "print '#{phrase}'"
 
-      setup(
-        ext_modules = cythonize("package_manager.pyx")
-      )
-    PYTHON
-    system python3, "setup.py", "build_ext", "--inplace"
-    assert_match phrase, shell_output("#{python3} -c 'import package_manager'")
+    system bin/"cythonize", "--inplace", "example.pyx"
+    assert_match phrase, shell_output("#{libexec}/bin/python -c 'import example'")
   end
 end

--- a/Formula/c/cython.rb
+++ b/Formula/c/cython.rb
@@ -9,12 +9,13 @@ class Cython < Formula
   head "https://github.com/cython/cython.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "be70819a19262dac44cf976ab33523a774cf17cd87835ebb79fd7aa725ec625e"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "6441816b31243f0a22b5bdb9205ab38dc26d108cbf2450c22ab470ec781e5967"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "643f1cfb0695386195931e8203d7585400083cc8a954c83d3b7b06113e45e450"
-    sha256 cellar: :any_skip_relocation, sonoma:        "955748e5cac120bf4a5390b3d6c2b1f7f3f9402d2cf39eb7af397f5252463f36"
-    sha256 cellar: :any,                 arm64_linux:   "80f95bf2ca4a8fe962ccd937ff248987f4e70f413e79d6c4f7173e7011399796"
-    sha256 cellar: :any,                 x86_64_linux:  "da644e004b46422958b2fcc2fbcce737d0f6c3193895e73ebe3a3ed565615d65"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "dee3caa30fd60b55f5e48e5980e34d504a819282445c13618c77a5ac12e4074f"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "4cecf57851f1a107f05be70108eaaae75d35e6975225a50ece15825f3d3afa90"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "8f96e8610eaf2b33349af4d0e6cd4b0e00b833f646fd0b64c3cc04152303526d"
+    sha256 cellar: :any_skip_relocation, sonoma:        "c4c903f7a5f57346add8b09bab97ceb1a4becc0e14bd30010cdabc0b4dc1839d"
+    sha256 cellar: :any,                 arm64_linux:   "162d1860c8f19d1b0f05b43988aaf9a4ee48cafab1a883d3c9d93c3dd9e1eedb"
+    sha256 cellar: :any,                 x86_64_linux:  "0a2bf44dfb82d24457b02eaafa2f8aa4e4bfaff818c0aae24f87342095cb0311"
   end
 
   depends_on "python@3.14"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Similar to #201015, this was added as key only [9 years ago](https://github.com/Homebrew/homebrew-core/commit/eb5b6293d24dbe005f7d5dbff324651407b4e635) when we didn't accept any PyPI formulae. Let's change that as it does have a CLI and also update to use a standard venv install