### PR TITLE
native-sdk 0.5.1 (new formula)

### DIFF
--- a/Formula/n/native-sdk.rb
+++ b/Formula/n/native-sdk.rb
@@ -1,0 +1,77 @@
+class NativeSdk < Formula
+  desc "Toolkit for building native desktop applications"
+  homepage "https://native-sdk.dev/"
+  url "https://github.com/vercel-labs/native/archive/refs/tags/v0.5.1.tar.gz"
+  sha256 "b5d0d37a4335be6a2e5da3ec7855938c5de46f4f3d5575b380e6110d1ccd8a38"
+  license "Apache-2.0"
+  head "https://github.com/vercel-labs/native.git", branch: "main"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
+  depends_on "zig" => :build
+  depends_on "node"
+
+  uses_from_macos "curl"
+  uses_from_macos "xz"
+
+  resource "typescript" do
+    url "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz"
+    sha256 "33cd0ee1beaa8c9e9d15a9da836c62ddea4c34a42d7c2d349dbc80d94165d22a"
+  end
+
+  deny_network_access!
+
+  def install
+    sdk_root = libexec/"native-sdk"
+
+    system "zig", "build", "cli",
+           *std_zig_args(prefix: sdk_root, release_mode: :small)
+
+    sdk_root.install "app.zon", "assets", "build", "build.zig", "build.zig.zon",
+                     "skill-data", "skills", "src"
+    sdk_root.install "LICENSE"
+    sdk_root.install "packages/native-sdk/README.md"
+    sdk_root.install "packages/native-sdk/native-sdk.d.ts"
+    sdk_root.install "packages/native-sdk/package.json"
+
+    (sdk_root/"packages/core").install \
+      "packages/core/package-lock.json",
+      "packages/core/package.json",
+      "packages/core/rt",
+      "packages/core/sdk",
+      "packages/core/src"
+
+    (sdk_root/"third_party/webview2").install \
+      "third_party/webview2/LICENSE.txt",
+      "third_party/webview2/README.md",
+      "third_party/webview2/include"
+
+    # stock typescript; upstream's package.json aliases it as "@typescript/old"
+    # https://github.com/vercel-labs/native/blob/v0.5.1/packages/core/package.json#L35
+    resource("typescript").stage do
+      (sdk_root/"node_modules/@typescript/old").install Dir["*"]
+    end
+
+    (bin/"native").write_env_script opt_libexec/"native-sdk/bin/native",
+                                    NATIVE_SDK_PATH: "${NATIVE_SDK_PATH:-#{opt_libexec}/native-sdk}"
+  end
+
+  test do
+    ENV.delete "NATIVE_SDK_PATH"
+
+    assert_match "native #{version}", shell_output("#{bin}/native version")
+
+    wrapper = (bin/"native").read
+    assert_match (opt_libexec/"native-sdk").to_s, wrapper
+    refute_match prefix.to_s, wrapper
+
+    system bin/"native", "init", testpath/"app"
+    assert_path_exists testpath/"app/src/core.ts"
+    assert_path_exists testpath/"app/node_modules/@native-sdk/core/package.json"
+    assert_match "checked 1 markup file",
+                 shell_output("#{bin}/native check #{testpath}/app 2>&1")
+  end
+end


### PR DESCRIPTION
-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

**Where AI was involved**

The formula itself was written with AI in the earlier PR #293333 (OpenAI Codex, GPT-5.6 Sol). It is not newly AI-generated code here.

For this resubmission I refined that formula (reduced it to the one TypeScript compiler the SDK actually loads) and personally ran every verification step below. Claude Code helped prepare the resubmission. No AI performed the verification.

Verified by me on macOS 26 (Tahoe), arm64:

- `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source native-sdk`: builds from source (`zig build cli`)
- `brew test native-sdk`: passes (`native version`, `native init`, `native check`)
- `brew audit --strict --new native-sdk`: passes, no offenses
- `brew style native-sdk`: passes, no offenses
- also ran `native build` on a scaffolded app to confirm the full check/build path works with the single resource

## Verification screenshots

<img width="1480" height="1040" alt="Screenshot 2026-07-15 at 21 22 16" src="https://github.com/user-attachments/assets/c1757ee0-f129-492d-8010-ff864085afde" />
<img width="1480" height="1040" alt="Screenshot 2026-07-15 at 20 44 25" src="https://github.com/user-attachments/assets/2f82efde-53e8-4487-8136-fdbc3ab86252" />
<img width="1480" height="1040" alt="Screenshot 2026-07-15 at 20 44 54" src="https://github.com/user-attachments/assets/d1fc95ae-10d9-468e-9e67-a7aac1848a1b" />
<img width="1480" height="1040" alt="Screenshot 2026-07-15 at 20 45 07" src="https://github.com/user-attachments/assets/85b6acd5-1f12-4316-9a82-97fb53ae7e81" />

-----

Adds Native SDK 0.5.1 as a source-built formula: it compiles the `native` CLI with `zig` and vendors the offline SDK payload (`deny_network_access!`), without consuming the project's precompiled platform binaries.

It vendors the single `typescript` compiler the SDK uses at build time. The `@typescript/typescript6` package the CLI declares is intentionally not vendored: nothing loads it at runtime ([`ts_core.zig:869`](https://github.com/vercel-labs/native/blob/v0.5.1/src/tooling/ts_core.zig#L869)), and the CLI writes that shim itself when it needs one.

Resubmission of #293333 (closed), now personally built/tested/audited by me on macOS 26 arm64, addressing the verification feedback there.


