### PR TITLE
openssl@3: use local files for patches

### DIFF
--- a/Formula/o/openssl@3.rb
+++ b/Formula/o/openssl@3.rb
@@ -54,23 +54,19 @@ class OpensslAT3 < Formula
 
   # Backport commits to avoid test timing failures
   patch do
-    url "https://github.com/openssl/openssl/commit/9061e9381306a053908177aca8509c262015cdf3.patch?full_index=1"
-    sha256 "9f68feae9abfaabe65f79d2877f3dde7aa0428c669ed6af45dc193544268438e"
+    file "Patches/openssl/9061e9381306a053908177aca8509c262015cdf3.patch"
     type :backport
   end
   patch do
-    url "https://github.com/openssl/openssl/commit/2e2438b494e7f661be5212e4732f7fab86bf6303.patch?full_index=1"
-    sha256 "543a5998951fe540444642123398ffaa6306938be573f95c0bc915f1e6af7a36"
+    file "Patches/openssl/2e2438b494e7f661be5212e4732f7fab86bf6303.patch"
     type :backport
   end
   patch do
-    url "https://github.com/openssl/openssl/commit/ea598f5dd23f1d64d8952e20fcf95d9f3a21d654.patch?full_index=1"
-    sha256 "05bb323a3495d68961fa8cf7a989edfb0fa6e6dcc7ccdcc4e55a4e3f946d2762"
+    file "Patches/openssl/ea598f5dd23f1d64d8952e20fcf95d9f3a21d654.patch"
     type :backport
   end
   patch do
-    url "https://github.com/openssl/openssl/commit/cffb97915813aeeef58ee9a0d33c05d3d45e1fe6.patch?full_index=1"
-    sha256 "fc34b4bf106c44a89ded746e35d587d73e8485393a93b52110ba95b06717dd69"
+    file "Patches/openssl/cffb97915813aeeef58ee9a0d33c05d3d45e1fe6.patch"
     type :backport
   end
 

--- a/Patches/openssl/2e2438b494e7f661be5212e4732f7fab86bf6303.patch
+++ b/Patches/openssl/2e2438b494e7f661be5212e4732f7fab86bf6303.patch
@@ -1,0 +1,46 @@
+From 2e2438b494e7f661be5212e4732f7fab86bf6303 Mon Sep 17 00:00:00 2001
+From: Milan Broz <gmazyland@gmail.com>
+Date: Tue, 17 Mar 2026 14:16:37 +0100
+Subject: [PATCH] test: Do not fail if packet cannot be extended in QUIC
+ multistream test
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+In some specific timings, the qtest_fault_resize_plain_packet function
+returns failure as there is not enough space in allocated buffer.
+
+There is no way to recover in this situation, let print
+information and keep the test finish instead of failure
+in TEST_error() call.
+
+This patch fixes test runs on Windows where I can reproduce
+this quite reliably.
+
+Signed-off-by: Milan Broz <gmazyland@gmail.com>
+
+Reviewed-by: Saša Nedvědický <sashan@openssl.org>
+Reviewed-by: Norbert Pocs <norbertp@openssl.org>
+MergeDate: Thu Mar 19 09:18:34 2026
+(Merged from https://github.com/openssl/openssl/pull/30461)
+---
+ test/helpers/quictestlib.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/test/helpers/quictestlib.c b/test/helpers/quictestlib.c
+index a0df212074bd3fad662407846979dffe213858d7..5405df6ebf3edf0830739b20f2a1cd34288b63ab 100644
+--- a/test/helpers/quictestlib.c
++++ b/test/helpers/quictestlib.c
+@@ -930,9 +930,10 @@ int qtest_fault_prepend_frame(QTEST_FAULT *fault, const unsigned char *frame,
+     old_len = fault->pplainio.buf_len;
+ 
+     /* Extend the size of the packet by the size of the new frame */
+-    if (!TEST_true(qtest_fault_resize_plain_packet(fault,
+-            old_len + frame_len)))
++    if (!qtest_fault_resize_plain_packet(fault, old_len + frame_len)) {
++        TEST_info("Cannot extend packet (%zu + %zu)", old_len, frame_len);
+         return 0;
++    }
+ 
+     memmove(buf + frame_len, buf, old_len);
+     memcpy(buf, frame, frame_len);

--- a/Patches/openssl/9061e9381306a053908177aca8509c262015cdf3.patch
+++ b/Patches/openssl/9061e9381306a053908177aca8509c262015cdf3.patch
@@ -1,0 +1,36 @@
+From 9061e9381306a053908177aca8509c262015cdf3 Mon Sep 17 00:00:00 2001
+From: Milan Broz <gmazyland@gmail.com>
+Date: Tue, 17 Mar 2026 14:09:47 +0100
+Subject: [PATCH] test: Increase timeout for QUIC multistream test
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+I can regularly hit timeout on Windows for QUIC multistream test.
+While increasing is not the best solution, it eliminates many
+failures during testing. This timeout only applies in specific
+situation, so run time should not be actually used often.
+
+Signed-off-by: Milan Broz <gmazyland@gmail.com>
+
+Reviewed-by: Saša Nedvědický <sashan@openssl.org>
+Reviewed-by: Norbert Pocs <norbertp@openssl.org>
+MergeDate: Thu Mar 19 09:18:32 2026
+(Merged from https://github.com/openssl/openssl/pull/30461)
+---
+ test/quic_multistream_test.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/test/quic_multistream_test.c b/test/quic_multistream_test.c
+index a3b46e57d05eec11415114c5bbfca13f05247a88..0bb0253b7ea774a9d3858e71459ee00bb3645d8a 100644
+--- a/test/quic_multistream_test.c
++++ b/test/quic_multistream_test.c
+@@ -1098,7 +1098,7 @@ static int run_script_worker(struct helper *h, const struct script_op *script,
+             first = 0;
+             offset = 0;
+             op_start_time = ossl_time_now();
+-            op_deadline = ossl_time_add(op_start_time, ossl_ms2time(60000));
++            op_deadline = ossl_time_add(op_start_time, ossl_ms2time(180000));
+         }
+ 
+         if (!TEST_int_le(ossl_time_compare(ossl_time_now(), op_deadline), 0)) {

--- a/Patches/openssl/cffb97915813aeeef58ee9a0d33c05d3d45e1fe6.patch
+++ b/Patches/openssl/cffb97915813aeeef58ee9a0d33c05d3d45e1fe6.patch
@@ -1,0 +1,46 @@
+From cffb97915813aeeef58ee9a0d33c05d3d45e1fe6 Mon Sep 17 00:00:00 2001
+From: Matt Caswell <matt@openssl.foundation>
+Date: Wed, 17 Jun 2026 11:18:12 +0100
+Subject: [PATCH] Fix intermittent failure in check_pc_flood radix test
+
+check_flood_stats read the path challenge/response counters immediately
+after the client's write returned, but the flood is delivered over a
+real socket and processed by the connection's assist thread
+asynchronously. Spin until the counters reach their expected values,
+the same way check_rejected already does, instead of failing on the
+first observation.
+
+Observed failure:
+https://github.com/openssl/openssl/actions/runs/27669771673/job/81831310551?pr=31538
+
+Assisted-by: Claude:claude-sonnet-4-6
+
+Reviewed-by: Nikola Pajkovsky <nikolap@openssl.org>
+Reviewed-by: Milan Broz <mbroz@openssl.org>
+MergeDate: Thu Jun 18 13:07:27 2026
+(Merged from https://github.com/openssl/openssl/pull/31561)
+
+(cherry picked from commit 75f59968b838dabc3ff441ae2841c10e0df64b2b)
+---
+ test/radix/quic_tests.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/test/radix/quic_tests.c b/test/radix/quic_tests.c
+index abdb277a428d80e1c0999a112d3a761740d67cb4..ab862fa1febf2174d461afe817cc8e6d5ec404f8 100644
+--- a/test/radix/quic_tests.c
++++ b/test/radix/quic_tests.c
+@@ -455,6 +455,14 @@ DEF_FUNC(check_flood_stats)
+     path_challenge_count = ossl_quic_channel_get_path_challenge_count(ch);
+     path_response_count = ossl_quic_channel_get_path_response_count(ch);
+ 
++    /*
++     * The flood is delivered over a real socket and processed by the
++     * connection's assist thread asynchronously, so give it a chance to
++     * catch up rather than failing on the first observation.
++     */
++    if (path_challenge_count < 16 || path_response_count < 1)
++        F_SPIN_AGAIN();
++
+     if (!TEST_uint64_t_eq(path_challenge_count, 16))
+         goto err;
+     if (!TEST_uint64_t_eq(path_response_count, 1))

--- a/Patches/openssl/ea598f5dd23f1d64d8952e20fcf95d9f3a21d654.patch
+++ b/Patches/openssl/ea598f5dd23f1d64d8952e20fcf95d9f3a21d654.patch
@@ -1,0 +1,230 @@
+From ea598f5dd23f1d64d8952e20fcf95d9f3a21d654 Mon Sep 17 00:00:00 2001
+From: Tomas Mraz <tomas@openssl.foundation>
+Date: Thu, 11 Jun 2026 17:37:31 +0200
+Subject: [PATCH] test: Invert bad TEST() condition calls
+
+False result of a TEST_xxx() call should always indicate
+erroneous condition.
+
+Fix such calls. Also fix some calls which
+treated TEST_xxx() result as non-boolean.
+
+Reviewed-by: Paul Dale <paul.dale@oracle.com>
+Reviewed-by: Richard Levitte <levitte@openssl.org>
+Reviewed-by: Norbert Pocs <norbertp@openssl.org>
+MergeDate: Mon Jun 15 07:38:52 2026
+(Merged from https://github.com/openssl/openssl/pull/31457)
+
+(cherry picked from commit 7c765bb6020b7c391dea8112f403e3b2109ff6dd)
+---
+ test/ca_internals_test.c |  4 ++--
+ test/evp_extra_test2.c   |  2 +-
+ test/hpke_test.c         | 22 +++++++++-------------
+ test/http_test.c         |  4 ++--
+ test/pkcs12_api_test.c   |  4 ++--
+ test/punycode_test.c     |  2 +-
+ test/radix/quic_tests.c  |  4 ++--
+ test/secmemtest.c        |  2 +-
+ test/sslapitest.c        |  4 ++--
+ 9 files changed, 22 insertions(+), 26 deletions(-)
+
+diff --git a/test/ca_internals_test.c b/test/ca_internals_test.c
+index 0b0b2f3b70976b0e4e3898f9b649684a9d09b4a3..ed922a36dd28ac8b8a4a1ad2b3b2afa614c8d548 100644
+--- a/test/ca_internals_test.c
++++ b/test/ca_internals_test.c
+@@ -48,13 +48,13 @@ static int test_do_updatedb(void)
+ 
+     testdate = test_get_argument(2);
+     testdateutc = test_asn1_string_to_time_t(testdate);
+-    if (TEST_time_t_lt(testdateutc, 0)) {
++    if (!TEST_time_t_ge(testdateutc, 0)) {
+         return 0;
+     }
+ 
+     indexfile = test_get_argument(1);
+     db = load_index(indexfile, NULL);
+-    if (TEST_ptr_null(db)) {
++    if (!TEST_ptr(db)) {
+         return 0;
+     }
+ 
+diff --git a/test/evp_extra_test2.c b/test/evp_extra_test2.c
+index ac1c7d84665db4ce1045f793bb57a7184a0928f2..c53057fba02abd180d36e0b9ef4ee844f70a0b35 100644
+--- a/test/evp_extra_test2.c
++++ b/test/evp_extra_test2.c
+@@ -494,7 +494,7 @@ static int test_new_keytype(void)
+     unsigned char *out = NULL, *secret = NULL, *secret2 = NULL;
+ 
+     /* without tls-provider key should not be create-able */
+-    if (TEST_ptr(key = EVP_PKEY_Q_keygen(mainctx, NULL, "XOR")))
++    if (!TEST_ptr_null(key = EVP_PKEY_Q_keygen(mainctx, NULL, "XOR")))
+         goto err;
+     /* prepare & load tls-provider */
+     if (!TEST_true(OSSL_PROVIDER_add_builtin(mainctx, "tls-provider",
+diff --git a/test/hpke_test.c b/test/hpke_test.c
+index c7b30012ad2b4bed385554a8083cb5fc0c8762ba..df3f4574a0f0654fd105d7d9a611dd2d8d244cd7 100644
+--- a/test/hpke_test.c
++++ b/test/hpke_test.c
+@@ -949,10 +949,9 @@ static int test_hpke_modes_suites(void)
+             hpke_suite.kem_id = kem_id;
+             if (hpke_mode == OSSL_HPKE_MODE_AUTH
+                 || hpke_mode == OSSL_HPKE_MODE_PSKAUTH) {
+-                if (TEST_true(OSSL_HPKE_keygen(hpke_suite, authpub, &authpublen,
++                if (!TEST_true(OSSL_HPKE_keygen(hpke_suite, authpub, &authpublen,
+                         &authpriv, NULL, 0,
+-                        testctx, NULL))
+-                    != 1) {
++                        testctx, NULL))) {
+                     overallresult = 0;
+                 }
+                 authpubp = authpub;
+@@ -1195,7 +1194,7 @@ static int test_hpke_suite_strs(void)
+             for (aeadind = 0; aeadind != OSSL_NELEM(aead_str_list); aeadind++) {
+                 BIO_snprintf(sstr, 128, "%s,%s,%s", kem_str_list[kemind],
+                     kdf_str_list[kdfind], aead_str_list[aeadind]);
+-                if (TEST_true(OSSL_HPKE_str2suite(sstr, &stirred)) != 1) {
++                if (!TEST_true(OSSL_HPKE_str2suite(sstr, &stirred))) {
+                     if (verbose)
+                         TEST_note("Unexpected str2suite fail for :%s",
+                             bogus_suite_strs[sind]);
+@@ -1205,9 +1204,8 @@ static int test_hpke_suite_strs(void)
+         }
+     }
+     for (sind = 0; sind != OSSL_NELEM(bogus_suite_strs); sind++) {
+-        if (TEST_false(OSSL_HPKE_str2suite(bogus_suite_strs[sind],
+-                &stirred))
+-            != 1) {
++        if (!TEST_false(OSSL_HPKE_str2suite(bogus_suite_strs[sind],
++                &stirred))) {
+             if (verbose)
+                 TEST_note("OSSL_HPKE_str2suite didn't fail for bogus[%d]:%s",
+                     sind, bogus_suite_strs[sind]);
+@@ -1250,20 +1248,18 @@ static int test_hpke_grease(void)
+     /* GREASEing */
+     /* check too short for public value */
+     g_pub_len = 10;
+-    if (TEST_false(OSSL_HPKE_get_grease_value(NULL, &g_suite,
++    if (!TEST_false(OSSL_HPKE_get_grease_value(NULL, &g_suite,
+             g_pub, &g_pub_len,
+             g_cipher, g_cipher_len,
+-            testctx, NULL))
+-        != 1) {
++            testctx, NULL))) {
+         overallresult = 0;
+     }
+     /* reset to work */
+     g_pub_len = OSSL_HPKE_TSTSIZE;
+-    if (TEST_true(OSSL_HPKE_get_grease_value(NULL, &g_suite,
++    if (!TEST_true(OSSL_HPKE_get_grease_value(NULL, &g_suite,
+             g_pub, &g_pub_len,
+             g_cipher, g_cipher_len,
+-            testctx, NULL))
+-        != 1) {
++            testctx, NULL))) {
+         overallresult = 0;
+     }
+     /* expansion */
+diff --git a/test/http_test.c b/test/http_test.c
+index f3d60d4feea9b9a150d65273d00a56063316ce44..04a12fd10ce386597573d6441034ad802674ab40 100644
+--- a/test/http_test.c
++++ b/test/http_test.c
+@@ -586,7 +586,7 @@ static int test_http_resp_hdr_limit(size_t limit)
+     int res = 0;
+     OSSL_HTTP_REQ_CTX *rctx = NULL;
+ 
+-    if (TEST_ptr(wbio) == 0 || TEST_ptr(rbio) == 0)
++    if (!TEST_ptr(wbio) || !TEST_ptr(rbio))
+         goto err;
+ 
+     mock_args.txt = text1;
+@@ -598,7 +598,7 @@ static int test_http_resp_hdr_limit(size_t limit)
+     BIO_set_callback_arg(wbio, (char *)&mock_args);
+ 
+     rctx = OSSL_HTTP_REQ_CTX_new(wbio, rbio, 8192);
+-    if (TEST_ptr(rctx) == 0)
++    if (!TEST_ptr(rctx))
+         goto err;
+ 
+     if (!TEST_true(OSSL_HTTP_REQ_CTX_set_request_line(rctx, 0 /* GET */,
+diff --git a/test/pkcs12_api_test.c b/test/pkcs12_api_test.c
+index 147d65bd665abc01ba9bee916b166a6d59a8befd..b98343da86af339c4fa87dd786114e7c6753c396 100644
+--- a/test/pkcs12_api_test.c
++++ b/test/pkcs12_api_test.c
+@@ -175,7 +175,7 @@ static int pkcs12_create_ex2_test(int test)
+             0, 0, 0,
+             testctx, NULL,
+             NULL, NULL);
+-        if (TEST_ptr(ptr))
++        if (!TEST_ptr_null(ptr))
+             goto err;
+ 
+         /* Can't proceed without a valid cert at least */
+@@ -201,7 +201,7 @@ static int pkcs12_create_ex2_test(int test)
+             testctx, NULL,
+             pkcs12_create_cb, (void *)&cb_ret);
+         /* PKCS12 not created */
+-        if (TEST_ptr(ptr))
++        if (!TEST_ptr_null(ptr))
+             goto err;
+     } else if (test == 2) {
+         /* Specified call back called - return failure */
+diff --git a/test/punycode_test.c b/test/punycode_test.c
+index 37f6056903c677686b3d2403efc82b43c0b2c06a..3591f0dc19a0973d990ed7369db3426da2386757 100644
+--- a/test/punycode_test.c
++++ b/test/punycode_test.c
+@@ -188,7 +188,7 @@ static int test_puny_overrun(void)
+     unsigned int bsize = OSSL_NELEM(buf) - 1;
+ 
+     if (!TEST_false(ossl_punycode_decode(in, strlen(in), buf, &bsize))) {
+-        if (TEST_mem_eq(buf, bsize * sizeof(*buf), out, sizeof(out)))
++        if (!TEST_mem_ne(buf, bsize * sizeof(*buf), out, sizeof(out)))
+             TEST_error("CRITICAL: buffer overrun detected!");
+         return 0;
+     }
+diff --git a/test/radix/quic_tests.c b/test/radix/quic_tests.c
+index 29a8cf3efaa54afd402198fb54ce7ef14d64594f..abdb277a428d80e1c0999a112d3a761740d67cb4 100644
+--- a/test/radix/quic_tests.c
++++ b/test/radix/quic_tests.c
+@@ -455,9 +455,9 @@ DEF_FUNC(check_flood_stats)
+     path_challenge_count = ossl_quic_channel_get_path_challenge_count(ch);
+     path_response_count = ossl_quic_channel_get_path_response_count(ch);
+ 
+-    if (TEST_uint64_t_ne(path_challenge_count, 16))
++    if (!TEST_uint64_t_eq(path_challenge_count, 16))
+         goto err;
+-    if (TEST_uint64_t_ne(path_response_count, 1))
++    if (!TEST_uint64_t_eq(path_response_count, 1))
+         goto err;
+ 
+     ok = 1;
+diff --git a/test/secmemtest.c b/test/secmemtest.c
+index 05b0bbc85796d37fe76f4a63b71a765aded1bc8b..b0ac91a38f6a18ad7e03044d80477f5fbba357ff 100644
+--- a/test/secmemtest.c
++++ b/test/secmemtest.c
+@@ -81,7 +81,7 @@ static int test_sec_mem(void)
+      * If init fails, then initialized should be false, if not, this
+      * could cause an infinite loop secure_malloc, but we don't test it
+      */
+-    if (TEST_false(CRYPTO_secure_malloc_init(16, 16)) && !TEST_false(CRYPTO_secure_malloc_initialized())) {
++    if (!TEST_true(CRYPTO_secure_malloc_init(16, 16)) && !TEST_false(CRYPTO_secure_malloc_initialized())) {
+         TEST_true(CRYPTO_secure_malloc_done());
+         goto end;
+     }
+diff --git a/test/sslapitest.c b/test/sslapitest.c
+index da93d49338048c6172fd5658d56e38d96ae1f3fa..68a52837b566e1746e9fa154a7e7b37d085b7c40 100644
+--- a/test/sslapitest.c
++++ b/test/sslapitest.c
+@@ -2524,11 +2524,11 @@ static int test_tlsext_status_type_multi(void)
+     if (!TEST_true(create_ssl_ctx_pair(libctx, TLS_server_method(), TLS_client_method(),
+             TLS1_VERSION, 0, &sctx, &cctx, leaf, skey)))
+         goto end;
+-    if (TEST_int_lt(SSL_CTX_use_certificate_chain_file(sctx, leaf_chain), 0))
++    if (!TEST_int_ge(SSL_CTX_use_certificate_chain_file(sctx, leaf_chain), 0))
+         goto end;
+     if (!TEST_true(SSL_CTX_load_verify_locations(cctx, root, NULL)))
+         goto end;
+-    if (TEST_int_ne(SSL_CTX_get_tlsext_status_type(cctx), -1))
++    if (!TEST_int_eq(SSL_CTX_get_tlsext_status_type(cctx), -1))
+         goto end;
+ 
+     /* set verify callback function */


### PR DESCRIPTION
Moving HTTPS patches to local files as OpenSSL is part of curl dependency tree so usually want to avoid HTTPS requirement.

These are exactly the same patches. Quick sha256 verification:
```console
❯ sha256 *
SHA256 (2e2438b494e7f661be5212e4732f7fab86bf6303.patch) = 543a5998951fe540444642123398ffaa6306938be573f95c0bc915f1e6af7a36
SHA256 (9061e9381306a053908177aca8509c262015cdf3.patch) = 9f68feae9abfaabe65f79d2877f3dde7aa0428c669ed6af45dc193544268438e
SHA256 (cffb97915813aeeef58ee9a0d33c05d3d45e1fe6.patch) = fc34b4bf106c44a89ded746e35d587d73e8485393a93b52110ba95b06717dd69
SHA256 (ea598f5dd23f1d64d8952e20fcf95d9f3a21d654.patch) = 05bb323a3495d68961fa8cf7a989edfb0fa6e6dcc7ccdcc4e55a4e3f946d2762
```

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
