### PR TITLE
batt: fix tests and use homebrew-generated service file

### DIFF
--- a/Formula/b/batt.rb
+++ b/Formula/b/batt.rb
@@ -13,9 +13,9 @@ class Batt < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "e9a8eba7cf7e021be0c298827143c00de15a616c38401c9a95cb288b0bbced60"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "6978b24b291f2b25640d27a297d9e7aa4632e8587c90f0d3e73da126d6f7fa86"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "e1b5bcce79047ed867ba0193e8b5f7fe38ba65fec443810a80b60f9365e34e58"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "f1a3326e9906d6cc8538095913010873f5419fbe646734dedc85288baa86158c"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "d4c0fb34c0e709602ce5fdcbd65bacbd5636805ab517128a2266669eaf611f4c"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "8312cfb4af9aa9ff5179a98d81b1d1d08d0a8efc6fc4c37281275b4887201e21"
   end
 
   depends_on "go" => :build

--- a/Formula/b/batt.rb
+++ b/Formula/b/batt.rb
@@ -2,8 +2,8 @@ class Batt < Formula
   desc "Control and limit battery charging on Apple Silicon MacBooks"
   homepage "https://github.com/charlie0129/batt"
   url "https://github.com/charlie0129/batt.git",
-      tag:      "v0.7.3",
-      revision: "569ec86b0a201fe0403db131f6eb13f495b62f37"
+      tag:      "v0.7.5",
+      revision: "8148dfc57114f01db7af11bc4ce6ed99b72ea9d8"
   license "GPL-2.0-only"
   head "https://github.com/charlie0129/batt.git", branch: "master"
 
@@ -23,40 +23,32 @@ class Batt < Formula
   depends_on :macos
 
   def install
-    # Point to the correct path for the binary
-    inreplace "hack/cc.chlc.batt.plist", "/path/to/batt", opt_bin/"batt"
-    # Limit config path to Homebrew prefix.
-    system "plutil", "-insert", "ProgramArguments",
-           "-string", "--config=#{etc}/batt.json", "-append",
-           "--", "hack/cc.chlc.batt.plist"
-    # Allow non-root access to the battery controller.
-    system "plutil", "-insert", "ProgramArguments",
-           "-string", "--always-allow-non-root-access", "-append",
-           "--", "hack/cc.chlc.batt.plist"
-    # Due to local changes version tag would show vx.x.x-dirty, override VERSION.
     # GOTAGS is set to disable built-in install/uninstall commands when building for Homebrew.
     system "make", "GOTAGS=brew", "VERSION=v#{version}"
     bin.install "bin/batt"
-    prefix.install "hack/cc.chlc.batt.plist"
 
     generate_completions_from_executable(bin/"batt", shell_parameter_format: :cobra)
   end
 
   def caveats
     <<~EOS
-      The batt service must be running before most of batt's commands will work.
+      The batt service must be running as root before most of batt's commands will work.
     EOS
   end
 
   service do
-    name macos: "cc.chlc.batt"
+    run [opt_bin/"batt", "daemon", "--log-level=debug", "--always-allow-non-root-access", "--config=#{etc}/batt.json"]
+    keep_alive true
     require_root true
+    process_type :interactive
+    log_path var/"log/batt.log"
+    error_log_path var/"log/batt.log"
   end
 
   test do
     # batt is only meaningful on Mac laptops. There is not much we can test
     # in a VM.
-    assert_match "operation not permitted", # Non-root daemon cannot listen in /var/run
+    assert_match "version=v#{version}", # Shows version
       shell_output("#{bin}/batt daemon --config=#{etc}/batt.json 2>&1", 1) # Non-root daemon exits with 1
     assert_match "batt daemon is not running",
       shell_output("#{bin}/batt status 2>&1", 1) # Cannot connect to daemon


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

- fix failing tests due to upstream changes. Previous auto-bump PR is failing #292881
- use homebrew-generated launchd service file
- bump to v0.7.5