### PR TITLE
libultrahdr: update checksum and revision for updated v2.0.0 release

### DIFF
--- a/Formula/lib/libultrahdr.rb
+++ b/Formula/lib/libultrahdr.rb
@@ -2,18 +2,10 @@ class Libultrahdr < Formula
   desc "Reference codec for the Ultra HDR format"
   homepage "https://developer.android.com/media/platform/hdr-image-format"
   url "https://github.com/google/libultrahdr/archive/refs/tags/v2.0.0.tar.gz"
-  sha256 "5e422540271b64473d069623136e207d0516999aac2f819fb6176a01a3f9f915"
+  sha256 "39a64a17c48f2f8a68b653b76663ab14ce357cb5ca5acaacd89e6bc97d2f409f"
   license "Apache-2.0"
+  revision 1
   compatibility_version 2
-
-  bottle do
-    sha256 cellar: :any, arm64_tahoe:   "bbfda15ba439949f899fbda932315d020bb8b302a35626d3653d280f610968ab"
-    sha256 cellar: :any, arm64_sequoia: "d66af7dedb5f7ab99726fdd28fd987e59927e919c32575411a518e97e16e7013"
-    sha256 cellar: :any, arm64_sonoma:  "53d1457c1cf34497c131f20bb38ae704f830ea15f4cfcbdc22d0a079a00589f2"
-    sha256 cellar: :any, sonoma:        "0b6771e28316662180a0a242d44fe63ca985a60bf19eb271c172604d8411275b"
-    sha256 cellar: :any, arm64_linux:   "f0826e58949cba2fb4588bcc7016573023445a8d65aa519216eaf50b72b2c4be"
-    sha256 cellar: :any, x86_64_linux:  "267677d00d922dc6212cbd8d4567123703db93ea494723996aab36ae39785480"
-  end
 
   depends_on "cmake" => :build
   depends_on "pkgconf" => :test


### PR DESCRIPTION
Updates the `sha256` checksum and adds `revision 1` for `libultrahdr` following the upstream release tag update to include cross-platform build fixes and ISO 21496-1 gain map support.