### PR TITLE
d2: update repository URL

### DIFF
--- a/Formula/d/d2.rb
+++ b/Formula/d/d2.rb
@@ -1,10 +1,10 @@
 class D2 < Formula
   desc "Modern diagram scripting language that turns text to diagrams"
   homepage "https://d2lang.com/"
-  url "https://github.com/terrastruct/d2/archive/refs/tags/v0.7.1.tar.gz"
+  url "https://github.com/d2lang/d2/archive/refs/tags/v0.7.1.tar.gz"
   sha256 "b784d6472d53fdaaa7ecc9bdbe23456e2b4a90e18736828028b3f951537e56a1"
   license "MPL-2.0"
-  head "https://github.com/terrastruct/d2.git", branch: "master"
+  head "https://github.com/d2lang/d2.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_tahoe:   "61a38ce31638ad307378e0031fce216fbf8e5082132ac4866ab5ca81e7337010"


### PR DESCRIPTION
The D2 repositories have moved from the Terrastruct GitHub organization to d2lang. This updates the stable and head source URLs while preserving the formula name, version, checksum, and bottles.

The archive at the new v0.7.1 URL has SHA-256 `b784d6472d53fdaaa7ecc9bdbe23456e2b4a90e18736828028b3f951537e56a1`, matching the existing formula.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

The local Homebrew CLI was unavailable, so the three local-only boxes remain unchecked. Homebrew's own CI completed successfully on Linux arm64/x86_64 and macOS 14/15/26, along with formula syntax, stable syntax, commit style, and audit-related checks.

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

Codex (OpenAI) assisted with the two-line URL change and PR preparation. The resulting diff was reviewed, the new release archive checksum was verified against the existing formula, and the full Homebrew CI result was checked before requesting review.

-----