### PR TITLE
pandoc: test if `-pie` works

### DIFF
--- a/Formula/p/pandoc.rb
+++ b/Formula/p/pandoc.rb
@@ -30,6 +30,29 @@ class Pandoc < Formula
   def install
     # Workaround to build aeson with GHC 9.14, https://github.com/haskell/aeson/issues/1155
     args = ["--allow-newer=base,containers,template-haskell"]
+    args << "--ghc-options=-pie" if OS.linux?
+
+    (buildpath/"cabal.project.local").write <<~EOS
+      -- Use split-sections to reduce binary sizes
+      if os(linux)
+        package *
+          split-sections: True
+
+      -- Allow building PIE on non-ARM Linux
+      if os(linux) && !arch(arm) && !arch(aarch64)
+        package *
+          ghc-options: -fPIC -fexternal-dynamic-refs
+
+      -- Avoid bundled libraries in packages
+      package direct-sqlite
+        flags: +systemlib
+
+      package persistent-sqlite
+        flags: +systemlib +use-pkgconfig
+
+      package system-libyaml
+        flags: +system-libyaml
+    EOS
 
     system "cabal", "v2-update"
     system "cabal", "v2-install", *args, *std_cabal_v2_args, "pandoc-cli"


### PR DESCRIPTION
Looking into this to add to std_cabal_v2_args for security hardening. aarch64 is position independent but x86_64 may fail if GHC static libraries weren't built with `-fPIC`.

Though I think GCC does default to `-fPIE` and `-fPIC` so could work.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
