### PR TITLE
libcdr: remove obsolete ICU build workaround

### DIFF
--- a/Formula/lib/libcdr.rb
+++ b/Formula/lib/libcdr.rb
@@ -30,13 +30,6 @@ class Libcdr < Formula
   end
 
   def install
-    # icu4c 75+ needs C++17 and icu4c 76+ needs icu-uc
-    # TODO: Remove after https://gerrit.libreoffice.org/c/libcdr/+/175709/1
-    icu4c = deps.find { |dep| dep.name.match?(/^icu4c(@\d+)?$/) }
-                .to_formula
-    ENV["ICU_LIBS"] = "-L#{icu4c.opt_lib} -licui18n -licuuc"
-    ENV.append "CXXFLAGS", "-std=gnu++17"
-
     system "./configure", "--disable-silent-rules",
                           "--disable-tests",
                           "--disable-werror",


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

configure now detects ICU >= 75 via pkg-config and selects C++17 itself.