### PR TITLE
various: deprecate by upstream

### DIFF
--- a/Formula/c/cfn-flip.rb
+++ b/Formula/c/cfn-flip.rb
@@ -17,6 +17,9 @@ class CfnFlip < Formula
     sha256 cellar: :any, x86_64_linux:  "a790d632f4cc2eb04499499df83fe4b804b4a4187e7cfbc20df5e80e262ec69b"
   end
 
+  deprecate! date: "2026-07-17", because: :deprecated_upstream, replacement_formula: "rain"
+  disable! date: "2027-01-17", because: :deprecated_upstream, replacement_formula: "rain"
+
   depends_on "libyaml"
   depends_on "python@3.14"
 

--- a/Formula/g/glooctl.rb
+++ b/Formula/g/glooctl.rb
@@ -24,6 +24,9 @@ class Glooctl < Formula
     sha256 cellar: :any,                 x86_64_linux:  "c984cc210f1070ccba0cffd121e43f63e91af724586b1a32db8e9c6b47205866"
   end
 
+  deprecate! date: "2026-12-31", because: :deprecated_upstream
+  disable! date: "2027-12-31", because: :deprecated_upstream
+
   depends_on "go" => :build
 
   def install

--- a/Formula/r/rbenv-chefdk.rb
+++ b/Formula/r/rbenv-chefdk.rb
@@ -12,6 +12,9 @@ class RbenvChefdk < Formula
     sha256 cellar: :any_skip_relocation, all: "dcdf8e0ad350e940be7783e378bf8c146bda6e446a13109511a9d4ed705170c0"
   end
 
+  deprecate! date: "2026-07-17", because: :deprecated_upstream
+  disable! date: "2027-01-17", because: :deprecated_upstream
+
   depends_on "rbenv"
 
   def install

--- a/Formula/r/rke.rb
+++ b/Formula/r/rke.rb
@@ -24,6 +24,9 @@ class Rke < Formula
     sha256 cellar: :any,                 x86_64_linux:  "07fe86aecc48fb728a7211c139c8233ec8fc3d4ad9da692fd2f098629e74f6ac"
   end
 
+  deprecate! date: "2026-07-31", because: :deprecated_upstream
+  disable! date: "2027-07-31", because: :deprecated_upstream
+
   depends_on "go" => :build
 
   def install


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

### cfn-flip

> NOTICE: For CLI usage, AWS CloudFormation Template Flip is now deprecated.
>
>You should use rain instead. rain fmt can convert CloudFormation templates between JSON and YAML.
>
>See the rain fmt documentation for details.
>
>This deprecation notice does not affect the API in this package which may continue to be used.

```
==> Analytics
install: 36 (30 days), 93 (90 days), 251 (365 days)
install-on-request: 36 (30 days), 93 (90 days), 251 (365 days)
build-error: 0 (30 days)
```

### glooctl

> Gloo OSS will reach end of life on December 31st, 2026. After that date, it will no longer receive releases, bug fixes, or security patches.

```
==> Analytics
install: 84 (30 days), 291 (90 days), 1,299 (365 days)
install-on-request: 84 (30 days), 291 (90 days), 1,299 (365 days)
build-error: 0 (30 days)
```

### rbenv-chefdk

> deprecated ChefDK has been replaced by Chef Workstation. See the rbenv-chef-workstation plugin instead.


```
==> Analytics
install: 0 (30 days), 4 (90 days), 25 (365 days)
install-on-request: 0 (30 days), 4 (90 days), 25 (365 days)
build-error: 0 (30 days)
```

### rke

>  Important Notice: RKE End of Life Announcement
Rancher Kubernetes Engine (RKE) is reaching its end of life. Version 1.8 will be the final release in the RKE 1.x series. We strongly recommend migrating to Rancher's newer Kubernetes distribution, RKE2, to stay supported, secure, and take advantage of the latest features and updates. For more details, please refer to the official SUSE EOL article.

https://support.scc.suse.com/s/kb/RKE-EOL-what-when-why?language=en_US

> Rancher Kubernetes Engine (RKE) has reached End of Life as we transition to RKE2 as our standard Kubernetes distribution. Extended support is available through July 31, 2026, exclusively for clusters running RKE version 1.7 or later and only for customers who have purchased this offering. No additional CVE fixes will be provided for RKE.


```
==> Analytics
install: 41 (30 days), 171 (90 days), 1,404 (365 days)
install-on-request: 41 (30 days), 171 (90 days), 1,404 (365 days)
build-error: 0 (30 days)
```