### PR TITLE
a*: use :goreleaser ldflags

### DIFF
--- a/Formula/a/ali.rb
+++ b/Formula/a/ali.rb
@@ -20,8 +20,7 @@ class Ali < Formula
   conflicts_with "nmh", because: "both install `ali` binaries"
 
   def install
-    ldflags = "-X main.version=#{version} -X main.commit= -X main.date=#{time.iso8601}}"
-    system "go", "build", *std_go_args(ldflags:)
+    system "go", "build", *std_go_args(ldflags: :goreleaser)
   end
 
   test do

--- a/Formula/a/aliddns.rb
+++ b/Formula/a/aliddns.rb
@@ -23,8 +23,7 @@ class Aliddns < Formula
   depends_on "go" => :build
 
   def install
-    ldflags = "-X main.version=#{version} -X main.commit=#{Utils.git_head} -X main.builtBy=#{tap.user}"
-    system "go", "build", "-mod=vendor", *std_go_args(ldflags:)
+    system "go", "build", "-mod=vendor", *std_go_args(ldflags: :goreleaser)
     pkgetc.install "aliddns.yaml"
   end
 

--- a/Formula/a/alp.rb
+++ b/Formula/a/alp.rb
@@ -19,7 +19,7 @@ class Alp < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args(ldflags: "-X main.version=#{version}"), "./cmd/alp"
+    system "go", "build", *std_go_args(ldflags: :goreleaser), "./cmd/alp"
 
     generate_completions_from_executable(bin/"alp", shell_parameter_format: :cobra)
   end

--- a/Formula/a/amfora.rb
+++ b/Formula/a/amfora.rb
@@ -23,8 +23,7 @@ class Amfora < Formula
   depends_on "go" => :build
 
   def install
-    ldflags = "-X main.version=#{version} -X main.commit=#{tap.user} -X main.builtBy=#{tap.user}"
-    system "go", "build", *std_go_args(ldflags:)
+    system "go", "build", *std_go_args(ldflags: :goreleaser)
     pkgshare.install "contrib/themes"
   end
 
@@ -36,11 +35,11 @@ class Amfora < Formula
     input, _, wait_thr = Open3.popen2 "script -q screenlog.txt"
     input.puts "stty rows 80 cols 43"
     input.puts bin/"amfora"
-    sleep 1
+    sleep 2
     input.putc "1"
-    sleep 1
+    sleep 2
     input.putc "1"
-    sleep 1
+    sleep 2
     input.putc "q"
 
     screenlog = (testpath/"screenlog.txt").read

--- a/Formula/a/apigeecli.rb
+++ b/Formula/a/apigeecli.rb
@@ -24,13 +24,8 @@ class Apigeecli < Formula
 
   def install
     ENV["CGO_ENABLED"] = "0"
-    ldflags = %W[
-      -X main.version=#{version}
-      -X main.commit=#{version}
-      -X main.date=#{time.iso8601}
-    ]
     gcflags = 'all="-l"'
-    system "go", "build", *std_go_args(ldflags:, gcflags:), "./cmd/apigeecli"
+    system "go", "build", *std_go_args(ldflags: :goreleaser, gcflags:), "./cmd/apigeecli"
 
     generate_completions_from_executable(bin/"apigeecli", shell_parameter_format: :cobra)
   end

--- a/Formula/a/aqua.rb
+++ b/Formula/a/aqua.rb
@@ -26,8 +26,7 @@ class Aqua < Formula
   depends_on "go" => :build
 
   def install
-    ldflags = "-X main.version=#{version} -X main.commit=#{tap.user} -X main.date=#{time.iso8601}"
-    system "go", "build", *std_go_args(ldflags:), "./cmd/aqua"
+    system "go", "build", *std_go_args(ldflags: :goreleaser), "./cmd/aqua"
 
     generate_completions_from_executable(bin/"aqua", "completion")
   end

--- a/Formula/a/autobrr.rb
+++ b/Formula/a/autobrr.rb
@@ -23,10 +23,8 @@ class Autobrr < Formula
     system "pnpm", "with", "current", "--dir", "web", "install"
     system "pnpm", "with", "current", "--dir", "web", "run", "build"
 
-    ldflags = "-X main.version=#{version} -X main.commit=#{tap.user}"
-
-    system "go", "build", *std_go_args(output: bin/"autobrr", ldflags:), "./cmd/autobrr"
-    system "go", "build", *std_go_args(output: bin/"autobrrctl", ldflags:), "./cmd/autobrrctl"
+    system "go", "build", *std_go_args(output: bin/"autobrr", ldflags: :goreleaser), "./cmd/autobrr"
+    system "go", "build", *std_go_args(output: bin/"autobrrctl", ldflags: :goreleaser), "./cmd/autobrrctl"
 
     (var/"autobrr").mkpath
   end

--- a/Formula/a/aws-spiffe-workload-helper.rb
+++ b/Formula/a/aws-spiffe-workload-helper.rb
@@ -18,7 +18,7 @@ class AwsSpiffeWorkloadHelper < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args(ldflags: "-X main.version=#{version}"), "./cmd"
+    system "go", "build", *std_go_args(ldflags: :goreleaser), "./cmd"
 
     generate_completions_from_executable(bin/"aws-spiffe-workload-helper", shell_parameter_format: :cobra)
   end


### PR DESCRIPTION
`ldflags: :goreleaser` will define similar variables to GoReleaser's default behavior. It does set our placeholder for `-X main.commit=#{tap.user}` so should only be used if Go code can handle it.

I am looking into extracting commit from tarball so we can provide it. Still would only be valid if upstream supports default `-X main.commit={{.Commit}}` rather than requiring `-X main.commit={{.ShortCommit}}`

Unused `-X` are okay and why GoReleaser can provide defaults.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
