### PR TITLE
fedify: switch to node to avoid bundling JavaScript runtime

### DIFF
--- a/Formula/f/fedify.rb
+++ b/Formula/f/fedify.rb
@@ -7,12 +7,8 @@ class Fedify < Formula
   head "https://github.com/fedify-dev/fedify.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "5153411632ac1909737eb81c2007ac71845088cbcd194b7016960f54f8fe706a"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "b4f284e3ffb20d12a196dabe61b41babd8a8ceaec1ec7ee830ed5c10499621f3"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "3660f20b01fcc09649e2bd05ed02284938f4e99f0519a20a19cae18da88ca49b"
-    sha256 cellar: :any_skip_relocation, sonoma:        "6edd4c6eaec44ebc44d92bdfa81a4030c625fdc8cae52a0c3bc35bb09d80e08b"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "9dbd24f3b2ff54e3c2695e7452448ebd75ff5aab7dba84c82877aa0f3dff7f41"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "9946cd382132c46a710c99cf430943c910780b818b78691f303bcbbd054cbc9a"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "47d053a9e367793401de533b7728ffd86f15a1b687da241c7760ac37ea23f6fa"
   end
 
   depends_on "node"

--- a/Formula/f/fedify.rb
+++ b/Formula/f/fedify.rb
@@ -1,8 +1,8 @@
 class Fedify < Formula
   desc "CLI toolchain for Fedify"
   homepage "https://fedify.dev/cli"
-  url "https://github.com/fedify-dev/fedify/archive/refs/tags/2.3.4.tar.gz"
-  sha256 "533d9ce174354a8a3dfac051728ed632e77a04d7514adc3d6150d3a866b06c44"
+  url "https://registry.npmjs.org/@fedify/cli/-/cli-2.3.4.tgz"
+  sha256 "97100e93607c886bce4390161128c32f825d424966ee12bc98263678b3e7d6ea"
   license "MIT"
   head "https://github.com/fedify-dev/fedify.git", branch: "main"
 
@@ -15,30 +15,12 @@ class Fedify < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "9946cd382132c46a710c99cf430943c910780b818b78691f303bcbbd054cbc9a"
   end
 
-  depends_on "deno" => :build
-
-  on_linux do
-    # We use a workaround to prevent modification of the `fedify` binary
-    # but this means brew cannot rewrite paths for non-default prefix
-    pour_bottle? only_if: :default_prefix
-  end
+  depends_on "node"
 
   def install
-    system "deno", "task", "codegen"
-    system "deno", "compile", "--allow-all", "--output=#{bin/"fedify"}", "packages/cli/src/mod.ts"
+    system "npm", "install", *std_npm_args
+    bin.install_symlink libexec.glob("bin/*")
     generate_completions_from_executable(bin/"fedify", "completions")
-
-    # FIXME: patchelf corrupts the ELF binary as Deno needs to find a magic
-    # trailer string `d3n0l4nd` at a specific location. This workaround should
-    # be made into a brew DSL to skip running patchelf.
-    if OS.linux? && build.bottle?
-      prefix.install bin/"fedify"
-      Utils::Gzip.compress(prefix/"fedify")
-    end
-  end
-
-  post_install_steps do
-    install_gzipped_executable "fedify.gz", "bin/fedify"
   end
 
   test do


### PR DESCRIPTION
This aligns with majority of node formulae and avoids needing patchelf workaround.

npm is an official installation now: https://fedify.dev/install
> `npm install -g @fedify/cli`

In the past, only deno build was available, but support for npm/bun was added in 1.8+ which matches our standard approach.

Main reason patchelf issue occurred was due to bundled JavaScript runtime (self-contained executable) which doesn't really match Homebrew/core policy.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
