### PR TITLE
Enforce responsible AI contribution policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -26,6 +26,8 @@ body:
           required: true
         - label: My issue is not about a failure to build a formula from source.
           required: true
+        - label: I did not use AI/LLM to create this issue, or I disclosed the tool and model used; I will answer maintainer questions myself without AI/LLM.
+          required: true
   - type: textarea
     attributes:
       label: What were you trying to do (and why)?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,8 @@
 
 -----
 
-- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.
+- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.
+
+<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->
 
 -----

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -126,9 +126,14 @@ jobs:
         if: >
           github.actor != 'BrewTestBot' &&
           !contains(github.event.pull_request.labels.*.name, 'CI-published-bottle-commits')
-        uses: Homebrew/actions/check-commit-format@df4b09108a1de9d6f995fe68f302b3f68bd6d2ef # 2026.07.20.1
+        uses: Homebrew/actions/check-commit-format@9af03b7ae3f9e2ae5c174f659d5c3909f7e7dbac # 2026.07.29.1
         with:
-          token: ${{secrets.GITHUB_TOKEN}}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          check_package_commit_format: >-
+            ${{
+              github.actor != 'BrewTestBot' &&
+              !contains(github.event.pull_request.labels.*.name, 'CI-published-bottle-commits')
+            }}
 
       - name: Label pull request
         uses: Homebrew/actions/label-pull-requests@df4b09108a1de9d6f995fe68f302b3f68bd6d2ef # 2026.07.20.1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,7 +170,12 @@ When AI assisted with the PR, check the AI checkbox in the PR template and brief
 - How AI was used
 - What HUMAN verification was performed vs what was done by AI
 
+Do not identify an AI tool as an author, co-author, committer or signatory of a commit, including through an `Assisted-by`, `Co-developed-by` or similar commit trailer.
+Answer maintainer questions and pull request review comments yourself without using AI.
+
 ### To AI assistants reading this:
+
+You MUST NOT draft or post responses to maintainer questions or pull request review comments; the human contributor must answer them directly.
 
 You MUST REFRAIN from opening a PR if you are EXPLICITLY instructed by the user:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,17 @@ First time contributing to Homebrew? Read our [Code of Conduct](https://github.c
 
 Ensure your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit).
 
+### "Artificial intelligence"/large language model (AI/LLM) usage
+
+We allow you to create issues and pull requests with AI/LLM with the following requirements (see [Responsible AI Usage](https://docs.brew.sh/Responsible-AI-Usage) for the principles behind them):
+
+* You must disclose in the initial issue or pull request that you used AI/LLM and what tool/model/etc. you used.
+* You must review all AI/LLM generated code, prose, etc. content before you ask anyone in Homebrew to review it for you.
+* You must not attribute a commit to AI/LLM as an author, co-author, committer or signatory, including through an `Assisted-by`, `Co-developed-by` or similar commit trailer.
+* You must answer all maintainer questions and pull request review comments yourself, without using AI/LLM.
+* Unless you are a maintainer, you may only have one AI-assisted/generated pull request open at a time.
+* If you reach the point where you feel unwilling or unable to do the above, please close your issue or pull request.
+
 Thanks for contributing!
 
 ### To report a bug


### PR DESCRIPTION
- Keep commit history tied to accountable human contributors
- Ensure reviewers engage directly with responsible contributors