### PR TITLE
Use install-step template tokens

### DIFF
--- a/Formula/p/postgresql@17.rb
+++ b/Formula/p/postgresql@17.rb
@@ -119,11 +119,11 @@ class PostgresqlAT17 < Formula
     mkdir_p "log", base: :var
     # Manually link files from keg to non-conflicting versioned directories in HOMEBREW_PREFIX.
     # Retain existing real directories for extensions if directory structure matches
-    link_dir "include/postgresql", "include/#{name}"
-    link_dir "lib/postgresql", "lib/#{name}"
-    link_dir "share/postgresql", "share/#{name}"
+    link_dir "include/postgresql", "include/{{name}}"
+    link_dir "lib/postgresql", "lib/{{name}}"
+    link_dir "share/postgresql", "share/{{name}}"
     # Also link versioned executables
-    link_children "bin", suffix: "-#{version.major}"
+    link_children "bin", suffix: "-{{version.major}}"
     # Don't initialize database, it clashes when testing other PostgreSQL versions.
     init_data_dir name, using: :postgresql_initdb, base: :var
   end

--- a/Formula/p/postgresql@18.rb
+++ b/Formula/p/postgresql@18.rb
@@ -121,11 +121,11 @@ class PostgresqlAT18 < Formula
     mkdir_p "log", base: :var
     # Manually link files from keg to non-conflicting versioned directories in HOMEBREW_PREFIX.
     # Retain existing real directories for extensions if directory structure matches
-    link_dir "include/postgresql", "include/#{name}"
-    link_dir "lib/postgresql", "lib/#{name}"
-    link_dir "share/postgresql", "share/#{name}"
+    link_dir "include/postgresql", "include/{{name}}"
+    link_dir "lib/postgresql", "lib/{{name}}"
+    link_dir "share/postgresql", "share/{{name}}"
     # Also link versioned executables
-    link_children "bin", suffix: "-#{version.major}"
+    link_children "bin", suffix: "-{{version.major}}"
     # Don't initialize database, it clashes when testing other PostgreSQL versions.
     init_data_dir name, using: :postgresql_initdb, base: :var
   end

--- a/Formula/p/python-freethreading.rb
+++ b/Formula/p/python-freethreading.rb
@@ -351,11 +351,12 @@ class PythonFreethreading < Formula
 
   post_install_steps do
     on_macos do
-      set_permissions "PythonT.framework/Versions/#{version.major_minor}/lib/python#{version.major_minor}t/venv/scripts/**/*",
+      set_permissions "PythonT.framework/Versions/{{version.major_minor}}/" \
+                      "lib/python{{version.major_minor}}t/venv/scripts/**/*",
                       "u+w", base: :frameworks, recursive: false
     end
     on_linux do
-      set_permissions "python#{version.major_minor}t/venv/scripts/**/*", "u+w", base: :lib, recursive: false
+      set_permissions "python{{version.major_minor}}t/venv/scripts/**/*", "u+w", base: :lib, recursive: false
     end
   end
 

--- a/Formula/p/python@3.12.rb
+++ b/Formula/p/python@3.12.rb
@@ -392,11 +392,12 @@ class PythonAT312 < Formula
 
   post_install_steps do
     on_macos do
-      set_permissions "Python.framework/Versions/#{version.major_minor}/lib/python#{version.major_minor}/venv/scripts/**/*",
+      set_permissions "Python.framework/Versions/{{version.major_minor}}/" \
+                      "lib/python{{version.major_minor}}/venv/scripts/**/*",
                       "u+w", base: :frameworks, recursive: false
     end
     on_linux do
-      set_permissions "python#{version.major_minor}/venv/scripts/**/*", "u+w", base: :lib, recursive: false
+      set_permissions "python{{version.major_minor}}/venv/scripts/**/*", "u+w", base: :lib, recursive: false
     end
   end
 

--- a/Formula/p/python@3.13.rb
+++ b/Formula/p/python@3.13.rb
@@ -379,11 +379,12 @@ class PythonAT313 < Formula
 
   post_install_steps do
     on_macos do
-      set_permissions "Python.framework/Versions/#{version.major_minor}/lib/python#{version.major_minor}/venv/scripts/**/*",
+      set_permissions "Python.framework/Versions/{{version.major_minor}}/" \
+                      "lib/python{{version.major_minor}}/venv/scripts/**/*",
                       "u+w", base: :frameworks, recursive: false
     end
     on_linux do
-      set_permissions "python#{version.major_minor}/venv/scripts/**/*", "u+w", base: :lib, recursive: false
+      set_permissions "python{{version.major_minor}}/venv/scripts/**/*", "u+w", base: :lib, recursive: false
     end
   end
 

--- a/Formula/p/python@3.14.rb
+++ b/Formula/p/python@3.14.rb
@@ -396,11 +396,12 @@ class PythonAT314 < Formula
 
   post_install_steps do
     on_macos do
-      set_permissions "Python.framework/Versions/#{version.major_minor}/lib/python#{version.major_minor}/venv/scripts/**/*",
+      set_permissions "Python.framework/Versions/{{version.major_minor}}/" \
+                      "lib/python{{version.major_minor}}/venv/scripts/**/*",
                       "u+w", base: :frameworks, recursive: false
     end
     on_linux do
-      set_permissions "python#{version.major_minor}/venv/scripts/**/*", "u+w", base: :lib, recursive: false
+      set_permissions "python{{version.major_minor}}/venv/scripts/**/*", "u+w", base: :lib, recursive: false
     end
   end
 


### PR DESCRIPTION
Six formulae use compatibility Ruby interpolation inside structured install steps.

- replace identity and version interpolation with explicit install-time tokens
- keep formula paths deferred through the JSON API
- preserve existing permissions and linking behaviour
- avoid serialising installation-specific values

Needs https://github.com/Homebrew/brew/pull/23347

AI disclosure: using OpenAI Codex 5.6 Sol max with local review and testing.
