### PR TITLE
supertux: update HEAD for SDL3, keep Linux files

### DIFF
--- a/Formula/s/supertux.rb
+++ b/Formula/s/supertux.rb
@@ -1,9 +1,15 @@
 class Supertux < Formula
   desc "Classic 2D jump'n run sidescroller game"
   homepage "https://www.supertux.org/"
-  url "https://github.com/SuperTux/supertux/releases/download/v0.7.0/SuperTux-v0.7.0-Source.tar.gz"
-  sha256 "32fc5b99b9994ed58e58341d6f21de925764b381256e108591136de53bc31da5"
   license "GPL-3.0-or-later"
+
+  stable do
+    url "https://github.com/SuperTux/supertux/releases/download/v0.7.0/SuperTux-v0.7.0-Source.tar.gz"
+    sha256 "32fc5b99b9994ed58e58341d6f21de925764b381256e108591136de53bc31da5"
+
+    depends_on "sdl2-compat"
+    depends_on "sdl2_image"
+  end
 
   livecheck do
     url :stable
@@ -22,8 +28,9 @@ class Supertux < Formula
   head do
     url "https://github.com/SuperTux/supertux.git", branch: "master"
 
-    depends_on "fmt"
-    depends_on "openal-soft"
+    depends_on "sdl3"
+    depends_on "sdl3_image"
+    depends_on "sdl3_ttf"
   end
 
   depends_on "cmake" => :build
@@ -37,8 +44,6 @@ class Supertux < Formula
   depends_on "libvorbis"
   depends_on "openal-soft"
   depends_on "physfs"
-  depends_on "sdl2-compat"
-  depends_on "sdl2_image"
 
   uses_from_macos "curl"
 
@@ -60,10 +65,12 @@ class Supertux < Formula
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
 
+    return unless OS.mac?
+
     # Remove unnecessary files
     rm_r(share/"applications")
     rm_r(share/"pixmaps")
-    rm_r(prefix/"MacOS") if OS.mac?
+    rm_r(prefix/"MacOS")
   end
 
   test do


### PR DESCRIPTION
HEAD switched to SDL3

Also can keep share/applications which integrate with GNOME/etc desktop to show as applications on Linux. Not important enough to rebottle and can just add in next version.


-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
