### PR TITLE
utiluti 1.5 (new formula)

### DIFF
--- a/Formula/u/utiluti.rb
+++ b/Formula/u/utiluti.rb
@@ -1,0 +1,24 @@
+class Utiluti < Formula
+  desc "macOS command-line tool to work with default apps"
+  homepage "https://github.com/scriptingosx/utiluti"
+  url "https://github.com/scriptingosx/utiluti/archive/refs/tags/v1.5.tar.gz"
+  sha256 "84acd1d0e63d85fcb4663639f040ddc5763a2ac317a6e1613de2d2c245faabc7"
+  license "Apache-2.0"
+  head "https://github.com/scriptingosx/utiluti.git", branch: "main"
+
+  depends_on :macos
+  uses_from_macos "swift" => :build, since: :tahoe # Swift 6.2
+
+  def install
+    system "swift", "build", "--disable-sandbox", "--configuration", "release"
+    system "swift", "package", "--disable-sandbox", "plugin", "generate-manual"
+    bin.install ".build/release/utiluti"
+    man1.install ".build/plugins/GenerateManual/outputs/utiluti/utiluti.1"
+    generate_completions_from_executable bin/"utiluti", "--generate-completion-script"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/utiluti --version")
+    assert_match "public.plain-text", shell_output("#{bin}/utiluti get-uti txt")
+  end
+end

--- a/Formula/u/utiluti.rb
+++ b/Formula/u/utiluti.rb
@@ -6,6 +6,13 @@ class Utiluti < Formula
   license "Apache-2.0"
   head "https://github.com/scriptingosx/utiluti.git", branch: "main"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "442eeea49c01e4615962ef30340a5bcc949906223c39e157b21b5160d5573c82"
+    sha256 cellar: :any,                 arm64_sequoia: "2b4bbc74f26387db21f628d23ebb880a0b5a794b18a15b886a63d8c5aff502f3"
+    sha256 cellar: :any,                 arm64_sonoma:  "5cad6055463553d8f64c68a1f78500835dded2a21395b5830be7c2c156ca5e0b"
+    sha256 cellar: :any,                 sonoma:        "6b3f20399145a7efafcd4756fc4efa4848afbb1c5aed2ff690715f8974d43a32"
+  end
+
   depends_on :macos
   uses_from_macos "swift" => :build, since: :tahoe # Swift 6.2
 

--- a/style_exceptions/not_a_binary_url_prefix_allowlist.json
+++ b/style_exceptions/not_a_binary_url_prefix_allowlist.json
@@ -5,6 +5,7 @@
   "flashrom",
   "organize-tool",
   "reattach-to-user-namespace",
+  "utiluti",
   "wallpaper",
   "x264"
 ]


### PR DESCRIPTION
This supersedes #261024 which was closed due to inactivity. This is a similar tool to `duti` but that tool has not been updated in quite some time. Additionally, the author is a respected resource in the macOS community and there's clearly some interest in having this tool on homebrew: https://github.com/scriptingosx/utiluti/issues/6

The binary exception was added because the `scriptingosx` username triggers the binary audit.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
