### PR TITLE
grow 1.1.1 (new formula)

### DIFF
--- a/Formula/g/grow.rb
+++ b/Formula/g/grow.rb
@@ -1,0 +1,35 @@
+# Upstream (Homebrew/homebrew-core) formula variant for Grow.
+#
+# Differs from packaging/harmonybrew/grow.rb (the OpenHarmony port):
+#   - default features ON (jemalloc + sandbox-enforce, matching the official
+#     release builds); only distro-pm is added to disable self-update
+#   - no `depends_on "zsh"`: macOS ships zsh, Linux falls back to bash
+# The source tarball carries the vendored crates (third_party/nix-ohos etc.);
+# their patches are behavior-neutral on macOS/Linux and exist for the
+# OpenHarmony target (Harmonybrew port), which upstream cannot build.
+class Grow < Formula
+  desc "Terminal-based AI coding agent with a Rust TUI (fork of xAI Grok Build)"
+  homepage "https://github.com/LordCasser/grow"
+  url "https://github.com/LordCasser/grow/archive/refs/tags/v1.1.1.tar.gz"
+  sha256 "2bbc6fada4bfa1bcc5eaaaa7bee6b791ff044703752101b77c2fb2e658961dd7"
+  license "Apache-2.0"
+  head "https://github.com/LordCasser/grow.git", branch: "main"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
+  depends_on "rust" => :build
+  depends_on "ripgrep"
+
+  def install
+    # distro-pm disables self-update: the package manager owns upgrades.
+    system "cargo", "install", *std_cargo_args(path: "crates/codegen/cli"), "--bin", "grow",
+           "--features", "distro-pm"
+  end
+
+  test do
+    assert_match "grow", shell_output("#{bin}/grow --version")
+  end
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`? (Verified with `brew audit --strict grow` and `brew audit --new grow` — both clean.)

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

**AI assistance disclosure**: This PR was prepared with the assistance of an AI coding agent. It drafted the formula following the Formula-Cookbook, ran and verified the local build/tests, and prepared this PR. All output was reviewed and verified: `brew style` and `brew audit` clean, `brew install --build-from-source grow` and `brew test grow` pass on macOS arm64 (Homebrew 6.0.13), and the v1.1.1 release workflow (9 platforms) is green. The commit is authored under my own identity.

-----

**About grow**: Grow is a terminal-based AI coding agent with a Rust TUI, forked from xAI Grok Build and independently evolved (BYOK-only model access, no xAI integration or telemetry; see the "Fork 之后改了什么" section of the README).

**Notes for reviewers**:
- **Vendored crates**: the source tarball vendors nix 0.26.4 (`third_party/nix-ohos`), nono and sqlite-vec. The patches exist for the OpenHarmony target (the Harmonybrew port, see `docs/ohos-porting.md`); on macOS/Linux they are behavior-identical to upstream and are refreshed with every release.
- **Self-update**: the `distro-pm` feature disables self-update at compile time, per the Acceptable-Formulae self-updating policy. Default features (jemalloc + sandbox-enforce) match the official release builds.
- `ripgrep` is a runtime dependency (bundled search tooling).
