### PR TITLE
Migrate glibc runtime setup (10/15)

### DIFF
--- a/Formula/g/glibc.rb
+++ b/Formula/g/glibc.rb
@@ -330,41 +330,10 @@ class Glibc < Formula
     rm_r(bootstrap_dir) if bootstrap_dir
   end
 
-  def post_install
-    # Rebuild ldconfig cache
-    rm(etc/"ld.so.cache") if (etc/"ld.so.cache").exist?
-    system sbin/"ldconfig"
-
-    # Compile locale definition files
-    mkdir_p lib/"locale"
-
-    # Get all extra installed locales from the system, except C locale
-    locales = ENV.filter_map do |k, v|
-      v if k[/^HOMEBREW_LANG$|^LANG$|^LC_/] && v != "C"
-    end
-
-    # en_US.UTF-8 is required by gawk make check
-    locales = (locales + ["en_US.UTF-8"]).sort.uniq
-    ohai "Installing locale data for #{locales.join(" ")}"
-    locales.each do |locale|
-      lang, charmap = locale.split(".", 2)
-      if charmap.present?
-        charmap = "UTF-8" if charmap == "utf8"
-        system bin/"localedef", "-i", lang, "-f", charmap, locale
-      else
-        system bin/"localedef", "-i", lang, locale
-      end
-    end
-
-    # Set the local time zone
-    sys_localtime = Pathname("/etc/localtime")
-    brew_localtime = etc/"localtime"
-    etc.install_symlink sys_localtime if sys_localtime.exist? && !brew_localtime.exist?
-
-    # Set zoneinfo correctly using the system installed zoneinfo
-    sys_zoneinfo = Pathname("/usr/share/zoneinfo")
-    brew_zoneinfo = share/"zoneinfo"
-    share.install_symlink sys_zoneinfo if sys_zoneinfo.exist? && !brew_zoneinfo.exist?
+  post_install_steps do
+    remove "ld.so.cache", base: :etc
+    run "ldconfig", base: :sbin
+    configure_glibc_runtime
   end
 
   def caveats

--- a/Formula/g/glibc@2.13.rb
+++ b/Formula/g/glibc@2.13.rb
@@ -151,37 +151,8 @@ class GlibcAT213 < Formula
     ].each(&:unlink)
   end
 
-  def post_install
-    # Compile locale definition files
-    mkdir_p lib/"locale"
-
-    # Get all extra installed locales from the system, except C locales
-    locales = ENV.filter_map do |k, v|
-      v if k[/^LANG$|^LC_/] && v != "C" && !v.start_with?("C.")
-    end
-
-    # en_US.UTF-8 is required by gawk make check
-    locales = (locales + ["en_US.UTF-8"]).sort.uniq
-    ohai "Installing locale data for #{locales.join(" ")}"
-    locales.each do |locale|
-      lang, charmap = locale.split(".", 2)
-      if charmap.present?
-        charmap = "UTF-8" if charmap == "utf8"
-        system bin/"localedef", "-i", lang, "-f", charmap, locale
-      else
-        system bin/"localedef", "-i", lang, locale
-      end
-    end
-
-    # Set the local time zone
-    sys_localtime = Pathname("/etc/localtime")
-    brew_localtime = etc/"localtime"
-    etc.install_symlink sys_localtime if sys_localtime.exist? && !brew_localtime.exist?
-
-    # Set zoneinfo correctly using the system installed zoneinfo
-    sys_zoneinfo = Pathname("/usr/share/zoneinfo")
-    brew_zoneinfo = share/"zoneinfo"
-    share.install_symlink sys_zoneinfo if sys_zoneinfo.exist? && !brew_zoneinfo.exist?
+  post_install_steps do
+    configure_glibc_runtime
   end
 
   test do

--- a/Formula/g/glibc@2.17.rb
+++ b/Formula/g/glibc@2.17.rb
@@ -157,37 +157,8 @@ class GlibcAT217 < Formula
     ].each(&:unlink)
   end
 
-  def post_install
-    # Compile locale definition files
-    mkdir_p lib/"locale"
-
-    # Get all extra installed locales from the system, except C locales
-    locales = ENV.filter_map do |k, v|
-      v if k[/^LANG$|^LC_/] && v != "C" && !v.start_with?("C.")
-    end
-
-    # en_US.UTF-8 is required by gawk make check
-    locales = (locales + ["en_US.UTF-8"]).sort.uniq
-    ohai "Installing locale data for #{locales.join(" ")}"
-    locales.each do |locale|
-      lang, charmap = locale.split(".", 2)
-      if charmap.present?
-        charmap = "UTF-8" if charmap == "utf8"
-        system bin/"localedef", "-i", lang, "-f", charmap, locale
-      else
-        system bin/"localedef", "-i", lang, locale
-      end
-    end
-
-    # Set the local time zone
-    sys_localtime = Pathname("/etc/localtime")
-    brew_localtime = etc/"localtime"
-    etc.install_symlink sys_localtime if sys_localtime.exist? && !brew_localtime.exist?
-
-    # Set zoneinfo correctly using the system installed zoneinfo
-    sys_zoneinfo = Pathname("/usr/share/zoneinfo")
-    brew_zoneinfo = share/"zoneinfo"
-    share.install_symlink sys_zoneinfo if sys_zoneinfo.exist? && !brew_zoneinfo.exist?
+  post_install_steps do
+    configure_glibc_runtime
   end
 
   test do


### PR DESCRIPTION
The current and legacy glibc formulae share locale generation and host
timezone-link behaviour.

- replace duplicated locale loops with the shared family action
- retain current glibc cache removal and `ldconfig` steps
- preserve legacy environment differences in brew
- depend on Homebrew/brew's matching
  `Add glibc runtime action` change

Needs https://github.com/Homebrew/brew/pull/23201

AI disclosure: using OpenAI Codex 5.6 Sol max with local review and testing.