### PR TITLE
rammap 1.1.2 (new formula)

### DIFF
--- a/Formula/r/rammap.rb
+++ b/Formula/r/rammap.rb
@@ -1,0 +1,42 @@
+class Rammap < Formula
+  desc "Extensible and performant aligner and read mapper"
+  homepage "https://github.com/jwanglab/rammap"
+  url "https://github.com/jwanglab/rammap/archive/refs/tags/v1.1.2.tar.gz"
+  sha256 "d6d349495da8fb26e50ce6408235a587a297f666063f01ca8ebf05439b47d33c"
+  license "MIT"
+  head "https://github.com/jwanglab/rammap.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args(path: "rammap")
+  end
+
+  test do
+    # Deterministic pseudo-random reference; a repetitive one would not seed.
+    seed = 12_345
+    reference = Array.new(1200) do
+      seed = ((seed * 1_103_515_245) + 12_345) % (2**31)
+      "ACGT"[(seed >> 16) % 4]
+    end.join
+    (testpath/"ref.fa").write ">chr1\n#{reference.scan(/.{1,60}/).join("\n")}\n"
+
+    # A read lifted verbatim out of the reference, so it must align exactly.
+    read = reference[300, 200]
+    (testpath/"reads.fq").write "@read1\n#{read}\n+\n#{"I" * read.length}\n"
+
+    paf = shell_output("#{bin}/rammap -x map-ont ref.fa reads.fq 2>/dev/null")
+    fields = paf.lines.first.chomp.split("\t")
+    assert_equal "read1", fields[0]
+    assert_equal "+", fields[4]
+    assert_equal "chr1", fields[5]
+    assert_equal "1200", fields[6]
+    assert_equal "60", fields[11]
+    assert_operator fields[9].to_i, :>=, 190
+
+    sam = shell_output("#{bin}/rammap -x map-ont -a ref.fa reads.fq 2>/dev/null")
+    assert_match "@SQ\tSN:chr1\tLN:1200", sam
+    assert_match "200M", sam
+    assert_match "NM:i:0", sam
+  end
+end


### PR DESCRIPTION
-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

AI-assisted contribution: the formula was written with Claude Code (Claude Opus 5), which also ran `brew install --build-from-source`, `brew test`, `brew audit --new --strict --online` and `brew style` on macOS 15 arm64 on my machine. I reviewed the formula and those results before opening this PR. The commit carries no AI attribution trailer.

-----

Built and tested locally on macOS arm64.

Adds rammap, a pure-Rust sequence aligner and read mapper that mirrors the minimap2 interface and output.

Notes for review:

- Plain `cargo install` via `std_cargo_args(path: "rammap")`; the repository is a two-crate workspace and only the `rammap` binary crate is installed.
- Bottle safety: upstream's `.cargo/config.toml` deliberately avoids `-C target-cpu=native`, and the SIMD kernels dispatch at runtime via `is_x86_feature_detected!`, so the build stays baseline-safe.
- The test aligns a read lifted verbatim out of a generated reference and checks both output formats: target name, strand, reference length and MAPQ in the PAF record, and `200M` with `NM:i:0` in the SAM record.
