### PR TITLE
root: Fix configure error, move to C++20.

### DIFF
--- a/Formula/r/root.rb
+++ b/Formula/r/root.rb
@@ -27,12 +27,13 @@ class Root < Formula
   end
 
   bottle do
-    sha256 arm64_tahoe:   "949607d7dbfe0eea5ae6f4ef8d5dbd89d21b521d50ac64820f7156897574f9fa"
-    sha256 arm64_sequoia: "076889d8ff040d340d85dc30f67449f315f5d09471409b40163aa8488a3541c1"
-    sha256 arm64_sonoma:  "8d6696072c4ebb91ccba82c9752af9c3ace44465fd8434b3d9bac7028df96a4d"
-    sha256 sonoma:        "bb5f54f40b7724399f91a8fbce447067038065905dfd7ff74e81c695ae2e420a"
-    sha256 arm64_linux:   "8bec594b3d9540c5aa21f2aa12fc9398c3cbc95bf905a14e56daa88db15a23f4"
-    sha256 x86_64_linux:  "29e5e205e38c1f3c90af9e987367a14f0c57ef7918d6e41a3b13cca295d1661d"
+    rebuild 1
+    sha256 arm64_tahoe:   "4af2d84e30335cb647494c05b310c7e61f31d9672d68473f82f83123b7e894d4"
+    sha256 arm64_sequoia: "eb02b27100382600a23bd4588d1f63310e7af51821d749301b4d8ab3b84e20a8"
+    sha256 arm64_sonoma:  "f0667b9b6432f24af42764e593b40e6ed394636a85079fd35f19bb6d84d0f16a"
+    sha256 sonoma:        "b4df5d06b8b2a105d52762eb22eee65ffee1cca8c6cac6a9eb0fbeb478620d6a"
+    sha256 arm64_linux:   "c005229de009a982aa9c3a15f3df617485aa7e0ef875c1a4dcf338feecb6bc18"
+    sha256 x86_64_linux:  "989fde2d6080aec4dcde97c69f50bb998ef49b01927e6fb89374b54ccb5ff8ee"
   end
 
   depends_on "cmake" => :build

--- a/Formula/r/root.rb
+++ b/Formula/r/root.rb
@@ -1,11 +1,22 @@
 class Root < Formula
   desc "Analyzing petabytes of data, scientifically"
   homepage "https://root.cern"
-  url "https://root.cern/download/root_v6.40.02.source.tar.gz"
-  sha256 "f631eebee3dbea128f1415f4b784f5e83637a2b431193bce75f10385f71efc56"
   license "LGPL-2.1-or-later"
   revision 1
   head "https://github.com/root-project/root.git", branch: "master"
+
+  stable do
+    url "https://root.cern/download/root_v6.40.02.source.tar.gz"
+    sha256 "f631eebee3dbea128f1415f4b784f5e83637a2b431193bce75f10385f71efc56"
+
+    # Fix variable quoting for CMake>v4.4
+    # Will be unnecessary as of root v6.40.04
+    patch do
+      url "https://github.com/root-project/root/commit/1cc376e3bf06ea54880fc4c14f0d3de6af82fdd3.patch?full_index=1"
+      sha256 "a3651e7de6c6de2f75e7f2f26c8120763fca74b194c7e5ec43255f7242b507c2"
+      type :backport
+    end
+  end
 
   livecheck do
     url "https://root.cern/install/all_releases/"
@@ -92,7 +103,7 @@ class Root < Formula
 
     args = %W[
       -DCLING_CXX_PATH=clang++
-      -DCMAKE_CXX_STANDARD=17
+      -DCMAKE_CXX_STANDARD=20
       -DCMAKE_INSTALL_ELISPDIR=#{elisp}
       -DPYTHON_EXECUTABLE=#{which(python3)}
       -DXROOTD_ROOT_DIR=#{formula_opt_prefix("xrootd")}


### PR DESCRIPTION
- A user asked [1] if root could support c++20. This should be a matter of updating the C++ standard in the formula.
- To fix the configure error, a backport from upstream was added. It will be unnecessary once the next root is released.

[1] https://root-forum.cern.ch/t/is-it-time-for-root-to-c-std20/64957

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
  - ~~It was with `--HEAD`, though, because an upstream fix is imminent~~
  - Now rerun successfully after backporting the configure fix. 
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
