### PR TITLE
graph-tool: reduce required dependencies

### DIFF
--- a/Formula/g/graph-tool.rb
+++ b/Formula/g/graph-tool.rb
@@ -14,12 +14,13 @@ class GraphTool < Formula
   end
 
   bottle do
-    sha256               arm64_tahoe:   "50e665849b87dd8ad617c2efd3afa0a4d0adef53b74071b2c7b5c4ce3f7063ae"
-    sha256               arm64_sequoia: "60a42b64ba10fdaf6084735181006859bd3465fbfa2a6701d660015734f0cb15"
-    sha256               arm64_sonoma:  "be2e852b0f3b95d195a2bb16ed953c7acfbd74dbb8ccd8f95326225f230eb21c"
-    sha256               sonoma:        "b9cb760c4878ec9f4eac0419013416ed0462968cb879944c65f14f7c75c31b7b"
-    sha256               arm64_linux:   "dc3a527a90809726450449ee90a4bb8f124a4a30ea2379e6e7881d07613f8b43"
-    sha256 cellar: :any, x86_64_linux:  "0ad4b6e3bd2ac87f703355e32585ff1e75159b33b9e483ad5b2ab233f532e343"
+    rebuild 1
+    sha256               arm64_tahoe:   "6afb00c1f7d70785dc11cee93c8e1737cb2d5418fe3277fa21bc82fada367d88"
+    sha256               arm64_sequoia: "6145b7a963a4d27c599e8f178bac270735416155fa8927a17ccdad5d89d54c41"
+    sha256               arm64_sonoma:  "b56bc924ea55f7c925469ffd2c1749f69c9c9ad5d27e7769ef6b619b43ac408c"
+    sha256               sonoma:        "ce2bccff3d23b5c7a5f26306a47104c1d0c5566fbf6bf84ee5f7e1e4b43ff592"
+    sha256               arm64_linux:   "500f1643dbc65fc8c035570ebb5cb2645f4b8f5f19206515bb0ce75436664e2c"
+    sha256 cellar: :any, x86_64_linux:  "aacef17c2a0dd105ba0b6e380bba2149d431212e44324949c4149e92cf60c8a3"
   end
 
   depends_on "cgal" => :build

--- a/Formula/g/graph-tool.rb
+++ b/Formula/g/graph-tool.rb
@@ -22,24 +22,24 @@ class GraphTool < Formula
     sha256 cellar: :any, x86_64_linux:  "0ad4b6e3bd2ac87f703355e32585ff1e75159b33b9e483ad5b2ab233f532e343"
   end
 
-  depends_on "google-sparsehash" => :build
-  depends_on "ninja" => :build
+  depends_on "cgal" => :build
+  depends_on "google-sparsehash" => :build # TODO: Remove in 3.x
   depends_on "pkgconf" => :build
+  depends_on "py3cairo" => [:build, :test]
+  depends_on "python-setuptools" => :build # for zstandard
+
+  # only test optional graph drawing feature to reduce required runtime dependencies
+  depends_on "gtk+3" => :test
+  depends_on "pygobject3" => :test
+  depends_on "python-matplotlib" => :test
 
   depends_on "boost"
   depends_on "boost-python3"
-  depends_on "cairomm@1.14"
-  depends_on "cgal"
-  depends_on "freetype"
+  depends_on "cairomm"
   depends_on "gmp"
-  depends_on "gtk+3"
-  depends_on "numpy"
-  depends_on "pillow"
-  depends_on "py3cairo"
-  depends_on "pygobject3"
+  depends_on "numpy" => :no_linkage
   depends_on "python@3.14"
-  depends_on "qhull"
-  depends_on "scipy"
+  depends_on "scipy" => :no_linkage
   depends_on "zstd"
 
   uses_from_macos "expat"
@@ -47,75 +47,18 @@ class GraphTool < Formula
   on_macos do
     depends_on "cairo"
     depends_on "libomp"
-    depends_on "libsigc++@2"
+    depends_on "libsigc++"
   end
 
-  on_linux do
-    depends_on "patchelf" => :build
-  end
-
-  pypi_packages package_name:     "",
-                exclude_packages: %w[numpy pillow],
-                extra_packages:   %w[matplotlib setuptools zstandard]
-
-  resource "contourpy" do
-    url "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz"
-    sha256 "083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880"
-  end
-
-  resource "cycler" do
-    url "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz"
-    sha256 "88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c"
-  end
-
-  resource "fonttools" do
-    url "https://files.pythonhosted.org/packages/84/69/c97f2c18e0db87d2c7b15da1974dace76ae938f1cfa22e2727a648b7ed43/fonttools-4.63.0.tar.gz"
-    sha256 "caeb583deeb5168e694b65cda8b4ee62abedfa66cf88488734466f2366b9c4e0"
-  end
-
-  resource "kiwisolver" do
-    url "https://files.pythonhosted.org/packages/d0/67/9c61eccb13f0bdca9307614e782fec49ffdde0f7a2314935d489fa93cd9c/kiwisolver-1.5.0.tar.gz"
-    sha256 "d4193f3d9dc3f6f79aaed0e5637f45d98850ebf01f7ca20e69457f3e8946b66a"
-  end
-
-  resource "matplotlib" do
-    url "https://files.pythonhosted.org/packages/1f/24/080c99d223d158d3a8902769269ab6da5b50f7a0e6e072513907e02b7a6c/matplotlib-3.11.0.tar.gz"
-    sha256 "68c0c7be01b30dcca3638934f7f591df73401235cbdbf0d1ab1c71e7db7f8b57"
-  end
-
-  resource "packaging" do
-    url "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz"
-    sha256 "ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661"
-  end
-
-  resource "pyparsing" do
-    url "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz"
-    sha256 "c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc"
-  end
-
-  resource "python-dateutil" do
-    url "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz"
-    sha256 "37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"
-  end
-
-  resource "setuptools" do
-    url "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz"
-    sha256 "025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef"
-  end
-
-  resource "six" do
-    url "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz"
-    sha256 "ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"
-  end
+  pypi_packages package_name:   "",
+                extra_packages: "zstandard"
 
   resource "zstandard" do
     url "https://files.pythonhosted.org/packages/fd/aa/3e0508d5a5dd96529cdc5a97011299056e14c6505b678fd58938792794b1/zstandard-0.25.0.tar.gz"
     sha256 "7713e1179d162cf5c7906da876ec2ccb9c3a9dcbdffef0cc7f70c3667a205f0b"
   end
 
-  def python3
-    "python3.14"
-  end
+  def python3 = "python3.14"
 
   # remove obsolete pointer_traits workaround for older libstdc++
   patch :DATA
@@ -130,38 +73,26 @@ class GraphTool < Formula
       ENV.remove "HOMEBREW_DEPENDENCIES", "expat"
     end
 
-    site_packages = Language::Python.site_packages(python3)
-    xy = Language::Python.major_minor_version(python3)
-    skipped = ["matplotlib", "zstandard"]
     venv = virtualenv_create(libexec, python3)
-    venv.pip_install resources.reject { |r| skipped.include? r.name }
-    python = venv.root/"bin/python"
-
-    resource("matplotlib").stage do
-      system python, "-m", "pip", "install", "--config-settings=setup-args=-Dsystem-freetype=true",
-                                             "--config-settings=setup-args=-Dsystem-qhull=true",
-                                             *std_pip_args(prefix: false, build_isolation: true), "."
-    end
-
     resource("zstandard").stage do
-      system python, "-m", "pip", "install", "--config-settings=--build-option=--system-zstd",
-                                             *std_pip_args(prefix: false), "."
+      args = ["--config-settings=--build-option=--system-zstd"]
+      system venv.root/"bin/python", "-m", "pip", "install", *args, *std_pip_args(prefix: false), "."
     end
 
-    # Linux build is not thread-safe.
-    ENV.deparallelize unless OS.mac?
-
-    # Enable openmp
     if OS.mac?
+      # Enable openmp
       ENV.append_to_cflags "-Xpreprocessor -fopenmp"
       ENV.append "LDFLAGS", "-L#{formula_opt_lib("libomp")} -lomp"
       ENV.append "CPPFLAGS", "-I#{formula_opt_include("libomp")}"
+    else
+      # Linux build is not thread-safe.
+      ENV.deparallelize
     end
 
     args = %W[
-      PYTHON=#{python}
-      --with-python-module-path=#{prefix/site_packages}
-      --with-boost-python=boost_python#{xy.to_s.delete(".")}
+      PYTHON=#{which(python3)}
+      --with-python-module-path=#{prefix/Language::Python.site_packages(python3)}
+      --with-boost-python=boost_#{python3.delete(".")}
       --with-boost-libdir=#{formula_opt_lib("boost")}
       --with-boost-coroutine=boost_coroutine
       --disable-silent-rules
@@ -174,10 +105,11 @@ class GraphTool < Formula
 
   def caveats
     <<~EOS
-      Only the main library is linked to avoid contaminating the shared site-packages.
-      Graph drawing and other features that require extra Python packages may be used
-      by adding the following formula-specific site-packages to your PYTHONPATH:
-        #{opt_libexec/Language::Python.site_packages(python3)}
+      If you want graph drawing, you will need to install additional formulae:
+        brew install gtk+3 py3cairo pygobject3 python-matplotlib
+
+      If you want zstd decompression, you can use the bundled Python package, e.g.
+        export PYTHONPATH="#{opt_libexec/Language::Python.site_packages(python3)}"
     EOS
   end
 
@@ -191,9 +123,7 @@ class GraphTool < Formula
       assert g.num_edges() == 1
       assert g.num_vertices() == 2
     PYTHON
-    assert_match "Graph drawing will not work", shell_output("#{python3} test.py 2>&1")
-    ENV["PYTHONPATH"] = libexec/Language::Python.site_packages(python3)
-    refute_match "Graph drawing will not work", shell_output("#{python3} test.py 2>&1")
+    refute_match "drawing will not work", shell_output("#{python3} test.py 2>&1")
   end
 end
 


### PR DESCRIPTION
Since we have kept around `python-matplotlib`, we can reduce the required dependencies and allow users who want it to install extra formulae.

Also update to latest `cairomm`.

Split out from #291826 to simplify 3.x PRs.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
