### PR TITLE
lightning: use local patch file

### DIFF
--- a/Formula/l/lightning.rb
+++ b/Formula/l/lightning.rb
@@ -20,16 +20,18 @@ class Lightning < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "f8a31092e058742cf79549bb7d50979296326151bec52214ea580dc823748a20"
   end
 
-  depends_on "binutils" => :build
+  depends_on "binutils" => :build # for libopcodes.a
 
   # upstream patch for fixing `Correct wrong ifdef causing missing mprotect call if NDEBUG is not defined`
+  # Using local patch file as repository url can 502-error and server's cgit version is included in patch
+  # https://cgit.git.savannah.gnu.org/cgit/lightning.git/patch/?id=bfd695a94668861a9447b29d2666f8b9c5dcd5bf
   patch do
-    url "https://cgit.git.savannah.gnu.org/cgit/lightning.git/patch/?id=bfd695a94668861a9447b29d2666f8b9c5dcd5bf"
-    sha256 "9264f463ce98e090e1386dd328cf02d542609c6375a6968d4024fbe8a6cabf8b"
+    file "Patches/lightning/bfd695a94668861a9447b29d2666f8b9c5dcd5bf.patch"
+    type :backport
   end
 
   def install
-    system "./configure", "--disable-silent-rules", *std_configure_args.reject { |s| s["--disable-debug"] }
+    system "./configure", "--disable-silent-rules", *std_configure_args
     system "make", "install"
   end
 

--- a/Patches/lightning/bfd695a94668861a9447b29d2666f8b9c5dcd5bf.patch
+++ b/Patches/lightning/bfd695a94668861a9447b29d2666f8b9c5dcd5bf.patch
@@ -1,0 +1,30 @@
+From bfd695a94668861a9447b29d2666f8b9c5dcd5bf Mon Sep 17 00:00:00 2001
+From: pcpa <paulo.cesar.pereira.de.andrade@gmail.com>
+Date: Tue, 3 Sep 2024 11:18:58 -0300
+Subject: Correct wrong ifdef causing missing mprotect call if NDEBUG is not
+ defined
+
+  This should fix OSX failure.
+  It also has not been detected earlier due to having assertions enabled
+in all test builds, to detect encoding errors.
+---
+ lib/lightning.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/lightning.c b/lib/lightning.c
+index ce0e295..83917ae 100644
+--- a/lib/lightning.c
++++ b/lib/lightning.c
+@@ -2620,8 +2620,8 @@ _jit_emit(jit_state_t *_jit)
+ #  endif
+ #  ifndef NDEBUG
+ 	result =
+-	mprotect(_jit->code.ptr, _jit->code.protect, PROT_READ | PROT_EXEC);
+ #  endif
++	mprotect(_jit->code.ptr, _jit->code.protect, PROT_READ | PROT_EXEC);
+ 	assert(result == 0);
+     }
+ #endif /* HAVE_MMAP */
+-- 
+cgit v1.3
+


### PR DESCRIPTION
Using local patch file as Savannah repo keeps erroring locally. Cgit is also well known for reproducibility problems due to how the version is included in patch.

Adding comment on `binutils` dependency.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
