### PR TITLE
kubernetes-cli@1.32, kubernetes-cli@1.33: remove livecheck

### DIFF
--- a/Formula/k/kubernetes-cli@1.32.rb
+++ b/Formula/k/kubernetes-cli@1.32.rb
@@ -6,11 +6,6 @@ class KubernetesCliAT132 < Formula
       revision: "6172d7357c6287643350a4fc7e048f24098f2a1b"
   license "Apache-2.0"
 
-  livecheck do
-    url :stable
-    regex(/^v?(1\.32(?:\.\d+)+)$/i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "1480fcc3b7de658c55b7e22009f52567c2ace6fe2b85c4d4b50596e7c69a658b"
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "e4b4394e40d4cbba21b447ba8cf06cda90db26fe10281f2a4feec0f3301e7b5e"

--- a/Formula/k/kubernetes-cli@1.33.rb
+++ b/Formula/k/kubernetes-cli@1.33.rb
@@ -6,11 +6,6 @@ class KubernetesCliAT133 < Formula
       revision: "c029d48d28322ad0369aabdcf8b656fd3195cd30"
   license "Apache-2.0"
 
-  livecheck do
-    url :stable
-    regex(/^v?(1\.33(?:\.\d+)+)$/i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "42a09e00b253c7edb43a8276717773865ea7f0b42f6fbf8d3ef1a9b0c6b8e8a2"
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "11f809ffb9c2656f1fa11acadf1a105be7211ee7a5c7b48da7f90e2d8b7d6bd5"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

`kubernetes-cli@1.32` reached end of life (EOL) on 2026-02-28 and `kubernetes-cli@1.33` reached EOL on 2026-06-28 and these formulae are now disabled. This removes their `livecheck` blocks, so they will be automatically skipped as disabled.