### PR TITLE
libssh2: add patches based on output of `brew vulns --no-fix-available`

### DIFF
--- a/Formula/lib/libssh2.rb
+++ b/Formula/lib/libssh2.rb
@@ -126,6 +126,36 @@ class Libssh2 < Formula
     resolves "CVE-2026-66035"
   end
 
+  # Remove after confirming this is included in the next release
+  # `brew vulns --no-fix-available` showed:
+  # libssh2 (1.11.1)
+  # OSV-2022-24 (UNKNOWN) - Null-dereference READ in session_startup
+  #   Fixed in: b89858b83d68d7e29e0c5b0bb803f8a68271710c
+  # OSV-2024-847 (UNKNOWN) - Null-dereference READ in _libssh2_packet_add
+  #   Fixed in: b89858b83d68d7e29e0c5b0bb803f8a68271710c
+  patch do
+    url "https://github.com/libssh2/libssh2/commit/b89858b83d68d7e29e0c5b0bb803f8a68271710c.patch?full_index=1"
+    sha256 "76bdf62172e16e2f74fdde35cd3daa3db27b753c48c4a7bdfd295463444eb936"
+    type :backport
+    resolves "OSV-2022-24"
+    resolves "OSV-2022-847"
+  end
+
+  # Remove after confirming this is included in the next release
+  # `brew vulns --no-fix-available` showed:
+  # libssh2 (1.11.1)
+  # OSV-2025-90 (UNKNOWN) - Null-dereference READ in ubsan_GetStackTrace
+  #   Fixed in: 631e2f82a32ef016299ebb1af66efeae0161f68e
+  # OSV-2025-92 (UNKNOWN) - Null-dereference READ in session_startup
+  #   Fixed in: 631e2f82a32ef016299ebb1af66efeae0161f68e
+  patch do
+    url "https://github.com/libssh2/libssh2/commit/631e2f82a32ef016299ebb1af66efeae0161f68e.patch?full_index=1"
+    sha256 "a790ab6c15c8dd6300ca8a651121ecc91e90e0eda1a221ad8108f51de05e1cf3"
+    type :backport
+    resolves "OSV-2022-90"
+    resolves "OSV-2022-92"
+  end
+
   def install
     args = %W[
       --disable-silent-rules


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

No AI on this one.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

```
% brew vulns --no-fix-available                                                              

Checking ... packages for vulnerabilities...
(... packages skipped - no supported source URL)

...

libssh2 (1.11.1)
  OSV-2022-24 (UNKNOWN) - Null-dereference READ in session_startup
    Fixed in: b89858b83d68d7e29e0c5b0bb803f8a68271710c
  OSV-2024-847 (UNKNOWN) - Null-dereference READ in _libssh2_packet_add
    Fixed in: b89858b83d68d7e29e0c5b0bb803f8a68271710c
  OSV-2025-433 (UNKNOWN) - Null-dereference READ in _libssh2_packet_add
  OSV-2025-90 (UNKNOWN) - Null-dereference READ in ubsan_GetStackTrace
    Fixed in: 631e2f82a32ef016299ebb1af66efeae0161f68e
  OSV-2025-92 (UNKNOWN) - Null-dereference READ in session_startup
    Fixed in: 631e2f82a32ef016299ebb1af66efeae0161f68e

...

3 resolved by formula patches (not counted; pass --no-ignore-patches to include):
  libssh2: CVE-2026-58050, CVE-2026-58051, CVE-2026-66032
 ```

Despite no _released_ fix being available, these have been patched upstream. These patches do not appear to be in the latest released version of libssh2, which is from before they were committed. 

Patch https://github.com/libssh2/libssh2/commit/b89858b83d68d7e29e0c5b0bb803f8a68271710c is linked to as the fix from:
- [OSV-2022-24](https://osv.dev/vulnerability/OSV-2022-24)
- [OSV-2024-847](https://osv.dev/vulnerability/OSV-2024-847)
but is not in latest https://github.com/libssh2/libssh2/releases

Patch https://github.com/libssh2/libssh2/commit/631e2f82a32ef016299ebb1af66efeae0161f68e is linked to as the fix from:
- [OSV-2025-90](https://osv.dev/vulnerability/OSV-2025-90)
- [OSV-2025-92](https://osv.dev/vulnerability/OSV-2025-92)
but is not in latest https://github.com/libssh2/libssh2/releases


