### PR TITLE
dnstracer dhcping: use https urls

### DIFF
--- a/Formula/d/dhcping.rb
+++ b/Formula/d/dhcping.rb
@@ -1,8 +1,8 @@
 class Dhcping < Formula
   desc "Perform a dhcp-request to check whether a dhcp-server is running"
-  homepage "http://www.mavetju.org/unix/general.php"
-  url "https://deb.debian.org/debian/pool/main/d/dhcping/dhcping_1.2.orig.tar.gz"
-  mirror "http://www.mavetju.org/download/dhcping-1.2.tar.gz"
+  homepage "https://www.mavetju.org/unix/general.php"
+  url "https://www.mavetju.org/download/dhcping-1.2.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/d/dhcping/dhcping_1.2.orig.tar.gz"
   sha256 "32ef86959b0bdce4b33d4b2b216eee7148f7de7037ced81b2116210bc7d3646a"
   license "BSD-2-Clause"
 
@@ -30,7 +30,7 @@ class Dhcping < Formula
   def install
     args = ["--mandir=#{man}"]
     # Help old config scripts identify arm64 linux
-    args << "--build=aarch64-unknown-linux-gnu" if OS.linux? && Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+    args << "--build=aarch64-unknown-linux-gnu" if OS.linux? && Hardware::CPU.arm64?
 
     system "./configure", *args, *std_configure_args
     system "make", "install"

--- a/Formula/d/dnstracer.rb
+++ b/Formula/d/dnstracer.rb
@@ -1,8 +1,8 @@
 class Dnstracer < Formula
   desc "Trace a chain of DNS servers to the source"
-  homepage "http://www.mavetju.org/unix/dnstracer.php"
-  url "https://deb.debian.org/debian/pool/main/d/dnstracer/dnstracer_1.9.orig.tar.gz"
-  mirror "http://www.mavetju.org/download/dnstracer-1.9.tar.gz"
+  homepage "https://www.mavetju.org/unix/dnstracer.php"
+  url "https://www.mavetju.org/download/dnstracer-1.9.tar.gz"
+  mirror "https://deb.debian.org/debian/pool/main/d/dnstracer/dnstracer_1.9.orig.tar.gz"
   sha256 "2ebc08af9693ba2d9fa0628416f2d8319ca1627e41d64553875d605b352afe9c"
   license "BSD-2-Clause"
 
@@ -11,7 +11,7 @@ class Dnstracer < Formula
   # 1.1 on the `/download/` page is given as 1.10 and this is erroneously
   # treated as newer than 1.9.
   livecheck do
-    url "http://www.mavetju.org/unix/general.php"
+    url "https://www.mavetju.org/unix/general.php"
     regex(/href=.*?dnstracer[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
Upstream added HTTPS so can use homepage as main url now
```console
❯ curl "https://www.mavetju.org/download/dnstracer-1.9.tar.gz" -s | sha256
2ebc08af9693ba2d9fa0628416f2d8319ca1627e41d64553875d605b352afe9c
```

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
