### PR TITLE
workflows/triage: reduce self-hosted based on prior runs

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -417,9 +417,6 @@ jobs:
 
             - label: CI-linux-self-hosted
               path: "Formula/.+/(\
-                dart-sdk|\
-                dotnet|\
-                envoy|\
                 qt@5|\
                 qtwebengine|\
                 texlive\


### PR DESCRIPTION
Removing these based on last runs done during timeframe we had no self-hosted Linux.

Can re-add if future runs show they are still needed (i.e. we may be on border line for some so parallelization or underlying runner hardware could impact result).

For remaining, 
* `qtwebengine` - does need self-hosted. It is probably only formula we need self-hosted arm linux (for single formula PR) as run take around 6 hour. Reason why it has remained in `brew unbottled --tag arm64_linux`
* `texlive` - no recent runs to compare. Disk space is usually issue here and I doubt it is any better. GitHub-hosted arm linux does work but can't control per-arch self-hosted usage.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
