### PR TITLE
ammonite-repl, snap, umple: remove redundant version

### DIFF
--- a/Formula/a/ammonite-repl.rb
+++ b/Formula/a/ammonite-repl.rb
@@ -2,7 +2,6 @@ class AmmoniteRepl < Formula
   desc "Ammonite is a cleanroom re-implementation of the Scala REPL"
   homepage "https://ammonite.io/"
   url "https://github.com/com-lihaoyi/Ammonite/releases/download/3.0.9/3.3-3.0.9"
-  version "3.0.9"
   sha256 "1f7ff08c10c0f1bf9afb81484a884b435d1e07b54e314aa3f8cdfd6d939e7dbc"
   license "MIT"
 

--- a/Formula/s/snap.rb
+++ b/Formula/s/snap.rb
@@ -2,7 +2,6 @@ class Snap < Formula
   desc "Tool to work with .snap files"
   homepage "https://snapcraft.io/"
   url "https://github.com/canonical/snapd/releases/download/2.76/snapd_2.76.vendor.tar.xz"
-  version "2.76"
   sha256 "78ad358dc685ab5a40b9ca0b3fc283ae7c8fbbabb4612182d512bde7efeef605"
   license "GPL-3.0-only"
 

--- a/Formula/u/umple.rb
+++ b/Formula/u/umple.rb
@@ -2,7 +2,6 @@ class Umple < Formula
   desc "Modeling tool/programming language that enables Model-Oriented Programming"
   homepage "https://cruise.umple.org/umple/"
   url "https://github.com/umple/umple/releases/download/v1.37.0/umple-1.37.0.8542.3a8c87689.jar"
-  version "1.37.0"
   sha256 "a411c76d445b7bb079035d6d4a1bc71a548ee173093dc74cec8cbea61dcfc401"
   license "MIT"
   version_scheme 1


### PR DESCRIPTION
Fix for the errors seen in CI:

```
==> brew audit --except=installed --tap=homebrew/core
==> FAILED
Full audit --except=installed --tap=homebrew/core output
  ammonite-repl
    * Stable: `version 3.0.9` is redundant with version scanned from URL
  snap
    * Stable: `version 2.76` is redundant with version scanned from URL
  umple
    * Stable: `version 1.37.0` is redundant with 
```

Probably resulting from https://github.com/Homebrew/brew/pull/23338.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----
