### PR TITLE
goimapnotify: update urls

### DIFF
--- a/Formula/g/goimapnotify.rb
+++ b/Formula/g/goimapnotify.rb
@@ -1,10 +1,21 @@
 class Goimapnotify < Formula
   desc "Execute scripts on IMAP mailbox changes using IDLE"
-  homepage "https://gitlab.com/shackra/goimapnotify"
-  url "https://gitlab.com/shackra/goimapnotify/-/archive/2.5.6/goimapnotify-2.5.6.tar.bz2"
-  sha256 "d0e9b80a0284ad19ad94103f4c5be7004a6921b0b7fc9981e07094eaf74ca16b"
+  homepage "https://radicle.network/nodes/jardin.jorgearaya.dev/rad:z39RJHSHs166S5kr8Qstj6kd1LFah"
+  url "https://jardin.jorgearaya.dev/z39RJHSHs166S5kr8Qstj6kd1LFah.git",
+      tag:      "2.5.7",
+      revision: "90e338b6fa8606bace92b3fb230f9e8fa81e8faf"
   license "GPL-3.0-or-later"
-  head "https://gitlab.com/shackra/goimapnotify.git", branch: "master"
+  head "https://jardin.jorgearaya.dev/z39RJHSHs166S5kr8Qstj6kd1LFah.git", branch: "master"
+
+  livecheck do
+    url "https://jardin.jorgearaya.dev/api/v1/repos/rad%3Az39RJHSHs166S5kr8Qstj6kd1LFah/remotes"
+    regex(/v?(\d+(?:\.\d+)+)$/i)
+    strategy :json do |json, regex|
+      json.filter_map do |item|
+        item["refs"]&.keys&.filter_map { |tag| tag[regex, 1] }
+      end.flatten
+    end
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "f95781ffbd87f18943ee5e89a71a16f54abf0369714bd772b7a1d82402d99dbb"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

The `goimapnotify` formula was added two weeks ago but a few days ago (2026-07-16) upstream updated the README to state that the GitLab repository is only a backup mirror and that the canonical repository is on Radicle. In the process, they appear to have deleted all tags from the GitLab repository, so the tag archive in the `stable` URL no longer works (it returns a 404 (Not Found) response).

This is an attempt to update the formula to use the Radicle repository but it's currently failing with a "fatal: Remote branch 2.5.6 not found in upstream origin" error when running `git clone --branch 2.5.6` during installation. Similarly, I've set up the `livecheck` block to check the "remotes" API endpoint, as `git ls-remote --tags` doesn't return anything for this repository (presumably due to the same issue).

I'm not sure if we can support a Radicle repository (or maybe this is just an issue with this node) but this is a draft for the sake of discussion. If we can't work through the technical issues, then we can simply deprecate or disable this formula.