### PR TITLE
Migrate existing rebuild actions (14/15)

### DIFF
--- a/Formula/e/easy-tag.rb
+++ b/Formula/e/easy-tag.rb
@@ -87,9 +87,9 @@ class EasyTag < Formula
     system "make", "install"
   end
 
-  def post_install
-    system "#{formula_opt_bin("glib")}/glib-compile-schemas", "#{HOMEBREW_PREFIX}/share/glib-2.0/schemas"
-    system "#{formula_opt_bin("gtk+3")}/gtk3-update-icon-cache", "-f", "-t", "#{HOMEBREW_PREFIX}/share/icons/hicolor"
+  post_install_steps do
+    compile_gsettings_schemas
+    update_gtk_icon_cache
   end
 
   test do

--- a/Formula/s/sysprof.rb
+++ b/Formula/s/sysprof.rb
@@ -57,8 +57,8 @@ class Sysprof < Formula
     pkgshare.install "examples"
   end
 
-  def post_install
-    system formula_opt_bin("gtk4")/"gtk4-update-icon-cache", "-f", "-t", HOMEBREW_PREFIX/"share/icons/hicolor"
+  post_install_steps do
+    update_gtk_icon_cache
   end
 
   test do


### PR DESCRIPTION
Two formulae only compile schemas or refresh the shared GTK icon cache
after installation.

- replace imperative commands with canonical cache actions
- preserve the existing order and shared Homebrew destinations
- remove both remaining Ruby `post_install` hooks
- depend on Homebrew/brew's matching
  `Align shared install step interfaces` change

Needs https://github.com/Homebrew/brew/pull/23193

AI disclosure: using OpenAI Codex 5.6 Sol max with local review and testing.