### PR TITLE
rustar-aligner 0.1.0 (new formula)

### DIFF
--- a/Formula/r/rustar-aligner.rb
+++ b/Formula/r/rustar-aligner.rb
@@ -1,0 +1,41 @@
+class RustarAligner < Formula
+  desc "Rust reimplementation of the STAR RNA-seq aligner"
+  homepage "https://scverse.org/rustar-aligner/"
+  url "https://github.com/scverse/rustar-aligner/archive/refs/tags/v0.1.0.tar.gz"
+  sha256 "36bc9b578bfec649b0339642a8eb0cce6bbdf1d8f6ab7a63e7848b0e4ad8e443"
+  license "MIT"
+  head "https://github.com/scverse/rustar-aligner.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    (testpath/"genome.fa").write <<~FASTA
+      >chr1
+      GATTACAGATTACAGGCCTAGCTAGCTAGGCATCGATCGTAGCTAGCATCGATCGATCGA
+      TCGATCGATCGATTTACGCATCGATCGGCTAGCTAGCATCGCATCGATCGATTACGCATC
+      GATCGATCGATCGCATCGATCGGATCGATTACAGGCCTAGCTAGCTAGGCATCGATCGTA
+    FASTA
+
+    system bin/"rustar-aligner", "--runMode", "genomeGenerate",
+           "--genomeDir", testpath/"index",
+           "--genomeFastaFiles", testpath/"genome.fa",
+           "--genomeSAindexNbases", "6"
+    assert_path_exists testpath/"index/SA"
+
+    (testpath/"reads.fq").write <<~FASTQ
+      @read1
+      TCGATCGATCGATTTACGCATCGATCGGCTAGCTAGCATCGCATCGATCGATTACGCATC
+      +
+      IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII
+    FASTQ
+
+    system bin/"rustar-aligner", "--genomeDir", testpath/"index",
+           "--readFilesIn", testpath/"reads.fq",
+           "--outSAMtype", "SAM"
+    assert_match "read1", (testpath/"Aligned.out.sam").read
+  end
+end


### PR DESCRIPTION
-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

AI-assisted contribution by Claude Opus 5, roughly 90% of the work (formula authoring, test block, running the local build/test/audit commands). I reviewed the formula and the command output.

Built and tested locally on macOS 15 running arm64 (Apple Silicon).

New formula for rustar-aligner, a Rust reimplementation of the STAR RNA-seq aligner published under the [scverse](https://github.com/scverse) organisation (scanpy / anndata / squidpy).

**Audit disclosure:** `brew audit --strict --new rustar-aligner` fails on exactly one point, and only that one:

```
rustar-aligner
  * GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)
```

Current metrics: 67 stars, 5 forks, 3 watchers, first release v0.1.0 (2026-05-04). So this is below the threshold and I am opening it for a maintainer judgement call rather than claiming it passes. Arguments for an exception, for what they are worth:

- It is published under the scverse organisation, the umbrella project for scanpy/anndata, so it is not a random personal repository.
- It targets a drop-in replacement for STAR (same index format, same `--camelCase` parameters, SAM/BAM-compatible output). STAR itself has had no upstream commit since 2025-03.
- Upstream reports 99.8% (SE) / 99.9% (PE) tie-adjusted concordance with STAR 2.7.x on a 10k-read benchmark.

If the notability bar is the blocker, I am fine with this sitting until the repo grows, or with closing it. Note also that upstream states the majority of the code was written with an AI assistant under maintainer review, which maintainers may want to factor in.

`brew style` is clean; the test block builds a genome index and aligns a read, asserting on the produced SAM.
