### PR TITLE
kata 0.14.2 (new formula)

### DIFF
--- a/Formula/k/kata.rb
+++ b/Formula/k/kata.rb
@@ -1,0 +1,33 @@
+class Kata < Formula
+  desc "Local-first, federated issue tracker for humans and coding agents"
+  homepage "https://katatracker.com"
+  url "https://github.com/kenn-io/kata/releases/download/v0.14.2/kata_0.14.2_source.tar.gz"
+  sha256 "d85107793192147cc069e1bb5213a852ad0892fc3387127d073e46c6967b3592"
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def install
+    ENV["CGO_ENABLED"] = "0"
+    ldflags = %W[
+      -X go.kenn.io/kata/internal/version.Version=v#{version}
+      -X go.kenn.io/kata/internal/version.Distribution=homebrew
+      -X go.kenn.io/kata/internal/version.BuildDate=#{time.iso8601}
+    ]
+    system "go", "build", *std_go_args(ldflags:), "-mod=vendor", "-buildvcs=false", "./cmd/kata"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/kata version")
+
+    ENV["KATA_HOME"] = testpath/"kata-home"
+    ENV["KATA_TELEMETRY_ENABLED"] = "0"
+    begin
+      system bin/"kata", "init", "--project", "homebrew-test"
+      system bin/"kata", "create", "Homebrew test issue"
+      assert_match "Homebrew test issue", shell_output("#{bin}/kata list")
+    ensure
+      system bin/"kata", "daemon", "stop"
+    end
+  end
+end

--- a/Formula/k/kata.rb
+++ b/Formula/k/kata.rb
@@ -5,6 +5,15 @@ class Kata < Formula
   sha256 "d85107793192147cc069e1bb5213a852ad0892fc3387127d073e46c6967b3592"
   license "MIT"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "8dddc58466b35dab13cfc74d3e178467ee994ba4a3ec4a5e4057bab23f2b5238"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "8dddc58466b35dab13cfc74d3e178467ee994ba4a3ec4a5e4057bab23f2b5238"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "8dddc58466b35dab13cfc74d3e178467ee994ba4a3ec4a5e4057bab23f2b5238"
+    sha256 cellar: :any_skip_relocation, sonoma:        "fd761c425a511e035c06c3cd94a13b4a21546010f0f1e03c5b11accd888381f6"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "f291ee8113f48661d9e4b0e0aab2d7f7177e309f311710393dc8a47c230d5242"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d5b1fc5fdd08fce1c2d67223a345fee2605212216f6d8e7d7680cc4558274eae"
+  end
+
   depends_on "go" => :build
 
   def install


### PR DESCRIPTION
Adds Kata 0.14.2, the stable release of a local-first issue tracker for coding agents and the humans steering them. The dedicated source archive includes vendored Go modules and production web assets so Homebrew can build the complete application from source with Go as its only build dependency.

The formula stamps Kata's Homebrew distribution marker. This disables install-capable self-updates and directs users to `brew upgrade kata`, while preserving the read-only update check. At submission, the upstream repository has 334 GitHub stars and is over three months old.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

I used OpenAI Codex (GPT-5) to help prepare and locally validate the formula. I reviewed the formula and created the commit myself. I will answer maintainer questions and review comments myself without AI/LLM.

-----