### PR TITLE
hfsutils: restore main url

### DIFF
--- a/Formula/h/hfsutils.rb
+++ b/Formula/h/hfsutils.rb
@@ -1,8 +1,8 @@
 class Hfsutils < Formula
   desc "Tools for reading and writing Macintosh volumes"
   homepage "https://www.mars.org/home/rob/proj/hfs/"
-  url "https://ftp2.osuosl.org/pub/clfs/conglomeration/hfsutils/hfsutils-3.2.6.tar.gz"
-  mirror "https://fossies.org/linux/misc/old/hfsutils-3.2.6.tar.gz"
+  url "https://ftp.mars.org/hfs/hfsutils-3.2.6.tar.gz"
+  mirror "https://ftp2.osuosl.org/pub/clfs/conglomeration/hfsutils/hfsutils-3.2.6.tar.gz"
   sha256 "bc9d22d6d252b920ec9cdf18e00b7655a6189b3f34f42e58d5bb152957289840"
   license "GPL-2.0-or-later"
 


### PR DESCRIPTION
We use this for livecheck already. Original homepage-based url was lost during chain of modifications 
- https://github.com/Homebrew/homebrew-core/commit/78fc5ac0875a20937f9fbe6896be674c0166afba 
- https://github.com/Homebrew/homebrew-core/commit/3a268b5ae0d83c84e2816ed6089f5c336b878080

As first commit moved to wrong subdomain.

```console
❯ curl -sI "https://www.mars.org/hfs/hfsutils-3.2.6.tar.gz" | grep -E 'HTTP|location'
HTTP/2 302
location: http://www.mars.org/

❯ curl -sI "https://ftp.mars.org/hfs/hfsutils-3.2.6.tar.gz" | grep -E 'HTTP|location'
HTTP/2 200

❯ curl -s "https://ftp.mars.org/hfs/hfsutils-3.2.6.tar.gz" | sha256
bc9d22d6d252b920ec9cdf18e00b7655a6189b3f34f42e58d5bb152957289840
```

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
