### PR TITLE
humanbound 2.7.0 (new formula)

### DIFF
--- a/Formula/h/humanbound.rb
+++ b/Formula/h/humanbound.rb
@@ -1,0 +1,142 @@
+class Humanbound < Formula
+  include Language::Python::Virtualenv
+
+  desc "Adversarial security testing engine, SDK, and CLI for AI agents"
+  homepage "https://docs.humanbound.ai/"
+  url "https://files.pythonhosted.org/packages/02/61/bb9cb8753c0cde98c6e5ab7307324ba414ccd5bd874206192e570bd9fd7f/humanbound-2.7.0.tar.gz"
+  sha256 "7876689210a9772eca0be3519d79cf99c1109bbf255b4d13dd9a3e54192ddacc"
+  license "Apache-2.0"
+
+  depends_on "certifi" => :no_linkage
+  depends_on "libyaml"
+  depends_on "pydantic" => :no_linkage
+  depends_on "python@3.14"
+
+  pypi_packages exclude_packages: %w[certifi pydantic]
+
+  resource "anyio" do
+    url "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz"
+    sha256 "cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f"
+  end
+
+  resource "backoff" do
+    url "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz"
+    sha256 "03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba"
+  end
+
+  resource "charset-normalizer" do
+    url "https://files.pythonhosted.org/packages/bd/2a/23f34ec9d04624958e137efdc394888716353190e75f25dd22c7a2c7a8aa/charset_normalizer-3.4.9.tar.gz"
+    sha256 "673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b"
+  end
+
+  resource "click" do
+    url "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz"
+    sha256 "9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6"
+  end
+
+  resource "distro" do
+    url "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz"
+    sha256 "2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed"
+  end
+
+  resource "h11" do
+    url "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz"
+    sha256 "4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"
+  end
+
+  resource "httpcore" do
+    url "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz"
+    sha256 "6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"
+  end
+
+  resource "httpx" do
+    url "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz"
+    sha256 "75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"
+  end
+
+  resource "idna" do
+    url "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz"
+    sha256 "ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848"
+  end
+
+  resource "markdown-it-py" do
+    url "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz"
+    sha256 "04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49"
+  end
+
+  resource "mdurl" do
+    url "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz"
+    sha256 "bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"
+  end
+
+  resource "posthog" do
+    url "https://files.pythonhosted.org/packages/36/f0/3af875ac3fd5863ed4874c9618d85eab3f7fd24b395827d99da0ef90aca6/posthog-7.28.0.tar.gz"
+    sha256 "9e048dee58f27373db622c0744be30c1a2b7f1df31049956d6341c9646fb3833"
+  end
+
+  resource "pygments" do
+    url "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz"
+    sha256 "6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"
+  end
+
+  resource "pyperclip" do
+    url "https://files.pythonhosted.org/packages/e8/52/d87eba7cb129b81563019d1679026e7a112ef76855d6159d24754dbd2a51/pyperclip-1.11.0.tar.gz"
+    sha256 "244035963e4428530d9e3a6101a1ef97209c6825edab1567beac148ccc1db1b6"
+  end
+
+  resource "pyyaml" do
+    url "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz"
+    sha256 "d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f"
+  end
+
+  resource "requests" do
+    url "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz"
+    sha256 "f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed"
+  end
+
+  resource "rich" do
+    url "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz"
+    sha256 "edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36"
+  end
+
+  resource "urllib3" do
+    url "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz"
+    sha256 "231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"
+  end
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    require "json"
+
+    assert_match version.to_s, shell_output("#{bin}/hb --version")
+
+    # reading results with none present must fail cleanly
+    output = shell_output("#{bin}/hb logs 2>&1", 1)
+    assert_match "No local test results", output
+
+    # starting a scan with no LLM provider configured must fail as expected
+    (testpath/"bot.json").write <<~EOS
+      {"streaming": null, "chat_completion": {"endpoint": "http://127.0.0.1:9/chat", "headers": {}, "payload": {"content": "$PROMPT"}}}
+    EOS
+    output = shell_output("#{bin}/hb test --local --endpoint bot.json 2>&1", 2)
+    assert_match "No LLM provider configured", output
+
+    # config round-trip: writes and reads back ~/.humanbound/config.yaml
+    system bin/"hb", "config", "set", "provider", "ollama"
+    assert_match "ollama", shell_output("#{bin}/hb config get provider")
+    assert_path_exists testpath/".humanbound/config.yaml"
+
+    # process a results file: read a run's logs.jsonl and export it as JSON
+    (testpath/".humanbound/results/exp-test").mkpath
+    (testpath/".humanbound/results/exp-test/logs.jsonl").write <<~EOS
+      {"thread_id": "t1", "result": "fail", "fail_category": "llm01", "explanation": "test finding", "severity": 82}
+    EOS
+    system bin/"hb", "logs", "--format", "json", "-o", "out.json"
+    logs = JSON.parse((testpath/"out.json").read)
+    assert_equal 1, logs["total"]
+    assert_equal "fail", logs["logs"].first["result"]
+  end
+end

--- a/Formula/h/humanbound.rb
+++ b/Formula/h/humanbound.rb
@@ -7,6 +7,15 @@ class Humanbound < Formula
   sha256 "7876689210a9772eca0be3519d79cf99c1109bbf255b4d13dd9a3e54192ddacc"
   license "Apache-2.0"
 
+  bottle do
+    sha256 cellar: :any, arm64_tahoe:   "d1fea0cc9e95534453684b35a7aeeccd802df24ac5d4669fadb0347c043ab774"
+    sha256 cellar: :any, arm64_sequoia: "dcb5b5a2488e0afec6e92577926ba04eed4a8f59df7e147a9d8a7e8c0a366c94"
+    sha256 cellar: :any, arm64_sonoma:  "05fe18751b6f9c05c1724d7c0b9abfa52b6f905afe13d95dc1180cc5f6c04e73"
+    sha256 cellar: :any, sonoma:        "b4c3016be0c92b665be9b790051b5b7bdb9d08c1ff4e0085adccec809dc3e164"
+    sha256 cellar: :any, arm64_linux:   "9d69dcc4a8c4d1d259eb2c2ac246bdcf5ecb276f624e7a317105ed2e8831d1fa"
+    sha256 cellar: :any, x86_64_linux:  "36fc1b0f72765e3f195111f069f2bdd44bd8154af0c8e121837d48eea6907e4f"
+  end
+
   depends_on "certifi" => :no_linkage
   depends_on "libyaml"
   depends_on "pydantic" => :no_linkage


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI assistance: the formula body and Python resource stanzas were drafted with an AI assistant (dependencies resolved via `pip install --dry-run --report` against PyPI; checksums taken from PyPI release metadata). Manually verified on macOS (Apple Silicon): `brew style`, `brew install --build-from-source` (via a local tap), `brew test`, and `brew audit --new --strict --online` all pass.

-----

New formula for [humanbound](https://github.com/humanbound/humanbound) — open-source adversarial security testing engine, SDK, and CLI for AI agents (`hb`). Installs the CLI from the PyPI sdist.