### PR TITLE
libgccjit: avoid building another 3-stage GCC

### DIFF
--- a/Formula/lib/libgccjit.rb
+++ b/Formula/lib/libgccjit.rb
@@ -23,14 +23,15 @@ class Libgccjit < Formula
   end
 
   bottle do
-    sha256 arm64_tahoe:   "97505cedf1e502c3b948e69cd48b9a3b78e4f61011cf275c4c963f76e34e933d"
-    sha256 arm64_sequoia: "a444a8d15c975b6bacc110928b80be9f9649547e325e71abbaeae64dcf03ce4f"
-    sha256 arm64_sonoma:  "f9a76ab97d22ad3c17d7d6cafa4566c18ab7009ccecec65c724098548e4e1fa3"
-    sha256 tahoe:         "45beaae24bfc185cf533177261ce568aafe975f4b3a5710d21fec94a987d56e5"
-    sha256 sequoia:       "bee819aabaf0c215d85ac6e3b14bab37ee9d61e9f888391aba2fbed1e94dcb27"
-    sha256 sonoma:        "326bd8002f8468200000f0081f2627c5cf5acb7b2013ff96dd9b993320de07cd"
-    sha256 arm64_linux:   "94c7d6b0162d06915340e852a51c43c7406427f4d323fc8a1908a78b1d62c7a4"
-    sha256 x86_64_linux:  "ce69005d6f81130017f8a503a1dda2dd1c07a433988741c0bf774ce409ae6629"
+    rebuild 1
+    sha256 arm64_tahoe:   "7f118c7d7c168c02ab79ced71d7f26f44cc0e89a045065aa80f48864123f2fb2"
+    sha256 arm64_sequoia: "20ac6b1e3bca525843d0c756b0810429c825d4c36833c6eb615c3c56a4f2de45"
+    sha256 arm64_sonoma:  "52cb55f46e15b9f213fdab33ea2f1fc81219094b164cf111c0ba8bef7334ef25"
+    sha256 tahoe:         "e7cdd96da95bb04a98b3c3372941a5843338d5b164d3a3d73a0893e5331b5c5c"
+    sha256 sequoia:       "3e58fd961848ea09ecd76f1e26274e9c43d0addb81e057449014f60bd3cfd2f3"
+    sha256 sonoma:        "8d3289f9bd7b540f5423270dd75f25e030ad9d62c2181c0efc90d88ebb92aa01"
+    sha256 arm64_linux:   "f9310c48056dd968a4275b777c3e17a341683dd3ba9a4e05492df901d5d25051"
+    sha256 x86_64_linux:  "cf29e7977bef28d309d9d16de4ca688e035c803a2deff58a41449b65c52836d4"
   end
 
   # The bottles are built on systems with the CLT installed, and do not work

--- a/Formula/lib/libgccjit.rb
+++ b/Formula/lib/libgccjit.rb
@@ -37,7 +37,7 @@ class Libgccjit < Formula
   # out of the box on Xcode-only systems due to an incorrect sysroot.
   pour_bottle? only_if: :clt_installed
 
-  depends_on "gcc" => :test
+  depends_on "gcc" => [:build, :test]
   depends_on "gmp"
   depends_on "isl"
   depends_on "libmpc"
@@ -58,6 +58,11 @@ class Libgccjit < Formula
   def install
     # GCC will suffer build errors if forced to use a particular linker.
     ENV.delete "LD"
+
+    # We can skip bootstrap process by using our already built GCC formula.
+    gcc_version = Formula["gcc"].version.major
+    ENV["CC"] = formula_opt_bin("gcc")/"gcc-#{gcc_version}"
+    ENV["CXX"] = formula_opt_bin("gcc")/"g++-#{gcc_version}"
 
     pkgversion = "Homebrew GCC #{pkg_version} #{build.used_options*" "}".strip
 
@@ -106,18 +111,17 @@ class Libgccjit < Formula
       inreplace "gcc/config/i386/t-linux64", "m64=../lib64", "m64="
       inreplace "gcc/config/aarch64/t-aarch64-linux", "lp64=../lib64", "lp64="
 
-      # Use our own (recent) binutils
-      args << "--with-as=#{formula_opt_bin("binutils")}/as"
-
       ENV.append_path "CPATH", formula_opt_include("zlib-ng-compat")
       ENV.append_path "LIBRARY_PATH", formula_opt_lib("zlib-ng-compat")
     end
 
     # Building jit needs --enable-host-shared, which slows down the compiler.
     mkdir "build-jit" do
-      system "../configure", *args, "--enable-languages=jit", "--enable-host-shared"
+      install_target = OS.mac? ? "install" : "install-strip"
+
+      system "../configure", *args, "--enable-languages=jit", "--enable-host-shared", "--disable-bootstrap"
       system "make", *make_args
-      system "make", "install"
+      system "make", install_target
     end
 
     # We only install the relevant libgccjit files from libexec and delete the rest.
@@ -189,11 +193,9 @@ class Libgccjit < Formula
     system gcc.to_s, *test_flags
     assert_equal "hello world", shell_output("./test")
 
-    # The test below fails with the host compiler on Linux.
-    return if OS.linux?
-
     # Also test with the host compiler, which many users use with libgccjit
     (testpath/"test").unlink
+    test_flags << "-Wl,-rpath,#{libs}" if OS.linux?
     system ENV.cc, *test_flags
     assert_equal "hello world", shell_output("./test")
   end


### PR DESCRIPTION
I think we can avoid a 3-stage GCC executable build by starting with our GCC formula similar to other distros.

Arch Linux's build - https://gitlab.archlinux.org/archlinux/packaging/packages/gcc/-/blob/main/PKGBUILD?ref_type=heads#L168-179
```
  # Build libgccjit separately, to avoid building all compilers with --enable-host-shared
  # which brings a performance penalty
  cd "$srcdir"/libgccjit-build

  ../gcc/configure \
    --enable-languages=jit \
    --disable-bootstrap \
    --enable-host-shared \
    "${_confflags[@]:?_confflags unset}"

  make -O all-gcc
```

Fedora's build - https://src.fedoraproject.org/rpms/gcc/blob/rawhide/f/gcc.spec#_1393-1406
```spec
CC="`%{gcc_target_platform}/libstdc++-v3/scripts/testsuite_flags --build-cc`"
CXX="`%{gcc_target_platform}/libstdc++-v3/scripts/testsuite_flags --build-cxx` `%{gcc_target_platform}/libstdc++-v3/scripts/testsuite_flags --build-includes`"

# Build libgccjit separately, so that normal compiler binaries aren't -fpic
# unnecessarily.
mkdir objlibgccjit
cd objlibgccjit
CC="$CC" CXX="$CXX" CFLAGS="$OPT_FLAGS" \
	CXXFLAGS="`echo " $OPT_FLAGS " | sed 's/ -Wall / /g;s/ -fexceptions / /g' \
		  | sed 's/ -Wformat-security / -Wformat -Wformat-security /'`" \
	XCFLAGS="$OPT_FLAGS" TCFLAGS="$OPT_FLAGS" \
	../../configure --disable-bootstrap --enable-host-shared \
	--enable-languages=jit --enable-libgdiagnostics $CONFIGURE_OPTS
make %{?_smp_mflags} BOOT_CFLAGS="$OPT_FLAGS" all-gcc
```

Install command from BLFS - https://www.linuxfromscratch.org/blfs/view/systemd/general/gcc.html#:~:text=make%20%2DC%20gcc%20jit.install%2Dcommon%20jit.install%2Dinfo

> If you need this library, configure GCC with these two options and install the library by running `make -C gcc jit.install-common jit.install-info`


-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
