### PR TITLE
ruby: use link_overwrite for part of post install

### DIFF
--- a/Formula/r/ruby.rb
+++ b/Formula/r/ruby.rb
@@ -56,6 +56,9 @@ class Ruby < Formula
     depends_on "zlib-ng-compat"
   end
 
+  # TODO: remove when enabling default_user_install
+  link_overwrite "bin/bundle", "bin/bundler"
+
   def determine_api_version
     Utils.safe_popen_read(bin/"ruby", "-e", "print Gem.ruby_api_version")
   end
@@ -161,10 +164,9 @@ class Ruby < Formula
   # Since Gem ships Bundle we want to provide that full/expected installation
   # but to do so we need to handle the case where someone has previously
   # installed bundle manually via `gem install`.
-  # TODO: remove when enabling default_user_install
+  # TODO: remove the `remove` step when enabling default_user_install
   post_install_steps do
-    remove ["bin/bundle", "bin/bundler", "lib/ruby/gems/{{version.major_minor}}.0/gems/bundler-*"],
-           base: :homebrew_prefix, recursive: true
+    remove "{{HOMEBREW_PREFIX}}/lib/ruby/gems/{{version.major_minor}}.0/gems/bundler-*", recursive: true
     on_macos do
       if_path_exists "opt/ruby@{{version.major_minor}}/lib/libruby.{{version.major_minor}}.dylib",
                      base: :homebrew_prefix do


### PR DESCRIPTION
Since we now link `ruby`, the remove in post install would happen too late, so use link_overwrite instead.

Also clarify TODO as the other step is unrelated and should be kept in 4.1 release (or would require a new DSL to handle in brew)

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
