### PR TITLE
Remove homepage check from CI

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -140,17 +140,6 @@ jobs:
                            --body "$FORMULA should be archived. Check $RUN_URL" \
                            --repo "$GITHUB_REPOSITORY"
 
-      - name: Check formula for unavailable homepage.
-        id: homepage
-        run: brew audit --online --skip-style --only homepage "$FORMULA"
-
-      - name: Report homepage issues
-        if: failure() && steps.homepage.conclusion == 'failure'
-        run:  |
-          gh issue comment "$REPORTING_ISSUE" \
-                           --body "$FORMULA has homepage issues. Check $RUN_URL" \
-                           --repo "$GITHUB_REPOSITORY"
-
       - name: Check formula for missing sources.
         id: fetch
         if: always() && steps.archived.conclusion != 'failure'


### PR DESCRIPTION
Removed checks for unavailable homepage and reporting issues related to it.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

This mostly catches bot protection nowadays and real issues will still be caught when an update releases.