### PR TITLE
Migrate post-install commands (5/15)

### DIFF
--- a/Formula/a/abricate.rb
+++ b/Formula/a/abricate.rb
@@ -159,8 +159,8 @@ class Abricate < Formula
     bin.env_script_all_files libexec/"bin", PERL5LIB: ENV["PERL5LIB"]
   end
 
-  def post_install
-    system bin/"abricate", "--setupdb"
+  post_install_steps do
+    run "abricate", args: ["--setupdb"], base: :bin
   end
 
   test do

--- a/Formula/b/bareos-client.rb
+++ b/Formula/b/bareos-client.rb
@@ -76,13 +76,11 @@ class BareosClient < Formula
     system "cmake", "--install", "build"
   end
 
-  def post_install
-    (var/"lib/bareos").mkpath
-    # If no configuration files are present,
-    # deploy them (copy them and replace variables).
-    unless (etc/"bareos/bareos-fd.d").exist?
-      system lib/"bareos/scripts/bareos-config", "deploy_config", "bareos-fd"
-      system lib/"bareos/scripts/bareos-config", "deploy_config", "bconsole"
+  post_install_steps do
+    mkdir_p "lib/bareos"
+    unless_path_exists "{{etc}}/bareos/bareos-fd.d" do
+      run "bareos/scripts/bareos-config", args: ["deploy_config", "bareos-fd"], base: :lib
+      run "bareos/scripts/bareos-config", args: ["deploy_config", "bconsole"], base: :lib
     end
   end
 

--- a/Formula/c/cayley.rb
+++ b/Formula/c/cayley.rb
@@ -51,12 +51,10 @@ class Cayley < Formula
     end
   end
 
-  def post_install
-    unless File.exist? var/"cayley"
-      (var/"cayley").mkpath
-
-      # Initialize the database
-      system bin/"cayley", "init", "--config=#{etc}/cayley.yml"
+  post_install_steps do
+    unless_path_exists "cayley" do
+      mkdir_p "cayley"
+      run "cayley", args: ["init", "--config={{etc}}/cayley.yml"], base: :bin
     end
   end
 

--- a/Formula/c/container.rb
+++ b/Formula/c/container.rb
@@ -74,8 +74,8 @@ class Container < Formula
   # container APIs aren't guaranteed to be backward compatible,
   # so we stop the system service to ensure no components are out of sync.
   # Ref: https://github.com/apple/container/issues/551#issuecomment-3246928923
-  def post_install
-    system libexec/"ensure-container-stopped.sh", "-a"
+  post_install_steps do
+    run "ensure-container-stopped.sh", args: ["-a"], base: :libexec
   end
 
   service do

--- a/Formula/c/cracklib.rb
+++ b/Formula/c/cracklib.rb
@@ -59,10 +59,10 @@ class Cracklib < Formula
     share.install resource("cracklib-words")
   end
 
-  def post_install
-    (var/"cracklib").mkpath
-    cp share/"cracklib-words-#{resource("cracklib-words").version}", var/"cracklib/cracklib-words"
-    system "#{bin}/cracklib-packer < #{var}/cracklib/cracklib-words"
+  post_install_steps do
+    mkdir_p "cracklib"
+    copy "cracklib-words-*", "cracklib/cracklib-words", source_base: :share, target_base: :var, source_glob: true
+    run "cracklib-packer", base: :bin, stdin_path: "cracklib/cracklib-words"
   end
 
   test do

--- a/Formula/d/dbus.rb
+++ b/Formula/d/dbus.rb
@@ -70,9 +70,8 @@ class Dbus < Formula
     mkdir etc/"dbus-1/session.d"
   end
 
-  def post_install
-    # Generate D-Bus's UUID for this machine
-    system bin/"dbus-uuidgen", "--ensure=#{var}/lib/dbus/machine-id"
+  post_install_steps do
+    run "dbus-uuidgen", args: ["--ensure={{var}}/lib/dbus/machine-id"], base: :bin
   end
 
   def caveats

--- a/Formula/d/docbook-xsl.rb
+++ b/Formula/d/docbook-xsl.rb
@@ -53,37 +53,35 @@ class DocbookXsl < Formula
     end
 
     bin.write_exec_script "#{prefix}/docbook-xsl/epub/bin/dbtoepub"
+
+    (libexec/"post-install").write <<~SH
+      #!/bin/sh
+      set -e
+      catalog="#{etc}/xml/catalog"
+      export XML_CATALOG_FILES="$catalog"
+      for names in "xsl xsl-nons" "xsl-ns xsl"; do
+        set -- $names
+        old_name="$1"
+        new_name="$2"
+        location="file://#{opt_prefix}/docbook-$old_name"
+        entry="$location/catalog.xml"
+        xmlcatalog --noout --del "$entry" "$catalog"
+        xmlcatalog --noout --add nextCatalog "" "$entry" "$catalog"
+        for url in "https://cdn.docbook.org/release/$new_name" \
+                   "http://docbook.sourceforge.net/release/$old_name"; do
+          for version in "#{version}" current; do
+            xmlcatalog --noout --del "$url/$version" "$catalog"
+            xmlcatalog --noout --add rewriteSystem "$url/$version" "$location" "$catalog"
+            xmlcatalog --noout --add rewriteURI "$url/$version" "$location" "$catalog"
+          done
+        done
+      done
+    SH
+    chmod 0755, libexec/"post-install"
   end
 
-  def post_install
-    etc_catalog = etc/"xml/catalog"
-    ENV["XML_CATALOG_FILES"] = etc_catalog
-
-    {
-      "xsl"    => "xsl-nons",
-      "xsl-ns" => "xsl",
-    }.each do |old_name, new_name|
-      loc = "file://#{opt_prefix}/docbook-#{old_name}"
-
-      # add/replace catalog entries
-      cat_loc = "#{loc}/catalog.xml"
-      system "xmlcatalog", "--noout", "--del", cat_loc, etc_catalog
-      system "xmlcatalog", "--noout", "--add", "nextCatalog", "", cat_loc, etc_catalog
-
-      # add rewrites for the new and old catalog URLs
-      rewrites = ["rewriteSystem", "rewriteURI"]
-      [
-        "https://cdn.docbook.org/release/#{new_name}",
-        "http://docbook.sourceforge.net/release/#{old_name}",
-      ].each do |url_prefix|
-        [version.to_s, "current"].each do |ver|
-          system "xmlcatalog", "--noout", "--del", "#{url_prefix}/#{ver}", etc_catalog
-          rewrites.each do |rewrite|
-            system "xmlcatalog", "--noout", "--add", rewrite, "#{url_prefix}/#{ver}", loc, etc_catalog
-          end
-        end
-      end
-    end
+  post_install_steps do
+    run "post-install", base: :libexec
   end
 
   test do

--- a/Formula/d/docbook.rb
+++ b/Formula/d/docbook.rb
@@ -96,25 +96,24 @@ class Docbook < Formula
     end
 
     (etc/"xml").mkpath
+    (libexec/"post-install").write <<~SH
+      #!/bin/sh
+      set -e
+      catalog="#{etc}/xml/catalog"
+      export XML_CATALOG_FILES="$catalog"
+      xmlcatalog="$(command -v xmlcatalog)"
+      [ -f "$catalog" ] || "$xmlcatalog" --noout --create "$catalog"
+      for version in #{resources.map(&:name).join(" ")}; do
+        entry="file://#{opt_prefix}/docbook/xml/$version/catalog.xml"
+        "$xmlcatalog" --noout --del "$entry" "$catalog"
+        "$xmlcatalog" --noout --add nextCatalog "" "$entry" "$catalog"
+      done
+    SH
+    chmod 0755, libexec/"post-install"
   end
 
-  def post_install
-    etc_catalog = etc/"xml/catalog"
-    ENV["XML_CATALOG_FILES"] = etc_catalog
-
-    # We use `/usr/bin/xmlcatalog` on macOS, but libxml2's `xmlcatalog` on Linux.
-    xmlcatalog = DevelopmentTools.locate("xmlcatalog")
-
-    # only create catalog file if it doesn't exist already to avoid content added
-    # by other formulae to be removed
-    system xmlcatalog, "--noout", "--create", etc_catalog unless etc_catalog.file?
-
-    resources.each do |version|
-      catalog = opt_prefix/"docbook/xml/#{version.name}/catalog.xml"
-
-      system xmlcatalog, "--noout", "--del", "file://#{catalog}", etc_catalog
-      system xmlcatalog, "--noout", "--add", "nextCatalog", "", "file://#{catalog}", etc_catalog
-    end
+  post_install_steps do
+    run "post-install", base: :libexec
   end
 
   def caveats

--- a/Formula/d/dsda-doom.rb
+++ b/Formula/d/dsda-doom.rb
@@ -60,21 +60,29 @@ class DsdaDoom < Formula
                     *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
+
+    (libexec/"post-install").write <<~SH
+      #!/bin/sh
+      set -e
+      parent="#{HOMEBREW_PREFIX}/share/games"
+      if [ -L "$parent" ]; then
+        original="$(cd "$parent" && pwd -P)"
+        rm "$parent"
+        mkdir -p "$parent"
+        if [ -d "$original" ]; then
+          for child in "$original"/* "$original"/.[!.]* "$original"/..?*; do
+            [ -e "$child" ] || [ -L "$child" ] || continue
+            ln -s "$child" "$parent/$(basename "$child")"
+          done
+        fi
+      fi
+      mkdir -p "$parent/doom"
+    SH
+    chmod 0755, libexec/"post-install"
   end
 
-  def post_install
-    path = doomwaddir(HOMEBREW_PREFIX)
-
-    # "share/games/" can be a symlink to another formula's keg so we need to
-    # convert it to a real directory to avoid writing into another keg.
-    # Could make "share/games/" into a :mkpath directory in brew to avoid this.
-    if (parent = path.parent).symlink?
-      original_path = parent.resolved_path
-      rm(parent)
-      parent.install_symlink original_path.children if original_path.exist?
-    end
-
-    path.mkpath
+  post_install_steps do
+    run "post-install", base: :libexec
   end
 
   def caveats

--- a/Formula/e/emscripten.rb
+++ b/Formula/e/emscripten.rb
@@ -227,28 +227,30 @@ class Emscripten < Formula
 
     # Replace universal binaries with their native slices
     deuniversalize_machos libexec/"node_modules/fsevents/fsevents.node"
+
+    (libexec/"post-install").write <<~SH
+      #!/bin/sh
+      set -e
+      config="#{opt_libexec}/.emscripten"
+      [ -e "$config" ] && exit 0
+      if [ -e "$HOME/.emscripten" ]; then
+        echo "Skipping configuration generation"
+        echo "You have a ~/.emscripten configuration file. Remove it and run brew postinstall emscripten"
+        exit 0
+      fi
+      "#{opt_bin}/emcc" --generate-config
+      sed -E -i.bak \
+        -e "s|^LLVM_ROOT[[:space:]]*[?+:!]?=.*$|LLVM_ROOT='#{opt_libexec}/llvm/bin'|" \
+        -e "s|^BINARYEN_ROOT[[:space:]]*[?+:!]?=.*$|BINARYEN_ROOT='#{opt_libexec}/binaryen'|" \
+        -e "s|^NODE_JS[[:space:]]*[?+:!]?=.*$|NODE_JS='#{formula_opt_bin("node")}/node'|" \
+        "$config"
+      rm -f "$config.bak"
+    SH
+    chmod 0755, libexec/"post-install"
   end
 
-  def post_install
-    return if (libexec/".emscripten").exist?
-
-    if File.exist?("#{Dir.home}/.emscripten")
-      ohai "Skipping configuration generation"
-      puts <<~EOS
-        You have a ~/.emscripten configuration file, so the default configuration
-        file was not generated. To generate the default configuration:
-          rm ~/.emscripten
-          brew postinstall emscripten
-      EOS
-      return
-    end
-
-    system bin/"emcc", "--generate-config"
-    inreplace libexec/".emscripten" do |s|
-      s.change_make_var! "LLVM_ROOT", "'#{libexec}/llvm/bin'"
-      s.change_make_var! "BINARYEN_ROOT", "'#{libexec}/binaryen'"
-      s.change_make_var! "NODE_JS", "'#{formula_opt_bin("node")}/node'"
-    end
+  post_install_steps do
+    run "post-install", base: :libexec
   end
 
   test do

--- a/Formula/f/fontconfig.rb
+++ b/Formula/f/fontconfig.rb
@@ -71,9 +71,8 @@ class Fontconfig < Formula
     system "meson", "install", "-C", "build"
   end
 
-  def post_install
-    ohai "Regenerating font cache, this may take a while"
-    system bin/"fc-cache", "--force", "--really-force", "--verbose"
+  post_install_steps do
+    run "fc-cache", args: ["--force", "--really-force", "--verbose"], base: :bin
   end
 
   test do

--- a/Formula/g/ghc.rb
+++ b/Formula/g/ghc.rb
@@ -163,8 +163,8 @@ class Ghc < Formula
     (ghc_libdir/"lib/package.conf.d/package.cache.lock").unlink
   end
 
-  def post_install
-    system bin/"ghc-pkg", "recache"
+  post_install_steps do
+    run "ghc-pkg", args: ["recache"], base: :bin
   end
 
   test do

--- a/Formula/g/ghc@9.10.rb
+++ b/Formula/g/ghc@9.10.rb
@@ -158,8 +158,8 @@ class GhcAT910 < Formula
     (lib/"ghc-#{version}/lib/package.conf.d/package.cache.lock").unlink
   end
 
-  def post_install
-    system bin/"ghc-pkg", "recache"
+  post_install_steps do
+    run "ghc-pkg", args: ["recache"], base: :bin
   end
 
   test do

--- a/Formula/g/ghc@9.12.rb
+++ b/Formula/g/ghc@9.12.rb
@@ -159,8 +159,8 @@ class GhcAT912 < Formula
     (lib/"ghc-#{version}/lib/package.conf.d/package.cache.lock").unlink
   end
 
-  def post_install
-    system bin/"ghc-pkg", "recache"
+  post_install_steps do
+    run "ghc-pkg", args: ["recache"], base: :bin
   end
 
   test do

--- a/Formula/g/ghc@9.2.rb
+++ b/Formula/g/ghc@9.2.rb
@@ -152,8 +152,8 @@ class GhcAT92 < Formula
     (lib/"ghc-#{version}/lib/package.conf.d/package.cache.lock").unlink
   end
 
-  def post_install
-    system bin/"ghc-pkg", "recache"
+  post_install_steps do
+    run "ghc-pkg", args: ["recache"], base: :bin
   end
 
   test do

--- a/Formula/g/ghc@9.4.rb
+++ b/Formula/g/ghc@9.4.rb
@@ -156,8 +156,8 @@ class GhcAT94 < Formula
     (lib/"ghc-#{version}/lib/package.conf.d/package.cache.lock").unlink
   end
 
-  def post_install
-    system bin/"ghc-pkg", "recache"
+  post_install_steps do
+    run "ghc-pkg", args: ["recache"], base: :bin
   end
 
   test do

--- a/Formula/g/ghc@9.6.rb
+++ b/Formula/g/ghc@9.6.rb
@@ -164,8 +164,8 @@ class GhcAT96 < Formula
     (lib/"ghc-#{version}/lib/package.conf.d/package.cache.lock").unlink
   end
 
-  def post_install
-    system bin/"ghc-pkg", "recache"
+  post_install_steps do
+    run "ghc-pkg", args: ["recache"], base: :bin
   end
 
   test do

--- a/Formula/g/ghc@9.8.rb
+++ b/Formula/g/ghc@9.8.rb
@@ -170,8 +170,8 @@ class GhcAT98 < Formula
     (lib/"ghc-#{version}/lib/package.conf.d/package.cache.lock").unlink
   end
 
-  def post_install
-    system bin/"ghc-pkg", "recache"
+  post_install_steps do
+    run "ghc-pkg", args: ["recache"], base: :bin
   end
 
   test do

--- a/Formula/g/glib-networking.rb
+++ b/Formula/g/glib-networking.rb
@@ -44,7 +44,8 @@ class GlibNetworking < Formula
   end
 
   post_install_steps do
-    gio_querymodules
+    run "{{HOMEBREW_PREFIX}}/opt/glib/bin/gio-querymodules",
+        args: ["{{HOMEBREW_PREFIX}}/lib/gio/modules"]
   end
 
   test do

--- a/Formula/g/gtk+3.rb
+++ b/Formula/g/gtk+3.rb
@@ -89,10 +89,11 @@ class Gtkx3 < Formula
     man1.install_symlink man1/"gtk-update-icon-cache.1" => "gtk3-update-icon-cache.1"
   end
 
-  def post_install
-    system "#{formula_opt_bin("glib")}/glib-compile-schemas", "#{HOMEBREW_PREFIX}/share/glib-2.0/schemas"
-    system bin/"gtk3-update-icon-cache", "-f", "-t", "#{HOMEBREW_PREFIX}/share/icons/hicolor"
-    system bin/"gtk-query-immodules-3.0 > #{HOMEBREW_PREFIX}/lib/gtk-3.0/3.0.0/immodules.cache"
+  post_install_steps do
+    compile_gsettings_schemas
+    run "gtk3-update-icon-cache", args: ["-f", "-t", "{{HOMEBREW_PREFIX}}/share/icons/hicolor"], base: :bin
+    run "gtk-query-immodules-3.0", base:        :bin,
+                                   stdout_path: "{{HOMEBREW_PREFIX}}/lib/gtk-3.0/3.0.0/immodules.cache"
   end
 
   test do

--- a/Formula/j/janet.rb
+++ b/Formula/j/janet.rb
@@ -36,20 +36,23 @@ class Janet < Formula
 
     system "make"
     system "make", "install"
-  end
-
-  def post_install
-    mkdir_p syspath unless syspath.exist?
 
     resource("jpm").stage do
-      ENV["PREFIX"] = prefix
-      ENV["JANET_BINPATH"] = HOMEBREW_PREFIX/"bin"
-      ENV["JANET_HEADERPATH"] = HOMEBREW_PREFIX/"include/janet"
-      ENV["JANET_LIBPATH"] = HOMEBREW_PREFIX/"lib"
-      ENV["JANET_MANPATH"] = HOMEBREW_PREFIX/"share/man/man1"
-      ENV["JANET_MODPATH"] = syspath
-      system bin/"janet", "bootstrap.janet"
+      (libexec/"jpm").install Dir["*"]
     end
+  end
+
+  post_install_steps do
+    mkdir_p "{{HOMEBREW_PREFIX}}/lib/janet"
+    run "janet", args: ["bootstrap.janet"], base: :bin, chdir: "{{libexec}}/jpm",
+         env: {
+           "PREFIX"           => "{{prefix}}",
+           "JANET_BINPATH"    => "{{HOMEBREW_PREFIX}}/bin",
+           "JANET_HEADERPATH" => "{{HOMEBREW_PREFIX}}/include/janet",
+           "JANET_LIBPATH"    => "{{HOMEBREW_PREFIX}}/lib",
+           "JANET_MANPATH"    => "{{HOMEBREW_PREFIX}}/share/man/man1",
+           "JANET_MODPATH"    => "{{HOMEBREW_PREFIX}}/lib/janet",
+         }
   end
 
   def caveats

--- a/Formula/k/kafka.rb
+++ b/Formula/k/kafka.rb
@@ -46,13 +46,22 @@ class Kafka < Formula
     mv "config", "kafka"
     etc.install "kafka"
     libexec.install_symlink etc/"kafka" => "config"
+
+    (libexec/"post-install").write <<~SH
+      #!/bin/sh
+      set -e
+      storage="#{opt_bin}/kafka-storage"
+      uuid="$($storage random-uuid)"
+      exec "$storage" format --standalone -t "$uuid" -c "#{etc}/kafka/server.properties"
+    SH
+    chmod 0755, libexec/"post-install"
   end
 
-  def post_install
-    # create directory for kafka stdout+stderr output logs when run by launchd
-    (var/"log/kafka").mkpath
-
-    generate_log_dir(etc/"kafka/server.properties") unless (var/"lib/kraft-combined-logs/meta.properties").exist?
+  post_install_steps do
+    mkdir_p "log/kafka"
+    unless_path_exists "lib/kraft-combined-logs/meta.properties" do
+      run "post-install", base: :libexec
+    end
   end
 
   def generate_log_dir(path)

--- a/Formula/m/minimal-racket.rb
+++ b/Formula/m/minimal-racket.rb
@@ -84,16 +84,10 @@ class MinimalRacket < Formula
     inreplace racket_config, prefix, opt_prefix
   end
 
-  def post_install
-    # Run raco setup to make sure core libraries are properly compiled.
-    # Sometimes the mtimes of .rkt and .zo files are messed up after a fresh
-    # install, making Racket take 15s to start up because interpreting is slow.
-    system bin/"raco", "setup"
-
-    return unless racket_config.read.include?(HOMEBREW_CELLAR)
-
-    ohai "Fixing up Cellar references in #{racket_config}..."
-    inreplace racket_config, %r{#{Regexp.escape(HOMEBREW_CELLAR)}/minimal-racket/[^/]}o, opt_prefix
+  post_install_steps do
+    run "raco", args: ["setup"], base: :bin
+    inreplace "racket/config.rktd", %r{{{HOMEBREW_CELLAR}}/minimal-racket/[^/]}, "{{opt_prefix}}",
+              base: :etc, audit_result: false
   end
 
   def caveats

--- a/Formula/m/mono.rb
+++ b/Formula/m/mono.rb
@@ -88,8 +88,10 @@ class Mono < Formula
     libexec.install bin/"mono-gdb.py", bin/"mono-sgen-gdb.py"
   end
 
-  def post_install
-    system bin/"cert-sync", Formula["ca-certificates"].pkgetc/"cert.pem" if OS.linux?
+  post_install_steps do
+    on_linux do
+      run "cert-sync", args: ["{{HOMEBREW_PREFIX}}/etc/ca-certificates/cert.pem"], base: :bin
+    end
   end
 
   def caveats

--- a/Formula/m/morpheus.rb
+++ b/Formula/m/morpheus.rb
@@ -72,11 +72,19 @@ class Morpheus < Formula
 
     # Set PATH environment variable including Homebrew prefix in macOS app bundle
     inreplace "#{prefix}/Morpheus.app/Contents/Info.plist", "HOMEBREW_BIN_PATH", "#{HOMEBREW_PREFIX}/bin"
+
+    (libexec/"post-install").write <<~SH
+      #!/bin/sh
+      [ "$(uname -m)" = "arm64" ] || exit 0
+      exec /usr/bin/codesign -f -s - "#{opt_prefix}/Morpheus.app"
+    SH
+    chmod 0755, libexec/"post-install"
   end
 
-  def post_install
-    # Sign to ensure proper execution of the app bundle
-    system "/usr/bin/codesign", "-f", "-s", "-", "#{prefix}/Morpheus.app" if OS.mac? && Hardware::CPU.arm?
+  post_install_steps do
+    on_macos do
+      run "post-install", base: :libexec
+    end
   end
 
   test do

--- a/Formula/o/opensearch.rb
+++ b/Formula/o/opensearch.rb
@@ -61,17 +61,23 @@ class Opensearch < Formula
     bin.env_script_all_files(libexec/"bin", JAVA_HOME: formula_opt_prefix("openjdk@25"))
   end
 
-  def post_install
-    # Make sure runtime directories exist
-    (var/"lib/opensearch").mkpath
-    (var/"log/opensearch").mkpath
-    ln_s etc/"opensearch", libexec/"config" unless (libexec/"config").exist?
-    (var/"opensearch/plugins").mkpath
-    ln_s var/"opensearch/plugins", libexec/"plugins" unless (libexec/"plugins").exist?
-    (var/"opensearch/extensions").mkpath
-    ln_s var/"opensearch/extensions", libexec/"extensions" unless (libexec/"extensions").exist?
-    # fix test not being able to create keystore because of sandbox permissions
-    system bin/"opensearch-keystore", "create" unless (etc/"opensearch/opensearch.keystore").exist?
+  post_install_steps do
+    mkdir_p "lib/opensearch"
+    mkdir_p "log/opensearch"
+    unless_path_exists "{{libexec}}/config" do
+      symlink "{{etc}}/opensearch", "config", target_base: :libexec
+    end
+    mkdir_p "opensearch/plugins"
+    unless_path_exists "{{libexec}}/plugins" do
+      symlink "{{var}}/opensearch/plugins", "plugins", target_base: :libexec
+    end
+    mkdir_p "opensearch/extensions"
+    unless_path_exists "{{libexec}}/extensions" do
+      symlink "{{var}}/opensearch/extensions", "extensions", target_base: :libexec
+    end
+    unless_path_exists "{{etc}}/opensearch/opensearch.keystore" do
+      run "opensearch-keystore", args: ["create"], base: :bin
+    end
   end
 
   def caveats

--- a/Formula/o/opentsdb.rb
+++ b/Formula/o/opentsdb.rb
@@ -83,17 +83,24 @@ class Opentsdb < Formula
 
     libexec.mkpath
     bin.env_script_all_files(libexec, env)
+
+    (libexec/"post-install").write <<~SH
+      #!/bin/sh
+      set -e
+      cleanup() { "#{formula_opt_bin("hbase")}/stop-hbase.sh"; }
+      trap cleanup EXIT
+      "#{formula_opt_bin("hbase")}/start-hbase.sh"
+      sleep 2
+      "#{opt_pkgshare}/tools/create_table_with_env.sh"
+      trap - EXIT
+      cleanup
+    SH
+    chmod 0755, libexec/"post-install"
   end
 
-  def post_install
-    (var/"cache/opentsdb").mkpath
-    system "#{formula_opt_bin("hbase")}/start-hbase.sh"
-    begin
-      sleep 2
-      system "#{pkgshare}/tools/create_table_with_env.sh"
-    ensure
-      system "#{formula_opt_bin("hbase")}/stop-hbase.sh"
-    end
+  post_install_steps do
+    mkdir_p "cache/opentsdb"
+    run "post-install", base: :libexec
   end
 
   service do

--- a/Formula/o/orientdb.rb
+++ b/Formula/o/orientdb.rb
@@ -39,22 +39,30 @@ class Orientdb < Formula
     (bin/"orientdb").write_env_script "#{libexec}/bin/orientdb.sh", JAVA_HOME: formula_opt_prefix("openjdk")
     (bin/"orientdb-console").write_env_script "#{libexec}/bin/console.sh", JAVA_HOME: formula_opt_prefix("openjdk")
     (bin/"orientdb-gremlin").write_env_script "#{libexec}/bin/gremlin.sh", JAVA_HOME: formula_opt_prefix("openjdk")
+
+    (libexec/"post-install").write <<~SH
+      #!/bin/sh
+      set -e
+      orientdb="#{opt_bin}/orientdb"
+      cleanup() { ORIENTDB_ROOT_PASSWORD=orientdb "$orientdb" stop; }
+      trap cleanup EXIT
+      ORIENTDB_ROOT_PASSWORD=orientdb "$orientdb" stop
+      sleep 3
+      ORIENTDB_ROOT_PASSWORD=orientdb "$orientdb" start
+      sleep 3
+      trap - EXIT
+      cleanup
+    SH
+    chmod 0755, libexec/"post-install"
   end
 
-  def post_install
-    (var/"db/orientdb").mkpath
-    (var/"run/orientdb").mkpath
-    (var/"log/orientdb").mkpath
-    touch "#{var}/log/orientdb/orientdb.err"
-    touch "#{var}/log/orientdb/orientdb.log"
-
-    ENV["ORIENTDB_ROOT_PASSWORD"] = "orientdb"
-    system bin/"orientdb", "stop"
-    sleep 3
-    system bin/"orientdb", "start"
-    sleep 3
-  ensure
-    system bin/"orientdb", "stop"
+  post_install_steps do
+    mkdir_p "db/orientdb"
+    mkdir_p "run/orientdb"
+    mkdir_p "log/orientdb"
+    touch "log/orientdb/orientdb.err"
+    touch "log/orientdb/orientdb.log"
+    run "post-install", base: :libexec
   end
 
   def caveats

--- a/Formula/r/rpm.rb
+++ b/Formula/r/rpm.rb
@@ -134,8 +134,10 @@ class Rpm < Formula
     (var/"lib/rpm").mkpath
   end
 
-  def post_install
-    safe_system bin/"rpmdb", "--initdb" unless (var/"lib/rpm/rpmdb.sqlite").exist?
+  post_install_steps do
+    unless_path_exists "lib/rpm/rpmdb.sqlite" do
+      run "rpmdb", args: ["--initdb"], base: :bin
+    end
   end
 
   test do

--- a/Formula/r/ruby.rb
+++ b/Formula/r/ruby.rb
@@ -155,38 +155,34 @@ class Ruby < Formula
     # instead of in the Cellar, making gems last across reinstalls
     config_file = lib/"ruby/#{api_version}/rubygems/defaults/operating_system.rb"
     config_file.write rubygems_config
+
+    (libexec/"post-install.rb").write <<~RUBY
+      require "fileutils"
+
+      FileUtils.rm_f ["#{rubygems_bindir}/bundle", "#{rubygems_bindir}/bundler"]
+      FileUtils.rm_rf Dir["#{HOMEBREW_PREFIX}/lib/ruby/gems/#{api_version}/gems/bundler-*"]
+      exit unless RUBY_PLATFORM.include?("darwin")
+
+      require "macho"
+
+      dylib = File.realpath("#{opt_lib}/libruby.dylib")
+      old_dylib_id = IO.popen(["/usr/bin/otool", "-D", dylib], &:read).lines[1].to_s.strip
+      new_dylib_id = old_dylib_id.sub("#{opt_prefix}/", "#{versioned_opt_prefix}/")
+      exit if old_dylib_id == new_dylib_id || !File.exist?(new_dylib_id)
+
+      dylib_mode = File.stat(dylib).mode
+      begin
+        File.chmod(0664, dylib)
+        MachO::Tools.change_dylib_id(dylib, new_dylib_id)
+        MachO.codesign!(dylib) if RbConfig::CONFIG["host_cpu"] == "arm64"
+      ensure
+        File.chmod(dylib_mode, dylib)
+      end
+    RUBY
   end
 
-  def post_install
-    # Since Gem ships Bundle we want to provide that full/expected installation
-    # but to do so we need to handle the case where someone has previously
-    # installed bundle manually via `gem install`.
-    # TODO: remove when enabling default_user_install
-    rm(%W[
-      #{rubygems_bindir}/bundle
-      #{rubygems_bindir}/bundler
-    ].select { |file| File.exist?(file) })
-    rm_r(Dir[HOMEBREW_PREFIX/"lib/ruby/gems/#{api_version}/gems/bundler-*"])
-
-    # Use versioned opt path so user-installed gems can work when user is switched to versioned Ruby.
-    # Needs to be done in postinstall since install names are modified by brew after install method.
-    # TODO: Consider adding a DSL for this to avoid performance cost of post install and binary patching
-    if OS.mac? && !versioned_formula?
-      dylib = (lib/"libruby.dylib").realpath
-      old_dylib_id = dylib.dylib_id
-      new_dylib_id = old_dylib_id.sub("#{opt_prefix}/", "#{versioned_opt_prefix}/")
-      return if old_dylib_id == new_dylib_id
-      return unless File.exist?(new_dylib_id)
-
-      dylib_mode = dylib.stat.mode
-      begin
-        chmod 0664, dylib
-        MachO::Tools.change_dylib_id(dylib, new_dylib_id)
-        MachO.codesign!(dylib) if Hardware::CPU.arm?
-      ensure
-        chmod dylib_mode, dylib
-      end
-    end
+  post_install_steps do
+    run "{{HOMEBREW_BREW_FILE}}", args: ["ruby", "--", "{{libexec}}/post-install.rb"]
   end
 
   def rubygems_config

--- a/Formula/t/texinfo.rb
+++ b/Formula/t/texinfo.rb
@@ -29,14 +29,21 @@ class Texinfo < Formula
     system "./configure", "--disable-install-warnings", *std_configure_args
     system "make", "install"
     doc.install Dir["doc/refcard/txirefcard*"]
+
+    (libexec/"post-install").write <<~SH
+      #!/bin/sh
+      info_dir="#{HOMEBREW_PREFIX}/share/info/dir"
+      rm -f "$info_dir"
+      for file in "#{HOMEBREW_PREFIX}/share/info/"*.info "#{HOMEBREW_PREFIX}/share/info/"*.info.gz; do
+        [ -e "$file" ] || continue
+        "#{opt_bin}/install-info" --quiet "$file" "$info_dir" || true
+      done
+    SH
+    chmod 0755, libexec/"post-install"
   end
 
-  def post_install
-    info_dir = HOMEBREW_PREFIX/"share/info/dir"
-    info_dir.delete if info_dir.exist?
-    info_dir.dirname.glob(["*.info", "*.info.gz"]) do |f|
-      quiet_system("#{bin}/install-info", "--quiet", f, info_dir)
-    end
+  post_install_steps do
+    run "post-install", base: :libexec
   end
 
   test do

--- a/Formula/t/tzdb.rb
+++ b/Formula/t/tzdb.rb
@@ -38,9 +38,8 @@ class Tzdb < Formula
     system "make", *make_args, "install"
   end
 
-  def post_install
-    # Generate default localtime, from Makefile.
-    system sbin/"zic", "-l", "Factory", "-p", "-", "-t", localtime
+  post_install_steps do
+    run "zic", args: ["-l", "Factory", "-p", "-", "-t", "{{etc}}/localtime"], base: :sbin
   end
 
   test do

--- a/Formula/v/visp.rb
+++ b/Formula/v/visp.rb
@@ -154,26 +154,26 @@ class Visp < Formula
     # Make sure software built against visp don't reference opencv's cellar path either
     inreplace [lib/"pkgconfig/visp.pc", lib/"cmake/visp/VISPConfig.cmake"],
               opencv.prefix.realpath, opencv.opt_prefix
+
+    (libexec/"post-install").write <<~SH
+      #!/bin/sh
+      set -e
+      sdk_path="$(xcrun --sdk macosx --show-sdk-path)"
+      for file in "#{opt_lib}/cmake/visp/VISPConfig.cmake" \
+                  "#{opt_lib}/cmake/visp/VISPModules.cmake" \
+                  "#{opt_lib}/pkgconfig/visp.pc"; do
+        sed -E -i.bak \
+          's|/(Applications/Xcode[^[:space:];]*/SDKs|Library/Developer/CommandLineTools/SDKs)/MacOSX[^[:space:];]*\\.sdk|'"$sdk_path"'|g' \
+          "$file"
+        rm -f "$file.bak"
+      done
+    SH
+    chmod 0755, libexec/"post-install"
   end
 
-  def post_install
-    # Replace SDK paths in bottle when pouring on different OS version than bottle OS.
-    # This avoids error like https://github.com/orgs/Homebrew/discussions/5853
-    # TODO: Consider handling this in brew, e.g. as part of keg cleaner or bottle relocation
-    if OS.mac? && (tab = Tab.for_formula(self)).poured_from_bottle
-      bottle_os = bottle&.tag&.to_macos_version
-      if bottle_os.nil? && (os_version = tab.built_on.fetch("os_version", "")[/\d+(?:\.\d+)*$/])
-        bottle_os = MacOSVersion.new(os_version).strip_patch
-      end
-      return if bottle_os.nil? || MacOS.version == bottle_os
-
-      sdk_path_files = [
-        lib/"cmake/visp/VISPConfig.cmake",
-        lib/"cmake/visp/VISPModules.cmake",
-        lib/"pkgconfig/visp.pc",
-      ]
-      bottle_sdk_path = MacOS.sdk_for_formula(self, bottle_os).path
-      inreplace sdk_path_files, bottle_sdk_path, MacOS.sdk_for_formula(self).path, audit_result: false
+  post_install_steps do
+    on_macos do
+      run "post-install", base: :libexec
     end
   end
 


### PR DESCRIPTION
Thirty-four formulae perform post-install work by invoking known
packaged or system executables with fixed arguments.

- serialise environments, streams, working directories and guards
- install literal helpers when processing needs a packaged script
- retain file preparation steps in mixed migrations
- depend on Homebrew/brew's matching
  `Add constrained install commands` change

Needs https://github.com/Homebrew/brew/pull/23186

