### PR TITLE
sentry-cli: update license

### DIFF
--- a/Formula/s/sentry-cli.rb
+++ b/Formula/s/sentry-cli.rb
@@ -3,7 +3,7 @@ class SentryCli < Formula
   homepage "https://docs.sentry.io/cli/"
   url "https://github.com/getsentry/sentry-cli/archive/refs/tags/3.6.2.tar.gz"
   sha256 "f2b2471393efe7df74d980829df6bb2af3bd0036f5f8bf3204717d96393e6205"
-  license "BSD-3-Clause"
+  license "FSL-1.1-MIT"
   head "https://github.com/getsentry/sentry-cli.git", branch: "master"
 
   livecheck do


### PR DESCRIPTION
As the primary maintainer of Sentry CLI, I am submitting this correction to help Homebrew bring its formula metadata in line with upstream.

The currently declared license is incorrect: the formula declares BSD-3-Clause, but we changed Sentry CLI's license to [FSL-1.1-MIT](https://fsl.software/) in [getsentry/sentry-cli#2975](https://github.com/getsentry/sentry-cli/pull/2975). Version 2.58.2 was the last release under the previous license; 2.58.3 and later use FSL-1.1-MIT, including the current 3.6.2 release.

This PR updates the formula's license metadata to FSL-1.1-MIT. I understand that FSL-1.1-MIT likely does not satisfy Homebrew's core licensing policy, so Homebrew may not be able to continue publishing Sentry CLI in homebrew/core. I am submitting this PR so Homebrew can determine the appropriate action, including whether to remove the formula, and I understand that removal is the likely outcome.

Please let me know if you would prefer a separate issue for this policy discussion, or if you would like me to modify this PR into the appropriate deprecation or removal change.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

I used OpenAI GPT-5.6-Luna with xhigh thinking via Pi Coding Agent to assist with this commit and PR description. I reviewed the generated content and verified the formula change and upstream license history.

-----
