### PR TITLE
openkermit 11.0.505

### DIFF
--- a/Formula/o/openkermit.rb
+++ b/Formula/o/openkermit.rb
@@ -10,6 +10,15 @@ class Openkermit < Formula
     strategy :github_latest
   end
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "9bb49244a3197278ad616a1db7bc66d6265b83df118069eac598db528e8cf0ac"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "0dfeaf19da1b723218fcb3755388148defd26f5d75de504eab8daae70a37d1f4"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "e23842bab8d10800310dd946ecf9647cc02d13ec40527eaea46241e08731b8fa"
+    sha256 cellar: :any_skip_relocation, sonoma:        "b22b75855c0f19b7d532f7e010cf355cbea2e99bc58b2139d30416c7e785d7ad"
+    sha256 cellar: :any,                 arm64_linux:   "b41d0c8ec805ecdb8e4a884157c3b2a40c7f8b1444d0a75e9c6d8359458757ae"
+    sha256 cellar: :any,                 x86_64_linux:  "1263fff09db1be9d264a60e4cbcbd329896362f08c274016964b291bcc0d78bb"
+  end
+
   uses_from_macos "libxcrypt"
   uses_from_macos "ncurses"
 

--- a/Formula/o/openkermit.rb
+++ b/Formula/o/openkermit.rb
@@ -1,0 +1,32 @@
+class Openkermit < Formula
+  desc "Scriptable network and serial communication for UNIX and VMS"
+  homepage "https://www.openkermit.org/"
+  url "https://github.com/openkermit/ckermit/archive/refs/tags/v11.0.505.tar.gz"
+  sha256 "c4cbbae6fd83e3aad318afdae72a993af9c5e73221e18d18f9b7a6937f3735c2"
+  license "BSD-3-Clause"
+
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
+  uses_from_macos "libxcrypt"
+  uses_from_macos "ncurses"
+
+  def install
+    os = OS.mac? ? "macosx" : "linux"
+    system "make", os, "KFLAGS=-DCK_NCURSES -I#{formula_opt_include("ncurses")}"
+
+    man1.mkpath
+
+    # The makefile adds /man to the end of manroot when running install
+    # hence we pass share here, not man.  If we don't pass anything it
+    # uses {prefix}/man
+    system "make", "prefix=#{prefix}", "manroot=#{share}", "install"
+  end
+
+  test do
+    system "#{bin}/kermit", "-C", "set host /network-type:pseudoterminal \"kermit -x\", get /bin/sh, bye, quit"
+    assert_path_exists "sh"
+  end
+end


### PR DESCRIPTION
Upstream development is now happening at https://openkermit.org/ with code at https://github.com/openkermit/ckermit/ .  C-Kermit 11.0 builds on the modernization work already done in the 10.0 beta series, and adds on full test suites with modern CI, first-class platform support for macOS, numerous macOS bug fixes (including some for basic functionality like recursive send).  It also adds IPv6 support and supports OpenSSL through version 4.0 (continuing to support older versions as well).

C-Kermit 11 has added a number of security hardening measures, and includes a fix for CVE-2025-68920.

I have evaluated every patch previously used here.  They are all obsolete with Update C-Kermit to latest upstream release 11.0.505

Upstream development is now happening at https://openkermit.org/ with code at https://github.com/openkermit/ckermit/ .  C-Kermit 11.0 builds on the modernization work already done in the 10.0 beta series, and adds on full test suites with modern CI, first-class platform support for macOS, numerous macOS bug fixes (including some for basic functionality like recursive send).  It also adds IPv6 support and supports OpenSSL through version 4.0 (continuing to support older versions as well).

C-Kermit 11 has added a number of security hardening measures, and includes a fix for CVE-2025-68920.

I have evaluated every patch previously used here.  They are all obsolete with the current C-Kermit.

I'm trying to keep this patch minimal, but once applied, it will be trivial to build with SSL; just use `make macos+ssl` or `make linux+ssl` (plus bring in the requisite libraries) at that point.  These builds are, in fact, the ones validated in upstream CI.  This would resolve #130987 and #131279 in a more modern way.

FYI I am the upstream maintainer, and will be happy to help with any questions. My goal is for all distros and distro-like projects to be able to package with minimal patches, so I would be happy to integrate any fixes upstream.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
