### PR TITLE
rust-wasm 1.97.0 (new formula)

### DIFF
--- a/Formula/r/rust-wasm.rb
+++ b/Formula/r/rust-wasm.rb
@@ -1,0 +1,190 @@
+class RustWasm < Formula
+  desc "Rust standard library and sysroot for WebAssembly targets"
+  homepage "https://www.rust-lang.org/"
+  url "https://static.rust-lang.org/dist/rustc-1.97.0-src.tar.gz"
+  sha256 "1c0855d8982a0fb1d0321b6054b55b732d3b1d17c846841eb7fd0ab37bf276f8"
+  license any_of: ["Apache-2.0", "MIT"]
+
+  livecheck do
+    formula "rust"
+  end
+
+  depends_on "wasmtime" => :test
+  depends_on "lld"
+  depends_on "rust"
+  depends_on "wasi-libc"
+  depends_on "wasm-component-ld"
+
+  # WebAssembly targets we build `std` for. `wasm32-unknown-unknown` is
+  # self-contained; the WASI targets link against `wasi-libc`.
+  def wasm_targets
+    %w[
+      wasm32-unknown-unknown
+      wasm32-wasip1
+      wasm32-wasip2
+    ]
+  end
+
+  def install
+    # `-Zbuild-std` compiles `std` from `rust`'s bundled source with the
+    # installed compiler, so the rlibs match that rustc exactly (no second
+    # compiler is built). The flag is unstable, so unlock it on the stable
+    # toolchain with RUSTC_BOOTSTRAP, exactly as `cargo -Zbuild-std` users do.
+    ENV["RUSTC_BOOTSTRAP"] = "1"
+
+    # `-Zbuild-std` bakes the paths it compiles from into the rlibs' debug and
+    # metadata info: `std` out of `rust`'s keg and the crates.io deps out of
+    # `buildpath`. Remap both to the virtual `/rustc/<commit>` prefix upstream
+    # rustc uses, so the bottled rlibs carry no builder-specific paths.
+    sysroot = Utils.safe_popen_read("rustc", "--print", "sysroot").chomp
+    commit = Utils.safe_popen_read("rustc", "--version", "--verbose")[/^commit-hash:\s*(\S+)$/, 1]
+    rustflags = %W[
+      --remap-path-prefix=#{sysroot}/lib/rustlib/src/rust=/rustc/#{commit}
+      --remap-path-prefix=#{buildpath}=/rustc/#{commit}
+    ]
+    ENV.append_to_rustflags rustflags.join(" ")
+
+    # `-Zbuild-std` only builds `std` as a dependency of a crate being
+    # compiled; it has no standalone "emit a sysroot" mode. So compile a
+    # minimal stub and harvest the `std` rlibs it pulls in (below).
+    # `[workspace]` stops cargo from treating the stub as a member of the
+    # unpacked rustc source workspace.
+    (buildpath/"stub/Cargo.toml").write <<~TOML
+      [package]
+      name = "rust-wasm-stub"
+      version = "0.0.0"
+      edition = "2021"
+
+      [lib]
+      crate-type = ["lib"]
+
+      [workspace]
+    TOML
+    (buildpath/"stub/src/lib.rs").write "#![no_std]\n"
+
+    wasm_targets.each do |target|
+      system "cargo", "build",
+                      "--lib",
+                      "--release",
+                      "--offline",
+                      "--manifest-path", buildpath/"stub/Cargo.toml",
+                      "--target-dir", buildpath/"target",
+                      "--target", target,
+                      "-Zbuild-std=std,panic_abort"
+
+      target_lib = lib/"rustlib"/target/"lib"
+      buildpath.glob("target/#{target}/release/deps/*.rlib").each do |rlib|
+        # Skip the stub crate itself; keep `std` and all of its dependencies.
+        next if rlib.basename.to_s.start_with?("librust_wasm_stub")
+
+        target_lib.install rlib
+      end
+    end
+
+    # WASI targets link statically against wasi-libc; rustc looks for the crt
+    # objects and libc under each target's `self-contained` directory.
+    wasi_lib = Formula["wasi-libc"].opt_share/"wasi-sysroot/lib"
+    wasi_crt = %w[crt1-command.o crt1-reactor.o libc.a]
+    wasm_targets.grep(/wasip/).each do |target|
+      self_contained = lib/"rustlib"/target/"lib/self-contained"
+      self_contained.mkpath
+      wasi_crt.each do |obj|
+        ln_s (wasi_lib/target/obj).relative_path_from(self_contained), self_contained
+      end
+    end
+
+    # Cargo configuration that selects this sysroot and the right wasm linker.
+    (pkgshare/"cargo-config.toml").write cargo_config
+  end
+
+  # Points cargo at this sysroot per target. `--sysroot` in per-target
+  # `rustflags` applies only when compiling for wasm, so host build scripts and
+  # proc-macros keep using `rust`'s own sysroot.
+  def cargo_config
+    <<~TOML
+      [target.wasm32-unknown-unknown]
+      rustflags = ["--sysroot", "#{HOMEBREW_PREFIX}"]
+      linker = "wasm-ld"
+
+      [target.wasm32-wasip1]
+      rustflags = ["--sysroot", "#{HOMEBREW_PREFIX}"]
+      linker = "wasm-ld"
+
+      [target.wasm32-wasip2]
+      rustflags = ["--sysroot", "#{HOMEBREW_PREFIX}"]
+    TOML
+  end
+
+  def caveats
+    example_target = wasm_targets.first
+    <<~EOS
+      Included targets: #{wasm_targets.join(", ")}
+
+      To cross-compile for, e.g., #{example_target}:
+        cargo build --config #{opt_pkgshare}/cargo-config.toml --target #{example_target}
+    EOS
+  end
+
+  test do
+    config = pkgshare/"cargo-config.toml"
+
+    # wasm32-unknown-unknown has no OS or runtime, so just confirm we can link a
+    # valid WebAssembly module against the freshly built `core`, driving cargo
+    # through the shipped config via `--config` (as the caveats suggest).
+    (testpath/"nostd/Cargo.toml").write <<~TOML
+      [package]
+      name = "nostd"
+      version = "0.0.0"
+      edition = "2021"
+
+      [lib]
+      crate-type = ["cdylib"]
+
+      [profile.release]
+      panic = "abort"
+
+      [workspace]
+    TOML
+    (testpath/"nostd/src/lib.rs").write <<~RUST
+      #![no_std]
+      #[panic_handler]
+      fn panic(_: &core::panic::PanicInfo) -> ! { loop {} }
+      #[no_mangle]
+      pub extern "C" fn add(a: i32, b: i32) -> i32 { a + b }
+    RUST
+    cd(testpath/"nostd") do
+      system "cargo", "build", "--release", "--offline",
+             "--config", config, "--target", "wasm32-unknown-unknown"
+    end
+    wasm = testpath/"nostd/target/wasm32-unknown-unknown/release/nostd.wasm"
+    assert_equal "\x00asm".b, wasm.binread(4)
+
+    # The WASI targets can actually run. Give each project its own
+    # `.cargo/config.toml` (target + an env var it prints) and layer ours in via
+    # `--config`, with no `--target` on the CLI: a running wasm binary that
+    # prints the greeting proves the project config and ours (sysroot + linker)
+    # both took effect.
+    wasm_targets.grep(/wasip/).each do |target|
+      name = target.tr("-", "_")
+      system "cargo", "new", "--bin", "--vcs", "none", testpath/name
+      (testpath/name/".cargo/config.toml").write <<~TOML
+        [build]
+        target = "#{target}"
+
+        [env]
+        RUST_WASM_GREETING = "hello from #{target}"
+      TOML
+      # atomic_write clobbers the main.rs that `cargo new` generated.
+      (testpath/name/"src/main.rs").atomic_write <<~RUST
+        fn main() {
+            println!("{}", env!("RUST_WASM_GREETING"));
+        }
+      RUST
+      cd(testpath/name) do
+        system "cargo", "build", "--release", "--offline", "--config", config
+      end
+      module_path = testpath/name/"target"/target/"release/#{name}.wasm"
+      assert_equal "hello from #{target}", shell_output("wasmtime run #{module_path}").strip
+    end
+  end
+end

--- a/Formula/r/rust-wasm.rb
+++ b/Formula/r/rust-wasm.rb
@@ -9,6 +9,15 @@ class RustWasm < Formula
     formula "rust"
   end
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "72014660a3027140caf15d15e91c010100544696a37749bfe46cb4388f75b378"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "72014660a3027140caf15d15e91c010100544696a37749bfe46cb4388f75b378"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "72014660a3027140caf15d15e91c010100544696a37749bfe46cb4388f75b378"
+    sha256 cellar: :any_skip_relocation, sonoma:        "671f3662e0b85193940c829c182b2f52ef90fbac26aaec564a3e3ced861119ce"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "e377edbce1435fc933c0fa82985f81bb6af75dcad43b8970172fa0a80b3ea416"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "7b5bb3ba49b94d616a2dc61d33cc6a51c2ef35ccc2ecdc66959270bee941a01e"
+  end
+
   depends_on "wasmtime" => :test
   depends_on "lld"
   depends_on "rust"

--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -113,6 +113,7 @@
     "qtwebview"
   ],
   ["qwt", "qwt-qt5"],
+  ["rust", "rust-wasm"],
   [
     "spirv-headers",
     "spirv-tools",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Claude Opus 4.8 with local review and testing.

-----

A handful of formulae use `rustup` because our Rust toolchain doesn't
support targeting WASM. This formula fixes that.

This currently fails `brew audit --new` because the source URL is the same as
the one for `rust`. That's expected.
