### PR TITLE
ffmpeg@2.8: update livecheck

### DIFF
--- a/Formula/f/ffmpeg@2.8.rb
+++ b/Formula/f/ffmpeg@2.8.rb
@@ -10,7 +10,7 @@ class FfmpegAT28 < Formula
   revision 8
 
   livecheck do
-    url "https://ffmpeg.org/download.html"
+    url "https://ffmpeg.org/olddownload.html"
     regex(/href=.*?ffmpeg[._-]v?(2\.8(?:\.\d+)*)\.t/i)
   end
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

The `livecheck` block for `ffmpeg@2.8` checks the first-party download page but it produces an "Unable to get versions" error, as there isn't a 2.8 version on the page anymore. The latest 2.8 version is only on the "Old releases" page (https://ffmpeg.org/olddownload.html) and that page clearly states, "These releases are not actively maintained, and their use is discouraged." Version 2.8.22 was released on 2023-10-29 and it seems unlikely that there will be a new version before this formula is disabled but there's no harm in continuing to check, so this updates the `livecheck` block `url` to the "Old releases" page.