### PR TITLE
libdap: replace `gcc@13` dependency with workaround

### DIFF
--- a/Formula/lib/libdap.rb
+++ b/Formula/lib/libdap.rb
@@ -39,18 +39,16 @@ class Libdap < Formula
   on_linux do
     depends_on "libtirpc"
     depends_on "util-linux"
-
-    on_arm do
-      # FIXME: illegal instruction in test_simple_3_error_1 with Ubuntu GCC
-      depends_on "gcc@13" => :build
-    end
   end
 
   def install
+    # Work around illegal instruction in test_simple_3_error_1 on arm linux
+    check_args = ["CXX=#{ENV.cxx} -fno-stack-protector"] if OS.linux? && Hardware::CPU.arm?
+
     system "autoreconf", "--force", "--install", "--verbose" if build.head?
     system "./configure", "--with-included-regex", *std_configure_args
     system "make"
-    system "make", "check"
+    system "make", "check", *check_args
     system "make", "install"
   end
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
