### PR TITLE
mcpsnoop 0.16.0 (new formula)

### DIFF
--- a/Formula/m/mcpsnoop.rb
+++ b/Formula/m/mcpsnoop.rb
@@ -6,6 +6,15 @@ class Mcpsnoop < Formula
   license "MIT"
   head "https://github.com/kerlenton/mcpsnoop.git", branch: "main"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "6e72eaa37abc6a68e278e04f74790b29d741a11193f68effe471498fe0532138"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "6e72eaa37abc6a68e278e04f74790b29d741a11193f68effe471498fe0532138"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "6e72eaa37abc6a68e278e04f74790b29d741a11193f68effe471498fe0532138"
+    sha256 cellar: :any_skip_relocation, sonoma:        "a28885e1e3d39ba74c6640d6958b5d6cf4006972900ca5f375be5652c97977a9"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "72efc4afca657c1cd93763a09799a8e0ebf532bb42f605facc39fde98ad9fb08"
+    sha256 cellar: :any,                 x86_64_linux:  "494c6e6a1a884666a54b9a286afd2a846f7a83a3fe89739a7c1c743b6825efa4"
+  end
+
   depends_on "go" => :build
 
   def install

--- a/Formula/m/mcpsnoop.rb
+++ b/Formula/m/mcpsnoop.rb
@@ -1,0 +1,24 @@
+class Mcpsnoop < Formula
+  desc "Transparent proxy and TUI for debugging MCP traffic"
+  homepage "https://github.com/kerlenton/mcpsnoop"
+  url "https://github.com/kerlenton/mcpsnoop/archive/refs/tags/v0.16.0.tar.gz"
+  sha256 "81803b0c5ea1f54dd03a9da9578d7f8aecf05f763deb922a58ea2fa46f34daea"
+  license "MIT"
+  head "https://github.com/kerlenton/mcpsnoop.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args(ldflags: "-X main.version=#{version}"), "./cmd/mcpsnoop"
+    generate_completions_from_executable(bin/"mcpsnoop", "completion")
+  end
+
+  test do
+    ENV["MCPSNOOP_HOME"] = testpath
+    assert_match version.to_s, shell_output("#{bin}/mcpsnoop version")
+
+    # Wrap a trivial "server" so the shim writes a real session, then check it.
+    system bin/"mcpsnoop", "--label", "brewtest", "--", "true"
+    assert_match "brewtest", shell_output("#{bin}/mcpsnoop export -T text")
+  end
+end


### PR DESCRIPTION
Transparent proxy and terminal UI for debugging Model Context Protocol traffic. It sits in the real data path between an AI client and an MCP server, so it sees the traffic the official MCP Inspector cannot: the Inspector connects as its own second client and never observes what your real client and server say to each other.

I am the author of the software. Per the self-submission notability threshold (>=225 stars), the repository is at 299 stars with 16 external contributors and 17 tagged releases since June.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.
