### PR TITLE
kuml 0.38.0 (new formula)

### DIFF
--- a/Formula/k/kuml.rb
+++ b/Formula/k/kuml.rb
@@ -1,0 +1,26 @@
+class Kuml < Formula
+  desc "Kotlin-native UML/SysML/C4 DSL — render, transform, generate diagrams"
+  homepage "https://kuml.dev"
+  url "https://github.com/kuml-dev/kUML/releases/download/v0.38.0/kuml-0.38.0.zip"
+  sha256 "9a1cda40742e61a5b89a162faab722ccdfacefcfd2a08614a4ed9e396dc128f5"
+  license "Apache-2.0"
+
+  depends_on "openjdk@21"
+
+  def install
+    # .bat launchers are meaningless on macOS/Linux, where Homebrew runs.
+    rm(Dir["bin/*.bat"])
+    libexec.install Dir["*"]
+    # Wraps the existing Gradle-generated launcher (bin/kuml, looks for
+    # JAVA_HOME or `java` on PATH) with an explicit JAVA_HOME pointing at
+    # the openjdk@21 keg, while still honouring HOMEBREW_JAVA_HOME if the
+    # user overrides it — the same idiom homebrew-core's own `gradle`
+    # formula uses for its Gradle-application-plugin bin/lib layout.
+    env = Language::Java.overridable_java_home_env("21")
+    (bin/"kuml").write_env_script libexec/"bin/kuml", env
+  end
+
+  test do
+    assert_match "Compiles kUML scripts", shell_output("#{bin}/kuml --help")
+  end
+end


### PR DESCRIPTION
kUML is an open-source (Apache-2.0) modelling tool that expresses UML 2.x, SysML 2, C4
and BPMN 2.0 as a type-safe Kotlin DSL, then renders/transforms/generates from it —
`kuml render diagram.kuml.kts --format svg` and similar. Homepage: https://kuml.dev,
source: https://github.com/kuml-dev/kUML.

This formula installs from `kuml-<version>.zip`, the plain Gradle `application`-plugin
distribution (`bin/kuml` + `lib/*.jar`, no bundled JRE) that kUML's release pipeline
already builds and publishes on every tag — separate from the self-contained,
jlink-bundled `kuml-runtime-*.zip` used by kUML's own tap
(`kuml-dev/homebrew-kuml`), which isn't eligible for core (platform/arch-specific
binary, not built from source or portable bytecode). This one is: an unmodified,
platform-independent Gradle distZip, `depends_on "openjdk@21"`, and the install method
mirrors homebrew-core's own `gradle` formula (same bin/lib layout) —
`libexec.install` + `Language::Java.overridable_java_home_env("21")` +
`write_env_script`.

One thing to flag proactively rather than wait for it to come up in review: the zip is
~150 MB / ~330 jars. kUML's CLI module shares its dependency tree with the rest of the
monorepo (some AI-provider SDKs, a couple of blockchain chain adapters, Compose
Multiplatform pieces used elsewhere in the project), so it's larger than a pure
diagram-rendering tool strictly needs. Happy to discuss whether that's acceptable or
whether upstream should split the CLI's dependencies down further before this is
merge-ready.

-----

<!-- Do not tick a checkbox if you haven't performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. Working with the maintainer of the `kuml` project, I (Claude, an Anthropic AI agent operating with the maintainer's explicit direction and review) drafted this formula end-to-end: identified that the project's own `homebrew-kuml` tap formula couldn't be upstreamed as-is (it installs a platform-specific, jlink-bundled runtime), found that the release pipeline already publishes a plain, portable `distZip` suitable for a `depends_on "openjdk@21"`-style formula, and modelled the install method on homebrew-core's own `gradle` formula (matching Gradle-application-plugin `bin`/`lib` layout). Manual verification performed before opening this PR: installed the formula locally (temporarily renamed to avoid colliding with the maintainer's existing tap installation), ran `brew audit --strict --online` and `brew style` (both clean), ran `brew test` (passing), inspected the generated launcher script by hand to confirm it resolves `JAVA_HOME` to the `openjdk@21` keg rather than a stray default `openjdk`, and ran `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source` per this template's own instructions.

-----
