### PR TITLE
oterm: fix startup crash with cohere 7.0.7

### DIFF
--- a/Formula/o/oterm.rb
+++ b/Formula/o/oterm.rb
@@ -6,7 +6,7 @@ class Oterm < Formula
   url "https://files.pythonhosted.org/packages/1d/19/23455c1d66786bca4d4c35fec11dfd92cd1b7eaad53d04ef4465b39950ca/oterm-0.20.0.tar.gz"
   sha256 "0974b01d228124426dd9178ff5e2682d4317f3814d927e385ae3389e7ad46e3d"
   license "MIT"
-  revision 1
+  revision 2
 
   bottle do
     sha256 cellar: :any, arm64_tahoe:   "f7a07744f9c438189db1d305726dd112ca258e6d6516a795c35a4eb25f55f4b3"
@@ -111,8 +111,8 @@ class Oterm < Formula
   end
 
   resource "cohere" do
-    url "https://files.pythonhosted.org/packages/32/03/66c95f6e8e2249e72510c8843095dc0c0c83fe432de9f3ef6e3eb22575f7/cohere-7.0.6.tar.gz"
-    sha256 "0b83763b6d8fd0151ab0f46d66e12b00e60a11fbe504d5c908fb3e355dff5f1b"
+    url "https://files.pythonhosted.org/packages/23/d7/3706b69660b24f82e530b31d74956a2e717de09cebce3a538429fef17698/cohere-7.0.7.tar.gz"
+    sha256 "a4be903dbe5800ed27430d08896dbd92f854f35ca288764b6459bd5874c50730"
   end
 
   resource "distro" do

--- a/Formula/o/oterm.rb
+++ b/Formula/o/oterm.rb
@@ -9,12 +9,12 @@ class Oterm < Formula
   revision 2
 
   bottle do
-    sha256 cellar: :any, arm64_tahoe:   "f7a07744f9c438189db1d305726dd112ca258e6d6516a795c35a4eb25f55f4b3"
-    sha256 cellar: :any, arm64_sequoia: "50781df875004b3aefe6f027785504f2f7ff51b9dea8ad485db3ad4599b7aa16"
-    sha256 cellar: :any, arm64_sonoma:  "b10207faa258e54c486f747eb8b97a769fcb64fd18562a415ca062ecb82b4ede"
-    sha256 cellar: :any, sonoma:        "9a4af994ad22cf8b9859baf5ffe4a3151ef8bf68b1b05bf7af041ce0a316d0f4"
-    sha256 cellar: :any, arm64_linux:   "9461e93a15a96e635e43cec2f22549ae3b5ed522f8dde11221137be70ceaa291"
-    sha256 cellar: :any, x86_64_linux:  "c4bc71a3fc67ce2e3062951f8c6f9e6a170eac9ba2be3a2ed972d8af7b2c2718"
+    sha256 cellar: :any, arm64_tahoe:   "58d2034ed936ff64d154fa3d16ce541a1133b66f47c8bcfe52a4cdb8c59cd810"
+    sha256 cellar: :any, arm64_sequoia: "2905055e7cd9c3cb4b36fe301f033449ad46fa922b11ab67f9101d7eb2739fd4"
+    sha256 cellar: :any, arm64_sonoma:  "aae8f9d5849ed6cfe35060963df15a0c880617449438036d2b277b3511b7a6ee"
+    sha256 cellar: :any, sonoma:        "6f7586f05429ce4f16f4713c48d8223a9d00ccc3d5526a6b36af1db2046bf760"
+    sha256 cellar: :any, arm64_linux:   "fd00fd67ab6c80fe167c876082de10fd5beafadfe8a7895ac191a8465382184d"
+    sha256 cellar: :any, x86_64_linux:  "37624244a9a97d27955cdd4ea9defd7386c60092acd16f51864d21c05c210ad9"
   end
 
   depends_on "pkgconf" => :build


### PR DESCRIPTION
cohere 7.0.6 removed `TextAssistantMessageV2ContentOneItem`, which pydantic-ai imports at startup; 7.0.7 restores it.

Closes #294674

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Issue is investigated by Claude and manually checked after that.

-----
