### PR TITLE
virtiofsd 1.14.0 (new formula)

### DIFF
--- a/Formula/v/virtiofsd.rb
+++ b/Formula/v/virtiofsd.rb
@@ -1,0 +1,36 @@
+class Virtiofsd < Formula
+  desc "Vhost-user virtio-fs device backend written in Rust"
+  homepage "https://gitlab.com/virtio-fs/virtiofsd"
+  url "https://gitlab.com/virtio-fs/virtiofsd/-/archive/v1.14.0/virtiofsd-v1.14.0.tar.bz2"
+  sha256 "0646c2cd5a733dd411afb49be8eff7f0a10bb4a286f75b822961e07ea6a654af"
+  license all_of: ["Apache-2.0", "BSD-3-Clause"]
+
+  depends_on "rust" => :build
+  depends_on "libcap-ng"
+  depends_on "libseccomp"
+  depends_on :linux
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    require "socket"
+
+    assert_match version.to_s, shell_output("#{bin}/virtiofsd --version")
+
+    sock = testpath/"virtiofsd.sock"
+    shared = testpath/"shared"
+    shared.mkpath
+
+    pid = spawn(bin/"virtiofsd", "--shared-dir", shared, "--socket-path", sock,
+                "--sandbox", "none", "--log-level", "off")
+    begin
+      sleep 2
+      assert_predicate sock, :socket?
+    ensure
+      Process.kill("TERM", pid)
+      Process.wait(pid)
+    end
+  end
+end

--- a/Formula/v/virtiofsd.rb
+++ b/Formula/v/virtiofsd.rb
@@ -5,6 +5,11 @@ class Virtiofsd < Formula
   sha256 "0646c2cd5a733dd411afb49be8eff7f0a10bb4a286f75b822961e07ea6a654af"
   license all_of: ["Apache-2.0", "BSD-3-Clause"]
 
+  bottle do
+    sha256 cellar: :any, arm64_linux:  "af1aab9fc68a2784268e0ecb254f90dbfdb9800a7df0b92b46b13dd45f6fda26"
+    sha256 cellar: :any, x86_64_linux: "8bd01117ad94d525b5ca73fba37f4bad0d4d2c04569a4d0a469aef5b14428291"
+  end
+
   depends_on "rust" => :build
   depends_on "libcap-ng"
   depends_on "libseccomp"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

DeepSeek V4 Flash was used to generate the `test` block (specifically the part which tests the socket stuff). I have manually verified the changes by comparing the socket reads/writes to the specifications of the vhost-user protocol.

-----
