### PR TITLE
tailscale: require root for Linux service

### DIFF
--- a/Formula/t/tailscale.rb
+++ b/Formula/t/tailscale.rb
@@ -39,8 +39,23 @@ class Tailscale < Formula
     generate_completions_from_executable(bin/"tailscale", shell_parameter_format: :cobra)
   end
 
+  def caveats
+    on_linux do
+      <<~EOS
+        tailscaled needs root privileges to configure iptables/nftables and DNS.
+        Start the root service with:
+          sudo --preserve-env=HOME brew services start tailscale
+
+        To run without root, use userspace-networking mode:
+          tailscaled --tun=userspace-networking
+      EOS
+    end
+  end
+
   service do
     run opt_bin/"tailscaled"
+    # See the caveats for userspace/non-root mode
+    require_root true
     keep_alive true
     log_path var/"log/tailscaled.log"
     error_log_path var/"log/tailscaled.log"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

AI-assisted contribution by Pi (gpt-5.6-sol), approximately 80% of the implementation and validation work. Pi drafted the formula diff and PR prose and ran the local style, audit, source-build, test, and `brew lgtm` checks; I reviewed the change, decided its scope, and am submitting it. No build, test, or audit verification was performed manually by me.

Built and tested locally on Ubuntu 26.04 running x86_64.

Require root for the managed Tailscale service and document the root and userspace-networking alternatives, following the `docker-engine.rb` precedent. This addresses Homebrew/brew#20576 and Homebrew/homebrew-core#210503; `require_root true` is advisory-only by Homebrew design (`services/cli.rb` warns but does not block non-root start), identical to the already-merged `docker-engine.rb`, so this is not a gap in the change. `brew style`, `brew audit --strict --online`, the source build, `brew test`, and `brew lgtm` passed; no formula revision is needed for this metadata-and-caveats-only change.