### PR TITLE
apache-polaris: update livecheck

### DIFF
--- a/Formula/a/apache-polaris.rb
+++ b/Formula/a/apache-polaris.rb
@@ -7,7 +7,7 @@ class ApachePolaris < Formula
 
   livecheck do
     url "https://polaris.apache.org/downloads/"
-    regex(/href=.*?apache-polaris-(\d+(?:\.\d+)+)-incubating\.t/i)
+    regex(%r{href=.*?/releases/v?(\d+(?:\.\d+)+)/?["' >]}i)
   end
 
   bottle do


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

The `livecheck` block for `apache-polaris` checks the first-party download page but it no longer directly links to tarball links. Instead, the page links to separate release pages and those pages link to the download files, so livecheck gives an "Unable to get versions" error. This updates the `livecheck` block to match the version from the release URLs on the page.

For what it's worth, 1.6.0 is the newest version but the build fails (the formula will need some changes), so I'm only doing this as a `livecheck` block update and the formula update can be handled separately.