### PR TITLE
mupdf: update mujs resource livecheck

### DIFF
--- a/Formula/m/mupdf.rb
+++ b/Formula/m/mupdf.rb
@@ -56,8 +56,11 @@ class Mupdf < Formula
     url "https://mujs.com/downloads/mujs-1.3.8.tar.gz"
     sha256 "506d34882f2620a2fdeb6db63dbb7a8ffd98f417689d8f3c84f2feac275e39a9"
 
+    # Resource `livecheck` blocks don't support package references (yet), so we
+    # can't use `formula "mujs"` here.
     livecheck do
-      "mujs"
+      url "https://mujs.com/downloads/"
+      regex(/href=.*?mujs[._-]v?(\d+(?:\.\d+)+)\.t/i)
     end
   end
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

The `livecheck` block in the `mujs` resource in the `mupdf` formula simply contains the text "mujs", which doesn't do anything and predictably leads to an "Unable to get versions" error for the resource. Presumably, this was intended to be `formula "mujs"` but `livecheck` blocks in resources don't support formula/cask references yet (only the special `formula :parent` reference).

This addresses the issue by updating the `mujs` resource `livecheck` block to duplicate the `mujs` formula's `livecheck` block for now.