### PR TITLE
openliberty-*: restore test

### DIFF
--- a/Formula/o/openliberty-jakartaee8.rb
+++ b/Formula/o/openliberty-jakartaee8.rb
@@ -33,17 +33,15 @@ class OpenlibertyJakartaee8 < Formula
 
   test do
     ENV["WLP_USER_DIR"] = testpath
-    output_log = testpath/"output.log"
 
-    pid = spawn bin/"openliberty-jakartaee8", "run", [:out, :err] => output_log.to_s
     begin
-      sleep 5 until output_log.exist? && output_log.read.include?("CWWKF0011I")
-      assert_match "<feature>javaee-8.0</feature>", (testpath/"servers/defaultServer/server.xml").read
+      system bin/"openliberty-jakartaee8", "start"
+      assert_path_exists testpath/"servers/.pid/defaultServer.pid"
     ensure
       system bin/"openliberty-jakartaee8", "stop"
     end
 
-    Process.wait(pid)
-    assert_match "CWWKE0036I", output_log.read
+    refute_path_exists testpath/"servers/.pid/defaultServer.pid"
+    assert_match "<feature>javaee-8.0</feature>", (testpath/"servers/defaultServer/server.xml").read
   end
 end

--- a/Formula/o/openliberty-jakartaee9.rb
+++ b/Formula/o/openliberty-jakartaee9.rb
@@ -34,17 +34,15 @@ class OpenlibertyJakartaee9 < Formula
 
   test do
     ENV["WLP_USER_DIR"] = testpath
-    output_log = testpath/"output.log"
 
-    pid = spawn bin/"openliberty-jakartaee9", "run", [:out, :err] => output_log.to_s
     begin
-      sleep 5 until output_log.exist? && output_log.read.include?("CWWKF0011I")
-      assert_match "<feature>jakartaee-9.1</feature>", (testpath/"servers/defaultServer/server.xml").read
+      system bin/"openliberty-jakartaee9", "start"
+      assert_path_exists testpath/"servers/.pid/defaultServer.pid"
     ensure
       system bin/"openliberty-jakartaee9", "stop"
     end
 
-    Process.wait(pid)
-    assert_match "CWWKE0036I", output_log.read
+    refute_path_exists testpath/"servers/.pid/defaultServer.pid"
+    assert_match "<feature>jakartaee-9.1</feature>", (testpath/"servers/defaultServer/server.xml").read
   end
 end

--- a/Formula/o/openliberty-microprofile4.rb
+++ b/Formula/o/openliberty-microprofile4.rb
@@ -33,17 +33,15 @@ class OpenlibertyMicroprofile4 < Formula
 
   test do
     ENV["WLP_USER_DIR"] = testpath
-    output_log = testpath/"output.log"
 
-    pid = spawn bin/"openliberty-microprofile4", "run", [:out, :err] => output_log.to_s
     begin
-      sleep 5 until output_log.exist? && output_log.read.include?("CWWKF0011I")
-      assert_match "<feature>microProfile-4.1</feature>", (testpath/"servers/defaultServer/server.xml").read
+      system bin/"openliberty-microprofile4", "start"
+      assert_path_exists testpath/"servers/.pid/defaultServer.pid"
     ensure
       system bin/"openliberty-microprofile4", "stop"
     end
 
-    Process.wait(pid)
-    assert_match "CWWKE0036I", output_log.read
+    refute_path_exists testpath/"servers/.pid/defaultServer.pid"
+    assert_match "<feature>microProfile-4.1</feature>", (testpath/"servers/defaultServer/server.xml").read
   end
 end

--- a/Formula/o/openliberty-webprofile8.rb
+++ b/Formula/o/openliberty-webprofile8.rb
@@ -33,17 +33,15 @@ class OpenlibertyWebprofile8 < Formula
 
   test do
     ENV["WLP_USER_DIR"] = testpath
-    output_log = testpath/"output.log"
 
-    pid = spawn bin/"openliberty-webprofile8", "run", [:out, :err] => output_log.to_s
     begin
-      sleep 5 until output_log.exist? && output_log.read.include?("CWWKF0011I")
-      assert_match "<feature>webProfile-8.0</feature>", (testpath/"servers/defaultServer/server.xml").read
+      system bin/"openliberty-webprofile8", "start"
+      assert_path_exists testpath/"servers/.pid/defaultServer.pid"
     ensure
       system bin/"openliberty-webprofile8", "stop"
     end
 
-    Process.wait(pid)
-    assert_match "CWWKE0036I", output_log.read
+    refute_path_exists testpath/"servers/.pid/defaultServer.pid"
+    assert_match "<feature>webProfile-8.0</feature>", (testpath/"servers/defaultServer/server.xml").read
   end
 end

--- a/Formula/o/openliberty-webprofile9.rb
+++ b/Formula/o/openliberty-webprofile9.rb
@@ -34,17 +34,15 @@ class OpenlibertyWebprofile9 < Formula
 
   test do
     ENV["WLP_USER_DIR"] = testpath
-    output_log = testpath/"output.log"
 
-    pid = spawn bin/"openliberty-webprofile9", "run", [:out, :err] => output_log.to_s
     begin
-      sleep 5 until output_log.exist? && output_log.read.include?("CWWKF0011I")
-      assert_match "<feature>webProfile-9.1</feature>", (testpath/"servers/defaultServer/server.xml").read
+      system bin/"openliberty-webprofile9", "start"
+      assert_path_exists testpath/"servers/.pid/defaultServer.pid"
     ensure
       system bin/"openliberty-webprofile9", "stop"
     end
 
-    Process.wait(pid)
-    assert_match "CWWKE0036I", output_log.read
+    refute_path_exists testpath/"servers/.pid/defaultServer.pid"
+    assert_match "<feature>webProfile-9.1</feature>", (testpath/"servers/defaultServer/server.xml").read
   end
 end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Brew behavior is fixed
- https://github.com/Homebrew/brew/pull/23348

so, revert to do better test 
- https://github.com/Homebrew/homebrew-core/pull/295197