### PR TITLE
decision-kit 1.0.1 (new formula)

### DIFF
--- a/Formula/d/decision-kit.rb
+++ b/Formula/d/decision-kit.rb
@@ -1,0 +1,18 @@
+class DecisionKit < Formula
+  desc "Open-source CLI for random picks, dice, coin flips, and team splits"
+  homepage "https://entscheidomat.com/"
+  url "https://github.com/knuthtimo-lab/decision-kit/archive/refs/tags/v1.0.1.tar.gz"
+  sha256 "892634237e1613f0930eed641ba2f6051f851f474c9fa802e5c2aad820dfac66"
+  license "MIT"
+
+  depends_on "node"
+
+  def install
+    libexec.install Dir["*"]
+    bin.write_exec_script libexec/"bin/cli.mjs"
+  end
+
+  test do
+    assert_match "Usage:", shell_output("#{bin}/decision-kit --help")
+  end
+end


### PR DESCRIPTION
## Summary

Adds `decision-kit`, an MIT-licensed command-line toolkit for random picks, tabletop dice notation, coin flips, Magic 8-Ball responses, and fair team splits.

## Upstream

- Homepage: https://entscheidomat.com/
- Source: https://github.com/knuthtimo-lab/decision-kit
- Release: https://github.com/knuthtimo-lab/decision-kit/releases/tag/v1.0.1

## Validation

- Built the TypeScript package with `npm run build`.
- Ran the CLI commands `--help`, `roll 2d6+3`, and `pick Pizza Sushi Curry`.
- Installed the packed package in a clean temporary prefix and ran its CLI successfully without React installed.
- Verified the immutable release archive SHA-256 and checked the formula diff for whitespace errors.

The Homebrew-specific install/audit could not be run locally because this Windows host has no functional macOS/Linux Homebrew runtime available. Please rely on CI for the platform build.

AI assistance was used to prepare this pull request. The package changes and validation results were reviewed before submission.
