### PR TITLE
ncview: update livecheck

### DIFF
--- a/Formula/n/ncview.rb
+++ b/Formula/n/ncview.rb
@@ -6,8 +6,10 @@ class Ncview < Formula
   license "GPL-3.0-only"
   revision 1
 
+  # The homepage typically links to the latest tarball but they sometimes
+  # forget, so we check the directory listing page for now.
   livecheck do
-    url :homepage
+    url "https://cirrus.ucsd.edu/~pierce/ncview/"
     regex(/href=.*?ncview[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

The `livecheck` block for `ncview` checks the homepage but it returns an "Unable to get versions" error because upstream forgot to create a link to the latest tarball (i.e., there's only "Download the source for version 2.1.11 (updated Nov 26, 2024)" text but no link). This updates the `livecheck` block for now to check the directory listing page where the `stable` tarball is found.