### PR TITLE
bettercap: remove resource

### DIFF
--- a/Formula/b/bettercap.rb
+++ b/Formula/b/bettercap.rb
@@ -25,14 +25,8 @@ class Bettercap < Formula
     depends_on "libnetfilter-queue"
   end
 
-  resource "ui" do
-    url "https://github.com/bettercap/ui.git",
-        revision: "ca482e9820552bc71acba6047504efbd0a05043f"
-  end
-
   def install
     ENV["CGO_ENABLED"] = "1" if OS.linux? && Hardware::CPU.arm?
-    (buildpath/"modules/ui/ui").install resource("ui")
     system "make", "build"
     bin.install "bettercap"
   end


### PR DESCRIPTION
Added in 2.40.0 when upstream used submodule
- https://github.com/Homebrew/homebrew-core/commit/fe09ba8ddc035050d2d224419482cf778f66b005

But they replaced it afterward:
- https://github.com/bettercap/bettercap/commit/ae466b702aa645720d18face4fdd4211b58e1a80

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
