### PR TITLE
otterdog: restore playwright resource livecheck

### DIFF
--- a/Formula/o/otterdog.rb
+++ b/Formula/o/otterdog.rb
@@ -31,19 +31,14 @@ class Otterdog < Formula
   # No sdist on PyPI, so we use the GitHub tarball
   # Ref: https://github.com/microsoft/playwright-python/issues/2579
   resource "playwright" do
-    # 1.61.0+ needed ahead of poetry.lock as driver CDN blobs for <=1.58 were removed, breaking source builds
     url "https://github.com/microsoft/playwright-python/archive/refs/tags/v1.61.0.tar.gz"
     sha256 "ed26e5ef51c730b2bb8019042cb529f56dd459acd1a9bcbe3c0373ca598104ed"
 
     # We track poetry.lock version while PyPI sdist is not available as it
     # guarantees a compatible version is installed.
-    # TODO: Restore the check below once otterdog's poetry.lock reaches playwright >= 1.61
-    # livecheck do
-    #   url "https://raw.githubusercontent.com/eclipse-csi/otterdog/refs/tags/v#{LATEST_VERSION}/poetry.lock"
-    #   regex(/name = "playwright"\nversion = "(\d+(?:\.\d+)+)"/i)
-    # end
     livecheck do
-      skip "Pinned ahead of upstream poetry.lock to keep source builds working"
+      url "https://raw.githubusercontent.com/eclipse-csi/otterdog/refs/tags/v#{LATEST_VERSION}/poetry.lock"
+      regex(/name = "playwright"\nversion = "(\d+(?:\.\d+)+)"/i)
     end
   end
 


### PR DESCRIPTION
Upstream's poetry.lock reached playwright 1.61.0 in v1.4.0, matching the pinned resource, so the temporary livecheck skip and the pinned-ahead comment are no longer needed.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
