### PR TITLE
wild 0.9.0 (new formula)

### DIFF
--- a/Formula/w/wild.rb
+++ b/Formula/w/wild.rb
@@ -1,0 +1,46 @@
+class Wild < Formula
+  desc "Very fast linker for Linux"
+  homepage "https://github.com/wild-linker/wild"
+  url "https://github.com/wild-linker/wild/archive/refs/tags/0.9.0.tar.gz"
+  sha256 "f70ac025d158fd2c41be8f895a90a8f39b8b89fefbbb8ad5f45441f57b80156a"
+  license any_of: ["Apache-2.0", "MIT"]
+
+  depends_on "rust" => :build
+
+  on_macos do
+    depends_on "binutils" => :test
+  end
+
+  def install
+    system "cargo", "install", "--profile=dist", *std_cargo_args(path: "wild")
+    bin.install_symlink "wild" => "ld.wild"
+  end
+
+  test do
+    (testpath/"test.c").write <<~C
+      int main(void) { return 0; }
+    C
+
+    linker_flag = case ENV.compiler
+    when /^gcc(-(\d|1[0-5]))?$/
+      # https://github.com/wild-linker/wild#cc-autotools-cmake-meson-etc
+      (testpath/"wild").install_symlink bin/"wild" => "ld"
+      "-B#{testpath}/wild"
+    when :clang, /^gcc-\d{2,}$/ then "-fuse-ld=wild"
+    else odie "unexpected compiler"
+    end
+
+    extra_flags = %w[-fPIE -pie]
+    extra_flags += %w[--target=x86_64-unknown-linux-gnu -nostdlib] unless OS.linux?
+
+    system ENV.cc, linker_flag, *extra_flags, "test.c", "-o", "test"
+    if OS.linux?
+      system "./test"
+    else
+      assert_match "ELF 64-bit LSB pie executable, x86-64", shell_output("file test")
+    end
+
+    readelf = OS.mac? ? formula_opt_bin("binutils")/"readelf" : DevelopmentTools.locate("readelf")
+    assert_match "Linker: Wild ", shell_output("#{readelf} --string-dump .comment test")
+  end
+end

--- a/Formula/w/wild.rb
+++ b/Formula/w/wild.rb
@@ -5,6 +5,15 @@ class Wild < Formula
   sha256 "f70ac025d158fd2c41be8f895a90a8f39b8b89fefbbb8ad5f45441f57b80156a"
   license any_of: ["Apache-2.0", "MIT"]
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "bb3ffb44608992713f44ff108a8a3cec15b93959fe1d5827b89a98591bd7884e"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "6f59b64ae99386954ab2ca228e199a06530f3ee2ce8f6e48534e168d1f6fee77"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "4718b235c3a6e16953f7ed2bb6c0c42befa87f28a0fd1e7e40624e90b929cce3"
+    sha256 cellar: :any_skip_relocation, sonoma:        "29fe9023e19b56cbc7d11a5dc6d779c7dfbaaa2f664e487934d13018c62637ed"
+    sha256 cellar: :any,                 arm64_linux:   "f849805d7e65b683ca759ec9ab4876e33b8ed2fc478353056c1e41e6abfaf1bb"
+    sha256 cellar: :any,                 x86_64_linux:  "ec382a40a394d0fd320dee1cbec2eb7a44fffc609f29cb761692104080779c3c"
+  end
+
   depends_on "rust" => :build
 
   on_macos do


### PR DESCRIPTION
Another alternative ELF linker which GCC 16+ officially supports.

Test is mostly copied from `mold`. Added an extra `readelf` check, particularly since older GCC requires some extra work to use.

I didn't create an extra `ld` symlink as upstream seems to recommend creating a temporary one instead if needed (`mold` has one but as part of official build system). Symlink would also be installed into an arbitrary location so not as useful.

See https://github.com/wild-linker/wild/tree/main#cc-autotools-cmake-meson-etc for upstream documented way of using with older GCC:

> Or (especially useful for older GCC versions), create a symlink `ld` pointing to `wild` and pass the
> directory to GCC:
> 
> ```sh
> ln -s /usr/bin/wild /tmp/ld
> 
> export CFLAGS="${CFLAGS} -B/tmp"
> export CXXFLAGS="${CXXFLAGS} -B/tmp"
> export LDFLAGS="${LDFLAGS} -B/tmp"
> ```

Repology: https://repology.org/project/wild/versions

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
