### PR TITLE
age-plugin-se 0.2.1

### DIFF
--- a/Formula/a/age-plugin-se.rb
+++ b/Formula/a/age-plugin-se.rb
@@ -7,12 +7,9 @@ class AgePluginSe < Formula
   head "https://github.com/remko/age-plugin-se.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "55a0b7d025debf0f2de2c023e0590391e04deedea8c90068d041dd2926616d26"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "b1a850c11897c463a544f04473ce8ed580cba03618ff480e6acf5c7ed4d856bd"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "fdafa89da43cac1983dbc16e5f974766b729c8eda0fe79b67f85f55c546da28f"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "a1e9f1d63e3860bb88c049baa8b4adaacb3263ce69b95b3bd78951752ad576fe"
-    sha256 cellar: :any_skip_relocation, sonoma:        "599dfc3ab78c9c6cf7bbacf9e3e0feab93a092d7689b66d485a6c8fc5971cdcc"
-    sha256 cellar: :any_skip_relocation, ventura:       "b5be656138ce5035388f1430e884a0ef0424464c409c45d1ef1a7d8f439f83d3"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:  "c0f6ab0e7b132e6ab579e0267efc666edbb8fe6aff0621d64c4bc5db2dd386cc"
+    sha256 cellar: :any,                 arm64_linux:  "9afcc177c0f73d09c3adc17a424be38da65a843311293b241e8915b6e4689dc6"
+    sha256 cellar: :any,                 x86_64_linux: "4d94ac4f95bf5f104863734bf3149d43ac3bacf116f851f083762e8a6cca143f"
   end
 
   depends_on "scdoc" => :build

--- a/Formula/a/age-plugin-se.rb
+++ b/Formula/a/age-plugin-se.rb
@@ -1,8 +1,8 @@
 class AgePluginSe < Formula
   desc "Age plugin for Apple Secure Enclave"
   homepage "https://github.com/remko/age-plugin-se"
-  url "https://github.com/remko/age-plugin-se/archive/refs/tags/v0.1.4.tar.gz"
-  sha256 "52d9b9583783988fbe5e94bbe72089a870d128a2eba197fc09a95c13926fb27a"
+  url "https://github.com/remko/age-plugin-se/archive/refs/tags/v0.2.1.tar.gz"
+  sha256 "a22ba4de99a6463b044894e0d7d26a2c9859be6577e2085b4082481e1ae6e6bc"
   license "MIT"
   head "https://github.com/remko/age-plugin-se.git", branch: "main"
 
@@ -16,15 +16,20 @@ class AgePluginSe < Formula
   end
 
   depends_on "scdoc" => :build
-  depends_on xcode: ["14.0", :build]
   depends_on "age" => :test
-  depends_on macos: :ventura
+
+  uses_from_macos "swift" => :build
+
+  on_macos do
+    depends_on macos: :tahoe # cannot build on Sequoia with Swift 6.2
+  end
 
   deny_network_access! [:postinstall, :test]
 
   def install
-    system "make", "PREFIX=#{prefix}", "RELEASE=1", "all"
-    system "make", "PREFIX=#{prefix}", "RELEASE=1", "install"
+    args = ["PREFIX=#{prefix}", "RELEASE=1", "SWIFT_BUILD_FLAGS=#{std_swift_args.join(" ")}"]
+    system "make", *args, "all"
+    system "make", *args, "install"
   end
 
   test do


### PR DESCRIPTION
Previously tried updating this with support for older macOS, but the `make patch-package-swift-legacy` workaround fails on up-to-date Sequoia.

At this point, let's just move up minimum to Tahoe.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
