### PR TITLE
rumbledb 2.1.0 (new formula)

### DIFF
--- a/Formula/r/rumbledb.rb
+++ b/Formula/r/rumbledb.rb
@@ -10,6 +10,10 @@ class Rumbledb < Formula
     strategy :github_latest
   end
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, all: "c3461f8f7ecc1a25a2d3c4036be2f21613dce95f08c8111a15618395e7ee4e42"
+  end
+
   depends_on "apache-spark"
   depends_on "openjdk@21"
 

--- a/Formula/r/rumbledb.rb
+++ b/Formula/r/rumbledb.rb
@@ -1,0 +1,27 @@
+class Rumbledb < Formula
+  desc "JSONiq and XQuery query engine on Apache Spark"
+  homepage "https://rumbledb.org/"
+  url "https://github.com/RumbleDB/rumble/releases/download/v2.1.0/rumbledb-2.1.0-brew.zip"
+  sha256 "250b9a79e6fed34c595f75bb60d786b366e335c361169d1447538442fd32f29b"
+  license "Apache-2.0"
+
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
+  depends_on "apache-spark"
+  depends_on "openjdk@21"
+
+  def install
+    libexec.install "jars"
+    (bin/"rumbledb").write_env_script formula_opt_bin("apache-spark")/"spark-submit",
+                                      libexec/"jars/rumbledb.jar",
+                                      Language::Java.overridable_java_home_env("21")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/rumbledb repl < /dev/null 2>&1")
+    assert_equal "2", shell_output("#{bin}/rumbledb -q '1+1'").strip
+  end
+end


### PR DESCRIPTION
RumbleDB is a JSONiq and XQuery query engine that runs on Apache Spark. This formula installs [RumbleDB 2.1.0 ](https://rumbledb.org/) and its dependency `apache-spark`, providing a `rumbledb` CLI.

## Notability

This formula was previously submitted in #95073 (2022) and closed for notability
reasons at the time:

> "this seems like a nice software, but not notable enough for us to package in
> Homebrew for now [...] Please consider hosting it in a personal tap"

Notability has grown substantially since then:

- 241 stars, 84 forks, 37 contributors, 131 open issues (up from far lower numbers in 2022)
- 43 releases, actively maintained, latest push today, latest release v2.1.0
- Used to teach the JSONiq standard at several universities
- Currently distributed via the community tap `rumbledb/homebrew-rumble`, which
  users have to manually tap today

Happy to answer more questions if still a concern.

-----

<!-- Do not tick a checkbox if you haven't performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. Specifically: Claude
  (via Claude Code) reviewed the formula and found one real issue that made 
  `brew audit --new --strict` fail. (conflicting recursive dependency: openjdk@21 was pulled in by apache-spark, but we pinned openjdk@17). 

  I manually verified all of this myself: built and tested from scratch on macOS with
  `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source rumble`, `brew test
  rumble`, and `brew audit --new --strict --online rumble` (all clean), and separately
  rebuilt from scratch inside a Linux Homebrew Docker. I confirmed RumbleDB 2.1.0 runs correctly under JDK 21.

-----