### PR TITLE
klee: update head to LLVM 18

### DIFF
--- a/Formula/k/klee.rb
+++ b/Formula/k/klee.rb
@@ -4,11 +4,21 @@ class Klee < Formula
 
   desc "Symbolic Execution Engine"
   homepage "https://klee-se.org"
-  url "https://github.com/klee/klee/archive/refs/tags/v3.2.tar.gz"
-  sha256 "83d9b9ce0ba187e48c0e55623bf1a68b5eb61376da7ce82551c9d885715a21dd"
   license "NCSA"
   revision 4
-  head "https://github.com/klee/klee.git", branch: "master"
+
+  stable do
+    url "https://github.com/klee/klee/archive/refs/tags/v3.2.tar.gz"
+    sha256 "83d9b9ce0ba187e48c0e55623bf1a68b5eb61376da7ce82551c9d885715a21dd"
+
+    depends_on "llvm@16"
+
+    # klee needs a version of libc++ compiled with wllvm
+    resource "libcxx" do
+      url "https://github.com/llvm/llvm-project/releases/download/llvmorg-16.0.6/llvm-project-16.0.6.src.tar.xz"
+      sha256 "ce5e71081d17ce9e86d7cbcfa28c4b04b9300f8fb7e78422b1feb6bc52c3028e"
+    end
+  end
 
   bottle do
     sha256 arm64_tahoe:   "b183270701fa8dfadaa3fd4cc2bf3544c28627c0a2a1e991f47186628e76c30b"
@@ -18,23 +28,27 @@ class Klee < Formula
     sha256 x86_64_linux:  "061ff90c401d5b1d36f01f9f83230865bf03600fa7d2733d7217a0b83b646a82"
   end
 
+  head do
+    url "https://github.com/klee/klee.git", branch: "master"
+
+    depends_on "llvm@18"
+
+    # klee needs a version of libc++ compiled with wllvm
+    resource "libcxx" do
+      url "https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/llvm-project-18.1.8.src.tar.xz"
+      sha256 "0b58557a6d32ceee97c8d533a59b9212d87e0fc4d2833924eb6c611247db2f2a"
+    end
+  end
+
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
+  depends_on "wllvm" => :build
 
-  depends_on "cryptominisat"
   depends_on "gperftools"
-  depends_on "llvm@16" # LLVM 17+ issue: https://github.com/klee/klee/issues/1754
   depends_on "python@3.14"
   depends_on "sqlite"
   depends_on "stp"
-  depends_on "wllvm"
   depends_on "z3"
-
-  on_macos do
-    depends_on "cryptominisat"
-    depends_on "gmp"
-    depends_on "minisat"
-  end
 
   on_linux do
     # klee seems to stall when run on arm64. May not be supported yet:
@@ -42,12 +56,6 @@ class Klee < Formula
     # * https://github.com/klee/klee/issues/1767
     depends_on arch: :x86_64
     depends_on "zlib-ng-compat"
-  end
-
-  # klee needs a version of libc++ compiled with wllvm
-  resource "libcxx" do
-    url "https://github.com/llvm/llvm-project/releases/download/llvmorg-16.0.6/llvm-project-16.0.6.src.tar.xz"
-    sha256 "ce5e71081d17ce9e86d7cbcfa28c4b04b9300f8fb7e78422b1feb6bc52c3028e"
   end
 
   resource "tabulate" do
@@ -68,7 +76,7 @@ class Klee < Formula
     # https://github.com/klee/klee/blob/v#{version}/scripts/build/p-libcxx.inc
     libcxx_args = std_cmake_args(install_prefix: libcxx_install_dir) + %W[
       -DRUNTIMES_CMAKE_ARGS=-DCMAKE_INSTALL_RPATH=#{rpath}
-      -DLLVM_ENABLE_RUNTIMES=libcxx;libcxxabi
+      -DLLVM_ENABLE_RUNTIMES=libcxx;libcxxabi#{";libunwind" if build.head?}
       -DLLVM_ENABLE_PROJECTS=
       -DLLVM_ENABLE_PROJECTS_USED:BOOL=ON
       -DLLVM_ENABLE_THREADS:BOOL=OFF
@@ -79,6 +87,7 @@ class Klee < Formula
       -DLIBCXX_ENABLE_STATIC_ABI_LIBRARY:BOOL=#{OS.mac? ? "OFF" : "ON"}
       -DLIBCXXABI_ENABLE_THREADS:BOOL=OFF
     ]
+    libcxx_args << "-DLIBCXXABI_USE_LLVM_UNWINDER:BOOL=ON" if build.head?
 
     with_env(
       CC:                 "wllvm",


### PR DESCRIPTION
Also remove indirect/build deps from runtime deps

LLVM 18 built and passed test for me on HEAD. LLVM 19+ still fails.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
