### PR TITLE
Migrate post-install inreplace calls (3/15)

### DIFF
--- a/Formula/n/nagios.rb
+++ b/Formula/n/nagios.rb
@@ -69,14 +69,11 @@ class Nagios < Formula
     system "make", "install-webconf"
   end
 
-  def post_install
-    (var/"lib/nagios/rw").mkpath
-
-    config = etc/"nagios/nagios.cfg"
-    return unless config.exist?
-    return if config.read.include?("nagios_user=#{ENV["USER"]}")
-
-    inreplace config, /^nagios_user=.*/, "nagios_user=#{ENV["USER"]}"
+  post_install_steps do
+    mkdir_p "lib/nagios/rw"
+    if_path_exists "{{etc}}/nagios/nagios.cfg" do
+      inreplace "nagios/nagios.cfg", /^nagios_user=.*/, "nagios_user={{user}}", base: :etc, audit_result: false
+    end
   end
 
   service do

--- a/Formula/u/unbound.rb
+++ b/Formula/u/unbound.rb
@@ -51,13 +51,11 @@ class Unbound < Formula
     system "make", "install"
   end
 
-  def post_install
-    conf = etc/"unbound/unbound.conf"
-    return unless conf.exist?
-    return unless conf.read.include?('username: "@@HOMEBREW-UNBOUND-USER@@"')
-
-    inreplace conf, 'username: "@@HOMEBREW-UNBOUND-USER@@"',
-                    "username: \"#{ENV["USER"]}\""
+  post_install_steps do
+    if_path_exists "{{etc}}/unbound/unbound.conf" do
+      inreplace "unbound/unbound.conf", 'username: "@@HOMEBREW-UNBOUND-USER@@"', 'username: "{{user}}"',
+                base: :etc, audit_result: false
+    end
   end
 
   service do

--- a/Formula/w/wemux.rb
+++ b/Formula/w/wemux.rb
@@ -20,8 +20,10 @@ class Wemux < Formula
     etc.install "wemux.conf.example" => "wemux.conf"
   end
 
-  def post_install
-    inreplace etc/"wemux.conf", "change_this", ENV["USER"], audit_result: false
+  post_install_steps do
+    if_path_exists "{{etc}}/wemux.conf" do
+      inreplace "wemux.conf", "change_this", "{{user}}", base: :etc, audit_result: false
+    end
   end
 
   def caveats


### PR DESCRIPTION
Three formulae only rewrite guarded configuration values after
installation and do not require arbitrary Ruby.

- use the shared `inreplace` spelling and option behaviour
- serialise literal and regular-expression substitutions
- preserve missing-file and already-migrated configuration behaviour
- depend on Homebrew/brew's matching
  `Add install step inreplace` change

Needs https://github.com/Homebrew/brew/pull/23182

