### PR TITLE
libtiff: use official mirror

### DIFF
--- a/Formula/lib/libtiff.rb
+++ b/Formula/lib/libtiff.rb
@@ -2,7 +2,7 @@ class Libtiff < Formula
   desc "TIFF library and utilities"
   homepage "https://libtiff.gitlab.io/libtiff/"
   url "https://download.osgeo.org/libtiff/tiff-4.7.2.tar.gz"
-  mirror "https://fossies.org/linux/misc/tiff-4.7.2.tar.gz"
+  mirror "https://ftp2.osuosl.org/pub/osgeo/download/libtiff/tiff-4.7.2.tar.gz"
   sha256 "672bd7d10aee4606171afb864f3570b83340f6a33e2c186dc0512f7145ffdf6a"
   license "libtiff"
   compatibility_version 1


### PR DESCRIPTION

```console
❯ curl -s "https://ftp2.osuosl.org/pub/osgeo/download/libtiff/tiff-4.7.2.tar.gz" | sha256
672bd7d10aee4606171afb864f3570b83340f6a33e2c186dc0512f7145ffdf6a
```

Listed at https://download.osgeo.org/ and works better for older copies of formula as Fossies only retains old versions for short timeframe.

Also generally better to keep Fossies traffic low to abide by https://fossies.org/about.html#terms_of_use


-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
