### PR TITLE
podcast-dl 11.7.5 (new formula)

### DIFF
--- a/Formula/p/podcast-dl.rb
+++ b/Formula/p/podcast-dl.rb
@@ -1,0 +1,35 @@
+class PodcastDl < Formula
+  desc "CLI for downloading and archiving podcasts"
+  homepage "https://github.com/lightpohl/podcast-dl"
+  url "https://registry.npmjs.org/podcast-dl/-/podcast-dl-11.7.5.tgz"
+  sha256 "57395141699bb60b24c9fdd1fa285c2b6002934dd6be99f7e019265e5b314db1"
+  license "MIT"
+  head "https://github.com/lightpohl/podcast-dl.git", branch: "main"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink libexec.glob("bin/*")
+  end
+
+  test do
+    (testpath/"feed.xml").write <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <rss version="2.0">
+        <channel>
+          <title>Homebrew Test Podcast</title>
+          <link>https://example.com/podcast</link>
+          <description>Fixture for formula testing.</description>
+          <item>
+            <title>Episode One</title>
+            <guid>episode-1</guid>
+            <enclosure url="https://example.com/episode.mp3" type="audio/mpeg" length="1"/>
+          </item>
+        </channel>
+      </rss>
+    XML
+
+    assert_match "Homebrew Test Podcast", shell_output("#{bin}/podcast-dl --file feed.xml --info")
+  end
+end

--- a/Formula/p/podcast-dl.rb
+++ b/Formula/p/podcast-dl.rb
@@ -6,6 +6,10 @@ class PodcastDl < Formula
   license "MIT"
   head "https://github.com/lightpohl/podcast-dl.git", branch: "main"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, all: "be17915149a8215a402ea72930ff2fa82d6cbcc349ed79fe1d0ec49de354a012"
+  end
+
   depends_on "node"
 
   def install


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

AI-assisted contribution by OpenAI Codex AI version GPT-5 for approximately 95% of the work. Formula research, implementation, stable and HEAD source builds, tests, audit, and `brew lgtm` were done by OpenAI Codex. The human contributor reviewed the final formula and authorized publication.

Built and tested locally on macOS 26.5.2 running arm64

Adds `podcast-dl` 11.7.5 from its npm source package.
