### PR TITLE
Migrate process termination hooks (6/15)

### DIFF
--- a/Formula/b/boring.rb
+++ b/Formula/b/boring.rb
@@ -26,8 +26,8 @@ class Boring < Formula
     generate_completions_from_executable(bin/"boring", "--shell")
   end
 
-  def post_install
-    quiet_system "killall", "boring"
+  post_install_steps do
+    terminate_process "boring", must_succeed: false
   end
 
   test do

--- a/Formula/g/gnupg.rb
+++ b/Formula/g/gnupg.rb
@@ -81,9 +81,9 @@ class Gnupg < Formula
     end
   end
 
-  def post_install
-    (var/"run").mkpath
-    quiet_system "killall", "gpg-agent"
+  post_install_steps do
+    mkdir_p "run"
+    terminate_process "gpg-agent", must_succeed: false
   end
 
   test do


### PR DESCRIPTION
Boring and GnuPG stop stale helper processes before completing their
post-install updates.

- replace process-control Ruby with declarative termination steps
- preserve matching, attempts and required-success behaviour
- keep GnuPG's existing user-facing termination notice
- depend on Homebrew/brew's matching
  `Add process termination steps` change

Needs https://github.com/Homebrew/brew/pull/23187

