### PR TITLE
Migrate formula permission steps (4/15)

### DIFF
--- a/Formula/c/cfengine.rb
+++ b/Formula/c/cfengine.rb
@@ -64,17 +64,11 @@ class Cfengine < Formula
     (pkgshare/"CoreBase").install resource("masterfiles")
   end
 
-  def post_install
-    workdir = var/"cfengine"
-    secure_dirs = %W[
-      #{workdir}/inputs
-      #{workdir}/outputs
-      #{workdir}/ppkeys
-      #{workdir}/plugins
-    ]
-    chmod 0700, secure_dirs
-    chmod 0750, workdir/"state"
-    chmod 0755, workdir/"modules"
+  post_install_steps do
+    set_permissions %w[cfengine/inputs cfengine/outputs cfengine/ppkeys cfengine/plugins], "0700",
+                    recursive: false
+    set_permissions "cfengine/state", "0750", recursive: false
+    set_permissions "cfengine/modules", "0755", recursive: false
   end
 
   test do

--- a/Formula/j/jnethack.rb
+++ b/Formula/j/jnethack.rb
@@ -64,20 +64,15 @@ class Jnethack < Formula
     bin.install_symlink libexec/"jnethack"
   end
 
-  def post_install
-    # These need to exist (even if empty) otherwise NetHack won't start
-    savedir = HOMEBREW_PREFIX/"share/jnethack"
-    mkdir_p savedir
-    cd savedir do
-      %w[xlogfile logfile perm record].each do |f|
-        touch f
-      end
-      mkdir_p "save"
-      touch "save/.keepme" # preserve on `brew cleanup`
-    end
-    # Set group-writeable for multiuser installs
-    chmod "g+w", savedir
-    chmod "g+w", savedir/"save"
+  post_install_steps do
+    mkdir_p "{{HOMEBREW_PREFIX}}/share/jnethack/save"
+    touch "{{HOMEBREW_PREFIX}}/share/jnethack/xlogfile"
+    touch "{{HOMEBREW_PREFIX}}/share/jnethack/logfile"
+    touch "{{HOMEBREW_PREFIX}}/share/jnethack/perm"
+    touch "{{HOMEBREW_PREFIX}}/share/jnethack/record"
+    touch "{{HOMEBREW_PREFIX}}/share/jnethack/save/.keepme"
+    set_permissions ["{{HOMEBREW_PREFIX}}/share/jnethack", "{{HOMEBREW_PREFIX}}/share/jnethack/save"], "g+w",
+                    recursive: false
   end
 
   test do

--- a/Formula/n/nethack.rb
+++ b/Formula/n/nethack.rb
@@ -103,20 +103,15 @@ class Nethack < Formula
     man6.install "doc/nethack.6"
   end
 
-  def post_install
-    # These need to exist (even if empty) otherwise nethack won't start
-    savedir = HOMEBREW_PREFIX/"share/nethack"
-    mkdir_p savedir
-    cd savedir do
-      %w[xlogfile logfile perm record].each do |f|
-        touch f
-      end
-      mkdir_p "save"
-      touch "save/.keepme" # preserve on `brew cleanup`
-    end
-    # Set group-writeable for multiuser installs
-    chmod "g+w", savedir
-    chmod "g+w", savedir/"save"
+  post_install_steps do
+    mkdir_p "{{HOMEBREW_PREFIX}}/share/nethack/save"
+    touch "{{HOMEBREW_PREFIX}}/share/nethack/xlogfile"
+    touch "{{HOMEBREW_PREFIX}}/share/nethack/logfile"
+    touch "{{HOMEBREW_PREFIX}}/share/nethack/perm"
+    touch "{{HOMEBREW_PREFIX}}/share/nethack/record"
+    touch "{{HOMEBREW_PREFIX}}/share/nethack/save/.keepme"
+    set_permissions ["{{HOMEBREW_PREFIX}}/share/nethack", "{{HOMEBREW_PREFIX}}/share/nethack/save"], "g+w",
+                    recursive: false
   end
 
   test do

--- a/Formula/p/python-freethreading.rb
+++ b/Formula/p/python-freethreading.rb
@@ -349,11 +349,14 @@ class PythonFreethreading < Formula
     INI
   end
 
-  def post_install
-    # Ensure the template venv activation scripts are writable
-    # to allow reinitializing an existing venv without throwing a permission error.
-    # See: https://github.com/python/cpython/issues/86079
-    chmod "u+w", lib_cellar.glob("venv/scripts/**/*").select(&:file?)
+  post_install_steps do
+    on_macos do
+      set_permissions "PythonT.framework/Versions/#{version.major_minor}/lib/python#{version.major_minor}t/venv/scripts/**/*",
+                      "u+w", base: :frameworks, recursive: false
+    end
+    on_linux do
+      set_permissions "python#{version.major_minor}t/venv/scripts/**/*", "u+w", base: :lib, recursive: false
+    end
   end
 
   def sitecustomize

--- a/Formula/p/python@3.12.rb
+++ b/Formula/p/python@3.12.rb
@@ -390,11 +390,14 @@ class PythonAT312 < Formula
     INI
   end
 
-  def post_install
-    # Ensure the template venv activation scripts are writable
-    # to allow reinitializing an existing venv without throwing a permission error.
-    # See: https://github.com/python/cpython/issues/86079
-    chmod "u+w", lib_cellar.glob("venv/scripts/**/*").select(&:file?)
+  post_install_steps do
+    on_macos do
+      set_permissions "Python.framework/Versions/#{version.major_minor}/lib/python#{version.major_minor}/venv/scripts/**/*",
+                      "u+w", base: :frameworks, recursive: false
+    end
+    on_linux do
+      set_permissions "python#{version.major_minor}/venv/scripts/**/*", "u+w", base: :lib, recursive: false
+    end
   end
 
   def sitecustomize

--- a/Formula/p/python@3.13.rb
+++ b/Formula/p/python@3.13.rb
@@ -377,11 +377,14 @@ class PythonAT313 < Formula
     INI
   end
 
-  def post_install
-    # Ensure the template venv activation scripts are writable
-    # to allow reinitializing an existing venv without throwing a permission error.
-    # See: https://github.com/python/cpython/issues/86079
-    chmod "u+w", lib_cellar.glob("venv/scripts/**/*").select(&:file?)
+  post_install_steps do
+    on_macos do
+      set_permissions "Python.framework/Versions/#{version.major_minor}/lib/python#{version.major_minor}/venv/scripts/**/*",
+                      "u+w", base: :frameworks, recursive: false
+    end
+    on_linux do
+      set_permissions "python#{version.major_minor}/venv/scripts/**/*", "u+w", base: :lib, recursive: false
+    end
   end
 
   def sitecustomize

--- a/Formula/p/python@3.14.rb
+++ b/Formula/p/python@3.14.rb
@@ -394,11 +394,14 @@ class PythonAT314 < Formula
     INI
   end
 
-  def post_install
-    # Ensure the template venv activation scripts are writable
-    # to allow reinitializing an existing venv without throwing a permission error.
-    # See: https://github.com/python/cpython/issues/86079
-    chmod "u+w", lib_cellar.glob("venv/scripts/**/*").select(&:file?)
+  post_install_steps do
+    on_macos do
+      set_permissions "Python.framework/Versions/#{version.major_minor}/lib/python#{version.major_minor}/venv/scripts/**/*",
+                      "u+w", base: :frameworks, recursive: false
+    end
+    on_linux do
+      set_permissions "python#{version.major_minor}/venv/scripts/**/*", "u+w", base: :lib, recursive: false
+    end
   end
 
   def sitecustomize


### PR DESCRIPTION
CFEngine, Python and the NetHack variants adjust modes on installed or
persistent paths without ownership changes or arbitrary Ruby.

- replace post-install hooks with declarative permission steps
- preserve recursive and directory-only updates
- keep shared game save directories group-writable
- keep CPython venv activation templates writable on macOS and Linux
- depend on Homebrew/brew's matching
  `Allow formula permission steps` change

Needs https://github.com/Homebrew/brew/pull/23185

