### PR TITLE
amber: fix build with Crystal 1.21

### DIFF
--- a/Formula/a/amber.rb
+++ b/Formula/a/amber.rb
@@ -37,7 +37,7 @@ class Amber < Formula
   end
 
   def install
-    system "shards", "install"
+    system "shards", "install", "--without-development"
     system "make", "install", "PREFIX=#{prefix}"
   end
 
@@ -56,7 +56,8 @@ class Amber < Formula
     end
 
     cd "test_app" do
-      assert_match "Building", shell_output("#{Formula["crystal"].bin}/shards build test_app")
+      shards = Formula["crystal"].bin/"shards"
+      assert_match "Building", shell_output("#{shards} --without-development build test_app -Dwithout_mt")
     end
     assert_path_exists testpath/"test_app/bin/test_app"
   end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

Fix test with crystal 1.21, but now requires `-Dwithout_mt` everytime.