### PR TITLE
xfg 1.10.06 (new formula)

### DIFF
--- a/Formula/x/xfg.rb
+++ b/Formula/x/xfg.rb
@@ -6,7 +6,7 @@ class Xfg < Formula
   license "GPL-3.0-or-later"
 
   depends_on "cmake" => :build
-  depends_on "boost"
+  depends_on "boost@1.85" # boost 1.86+ breaks io_service compat
   depends_on "openssl@3"
   depends_on "icu4c"
   depends_on "jsoncpp"

--- a/Formula/x/xfg.rb
+++ b/Formula/x/xfg.rb
@@ -6,7 +6,7 @@ class Xfg < Formula
   license "GPL-3.0-or-later"
 
   depends_on "cmake" => :build
-  depends_on "boost@1.85"
+  depends_on "boost"
   depends_on "openssl@3"
   depends_on "icu4c"
   depends_on "jsoncpp"
@@ -14,14 +14,14 @@ class Xfg < Formula
   conflicts_with "fuego"
 
   def install
-    system "cmake", "-B", "build", "-DCMAKE_BUILD_TYPE=Release", *std_cmake_args
-    system "cmake", "--build", "build", "-j", Hardware::CPU.cpus
+    system "cmake", "-B", "build", *std_cmake_args
+    system "cmake", "--build", "build"
     system "cmake", "--install", "build"
     cd "tui" do
-      system "go", "build", "-o", bin/"fuego-tui"
+      system "go", "build", *std_go_args(output: bin/"fuego-tui"), "."
     end
     cd "swapxfg" do
-      system "go", "build", "-o", bin/"swapxfg", "."
+      system "go", "build", *std_go_args(output: bin/"swapxfg"), "."
     end
   end
 

--- a/Formula/x/xfg.rb
+++ b/Formula/x/xfg.rb
@@ -1,0 +1,38 @@
+class Xfg < Formula
+  desc "Sovereign private blockchain banking node suite"
+  homepage "https://usexfg.org"
+  url "https://github.com/usexfg/fuego-suite/archive/refs/tags/1.10.06.tar.gz"
+  sha256 "f27cf99358268296579caef1910f01524113419a2bfdf39492d6a614bbfdf505"
+  license "GPL-3.0-or-later"
+
+  depends_on "cmake" => :build
+  depends_on "boost@1.85"
+  depends_on "openssl@3"
+  depends_on "icu4c"
+  depends_on "jsoncpp"
+
+  conflicts_with "fuego"
+
+  def install
+    system "cmake", "-B", "build", "-DCMAKE_BUILD_TYPE=Release", *std_cmake_args
+    system "cmake", "--build", "build", "-j", Hardware::CPU.cpus
+    system "cmake", "--install", "build"
+    cd "tui" do
+      system "go", "build", "-o", bin/"fuego-tui"
+    end
+    cd "swapxfg" do
+      system "go", "build", "-o", bin/"swapxfg", "."
+    end
+  end
+
+  test do
+    # Verify wallet CLI can create a testnet wallet (no running node needed)
+    wallet_path = testpath/"test_wallet.bin"
+    system "#{bin}/fire_wallet", "--testnet", "--generate-new-wallet", wallet_path.to_s,
+           "--password", "test_password"
+    assert_predicate wallet_path, :exist?
+
+    # Verify daemon responds to valid arguments
+    assert_match "Fuego", shell_output("#{bin}/fuegod --help 2>&1", 1)
+  end
+end


### PR DESCRIPTION
- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

AI was used to generate the initial formula template. I reviewed and verified the formula content, dependencies, and build instructions.

## xfg 1.10.06 (new formula)

Sovereign private blockchain banking node suite.

### Changes from previous PR

- Uses `cmake --install` instead of manual binary installation
- Added proper CMake install() targets in CMakeLists.txt
- Added functional test that creates a testnet wallet
- Uses `std_go_args` for Go builds
- Pinned boost@1.85 for io_service compatibility (boost 1.86+ breaks our build)

### Links

- Website: https://usexfg.org
- Repository: https://github.com/usexfg/fuego-suite
- License: GPL-3.0-or-later