### PR TITLE
lando-cli 3.26.8 revision bump due to retag

### DIFF
--- a/Formula/l/lando-cli.rb
+++ b/Formula/l/lando-cli.rb
@@ -2,8 +2,9 @@ class LandoCli < Formula
   desc "Cli part of Lando"
   homepage "https://docs.lando.dev/cli"
   url "https://github.com/lando/core/archive/refs/tags/v3.26.8.tar.gz"
-  sha256 "03347869863605bad123b48660c3a3429c97fce92020737cf195412b604f3c85"
+  sha256 "3ea7993d42c747c174823df6b89404c6d1e2a0dd1bc7864ad13a2aaa025b5c2b"
   license "MIT"
+  revision 1
   head "https://github.com/lando/core.git", branch: "main"
 
   livecheck do

--- a/Formula/l/lando-cli.rb
+++ b/Formula/l/lando-cli.rb
@@ -13,12 +13,12 @@ class LandoCli < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "fe7601f34cce01677435ebd55899f56f9250501b11866c6541b6870c7658ffe0"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "fe7601f34cce01677435ebd55899f56f9250501b11866c6541b6870c7658ffe0"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "fe7601f34cce01677435ebd55899f56f9250501b11866c6541b6870c7658ffe0"
-    sha256 cellar: :any_skip_relocation, sonoma:        "fe7601f34cce01677435ebd55899f56f9250501b11866c6541b6870c7658ffe0"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "b9b8ae302fcdd533b6b980f14cc7dc37342d17a919428fba5702bf5a3adda16b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b9b8ae302fcdd533b6b980f14cc7dc37342d17a919428fba5702bf5a3adda16b"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "80742158d267937efa38dc1393d4442c8dde907a52592b21fdc7365a228186e8"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "80742158d267937efa38dc1393d4442c8dde907a52592b21fdc7365a228186e8"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "80742158d267937efa38dc1393d4442c8dde907a52592b21fdc7365a228186e8"
+    sha256 cellar: :any_skip_relocation, sonoma:        "80742158d267937efa38dc1393d4442c8dde907a52592b21fdc7365a228186e8"
+    sha256 cellar: :any_skip_relocation, arm64_linux:   "b01685c496c00a10738be019d776da87bcdf637e080c915109f4ae14636d5899"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b01685c496c00a10738be019d776da87bcdf637e080c915109f4ae14636d5899"
   end
 
   depends_on "node"


### PR DESCRIPTION
-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

AI assistance: OpenClaw agent (xAI Grok) drafted the formula edit and PR text. Human (Aaron Feledy / Lando co-maintainer) requested the PR and verified:
- live GitHub source archive for `v3.26.8` hashes to `3ea7993d42c747c174823df6b89404c6d1e2a0dd1bc7864ad13a2aaa025b5c2b`
- formula change is only sha256 update + `revision 1`
- upstream issue confirming intentional retag: https://github.com/lando/core/issues/493

Local `brew install --build-from-source` / `brew test` / `brew audit --strict` were not run in this environment (no Homebrew install here). Relying on BrewTestBot for those.

-----

Upstream `lando/core` retagged `v3.26.8` during release recovery. The GitHub-generated source tarball checksum changed after homebrew-core had already merged `lando-cli 3.26.8` with the old hash.

- old: `03347869863605bad123b48660c3a3429c97fce92020737cf195412b604f3c85`
- new: `3ea7993d42c747c174823df6b89404c6d1e2a0dd1bc7864ad13a2aaa025b5c2b`

This PR updates the formula sha256 and adds `revision 1` so bottles rebuild as `3.26.8_1`.