### PR TITLE
app-dev-clean 0.1.0 (new formula)

### DIFF
--- a/Formula/a/app-dev-clean.rb
+++ b/Formula/a/app-dev-clean.rb
@@ -1,0 +1,21 @@
+class AppDevClean < Formula
+  desc "Dev-cache cleaner for React Native, Expo, Flutter, Android, and iOS projects"
+  homepage "https://github.com/latif-essam/app-dev-clean"
+  url "https://github.com/latif-essam/app-dev-clean/archive/refs/tags/v0.1.0.tar.gz"
+  sha256 "d50a6103b61aff56d05f21cf65ca189afff0c521715e62058d94f324fecab984"
+  license "MIT"
+  head "https://github.com/latif-essam/app-dev-clean.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args(ldflags: "-X main.version=#{version}")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/app-dev-clean --version")
+
+    output = shell_output("#{bin}/app-dev-clean js 2>&1", 1)
+    assert_match "refusing local cleanup", output
+  end
+end


### PR DESCRIPTION
Cross-platform dev-cache cleaner for React Native, Expo, Flutter, native Android
(Gradle) and native iOS/macOS (Xcode/SwiftPM) projects.

It walks up from the working directory to the real project root, detects the
project type(s), and offers only the cleanup targets that apply — a repo can
match several types at once (a bare Expo app is both `expo` and `rn`), in which
case the offered targets are the deduped union. Outside a recognised project it
refuses to do any local cleanup and exits non-zero, so it can't delete the wrong
thing from the wrong directory. `--dry-run` reports reclaimable space without
deleting anything or invoking destructive external commands.

- Upstream: https://github.com/latif-essam/app-dev-clean
- Release: https://github.com/latif-essam/app-dev-clean/releases/tag/v0.1.0
- Licence: MIT
- Single Go binary, no runtime dependencies; CI covers ubuntu, macOS and Windows.

Checked locally on macOS arm64 (Homebrew 6.0.13): `brew audit --new`,
`brew style`, `brew install --build-from-source` and `brew test` all pass.
`brew style` also passes against this branch in a homebrew-core checkout.

The `test do` block asserts the version and the refusal-outside-a-project
behaviour, which is the tool's core safety guarantee. It deletes nothing.

Note: upstream also ships a short `adc` alias via its own tap. That symlink is
deliberately omitted here rather than claiming a generic three-letter name in a
shared `bin`.
