### PR TITLE
various: deprecated by upstream or unmaintained

### DIFF
--- a/Formula/a/ammonite-repl.rb
+++ b/Formula/a/ammonite-repl.rb
@@ -19,6 +19,9 @@ class AmmoniteRepl < Formula
     sha256 cellar: :any_skip_relocation, all: "1ae1d432270e48a8f23305a392d6a84006d52b1bbd660fa2ff90f1f29ab5a27f"
   end
 
+  deprecate! date: "2026-07-17", because: :deprecated_upstream, replacement_formula: "scala-cli"
+  disable! date: "2027-01-17", because: :deprecated_upstream, replacement_formula: "scala-cli"
+
   depends_on "openjdk"
 
   def install

--- a/Formula/b/bltool.rb
+++ b/Formula/b/bltool.rb
@@ -15,6 +15,9 @@ class Bltool < Formula
     depends_on "leiningen" => :build
   end
 
+  deprecate! date: "2026-07-17", because: :deprecated_upstream
+  disable! date: "2027-01-17", because: :deprecated_upstream
+
   depends_on "openjdk"
 
   def install

--- a/Formula/c/cargo-sweep.rb
+++ b/Formula/c/cargo-sweep.rb
@@ -15,6 +15,9 @@ class CargoSweep < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "36c2b2a5eab5851f3217b5ea39694cf3f7e58b72be8a3fb858ecfaf65502cb2c"
   end
 
+  deprecate! date: "2026-07-17", because: :deprecated_upstream
+  disable! date: "2027-01-17", because: :deprecated_upstream
+
   depends_on "rust" => :build
   depends_on "rustup" => :test
 

--- a/Formula/f/flif.rb
+++ b/Formula/f/flif.rb
@@ -16,6 +16,9 @@ class Flif < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "7fe8d950811505c384945d0dd7901010b548cd1f06a59bd6438f2f8417cc01b3"
   end
 
+  deprecate! date: "2026-07-17", because: :deprecated_upstream, replacement_formula: "jpeg-xl"
+  disable! date: "2027-01-17", because: :deprecated_upstream, replacement_formula: "jpeg-xl"
+
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
   depends_on "libpng"

--- a/Formula/i/ios-class-guard.rb
+++ b/Formula/i/ios-class-guard.rb
@@ -32,6 +32,9 @@ class IosClassGuard < Formula
     sha256 cellar: :any_skip_relocation, catalina:       "807b425c949e9a25331abd13967721d6f58d3a1674fcc8175744e713e81ee5d3"
   end
 
+  deprecate! date: "2026-07-17", because: :deprecated_upstream
+  disable! date: "2027-01-17", because: :deprecated_upstream
+
   depends_on xcode: :build
   depends_on :macos
 

--- a/Formula/l/leaps.rb
+++ b/Formula/l/leaps.rb
@@ -22,6 +22,9 @@ class Leaps < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "8c1f94e5c2315b93194e5b5573de8ac9d57fe7b791e20538839df29b940d4824"
   end
 
+  deprecate! date: "2026-07-17", because: :unmaintained
+  disable! date: "2027-01-17", because: :unmaintained
+
   depends_on "go" => :build
 
   def install

--- a/Formula/p/ppss.rb
+++ b/Formula/p/ppss.rb
@@ -10,6 +10,9 @@ class Ppss < Formula
     sha256 cellar: :any_skip_relocation, all: "e341e42c45d8ab9d5251b5330405329c45f1342a2cd94a466764b894a2b9ac6c"
   end
 
+  deprecate! date: "2026-07-17", because: :deprecated_upstream
+  disable! date: "2027-01-17", because: :deprecated_upstream
+
   def install
     bin.install "ppss"
   end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

### ammonite-repl


> NOTE: Ammonite is now deprecated.
>
>For Scala scripting functionality, please see the scripting functionality present in the Mill build tool (https://mill-build.org/mill/scalalib/intro.html#_single_file_scripts)
>
>For Scala REPL functionality, most of Ammonite's REPL features (Ctrl-C handling, pretty-printed output, dynamically importing libraries, etc.) has been ported to the upstream Scala REPL 3.8.2 and above (#24194, #23849, #24131, etc.)


```
==> Analytics
install: 18 (30 days), 128 (90 days), 1,446 (365 days)
install-on-request: 18 (30 days), 128 (90 days), 1,446 (365 days)
build-error: 0 (30 days
```


### bltool

> NOTE: This project is no longer maintained. It is known to have issues with the current version of the backloggery site.

```
==> Analytics
install: 7 (30 days), 52 (90 days), 231 (365 days)
install-on-request: 7 (30 days), 52 (90 days), 231 (365 days)
build-error: 0 (30 days)
```

### cargo-sweep

>⚠️⚠️ Warning: cargo-sweep is currently unmaintained. ⚠️⚠️
>
>The project has issues and is lacking a dedicated maintainer to contribute and/or review contributions from others.
>
>If you're looking for an alternative, check cargo-clean-all.


```
==> Analytics
install: 31 (30 days), 59 (90 days), 1,413 (365 days)
install-on-request: 31 (30 days), 59 (90 days), 1,412 (365 days)
build-error: 0 (30 days)
```

### flif

>FLIF development has stopped since FLIF is superseded by FUIF and then again by JPEG XL, which is based on a combination of Pik and FUIF. A royalty-free and open source reference implementation of JPEG XL is available on GitHub. For more information, see JPEG XL community page or visit the JPEG XL Discord server.


```
==> Analytics
install: 9 (30 days), 50 (90 days), 130 (365 days)
install-on-request: 9 (30 days), 50 (90 days), 129 (365 days)
build-error: 0 (30 days)
```

### ios-class-guard

> This repository is no longer maintained. Issue reports and pull requests will not be attended.


```
==> Analytics
install: 2 (30 days), 8 (90 days), 44 (365 days)
install-on-request: 2 (30 days), 8 (90 days), 44 (365 days)
build-error: 0 (30 days)
```

### leaps

>WARNING: This project is no longer actively maintained.

I mostly leave the formulae with not actively maintained, which means not yet deprecated. But the last version of this formula was published 8 years ago, so I think this is fine to deprecate.

```
==> Analytics
install: 13 (30 days), 16 (90 days), 61 (365 days)
install-on-request: 13 (30 days), 16 (90 days), 61 (365 days)
build-error: 0 (30 days)
```

### ppss


> >>> THIS PROJECT IS NO LONGER UNDER ANY DEVELOPMENT OR MAINTENANCE <<<


```
==> Analytics
install: 0 (30 days), 3 (90 days), 13 (365 days)
install-on-request: 0 (30 days), 3 (90 days), 13 (365 days)
build-error: 0 (30 days)
```