### PR TITLE
goredo: update homepage url and remove deprecation

### DIFF
--- a/Formula/g/goredo.rb
+++ b/Formula/g/goredo.rb
@@ -1,12 +1,12 @@
 class Goredo < Formula
   desc "Go implementation of djb's redo, a Makefile replacement that sucks less"
-  homepage "http://www.goredo.stargrave.org/"
-  url "http://www.goredo.stargrave.org/download/goredo-2.9.2.tar.zst"
+  homepage "https://goredo.dabase.com/"
+  url "https://goredo.dabase.com/download/goredo-2.9.2.tar.zst"
   sha256 "b15cf99b6d11e586223f24712d90d739e6e115abe4b423d26da9412b90339f41"
   license "GPL-3.0-only"
 
   livecheck do
-    url "http://www.goredo.stargrave.org/NEWS.html"
+    url "https://goredo.dabase.com/NEWS.html"
     regex(/v?(\d+(?:\.\d+)+)/i)
   end
 
@@ -18,8 +18,6 @@ class Goredo < Formula
     sha256 cellar: :any_skip_relocation, arm64_linux:   "40130e96098f3b230a9078a20f2e99c9bafd40195a00958f35ed0fcf066071ea"
     sha256 cellar: :any,                 x86_64_linux:  "8e64cb8bca78f14f3d6040cb27de1c52bd82e8260c65dc531fd675d258ae77e0"
   end
-
-  deprecate! date: "2026-07-02", because: "is not available via HTTPS"
 
   depends_on "go" => :build
 


### PR DESCRIPTION
-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. Claude Code (Sonnet 5) was used to reapply the homepage/url switch to the HTTPS mirror and remove the deprecation notice, and to run the local build/test/audit checks. Human verified: change rationale, diff review, and PR submission.

-----

Reverts the formula back to the `goredo.dabase.com` HTTPS mirror, undoing the deprecation added when it was pointed at the upstream `stargrave.org` HTTP-only site.

Upstream (`goredo.cypherpunks.su`, mirrored at `stargrave.org`) is intentionally HTTP-only, since the author does not trust the CA system for root certificates. `goredo.dabase.com` mirrors the same releases over HTTPS so the formula can satisfy Homebrew's HTTPS requirement without depending on upstream changing its stance.