### PR TITLE
bx 1.8.0 (new formula)

### DIFF
--- a/Formula/b/bx.rb
+++ b/Formula/b/bx.rb
@@ -1,0 +1,19 @@
+class Bx < Formula
+  desc "Launch apps in a macOS sandbox with only the project directory accessible"
+  homepage "https://github.com/holtwick/bx-mac"
+  url "https://registry.npmjs.org/bx-mac/-/bx-mac-1.8.0.tgz"
+  sha256 "d4f35bc7035b1d3509983bbf4c27c38da88481e6a3c308ba3181f30ebd319184"
+  license "MIT"
+
+  depends_on :macos
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/bx --version")
+  end
+end


### PR DESCRIPTION
Adds `bx`, a macOS sandbox launcher for developer tools (VSCode, Xcode, terminal shells, Claude Code, arbitrary commands). It locks down the home directory so only the explicitly provided project directory stays accessible, using `sandbox-exec` with a generated SBPL profile.

- Homepage/source: https://github.com/holtwick/bx-mac
- License: MIT
- macOS-only (relies on `sandbox-exec`), hence `depends_on :macos`
- No runtime dependencies; the published npm tarball is a single bundled `dist/bx.js` (~28 kB)

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
