### PR TITLE
detekt: update livecheck

### DIFF
--- a/Formula/d/detekt.rb
+++ b/Formula/d/detekt.rb
@@ -6,7 +6,7 @@ class Detekt < Formula
   license "Apache-2.0"
 
   livecheck do
-    url :homepage
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

The homepage for `detekt` was changed a month ago but the `livecheck` block was relying on the homepage being the GitHub repository URL. This `livecheck` block was added several years ago at a time when the formula used a non-GitHub `stable` URL but it wasn't updated to use `url :stable` when the `stable` URL was switched to GitHub, so this check broke when the homepage changed. This updates the check to use `url :stable`, which fixes the "Unable to get versions" error.