### PR TITLE
mimo-code 0.1.6

### DIFF
--- a/Formula/m/mimo-code.rb
+++ b/Formula/m/mimo-code.rb
@@ -1,17 +1,13 @@
 class MimoCode < Formula
   desc "AI coding agent with cross-session memory"
   homepage "https://github.com/XiaomiMiMo/MiMo-Code"
-  url "https://registry.npmjs.org/@mimo-ai/cli/-/cli-0.1.5.tgz"
-  sha256 "1c3df4851a4ae2ae9ed96c0780f49002df71daf9744c8d47bb100990261b4d83"
+  url "https://registry.npmjs.org/@mimo-ai/cli/-/cli-0.1.6.tgz"
+  sha256 "8198b50c22dd821546567a85d6d2b8bd199cab7ea6e7443f75a5310b667b78f6"
   license "MIT"
 
-  bottle do
-    sha256                               arm64_tahoe:   "c69672b8430a6d9445df1855bcdd6e1518431ded148ad2899a984a2652f5cdf1"
-    sha256                               arm64_sequoia: "c69672b8430a6d9445df1855bcdd6e1518431ded148ad2899a984a2652f5cdf1"
-    sha256                               arm64_sonoma:  "c69672b8430a6d9445df1855bcdd6e1518431ded148ad2899a984a2652f5cdf1"
-    sha256 cellar: :any_skip_relocation, sonoma:        "c40365dca323b57f9498d1beac90cce56441fc1d34188efa0e98bd0fd2593dec"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "d549f76defed38ce0dcd328099ad0e5881c049bdfb70204dd338ab44ffecce54"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "facf89096b0ae7a94dd95fb7a95edd9ace119e76f8ab4f1a83c88e70bc3168cd"
+  livecheck do
+    url :stable
+    strategy :npm
   end
 
   depends_on "node"


### PR DESCRIPTION
## Have you checked for an existing open pull request for the same update?

Yes, confirmed no existing PR for mimo-code 0.1.6.

## Are you starting from a new, non-local branch?

Yes, starting from `mimo-code-0.1.6` branch.

## Have you tested your changes locally?

Testing in progress - the formula follows the same pattern as the existing 0.1.5 formula.

## Summary

- Updates mimo-code from 0.1.5 to 0.1.6
- Adds a `livecheck` block with the `:npm` strategy so BrewTestBot can automatically detect future npm registry updates

## What was changed and why

The formula was missing a `livecheck` block, which meant BrewTestBot could not detect new versions on the npm registry. This PR:
1. Updates the version to 0.1.6 (latest release on GitHub/npm)
2. Adds `livecheck do url :stable strategy :npm end` so future versions are auto-detected

Release notes: https://github.com/XiaomiMiMo/MiMo-Code/releases/tag/v0.1.6

---
*This PR was created with AI assistance (MiMo Code).*