### PR TITLE
zeroclaw: install zerocode TUI

### DIFF
--- a/Formula/z/zeroclaw.rb
+++ b/Formula/z/zeroclaw.rb
@@ -8,12 +8,12 @@ class Zeroclaw < Formula
   head "https://github.com/zeroclaw-labs/zeroclaw.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "f1a9e0062d0021915442673e314d03374495a8adbc3765c6c7dc50c2af79dccd"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "df2c16ac74a9cf9d7b99159ffdd916e14fc39f8b4d0ee19c01159557027ee197"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "93fd9e391202177d10c8ee71230e5dea61ffb5c1d47812b2dfa405d7abdd8ebd"
-    sha256 cellar: :any_skip_relocation, sonoma:        "33439a23a16befddcfaddfa809134e764f5499f879147d2200d1ac20fbaa5446"
-    sha256 cellar: :any,                 arm64_linux:   "257670e85928a0ea46cf71dccc15f310b6dbe432cb159d31c1f7e25710d22489"
-    sha256 cellar: :any,                 x86_64_linux:  "7a6775fa1d105b09a35e5018ae629c9544a4594f294aad48cb5e1af4e859a1ef"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "1298729feddca109334ab079e38c11f5907d706c9d1060778da6bb49681f2eb8"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "2bb4b5a590f7a250207d15b97c4b33ceaad79097f41f3c3df7e2ba9391ea6631"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "c066be1f46ef47c939de53e10070dcc7948e58e450c270fa30c727afaa976fee"
+    sha256 cellar: :any_skip_relocation, sonoma:        "802fe3d43438e6efe6cb77c15891f4a85f2f1196acafada0d022727bc346b526"
+    sha256 cellar: :any,                 arm64_linux:   "c83652f517c3e832458157c9a2492ed10984029211e4b504e995564aff3395fa"
+    sha256 cellar: :any,                 x86_64_linux:  "93c426e4f56828ef4394d6f5f2004cb935c0935525ac9acec11cb47b09e1ec83"
   end
 
   depends_on "rust" => :build

--- a/Formula/z/zeroclaw.rb
+++ b/Formula/z/zeroclaw.rb
@@ -4,6 +4,7 @@ class Zeroclaw < Formula
   url "https://github.com/zeroclaw-labs/zeroclaw/archive/refs/tags/v0.8.3.tar.gz"
   sha256 "9dd537164012bd122cdc4837b09a20146ea3311aa493cd642a870778871f0d27"
   license any_of: ["Apache-2.0", "MIT"]
+  revision 1
   head "https://github.com/zeroclaw-labs/zeroclaw.git", branch: "master"
 
   bottle do
@@ -19,6 +20,7 @@ class Zeroclaw < Formula
 
   def install
     system "cargo", "install", *std_cargo_args
+    system "cargo", "install", *std_cargo_args(path: "apps/zerocode")
   end
 
   service do
@@ -30,6 +32,7 @@ class Zeroclaw < Formula
 
   test do
     assert_match version.to_s, shell_output("#{bin}/zeroclaw --version")
+    assert_match version.to_s, shell_output("#{bin}/zerocode --version")
 
     ENV["ZEROCLAW_WORKSPACE"] = testpath.to_s
     assert_match "ZeroClaw Status", shell_output("#{bin}/zeroclaw status")


### PR DESCRIPTION
Install the version-matched `zerocode` TUI alongside `zeroclaw`. The upstream workspace ships both binaries, but the formula currently installs only the root package. This adds `revision 1` for the packaging change.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

AI assistance was used to identify the missing workspace-package install and prepare the formula edit. I reviewed the exact three-line diff, confirmed the `apps/zerocode` package path in the upstream source, and ran Ruby syntax, `git diff --check`, and `brew style` successfully. The local source build, formula test, and strict audit were intentionally not run. BrewTestBot passed on Linux arm64/x86_64, macOS 14 arm64/x86_64, macOS 15 arm64, and macOS 26 arm64 on the PR head.
