### PR TITLE
opencrabs 0.3.78 (new formula)

### DIFF
--- a/Formula/o/opencrabs.rb
+++ b/Formula/o/opencrabs.rb
@@ -1,0 +1,35 @@
+class Opencrabs < Formula
+  desc "Autonomous, self-improving AI agent in a single Rust binary"
+  homepage "https://opencrabs.com"
+  url "https://github.com/adolfousier/opencrabs/archive/refs/tags/v0.3.78.tar.gz"
+  sha256 "1ced91fe756beb7b09764bd3c8864014f07bd04b5471e0f2aa82c29996744570"
+  license "MIT"
+  head "https://github.com/adolfousier/opencrabs.git", branch: "main"
+
+  depends_on "cmake" => :build
+  depends_on "llvm" => :build
+  depends_on "pkgconf" => :build
+  depends_on "rust" => :build
+  depends_on "rtk"
+
+  on_linux do
+    depends_on "alsa-lib"
+    depends_on "openssl@3"
+  end
+
+  def install
+    ENV["LIBCLANG_PATH"] = formula_opt_lib("llvm").to_s
+
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    system bin/"opencrabs", "init"
+
+    config = testpath/".opencrabs/config.toml"
+    assert_path_exists config
+    assert_match "[provider_registry]", config.read
+
+    assert_match "Database:", shell_output("#{bin}/opencrabs config")
+  end
+end

--- a/Formula/o/opencrabs.rb
+++ b/Formula/o/opencrabs.rb
@@ -6,6 +6,15 @@ class Opencrabs < Formula
   license "MIT"
   head "https://github.com/adolfousier/opencrabs.git", branch: "main"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "1f098cfc65e1ff41ceb67e7261ff1d481b31cfd55a07b8527633f0310c89bc35"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "970679649163faf419982d23d1d82556343e38f4a351ae64caa047f5487f139e"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "0f1b44017a6b340df6b8eb3f73e3ed096b498ab549ef898b5401b4671f81a72c"
+    sha256 cellar: :any_skip_relocation, sonoma:        "840450f77b056f042792bf821b74475e02672f8b314aa1eba84eba2121957f77"
+    sha256 cellar: :any,                 arm64_linux:   "65bdc5432d87a0ed8d32d7a4f0c0786051cda1ca3cb49691d7fc4b0bdd419ad0"
+    sha256 cellar: :any,                 x86_64_linux:  "9d6887627934e9a805e2832c06ab9eee7d2966804459e7bb5baf210fc6ba021f"
+  end
+
   depends_on "cmake" => :build
   depends_on "llvm" => :build
   depends_on "pkgconf" => :build


### PR DESCRIPTION
-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

AI was used. I wrote this formula with help from Open Crabs with Claude (Anthropic). I read and checked the output myself, no commit is credited to AI, and I will answer every review comment myself without AI.

-----

This is a new formula for OpenCrabs.

OpenCrabs is an AI agent you run in your terminal. It is a single Rust binary. The project is MIT licensed, has about 846 stars and 87 forks, and ships regular releases. Version 0.3.78 is the current one.

Notes on the dependencies, since a few of them are easy to get wrong:

`alsa-lib` is listed for Linux only. It is needed by `alsa-sys`, which comes in through `rodio` for the speech features that are on by default. macOS uses CoreAudio instead, so it does not need it.

There is no `opus` dependency, even though `opusic-sys` shows up in the dependency tree. That crate builds and links its own copy of opus. Two things back this up: the project's own CI builds on Linux with only `libasound2-dev` installed, and the finished binary does not link to a system libopus.

`cmake` is a build dependency because `llama-cpp-2` needs it.

One more thing worth mentioning. The project also publishes its own prebuilt binaries, and those archives include a small helper tool called `rtk`. This formula leaves that helper out, because homebrew-core does not accept prebuilt third party binaries. Nothing breaks without it. OpenCrabs downloads the right one by itself the first time it needs it.
