### PR TITLE
gdal 3.13.2

### DIFF
--- a/Formula/g/gdal.rb
+++ b/Formula/g/gdal.rb
@@ -12,12 +12,12 @@ class Gdal < Formula
   end
 
   bottle do
-    sha256 arm64_tahoe:   "dca8ec9c19326ea042633e5d500bfb21935c279fadad0f0ea10e3a0aa584aea7"
-    sha256 arm64_sequoia: "a52a0fb222e566e74dd47d406405e16a55bf0848e3a6b69511b266c92e15242b"
-    sha256 arm64_sonoma:  "d3f150dfe29242ad9c5968facd17c3d3416d30dda8ca6832123d046fff9d7d68"
-    sha256 sonoma:        "b03aa7feac15e181541e808a811ddd14e1da42262a3d41168026efefbde7179f"
-    sha256 arm64_linux:   "14c13532a8efc73a38d34f6d86b191d7cbc64d8195257d569f0b6da9a82255d0"
-    sha256 x86_64_linux:  "413020fbea7a421c31d6c405e4d3fc60984e015d158a172b35e02f5418fd595d"
+    sha256 arm64_tahoe:   "9ac1e11ada9a6a90c32a07d000763edd8699794b03c52e50fe0383165f515bb7"
+    sha256 arm64_sequoia: "edc7adb896fb17e4ab187d03df0c7500845ff2b6d01a61b75eb509ceb6cd70ee"
+    sha256 arm64_sonoma:  "e8c98505fb467cd491d82c56206fce7377f218b4c5a82ed24e8f56efb080d5ec"
+    sha256 sonoma:        "c2fcd8b0159b8fe217e8552813e8c35722097c36da5c8447e0c0a61c04dfab91"
+    sha256 arm64_linux:   "38d37dfec17a04edd06d3260e0ed8c18739d19b7a1967a94ce6fb50c51b6225c"
+    sha256 x86_64_linux:  "597e3155d5940b0f27107fcd6bbb68a9e85a446f6204c1337e3148f3a5e6aeed"
   end
 
   head do

--- a/Formula/g/gdal.rb
+++ b/Formula/g/gdal.rb
@@ -1,15 +1,14 @@
 class Gdal < Formula
   desc "Geospatial Data Abstraction Library"
   homepage "https://gdal.org/en/stable/"
-  url "https://github.com/OSGeo/gdal/releases/download/v3.13.1/gdal-3.13.1.tar.gz"
-  sha256 "e04e9813bd215b56753d5554330c53be25f3df2d7ed7e6413a19e6b66751c675"
+  url "https://github.com/OSGeo/gdal/releases/download/v3.13.2/gdal-3.13.2.tar.gz"
+  sha256 "1051c33db1d9e6a05907ac07cd06f5ce8ac0658f317c3229774cc2198a6c1252"
   license "MIT"
-  revision 4
   compatibility_version 2
 
   livecheck do
-    url "https://download.osgeo.org/gdal/CURRENT/"
-    regex(/href=.*?gdal[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do
@@ -26,6 +25,7 @@ class Gdal < Formula
     depends_on "doxygen" => :build
   end
 
+  depends_on "ant" => :build
   depends_on "boost" => :build
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build


### PR DESCRIPTION
- Update GDAL to 3.13.2.
- Fix livecheck to use the latest GitHub release.
- Add Ant as a build dependency.

The existing livecheck URL only reports GDAL 3.12.2, so BrewTestBot did not detect this release.

The source build also needs Ant for the Java bindings. Without it, the build fails because Homebrew's isolated environment cannot find Ant.