### PR TITLE
nginx: remove old compatibility symlink

### DIFF
--- a/Formula/n/nginx.rb
+++ b/Formula/n/nginx.rb
@@ -15,12 +15,13 @@ class Nginx < Formula
   end
 
   bottle do
-    sha256 arm64_tahoe:   "e0773ed80b56bf9c51c0022faa28dee9ebc329e1637e4d620edf5c54dc621928"
-    sha256 arm64_sequoia: "56d837f739f2f8f7bb3184f25ff9cc5d2bb77e9d0bca03606287871a943a843e"
-    sha256 arm64_sonoma:  "7fde7eda4f038ef3001e97f1c4937c36bb3091c299787d1358703c84bdb824d8"
-    sha256 sonoma:        "5eba9b21bfd0bab7ab89341b5b85a8ca0051d3d3b50639ffc45f4aac18061e57"
-    sha256 arm64_linux:   "c130638817fe45b3986dbdce98fa991faa81d560a939091a9e6ea337606d07b7"
-    sha256 x86_64_linux:  "32e55bde0724ffac242a88765d9436c553abcd43ca1499bb6a4d2d24fef620a5"
+    rebuild 1
+    sha256 arm64_tahoe:   "c43bb6190e50282b4d63710a3cdeee7ddba11c4791305d06eeb58182cd70dd19"
+    sha256 arm64_sequoia: "d40751783d21f723fd931d65f8fbf5da8ff1d350d653ff0857d3c1288daf4e3b"
+    sha256 arm64_sonoma:  "0b2ae8178c6fc14e8cf869de2e0a7ea5b131fafcdddd79018229ca79578d50fc"
+    sha256 sonoma:        "cc16dd0eded86e701a8da80dcce7d8e8c5baa7f58f91cd29c7597b97d141f193"
+    sha256 arm64_linux:   "475264fb6dbac5c2c925238a6ec235883159001accd3b8904775c6565f1afe57"
+    sha256 x86_64_linux:  "0696880723841d787a3f1ee617ca249df307e16b33ccc1a24874e1a7c73d9929"
   end
 
   depends_on "openssl@3"

--- a/Formula/n/nginx.rb
+++ b/Formula/n/nginx.rb
@@ -130,12 +130,6 @@ class Nginx < Formula
     end
 
     prefix.install_symlink dst => "html"
-
-    # for most of this formula's life the binary has been placed in sbin
-    # and Homebrew used to suggest the user copy the plist for nginx to their
-    # ~/Library/LaunchAgents directory. So we need to have a symlink there
-    # for such cases
-    sbin.install_symlink bin/"nginx" if rack.subdirs.any? { |d| d.join("sbin").directory? }
   end
 
   def caveats


### PR DESCRIPTION
This compatibility symlink was added back in 2013-04-12 for version 1.2.8. Since we switched from plist stanza to service, most users should have migrated.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
