### PR TITLE
gcc libgccjit: remove build.used_options, remove some comments

### DIFF
--- a/Formula/g/gcc.rb
+++ b/Formula/g/gcc.rb
@@ -80,7 +80,7 @@ class Gcc < Formula
     languages = %w[c c++ objc obj-c++ fortran]
     languages << "m2" unless OS.mac?
 
-    pkgversion = "Homebrew GCC #{pkg_version} #{build.used_options*" "}".strip
+    pkgversion = "Homebrew GCC #{pkg_version}"
 
     # Use `lib/gcc/current` to provide a path that doesn't change with GCC's version.
     args = %W[
@@ -105,7 +105,6 @@ class Gcc < Formula
       cpu = Hardware::CPU.arm? ? "aarch64" : "x86_64"
       args << "--build=#{cpu}-apple-darwin#{OS.kernel_version.major}"
 
-      # System headers may not be in /usr/include
       sdk = MacOS.sdk_path
       args << "--with-sysroot=#{sdk}" if sdk
 
@@ -117,7 +116,6 @@ class Gcc < Formula
         LDFLAGS_FOR_TARGET=-Wl,-headerpad_max_install_names
       ]
     else
-      # Fix Linux error: gnu/stubs-32.h: No such file or directory.
       args << "--disable-multilib"
 
       # Enable to PIE by default to match what the host GCC uses

--- a/Formula/lib/libgccjit.rb
+++ b/Formula/lib/libgccjit.rb
@@ -65,7 +65,7 @@ class Libgccjit < Formula
     ENV["CC"] = formula_opt_bin("gcc")/"gcc-#{gcc_version}"
     ENV["CXX"] = formula_opt_bin("gcc")/"g++-#{gcc_version}"
 
-    pkgversion = "Homebrew GCC #{pkg_version} #{build.used_options*" "}".strip
+    pkgversion = "Homebrew GCC #{pkg_version}"
 
     # Use `lib/gcc/current` to align with the GCC formula.
     args = %W[
@@ -88,7 +88,6 @@ class Libgccjit < Formula
       cpu = Hardware::CPU.arm? ? "aarch64" : "x86_64"
       args << "--build=#{cpu}-apple-darwin#{OS.kernel_version.major}"
 
-      # System headers may not be in /usr/include
       sdk = MacOS.sdk_path
       args << "--with-sysroot=#{sdk}" if sdk
 
@@ -104,7 +103,6 @@ class Libgccjit < Formula
 
       make_args = %W[BOOT_LDFLAGS=#{ldflags.join(" ")}]
     else
-      # Fix Linux error: gnu/stubs-32.h: No such file or directory.
       args << "--disable-multilib"
 
       # Change the default directory name for 64-bit libraries to `lib`
@@ -117,7 +115,7 @@ class Libgccjit < Formula
     end
 
     # Building jit needs --enable-host-shared, which slows down the compiler.
-    mkdir "build-jit" do
+    mkdir "build" do
       install_target = OS.mac? ? "install" : "install-strip"
 
       system "../configure", *args, "--enable-languages=jit", "--enable-host-shared", "--disable-bootstrap"


### PR DESCRIPTION
`build.used_options` shouldn't be used anymore.

`--with-sysroot=` is self-expanatory. We typically don't comment this and similar arguments in other formulae.

`--disable-multilib` should be straightforward also as we don't build 32-bit libraries (no 32-bit glibc or other libraries. Highly unlikely that we will ever support this).

---

Cleaning these up prior to adding some new changes, e.g.
* updating some hardening options. Will likely make SSP default and may build with  full RELRO. Performance impact is minimal for these (making compiler PIE/PIC seems to be highest performance loss).
* looking at enabling PGO. Improves performance by ~10-15% but will take longer to build the bottle. Similar to situation in LLVM though likely won't enable LTO as I haven't seen much benefit.
* may switch to RELR for more efficient format than RELA/REL. Provides some space savings and I think it is supposed to be faster startup for binaries. 
  * Would be nice to use by default but a bit difficult until we move to Ubuntu 26.04 as Binutils 2.43 is needed for aarch64 support (but possible when brew binutils is dependency). Could do a `ld -v` scoped injection of linker flag.


-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
