### PR TITLE
orientdb 3.2.55

### DIFF
--- a/Formula/o/orientdb.rb
+++ b/Formula/o/orientdb.rb
@@ -1,17 +1,13 @@
 class Orientdb < Formula
   desc "Graph database"
   homepage "https://orientdb.dev"
-  url "https://search.maven.org/remotecontent?filepath=com/orientechnologies/orientdb-community/3.2.53/orientdb-community-3.2.53.zip"
-  sha256 "d6c9f225849b738fa2f10df78fd82887676717a6692e87e5391821018e060503"
+  url "https://search.maven.org/remotecontent?filepath=com/orientechnologies/orientdb-community/3.2.55/orientdb-community-3.2.55.zip"
+  sha256 "3486b70d5013d961e272e0c0d681cf85dd8df6b23c028e0e671c246097fdf3f1"
   license "Apache-2.0"
 
-  # The GitHub release description contains links to files on Maven.
   livecheck do
-    url :homepage
-    regex(/orientdb-community[._-]v?(\d+(?:\.\d+)+)\.zip/i)
-    strategy :github_latest do |json, regex|
-      json["body"]&.scan(regex)&.map { |match| match[0] }
-    end
+    url "https://orientdb.dev/downloads/"
+    regex(/href=.*?orientdb-community[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 
   bottle do

--- a/Formula/o/orientdb.rb
+++ b/Formula/o/orientdb.rb
@@ -11,7 +11,7 @@ class Orientdb < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "7d7746f73ad50077d28d7379fdc3676411a52cc6f816776b0177f947b48815d9"
+    sha256 cellar: :any_skip_relocation, all: "af6e499bb0fd20f689e22386151c9193afbae03c97b6565516d4cd9b92780f29"
   end
 
   depends_on "maven" => :build


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

`orientdb` is autobumped but the workflow failed to update to version 3.2.55 because the `livecheck` block was returning an "Unable to get versions" error, as the `GithubLatest` strategy doesn't apply to the updated homepage URL. This updates the version and modifies the `livecheck` block to check the first-party download page, which links to the `stable` archive.