### PR TITLE
chiko: fix flaky test

### DIFF
--- a/Formula/c/chiko.rb
+++ b/Formula/c/chiko.rb
@@ -27,7 +27,7 @@ class Chiko < Formula
 
     PTY.spawn(bin/"chiko") do |r, w, _pid|
       w.write "q"
-      assert_match "The Ultimate Beauty GRPC Client", r.read
+      assert_match "Chiko dev", r.read
     rescue Errno::EIO
       # GNU/Linux raises EIO when read is done on closed pty
     end


### PR DESCRIPTION



Banner "The Ultimate Beauty GRPC Client" only renders in the animated splash frame, so quitting immediately with "q" races it (matched ~4/15 runs). Match the always-present "Chiko dev" title bar instead.

-----

- https://github.com/Homebrew/homebrew-core/pull/295226