### PR TITLE
tmpmail: deprecating due to not maintained upstream

### DIFF
--- a/Formula/t/tmpmail.rb
+++ b/Formula/t/tmpmail.rb
@@ -10,6 +10,9 @@ class Tmpmail < Formula
     sha256 cellar: :any_skip_relocation, all: "81e6aa8ea9a04b09f48bde663f58eb155061f1f83f8647727371a72cafaf9c0d"
   end
 
+  deprecate! date: "2026-08-02", because: :unmaintained
+  disable! date: "2027-08-02", because: :unmaintained
+
   depends_on "w3m"
   depends_on "xclip"
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
Deprecating formula `tmpmail` as last commit to upstream was on 2022-05-06. The third party API that the project depends on is no longer accessible, likely since early 2025. Disabling one year after deprecation. 