### PR TITLE
lazyrsync 0.2.0 (new formula)

### DIFF
--- a/Formula/l/lazyrsync.rb
+++ b/Formula/l/lazyrsync.rb
@@ -1,0 +1,40 @@
+class Lazyrsync < Formula
+  desc "Terminal UI for rsync with profiles, dry-run preview and live progress"
+  homepage "https://lazyrsync.westpoint.io"
+  url "https://github.com/westpoint-io/lazyrsync/archive/refs/tags/v0.2.0.tar.gz"
+  sha256 "4ce106e10a258ccb4fdf8958b49746f7a1f9386592ede441f620a7f41ffb7d75"
+  license "MIT"
+  head "https://github.com/westpoint-io/lazyrsync.git", branch: "main"
+
+  depends_on "rust" => :build
+  # macOS's openrsync lacks --itemize-changes, --info=progress2 and --link-dest,
+  # which the preview, progress and snapshot features require
+  depends_on "rsync"
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    (testpath/"src").mkpath
+    (testpath/"src/hello.txt").write "hello"
+    (testpath/"config/lazyrsync").mkpath
+    (testpath/"config/lazyrsync/profiles.toml").write <<~TOML
+      [[profile]]
+      name = "smoke"
+
+      [[profile.task]]
+      label  = "files"
+      source = "#{testpath}/src/"
+      dest   = "#{testpath}/dst/"
+    TOML
+
+    ENV["XDG_CONFIG_HOME"] = testpath/"config"
+
+    assert_match "#{testpath}/src/", shell_output("#{bin}/lazyrsync list")
+    assert_match "hello.txt", shell_output("#{bin}/lazyrsync run smoke -n")
+    refute_path_exists testpath/"dst/hello.txt"
+
+    assert_match version.to_s, shell_output("#{bin}/lazyrsync --version")
+  end
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

I am the author of lazyrsync, submitting my own project. The formula was drafted with Claude Code (Claude Opus 5); I reviewed it myself, and it was verified with `brew audit --new --strict --online`, `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source` and `brew test` on Linux.

-----
