### PR TITLE
kandev 0.86.1 (new formula)

### DIFF
--- a/Formula/k/kandev.rb
+++ b/Formula/k/kandev.rb
@@ -1,0 +1,51 @@
+class Kandev < Formula
+  desc "Manage tasks, orchestrate agents, review changes, and ship value"
+  homepage "https://kandev.ai"
+  url "https://github.com/kdlbs/kandev/archive/refs/tags/v0.86.1.tar.gz"
+  sha256 "dd7dff4c8af3f407d29fa5e523f99ea3c48d417d9d1e76ceaf2cc1ff320d9333"
+  license "AGPL-3.0-only"
+  head "https://github.com/kdlbs/kandev.git", branch: "main"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
+  depends_on "go" => :build
+  depends_on "node@24" => :build
+  depends_on "pnpm@10" => :build
+
+  def install
+    inreplace "apps/pnpm-workspace.yaml", "packages:", "managePackageManagerVersions: false\n\npackages:"
+    system "pnpm", "--dir", "apps", "install", "--frozen-lockfile"
+
+    bundle = buildpath/"dist/homebrew"
+    system "make", "runtime-bundle",
+           "GOFLAGS=-trimpath",
+           "PNPM=pnpm",
+           "RUNTIME_BUNDLE_DIR=#{bundle}",
+           "RUNTIME_VERSION=#{version}"
+    libexec.install bundle.children
+
+    (bin/"kandev").write_env_script libexec/"bin/kandev",
+      KANDEV_BUNDLE_DIR: libexec.to_s,
+      KANDEV_VERSION:    version.to_s
+  end
+
+  test do
+    assert_equal version.to_s, shell_output("#{bin}/kandev --version").strip
+
+    ENV["KANDEV_HOME_DIR"] = testpath.to_s
+    ENV["KANDEV_DATABASE_PATH"] = (testpath/"kandev.db").to_s
+    ENV["KANDEV_SERVER_HOST"] = "127.0.0.1"
+    port = free_port
+    pid = spawn bin/"kandev", "--headless", "--port", port.to_s
+    curl = "curl --silent --show-error --fail --retry 30 --retry-connrefused --retry-delay 1"
+    health = shell_output("#{curl} http://127.0.0.1:#{port}/health")
+    assert_match '"status":"ok"', health
+    assert_match "<title>Kandev</title>", shell_output("#{curl} http://127.0.0.1:#{port}/")
+  ensure
+    Process.kill("TERM", pid) if pid
+    Process.wait(pid) if pid
+  end
+end

--- a/audit_exceptions/mismatched_binary_allowlist.json
+++ b/audit_exceptions/mismatched_binary_allowlist.json
@@ -7,6 +7,7 @@
   "faust": "share/faust/android/app/lib/libsndfile/lib/*/libsndfile.so",
   "ghidra": "libexec/docs/GhidraClass/ExerciseFiles/Advanced/*",
   "i686-elf-grub": "lib/i686-elf/grub/i386-pc/*",
+  "kandev": "libexec/bin/agentctl-{darwin,linux}-{amd64,arm64}",
   "lima": "share/lima/lima-guestagent.Linux-*",
   "picotool": "share/picotool/*.elf",
   "preevy": "libexec/lib/node_modules/preevy/node_modules/@preevy/compose-tunnel-agent/out/*.node",


### PR DESCRIPTION
Adds `kandev`, an open-source workspace for managing tasks, orchestrating coding agents, reviewing changes, and shipping work.

The formula builds the complete native runtime from source: the Go launcher and backend, local and cross-platform `agentctl` helpers, and the embedded Vite web application. The wrapper sets `KANDEV_BUNDLE_DIR` and `KANDEV_VERSION` so the launcher uses the runtime installed under Homebrew's `libexec` and reports the formula version.

Homepage: https://kandev.ai
Source:   https://github.com/kdlbs/kandev
License:  AGPL-3.0-only
Build:    go, node@24, pnpm@10

The runtime includes four cross-platform `agentctl` helpers used for remote Darwin and Linux targets. Their paths are narrowly scoped in `mismatched_binary_allowlist.json`.

A prebuilt-binary tap ([kdlbs/homebrew-kandev](https://github.com/kdlbs/homebrew-kandev)) remains available for users who prefer a shorter installation. This source formula allows `brew install kandev` directly from Homebrew Core.

Validated from source in Homebrew's Linux container:

```sh
HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source homebrew/core/kandev
brew test homebrew/core/kandev
brew style homebrew/core/kandev
brew audit --new --online homebrew/core/kandev
brew linkage --test kandev
brew livecheck homebrew/core/kandev
```

The source installation, version test, headless server health test, web application test, audit, style, linkage, and livecheck all passed.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

OpenAI Codex (GPT-5.6-Sol) assisted with repository analysis and drafting the formula and PR text. I manually reviewed its complete output and verified the source installation, tests, audit, style, linkage, and livecheck.

-----
