### PR TITLE
Align canonical install step names (15/15)

### DIFF
--- a/Formula/a/aravis.rb
+++ b/Formula/a/aravis.rb
@@ -51,7 +51,7 @@ class Aravis < Formula
   end
 
   post_install_steps do
-    gtk_update_icon_cache
+    update_gtk_icon_cache
   end
 
   def caveats

--- a/Formula/b/baobab.rb
+++ b/Formula/b/baobab.rb
@@ -51,7 +51,7 @@ class Baobab < Formula
 
   post_install_steps do
     compile_gsettings_schemas
-    gtk_update_icon_cache
+    update_gtk_icon_cache
   end
 
   test do

--- a/Formula/e/enter-tex.rb
+++ b/Formula/e/enter-tex.rb
@@ -58,7 +58,7 @@ class EnterTex < Formula
 
   post_install_steps do
     compile_gsettings_schemas
-    gtk_update_icon_cache
+    update_gtk_icon_cache
   end
 
   test do

--- a/Formula/e/evince.rb
+++ b/Formula/e/evince.rb
@@ -74,7 +74,7 @@ class Evince < Formula
 
   post_install_steps do
     compile_gsettings_schemas
-    gtk_update_icon_cache
+    update_gtk_icon_cache
   end
 
   test do

--- a/Formula/f/file-roller.rb
+++ b/Formula/f/file-roller.rb
@@ -48,7 +48,7 @@ class FileRoller < Formula
 
   post_install_steps do
     compile_gsettings_schemas
-    gtk_update_icon_cache
+    update_gtk_icon_cache
     update_desktop_database
   end
 

--- a/Formula/g/gdk-pixbuf.rb
+++ b/Formula/g/gdk-pixbuf.rb
@@ -59,7 +59,7 @@ class GdkPixbuf < Formula
   end
 
   post_install_steps do
-    gdk_pixbuf_query_loaders
+    update_gdk_pixbuf_loaders_cache
   end
 
   test do

--- a/Formula/g/gedit.rb
+++ b/Formula/g/gedit.rb
@@ -74,7 +74,7 @@ class Gedit < Formula
 
   post_install_steps do
     compile_gsettings_schemas
-    gtk_update_icon_cache
+    update_gtk_icon_cache
   end
 
   test do

--- a/Formula/g/geocode-glib.rb
+++ b/Formula/g/geocode-glib.rb
@@ -44,7 +44,7 @@ class GeocodeGlib < Formula
   end
 
   post_install_steps do
-    gtk_update_icon_cache
+    update_gtk_icon_cache
   end
 
   test do

--- a/Formula/g/ghex.rb
+++ b/Formula/g/ghex.rb
@@ -49,7 +49,7 @@ class Ghex < Formula
 
   post_install_steps do
     compile_gsettings_schemas
-    gtk_update_icon_cache
+    update_gtk_icon_cache
   end
 
   test do

--- a/Formula/g/gitg.rb
+++ b/Formula/g/gitg.rb
@@ -78,7 +78,7 @@ class Gitg < Formula
 
   post_install_steps do
     compile_gsettings_schemas
-    gtk_update_icon_cache
+    update_gtk_icon_cache
   end
 
   test do

--- a/Formula/g/glade.rb
+++ b/Formula/g/glade.rb
@@ -58,7 +58,7 @@ class Glade < Formula
   end
 
   post_install_steps do
-    gtk_update_icon_cache
+    update_gtk_icon_cache
   end
 
   test do

--- a/Formula/g/gnome-builder.rb
+++ b/Formula/g/gnome-builder.rb
@@ -75,7 +75,7 @@ class GnomeBuilder < Formula
 
   post_install_steps do
     compile_gsettings_schemas
-    gtk_update_icon_cache
+    update_gtk_icon_cache
   end
 
   test do

--- a/Formula/g/gnome-online-accounts.rb
+++ b/Formula/g/gnome-online-accounts.rb
@@ -65,7 +65,7 @@ class GnomeOnlineAccounts < Formula
 
   post_install_steps do
     compile_gsettings_schemas
-    gtk_update_icon_cache
+    update_gtk_icon_cache
   end
 
   test do

--- a/Formula/g/gnome-papers.rb
+++ b/Formula/g/gnome-papers.rb
@@ -85,7 +85,7 @@ class GnomePapers < Formula
 
   post_install_steps do
     compile_gsettings_schemas
-    gtk_update_icon_cache
+    update_gtk_icon_cache
   end
 
   test do

--- a/Formula/g/gnome-recipes.rb
+++ b/Formula/g/gnome-recipes.rb
@@ -62,7 +62,7 @@ class GnomeRecipes < Formula
 
   post_install_steps do
     compile_gsettings_schemas
-    gtk_update_icon_cache
+    update_gtk_icon_cache
   end
 
   test do

--- a/Formula/g/gnutls.rb
+++ b/Formula/g/gnutls.rb
@@ -87,7 +87,7 @@ class Gnutls < Formula
   end
 
   post_install_steps do
-    symlink "{{etc}}/ca-certificates/cert.pem", "{{pkgetc}}/cert.pem", force: true
+    symlink "{{etc}}/ca-certificates/cert.pem", "{{pkgetc}}/cert.pem", overwrite: true
   end
 
   def caveats

--- a/Formula/g/gtk4.rb
+++ b/Formula/g/gtk4.rb
@@ -105,7 +105,7 @@ class Gtk4 < Formula
 
   post_install_steps do
     compile_gsettings_schemas
-    gtk_update_icon_cache
+    update_gtk_icon_cache
   end
 
   test do

--- a/Formula/g/gtranslator.rb
+++ b/Formula/g/gtranslator.rb
@@ -47,7 +47,7 @@ class Gtranslator < Formula
 
   post_install_steps do
     compile_gsettings_schemas
-    gtk_update_icon_cache
+    update_gtk_icon_cache
   end
 
   test do

--- a/Formula/i/i2pd.rb
+++ b/Formula/i/i2pd.rb
@@ -45,10 +45,10 @@ class I2pd < Formula
 
   post_install_steps do
     # Create symlinks to certificates and configs
-    symlink "{{pkgshare}}/certificates",    "{{var}}/lib/i2pd/certificates",      force: true
-    symlink "{{pkgetc}}/i2pd.conf",         "{{var}}/lib/i2pd/i2pd.conf",         force: true
-    symlink "{{pkgetc}}/subscriptions.txt", "{{var}}/lib/i2pd/subscriptions.txt", force: true
-    symlink "{{pkgetc}}/tunnels.conf",      "{{var}}/lib/i2pd/tunnels.conf",      force: true
+    symlink "{{pkgshare}}/certificates",    "{{var}}/lib/i2pd/certificates",      overwrite: true
+    symlink "{{pkgetc}}/i2pd.conf",         "{{var}}/lib/i2pd/i2pd.conf",         overwrite: true
+    symlink "{{pkgetc}}/subscriptions.txt", "{{var}}/lib/i2pd/subscriptions.txt", overwrite: true
+    symlink "{{pkgetc}}/tunnels.conf",      "{{var}}/lib/i2pd/tunnels.conf",      overwrite: true
   end
 
   service do

--- a/Formula/l/lxi-tools.rb
+++ b/Formula/l/lxi-tools.rb
@@ -46,7 +46,7 @@ class LxiTools < Formula
 
   post_install_steps do
     compile_gsettings_schemas
-    gtk_update_icon_cache
+    update_gtk_icon_cache
     update_desktop_database
   end
 

--- a/Formula/lib/libressl.rb
+++ b/Formula/lib/libressl.rb
@@ -50,7 +50,7 @@ class Libressl < Formula
   end
 
   post_install_steps do
-    symlink "{{etc}}/ca-certificates/cert.pem", "{{pkgetc}}/cert.pem", force: true
+    symlink "{{etc}}/ca-certificates/cert.pem", "{{pkgetc}}/cert.pem", overwrite: true
   end
 
   def caveats

--- a/Formula/lib/librsvg.rb
+++ b/Formula/lib/librsvg.rb
@@ -73,7 +73,7 @@ class Librsvg < Formula
   end
 
   post_install_steps do
-    gdk_pixbuf_query_loaders
+    update_gdk_pixbuf_loaders_cache
   end
 
   test do

--- a/Formula/m/mariadb.rb
+++ b/Formula/m/mariadb.rb
@@ -149,7 +149,7 @@ class Mariadb < Formula
   post_install_steps do
     # Make sure the var/mysql directory exists
     # Don't initialize database, it clashes when testing other MySQL-like implementations.
-    init_data_dir "mysql", using: :mariadb_install_db, base: :var
+    init_data_dir "mysql", using: :mariadb, base: :var
   end
 
   def caveats

--- a/Formula/m/mariadb@10.11.rb
+++ b/Formula/m/mariadb@10.11.rb
@@ -155,7 +155,7 @@ class MariadbAT1011 < Formula
   post_install_steps do
     # Make sure the var/mysql directory exists
     # Don't initialize database, it clashes when testing other MySQL-like implementations.
-    init_data_dir "mysql", using: :mariadb_install_db, base: :var
+    init_data_dir "mysql", using: :mariadb, base: :var
   end
 
   def caveats

--- a/Formula/m/mariadb@10.5.rb
+++ b/Formula/m/mariadb@10.5.rb
@@ -149,7 +149,7 @@ class MariadbAT105 < Formula
   post_install_steps do
     # Make sure the var/mysql directory exists
     # Don't initialize database, it clashes when testing other MySQL-like implementations.
-    init_data_dir "mysql", using: :mariadb_install_db, base: :var
+    init_data_dir "mysql", using: :mariadb, base: :var
   end
 
   def caveats

--- a/Formula/m/mariadb@10.6.rb
+++ b/Formula/m/mariadb@10.6.rb
@@ -150,7 +150,7 @@ class MariadbAT106 < Formula
   post_install_steps do
     # Make sure the var/mysql directory exists
     # Don't initialize database, it clashes when testing other MySQL-like implementations.
-    init_data_dir "mysql", using: :mariadb_install_db, base: :var
+    init_data_dir "mysql", using: :mariadb, base: :var
   end
 
   def caveats

--- a/Formula/m/mariadb@11.4.rb
+++ b/Formula/m/mariadb@11.4.rb
@@ -151,7 +151,7 @@ class MariadbAT114 < Formula
   post_install_steps do
     # Make sure the var/mysql directory exists
     # Don't initialize database, it clashes when testing other MySQL-like implementations.
-    init_data_dir "mysql", using: :mariadb_install_db, base: :var
+    init_data_dir "mysql", using: :mariadb, base: :var
   end
 
   def caveats

--- a/Formula/m/mariadb@11.8.rb
+++ b/Formula/m/mariadb@11.8.rb
@@ -153,7 +153,7 @@ class MariadbAT118 < Formula
   post_install_steps do
     # Make sure the var/mysql directory exists
     # Don't initialize database, it clashes when testing other MySQL-like implementations.
-    init_data_dir "mysql", using: :mariadb_install_db, base: :var
+    init_data_dir "mysql", using: :mariadb, base: :var
   end
 
   def caveats

--- a/Formula/m/mysql.rb
+++ b/Formula/m/mysql.rb
@@ -165,7 +165,7 @@ class Mysql < Formula
   post_install_steps do
     # Make sure the var/mysql directory exists
     # Don't initialize database, it clashes when testing other MySQL-like implementations.
-    init_data_dir "mysql", using: :mysql_initialize, base: :var
+    init_data_dir "mysql", using: :mysql, base: :var
   end
 
   def caveats

--- a/Formula/m/mysql@8.0.rb
+++ b/Formula/m/mysql@8.0.rb
@@ -136,7 +136,7 @@ class MysqlAT80 < Formula
   post_install_steps do
     # Make sure the var/mysql directory exists
     # Don't initialize database, it clashes when testing other MySQL-like implementations.
-    init_data_dir "mysql", using: :mysql_initialize, base: :var
+    init_data_dir "mysql", using: :mysql, base: :var
   end
 
   def caveats

--- a/Formula/m/mysql@8.4.rb
+++ b/Formula/m/mysql@8.4.rb
@@ -141,7 +141,7 @@ class MysqlAT84 < Formula
   post_install_steps do
     # Make sure the var/mysql directory exists
     # Don't initialize database, it clashes when testing other MySQL-like implementations.
-    init_data_dir "mysql", using: :mysql_initialize, base: :var
+    init_data_dir "mysql", using: :mysql, base: :var
   end
 
   def caveats

--- a/Formula/n/nip4.rb
+++ b/Formula/n/nip4.rb
@@ -48,7 +48,7 @@ class Nip4 < Formula
 
   post_install_steps do
     compile_gsettings_schemas
-    gtk_update_icon_cache
+    update_gtk_icon_cache
   end
 
   test do

--- a/Formula/n/node@18.rb
+++ b/Formula/n/node@18.rb
@@ -80,7 +80,7 @@ class NodeAT18 < Formula
   end
 
   post_install_steps do
-    write "lib/node_modules/npm/npmrc", "prefix = {{HOMEBREW_PREFIX}}\n", base: :prefix, overwrite: true
+    write_file "lib/node_modules/npm/npmrc", "prefix = {{HOMEBREW_PREFIX}}\n", base: :prefix
   end
 
   test do

--- a/Formula/o/openssl@3.0.rb
+++ b/Formula/o/openssl@3.0.rb
@@ -106,7 +106,7 @@ class OpensslAT30 < Formula
   def openssldir = pkgetc
 
   post_install_steps do
-    symlink "{{etc}}/ca-certificates/cert.pem", "{{pkgetc}}/cert.pem", force: true
+    symlink "{{etc}}/ca-certificates/cert.pem", "{{pkgetc}}/cert.pem", overwrite: true
   end
 
   def caveats

--- a/Formula/o/openssl@3.5.rb
+++ b/Formula/o/openssl@3.5.rb
@@ -110,7 +110,7 @@ class OpensslAT35 < Formula
   def openssldir = pkgetc
 
   post_install_steps do
-    symlink "{{etc}}/ca-certificates/cert.pem", "{{pkgetc}}/cert.pem", force: true
+    symlink "{{etc}}/ca-certificates/cert.pem", "{{pkgetc}}/cert.pem", overwrite: true
   end
 
   def caveats

--- a/Formula/o/openssl@3.rb
+++ b/Formula/o/openssl@3.rb
@@ -136,7 +136,7 @@ class OpensslAT3 < Formula
   def openssldir = pkgetc
 
   post_install_steps do
-    symlink "{{etc}}/ca-certificates/cert.pem", "{{pkgetc}}/cert.pem", force: true
+    symlink "{{etc}}/ca-certificates/cert.pem", "{{pkgetc}}/cert.pem", overwrite: true
   end
 
   def caveats

--- a/Formula/o/openssl@4.rb
+++ b/Formula/o/openssl@4.rb
@@ -66,7 +66,7 @@ class OpensslAT4 < Formula
   end
 
   post_install_steps do
-    symlink "{{etc}}/ca-certificates/cert.pem", "{{pkgetc}}/cert.pem", force: true
+    symlink "{{etc}}/ca-certificates/cert.pem", "{{pkgetc}}/cert.pem", overwrite: true
   end
 
   def caveats

--- a/Formula/p/postgresql@12.rb
+++ b/Formula/p/postgresql@12.rb
@@ -99,7 +99,7 @@ class PostgresqlAT12 < Formula
   post_install_steps do
     mkdir_p "log", base: :var
     # Don't initialize database, it clashes when testing other PostgreSQL versions.
-    init_data_dir "postgresql@12", using: :postgresql_initdb, locale: "C", base: :var
+    init_data_dir "postgresql@12", using: :postgresql, locale: "C", base: :var
   end
 
   def postgresql_datadir

--- a/Formula/p/postgresql@13.rb
+++ b/Formula/p/postgresql@13.rb
@@ -98,7 +98,7 @@ class PostgresqlAT13 < Formula
   post_install_steps do
     mkdir_p "log", base: :var
     # Don't initialize database, it clashes when testing other PostgreSQL versions.
-    init_data_dir "postgresql@13", using: :postgresql_initdb, base: :var
+    init_data_dir "postgresql@13", using: :postgresql, base: :var
   end
 
   def postgresql_datadir

--- a/Formula/p/postgresql@14.rb
+++ b/Formula/p/postgresql@14.rb
@@ -96,7 +96,7 @@ class PostgresqlAT14 < Formula
   post_install_steps do
     mkdir_p "log", base: :var
     # Don't initialize database, it clashes when testing other PostgreSQL versions.
-    init_data_dir "postgresql@14", using: :postgresql_initdb, base: :var
+    init_data_dir "postgresql@14", using: :postgresql, base: :var
   end
 
   def postgresql_datadir

--- a/Formula/p/postgresql@15.rb
+++ b/Formula/p/postgresql@15.rb
@@ -119,7 +119,7 @@ class PostgresqlAT15 < Formula
   post_install_steps do
     mkdir_p "log", base: :var
     # Don't initialize database, it clashes when testing other PostgreSQL versions.
-    init_data_dir "postgresql@15", using: :postgresql_initdb, base: :var
+    init_data_dir "postgresql@15", using: :postgresql, base: :var
   end
 
   def postgresql_datadir

--- a/Formula/p/postgresql@16.rb
+++ b/Formula/p/postgresql@16.rb
@@ -114,7 +114,7 @@ class PostgresqlAT16 < Formula
   post_install_steps do
     mkdir_p "log", base: :var
     # Don't initialize database, it clashes when testing other PostgreSQL versions.
-    init_data_dir "postgresql@16", using: :postgresql_initdb, base: :var
+    init_data_dir "postgresql@16", using: :postgresql, base: :var
   end
 
   def postgresql_datadir

--- a/Formula/p/postgresql@17.rb
+++ b/Formula/p/postgresql@17.rb
@@ -119,13 +119,13 @@ class PostgresqlAT17 < Formula
     mkdir_p "log", base: :var
     # Manually link files from keg to non-conflicting versioned directories in HOMEBREW_PREFIX.
     # Retain existing real directories for extensions if directory structure matches
-    link_dir "include/postgresql", "include/{{name}}"
-    link_dir "lib/postgresql", "lib/{{name}}"
-    link_dir "share/postgresql", "share/{{name}}"
+    symlink_tree "include/postgresql", "include/{{formula_name}}"
+    symlink_tree "lib/postgresql", "lib/{{formula_name}}"
+    symlink_tree "share/postgresql", "share/{{formula_name}}"
     # Also link versioned executables
-    link_children "bin", suffix: "-{{version.major}}"
+    symlink_children "bin", suffix: "-{{version.major}}"
     # Don't initialize database, it clashes when testing other PostgreSQL versions.
-    init_data_dir name, using: :postgresql_initdb, base: :var
+    init_data_dir formula_name, using: :postgresql, base: :var
   end
 
   def postgresql_datadir

--- a/Formula/p/postgresql@18.rb
+++ b/Formula/p/postgresql@18.rb
@@ -121,13 +121,13 @@ class PostgresqlAT18 < Formula
     mkdir_p "log", base: :var
     # Manually link files from keg to non-conflicting versioned directories in HOMEBREW_PREFIX.
     # Retain existing real directories for extensions if directory structure matches
-    link_dir "include/postgresql", "include/{{name}}"
-    link_dir "lib/postgresql", "lib/{{name}}"
-    link_dir "share/postgresql", "share/{{name}}"
+    symlink_tree "include/postgresql", "include/{{formula_name}}"
+    symlink_tree "lib/postgresql", "lib/{{formula_name}}"
+    symlink_tree "share/postgresql", "share/{{formula_name}}"
     # Also link versioned executables
-    link_children "bin", suffix: "-{{version.major}}"
+    symlink_children "bin", suffix: "-{{version.major}}"
     # Don't initialize database, it clashes when testing other PostgreSQL versions.
-    init_data_dir name, using: :postgresql_initdb, base: :var
+    init_data_dir formula_name, using: :postgresql, base: :var
   end
 
   def postgresql_datadir

--- a/Formula/q/quictls.rb
+++ b/Formula/q/quictls.rb
@@ -106,7 +106,7 @@ class Quictls < Formula
   end
 
   post_install_steps do
-    symlink "{{etc}}/ca-certificates/cert.pem", "{{pkgetc}}/cert.pem", force: true
+    symlink "{{etc}}/ca-certificates/cert.pem", "{{pkgetc}}/cert.pem", overwrite: true
   end
 
   def caveats

--- a/Formula/s/sbtenv.rb
+++ b/Formula/s/sbtenv.rb
@@ -28,7 +28,7 @@ class Sbtenv < Formula
 
   # Var symlinks must be done in post install as bottling converts symlinks to real files
   post_install_steps do
-    symlink "{{prefix}}/default-plugins/sbt-install", "{{var}}/lib/sbtenv/plugins/sbt-install", force: true
+    symlink "{{prefix}}/default-plugins/sbt-install", "{{var}}/lib/sbtenv/plugins/sbt-install", overwrite: true
   end
 
   test do

--- a/Formula/s/scalaenv.rb
+++ b/Formula/s/scalaenv.rb
@@ -30,7 +30,7 @@ class Scalaenv < Formula
   end
 
   post_install_steps do
-    symlink "{{prefix}}/default-plugins/scala-install", "{{var}}/lib/scalaenv/plugins/scala-install", force: true
+    symlink "{{prefix}}/default-plugins/scala-install", "{{var}}/lib/scalaenv/plugins/scala-install", overwrite: true
   end
 
   test do

--- a/Formula/s/simple-scan.rb
+++ b/Formula/s/simple-scan.rb
@@ -48,7 +48,7 @@ class SimpleScan < Formula
 
   post_install_steps do
     compile_gsettings_schemas
-    gtk_update_icon_cache
+    update_gtk_icon_cache
   end
 
   test do

--- a/Formula/t/tronbyt-server.rb
+++ b/Formula/t/tronbyt-server.rb
@@ -32,11 +32,13 @@ class TronbytServer < Formula
 
   post_install_steps do
     mkdir_p "tronbyt-server", base: :var
-    write "tronbyt-server/.env", <<~EOS, base: :var
-      # Add application configuration here.
-      # For example:
-      # LOG_LEVEL=INFO
-    EOS
+    unless_path_exists "tronbyt-server/.env", base: :var do
+      write_file "tronbyt-server/.env", <<~EOS, base: :var
+        # Add application configuration here.
+        # For example:
+        # LOG_LEVEL=INFO
+      EOS
+    end
   end
 
   def caveats

--- a/Formula/v/vipsdisp.rb
+++ b/Formula/v/vipsdisp.rb
@@ -43,7 +43,7 @@ class Vipsdisp < Formula
 
   post_install_steps do
     compile_gsettings_schemas
-    gtk_update_icon_cache
+    update_gtk_icon_cache
   end
 
   test do

--- a/Formula/v/virt-manager.rb
+++ b/Formula/v/virt-manager.rb
@@ -111,7 +111,7 @@ class VirtManager < Formula
 
   post_install_steps do
     compile_gsettings_schemas
-    gtk_update_icon_cache
+    update_gtk_icon_cache
   end
 
   test do

--- a/Formula/w/webp-pixbuf-loader.rb
+++ b/Formula/w/webp-pixbuf-loader.rb
@@ -30,7 +30,7 @@ class WebpPixbufLoader < Formula
   end
 
   post_install_steps do
-    gdk_pixbuf_query_loaders
+    update_gdk_pixbuf_loaders_cache
   end
 
   test do

--- a/Formula/z/zenity.rb
+++ b/Formula/z/zenity.rb
@@ -40,7 +40,7 @@ class Zenity < Formula
   end
 
   post_install_steps do
-    gtk_update_icon_cache
+    update_gtk_icon_cache
   end
 
   test do


### PR DESCRIPTION
Fifty-three existing structured formulae should use the current shared
vocabulary while brew retains released aliases for compatibility.

- replace short file and link aliases with canonical operation names
- use context-specific tokens and service initialiser values
- update cache steps without changing behaviour
- depend on Homebrew/brew's matching
  `Align shared install step interfaces` change

Needs https://github.com/Homebrew/brew/pull/23193

AI disclosure: using OpenAI Codex 5.6 Sol max with local review and testing.