### PR TITLE
pitchfork: fix ui being unbuilt.

### DIFF
--- a/Formula/p/pitchfork.rb
+++ b/Formula/p/pitchfork.rb
@@ -15,11 +15,16 @@ class Pitchfork < Formula
     sha256 cellar: :any,                 x86_64_linux:  "7e2e450f11ce36ae272db528b2e901c0a9e33ac38c606b51516e1e84fe6a10d0"
   end
 
+  depends_on "node" => :build
+  depends_on "pnpm" => :build
   depends_on "rust" => :build
   depends_on "usage"
 
   def install
-    (buildpath/"ui/dist").mkpath
+    cd "ui" do
+      system "pnpm", "install", "--frozen-lockfile"
+      system "pnpm", "build"
+    end
 
     system "cargo", "install", *std_cargo_args
     generate_completions_from_executable(bin/"pitchfork", "completion")
@@ -32,5 +37,12 @@ class Pitchfork < Formula
     config = (testpath/"pitchfork.toml").read
     assert_match 'run = "echo brewed"', config
     assert_match 'ready_output = "brewed"', config
+
+    port = free_port
+    pid = spawn bin/"pitchfork", "supervisor", "run", "--web-port", port.to_s
+    sleep 1
+    assert_match "<title>Pitchfork</title>", shell_output("curl -s http://127.0.0.1:#{port}")
+  ensure
+    Process.kill("TERM", pid) if pid
   end
 end

--- a/Formula/p/pitchfork.rb
+++ b/Formula/p/pitchfork.rb
@@ -7,12 +7,13 @@ class Pitchfork < Formula
   head "https://github.com/jdx/pitchfork.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "8b56dccb8e7f6de0ced583f9b792521f2d1092b9d27ff693b7ff555bf05e1166"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "4993d62f28c52c7e74c4d56e003e8c1a1a9e011cc55f52595f27a345cd85d851"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "3f162ad0fa676be6b9d0ca34aa079f055ab7f90b4171b7c9e7b7deeab697a8a9"
-    sha256 cellar: :any_skip_relocation, sonoma:        "2546005ee5495946dda66a83b858f3b980ed85de0f59a861636a91da8f7c1373"
-    sha256 cellar: :any,                 arm64_linux:   "23db02694c30a11dddabaa95dbe719b3936e0b9ca9f1eac203ad31ab6aefcf19"
-    sha256 cellar: :any,                 x86_64_linux:  "7e2e450f11ce36ae272db528b2e901c0a9e33ac38c606b51516e1e84fe6a10d0"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "3d8e3f2d3369d38452997008376b23342244ac1a387d0ffc05c7453e0452e994"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "31b89994e55e8bd6955f36523bd7b85cb4b828b612013295cf2e456e77834c57"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "db796c6d18484443da5fc112115d0618a0e023ac7555a49428104caa351aa474"
+    sha256 cellar: :any_skip_relocation, sonoma:        "71ed98c737059e0c1e85c5992d3210b404fe20f306a93858ef764152ad2968cf"
+    sha256 cellar: :any,                 arm64_linux:   "29069c11f5bebdeed3507cf6efc16887c68ee658f97bb51b1529b6d1cec686d5"
+    sha256 cellar: :any,                 x86_64_linux:  "ecfa00309e931df08cbd7d46ae6a989a40c53e5087052eb70b4d8326c5673890"
   end
 
   depends_on "node" => :build


### PR DESCRIPTION
-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

Codex (GPT-5.6) made this change

-----

The pitchfork formula wasn't building the UI, so when you ran the pitchfork web UI it'd just have a generic 404 screen. This updates the formula to actually build the web UI.