### PR TITLE
gcc: default to gnu-style hash

### DIFF
--- a/Formula/g/gcc.rb
+++ b/Formula/g/gcc.rb
@@ -117,6 +117,7 @@ class Gcc < Formula
       ]
     else
       args << "--disable-multilib"
+      args << "--with-linker-hash-style=gnu"
 
       # Enable to PIE by default to match what the host GCC uses
       args << "--enable-default-pie"

--- a/Formula/g/gcc.rb
+++ b/Formula/g/gcc.rb
@@ -25,15 +25,15 @@ class Gcc < Formula
   end
 
   bottle do
-    rebuild 2
-    sha256               arm64_tahoe:   "62d968d6919eacff601b0282fefccb38b8382d6f7169ea26a0662712e7f29f43"
-    sha256               arm64_sequoia: "6839eac9682dee9c9ab28ab96c5f6308a3a2d96ed499fbb4c43e10d6cc3691a5"
-    sha256               arm64_sonoma:  "7a051bdd1684ab105b32c11e16fdb1666f4b00570a5937a5d043a211ca0a60fb"
-    sha256               tahoe:         "8f85390a62209522d9630c85c2747290f87538f5e859e1c9a41dfe306324acdc"
-    sha256               sequoia:       "74045addfa1423d6ae6c61b1262bf5dceab762da3139a8882d1c3efd4f67407e"
-    sha256               sonoma:        "e4d2195790a199de6d34c15a46967ad5d29f921af09658275e879090d19c0eb5"
-    sha256 cellar: :any, arm64_linux:   "d96f44d6c8f398d961ce53f7d1eac98f46ed0781866905fe6aa29c8a9d644c5b"
-    sha256 cellar: :any, x86_64_linux:  "6b8edf7db3aaa4c67a412a448fcf97ed5ad5e1d157cb9c0f99d68b8c30aca484"
+    rebuild 3
+    sha256               arm64_tahoe:   "c2baec865938218940ee914d4cad1d8be1a92d6f0b6c758515e1e02b6ca2d84d"
+    sha256               arm64_sequoia: "3335d0d7ce2f4196aa04cbc327b9c1d9de02f7b0260319345787f8faf172169c"
+    sha256               arm64_sonoma:  "202e038d7755cfa3d34e90ca4292be607d1a22c97994a35e1b696d7e205f2931"
+    sha256               tahoe:         "dd7be82c88674e8075f4cd089bbf3e5485cd6e64d61984f195dd4c8cad52642f"
+    sha256               sequoia:       "59e29adc7a91e0afee8710f5552ef9c0ffc9e124d2cdbb7ac2baa1cb04674deb"
+    sha256               sonoma:        "21154aff4df82d0a00c6fabe9efc2cf5c50ddd4402b8f450d154ae070c90d08a"
+    sha256 cellar: :any, arm64_linux:   "d17041cb30c6eae581830d0313ec8e5a186d3090c08a3ea6693fb34bc0d6d196"
+    sha256 cellar: :any, x86_64_linux:  "f65155dcf09049ae420ffbc246d96b84ecd1391ac16bc545da600770f05e43ee"
   end
 
   # The bottles are built on systems with the CLT installed, and do not work


### PR DESCRIPTION
I had already updated `binutils` to default to this (all direct `ld` usage) so aligning `gcc`. GNU hash is the more performant/efficient option.

Linux distros that set this option include:
- Alpine - https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/main/gcc/APKBUILD#L315-318
- Arch Linux - https://gitlab.archlinux.org/archlinux/packaging/packages/gcc/-/blob/main/PKGBUILD?ref_type=heads#L122
- Fedora/RHEL - https://src.fedoraproject.org/rpms/gcc/blob/rawhide/f/gcc.spec#_1215-1216

Debian/Ubuntu uses older approach where they patch in `--hash-style=gnu`
- https://salsa.debian.org/toolchain-team/gcc/-/blob/master/debian/patches/gcc-hash-style-gnu.diff

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
