### PR TITLE
Specify formula install-step var bases

### DIFF
--- a/Formula/a/arcadedb.rb
+++ b/Formula/a/arcadedb.rb
@@ -35,19 +35,19 @@ class Arcadedb < Formula
   end
 
   post_install_steps do
-    unless_path_exists "arcadedb/config/arcadedb-log.properties" do
+    unless_path_exists "arcadedb/config/arcadedb-log.properties", base: :var do
       copy "config/arcadedb-log.properties", "arcadedb/config/arcadedb-log.properties",
            source_base: :libexec, target_base: :var
     end
-    unless_path_exists "arcadedb/config/server-groups.json" do
+    unless_path_exists "arcadedb/config/server-groups.json", base: :var do
       copy "config/server-groups.json", "arcadedb/config/server-groups.json",
            source_base: :libexec, target_base: :var
     end
-    unless_path_exists "arcadedb/config/gremlin-server.yaml" do
+    unless_path_exists "arcadedb/config/gremlin-server.yaml", base: :var do
       copy "config/gremlin-server.yaml", "arcadedb/config/gremlin-server.yaml",
            source_base: :libexec, target_base: :var
     end
-    unless_path_exists "arcadedb/config/gremlin-server.groovy" do
+    unless_path_exists "arcadedb/config/gremlin-server.groovy", base: :var do
       copy "config/gremlin-server.groovy", "arcadedb/config/gremlin-server.groovy",
            source_base: :libexec, target_base: :var
     end

--- a/Formula/b/bareos-client.rb
+++ b/Formula/b/bareos-client.rb
@@ -77,7 +77,7 @@ class BareosClient < Formula
   end
 
   post_install_steps do
-    mkdir_p "lib/bareos"
+    mkdir_p "lib/bareos", base: :var
     unless_path_exists "{{etc}}/bareos/bareos-fd.d" do
       run "bareos/scripts/bareos-config", args: ["deploy_config", "bareos-fd"], base: :lib
       run "bareos/scripts/bareos-config", args: ["deploy_config", "bconsole"], base: :lib

--- a/Formula/c/cayley.rb
+++ b/Formula/c/cayley.rb
@@ -52,8 +52,8 @@ class Cayley < Formula
   end
 
   post_install_steps do
-    unless_path_exists "cayley" do
-      mkdir_p "cayley"
+    unless_path_exists "cayley", base: :var do
+      mkdir_p "cayley", base: :var
       run "cayley", args: ["init", "--config={{etc}}/cayley.yml"], base: :bin
     end
   end

--- a/Formula/c/cfengine.rb
+++ b/Formula/c/cfengine.rb
@@ -66,9 +66,9 @@ class Cfengine < Formula
 
   post_install_steps do
     set_permissions %w[cfengine/inputs cfengine/outputs cfengine/ppkeys cfengine/plugins], "0700",
-                    recursive: false
-    set_permissions "cfengine/state", "0750", recursive: false
-    set_permissions "cfengine/modules", "0755", recursive: false
+                    recursive: false, base: :var
+    set_permissions "cfengine/state", "0750", recursive: false, base: :var
+    set_permissions "cfengine/modules", "0755", recursive: false, base: :var
   end
 
   test do

--- a/Formula/c/cracklib.rb
+++ b/Formula/c/cracklib.rb
@@ -60,9 +60,9 @@ class Cracklib < Formula
   end
 
   post_install_steps do
-    mkdir_p "cracklib"
+    mkdir_p "cracklib", base: :var
     copy "cracklib-words-*", "cracklib/cracklib-words", source_base: :share, target_base: :var, source_glob: true
-    run "cracklib-packer", base: :bin, stdin_path: "cracklib/cracklib-words"
+    run "cracklib-packer", base: :bin, stdin_path: "{{var}}/cracklib/cracklib-words"
   end
 
   test do

--- a/Formula/g/gnupg.rb
+++ b/Formula/g/gnupg.rb
@@ -82,7 +82,7 @@ class Gnupg < Formula
   end
 
   post_install_steps do
-    mkdir_p "run"
+    mkdir_p "run", base: :var
     terminate_process "gpg-agent", must_succeed: false
   end
 

--- a/Formula/i/icecast.rb
+++ b/Formula/i/icecast.rb
@@ -49,9 +49,9 @@ class Icecast < Formula
   end
 
   post_install_steps do
-    mkdir_p "log/icecast"
-    touch "log/icecast/access.log"
-    touch "log/icecast/error.log"
+    mkdir_p "log/icecast", base: :var
+    touch "log/icecast/access.log", base: :var
+    touch "log/icecast/error.log", base: :var
   end
 
   test do

--- a/Formula/k/kafka.rb
+++ b/Formula/k/kafka.rb
@@ -59,8 +59,8 @@ class Kafka < Formula
   end
 
   post_install_steps do
-    mkdir_p "log/kafka"
-    unless_path_exists "lib/kraft-combined-logs/meta.properties" do
+    mkdir_p "log/kafka", base: :var
+    unless_path_exists "lib/kraft-combined-logs/meta.properties", base: :var do
       run "post-install", base: :libexec
     end
   end

--- a/Formula/m/mariadb.rb
+++ b/Formula/m/mariadb.rb
@@ -149,7 +149,7 @@ class Mariadb < Formula
   post_install_steps do
     # Make sure the var/mysql directory exists
     # Don't initialize database, it clashes when testing other MySQL-like implementations.
-    init_data_dir "mysql", using: :mariadb_install_db
+    init_data_dir "mysql", using: :mariadb_install_db, base: :var
   end
 
   def caveats

--- a/Formula/m/mariadb@10.11.rb
+++ b/Formula/m/mariadb@10.11.rb
@@ -155,7 +155,7 @@ class MariadbAT1011 < Formula
   post_install_steps do
     # Make sure the var/mysql directory exists
     # Don't initialize database, it clashes when testing other MySQL-like implementations.
-    init_data_dir "mysql", using: :mariadb_install_db
+    init_data_dir "mysql", using: :mariadb_install_db, base: :var
   end
 
   def caveats

--- a/Formula/m/mariadb@10.5.rb
+++ b/Formula/m/mariadb@10.5.rb
@@ -149,7 +149,7 @@ class MariadbAT105 < Formula
   post_install_steps do
     # Make sure the var/mysql directory exists
     # Don't initialize database, it clashes when testing other MySQL-like implementations.
-    init_data_dir "mysql", using: :mariadb_install_db
+    init_data_dir "mysql", using: :mariadb_install_db, base: :var
   end
 
   def caveats

--- a/Formula/m/mariadb@10.6.rb
+++ b/Formula/m/mariadb@10.6.rb
@@ -150,7 +150,7 @@ class MariadbAT106 < Formula
   post_install_steps do
     # Make sure the var/mysql directory exists
     # Don't initialize database, it clashes when testing other MySQL-like implementations.
-    init_data_dir "mysql", using: :mariadb_install_db
+    init_data_dir "mysql", using: :mariadb_install_db, base: :var
   end
 
   def caveats

--- a/Formula/m/mariadb@11.4.rb
+++ b/Formula/m/mariadb@11.4.rb
@@ -151,7 +151,7 @@ class MariadbAT114 < Formula
   post_install_steps do
     # Make sure the var/mysql directory exists
     # Don't initialize database, it clashes when testing other MySQL-like implementations.
-    init_data_dir "mysql", using: :mariadb_install_db
+    init_data_dir "mysql", using: :mariadb_install_db, base: :var
   end
 
   def caveats

--- a/Formula/m/mariadb@11.8.rb
+++ b/Formula/m/mariadb@11.8.rb
@@ -153,7 +153,7 @@ class MariadbAT118 < Formula
   post_install_steps do
     # Make sure the var/mysql directory exists
     # Don't initialize database, it clashes when testing other MySQL-like implementations.
-    init_data_dir "mysql", using: :mariadb_install_db
+    init_data_dir "mysql", using: :mariadb_install_db, base: :var
   end
 
   def caveats

--- a/Formula/m/minio.rb
+++ b/Formula/m/minio.rb
@@ -49,7 +49,7 @@ class Minio < Formula
   end
 
   post_install_steps do
-    mkdir_p "minio"
+    mkdir_p "minio", base: :var
     mkdir_p "minio", base: :etc
   end
 

--- a/Formula/m/mysql.rb
+++ b/Formula/m/mysql.rb
@@ -165,7 +165,7 @@ class Mysql < Formula
   post_install_steps do
     # Make sure the var/mysql directory exists
     # Don't initialize database, it clashes when testing other MySQL-like implementations.
-    init_data_dir "mysql", using: :mysql_initialize
+    init_data_dir "mysql", using: :mysql_initialize, base: :var
   end
 
   def caveats

--- a/Formula/m/mysql@8.0.rb
+++ b/Formula/m/mysql@8.0.rb
@@ -136,7 +136,7 @@ class MysqlAT80 < Formula
   post_install_steps do
     # Make sure the var/mysql directory exists
     # Don't initialize database, it clashes when testing other MySQL-like implementations.
-    init_data_dir "mysql", using: :mysql_initialize
+    init_data_dir "mysql", using: :mysql_initialize, base: :var
   end
 
   def caveats

--- a/Formula/m/mysql@8.4.rb
+++ b/Formula/m/mysql@8.4.rb
@@ -141,7 +141,7 @@ class MysqlAT84 < Formula
   post_install_steps do
     # Make sure the var/mysql directory exists
     # Don't initialize database, it clashes when testing other MySQL-like implementations.
-    init_data_dir "mysql", using: :mysql_initialize
+    init_data_dir "mysql", using: :mysql_initialize, base: :var
   end
 
   def caveats

--- a/Formula/n/nagios.rb
+++ b/Formula/n/nagios.rb
@@ -70,7 +70,7 @@ class Nagios < Formula
   end
 
   post_install_steps do
-    mkdir_p "lib/nagios/rw"
+    mkdir_p "lib/nagios/rw", base: :var
     if_path_exists "{{etc}}/nagios/nagios.cfg" do
       inreplace "nagios/nagios.cfg", /^nagios_user=.*/, "nagios_user={{user}}", base: :etc, audit_result: false
     end

--- a/Formula/o/opensearch.rb
+++ b/Formula/o/opensearch.rb
@@ -62,16 +62,16 @@ class Opensearch < Formula
   end
 
   post_install_steps do
-    mkdir_p "lib/opensearch"
-    mkdir_p "log/opensearch"
+    mkdir_p "lib/opensearch", base: :var
+    mkdir_p "log/opensearch", base: :var
     unless_path_exists "{{libexec}}/config" do
       symlink "{{etc}}/opensearch", "config", target_base: :libexec
     end
-    mkdir_p "opensearch/plugins"
+    mkdir_p "opensearch/plugins", base: :var
     unless_path_exists "{{libexec}}/plugins" do
       symlink "{{var}}/opensearch/plugins", "plugins", target_base: :libexec
     end
-    mkdir_p "opensearch/extensions"
+    mkdir_p "opensearch/extensions", base: :var
     unless_path_exists "{{libexec}}/extensions" do
       symlink "{{var}}/opensearch/extensions", "extensions", target_base: :libexec
     end

--- a/Formula/o/opentsdb.rb
+++ b/Formula/o/opentsdb.rb
@@ -99,7 +99,7 @@ class Opentsdb < Formula
   end
 
   post_install_steps do
-    mkdir_p "cache/opentsdb"
+    mkdir_p "cache/opentsdb", base: :var
     run "post-install", base: :libexec
   end
 

--- a/Formula/o/orientdb.rb
+++ b/Formula/o/orientdb.rb
@@ -58,11 +58,11 @@ class Orientdb < Formula
   end
 
   post_install_steps do
-    mkdir_p "db/orientdb"
-    mkdir_p "run/orientdb"
-    mkdir_p "log/orientdb"
-    touch "log/orientdb/orientdb.err"
-    touch "log/orientdb/orientdb.log"
+    mkdir_p "db/orientdb", base: :var
+    mkdir_p "run/orientdb", base: :var
+    mkdir_p "log/orientdb", base: :var
+    touch "log/orientdb/orientdb.err", base: :var
+    touch "log/orientdb/orientdb.log", base: :var
     run "post-install", base: :libexec
   end
 

--- a/Formula/p/percona-server.rb
+++ b/Formula/p/percona-server.rb
@@ -161,7 +161,7 @@ class PerconaServer < Formula
     if_path_exists "/etc/{my.cnf,mysql/my.cnf}" do
       warn "A system my.cnf may interfere with a Homebrew-built server starting correctly."
     end
-    init_data_dir "mysql", using: :mysql
+    init_data_dir "mysql", using: :mysql, base: :var
   end
 
   def caveats

--- a/Formula/p/percona-server@8.0.rb
+++ b/Formula/p/percona-server@8.0.rb
@@ -183,7 +183,7 @@ class PerconaServerAT80 < Formula
     if_path_exists "/etc/{my.cnf,mysql/my.cnf}" do
       warn "A system my.cnf may interfere with a Homebrew-built server starting correctly."
     end
-    init_data_dir "mysql", using: :mysql
+    init_data_dir "mysql", using: :mysql, base: :var
   end
 
   def caveats

--- a/Formula/p/postgresql@12.rb
+++ b/Formula/p/postgresql@12.rb
@@ -97,9 +97,9 @@ class PostgresqlAT12 < Formula
   end
 
   post_install_steps do
-    mkdir_p "log"
+    mkdir_p "log", base: :var
     # Don't initialize database, it clashes when testing other PostgreSQL versions.
-    init_data_dir "postgresql@12", using: :postgresql_initdb, locale: "C"
+    init_data_dir "postgresql@12", using: :postgresql_initdb, locale: "C", base: :var
   end
 
   def postgresql_datadir

--- a/Formula/p/postgresql@13.rb
+++ b/Formula/p/postgresql@13.rb
@@ -96,9 +96,9 @@ class PostgresqlAT13 < Formula
   end
 
   post_install_steps do
-    mkdir_p "log"
+    mkdir_p "log", base: :var
     # Don't initialize database, it clashes when testing other PostgreSQL versions.
-    init_data_dir "postgresql@13", using: :postgresql_initdb
+    init_data_dir "postgresql@13", using: :postgresql_initdb, base: :var
   end
 
   def postgresql_datadir

--- a/Formula/p/postgresql@14.rb
+++ b/Formula/p/postgresql@14.rb
@@ -94,9 +94,9 @@ class PostgresqlAT14 < Formula
   end
 
   post_install_steps do
-    mkdir_p "log"
+    mkdir_p "log", base: :var
     # Don't initialize database, it clashes when testing other PostgreSQL versions.
-    init_data_dir "postgresql@14", using: :postgresql_initdb
+    init_data_dir "postgresql@14", using: :postgresql_initdb, base: :var
   end
 
   def postgresql_datadir

--- a/Formula/p/postgresql@15.rb
+++ b/Formula/p/postgresql@15.rb
@@ -117,9 +117,9 @@ class PostgresqlAT15 < Formula
   end
 
   post_install_steps do
-    mkdir_p "log"
+    mkdir_p "log", base: :var
     # Don't initialize database, it clashes when testing other PostgreSQL versions.
-    init_data_dir "postgresql@15", using: :postgresql_initdb
+    init_data_dir "postgresql@15", using: :postgresql_initdb, base: :var
   end
 
   def postgresql_datadir

--- a/Formula/p/postgresql@16.rb
+++ b/Formula/p/postgresql@16.rb
@@ -112,9 +112,9 @@ class PostgresqlAT16 < Formula
   end
 
   post_install_steps do
-    mkdir_p "log"
+    mkdir_p "log", base: :var
     # Don't initialize database, it clashes when testing other PostgreSQL versions.
-    init_data_dir "postgresql@16", using: :postgresql_initdb
+    init_data_dir "postgresql@16", using: :postgresql_initdb, base: :var
   end
 
   def postgresql_datadir

--- a/Formula/p/postgresql@17.rb
+++ b/Formula/p/postgresql@17.rb
@@ -116,7 +116,7 @@ class PostgresqlAT17 < Formula
   end
 
   post_install_steps do
-    mkdir_p "log"
+    mkdir_p "log", base: :var
     # Manually link files from keg to non-conflicting versioned directories in HOMEBREW_PREFIX.
     # Retain existing real directories for extensions if directory structure matches
     link_dir "include/postgresql", "include/#{name}"
@@ -125,7 +125,7 @@ class PostgresqlAT17 < Formula
     # Also link versioned executables
     link_children "bin", suffix: "-#{version.major}"
     # Don't initialize database, it clashes when testing other PostgreSQL versions.
-    init_data_dir name, using: :postgresql_initdb
+    init_data_dir name, using: :postgresql_initdb, base: :var
   end
 
   def postgresql_datadir

--- a/Formula/p/postgresql@18.rb
+++ b/Formula/p/postgresql@18.rb
@@ -118,7 +118,7 @@ class PostgresqlAT18 < Formula
   end
 
   post_install_steps do
-    mkdir_p "log"
+    mkdir_p "log", base: :var
     # Manually link files from keg to non-conflicting versioned directories in HOMEBREW_PREFIX.
     # Retain existing real directories for extensions if directory structure matches
     link_dir "include/postgresql", "include/#{name}"
@@ -127,7 +127,7 @@ class PostgresqlAT18 < Formula
     # Also link versioned executables
     link_children "bin", suffix: "-#{version.major}"
     # Don't initialize database, it clashes when testing other PostgreSQL versions.
-    init_data_dir name, using: :postgresql_initdb
+    init_data_dir name, using: :postgresql_initdb, base: :var
   end
 
   def postgresql_datadir

--- a/Formula/r/rpm.rb
+++ b/Formula/r/rpm.rb
@@ -135,7 +135,7 @@ class Rpm < Formula
   end
 
   post_install_steps do
-    unless_path_exists "lib/rpm/rpmdb.sqlite" do
+    unless_path_exists "lib/rpm/rpmdb.sqlite", base: :var do
       run "rpmdb", args: ["--initdb"], base: :bin
     end
   end

--- a/Formula/s/seaweedfs.rb
+++ b/Formula/s/seaweedfs.rb
@@ -29,7 +29,7 @@ class Seaweedfs < Formula
   end
 
   post_install_steps do
-    mkdir_p "seaweedfs"
+    mkdir_p "seaweedfs", base: :var
   end
 
   service do

--- a/Formula/s/solr@8.11.rb
+++ b/Formula/s/solr@8.11.rb
@@ -41,8 +41,8 @@ class SolrAT811 < Formula
   end
 
   post_install_steps do
-    mkdir_p "run/solr"
-    mkdir_p "log/solr"
+    mkdir_p "run/solr", base: :var
+    mkdir_p "log/solr", base: :var
   end
 
   service do

--- a/Formula/t/tronbyt-server.rb
+++ b/Formula/t/tronbyt-server.rb
@@ -31,8 +31,8 @@ class TronbytServer < Formula
   end
 
   post_install_steps do
-    mkdir_p "tronbyt-server"
-    write "tronbyt-server/.env", <<~EOS
+    mkdir_p "tronbyt-server", base: :var
+    write "tronbyt-server/.env", <<~EOS, base: :var
       # Add application configuration here.
       # For example:
       # LOG_LEVEL=INFO


### PR DESCRIPTION
Require relative formula install-step paths to specify their base explicitly.

The cop autocorrects paths that previously relied on the `var` compatibility default. Absolute paths and install-time path tokens remain unchanged. Run path options are rewritten using the explicit `var` token where no separate base keyword exists.

AI disclosure: using OpenAI Codex 5.6 Sol max with local review and testing.
