### PR TITLE
prime-agent 0.7.0 (new formula)

### DIFF
--- a/Formula/p/prime-agent.rb
+++ b/Formula/p/prime-agent.rb
@@ -1,0 +1,36 @@
+class PrimeAgent < Formula
+  desc "Self-improving RLM agent for coding workflows and long-running autonomous tasks"
+  homepage "https://github.com/PrimeIntellect-ai/prime-agent"
+  url "https://github.com/PrimeIntellect-ai/prime-agent/releases/download/v0.7.0/prime-agent-0.7.0.tgz"
+  sha256 "88b6578518c72cd51a825bc80f28e0fef9a64c67de4a7d6fd7afd7ca1b34da0b"
+  license "MIT"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *std_npm_args
+
+    node_modules = libexec/"lib/node_modules/prime-agent/node_modules"
+    os = OS.mac? ? "darwin" : "linux"
+    arch = Hardware::CPU.intel? ? "x64" : "arm64"
+
+    koffi = node_modules/"koffi/build/koffi"
+    koffi.children.each { |dir| rm_r(dir) if dir.basename.to_s != "#{os}_#{arch}" }
+
+    zeromq = node_modules/"zeromq/build"
+    zeromq.children.each { |entry| rm_r(entry) if entry.directory? && entry.basename.to_s != os }
+    (zeromq/os).children.each { |dir| rm_r(dir) if dir.basename.to_s != arch }
+    (zeromq/os/arch/"node").children.each { |dir| rm_r(dir) if dir.basename.to_s.start_with?("musl") } if OS.linux?
+
+    if OS.mac?
+      universal = Dir[node_modules/"@mariozechner/clipboard-darwin-universal/*.node"]
+      deuniversalize_machos(*universal) if universal.any?
+    end
+
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/prime-agent --version")
+  end
+end


### PR DESCRIPTION
this pr adds [prime-agent](https://github.com/PrimeIntellect-ai/prime-agent) to homebrew/core.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

The Ruby code was generated initially using `brew create`. The install script was generated via prime-agent using Claude Fable 5. I verified the changes by running the requested audits and running the locally installed `prime-agent` after the fact. All audit passes. This PR description is written by myself.

-----
