### PR TITLE
mpv: enable pipewire

### DIFF
--- a/Formula/m/mpv.rb
+++ b/Formula/m/mpv.rb
@@ -64,6 +64,7 @@ class Mpv < Formula
     depends_on "libxscrnsaver"
     depends_on "libxv"
     depends_on "mesa"
+    depends_on "pipewire"
     depends_on "pulseaudio"
     depends_on "wayland"
     depends_on "wayland-protocols" => :no_linkage # needed by mpv.pc

--- a/Formula/m/mpv.rb
+++ b/Formula/m/mpv.rb
@@ -18,12 +18,13 @@ class Mpv < Formula
   end
 
   bottle do
-    sha256               arm64_tahoe:   "649109b87d486e369e3ee9c8b6703c3cb17229476881b4b509ca91f0441a17f2"
-    sha256               arm64_sequoia: "484dec512afcfcc30f51aad01022b1bd97aac0fe7c85aafc3b341a25996dd49c"
-    sha256               arm64_sonoma:  "5dd9a950ca0a81ad4319a3f2a203b6e0bd7142b6dc597859ea4acf6dabfadbab"
-    sha256 cellar: :any, sonoma:        "6992a25c76e33dda932ddff26da1e75602e9b402bfe9717792ede3989c2c4ac5"
-    sha256               arm64_linux:   "4df7a2cc6a6a73ab89d69635eedddd00e89176423ace64351c7767813f45a579"
-    sha256               x86_64_linux:  "d795ebc793a8cb4c8548a3dc018fac38a33de14465390ec9d66e586e0fe6c7be"
+    rebuild 1
+    sha256               arm64_tahoe:   "0056b72213336a232c8d8a0f70dea46b43baac856f898ff891754660a3bbb5c1"
+    sha256               arm64_sequoia: "d594fd4964183fcf6313fccf3a2dac5ac3e28ab59848fe6ffbc446ce9ab20b1d"
+    sha256               arm64_sonoma:  "274495c2986f894e27b1fec9652b07b4326ef77a764217b02b99da7a15f0066f"
+    sha256 cellar: :any, sonoma:        "73f9cd88e549e1ceedb1f162c5ff0e62b827691b2f3b15d2ebbdb8ef64f6dd78"
+    sha256               arm64_linux:   "af0fcc75360279e3aa657ed51a7739f77f4461c26c88b7212a826a3efbf3e169"
+    sha256               x86_64_linux:  "a8a46da28614723b7fd14ce87bbce65092b5bda0821b82d0d702b70cbc30219f"
   end
 
   depends_on "docutils" => :build


### PR DESCRIPTION
We got a couple requests for this so enable PipeWire support which aligns with default on many major distros (Ubuntu 24.04+, Fedora 34+, etc).

Spun up an Ubuntu 24.04 VM to test.

Before, can see that pulseaudio is picked (and unable to use `--ao=pipewire`)
- Audio output of mpv and lsof to verify
    ```
    AO: [pulse] 44100Hz stereo 2ch float
    ```
    ```console
    $ lsof -p 6211 | grep -iE 'pulseaudio|pipewire'
    mpv     6211 linuxbrew  DEL       REG                0,1             5028 /memfd:pulseaudio
    mpv     6211 linuxbrew  mem       REG              253,2    688608 680257 /home/linuxbrew/.linuxbrew/Cellar/pulseaudio/17.0/lib/pulseaudio/libpulsecommon-17.0.so
    mpv     6211 linuxbrew  mem       REG              253,2    481080 680251 /home/linuxbrew/.linuxbrew/Cellar/pulseaudio/17.0/lib/libpulse.so.0.24.3
    mpv     6211 linuxbrew   18u      REG                0,1  67108864   5028 /memfd:pulseaudio (deleted)
    ```

With build from PR, PipeWire is picked and audio worked for me.
- Audio output of mpv and lsof to verify
    ```
    AO: [pipewire] 44100Hz stereo 2ch floatp
    ```
    ```console
    $ lsof -p 11077 | grep -iE 'pulseaudio|pipewire'
    mpv     11077 linuxbrew  mem       REG              253,2    988552 681173 /home/linuxbrew/.linuxbrew/Cellar/pipewire/1.6.8/lib/spa-0.2/audioconvert/libspa-audioconvert.so
    mpv     11077 linuxbrew  mem       REG              253,2    400672 681154 /home/linuxbrew/.linuxbrew/Cellar/pipewire/1.6.8/lib/pipewire-0.3/libpipewire-module-session-manager.so
    mpv     11077 linuxbrew  mem       REG              253,2    138648 681052 /home/linuxbrew/.linuxbrew/Cellar/pipewire/1.6.8/lib/pipewire-0.3/libpipewire-module-metadata.so
    mpv     11077 linuxbrew  mem       REG              253,2    203216 681032 /home/linuxbrew/.linuxbrew/Cellar/pipewire/1.6.8/lib/pipewire-0.3/libpipewire-module-adapter.so
    mpv     11077 linuxbrew  mem       REG              253,2    137752 681036 /home/linuxbrew/.linuxbrew/Cellar/pipewire/1.6.8/lib/pipewire-0.3/libpipewire-module-client-device.so
    mpv     11077 linuxbrew  mem       REG              253,2    399656 681037 /home/linuxbrew/.linuxbrew/Cellar/pipewire/1.6.8/lib/pipewire-0.3/libpipewire-module-client-node.so
    mpv     11077 linuxbrew  mem       REG              253,2    402216 681064 /home/linuxbrew/.linuxbrew/Cellar/pipewire/1.6.8/lib/pipewire-0.3/libpipewire-module-protocol-native.so
    mpv     11077 linuxbrew  mem       REG              253,2    138064 681149 /home/linuxbrew/.linuxbrew/Cellar/pipewire/1.6.8/lib/pipewire-0.3/libpipewire-module-rt.so
    mpv     11077 linuxbrew  mem       REG              253,2    136552 681189 /home/linuxbrew/.linuxbrew/Cellar/pipewire/1.6.8/lib/spa-0.2/support/libspa-dbus.so
    mpv     11077 linuxbrew  mem       REG              253,2    135600 681190 /home/linuxbrew/.linuxbrew/Cellar/pipewire/1.6.8/lib/spa-0.2/support/libspa-journal.so
    mpv     11077 linuxbrew  mem       REG              253,2    334864 681191 /home/linuxbrew/.linuxbrew/Cellar/pipewire/1.6.8/lib/spa-0.2/support/libspa-support.so
    mpv     11077 linuxbrew  mem       REG              253,2    688608 680257 /home/linuxbrew/.linuxbrew/Cellar/pulseaudio/17.0/lib/pulseaudio/libpulsecommon-17.0.so
    mpv     11077 linuxbrew  mem       REG              253,2    481080 680251 /home/linuxbrew/.linuxbrew/Cellar/pulseaudio/17.0/lib/libpulse.so.0.24.3
    mpv     11077 linuxbrew  mem       REG              253,2   1400072 681002 /home/linuxbrew/.linuxbrew/Cellar/pipewire/1.6.8/lib/libpipewire-0.3.so.0.1608.0
    mpv     11077 linuxbrew  DEL       REG                0,1             5672 /memfd:pipewire-memfd:flags=0x0000000f,type=2,size=32816
    mpv     11077 linuxbrew  DEL       REG                0,1             5671 /memfd:pipewire-memfd:flags=0x0000000f,type=2,size=32816
    mpv     11077 linuxbrew  DEL       REG                0,1             2789 /memfd:pipewire-memfd:flags=0x0000000f,type=2,size=2312
    mpv     11077 linuxbrew  DEL       REG                0,1             5653 /memfd:pipewire-memfd:flags=0x0000000f,type=2,size=4096
    mpv     11077 linuxbrew  DEL       REG                0,1             5652 /memfd:pipewire-memfd:flags=0x0000000f,type=2,size=2312
    mpv     11077 linuxbrew  DEL       REG                0,1            15515 /memfd:pipewire-memfd:flags=0x0000000f,type=2,size=2312
    mpv     11077 linuxbrew   28u      REG                0,1      2312  15515 /memfd:pipewire-memfd:flags=0x0000000f,type=2,size=2312 (deleted)
    ...
    ```

Can still force pulseaudio by `--ao=pulse` if any issues with PipeWire. 

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
