### PR TITLE
exiftool: update livecheck

### DIFF
--- a/Formula/e/exiftool.rb
+++ b/Formula/e/exiftool.rb
@@ -14,7 +14,8 @@ class Exiftool < Formula
 
   livecheck do
     url "https://exiftool.sourceforge.net/history.html"
-    regex(/production release is.*?href=.*?Image[._-]ExifTool[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/production\s+release\s+is.*?href=.*?Image[._-]ExifTool[._-]v?(\d+(?:\.\d+)+)\.t/im)
+    strategy :page_match
   end
 
   bottle do


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

The `livecheck` block for `exiftool` is failing with an "Unable to get versions" error, as livecheck applies the `Sourceforge` strategy to the `url` and fails. This adds `strategy :page_match`, to override the default strategy for the `url`. Besides that, this updates the regex to use `\s+` instead of explicit spaces and to use the `m` flag, as this text could be broken across multiple lines and we would need `.*?` to be able to match newlines.