### PR TITLE
Migrate post-install removals (2/15)

### DIFF
--- a/Formula/r/rustup.rb
+++ b/Formula/r/rustup.rb
@@ -9,12 +9,13 @@ class Rustup < Formula
   head "https://github.com/rust-lang/rustup.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "64be4eda51e96b7372ca85f1e9c224a46ed3ff45c1fd6a5f4ec75400d2123841"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "359c352d6b02d76d4a8d7499d12cd887a599432af5b99f334125aa2d7109fe99"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "1d751f814b493e7ef4412512219aceaccc4a16974ba88118a35b2734f7641dc7"
-    sha256 cellar: :any_skip_relocation, sonoma:        "e68c9a5c36eb99862049114b415a2502aff64fb11e815c4f441e3d21a646c2a5"
-    sha256 cellar: :any,                 arm64_linux:   "5f6d0fa5e4cf9be2d1e4e784072a1d54f165e2188c2af262b4d7a889b2dbbb70"
-    sha256 cellar: :any,                 x86_64_linux:  "59486bb4ea00d23c54817e5f28220058ae8525deff4d839ee0cf19192541077f"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "6053ea3e9235d17c34d3ab698ac44345169e4c789270f51e6929c2c503b4644f"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "1a50690a9ebf8736dc495b6c16680e34802ac3d12f5653c986b87dcf5546384d"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "0256d6c93615b741a4b81a6c6e34c202397e079468e4917b4bf2099b0803b672"
+    sha256 cellar: :any_skip_relocation, sonoma:        "0369ffb86c5f5a76c0128e90efe1945e070dbf2532756fc539ed89ae7b378c2a"
+    sha256 cellar: :any,                 arm64_linux:   "8ea0b765f548e4fb7e973838599f6bd6b63e54da6412abe4982d17703fccc3a8"
+    sha256 cellar: :any,                 x86_64_linux:  "f5dd4c3593e1b5d8acbd6885c10f69e4261dc945ccd903a0517a421444b14734"
   end
 
   keg_only "it conflicts with rust"

--- a/Formula/r/rustup.rb
+++ b/Formula/r/rustup.rb
@@ -56,17 +56,16 @@ class Rustup < Formula
     end
   end
 
-  def post_install
-    (HOMEBREW_PREFIX/"bin").install_symlink bin/"rustup"
-    (HOMEBREW_PREFIX/"etc/bash_completion.d").install_symlink bash_completion/"rustup"
-    (HOMEBREW_PREFIX/"share/zsh/site-functions").install_symlink zsh_completion/"_rustup"
-    (HOMEBREW_PREFIX/"share/fish/vendor_completions.d").install_symlink fish_completion/"rustup.fish"
-    (HOMEBREW_PREFIX/"share/pwsh/completions").install_symlink pwsh_completion/"_rustup.ps1"
-
-    # Remove the old Homebrew-created symlink during upgrades, but leave any
-    # user-managed `rustup-init` file alone.
-    rustup_init = HOMEBREW_PREFIX/"bin/rustup-init"
-    rustup_init.unlink if rustup_init.symlink? && rustup_init.readlink.to_s.match?(%r{(?:Cellar|opt)/rustup/})
+  post_install_steps do
+    symlink "{{bin}}/rustup", "{{HOMEBREW_PREFIX}}/bin/rustup", force: true
+    symlink "{{bash_completion}}/rustup", "{{HOMEBREW_PREFIX}}/etc/bash_completion.d/rustup", force: true
+    symlink "{{zsh_completion}}/_rustup", "{{HOMEBREW_PREFIX}}/share/zsh/site-functions/_rustup", force: true
+    symlink "{{fish_completion}}/rustup.fish", "{{HOMEBREW_PREFIX}}/share/fish/vendor_completions.d/rustup.fish",
+            force: true
+    symlink "{{pwsh_completion}}/_rustup.ps1", "{{HOMEBREW_PREFIX}}/share/pwsh/completions/_rustup.ps1",
+            force: true
+    remove "{{HOMEBREW_PREFIX}}/bin/rustup-init", symlink_target_contains: "Cellar/rustup/"
+    remove "{{HOMEBREW_PREFIX}}/bin/rustup-init", symlink_target_contains: "opt/rustup/"
   end
 
   def caveats


### PR DESCRIPTION
Nginx, Node and Rustup remove stale generated paths while preserving
user and cross-version state.

- replace Ruby hooks with scoped remove steps
- retain Node's shared npm payload, links and generated configuration
- preserve glob expansion and guarded recursive removal
- depend on Homebrew/brew's matching `Add install step removals` change

Needs https://github.com/Homebrew/brew/pull/23181

