### PR TITLE
deepline 0.1.266 (new formula)

### DIFF
--- a/Formula/d/deepline.rb
+++ b/Formula/d/deepline.rb
@@ -5,6 +5,15 @@ class Deepline < Formula
   sha256 "f11e9b78106858b6082eef3f26baedb084e2c37736144c3556d715c789a22961"
   license "MIT"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "7a44043854b3126a70486934b14585cdacb6c9d3a8fa0b1e7757bbe53b85391b"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "7a44043854b3126a70486934b14585cdacb6c9d3a8fa0b1e7757bbe53b85391b"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "7a44043854b3126a70486934b14585cdacb6c9d3a8fa0b1e7757bbe53b85391b"
+    sha256 cellar: :any_skip_relocation, sonoma:        "a360f15ab2c78a0b8161a923e858520e154e765f72ac5436a4af8dce2dfaac90"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "dfe0d97537fb45f27f4a9994c1ff8497f91394444556883017f90f7a7e0db9d0"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c7a2a74b58b9589db6f33158267275db1bdb9dd469b1d9562b6257f39ed80df8"
+  end
+
   depends_on "node"
 
   def install

--- a/Formula/d/deepline.rb
+++ b/Formula/d/deepline.rb
@@ -1,0 +1,19 @@
+class Deepline < Formula
+  desc "CLI for Deepline data enrichment and durable plays"
+  homepage "https://code.deepline.com"
+  url "https://registry.npmjs.org/deepline/-/deepline-0.1.266.tgz"
+  sha256 "f11e9b78106858b6082eef3f26baedb084e2c37736144c3556d715c789a22961"
+  license "MIT"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink libexec.glob("bin/*")
+  end
+
+  test do
+    assert_match '"status": "not connected"',
+      shell_output("#{bin}/deepline auth status --auth-scope folder")
+  end
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI assisted with the formula and PR text. I manually verified the formula's Ruby syntax and ran `deepline@0.1.266 auth status --auth-scope folder` in an empty home directory with no Deepline API key; it returned the expected `not connected` status.

Replacement for #294875, whose PR record was pinned to an invalid commit after a history-repair force-push.

Formula: `deepline`.

-----
