### PR TITLE
xfg 1.10.09 (new formula)

### DIFF
--- a/Formula/x/xfg.rb
+++ b/Formula/x/xfg.rb
@@ -1,0 +1,28 @@
+class Xfg < Formula
+  desc "Sovereign private blockchain banking node suite"
+  homepage "https://usexfg.org"
+  url "https://github.com/usexfg/fuego-suite/archive/refs/tags/1.10.09.tar.gz"
+  sha256 "e84861248de2a582cacd8a48fc8332fd38b9b9fee4b75263080a707bcc41eb5b"
+  license "GPL-3.0-or-later"
+
+  depends_on "cmake" => :build
+  depends_on "boost"
+  depends_on "icu4c@78"
+  depends_on "jsoncpp"
+  depends_on "openssl@4"
+  depends_on "secp256k1"
+
+  conflicts_with "fuego"
+
+  def install
+    system "cmake", "-B", "build", "-DUSE_VENDORED_SECP256K1=OFF", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    output = shell_output("#{bin}/fuegod --print-genesis-tx 2>&1", 1)
+    assert_match "GENESIS_COINBASE_TX_HEX", output
+    assert_match "013c01ff0001", output
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

AI was used to generate the initial formula template. I reviewed and verified the formula content, dependencies, build instructions, and ran all local checks (`brew install`, `brew test`, `brew audit --new`, `brew style`).

## xfg 1.10.09 (new formula)

Sovereign private blockchain banking node suite.

### What does it do?

Fuego is a decentralized p2p privacy blockchain banking network based on the CryptoNote protocol. This formula provides the full node suite.

### What's included?

- `fuegod` — main daemon
- `fire_wallet` — CLI wallet
- `walletd` — wallet daemon
- `testnetd` — testnet daemon
- `test_wallet` — testnet wallet
- `xfg-swapd` — swap daemon
- `optimizer` — blockchain optimizer
- `FuegoI2P` — I2P router

### Build verification

- Locally built and installed with `cmake --install` (boost 1.90, OpenSSL 4.0.1, secp256k1)
- `brew test` passes — `fuegod --print-genesis-tx` exercises crypto engine, block serialization, coinbase construction
- `brew audit --new` passes
- `brew style` passes

### Notes

- Requires `secp256k1` as dependency (submodule not in tarball)
- Uses `-DUSE_VENDORED_SECP256K1=OFF` to link against brew's secp256k1
- Go binaries (fuego-tui, swapxfg) excluded for now — will add in follow-up PR once vendoring is resolved

### Links

- Website: https://usexfg.org
- Repository: https://github.com/usexfg/fuego-suite
- License: GPL-3.0-or-later