### PR TITLE
workflows: run bump-portable-ruby on macOS

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -615,7 +615,7 @@ jobs:
       github.repository_owner == 'Homebrew' &&
       needs.upload.result == 'success' &&
       needs.upload.outputs.portable_ruby == 'true'
-    runs-on: ubuntu-latest
+    runs-on: macos-26
     permissions:
       contents: read
     steps:
@@ -720,7 +720,7 @@ jobs:
           BRANCH: ${{ steps.resolve.outputs.branch }}
         run: |
           cat <<MESSAGE > body.txt
-          Bumps the vendored \`portable-ruby\` to ${PKG_VERSION}.
+          Bumps \`portable-ruby\` to ${PKG_VERSION}.
 
           Source: Homebrew/homebrew-core#${PR}
 
@@ -731,5 +731,5 @@ jobs:
             --repo Homebrew/brew \
             --base main \
             --head "${BRANCH}" \
-            --title "Bump vendored portable-ruby to ${PKG_VERSION}" \
+            --title "Bump portable-ruby to ${PKG_VERSION}" \
             --body-file body.txt


### PR DESCRIPTION
Minor adjustments to the bump workflow for Portable Ruby.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
