### PR TITLE
rsync: Restore support for file flags

### DIFF
--- a/Formula/r/rsync.rb
+++ b/Formula/r/rsync.rb
@@ -5,6 +5,7 @@ class Rsync < Formula
   mirror "https://github.com/RsyncProject/rsync/releases/download/v3.4.4/rsync-3.4.4.tar.gz"
   sha256 "bd88cf82fa653da32314fb229136407c5c90f80d1758d8f4b091767877d8fa96"
   license "GPL-3.0-or-later"
+  revision 1
 
   livecheck do
     url "https://rsync.samba.org/ftp/rsync/?C=M&O=D"
@@ -28,6 +29,11 @@ class Rsync < Formula
 
   on_linux do
     depends_on "zlib-ng-compat"
+  end
+
+  patch :p0 do
+    url "https://github.com/macports/macports-ports/raw/07d4977a98e68f98b8835b67a6a7a168cc13f145/net/rsync/files/fileflags.diff"
+    sha256 "b3bf038c732f2610b7e0d1cdaa42d7b0f2316d4c0c9c867e5e443db82901e3a6"
   end
 
   def install


### PR DESCRIPTION
Up until v3.4.1, the `rsync` formula incorporated the `fileflags.diff` patch distributed by the rsync project. The patch would add support for the `--fileflags` option, allowing BSD-style file flags (immutability, `hidden`, etc.) to be preserved.

The official patch bundle is no longer maintained, for reasons I’m not familiar with. Consequently, Homebrew rsync lost support for file flags in 722f7ba.

The patch was recently updated for rsync 3.4.4 in the FreeBSD project and subsequently adopted by MacPorts as well.

[FreeBSD commit](https://github.com/freebsd/freebsd-ports/commit/f0211e11c062ab148ef063283ffcc4c491a0bcc0)
[MacPorts commit](https://github.com/macports/macports-ports/commit/07d4977a98e68f98b8835b67a6a7a168cc13f145)

This PR brings the same patch to Homebrew. I have opted to use the MacPorts version, as it also patches the pre-built manpage. Apart from that, it is identical to the FreeBSD version.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
