### PR TITLE
xz: remove HTTP mirror check which is now part of audit

### DIFF
--- a/Formula/x/xz.rb
+++ b/Formula/x/xz.rb
@@ -23,10 +23,10 @@ class Xz < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "61032fd340234974371a87c9908c998d9a52bebdf056b83e629ebf7aa038840f"
   end
 
-  deny_network_access! [:build, :postinstall]
+  deny_network_access!
 
   def install
-    system "./configure", *std_configure_args, "--disable-silent-rules", "--disable-nls"
+    system "./configure", "--disable-silent-rules", "--disable-nls", *std_configure_args
     system "make", "check"
     system "make", "install"
   end
@@ -43,17 +43,5 @@ class Xz < Formula
     # decompress: data.txt.xz -> data.txt
     system bin/"xz", "-d", "#{path}.xz"
     assert_equal original_contents, path.read
-
-    # Check that http mirror works
-    xz_tar = testpath/"xz.tar.gz"
-    stable.mirrors.each do |mirror|
-      next if mirror.start_with?("https")
-
-      xz_tar.unlink if xz_tar.exist?
-
-      # Set fake CA Cert to block any HTTPS redirects.
-      system "curl", "--location", mirror, "--cacert", "/fake", "--output", xz_tar
-      assert_equal stable.checksum.hexdigest, xz_tar.sha256
-    end
   end
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
