### PR TITLE
xcinfo: deprecate, update urls

### DIFF
--- a/Formula/x/xcinfo.rb
+++ b/Formula/x/xcinfo.rb
@@ -1,12 +1,12 @@
 class Xcinfo < Formula
   desc "Tool to get information about and install available Xcode versions"
-  homepage "https://github.com/xcodereleases/xcinfo"
+  homepage "https://github.com/XcodeReleasesOrg/xcinfo"
   license "MIT"
-  head "https://github.com/xcodereleases/xcinfo.git", branch: "master"
+  head "https://github.com/XcodeReleasesOrg/xcinfo.git", branch: "master"
 
   stable do
     # TODO: Remove maximum_macos on the next release and update license
-    url "https://github.com/xcodereleases/xcinfo/archive/refs/tags/1.0.3.tar.gz"
+    url "https://github.com/XcodeReleasesOrg/xcinfo/archive/refs/tags/1.0.3.tar.gz"
     sha256 "b22f56193e4de8b71bbdaf99c17cec03f291d333d095311ad7aab74b5fb50c5a"
     depends_on maximum_macos: [:sonoma, :build]
   end
@@ -17,6 +17,10 @@ class Xcinfo < Formula
     sha256 cellar: :any_skip_relocation, sonoma:        "209fabe73333978156fc9bf344645a62b1eaeaa5c9fa872ce52993f4b1717533"
     sha256 cellar: :any_skip_relocation, ventura:       "f3b5b7c1fa92151ca33febdc63092f6af054f3c8bd7f9b5fb668157bf139b19d"
   end
+
+  # Last release on 2023-04-03 and no longer builds on Tier 1
+  deprecate! date: "2026-08-10", because: :does_not_build
+  disable! date: "2027-02-10", because: :does_not_build
 
   depends_on xcode: ["14.2", :build]
   depends_on macos: :ventura


### PR DESCRIPTION
```console
❯ curl -sI "https://github.com/xcodereleases/xcinfo" | grep location:
location: https://github.com/XcodeReleasesOrg/xcinfo

❯ curl -sL "https://github.com/XcodeReleasesOrg/xcinfo/archive/refs/tags/1.0.3.tar.gz" | sha256
b22f56193e4de8b71bbdaf99c17cec03f291d333d095311ad7aab74b5fb50c5a
```

Previously only built on Ventura and Sonoma. Now Sonoma is also failing so no longer able to test on CI.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
