### PR TITLE
kimi-cli: deprecated by upstream

### DIFF
--- a/Formula/k/kimi-cli.rb
+++ b/Formula/k/kimi-cli.rb
@@ -19,6 +19,10 @@ class KimiCli < Formula
     sha256 cellar: :any, x86_64_linux:  "7021d98dca45e1efb96ab2a23e178d76a5b399520db862b383d1ba5c160ab63f"
   end
 
+  # Deprecated upstream: https://github.com/MoonshotAI/kimi-cli#readme
+  deprecate! date: "2026-07-17", because: :deprecated_upstream, replacement_formula: "kimi-code"
+  disable! date: "2027-01-17", because: :deprecated_upstream, replacement_formula: "kimi-code"
+
   depends_on "pkgconf" => :build
   depends_on "pybind11" => :build # for `google-re2`
   depends_on "rust" => :build # for jiter


### PR DESCRIPTION
-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI-assisted contribution by Kimi Code CLI for the formula edit; the change and the upstream announcement were reviewed by the user before submission. `brew style` and `brew audit --strict` pass locally. This is a deprecate-only metadata change, so the local build/test boxes are intentionally left unchecked; CI will cover them.

Prepared on macOS 26.3.2 running arm64.

Deprecate `kimi-cli`: the upstream README announces that Kimi CLI is evolving into [Kimi Code CLI](https://github.com/MoonshotAI/kimi-code) and that the project will be gradually wound down: https://github.com/MoonshotAI/kimi-cli


Note: the PR author is a maintainer of [Kimi Code CLI](https://github.com/MoonshotAI/kimi-code), the successor project to kimi-cli.
