### PR TITLE
crw 0.30.0 (new formula)

### DIFF
--- a/Formula/c/crw.rb
+++ b/Formula/c/crw.rb
@@ -1,0 +1,30 @@
+class Crw < Formula
+  desc "Web scraper for AI agents: scrape any URL to markdown in one command"
+  homepage "https://github.com/us/crw"
+  url "https://github.com/us/crw/archive/refs/tags/v0.24.0.tar.gz"
+  sha256 "859b61750ae9d587105a120924c1df99e626d23ae2fafc42421d2e215a632195"
+  license "AGPL-3.0-only"
+  head "https://github.com/us/crw.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args(path: "crates/crw-cli")
+  end
+
+  test do
+    assert_match "crw #{version}", shell_output("#{bin}/crw --version")
+
+    # Scrape over HTTP without reaching the public internet: crw serves its own
+    # REST API, then scrapes that endpoint through the full fetch/extract path.
+    port = free_port
+    pid = spawn bin/"crw", "serve", "--port", port.to_s
+    sleep 5
+
+    output = shell_output("#{bin}/crw scrape http://127.0.0.1:#{port}/health --format text")
+    assert_match "\"status\":\"ok\"", output
+  ensure
+    Process.kill("TERM", pid)
+    Process.wait(pid)
+  end
+end

--- a/Formula/c/crw.rb
+++ b/Formula/c/crw.rb
@@ -1,8 +1,8 @@
 class Crw < Formula
   desc "Web scraper for AI agents: scrape any URL to markdown in one command"
   homepage "https://github.com/us/crw"
-  url "https://github.com/us/crw/archive/refs/tags/v0.24.0.tar.gz"
-  sha256 "859b61750ae9d587105a120924c1df99e626d23ae2fafc42421d2e215a632195"
+  url "https://github.com/us/crw/archive/refs/tags/v0.30.0.tar.gz"
+  sha256 "61e00c46e1107595fa8d458bf4d41e4f05221e9b13e5f14d4cb9febf0740549c"
   license "AGPL-3.0-only"
   head "https://github.com/us/crw.git", branch: "main"
 


### PR DESCRIPTION
crw is a web scraper and crawler for AI agents: it fetches a URL and returns clean markdown, and it also crawls, maps and searches sites. Single Rust binary, no runtime dependencies.

- Repository: https://github.com/us/crw, actively maintained, tagged releases
- License: AGPL-3.0-only
- Builds from source from the workspace's `crw-cli` crate

The project currently distributes through its own tap; this submits it to core so `brew install crw` works without one.

Rebased onto the current release: the formula now points at v0.30.0 (it was opened against v0.24.0, which has since been superseded).

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

Being straight about the two unticked boxes: I have not run `brew install --build-from-source` / `brew test` through brew itself, my sandbox keeps dying on the full Rust build under brew. What I did run for v0.30.0, on macOS arm64:

- `cargo install --locked --path crates/crw-cli` from the exact v0.30.0 tarball this formula downloads, which finished clean and reports `crw 0.30.0`
- the test block's own sequence by hand against that binary: `crw serve --port <free port>`, then `crw scrape http://127.0.0.1:<port>/health --format text`, which returned `{"active_crawl_jobs":0,"status":"ok","version":"0.30.0"}`, so the `"status":"ok"` assertion holds
- `brew audit --new`, no findings

Build and bottling were also exercised by this PR's CI, which passed on macOS 14/15/26-arm64, macOS 14-x86_64, Linux arm64 and Linux x86_64. Happy to complete the full local brew run if you would rather have that before review.

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI assistance was used to draft the formula and this description. Verification steps taken are listed above: a from-source `cargo install --locked` of the exact v0.30.0 tarball, a hand run of the test block's commands against the resulting binary, `brew audit --new`, and the CI bottle builds. The `sha256` was taken from the downloaded tarball, not copied from elsewhere.
