### PR TITLE
noti: use stable source tarball

### DIFF
--- a/Formula/n/noti.rb
+++ b/Formula/n/noti.rb
@@ -7,13 +7,13 @@ class Noti < Formula
   head "https://codeberg.org/roble/noti.git", branch: "main"
 
   bottle do
-    rebuild 2
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "205fe66ef02286919f06b260301a75472820d41a914be5691af77a1cfb588301"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "41ae7991b41308c734a42e36a7d436004224087da7897cc7f580a23ed5c8e5cb"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "5f076e36e31923537c7e15c47a468870a66ce4b80730040df5405d58a013df80"
-    sha256 cellar: :any_skip_relocation, sonoma:        "39562685ad53b0bbf54a75820d138536ef69d7c9a9f51f22ba5cf8e3f23cc496"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "d386468c18c625ea2abc7b43e00e37bae36e037496879522c60e6066e8ae3cf6"
-    sha256 cellar: :any,                 x86_64_linux:  "abac47c0ec93ba018d66619164fafa2f6edb605681546fb04cc2e1d603fdf97c"
+    rebuild 3
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "6e50c0597615b77b809704af275ed40e824c759c2fa52f65640cfd5b0f7e2813"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "a2c95dad055f5087ff95dc3f5e3d9e937010c18eed32dfc2722b88e499206558"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "429fafc4300952a312804b4161d38ecac170b09e7c135723bfe7b44e621fc4cf"
+    sha256 cellar: :any_skip_relocation, sonoma:        "1c5ba0b872b8dfe253f307dc46827f1d628a4ca645dd096ef5fe7e565302adaf"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "258fa69edb789108c001f7b0179c6819070d979b04bdde4091c6a770a1128d2c"
+    sha256 cellar: :any,                 x86_64_linux:  "a5f24bb1e6e01884ce4c4358ffe70ad35be18d05f4fb4e76207b30b9f98ee519"
   end
 
   depends_on "go" => :build

--- a/Formula/n/noti.rb
+++ b/Formula/n/noti.rb
@@ -1,8 +1,8 @@
 class Noti < Formula
   desc "Trigger notifications when a process completes"
   homepage "https://codeberg.org/roble/noti"
-  url "https://codeberg.org/roble/noti/archive/3.8.0.tar.gz"
-  sha256 "107b9169c63c623556f554d54d82118da72f871ad8eddda3a49a613ff7deaf30"
+  url "https://codeberg.org/roble/noti/releases/download/3.8.0/noti3.8.0.tar.gz"
+  sha256 "f25d005a877cbb401766da8d00791984ac44f9e0062bd52a0ee4fb0a5ca44109"
   license "MIT"
   head "https://codeberg.org/roble/noti.git", branch: "main"
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

This change uses more stable source tarballs to build noti.

Related issues:
- https://codeberg.org/roble/noti/issues/166
- https://github.com/Homebrew/homebrew-core/pull/292827