### PR TITLE
circleci 1.0.47091

### DIFF
--- a/Formula/c/circleci.rb
+++ b/Formula/c/circleci.rb
@@ -14,12 +14,12 @@ class Circleci < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "6fdb2236dda01251a520b307ec0b92e48c232853dd46a9a319be15beb3814442"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "02f65671b801f3f6b7e6a5fa83a8acb47c80d2d1e031b367b3253c6d483912ce"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "9eb19422042bd2dd55c1e3c6f3c5e11a45255160f8f3f3629a5e93e2a8291d73"
-    sha256 cellar: :any_skip_relocation, sonoma:        "2e1f39e67fcb12360160f0b6ff7d3b7455fa0ecdf54b567df144a78ada1cde8f"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "819f3a248e632f3558d19608b6413c405e5d6027e1791c234e0448cd531949c8"
-    sha256 cellar: :any,                 x86_64_linux:  "0ce55580d8ff8e0f54ebf64ba551af27d582039d24152bcd0a2fdd15179d1ab7"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "2bb3e694faef9765aa501db93fc9f79c33e23c6346953e654d5a5611bed14f6b"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "dabe087a59efaa6b88f75bf8f7158d2fa05327f2421e16486f29bfc831cd3c27"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "77e238c92f0ab868e30324b1b7bdf679b7e17e5511c1f7bc460881322c0401e1"
+    sha256 cellar: :any_skip_relocation, sonoma:        "aaabe54c56eb5dd6219b62da993e691866748772b728981708df3d523921280d"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "94aeb7dd1028b40df92721aa135eaf4f402fa130b8218f66332392745d9e076b"
+    sha256 cellar: :any,                 x86_64_linux:  "55682cb6177b7dfcb1bff551f8ae52385b2b7ec908235199b60d858d0ad0a0c8"
   end
 
   depends_on "go" => :build

--- a/Formula/c/circleci.rb
+++ b/Formula/c/circleci.rb
@@ -1,10 +1,10 @@
 class Circleci < Formula
-  desc "Enables you to reproduce the CircleCI environment locally"
-  homepage "https://circleci.com/docs/guides/toolkit/local-cli/"
+  desc "Official command-line tool for CircleCI"
+  homepage "https://cli.circleci.com"
   # Updates should be pushed no more frequently than once per week.
   url "https://github.com/CircleCI-Public/circleci-cli.git",
-      tag:      "v0.1.38646",
-      revision: "f96353c6bb0085274f4061376e7c3ad719f265bc"
+      tag:      "v1.0.47091",
+      revision: "66186e495abd408f2e9f0022d27b64793bfb783b"
   license "MIT"
   head "https://github.com/CircleCI-Public/circleci-cli.git", branch: "main"
 
@@ -25,28 +25,19 @@ class Circleci < Formula
   depends_on "go" => :build
 
   def install
-    ldflags = %W[
-      -X github.com/CircleCI-Public/circleci-cli/version.packageManager=#{tap.user.downcase}
-      -X github.com/CircleCI-Public/circleci-cli/version.Version=#{version}
-      -X github.com/CircleCI-Public/circleci-cli/version.Commit=#{Utils.git_short_head}
-      -X github.com/CircleCI-Public/circleci-cli/telemetry.SegmentEndpoint=https://api.segment.io
-    ]
-    system "go", "build", *std_go_args(ldflags:)
+    ldflags = "-X main.version=#{version}"
+    system "go", "build", *std_go_args(ldflags:), "./cmd/circleci"
 
-    generate_completions_from_executable(bin/"circleci", "--skip-update-check", "completion",
-                                        shells: [:bash, :zsh])
+    generate_completions_from_executable(bin/"circleci", "completion")
+    system bin/"circleci", "man", "--output", man1/"circleci.1"
   end
 
   test do
-    ENV["CIRCLECI_CLI_TELEMETRY_OPTOUT"] = "1"
+    ENV["DO_NOT_TRACK"] = "1"
     # assert basic script execution
-    assert_match(/#{version}\+.{7}/, shell_output("#{bin}/circleci version").strip)
+    assert_match(/^circleci #{version} \(\h{12}\)$/, shell_output("#{bin}/circleci version").strip)
     (testpath/".circleci.yml").write("{version: 2.1}")
     output = shell_output("#{bin}/circleci config pack #{testpath}/.circleci.yml")
     assert_match "version: 2.1", output
-    # assert update is not included in output of help meaning it was not included in the build
-    assert_match(/update.+This command is unavailable on your platform/, shell_output("#{bin}/circleci help 2>&1"))
-    assert_match "update is not available because this tool was installed using homebrew.",
-      shell_output("#{bin}/circleci update")
   end
 end


### PR DESCRIPTION
Update to the new 1.x series for the CircleCI CLI.

- Fix build tags.
- Generate completions for all shells now supported.
- Man page now supported.
- Telemetry opt out env var changed to standard one.
- Version is outputted slightly differently.
- There's no self update functionality any more.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
  - There is #297274 auto-generated, but it won't pass without the same changes as here.
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
