### PR TITLE
alsa-lib: fix ALSA plugin support which impacts systems running PipeWire

### DIFF
--- a/Formula/a/alsa-lib.rb
+++ b/Formula/a/alsa-lib.rb
@@ -4,6 +4,7 @@ class AlsaLib < Formula
   url "https://www.alsa-project.org/files/pub/lib/alsa-lib-1.2.16.1.tar.bz2"
   sha256 "f740db7f488255944ffd4428416ee3390a96742856916433df468c281436480e"
   license all_of: ["LGPL-2.1-or-later", "GPL-2.0-or-later"]
+  revision 1
   compatibility_version 1
 
   livecheck do
@@ -18,10 +19,15 @@ class AlsaLib < Formula
 
   depends_on :linux
 
+  skip_clean "lib/alsa-lib"
+
   def install
     system "./configure", "--disable-silent-rules", *std_configure_args
     system "make", "install"
     prefix.install "aserver/COPYING" => "COPYING-aserver"
+
+    # Load plugins installed by other formulae, e.g. pipewire
+    lib.install_symlink HOMEBREW_PREFIX/"lib/alsa-lib"
   end
 
   test do
@@ -36,5 +42,7 @@ class AlsaLib < Formula
     C
     system ENV.cc, "test.c", "-L#{lib}", "-lasound", "-o", "test"
     system "./test"
+
+    assert_predicate lib/"alsa-lib", :symlink?
   end
 end


### PR DESCRIPTION
On systems using PipeWire (e.g. Fedora, Ubuntu 24.04+, etc), `alsa-lib` needs to communicate with the PipeWire server via the plugin provided by PipeWire. This is currently broken by default as `alsa-lib` expects plugins to be installed within same prefix which isn't possible in Homebrew.

Revision bumping as this will impact the majority of users based on analytics (i.e. ubuntu 24.04 is most installed while Fedora-based Bazzite is now the most installed non-ubuntu)

Fixes https://github.com/orgs/Homebrew/discussions/6973

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
