### PR TITLE
plow: fix test and remove duplicate ldflags

### DIFF
--- a/Formula/p/plow.rb
+++ b/Formula/p/plow.rb
@@ -17,15 +17,30 @@ class Plow < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args(ldflags: "-s -w -X main.version=#{version}")
+    system "go", "build", *std_go_args(ldflags: "-X main.version=#{version}")
 
     generate_completions_from_executable(bin/"plow", shell_parameter_format: "--completion-script-",
                                                      shells:                 [:bash, :zsh])
   end
 
   test do
-    output = "2xx"
-    assert_match output.to_s, shell_output("#{bin}/plow -n 1 https://httpbin.org/get")
+    require "socket"
+
+    server = TCPServer.new("127.0.0.1", 0)
+    port = server.addr[1]
+    begin
+      responder = Thread.new do
+        socket = server.accept
+        socket.gets("\r\n\r\n")
+        socket.print "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok"
+        socket.close
+      end
+
+      assert_match "2xx", shell_output("#{bin}/plow -n 1 --summary --listen= http://127.0.0.1:#{port}/")
+    ensure
+      responder.kill
+      server.close
+    end
 
     assert_match version.to_s, shell_output("#{bin}/plow --version")
   end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

The test benchmarked `httpbin.org`, so it failed whenever that service was unreachable. Serve a local response instead, and disable the Web UI listener so the test does not bind a fixed port.

`-s -w` is already part of `std_go_args`.

Splited from 
- https://github.com/Homebrew/homebrew-core/pull/295507
