### PR TITLE
lume: update livecheck to workaround aberrant tag

### DIFF
--- a/Formula/l/lume.rb
+++ b/Formula/l/lume.rb
@@ -7,8 +7,8 @@ class Lume < Formula
   head "https://github.com/trycua/cua.git", branch: "main"
 
   livecheck do
-    url :stable
-    regex(/^(?:lume[._-])?v?(\d+(?:\.\d+)+)$/i)
+    url "https://cua.ai/lume/install.sh"
+    regex(/^LUME_BAKED_VERSION="v?(\d+(?:\.\d+)+)" # x-release-please-version$/i)
   end
 
   bottle do


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----

Upstream has an aberrant `lume-v0.19.0` tag but the latest release is lume-v0.5.1. Reported upstream at https://github.com/trycua/cua/issues/2998.

[Official docs](https://cua.ai/docs/how-to-guides/lume/install-lume#update-lume) give two ways to find the latest version: https://github.com/trycua/cua/releases?q=lume&expanded=true or `lume check-update`, which also [checks GitHub Releases](https://github.com/trycua/cua/blob/main/libs/lume/src/Update/VersionCheck.swift#L5).

The lume-v0.19.0 tag’s source even contains `VERSION = 0.5.1`:

```shell
curl -fsSL 'https://raw.githubusercontent.com/trycua/cua/refs/tags/lume-v0.19.0/libs/lume/VERSION'
0.5.1
```

Given that upstream parses GitHub Releases, this PR just adds `strategy :github_releases` to livecheck until the tag is sorted out upstream. After this change:

```shell
brew livecheck --formula --auto lume
lume: 0.19.0 ==> 0.5.1
```