### PR TITLE
asimov: update homepage and url after repo transfer

### DIFF
--- a/Formula/a/asimov.rb
+++ b/Formula/a/asimov.rb
@@ -1,10 +1,10 @@
 class Asimov < Formula
   desc "Automatically exclude development dependencies from Time Machine backups"
-  homepage "https://github.com/stevegrunwell/asimov"
-  url "https://github.com/stevegrunwell/asimov/archive/refs/tags/v0.8.0.tar.gz"
+  homepage "https://github.com/AsimovMac/asimov"
+  url "https://github.com/AsimovMac/asimov/archive/refs/tags/v0.8.0.tar.gz"
   sha256 "70799e8b9428fd320322cd24b50336890ed58e887a15e13af074a733db6e823b"
   license "MIT"
-  head "https://github.com/stevegrunwell/asimov.git", branch: "main"
+  head "https://github.com/AsimovMac/asimov.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "3b0cc2120e45618002a6af04f32c81a7b6e956cda2ba4cbc20c706585aaca465"


### PR DESCRIPTION
The `asimov` repository was transferred from `stevegrunwell/asimov` to the `AsimovMac` organization as part of a maintainer handover (see AsimovMac/asimov#99). The old URL still redirects, but this updates `homepage`, `url`, and `head` to point at the new canonical location.

Version and checksum are unchanged: the `v0.8.0` tag references the same commit, so the source tarball is byte-identical — sha256 `70799e8b9428fd320322cd24b50336890ed58e887a15e13af074a733db6e823b` verified against the new AsimovMac URL. Future version bumps continue to be handled by BrewTestBot autobump.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

AI (Claude Code) drafted the one-line-each `homepage`/`url`/`head` edit and this PR description. Manual verification performed locally before submission: confirmed the AsimovMac `v0.8.0` source tarball hashes byte-identically to the existing formula checksum (so no `sha256` change), then ran `brew style` (no offenses), `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source asimov`, `brew test asimov` (pass), and `brew audit --strict asimov` (pass).
