### PR TITLE
formulae: move xcode requirement to on_macos

### DIFF
--- a/Formula/p/periphery.rb
+++ b/Formula/p/periphery.rb
@@ -16,11 +16,13 @@ class Periphery < Formula
   # We need the CLT installed for libIndexStore.dylib.
   pour_bottle? only_if: :clt_installed
 
-  depends_on xcode: ["16.4", :build]
-
   uses_from_macos "curl"
   uses_from_macos "libxml2"
   uses_from_macos "swift"
+
+  on_macos do
+    depends_on xcode: ["16.4", :build]
+  end
 
   def clt_lib_directory
     on_macos do

--- a/Formula/p/plank.rb
+++ b/Formula/p/plank.rb
@@ -27,9 +27,11 @@ class Plank < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "ea941cd9c41a8ac9cb53678eaf17d5f0eeb04930758bcac1be793d17d60fe861"
   end
 
-  depends_on xcode: ["11.3", :build]
-
   uses_from_macos "swift" => :build
+
+  on_macos do
+    depends_on xcode: ["11.3", :build]
+  end
 
   # fix build failures
   patch do

--- a/Formula/q/quazip.rb
+++ b/Formula/q/quazip.rb
@@ -15,11 +15,14 @@ class Quazip < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on xcode: :build
   depends_on "qt5compat"
   depends_on "qtbase"
 
   uses_from_macos "bzip2"
+
+  on_macos do
+    depends_on xcode: :build
+  end
 
   on_linux do
     depends_on "zlib-ng-compat"

--- a/Formula/q/qxmpp.rb
+++ b/Formula/q/qxmpp.rb
@@ -16,12 +16,12 @@ class Qxmpp < Formula
 
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
-  depends_on xcode: :build
   depends_on "openssl@3"
   depends_on "qtbase"
 
   on_macos do
     depends_on "llvm" => :build if DevelopmentTools.clang_build_version <= 1400
+    depends_on xcode: :build
   end
 
   fails_with :clang do

--- a/Formula/s/skip.rb
+++ b/Formula/s/skip.rb
@@ -15,7 +15,6 @@ class Skip < Formula
     sha256                               x86_64_linux:  "a214c209cc255477acdd1ed4424cf37155fef210b2c22915395eadd1b2b61774"
   end
 
-  depends_on xcode: :build
   depends_on "gradle"
   depends_on "openjdk"
   depends_on "swiftly"
@@ -23,6 +22,10 @@ class Skip < Formula
   uses_from_macos "swift" => [:build, :test]
   uses_from_macos "curl"
   uses_from_macos "libxml2"
+
+  on_macos do
+    depends_on xcode: :build
+  end
 
   on_linux do
     depends_on "libarchive"

--- a/Formula/s/sourcedocs.rb
+++ b/Formula/s/sourcedocs.rb
@@ -17,8 +17,11 @@ class Sourcedocs < Formula
     sha256                               x86_64_linux:  "2c97cd8daa81d7c7e546e71cdfdf17db555dee5260d434287266f20edb3a25a6"
   end
 
-  depends_on xcode: ["12.0", :build, :test]
   uses_from_macos "swift"
+
+  on_macos do
+    depends_on xcode: ["12.0", :build, :test]
+  end
 
   # Workaround until SourceKitten dependency is updated
   # Ref: https://github.com/SourceDocs/SourceDocs/pull/83

--- a/Formula/s/sourcekitten.rb
+++ b/Formula/s/sourcekitten.rb
@@ -17,10 +17,12 @@ class Sourcekitten < Formula
     sha256                               x86_64_linux:  "c3cd592a6d2596a5f3ce0ed67ccd63498bcfd66f5ea4dace5fc163aef6a201b1"
   end
 
-  depends_on xcode: ["14.0", :build]
-  depends_on xcode: "6.0"
-
   uses_from_macos "swift"
+
+  on_macos do
+    depends_on xcode: ["14.0", :build]
+    depends_on xcode: "6.0"
+  end
 
   def install
     system "make", "prefix_install", "PREFIX=#{prefix}", "TEMPORARY_FOLDER=#{buildpath}/SourceKitten.dst"

--- a/Formula/s/sourcery.rb
+++ b/Formula/s/sourcery.rb
@@ -17,8 +17,6 @@ class Sourcery < Formula
     sha256                               x86_64_linux:  "017c7fc58e6665e6cd19bf0fc37af3dd77c2bc93d991d329b69814ff6b4f20f9"
   end
 
-  depends_on xcode: "14.3"
-
   uses_from_macos "ruby" => :build
   uses_from_macos "swift" => :build, since: :sonoma # swift 5.10+
   uses_from_macos "curl"
@@ -26,6 +24,10 @@ class Sourcery < Formula
   uses_from_macos "ncurses"
   uses_from_macos "sqlite"
   uses_from_macos "swift"
+
+  on_macos do
+    depends_on xcode: "14.3"
+  end
 
   def install
     # Build script is unfortunately not customisable.

--- a/Formula/x/xclogparser.rb
+++ b/Formula/x/xclogparser.rb
@@ -14,9 +14,11 @@ class Xclogparser < Formula
     sha256                               x86_64_linux:  "0670849f06a3fbdcc3ac6bcadd760ee43e9319e1d71aa9e15a102d83cb3ffba7"
   end
 
-  depends_on xcode: "13.0"
-
   uses_from_macos "swift"
+
+  on_macos do
+    depends_on xcode: "13.0"
+  end
 
   on_linux do
     depends_on "zlib-ng-compat"

--- a/Formula/x/xcsift.rb
+++ b/Formula/x/xcsift.rb
@@ -15,8 +15,11 @@ class Xcsift < Formula
     sha256 cellar: :any,                 x86_64_linux:  "5be4785031071d0b9821a9f010f33e6121fb01c25e634f6584a951b06abb8c82"
   end
 
-  depends_on xcode: ["16.0", :build]
   uses_from_macos "swift" => :build, since: :sonoma
+
+  on_macos do
+    depends_on xcode: ["16.0", :build]
+  end
 
   def install
     inreplace "Sources/xcsift/main.swift", "VERSION_PLACEHOLDER", version.to_s


### PR DESCRIPTION
We recently moved all macOS-requirement handling to imply macOS unless put in `on_macos` block so adjusting Xcode requirement for similar reason. Xcode only makes sense on macOS. Later on should add brew checks to handle these better.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
