### PR TITLE
hister 0.16.0 (new formula)

### DIFF
--- a/Formula/h/hister.rb
+++ b/Formula/h/hister.rb
@@ -1,0 +1,50 @@
+class Hister < Formula
+  desc "Your own search engine"
+  homepage "https://hister.org/"
+  url "https://github.com/asciimoo/hister/archive/refs/tags/v0.16.0.tar.gz"
+  sha256 "fd7373b2bfa6fbec4fe622a8f611c661399b1a5ad38cdc2351ab2feb8fca36b1"
+  license "AGPL-3.0-or-later"
+  head "https://github.com/asciimoo/hister.git", branch: "master"
+
+  depends_on "go" => :build
+  depends_on "node" => :build
+
+  def install
+    ENV["CGO_ENABLED"] = "1"
+    system "go", "generate", "./..."
+    system "go", "build", *std_go_args
+
+    (var/"hister").mkpath
+  end
+
+  service do
+    run [opt_bin/"hister", "listen"]
+    keep_alive true
+    log_path var/"log/hister.log"
+    error_log_path var/"log/hister.log"
+    working_dir var/"hister"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/hister --version")
+
+    # Generate a default config; exercises the config package and embedded defaults.
+    config = testpath/"hister.yml"
+    system bin/"hister", "create-config", config
+    assert_match "app:", config.read
+
+    # Keep the data directory inside the test sandbox.
+    inreplace config, /^(\s*directory:).*$/, "\\1 #{testpath}"
+
+    # Spawn the server and confirm the embedded web UI responds.
+    port = free_port
+    pid = spawn bin/"hister", "--config", config, "listen", "--address", "127.0.0.1:#{port}"
+    begin
+      sleep 5
+      assert_match(/<html|<!doctype/i, shell_output("curl -fsS http://127.0.0.1:#{port}/"))
+    ensure
+      Process.kill("TERM", pid)
+      Process.wait(pid)
+    end
+  end
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Verified locally (macOS arm64, Homebrew 6.0.12) on hister 0.16.0:

- `brew audit --new hister` exits 0
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source hister` builds in 1m16s
- `brew test hister` passes: checks `--version`, generates a config with `create-config`, starts `hister listen` on a free port and asserts the embedded web UI returns HTML (server logged a 200)
- the v0.16.0 tarball sha256 was computed from the download, not copied

AI disclosure detail: the formula was drafted with AI assistance (Claude Code); every command above was run on this machine and its result is reported as observed.

New formula for hister (self-hosted search engine, AGPL-3.0-or-later), requested by the upstream maintainer in asciimoo/hister#353. Bumped 0.12.0 -> current 0.16.0. Supersedes #278900 (closed by the stale bot) and #291218 (closed for an outdated PR template).
