### PR TITLE
osc-cli: deprecated by upstream

### DIFF
--- a/Formula/o/osc-cli.rb
+++ b/Formula/o/osc-cli.rb
@@ -12,6 +12,9 @@ class OscCli < Formula
     sha256 cellar: :any_skip_relocation, all: "0b5095bc6803da7dc7288c74f6b8f6bb885431f733f2129ac02f247a24b4d9bb"
   end
 
+  deprecate! date: "2026-07-17", because: :deprecated_upstream, replacement_formula: "octl"
+  disable! date: "2027-01-17", because: :deprecated_upstream, replacement_formula: "octl"
+
   depends_on "certifi" => :no_linkage
   depends_on "python@3.14"
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Deprecate by upstream

>Warning
>
>osc-cli is deprecated and is no longer actively maintained.
>
>We recommend using octl instead. octl is our latest CLI project and is actively maintained.


```
==> Analytics
install: 19 (30 days), 65 (90 days), 291 (365 days)
install-on-request: 19 (30 days), 65 (90 days), 291 (365 days)
build-error: 0 (30 days)
```