### PR TITLE
kcov: replace `inreplace` with upstream patch

### DIFF
--- a/Formula/k/kcov.rb
+++ b/Formula/k/kcov.rb
@@ -1,11 +1,21 @@
 class Kcov < Formula
   desc "Code coverage tester for compiled programs, Python, and shell scripts"
   homepage "https://simonkagstrom.github.io/kcov/"
-  url "https://github.com/SimonKagstrom/kcov/archive/refs/tags/v43.tar.gz"
-  sha256 "4cbba86af11f72de0c7514e09d59c7927ed25df7cebdad087f6d3623213b95bf"
   license "GPL-2.0-or-later"
   revision 1
   head "https://github.com/SimonKagstrom/kcov.git", branch: "master"
+
+  stable do
+    url "https://github.com/SimonKagstrom/kcov/archive/refs/tags/v43.tar.gz"
+    sha256 "4cbba86af11f72de0c7514e09d59c7927ed25df7cebdad087f6d3623213b95bf"
+
+    patch do
+      url "https://github.com/SimonKagstrom/kcov/commit/698f612b01e776dfbc4bab11d320097425918423.patch?full_index=1"
+      sha256 "9465fa31cde08a449e03b8b9ac6149d2ad6eb337189c348000def5eabd58d519"
+      type :backport
+      resolves "https://github.com/SimonKagstrom/kcov/issues/475"
+    end
+  end
 
   # We check the Git tags because, as of writing, the "latest" release on GitHub
   # is a prerelease version (`pre-v40`), so we can't rely on it being correct.
@@ -39,10 +49,6 @@ class Kcov < Formula
   end
 
   def install
-    # Fix to find libdwarf header files
-    # Issue ref: https://github.com/SimonKagstrom/kcov/issues/475
-    inreplace "cmake/FindDwarfutils.cmake", "libdwarf-0", "libdwarf-#{Formula["dwarfutils"].version.major}"
-
     system "cmake", "-S", ".", "-B", "build", "-DSPECIFY_RPATH=ON", *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
