### PR TITLE
pkgconf: use github as HTTPS mirror, update muon resource

### DIFF
--- a/Formula/p/pkgconf.rb
+++ b/Formula/p/pkgconf.rb
@@ -2,7 +2,7 @@ class Pkgconf < Formula
   desc "Package compiler and linker metadata toolkit"
   homepage "https://github.com/pkgconf/pkgconf"
   url "https://distfiles.ariadne.space/pkgconf/pkgconf-3.0.3.tar.xz"
-  mirror "https://fossies.org/linux/misc/pkgconf-3.0.3.tar.xz"
+  mirror "https://github.com/pkgconf/pkgconf/releases/download/pkgconf-3.0.3/pkgconf-3.0.3.tar.xz"
   mirror "http://fresh-center.net/linux/misc/pkgconf-3.0.3.tar.xz"
   sha256 "aa033abb2b777ba4e66635495a931e53c49d86e4e4e38af68c0f76d666cbd8cf"
   license "ISC"
@@ -29,15 +29,16 @@ class Pkgconf < Formula
 
     # Using a resource to avoiding dependency tree from brew `meson` or `muon`.
     # The version should align to available HTTP mirror rather than latest.
+    # TODO: check on mirrors in future if better alternatives are available.
     resource "muon" do
-      url "https://muon.build/releases/v0.5.0/muon-v0.5.0.tar.gz"
-      mirror "https://deb.debian.org/debian/pool/main/m/muon-meson/muon-meson_0.5.0.orig.tar.gz"
-      mirror "http://deb.debian.org/debian/pool/main/m/muon-meson/muon-meson_0.5.0.orig.tar.gz"
-      sha256 "24aa4d29ed272893f6e6d355b1ec4ef20647438454e88161bdb9defd7c6faf77"
+      url "https://muon.build/releases/v0.6.0/muon-v0.6.0.tar.gz"
+      mirror "https://pkg.freebsd.org/ports-distfiles/muon/0.6.0/muon-v0.6.0.tar.gz"
+      mirror "http://pkg.freebsd.org/ports-distfiles/muon/0.6.0/muon-v0.6.0.tar.gz"
+      sha256 "90a8428bc2178c59b9f7ddd1cb1cc6355f4df0c3ac023f7eefd159ae4f054024"
 
       livecheck do
-        url "https://deb.debian.org/debian/pool/main/m/muon-meson/"
-        regex(/href=.*?muon-meson[._-]v?(\d+(?:\.\d+)+)\.orig\.t/i)
+        url "https://raw.githubusercontent.com/freebsd/freebsd-ports/refs/heads/main/devel/muon/distinfo"
+        regex(/muon[._-]v?(\d+(?:\.\d+)+)\.t/i)
       end
     end
   end


### PR DESCRIPTION
Can use official GitHub as mirror which is usually more stable than Fossies mirrors.

Also update muon resource. Some notes:
- Since Debian is still on 0.5.0, switch to FreeBSD.
- Alpine could be a better option (as they have been fastest Linux to update to stable release) but not as easy to livecheck as their git repo seems to block some curl requests.
- When pkgconf 3.1.0 is out, we can reconsider which mirror to use (and if we want to create a `muon-minimal` formula)

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
