### PR TITLE
cgal: backport fix for debug_gdb_scripts

### DIFF
--- a/Formula/c/cgal.rb
+++ b/Formula/c/cgal.rb
@@ -12,7 +12,8 @@ class Cgal < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "d1bb0e37c68a4b20edc5df7ff186b70687975f48add6c65885bbf8df0ac8e982"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "dbe2a9a20e71d785f684a9bdaa194887116b960454150d26c33e20071ac191cd"
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/c/cgal.rb
+++ b/Formula/c/cgal.rb
@@ -26,6 +26,13 @@ class Cgal < Formula
     depends_on "openssl@3"
   end
 
+  # Backport fix for .debug_gdb_scripts section to avoid errors on some linkers
+  patch :p2 do
+    url "https://github.com/CGAL/cgal/commit/eb2257df4da4c52c75fe384e803d9a6376057b8a.patch?full_index=1"
+    sha256 "2686aea78dc3a58180eb1744dea44f27bd4d692ae8cfc9a4fab2a616fd6b7535"
+    type :backport
+  end
+
   def install
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args
     system "cmake", "--build", "build"


### PR DESCRIPTION
Seen in `graph-tool` PR when experimenting with LLD and Mold linkers.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
