### PR TITLE
vapoursynth-mvtools: add livecheck

### DIFF
--- a/Formula/v/vapoursynth-mvtools.rb
+++ b/Formula/v/vapoursynth-mvtools.rb
@@ -6,6 +6,11 @@ class VapoursynthMvtools < Formula
   license "GPL-2.0-or-later"
   head "https://github.com/dubhatervapoursynth/vapoursynth-mvtools.git", branch: "master"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)*)$/i)
+  end
+
   bottle do
     sha256 cellar: :any, arm64_tahoe:   "6f51dd40f80a4b3de5a353b3536cf3b938aab0191a89661566a471e1f191b189"
     sha256 cellar: :any, arm64_sequoia: "f6dfd685bbce67d76cb7f6667b772bf7e08720595c455d14d2b51c7a60a597e6"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

By default, livecheck checks the Git tags for `vapoursynth-mvtools` and returns 29_2 as newest but there isn't a release for this tag and `brew audit` fails with a "Version 29_2 should not end with an underline and a number" error. This adds a `livecheck` block that restricts matching to versions like 2.0 (an older format) or 29 (the current format) and omits versions like 29_2.