### PR TITLE
winnowmap 2.03 (new formula)

### DIFF
--- a/Formula/w/winnowmap.rb
+++ b/Formula/w/winnowmap.rb
@@ -1,0 +1,67 @@
+class Winnowmap < Formula
+  desc "Long-read/genome alignment using weighted minimizers"
+  homepage "https://github.com/marbl/Winnowmap"
+  url "https://github.com/marbl/Winnowmap/archive/refs/tags/v2.03.tar.gz"
+  sha256 "f6375960ee2184b68c0f56d3ca95e12ec3218f9e44aeecbdb14f85f581112c83"
+  license all_of: [:public_domain, "MIT"]
+  head "https://github.com/marbl/Winnowmap.git", branch: "master"
+
+  # meryl (bundled Canu k-mer counter) refuses to compile with Clang, and both
+  # tools use OpenMP, so build the whole project with GCC.
+  depends_on "gcc"
+
+  on_linux do
+    depends_on "zlib-ng-compat"
+  end
+
+  def install
+    gcc = Formula["gcc"]
+    gcc_major = gcc.version.major
+    args = %W[
+      CC=#{gcc.opt_bin}/gcc-#{gcc_major}
+      CXX=#{gcc.opt_bin}/g++-#{gcc_major}
+    ]
+    # Use the bundled sse2neon shim on ARM, mirroring minimap2's own build.
+    args += ["arm_neon=1", "aarch64=1"] if Hardware::CPU.arm?
+
+    # Bundled meryl includes <sys/sysctl.h>, which glibc removed in 2.32. That
+    # header is also what defines HW_PHYSMEM, the only guard around meryl's
+    # sysctl() calls, so skipping it on Linux selects the sysconf() code path
+    # meryl already provides. Fixed upstream after v2.03 but never released:
+    # https://github.com/marbl/Winnowmap/issues/28
+    inreplace "ext/meryl/src/utility/src/utility/system.C",
+              "#if !defined(__CYGWIN__) && !defined(_WIN32)",
+              "#if !defined(__CYGWIN__) && !defined(_WIN32) && !defined(__linux__)"
+
+    # The top-level Makefile exports CPPFLAGS and runs the src sub-make with -e,
+    # so the environment wins and src/Makefile's own aarch64 `-fsigned-char` is
+    # dropped. Only bites where char is unsigned by default, i.e. ARM Linux;
+    # macOS and x86 keep char signed, which is why upstream never hit it.
+    # Reported upstream: https://github.com/marbl/Winnowmap/issues/59
+    inreplace "Makefile", "+$(MAKE) -e -C src", "+$(MAKE) -C src"
+
+    system "make", *args
+    bin.install "bin/winnowmap", "bin/meryl"
+  end
+
+  test do
+    # Build a small reference and take an exact substring as a read; it must map
+    # back to the originating position with a full-length match.
+    ref = "ACGTACGTAGCTAGCTAGCTAGCTACGATCGATCGATCGATCGATCGTAGCTAGCTAGCATCGA" \
+          "TCGATCGTAGCTAGCTAGCACGTACGTACGTTTGGCCAATTGGCCAATTAGGCCTTAAGGCCTT" \
+          "AACCGGTTAACCGGTTGGATCCGGATCCAAGCTTAAGCTTGAATTCGAATTCCTGCAGGCTGCAG"
+    (testpath/"ref.fa").write ">ref\n#{ref}\n"
+    read = ref[40, 120]
+    (testpath/"reads.fq").write "@r1\n#{read}\n+\n#{"I" * read.length}\n"
+
+    # meryl counts k-mers used by Winnowmap for weighting
+    system bin/"meryl", "count", "k=15", "output", testpath/"db.meryl", testpath/"ref.fa"
+    assert_predicate testpath/"db.meryl", :directory?
+
+    output = shell_output("#{bin}/winnowmap -ax map-ont #{testpath}/ref.fa #{testpath}/reads.fq 2>/dev/null")
+    record = output.lines.grep_v(/^@/).first.split("\t")
+    assert_equal "r1", record[0]
+    assert_equal "ref", record[2]     # mapped to the reference
+    assert_equal "41", record[3]      # 1-based position of the substring
+  end
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

AI-assisted contribution by Claude Code (Opus 4.8) of ~80% of the work. Build/test/audit on macOS arm64, plus the Linux reproduction and fix verification in Docker (x86_64 and arm64), were run by the AI; formula design and final review by the human contributor.

Built and tested locally on macOS 26.5.2 (Darwin 25.5.0) running arm64.

New formula for winnowmap, a long-read/genome aligner using weighted minimizers for improved mapping in repetitive reference regions (e.g. ONT ultra-long reads, centromeres). The bundled meryl k-mer counter refuses to build with Clang and both tools use OpenMP, so the project is built with GCC; on ARM the bundled sse2neon shim is used via `arm_neon=1 aarch64=1`, mirroring minimap2's own build.

Two upstream portability bugs are patched to build on Linux, each verified in a container:

- Bundled meryl includes `<sys/sysctl.h>`, which glibc removed in 2.32. That header is also the only thing defining `HW_PHYSMEM`, the guard around meryl's `sysctl()` calls, so excluding it on Linux selects the `sysconf()` path meryl already ships. Fixed upstream after v2.03 but never released: https://github.com/marbl/Winnowmap/issues/28
- The top-level Makefile exports `CPPFLAGS` and runs the `src` sub-make with `-e`, so the environment wins and `src/Makefile`'s own aarch64 `-fsigned-char` is discarded, breaking the ARM Linux build (`char` is unsigned there). Dropping `-e` lets upstream's own logic apply. Reported upstream: https://github.com/marbl/Winnowmap/issues/59
