### PR TITLE
xcode-offload 0.3.2 (new formula)

### DIFF
--- a/Formula/x/xcode-offload.rb
+++ b/Formula/x/xcode-offload.rb
@@ -1,0 +1,25 @@
+class XcodeOffload < Formula
+  desc "APFS-backed external storage for Xcode and CoreSimulator"
+  homepage "https://rudironsoni.github.io/xcode-offload/"
+  url "https://github.com/rudironsoni/xcode-offload/archive/refs/tags/v0.3.2.tar.gz"
+  sha256 "9d9e5af55ee5ba6bb6ac8392b32e80fe35188abc51b18326efa752434c847b9f"
+  license "MIT"
+  head "https://github.com/rudironsoni/xcode-offload.git", branch: "main"
+
+  depends_on xcode: ["16.3", :build]
+  depends_on macos: :ventura
+
+  uses_from_macos "swift"
+
+  def install
+    ENV["XCODE_OFFLOAD_RELEASE_TAG"] = "v#{version}"
+    system "make", "generate-version-source"
+    system "swift", "build", "--disable-sandbox", "--configuration", "release", "--product", "xcode-offload"
+    bin.install ".build/release/xcode-offload"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/xcode-offload version")
+    assert_match "manages external Xcode", shell_output("#{bin}/xcode-offload help")
+  end
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----


Codex, powered by GPT-5, assisted with drafting the formula and executing the contribution workflow. I manually reviewed the one-file diff and verified the source archive checksum, source build, installed binary, formula test, strict online audit, style check, typecheck, and `brew lgtm --online`.

Adds `xcode-offload` 0.3.2, a macOS CLI that manages APFS-backed external storage for Xcode and CoreSimulator.

Validation:

- `brew style Formula/x/xcode-offload.rb`
- `HOMEBREW_NO_INSTALL_FROM_API=1 HOMEBREW_NO_REQUIRE_TAP_TRUST=1 brew install --build-from-source rudironsoni/core/xcode-offload`
- `brew test rudironsoni/core/xcode-offload`
- `brew audit --new --strict --online rudironsoni/core/xcode-offload`
- `brew lgtm --online`

Policy note: this is a self-submission. As of 2026-07-25, the upstream repository is 23 days old and has 0 stars, forks, and watchers, which is below Homebrew published notability thresholds. The project is already distributed through `rudironsoni/tap`. I am submitting it so the maintainers can decide whether an exception is warranted.
