### PR TITLE
rtp2httpd 3.15.3 (new formula)

### DIFF
--- a/Formula/r/rtp2httpd.rb
+++ b/Formula/r/rtp2httpd.rb
@@ -1,0 +1,44 @@
+class Rtp2httpd < Formula
+  desc "Multicast RTP/RTSP-to-HTTP converter with web player and status dashboard"
+  homepage "https://rtp2httpd.com"
+  url "https://github.com/stackia/rtp2httpd/archive/refs/tags/v3.15.3.tar.gz"
+  sha256 "406bd58db75eae446100fdf1af63d63401065c460cdb74bb2d5622154b8ae737"
+  license "GPL-2.0-only"
+  head "https://github.com/stackia/rtp2httpd.git", branch: "main"
+
+  depends_on "cmake" => :build
+
+  def install
+    ENV["RELEASE_VERSION"] = version.to_s
+
+    system "cmake", "-S", ".", "-B", "build",
+                    "-DCMAKE_INSTALL_SYSCONFDIR=#{etc}",
+                    "-DENABLE_AGGRESSIVE_OPT=ON",
+                    *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+
+    (var/"run").mkpath
+  end
+
+  service do
+    run [opt_bin/"rtp2httpd", "--config", etc/"rtp2httpd.conf",
+         "--pid-file", var/"run/rtp2httpd.pid"]
+    keep_alive true
+    log_path var/"log/rtp2httpd.log"
+    error_log_path var/"log/rtp2httpd.log"
+  end
+
+  test do
+    port = free_port
+    pid = spawn bin/"rtp2httpd", "--noconfig", "--listen", "127.0.0.1:#{port}"
+    sleep 2
+
+    assert_match "rtp2httpd", shell_output("curl --silent http://127.0.0.1:#{port}/status")
+  ensure
+    if pid
+      Process.kill("TERM", pid)
+      Process.wait(pid)
+    end
+  end
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

AI-assisted contribution by OpenAI Codex (GPT-5) for 100% of the work. Source build, functional test, strict online audit, style, lgtm, and Homebrew Service checks were performed locally by Codex; no separate human verification was performed.

Built and tested locally on macOS 26.5.1 running arm64.

Adds the rtp2httpd 3.15.3 formula with Homebrew Services support.
