### PR TITLE
simutrans 124.5

### DIFF
--- a/Formula/s/simutrans.rb
+++ b/Formula/s/simutrans.rb
@@ -1,10 +1,9 @@
 class Simutrans < Formula
   desc "Transport simulator"
   homepage "https://www.simutrans.com/"
-  url "svn://servers.simutrans.org/simutrans/trunk/", revision: "11671"
-  version "124.3.1"
+  url "svn://servers.simutrans.org/simutrans/trunk/", revision: "11993"
+  version "124.5"
   license "Artistic-1.0"
-  revision 1
   head "https://github.com/simutrans/simutrans.git", branch: "master"
 
   livecheck do
@@ -46,8 +45,8 @@ class Simutrans < Formula
   end
 
   resource "pak64" do
-    url "https://downloads.sourceforge.net/project/simutrans/pak64/124-3/simupak64-124-3.zip"
-    sha256 "ecde0e15301320549e92a9113fcdd1ada3b7f9aa1fce3d59a5dc98d56d648756"
+    url "https://downloads.sourceforge.net/project/simutrans/pak64/124-4/simupak64-124-4.zip"
+    sha256 "edc6f9ca8d94af7bfcc9628ce1e7ddf468b07118cde0a50a8b5d0d30c22218ee"
   end
   resource "soundfont" do
     url "https://src.fedoraproject.org/repo/pkgs/PersonalCopy-Lite-soundfont/PCLite.sf2/629732b7552c12a8fae5b046d306273a/PCLite.sf2"
@@ -55,9 +54,6 @@ class Simutrans < Formula
   end
 
   def install
-    # fixed in 9aa819, remove in next release
-    inreplace "cmake/MacBundle.cmake", "SOURCE_DIR}src", "SOURCE_DIR}/src"
-
     # These translations are dynamically generated.
     system "./tools/get_lang_files.sh"
 

--- a/Formula/s/simutrans.rb
+++ b/Formula/s/simutrans.rb
@@ -17,13 +17,12 @@ class Simutrans < Formula
   no_autobump! because: :incompatible_version_format
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_tahoe:   "1fd7de0f2f6d759224c301571e17f5057755b13ad09ead31dbc2589c6ea0c4f8"
-    sha256 cellar: :any,                 arm64_sequoia: "5534b80d0083a84792de4c454e8856c96101d3d932bfa04c2b413731119d9530"
-    sha256 cellar: :any,                 arm64_sonoma:  "f5b0dcbb5ee3432922b76039f1f7a8ebd935abb9cab334986a50405e1b172640"
-    sha256 cellar: :any,                 sonoma:        "54bcf8151b603d18cdb4b2c50d627289797bc65b21d58282e41567a601c0bce9"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "365b26012ec707690ec42834ab7ac2753d8547246fde48f13bf8e66274f328ff"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "ba5871955287bcbe8520ed25d63be1c4ce7c9b797caab0c2cac970676f9b4c44"
+    sha256 cellar: :any, arm64_tahoe:   "9416e74ce4f562883c0ff06baaded29fd451a1287d1547823581f55cc1626742"
+    sha256 cellar: :any, arm64_sequoia: "a6cd38e5e313c1cce8d93316f2fdd573752df936ee0587e272d80578156e2271"
+    sha256 cellar: :any, arm64_sonoma:  "d0208918d7fb9691c3d04ecd169e3ae54e017b1455c84dca9f45ea07ec919729"
+    sha256 cellar: :any, sonoma:        "a023cf4bbea6b5ca1eb15ba383c35ea3ab06d610edaea99e52ad74a0199482ac"
+    sha256 cellar: :any, arm64_linux:   "2c73684b77cc59a82487de4e1b03f5a7c2696f483065b395cfcc33a961411ba1"
+    sha256 cellar: :any, x86_64_linux:  "407b04e50236fb72b705df2ef9583618155c0d8dc452e7825ec43d4087674d9f"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

-----

Updates `simutrans` 124.3.1 -> 124.5, drops the stale `revision 1`, and removes an
`inreplace` workaround that upstream has fixed.

### Revision

The formula pins an SVN revision rather than a tarball, so this needs the revision behind
the release. The upstream GitHub repo is a git-svn mirror and its annotated tag for
`124.5` records it:

```
Final Release of 124.5

git-svn-id: svn://localhost/simutrans/trunk@11993 8aca7d54-2c30-db11-9de9-000461428c89
```

Checked against the revision the formula already pins, as a sanity check on the method:

| tag | git-svn-id |
|---|---|
| 124.3.1 | `trunk@11671` — matches the current formula |
| 124.5 | `trunk@11993` |

124.5 is a stable release: published on SourceForge under `files/simutrans/124-5/` and
tagged `124.5` on the mirror. 124.4 and 124.4.1 shipped in between; this goes straight to
the latest.

### Removing the MacBundle.cmake workaround

The build fails at 124.5 without this. The existing workaround is:

```ruby
# fixed in 9aa819, remove in next release
inreplace "cmake/MacBundle.cmake", "SOURCE_DIR}src", "SOURCE_DIR}/src"
```

Upstream at r11993 already reads `${SOURCE_DIR}/src/simutrans/simversion.h`, so the
pattern no longer matches and `inreplace` aborts:

```
Error: inreplace failed
cmake/MacBundle.cmake:
  expected replacement of "SOURCE_DIR}src" with "SOURCE_DIR}/src"
```

This is the "next release" the comment refers to, so the workaround is removed.

This formula carries `no_autobump! because: :incompatible_version_format`, so BrewTestBot
doesn't pick it up — the last version bump was #218402 in April 2025.

### Verification

Run locally on macOS 26 (arm64, Tahoe):

```
brew install --build-from-source simutrans
  🍺  /opt/homebrew/Cellar/simutrans/124.5: 2,128 files, 59.8MB, built in 46 seconds

brew test simutrans          # passes
brew audit --strict simutrans # passes, no output
```
