### PR TITLE
ompl: update livecheck

### DIFF
--- a/Formula/o/ompl.rb
+++ b/Formula/o/ompl.rb
@@ -11,7 +11,7 @@ class Ompl < Formula
   # isn't a reliable indicator of the latest version on this repository.
   livecheck do
     url "https://ompl.kavrakilab.org/download.html"
-    regex(%r{href=.*?/ompl/ompl/archive/v?(\d+(?:\.\d+)+)\.t}i)
+    regex(/href=.*?ompl[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

The `livecheck` block for `ompl` checks the first-party download page but it's currently returning an "Unable to get versions" error, as upstream now links to a tarball from GitHub and the URL has a different format that the regex doesn't match. This updates the regex to match the version from the current tarball URL on the page.

For what it's worth, the newest version is 2.0.1 but it's a major version and may involve some notable changes to the formula, so I've simply updated the `livecheck` block here.