### PR TITLE
ovh-ttyrec 1.2.0.0 (new formula)

### DIFF
--- a/Formula/o/ovh-ttyrec.rb
+++ b/Formula/o/ovh-ttyrec.rb
@@ -1,0 +1,22 @@
+class OvhTtyrec < Formula
+  desc "Enhanced (but compatible) version of the classic ttyrec"
+  homepage "https://github.com/ovh/ovh-ttyrec"
+  url "https://github.com/ovh/ovh-ttyrec/archive/refs/tags/v1.2.0.0.tar.gz"
+  sha256 "74a474ea33090a9a814c186429c2f725c0bfa1f9d3ceee03caf999daf047eb41"
+  license all_of: ["BSD-3-Clause", "BSD-4-Clause-UC"]
+
+  depends_on "zstd"
+
+  def install
+    ENV["NO_STATIC_ZSTD"] = "1"
+    system "./configure", "--disable-silent-rules", *std_configure_args
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.tty").binwrite([0, 0, 4].pack("V3") + "test" + [9, 0, 3].pack("V3") + "end")
+
+    assert_equal "9\ttest.tty", shell_output("#{bin}/ttytime test.tty").strip
+  end
+end

--- a/Formula/o/ovh-ttyrec.rb
+++ b/Formula/o/ovh-ttyrec.rb
@@ -5,6 +5,15 @@ class OvhTtyrec < Formula
   sha256 "74a474ea33090a9a814c186429c2f725c0bfa1f9d3ceee03caf999daf047eb41"
   license all_of: ["BSD-3-Clause", "BSD-4-Clause-UC"]
 
+  bottle do
+    sha256 cellar: :any, arm64_tahoe:   "a230c45574d67b74fa0fa4bf2fb756cacebb3bc8ab83d3167db999c542e49e36"
+    sha256 cellar: :any, arm64_sequoia: "20a97830384deca10281cf7ad0f23e1bfebb835a134eefcf2a279ad52cb69554"
+    sha256 cellar: :any, arm64_sonoma:  "4dbe262314355b29ef3aaa4a4c22434ce9f6ad16bef5e10fe2c39d73c452cb71"
+    sha256 cellar: :any, sonoma:        "a306c3d4ce9a5813ea869c351ba18a077ec99dd77fd1a2f134454fca8c60be63"
+    sha256 cellar: :any, arm64_linux:   "a05d2af513ccc1705cc444442998940c77f8ebc205d5d279bcdca193a3b9c30b"
+    sha256 cellar: :any, x86_64_linux:  "fb32053d1909df6d7b2f6e7deb847dff5ee1028cb9018ee7356923fdcb6d5d38"
+  end
+
   depends_on "zstd"
 
   def install


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Fork of unmaintained `ttyrec`. Will likely deprecate `ttyrec` afterward. 

Was considering whether to apply fork policy and replace `ttyrec` directly given Debian[^1] and Gentoo[^2] switched, but decided to keep separate for now as upstream picked a separate name (`ovh-ttyrec`). Still an option if preferred.

Repology: https://repology.org/project/ovh-ttyrec/versions

[^1]: https://salsa.debian.org/salvage-team/ttyrec/-/commit/85ffe519c8136568df2b0096711a32cd624ca128
[^2]: https://gitweb.gentoo.org/repo/gentoo.git/commit/app-misc/ttyrec?id=320ad1589ec09bc94e305d557047751cab8f80d6

