### PR TITLE
flyscrape php*: fix sandbox dependent tests

### DIFF
--- a/Formula/f/flyscrape.rb
+++ b/Formula/f/flyscrape.rb
@@ -29,14 +29,8 @@ class Flyscrape < Formula
   end
 
   test do
-    test_config = pkgshare/"examples/hackernews.js"
-    return_status = OS.mac? ? 1 : 0
-    output = shell_output("#{bin}/flyscrape run #{test_config} 2>&1", return_status)
-    expected = if OS.mac?
-      "failed to create database file"
-    else
-      "\"url\": \"https://news.ycombinator.com/\""
-    end
-    assert_match expected, output
+    cp pkgshare/"examples/hackernews.js", testpath
+    output = shell_output("#{bin}/flyscrape run hackernews.js 2>&1")
+    assert_match "\"url\": \"https://news.ycombinator.com/\"", output
   end
 end

--- a/Formula/p/php.rb
+++ b/Formula/p/php.rb
@@ -364,6 +364,7 @@ class Php < Formula
       ErrorLog "#{testpath}/httpd-error.log"
       ServerRoot "#{formula_opt_prefix("httpd")}"
       PidFile "#{testpath}/httpd.pid"
+      Mutex file:#{testpath} default
       LoadModule authz_core_module lib/httpd/modules/mod_authz_core.so
       LoadModule unixd_module lib/httpd/modules/mod_unixd.so
       LoadModule dir_module lib/httpd/modules/mod_dir.so

--- a/Formula/p/php@8.2.rb
+++ b/Formula/p/php@8.2.rb
@@ -390,6 +390,7 @@ class PhpAT82 < Formula
       ErrorLog "#{testpath}/httpd-error.log"
       ServerRoot "#{formula_opt_prefix("httpd")}"
       PidFile "#{testpath}/httpd.pid"
+      Mutex file:#{testpath} default
       LoadModule authz_core_module lib/httpd/modules/mod_authz_core.so
       LoadModule unixd_module lib/httpd/modules/mod_unixd.so
       LoadModule dir_module lib/httpd/modules/mod_dir.so

--- a/Formula/p/php@8.3.rb
+++ b/Formula/p/php@8.3.rb
@@ -390,6 +390,7 @@ class PhpAT83 < Formula
       ErrorLog "#{testpath}/httpd-error.log"
       ServerRoot "#{formula_opt_prefix("httpd")}"
       PidFile "#{testpath}/httpd.pid"
+      Mutex file:#{testpath} default
       LoadModule authz_core_module lib/httpd/modules/mod_authz_core.so
       LoadModule unixd_module lib/httpd/modules/mod_unixd.so
       LoadModule dir_module lib/httpd/modules/mod_dir.so

--- a/Formula/p/php@8.4.rb
+++ b/Formula/p/php@8.4.rb
@@ -396,6 +396,7 @@ class PhpAT84 < Formula
       ErrorLog "#{testpath}/httpd-error.log"
       ServerRoot "#{formula_opt_prefix("httpd")}"
       PidFile "#{testpath}/httpd.pid"
+      Mutex file:#{testpath} default
       LoadModule authz_core_module lib/httpd/modules/mod_authz_core.so
       LoadModule unixd_module lib/httpd/modules/mod_unixd.so
       LoadModule dir_module lib/httpd/modules/mod_dir.so


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Fix failed tests on linux, found from
- https://github.com/Homebrew/homebrew-core/actions/runs/30143676159/job/89642697207?pr=295089
