### PR TITLE
lft: remove patch and update tarball

### DIFF
--- a/Formula/l/lft.rb
+++ b/Formula/l/lft.rb
@@ -2,7 +2,7 @@ class Lft < Formula
   desc "Layer Four Traceroute (LFT), an advanced traceroute tool"
   homepage "https://pwhois.org/lft/"
   url "https://pwhois.org/dl/index.who?file=lft-3.99.tar.gz"
-  sha256 "ede57f7782f3034267db654c56a95c43d342f4c00fe34ec234505a04e13b1291"
+  sha256 "f34707b543391eb887ba8479f7d2c2670bfefc3afb244dc5d34a2a41d7b317eb"
   license "VOSTROM"
 
   livecheck do
@@ -22,12 +22,6 @@ class Lft < Formula
   uses_from_macos "libpcap"
 
   def install
-    # FIXME: Drop pathwatch build references as its still testing and no usage in source files
-    inreplace "Makefile.in" do |s|
-      s.gsub! " lft_pathwatch.o", ""
-      s.gsub! " lft_pathwatch.h", ""
-    end
-
     args = %w[
       --disable-async-dns
       --disable-ncurses

--- a/Formula/l/lft.rb
+++ b/Formula/l/lft.rb
@@ -11,12 +11,13 @@ class Lft < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "c1ba17be6362157133e65a17b1f2d0216f2e5502e48af943b324583ea696b8a3"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "362b211ae4a1a8fec0bb127667355871fe6ee2f9b669cfe3672f9a040f4af2cb"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "172e828c28d5ff5b7b0058c86ecd5009fa090170737eabf0b716555c1daf8dd5"
-    sha256 cellar: :any_skip_relocation, sonoma:        "5de7a22f2afa631c3f46b47252eeb80753f5b70348c80bca8ba85d43c87e5a00"
-    sha256 cellar: :any,                 arm64_linux:   "ef6f383d4689cf6f2ef05c3eeb4c30e3dba3744ecf570b6dcd61db84911163f5"
-    sha256 cellar: :any,                 x86_64_linux:  "81fe8bb11d1638551327990c7e51d8248ba6c18e665c95a2ee043208f0c5b4d0"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "933eb55aebcd31bad7a92d7f66a16112fb29c210ee304c1a3f4da88613b21ebf"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "d06753c89b74b036d49a9fb3ff58bb0256ef5079f3e45da74ec26d01a6ef3986"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "c3ceb356cdbf4981bd828eb00ca62085bfaf85fa41f22bb0041f72e3a97383ad"
+    sha256 cellar: :any_skip_relocation, sonoma:        "875ac88eb54f3107af0c6a51fedfe79b8a10f392f29646e88c81289c3cc58384"
+    sha256 cellar: :any,                 arm64_linux:   "fd71aae2b9658b116d176f399a485fbe461c3c5393428ae1ced2b1dff3d9181e"
+    sha256 cellar: :any,                 x86_64_linux:  "47679beec08006969cbeb24e30c2499aca5dd94361debece13329e7adc7807d6"
   end
 
   uses_from_macos "libpcap"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Upstream update the tarball to fix makefile changes with the same version, so should update checksum amd remove patches

Through email, I receive this.
> Daeho, I’m sorry I didn’t update the latest 3.99 build from subversion on my end, it’s been updated now and I apologize. If you re-download it there should be no more Makefile errors. There’s no code changes so I didn’t bump the version (still 3.99), but this was missing a file from the build system in Makefile.in that points to a test harness. It’s corrected.
