### PR TITLE
envoy: remove unused deps

### DIFF
--- a/Formula/e/envoy.rb
+++ b/Formula/e/envoy.rb
@@ -20,29 +20,17 @@ class Envoy < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "505878e18779ea5426065598359368f2aca6ce572ef2b79609f8539a3efdd9eb"
   end
 
-  depends_on "autoconf" => :build
-  depends_on "automake" => :build
   depends_on "bazel@8" => :build
   depends_on "cmake" => :build
   depends_on "go" => :build
-  depends_on "libtool" => :build
   depends_on "llvm@18" => :build
   depends_on "ninja" => :build
   depends_on "pkgconf" => :build
-  depends_on "wget" => :build
-  depends_on xcode: :build
 
-  uses_from_macos "ncurses" => :build
   uses_from_macos "python" => :build
 
   on_macos do
-    depends_on "aspell" => :build
-    depends_on "clang-format" => :build
-  end
-
-  on_linux do
-    depends_on "libxml2" => :build
-    depends_on "lld" => :build
+    depends_on xcode: :build
   end
 
   def llvm_formula
@@ -104,12 +92,10 @@ class Envoy < Formula
     ln_sf llvm/"libexec", llvm_path/"libexec"
     ln_sf llvm/"share", llvm_path/"share"
 
-    if OS.mac?
-      # rules_foreign_cc expects "libtool" for AR on Darwin.
-      ln_sf which("libtool"), llvm_path/"bin/libtool"
-    end
-    ln_sf formula_opt_bin("libtool")/"glibtool", llvm_path/"bin/glibtool"
+    # rules_foreign_cc expects "libtool" for AR on Darwin.
+    ln_sf which("libtool"), llvm_path/"bin/libtool" if OS.mac?
     ENV["BAZEL_LLVM_PATH"] = llvm_path
+    ENV["BAZEL_USE_HOST_SYSROOT"] = "True"
 
     # clang-common links these archives in foreign_cc bootstrap; provide them from brewed llvm.
     if OS.linux?


### PR DESCRIPTION
* `autoconf`, `automake`, `libtool` - these were used to build gperftools. Now upstream uses tcmalloc repo which doesn't use autotools and tcmalloc is also disabled on macOS.
* `wget` doesn't seem to be used
* `ncurses` and `libxml2` seem to be for unused hermetic LLVM
* `aspell` and `clang-format` seem to be developer tools not used for release build
* `lld` isn't needed as that is for LLVM 22 while build already has lld inside `llvm@18`. This just results in installing 2 LLVMs.

Also set BAZEL_USE_HOST_SYSROOT=True following upstream documentation https://github.com/envoyproxy/envoy/blob/main/bazel/README.md#building-with-host-provided-toolchains

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
