### PR TITLE
herdr: update repository URLs

### DIFF
--- a/Formula/h/herdr.rb
+++ b/Formula/h/herdr.rb
@@ -1,10 +1,10 @@
 class Herdr < Formula
   desc "Agent multiplexer that lives in your terminal"
   homepage "https://herdr.dev"
-  url "https://github.com/ogulcancelik/herdr/archive/refs/tags/v0.7.5.tar.gz"
+  url "https://github.com/herdrdev/herdr/archive/refs/tags/v0.7.5.tar.gz"
   sha256 "5ea0f1003af1801a6a85d201b6fa7e1de46686fccb7df1d3fa3a03c4ec2be68c"
   license "AGPL-3.0-or-later"
-  head "https://github.com/ogulcancelik/herdr.git", branch: "master"
+  head "https://github.com/herdrdev/herdr.git", branch: "master"
 
   livecheck do
     url :stable
@@ -21,7 +21,7 @@ class Herdr < Formula
   end
 
   depends_on "rust" => :build
-  depends_on "zig@0.15" => :build # upstream issue, https://github.com/ogulcancelik/herdr/issues/285
+  depends_on "zig@0.15" => :build # upstream issue, https://github.com/herdrdev/herdr/issues/285
 
   def install
     ENV.prepend_path "PATH", formula_opt_bin("zig@0.15")


### PR DESCRIPTION
Herdr moved from `ogulcancelik/herdr` to the `herdrdev/herdr` organization.

This updates the stable source URL, HEAD repository, and upstream issue link to their canonical locations. The `v0.7.5` archive retains the existing SHA256, so no revision or bottle rebuild is needed.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source herdr`?
- [ ] Is your test running fine `brew test herdr`?
- [ ] Does your build pass `brew audit --strict herdr` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source herdr`)?

-----

- [x] I disclosed the AI/LLM usage below, reviewed its output, did not attribute the commit to AI, and will answer maintainer questions and review comments myself without AI/LLM.

OpenAI Codex was used to inspect the current formula, verify the canonical repository URLs, and draft the change. I reviewed the diff and verified that the canonical `v0.7.5` archive matches the existing SHA256.

-----
