### PR TITLE
Migrate gzipped executables (9/15)

### DIFF
--- a/Formula/b/bazel.rb
+++ b/Formula/b/bazel.rb
@@ -108,12 +108,9 @@ class Bazel < Formula
     end
   end
 
-  def post_install
-    if File.exist?("#{bazel_real}.gz")
-      rm(bazel_real)
-      system "gunzip", "#{bazel_real}.gz"
-      bazel_real.chmod 0755
-    end
+  post_install_steps do
+    install_gzipped_executable "bin/bazel-real.gz", "bin/bazel-real",
+                                  source_base: :libexec, target_base: :libexec
   end
 
   test do

--- a/Formula/b/bazel@7.rb
+++ b/Formula/b/bazel@7.rb
@@ -94,12 +94,9 @@ class BazelAT7 < Formula
     end
   end
 
-  def post_install
-    if File.exist?("#{bazel_real}.gz")
-      rm(bazel_real)
-      system "gunzip", "#{bazel_real}.gz"
-      bazel_real.chmod 0755
-    end
+  post_install_steps do
+    install_gzipped_executable "bin/bazel-real.gz", "bin/bazel-real",
+                                  source_base: :libexec, target_base: :libexec
   end
 
   test do

--- a/Formula/b/bazel@8.rb
+++ b/Formula/b/bazel@8.rb
@@ -112,12 +112,9 @@ class BazelAT8 < Formula
     end
   end
 
-  def post_install
-    if File.exist?("#{bazel_real}.gz")
-      rm(bazel_real)
-      system "gunzip", "#{bazel_real}.gz"
-      bazel_real.chmod 0755
-    end
+  post_install_steps do
+    install_gzipped_executable "bin/bazel-real.gz", "bin/bazel-real",
+                                  source_base: :libexec, target_base: :libexec
   end
 
   test do

--- a/Formula/b/buildapp.rb
+++ b/Formula/b/buildapp.rb
@@ -31,12 +31,8 @@ class Buildapp < Formula
     end
   end
 
-  def post_install
-    if (prefix/"buildapp.gz").exist?
-      system "gunzip", prefix/"buildapp.gz"
-      bin.install prefix/"buildapp"
-      (bin/"buildapp").chmod 0755
-    end
+  post_install_steps do
+    install_gzipped_executable "buildapp.gz", "bin/buildapp"
   end
 
   test do

--- a/Formula/b/bun.rb
+++ b/Formula/b/bun.rb
@@ -150,12 +150,8 @@ class Bun < Formula
     end
   end
 
-  def post_install
-    if (prefix/"bun.gz").exist?
-      system "gunzip", prefix/"bun.gz"
-      (prefix/"bun").chmod 0755
-      bin.install prefix/"bun"
-    end
+  post_install_steps do
+    install_gzipped_executable "bun.gz", "bin/bun"
   end
 
   test do

--- a/Formula/c/cafeobj.rb
+++ b/Formula/c/cafeobj.rb
@@ -56,12 +56,9 @@ class Cafeobj < Formula
     end
   end
 
-  def post_install
-    if (prefix/"cafeobj.sbcl.gz").exist?
-      system "gunzip", prefix/"cafeobj.sbcl.gz"
-      (prefix/"cafeobj.sbcl").chmod (lib/"cafeobj-#{version.major_minor}/sbcl/cafeobj.sbcl").lstat.mode
-      (lib/"cafeobj-#{version.major_minor}/sbcl").install prefix/"cafeobj.sbcl"
-    end
+  post_install_steps do
+    install_gzipped_executable "cafeobj.sbcl.gz", "cafeobj-#{version.major_minor}/sbcl/cafeobj.sbcl",
+                                  target_base: :lib
   end
 
   test do

--- a/Formula/f/fedify.rb
+++ b/Formula/f/fedify.rb
@@ -37,12 +37,8 @@ class Fedify < Formula
     end
   end
 
-  def post_install
-    if (prefix/"fedify.gz").exist?
-      system "gunzip", prefix/"fedify.gz"
-      bin.install prefix/"fedify"
-      (bin/"fedify").chmod 0755
-    end
+  post_install_steps do
+    install_gzipped_executable "fedify.gz", "bin/fedify"
   end
 
   test do

--- a/Formula/p/pgloader.rb
+++ b/Formula/p/pgloader.rb
@@ -84,12 +84,8 @@ class Pgloader < Formula
     end
   end
 
-  def post_install
-    if (prefix/"pgloader.gz").exist?
-      system "gunzip", prefix/"pgloader.gz"
-      bin.install prefix/"pgloader"
-      (bin/"pgloader").chmod 0755
-    end
+  post_install_steps do
+    install_gzipped_executable "pgloader.gz", "bin/pgloader"
   end
 
   test do


### PR DESCRIPTION
Eight formulae expand a staged gzipped executable into an installed
command after pouring or building.

- replace repeated decompression, copy and chmod sequences
- preserve formula-specific sources, destinations and modes
- use the shared executable action for every migrated formula
- depend on Homebrew/brew's matching
  `Add gzipped executable action` change

Needs https://github.com/Homebrew/brew/pull/23200

