### PR TITLE
hermes-agent: revert deprecation, fix socksio build with flit-core 4

### DIFF
--- a/Formula/h/hermes-agent.rb
+++ b/Formula/h/hermes-agent.rb
@@ -14,12 +14,13 @@ class HermesAgent < Formula
   end
 
   bottle do
-    sha256 cellar: :any, arm64_tahoe:   "2969a37ff38c3e4964d7579f777296eeba4a8fccb5ee7830b3c8da009b440e93"
-    sha256 cellar: :any, arm64_sequoia: "60aa32478b9ec9a297a7c9ae116c2e4b2dc41f82f527af76edcf54a4979fa1f3"
-    sha256 cellar: :any, arm64_sonoma:  "defc3c9852f1e57392da07b3ae7f5ed6091bb04eb5130a770b7be6d224fb2d59"
-    sha256 cellar: :any, sonoma:        "3b1e3788de6de77ca4ab24eabc1ce61d44c61799bc85649eaf15e60b0925efa2"
-    sha256 cellar: :any, arm64_linux:   "5208bbffb2c9c342c734d0a445e309c86cf82955ca533c3bd55a8d1b9376e3b6"
-    sha256 cellar: :any, x86_64_linux:  "62dad23f60f0a785378ef2ea188255a724633e437cd5305ff667643a10a036f2"
+    rebuild 1
+    sha256 cellar: :any, arm64_tahoe:   "1bc6279e603665a0acfa30e3ff91d3f6865cac52b0f2c6aa3bc68a0aab726b5c"
+    sha256 cellar: :any, arm64_sequoia: "0934c99e0c73fac31d7f6108648a556e701efd2f9a5dcb943fd456e571e03cf5"
+    sha256 cellar: :any, arm64_sonoma:  "683d5a776b5b0b86040a9b129e3b3914493b33d319f20d75769d4a027e5b5185"
+    sha256 cellar: :any, sonoma:        "6ee92f5c1d30139af7dd6664c65b9a9b1b6738c8eaecb985c16c5b4a2a11cbfa"
+    sha256 cellar: :any, arm64_linux:   "8abedc52d0aebc371f4515bb85cb77891d0cb91dff46b39739d554efce16c114"
+    sha256 cellar: :any, x86_64_linux:  "a2ec5b0ffadaf401540ca16ee1c096da45d9b7d1a8ed5f800866be4de30782fd"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/h/hermes-agent.rb
+++ b/Formula/h/hermes-agent.rb
@@ -22,11 +22,6 @@ class HermesAgent < Formula
     sha256 cellar: :any, x86_64_linux:  "62dad23f60f0a785378ef2ea188255a724633e437cd5305ff667643a10a036f2"
   end
 
-  # Support for brew was removed in https://github.com/NousResearch/hermes-agent/pull/68217
-  # Formula can not be updated
-  deprecate! date: "2026-08-03", because: "Upstream does not suppoort brew anymore"
-  disable! date: "2027-02-03", because: :unmaintained
-
   depends_on "pkgconf" => :build
   depends_on "rust" => :build
   depends_on "certifi" => :no_linkage
@@ -296,7 +291,13 @@ class HermesAgent < Formula
     # Allow to build with Python 3.14
     inreplace "pyproject.toml", "requires-python = \">=3.11,<3.14\"", "requires-python = \">=3.11,<3.15\""
 
-    virtualenv_install_with_resources
+    venv = virtualenv_install_with_resources(without: "socksio")
+    resource("socksio").stage do
+      # Cap flit-core below 4 as socksio's legacy `[tool.flit.metadata]`
+      # pyproject table is no longer supported since flit-core 4
+      inreplace "pyproject.toml", "flit_core >=2", "flit_core >=2,<4"
+      venv.pip_install Pathname.pwd
+    end
   end
 
   test do


### PR DESCRIPTION
-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

-----

AI-assisted contribution by Claude Code (Claude Fable 5, model `claude-fable-5`) for ~95% of the work (CI failure diagnosis, formula change, and running the validation commands). Build, test and audit were executed by the AI on the contributor's machine; the contributor reviewed the diff, the validation output and this description.

Built and tested locally on macOS 26 (Tahoe) running arm64.

Supersedes #297271: the revert is included as a single squashed commit (Sean Molenaar credited via Co-authored-by, thanks @SMillerDev), plus the build fix that PR's CI needs.

Why that CI failed — unrelated to the revert: flit_core 4.0.1 (PyPI, 2026-08-04) removed the legacy `[tool.flit.metadata]` table. The `socksio` resource's existing patch unpins its build requirement to `flit_core >=2`, so PEP 517 build isolation now picks flit_core 4 and `socksio` 1.0.0 fails with `flit_core.config.ConfigError` before the wheel's requirements can even be read. socksio upstream is dormant (no release since 1.0.0, last commit 2024), so the formula caps `flit_core >=2,<4` while building that resource, restoring the known-good backend (3.x) used when the 2026.8.3 bottles were built.
