### PR TITLE
xbee-comm: deprecate

### DIFF
--- a/Formula/x/xbee-comm.rb
+++ b/Formula/x/xbee-comm.rb
@@ -25,6 +25,10 @@ class XbeeComm < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "cf23d16b599dc5427dd3552004d307bacd82b77b89ac2bd0a018bf1f986fc720"
   end
 
+  # Last release on 2012-05-11
+  deprecate! date: "2026-07-19", because: :unmaintained
+  disable! date: "2027-07-19", because: :unmaintained
+
   depends_on "autoconf" => :build
   depends_on "automake" => :build
 


### PR DESCRIPTION
Under current Homebrew/core criteria, this formula wouldn't have been accepted, i.e. it is a fork and does not meet notability.

Unmaintained, unpopular and lacks a proper test

```
install: 1 (30 days), 1 (90 days), 7 (365 days)
```


-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
