### PR TITLE
tasksh: drop brewed readline on macOS

### DIFF
--- a/Formula/t/tasksh.rb
+++ b/Formula/t/tasksh.rb
@@ -4,7 +4,7 @@ class Tasksh < Formula
   url "https://github.com/GothenburgBitFactory/taskshell/releases/download/v1.2.0/tasksh-1.2.0.tar.gz"
   sha256 "6e42f949bfd7fbdde4870af0e7b923114cc96c4344f82d9d924e984629e21ffd"
   license "MIT"
-  revision 1
+  revision 2
   head "https://github.com/GothenburgBitFactory/taskshell.git", branch: "master"
 
   livecheck do
@@ -30,7 +30,6 @@ class Tasksh < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "readline" # Possible opportunistic linkage. TODO: Check if this can be removed.
   depends_on "task"
 
   on_linux do


### PR DESCRIPTION
Resolves the opportunistic-linkage TODO: without the dependency the
build links the macOS libedit readline shim and `brew test` passes,
so keep readline only on Linux where no system provider exists.
Revision bump since existing macOS bottles link brewed readline.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>