### PR TITLE
ghc: build with -fPIC

### DIFF
--- a/Formula/g/ghc.rb
+++ b/Formula/g/ghc.rb
@@ -149,6 +149,10 @@ class Ghc < Formula
       --docs=no-sphinx-html
       --docs=no-sphinx-pdfs
     ]
+    # Build PIC so static libraries can be used to build PIE in dependents. This is the default on ARM:
+    # https://gitlab.haskell.org/ghc/ghc/-/blob/ghc-9.14.1-release/compiler/GHC/Driver/DynFlags.hs#L1275-1300
+    hadrian_args << "*.*.ghc.*.opts += -fPIC -fexternal-dynamic-refs" if OS.linux? && !Hardware::CPU.arm?
+
     # Let hadrian handle its own parallelization
     ENV.deparallelize { system "hadrian/build", "install", *hadrian_args }
 

--- a/Formula/g/ghc.rb
+++ b/Formula/g/ghc.rb
@@ -15,12 +15,13 @@ class Ghc < Formula
   end
 
   bottle do
-    sha256 cellar: :any, arm64_tahoe:   "3aa7ca72a5dba98f0f1f0ed5273f7465dfb14d5a54d8d08ec33bbe2a388fe3bf"
-    sha256 cellar: :any, arm64_sequoia: "d3afc8f7d175aae4d4087eb760b981ffed1a47bcc7fed0d094d25d9926d251fc"
-    sha256 cellar: :any, arm64_sonoma:  "74f1eda05d5796e81eba49f0598e9dbed4d7757362bdd380dc3e690245353394"
-    sha256 cellar: :any, sonoma:        "ed24dd4a13fe0bf6eb58d72d2c0ea32644989cbaa47cc3e674345e06d2d012ce"
-    sha256               arm64_linux:   "f4d2e86164d8462309958ceaf78f10c0707ee9899653c7cf315af9ccdf8588a3"
-    sha256               x86_64_linux:  "ab8e3190b14771a1ab62d0fd003965a31efd6ae5ca42e3a02ebceb63e302c4fb"
+    rebuild 1
+    sha256 cellar: :any, arm64_tahoe:   "69ab0221afe0fa73b2819d8e288a60e5ce6e00bcdf6c933c9ec4cc306cabd448"
+    sha256 cellar: :any, arm64_sequoia: "a129e3570a5e3e094260dd7a8a50f479b6039144bce68b9dc7926e9a051208ec"
+    sha256 cellar: :any, arm64_sonoma:  "b0a5f9c9f48feb6eb68343278546b186d360e9a0d4bcc6aa88ad261356b400a9"
+    sha256 cellar: :any, sonoma:        "bae28c63fc0fc65b667bf86b1fa87554ac0c83101c4f7e0bbec51e31c2106666"
+    sha256               arm64_linux:   "d6bf3ff37a93a44eafb83b7f52cf392ddf820d793a02135261e46a94edf764ff"
+    sha256               x86_64_linux:  "03fbc89d0320781df97cb5745a397cda9207576b1f950342bb7c8a38197dc4c6"
   end
 
   depends_on "autoconf" => :build


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

This is similar to option available at nix[^1]
```nix
    lib.optionals enableRelocatedStaticLibs [
      "*.*.ghc.*.opts += -fPIC -fexternal-dynamic-refs"
```

The main advantage is we can improve ELF binary security by building PIE which enables ASLR and also allows enabling full RELRO. Disadvantage is a performance cost (similar to cost of dynamic linkage).

Linux distros don't need this as they can go the dynamic linking route and essentially package all of Hackage. This won't work in Homebrew without major changes and increased maintenance cost.

---

Hadrian argument explanation[^2]:
- For "all build stages", "all packages", "all GHC commands", pass options:
  - [-fPIC](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/phases.html#ghc-flag-fPIC)
  - [-fexternal-dynamic-refs](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/phases.html#ghc-flag-fexternal-dynamic-refs)
- These options are what upstream uses by default on Linux platforms where PIC is default (e.g. arm64): https://gitlab.haskell.org/ghc/ghc/-/blob/ghc-9.14.1-release/compiler/GHC/Driver/DynFlags.hs#L1275-1300

[^1]: https://github.com/NixOS/nixpkgs/blob/465ae3ed88621e0b672fa33615ac0b4685eaa2c4/pkgs/development/compilers/ghc/common-hadrian.nix#L401-L402
[^2]: https://gitlab.haskell.org/ghc/ghc/blob/master/hadrian/doc/user-settings.md#key--value-and-key--value-style-settings