### PR TITLE
advai-cli 1.0.10

### DIFF
--- a/Formula/a/advai-cli.rb
+++ b/Formula/a/advai-cli.rb
@@ -3,8 +3,8 @@ class AdvaiCli < Formula
 
   desc "CLI for managing skills and external CLIs"
   homepage "https://github.com/Advai-X/advai-cli"
-  url "https://files.pythonhosted.org/packages/89/94/d8326155c88e6995f722158407574fccc77a813fb41768d3e69ca09858e2/advai_cli-1.0.9.tar.gz"
-  sha256 "471a30bcfc9f3f1693eea612101b66e740282d3706f9ccafca9fe3af88543468"
+  url "https://files.pythonhosted.org/packages/32/24/f06412429212844c19320cc689e8859d744075a28db2732bf244d5e1a0d5/advai_cli-1.0.10.tar.gz"
+  sha256 "e91db8eba55f8e796c14f11a0482f6d073087ecf4bb332bccd5dd44727acc2ce"
   license "MIT"
 
   bottle do

--- a/Formula/a/advai-cli.rb
+++ b/Formula/a/advai-cli.rb
@@ -8,12 +8,12 @@ class AdvaiCli < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "f175083c56d4d999e7c72cecf4f316c761ac5166822de0569a9a655ff5b9b018"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "38a57a4241f7cce12ab71a117a245fefa938999085b8f5130f4f4a7aeec06b0d"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "2d7b9eeebfdf0caea36fc2469a3d2a1aed1b0c7747e5dc20371006b8827e05f1"
-    sha256 cellar: :any_skip_relocation, sonoma:        "486f4e5206d020c69c85e9cc81b2a7e1e47fd7ef82a8cf78f4b27daa84228080"
-    sha256 cellar: :any,                 arm64_linux:   "1859ff04bd34a8be7a0b47828bc85d8e6bce602c718722af8ce0b08dcb47bfa9"
-    sha256 cellar: :any,                 x86_64_linux:  "35c177f7a91fb53d3fda0e7cddf72afaf448504431343ab7223bcaf40ce3058a"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "9c476e0d353143e3a3f6d6b3a65d7c6bacf72f5ab7e52c331b92cf0ecfe76c4f"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "89b087e00e636718cce121a42ff4694504b7ae09f023a48deb9992b0d6b2ffc9"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "f97d6d9ca929b9869a8f5d48ea9521326a7c1228f47c13933aa13fbae6938fd7"
+    sha256 cellar: :any_skip_relocation, sonoma:        "3154a898e7fd76cba8a1afb6e9e846fecf93fedd84857e7eb139fd1528d76a0b"
+    sha256 cellar: :any,                 arm64_linux:   "e27ad395a7f0327778788cfcbd1e7dd81e566b9447e406c0feaba577607e6253"
+    sha256 cellar: :any,                 x86_64_linux:  "7040752e4410049d032bbf1052ecae815d5f6159666acbe95bd8a4cbb2a76701"
   end
 
   depends_on "python@3.14"


### PR DESCRIPTION
-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. I used AI to help prepare the version bump PR body and review the Homebrew formula diff. I manually verified the PyPI `1.0.10` source URL, the SHA256, the branch and commit naming, and the final formula contents before pushing.

-----

## What does this PR do?

Bumps `advai-cli` from `1.0.9` to `1.0.10`.

## Upstream

- Repository: https://github.com/Advai-X/advai-cli
- PyPI: https://pypi.org/project/advai-cli/
- Release: https://github.com/Advai-X/advai-cli/releases/tag/v1.0.10

## Notes

- Updates the PyPI sdist URL and SHA256 for `1.0.10`.
- Keeps the existing bottle block in place and leaves bottle regeneration to BrewTestBot.
- I have not completed a fresh local `brew install --build-from-source`, `brew test`, and `brew audit --strict` run on this machine before opening this PR.
