### PR TITLE
jolli-cli 0.99.7 (new formula)

### DIFF
--- a/Formula/j/jolli-cli.rb
+++ b/Formula/j/jolli-cli.rb
@@ -1,0 +1,31 @@
+class JolliCli < Formula
+  desc "Capture and sync development memory from your terminal"
+  homepage "https://jolli.ai"
+  url "https://registry.npmjs.org/@jolli.ai/cli/-/cli-0.99.7.tgz"
+  sha256 "7cd7faa286a02a7c719c5baf09b2d05f01c52d2bdb042e8094c7d1aecf4fae36"
+  license "Apache-2.0"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    ENV["HOME"] = testpath.to_s
+    ENV["DO_NOT_TRACK"] = "1"
+
+    system "git", "init", "repo"
+    cd "repo" do
+      system bin/"jolli", "enable", "--yes"
+      hook = testpath/"repo/.git/hooks/post-commit"
+      assert_path_exists hook
+      assert_match "JolliMemory post-commit hook", hook.read
+
+      status = shell_output("#{bin}/jolli status")
+      assert_match "Jolli Memory Status (v#{version})", status
+      assert_match "Git", status
+    end
+  end
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI usage: the formula was drafted and iterated with Claude Code (Anthropic).
Manual verification: `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source`, `brew test`, `brew style`, and `brew audit --strict` / `brew audit --new` were all run locally (Linux) and pass; the installed `jolli --version` output was checked against the formula version, and the pinned tarball `sha256` was recomputed from the npm registry and matches.

-----

New formula for the Jolli Memory CLI (`jolli`), a command-line tool for capturing and syncing development memory from the terminal.

**License:** Apache-2.0 — both the npm package ([`@jolli.ai/cli`](https://www.npmjs.com/package/@jolli.ai/cli)) and the upstream repository ([jolliai/jolliai](https://github.com/jolliai/jolliai)) are licensed under Apache-2.0.

Notes:

- Installs from the published npm registry tarball with a pinned `sha256` via `std_npm_args` (no network access during build).
- `depends_on "node"` satisfies the CLI's Node.js runtime requirement.
- Disclosure: I work on this project at Jolli.
