### PR TITLE
ckan: migrate from Mono to .NET

### DIFF
--- a/Formula/c/ckan.rb
+++ b/Formula/c/ckan.rb
@@ -1,8 +1,8 @@
 class Ckan < Formula
   desc "Comprehensive Kerbal Archive Network"
   homepage "https://github.com/KSP-CKAN/CKAN/"
-  url "https://github.com/KSP-CKAN/CKAN/releases/download/v1.36.4/ckan.exe"
-  sha256 "7748082cdfcf2dbb5f502261b18afc85003193894c60427d04b0ac7a8dfef7de"
+  url "https://github.com/KSP-CKAN/CKAN/archive/refs/tags/v1.36.4.tar.gz"
+  sha256 "5b7d4257ccd760b809cd75a6b2b7bfb2fcf42c8bd492d6c1b61b04e7649b2aaf"
   license "MIT"
 
   livecheck do
@@ -10,27 +10,36 @@ class Ckan < Formula
     strategy :github_latest
   end
 
-  bottle do
-    sha256 cellar: :any_skip_relocation, all: "c0cf6076bb24c81f0b6c26fa2f14e1c0ef2b341190185e9c69a10cafd1ae813f"
-  end
-
-  depends_on "mono"
+  depends_on "dotnet"
 
   def install
-    (libexec/"bin").install "ckan.exe"
-    (bin/"ckan").write <<~SHELL
-      #!/bin/sh
-      exec mono "#{libexec}/bin/ckan.exe" "$@"
-    SHELL
+    ENV["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1"
+
+    dotnet = Formula["dotnet"]
+    args = %W[
+      --configuration Release
+      --framework net#{dotnet.version.major_minor}
+      --output #{libexec}
+      --no-self-contained
+      --use-current-runtime
+      -p:AppHostRelativeDotNet=#{dotnet.opt_libexec.relative_path_from(libexec)}
+    ]
+
+    system "dotnet", "publish", "Cmdline/CKAN-cmdline.csproj", *args
+    bin.install_symlink libexec/"CKAN-CmdLine" => "ckan"
   end
 
   def caveats
-    <<~EOS
-      To use the CKAN GUI, install the ckan-app cask.
-    EOS
+    on_macos do
+      <<~EOS
+        If upgrading from a prior Mono-based install, you may want to migrate your
+        appdata in "$HOME/.local/share/CKAN" to "$HOME/Library/Application Support/CKAN"
+      EOS
+    end
   end
 
   test do
+    ENV["CKAN_CONFIG_FILE"] = testpath/"config.json"
     assert_match version.to_s, shell_output("#{bin}/ckan version")
 
     output = shell_output("#{bin}/ckan update", 1)


### PR DESCRIPTION
This avoids installing the pre-built .exe.

Also stop recommending the deprecated ckan-app. Can be restored if upstream app meets Gatekeeper requirement.

The extra caveat is because user may need to manually migrate data. App does following: https://github.com/KSP-CKAN/CKAN/commit/926f8baec22cdd70c6072ea8ad8c7045a5a4cf24

Due to native binaries, this will need to drop existing `all` bottle.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
