### PR TITLE
mp3rgain 3.0.0 (new formula)

### DIFF
--- a/Formula/m/mp3rgain.rb
+++ b/Formula/m/mp3rgain.rb
@@ -1,0 +1,21 @@
+class Mp3rgain < Formula
+  desc "Lossless MP3/M4A/FLAC/OGG volume adjustment (modern mp3gain replacement)"
+  homepage "https://github.com/M-Igashi/mp3rgain"
+  url "https://github.com/M-Igashi/mp3rgain/archive/refs/tags/v3.0.0.tar.gz"
+  sha256 "f2507338804ac2d5c7e7728a33222b38e0c59dfdeaf907e19487a9d436602ecc"
+  license "MIT"
+  head "https://github.com/M-Igashi/mp3rgain.git", branch: "master"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    cp test_fixtures("test.mp3"), testpath/"test.mp3"
+    system bin/"mp3rgain", "-g", "1", testpath/"test.mp3"
+    assert_match "MP3GAIN_UNDO", shell_output("#{bin}/mp3rgain -s c #{testpath}/test.mp3")
+    assert_match version.to_s, shell_output("#{bin}/mp3rgain --version")
+  end
+end


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

AI disclosure: I used Claude Code (Anthropic, model Claude Fable 5) to help draft the formula and run the local verification steps. I am the upstream author of mp3rgain and have reviewed the formula and all verification output myself. All checks above were actually performed on my machine (macOS arm64): `brew style`, `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source mp3rgain`, `brew test mp3rgain`, and `brew audit --new --strict --online mp3rgain` all pass.

-----

mp3rgain is a lossless volume normalizer for MP3/M4A/FLAC/OGG files using ReplayGain — a modern Rust reimplementation of the classic mp3gain tool. It adjusts volume by modifying the MP3 global gain field (or tags for other formats) without re-encoding, and writes undo information so changes are reversible.

- Upstream: https://github.com/M-Igashi/mp3rgain (94 stars, 57 releases, active since January 2026). I am the upstream author.
- License: MIT
- Pure Rust, no C library dependencies; builds with `cargo install *std_cargo_args`
- Currently distributed via a tap (`M-Igashi/tap`); I plan to deprecate the CLI formula there once this is merged.
