### PR TITLE
advai-cli 1.0.11

### DIFF
--- a/Formula/a/advai-cli.rb
+++ b/Formula/a/advai-cli.rb
@@ -3,8 +3,8 @@ class AdvaiCli < Formula
 
   desc "CLI for managing skills and external CLIs"
   homepage "https://github.com/Advai-X/advai-cli"
-  url "https://files.pythonhosted.org/packages/32/24/f06412429212844c19320cc689e8859d744075a28db2732bf244d5e1a0d5/advai_cli-1.0.10.tar.gz"
-  sha256 "e91db8eba55f8e796c14f11a0482f6d073087ecf4bb332bccd5dd44727acc2ce"
+  url "https://files.pythonhosted.org/packages/9d/3f/de8343b82c6f5a25ce311c8f356a06f016e557823918610b2e016d1d612a/advai_cli-1.0.11.tar.gz"
+  sha256 "b1d37bbb1d34b81c2104cbcb2f94d31db0945ecc5309b1a8d0642738fe222009"
   license "MIT"
 
   bottle do


### PR DESCRIPTION
-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. I used AI to help prepare the version bump PR body and review the Homebrew formula diff. I manually verified the PyPI `1.0.11` source URL, the SHA256, the branch and commit naming, and the final formula contents before pushing.

-----

## What does this PR do?

Bumps `advai-cli` from `1.0.10` to `1.0.11`.

## Upstream

- Repository: https://github.com/Advai-X/advai-cli
- PyPI: https://pypi.org/project/advai-cli/
- Release: https://github.com/Advai-X/advai-cli/releases/tag/v1.0.11

## Notes

- Updates the PyPI sdist URL and SHA256 for `1.0.11`.
- Keeps the existing bottle block in place and leaves bottle regeneration to BrewTestBot.
- I have not completed a fresh local `brew install --build-from-source`, `brew test`, and `brew audit --strict` run on this machine before opening this PR.
