### PR TITLE
aamath: deprecate

### DIFF
--- a/Formula/a/aamath.rb
+++ b/Formula/a/aamath.rb
@@ -1,15 +1,10 @@
 class Aamath < Formula
   desc "Renders mathematical expressions as ASCII art"
-  homepage "http://fuse.superglue.se/aamath/"
+  homepage "https://web.archive.org/web/20260501180020/http://fuse.superglue.se/aamath/"
   url "https://cdn.netbsd.org/pub/pkgsrc/distfiles/aamath-0.3.tar.gz"
   mirror "http://fuse.superglue.se/aamath/aamath-0.3.tar.gz"
   sha256 "9843f4588695e2cd55ce5d8f58921d4f255e0e65ed9569e1dcddf3f68f77b631"
   license "GPL-2.0-only"
-
-  livecheck do
-    url :homepage
-    regex(/href=.*?aamath[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
 
   bottle do
     rebuild 1
@@ -20,6 +15,11 @@ class Aamath < Formula
     sha256 cellar: :any_skip_relocation, arm64_linux:   "912312e5d565a7255691d9cff437f1e66419054dc75365cda3af747ef5bf5c6f"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "79b5ff4704b7f8393182ee3b68f5343a745e5e62ad4b2db90b3b4f28c186ae52"
   end
+
+  # Last release on 2005-06-22 and requires non-upstreamed patch to build.
+  # As of deprecation date, homepage is down and HTTP-only.
+  deprecate! date: "2026-07-17", because: :unmaintained
+  disable! date: "2027-01-05", because: :unmaintained
 
   uses_from_macos "bison" => :build # for yacc
   uses_from_macos "flex" => :build


### PR DESCRIPTION
Disable date aligned with other HTTP formulae so they get removed together.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
