### PR TITLE
cmuclmtk: deprecated by unmaintained

### DIFF
--- a/Formula/c/cmuclmtk.rb
+++ b/Formula/c/cmuclmtk.rb
@@ -5,14 +5,6 @@ class Cmuclmtk < Formula
   sha256 "d23e47f00224667c059d69ac942f15dc3d4c3dd40e827318a6213699b7fa2915"
   license "BSD-2-Clause"
 
-  # We check the "cmuclmtk" directory page since versions aren't present in the
-  # RSS feed as of writing.
-  livecheck do
-    url "https://sourceforge.net/projects/cmusphinx/files/cmuclmtk/"
-    regex(%r{href=.*?/v?(\d+(?:\.\d+)+)/?["' >]}i)
-    strategy :page_match
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:    "e382dbebb03c49d129bb2eacd23102d828d9814296bb751f275e2bd5cd4ac8e4"
     sha256 cellar: :any,                 arm64_sequoia:  "17749777bf2cedd02ab511ce2bab36a69389ea9c1f0b03c8a92927e3e54a5fae"
@@ -28,6 +20,9 @@ class Cmuclmtk < Formula
     sha256 cellar: :any_skip_relocation, arm64_linux:    "fbf62c45fadfecaf2d9cd51668c6ea132d904afe1e456f099f067427667b1284"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "708324bb6cf751c76f927c6a648416ee38012499dddfc80c4b2c50cf36431c4d"
   end
+
+  deprecate! date: "2026-07-18", because: :unmaintained
+  disable! date: "2027-01-18", because: :unmaintained
 
   depends_on "pkgconf" => :build
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Upstream sourceforge is marked as abandoned, and moved to github. But only selected tools are moved and leaves `cmuclmtk` at the sourceforge, so it is really unmaintained.

```
==> Analytics
install: 0 (30 days), 5 (90 days), 14 (365 days)
install-on-request: 0 (30 days), 5 (90 days), 14 (365 days)
build-error: 0 (30 days)
```