### PR TITLE
tern: fix build and test

### DIFF
--- a/Formula/t/tern.rb
+++ b/Formula/t/tern.rb
@@ -11,13 +11,13 @@ class Tern < Formula
   no_autobump! because: "`update-python-resources` cannot determine dependencies"
 
   bottle do
-    rebuild 7
-    sha256 cellar: :any,                 arm64_tahoe:   "e46ade560dae11e2b9648e11376b4c52deea6dbd1bfe81be681d99dd62eeb4a5"
-    sha256 cellar: :any,                 arm64_sequoia: "6e712c642363091318a957abf67d61d74d889a0e212e4524341f47feaac722ce"
-    sha256 cellar: :any,                 arm64_sonoma:  "473fb5430e09556facd8d2addcca1a69f266485f5e73ff23f9b3eb15201ff7f9"
-    sha256 cellar: :any,                 sonoma:        "d46ed204d49b0670c2de94063662bda2fd7d9e20e07bd24625053bbdcc3f8dd5"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "9428d38d4d3b50c4f3ee0e9fc5799235f3a9215e5eec66b2c32716c1cfb5c0a3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "89d5aaf7868a4a9149f232f8bb253252dad574563fb983b98343527ac4fd9762"
+    rebuild 8
+    sha256 cellar: :any, arm64_tahoe:   "01fb256ab5222bbf6e9f63458b314b0bcbdd7012a5928662b79d1401a2c1c916"
+    sha256 cellar: :any, arm64_sequoia: "65e943141485c639cab0f424b36e84a397ca040f8a4da2ec027c2ecf586f77e5"
+    sha256 cellar: :any, arm64_sonoma:  "602b1cd41c112dabb603311cafef2a74bb573391217dfdaaaa18293a45598e5c"
+    sha256 cellar: :any, sonoma:        "2cfc8b78af35be6bb91d31402910a3ed6674f68f04a097274946ebe48e22683b"
+    sha256 cellar: :any, arm64_linux:   "fcd1578fefbe906c1a653120f22a404896575e4886dc79233458b1b4ae0061dd"
+    sha256 cellar: :any, x86_64_linux:  "e6e505ad15ae9351c9c50a5e0465fd145f46b2ce4314971692e42b23158d6992"
   end
 
   depends_on "certifi" => :no_linkage

--- a/Formula/t/tern.rb
+++ b/Formula/t/tern.rb
@@ -20,7 +20,7 @@ class Tern < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "89d5aaf7868a4a9149f232f8bb253252dad574563fb983b98343527ac4fd9762"
   end
 
-  depends_on "certifi"
+  depends_on "certifi" => :no_linkage
   depends_on "libyaml"
   depends_on "python@3.14"
 
@@ -94,8 +94,8 @@ class Tern < Formula
   end
 
   resource "pbr" do
-    url "https://files.pythonhosted.org/packages/ad/8d/23253ab92d4731eb34383a69b39568ca63a1685bec1e9946e91a32fc87ad/pbr-7.0.1.tar.gz"
-    sha256 "3ecbcb11d2b8551588ec816b3756b1eb4394186c3b689b17e04850dfc20f7e57"
+    url "https://files.pythonhosted.org/packages/5e/ab/1de9a4f730edde1bdbbc2b8d19f8fa326f036b4f18b2f72cfbea7dc53c26/pbr-7.0.3.tar.gz"
+    sha256 "b46004ec30a5324672683ec848aed9e8fc500b0d261d40a3229c2d2bbfcedc29"
   end
 
   resource "prettytable" do
@@ -148,6 +148,14 @@ class Tern < Formula
     sha256 "3239df9f44da632f96012472805d40a23281a991027ce11d2f45a6f24ac4c3da"
   end
 
+  # `pkg_resources` is gone from setuptools 81, so use `importlib.resources`
+  patch do
+    url "https://github.com/tern-tools/tern/commit/f2546fa2d39468ed8c1fd3e7438955547b35182a.patch?full_index=1"
+    sha256 "f4940c919c07ab00fbebe9d6145cba4d6a69bc902ee512c2b21f0bc9726c1288"
+    type :unofficial
+    resolves "https://github.com/tern-tools/tern/pull/1261"
+  end
+
   def install
     virtualenv_install_with_resources
   end
@@ -160,11 +168,7 @@ class Tern < Formula
   end
 
   test do
-    output = if OS.mac?
-      shell_output("#{bin}/tern report --image alpine:3.13.5 2>&1", 1)
-    else
-      shell_output("#{bin}/tern report --image alpine:3.13.5 2>&1")
-    end
+    output = shell_output("#{bin}/tern report --image alpine:3.13.5 2>&1", 1)
     assert_match "rootfs - Running command", output
     assert_path_exists testpath/"tern.log"
 


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

Claude is used to investigate the build failures and how to fix. 

-----

`pbr` 7.0.1 imports `pkg_resources` while building, which pip's isolated build environment no longer provides since setuptools 81 removed it; 7.0.3 dropped that import.

`tern` itself imported it at runtime too, so carry the upstream fix until it is released.

The Linux test now expects a failure like macOS does, as `sudo` is unavailable in the CI container.

This is for
- https://github.com/Homebrew/homebrew-core/pull/297256