### PR TITLE
cgvg: change archive url and homepage due to expired certificate, add head

### DIFF
--- a/Formula/c/cgvg.rb
+++ b/Formula/c/cgvg.rb
@@ -1,14 +1,11 @@
 class Cgvg < Formula
   desc "Command-line source browsing tool"
-  homepage "https://uzix.org/cgvg.html"
-  url "https://uzix.org/cgvg/cgvg-1.6.3.tar.gz"
+  homepage "https://github.com/uzi/cgvg"
+  url "https://github.com/uzi/cgvg/archive/refs/tags/v1.6.3.tar.gz"
+  mirror "https://uzix.org/cgvg/cgvg-1.6.3.tar.gz"
   sha256 "d879f541abcc988841a8d86f0c0781ded6e70498a63c9befdd52baf4649a12f3"
   license "GPL-2.0-or-later"
-
-  livecheck do
-    url :homepage
-    regex(/href=.*?cgvg[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
+  head "https://github.com/uzi/cgvg.git", branch: "master"
 
   bottle do
     rebuild 2


### PR DESCRIPTION
Ref
* Found in https://github.com/Homebrew/homebrew-core/issues/139929
* https://uzix.org/ links to http://github.com/uzi 
* https://github.com/uzi/cgvg

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
