### PR TITLE
bison m4: add HTTP mirror as part of curl deps on Linux

### DIFF
--- a/Formula/b/bison.rb
+++ b/Formula/b/bison.rb
@@ -4,6 +4,7 @@ class Bison < Formula
   # X.Y.9Z are beta releases that sometimes get accidentally uploaded to the release FTP
   url "https://ftpmirror.gnu.org/gnu/bison/bison-3.8.2.tar.xz"
   mirror "https://ftp.gnu.org/gnu/bison/bison-3.8.2.tar.xz"
+  mirror "http://ftp.gnu.org/gnu/bison/bison-3.8.2.tar.xz"
   sha256 "9bba0214ccf7f1079c5d59210045227bcf619519840ebfa80cd3849cff5a5bf2"
   license "GPL-3.0-or-later"
   version_scheme 1

--- a/Formula/m/m4.rb
+++ b/Formula/m/m4.rb
@@ -3,6 +3,7 @@ class M4 < Formula
   homepage "https://www.gnu.org/software/m4/"
   url "https://ftpmirror.gnu.org/gnu/m4/m4-1.4.21.tar.xz"
   mirror "https://ftp.gnu.org/gnu/m4/m4-1.4.21.tar.xz"
+  mirror "http://ftp.gnu.org/gnu/m4/m4-1.4.21.tar.xz"
   sha256 "f25c6ab51548a73a75558742fb031e0625d6485fe5f9155949d6486a2408ab66"
   license "GPL-3.0-or-later"
   compatibility_version 1


### PR DESCRIPTION
Dependency needed to  build `krb5` which is currently a dependency of `curl`
```
krb5
├── openssl@3
│   └── ca-certificates
├── bison  [build]
│   └── m4
└── keyutils
```

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
