### PR TITLE
go@*: remove dead mirrors

### DIFF
--- a/Formula/g/go@1.21.rb
+++ b/Formula/g/go@1.21.rb
@@ -2,7 +2,6 @@ class GoAT121 < Formula
   desc "Open source programming language to build simple/reliable/efficient software"
   homepage "https://go.dev/"
   url "https://go.dev/dl/go1.21.13.src.tar.gz"
-  mirror "https://fossies.org/linux/misc/go1.21.13.src.tar.gz"
   sha256 "71fb31606a1de48d129d591e8717a63e0c5565ffba09a24ea9f899a13214c34d"
   license "BSD-3-Clause"
   revision 1

--- a/Formula/g/go@1.22.rb
+++ b/Formula/g/go@1.22.rb
@@ -2,7 +2,6 @@ class GoAT122 < Formula
   desc "Open source programming language to build simple/reliable/efficient software"
   homepage "https://go.dev/"
   url "https://go.dev/dl/go1.22.12.src.tar.gz"
-  mirror "https://fossies.org/linux/misc/go1.22.12.src.tar.gz"
   sha256 "012a7e1f37f362c0918c1dfa3334458ac2da1628c4b9cf4d9ca02db986e17d71"
   license "BSD-3-Clause"
 

--- a/Formula/g/go@1.23.rb
+++ b/Formula/g/go@1.23.rb
@@ -2,7 +2,6 @@ class GoAT123 < Formula
   desc "Open source programming language to build simple/reliable/efficient software"
   homepage "https://go.dev/"
   url "https://go.dev/dl/go1.23.12.src.tar.gz"
-  mirror "https://fossies.org/linux/misc/go1.23.12.src.tar.gz"
   sha256 "e1cce9379a24e895714a412c7ddd157d2614d9edbe83a84449b6e1840b4f1226"
   license "BSD-3-Clause"
 

--- a/Formula/g/go@1.24.rb
+++ b/Formula/g/go@1.24.rb
@@ -2,7 +2,6 @@ class GoAT124 < Formula
   desc "Open source programming language to build simple/reliable/efficient software"
   homepage "https://go.dev/"
   url "https://go.dev/dl/go1.24.13.src.tar.gz"
-  mirror "https://fossies.org/linux/misc/go1.24.13.src.tar.gz"
   sha256 "639a6204c2486b137df1eb6e78ee3ed038f9877d0e4b5a465e796a2153f858d7"
   license "BSD-3-Clause"
   revision 1


### PR DESCRIPTION
Only supported versions are still mirrored so clean these up
```
❯ curl -sI "https://fossies.org/linux/misc/go1.24.13.src.tar.gz" | head -1
HTTP/1.1 410 Gone
```

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
