### PR TITLE
asimov 0.12.0

### DIFF
--- a/Formula/a/asimov.rb
+++ b/Formula/a/asimov.rb
@@ -1,8 +1,8 @@
 class Asimov < Formula
   desc "Automatically exclude development dependencies from Time Machine backups"
   homepage "https://github.com/AsimovMac/asimov"
-  url "https://github.com/AsimovMac/asimov/archive/refs/tags/v0.11.0.tar.gz"
-  sha256 "9fa0b1551cd3e741288701f589c1b1f42d16cb655f60283dce3a1bc7c5b9af67"
+  url "https://github.com/AsimovMac/asimov/archive/refs/tags/v0.12.0.tar.gz"
+  sha256 "1bd90fbf33d5e72bf578be3959c3a9e3cfb36951e364572d5f9f607889da86db"
   license "MIT"
   head "https://github.com/AsimovMac/asimov.git", branch: "main"
 
@@ -11,7 +11,9 @@ class Asimov < Formula
   end
 
   def install
-    bin.install buildpath/"asimov"
+    bin.install "bin/asimov"
+    libexec.install "lib/asimov"
+    pkgshare.install Dir["data/*"]
   end
 
   # Asimov will run in the background on a daily basis

--- a/Formula/a/asimov.rb
+++ b/Formula/a/asimov.rb
@@ -7,7 +7,7 @@ class Asimov < Formula
   head "https://github.com/AsimovMac/asimov.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "844e1015e05c3a47a7f7dcd1a9255369c0854c1c0416fdeef44eb99e0f507834"
+    sha256 cellar: :any_skip_relocation, all: "752278f6104a90ad8a42ede78f72583c85494a3e2601269d0388425f7228b8fb"
   end
 
   def install


### PR DESCRIPTION
Upstream release: https://github.com/AsimovMac/asimov/releases/tag/v0.12.0

This one needs a manual PR rather than an autobump: as of 0.12.0 asimov is no longer a single script, so `bin.install buildpath/"asimov"` would fail. It ships a launcher, a library, and data files, which have to land under one prefix:

```
bin/asimov
libexec/asimov/*.sh
share/asimov/*.tsv
```

The launcher resolves its own physical path through the `bin` symlink before probing for the library, so the cellar layout works as installed.

Verified locally on arm64 Sequoia:

- `brew style Formula/a/asimov.rb` — no offenses
- `brew audit --strict --online asimov` — no offenses
- `brew install --build-from-source asimov` then `brew test asimov` — pass
- `asimov --version` reports 0.12.0, and a `--dry-run` against a fixture tree finds the expected directories

The `bottle` block is removed so BrewTestBot can rebuild it.