### PR TITLE
open-code-review 1.8.6 (new formula)

### DIFF
--- a/Formula/o/open-code-review.rb
+++ b/Formula/o/open-code-review.rb
@@ -6,6 +6,15 @@ class OpenCodeReview < Formula
   license "Apache-2.0"
   head "https://github.com/alibaba/open-code-review.git", branch: "main"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "785214bb0bb3e12ff54b5ec96c66da27fa195176532f6a890cf3dcfb5267c82b"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "785214bb0bb3e12ff54b5ec96c66da27fa195176532f6a890cf3dcfb5267c82b"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "785214bb0bb3e12ff54b5ec96c66da27fa195176532f6a890cf3dcfb5267c82b"
+    sha256 cellar: :any_skip_relocation, sonoma:        "e4a4d7a2abbf32cc7667352cd07bd44d9016bee51e045af2dfcfddc65f2a23b0"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "c395b04fd22ec48ca86df97f322af10f487da514eb25a604a4b96c31e34d0203"
+    sha256 cellar: :any,                 x86_64_linux:  "bbe602c73a9cbd28cf74cbfc256af18d65517ae1448049525420842af6907770"
+  end
+
   depends_on "go" => :build
 
   def install

--- a/Formula/o/open-code-review.rb
+++ b/Formula/o/open-code-review.rb
@@ -1,0 +1,28 @@
+class OpenCodeReview < Formula
+  desc "AI-powered code review tool with deterministic pipelines and an LLM agent"
+  homepage "https://github.com/alibaba/open-code-review"
+  url "https://github.com/alibaba/open-code-review/archive/refs/tags/v1.8.6.tar.gz"
+  sha256 "91229340a3f66da8e91d39465a1fb030afa3edb298d279f644527509ea45e044"
+  license "Apache-2.0"
+  head "https://github.com/alibaba/open-code-review.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = "-X main.Version=#{version}"
+    system "go", "build", *std_go_args(ldflags:, output: bin/"ocr"), "./cmd/opencodereview"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/ocr --version")
+
+    # "rules check" resolves which built-in review rule applies to a file.
+    # It runs fully offline but expects to sit inside a git repo.
+    system "git", "init", testpath
+    (testpath/"main.go").write "package main\n"
+    output = shell_output("#{bin}/ocr rules check main.go")
+    assert_match "File: main.go", output
+    assert_match "Pattern: **/*.go", output
+    assert_match "Source: System built-in", output
+  end
+end


### PR DESCRIPTION
Adds a formula for [open-code-review](https://github.com/alibaba/open-code-review), an AI-powered code review tool (binary `ocr`). Build-only dependency on `go`; upstream release v1.8.6.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

AI disclosure: this formula was drafted with assistance from Claude (Anthropic). I reviewed the formula myself and verified it locally on macOS (Apple Silicon): `brew style`, `brew audit --strict --new`, `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source`, and `brew test` all pass, and `ocr version` / `ocr --version` output the correct version. I will answer maintainer questions and review comments myself without AI/LLM.
