### PR TITLE
algolia: update desc

### DIFF
--- a/Formula/a/algolia.rb
+++ b/Formula/a/algolia.rb
@@ -1,5 +1,5 @@
 class Algolia < Formula
-  desc "CLI for Algolia"
+  desc "Command-line tool to manage Algolia applications, accounts, and search resources"
   homepage "https://www.algolia.com/doc/tools/cli/get-started"
   url "https://github.com/algolia/cli/archive/refs/tags/v1.13.0.tar.gz"
   sha256 "9e861fa2d60d09ca773409f86c45b0ecdfd7c040da01e498e6c8094d0d3aed3f"


### PR DESCRIPTION
Updates the `desc` for `algolia` so it describes what the CLI does and is discoverable by name/keyword: it manages Algolia accounts and applications in addition to search resources.

- Before: `CLI for Algolia`
- After: `Command-line tool to manage Algolia applications, accounts, and search resources`

Metadata-only change (`desc` field).

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

This PR was prepared with the assistance of an AI coding agent (Claude Code). The agent edited only the `desc` string of `Formula/a/algolia.rb`. Manual verification: confirmed the new description satisfies Homebrew's `DescHelper` rubocop rules by reading `Library/Homebrew/rubocops/shared/desc_helper.rb` directly — it is 80 characters (`MAX_DESC_LENGTH` is 80, and the check passes on `<= 80`), starts with a capital letter, does not start with an article or the formula name, uses the hyphenated "command-line" spelling, and has no trailing full stop. The branch is a single commit on top of the current upstream `main`, so the diff is a one-line change; no other lines were modified. `brew install`/`brew test`/`brew audit` were not run locally (metadata-only change), so those boxes are left unticked.