### PR TITLE
glibc: skip tests due to bubblewrap

### DIFF
--- a/Formula/g/glibc.rb
+++ b/Formula/g/glibc.rb
@@ -249,11 +249,17 @@ class Glibc < Formula
 
         # Avoid Intel CI runner timeout on tst-malloc-too-large-malloc-hugetlb2
         ENV["TIMEOUTFACTOR"] = "4" if Hardware::CPU.intel?
+
+        # Workaround to skip test failures seen when running in bubblewrap
+        xfail_tests = [
+          "test-xfail-tst-nss-files-hosts-long=yes", # error: tst-nss-files-hosts-long.c:36: ahostsv4 failed
+          "test-xfail-tst-setuid3=yes",              # runs setuid(0) expecting EPERM
+        ]
       end
 
       system "../configure", *args, "CFLAGS=#{cflags}"
       system "make", "all"
-      system "make", "check" if build.bottle?
+      system "make", "check", *xfail_tests if build.bottle?
       system "make", "install", "localedir=#{share}/locale"
       prefix.install_symlink "lib" => "lib64"
     end

--- a/Patches/glibc/2.39-test-fixes.patch
+++ b/Patches/glibc/2.39-test-fixes.patch
@@ -358,3 +358,78 @@ index 040cb8dd48..1b7ab4b495 100644
  
  __END_DECLS
  
+From 55873e86e1861ffe010a83455ac7eb5df239ec3e Mon Sep 17 00:00:00 2001
+From: Florian Weimer <fweimer@redhat.com>
+Date: Mon, 4 May 2026 17:18:38 +0200
+Subject: [PATCH] support: Improve tst-support_descriptors compatibility with
+ containers
+
+If /dev/null is bind-mounted, /dev and /dev/null are on different
+devices, so the expected failure has an additional line describe
+the device change.
+
+Reviewed-by: Carlos O'Donell <carlos@redhat.com>
+---
+ support/tst-support_descriptors.c | 41 +++++++++++++++++++++++++------
+ 1 file changed, 34 insertions(+), 7 deletions(-)
+
+diff --git a/support/tst-support_descriptors.c b/support/tst-support_descriptors.c
+index 97d7284c69..d25cb7d67a 100644
+--- a/support/tst-support_descriptors.c
++++ b/support/tst-support_descriptors.c
+@@ -128,21 +128,48 @@ test_run (void)
+   support_capture_subprocess_free (&proc);
+   free (expected);
+ 
+-  expected = xasprintf ("\nDifferences:\n"
+-                        "error: descriptor %d changed from \"/dev/null\""
+-                        " to \"/dev\"\n"
+-                        "error: descriptor %d changed ino ",
+-                        free_descriptor, free_descriptor);
+   good = good && !support_record_failure_is_failed ();
+   proc = support_capture_subprocess (&subprocess_changed_descriptor, NULL);
+   good = good && support_record_failure_is_failed ();
+   support_record_failure_reset (); /* Discard the reported error.  */
+   report_subprocess_output ("subprocess_changed_descriptor", &proc);
+-  TEST_VERIFY (strstr (proc.out.buffer, expected) != NULL);
++
++  expected = xasprintf ("\nDifferences:\n"
++                        "error: descriptor %d changed from \"/dev/null\""
++                        " to \"/dev\"\n"
++                        "error: descriptor %d changed ino ",
++                        free_descriptor, free_descriptor);
++  if (strstr (proc.out.buffer, expected) != NULL)
++    {
++      /* No change of device.  */
++      free (expected);
++    }
++  else
++    {
++      /* The device changed in addition to the inode number.  This
++         happens if /dev/null is bind-mounted from another file
++         system, so that /dev is on a difference device.  */
++      expected = xasprintf ("\nDifferences:\n"
++                            "error: descriptor %d changed from \"/dev/null\""
++                            " to \"/dev\"\n"
++                            "error: descriptor %d changed device ",
++                            free_descriptor, free_descriptor);
++      TEST_VERIFY (strstr (proc.out.buffer, expected) != NULL);
++      free (expected);
++
++      /* We assume that the inode number changes, although in theory
++         it is possible that the directory happens to have the same
++         inode number as the null device because it is on a different
++         file system.  */
++      expected = xasprintf ("\nerror: descriptor %d changed ino ",
++                            free_descriptor);
++      TEST_VERIFY (strstr (proc.out.buffer, expected) != NULL);
++      free (expected);
++    }
++
+   support_capture_subprocess_check (&proc, "subprocess_changed_descriptor",
+                                     0, sc_allow_stdout);
+   support_capture_subprocess_free (&proc);
+-  free (expected);
+ }
+ 
+ static int


### PR DESCRIPTION
~~Testing only PR to see if any `make check` failures happen in unchanged formula.~~

Some tests may be failing due to Linux sandbox.
- [x] nptl/tst-setuid3 - bwrap issue. will need to ignore failure
- [ ] nss/tst-nss-files-hosts-long - not entirely sure but may be sandbox related. Tried locally but test got skipped as unsupported from setup so can't debug further.
- [x] support/tst-support_descriptors - https://sourceware.org/git/?p=glibc.git;a=commit;h=55873e86e1861ffe010a83455ac7eb5df239ec3e

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
