### PR TITLE
simpleaf 0.27.0 (new formula)

### DIFF
--- a/Formula/s/simpleaf.rb
+++ b/Formula/s/simpleaf.rb
@@ -1,0 +1,42 @@
+class Simpleaf < Formula
+  desc "Rust framework to make using alevin-fry even simpler"
+  homepage "https://simpleaf.readthedocs.io/"
+  url "https://github.com/COMBINE-lab/simpleaf/archive/refs/tags/v0.27.0.tar.gz"
+  sha256 "8a8f4968e42964b976ef6e8df4f8278ef15ff233ea3c01c0ef9b43ace8b068b9"
+  license "BSD-3-Clause"
+  head "https://github.com/COMBINE-lab/simpleaf.git", branch: "main"
+
+  # hdf5-metno-sys is pulled in via af-anndata -> anndata-hdf5, which enables its
+  # `static` feature unconditionally, so HDF5 is always built from vendored sources.
+  depends_on "cmake" => :build
+  depends_on "rust" => :build
+
+  def install
+    # The vendored HDF5 build records `CMAKE_C_COMPILER` in its build settings
+    # blob, which ends up in the binary, so bypass the compiler shims.
+    ENV["CC"] = DevelopmentTools.locate(ENV.cc)
+    ENV["CXX"] = DevelopmentTools.locate(ENV.cxx)
+
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    ENV["ALEVIN_FRY_HOME"] = testpath
+
+    (testpath/"chemistries.json").write <<~JSON
+      {
+        "brew-test-chem": {
+          "geometry": "1{b[16]u[12]x:}2{r:}",
+          "expected_ori": "fw",
+          "version": "0.1.0"
+        }
+      }
+    JSON
+
+    output = shell_output("#{bin}/simpleaf chemistry lookup --name brew-test-chem")
+    assert_match "1{b[16]u[12]x:}2{r:}", output
+    assert_match "fw", output
+
+    assert_match version.to_s, shell_output("#{bin}/simpleaf --version")
+  end
+end


### PR DESCRIPTION
-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

AI-assisted contribution by Claude Code (Claude Opus 5) of ~85% of the work: the AI wrote the formula and ran `brew install --build-from-source`, `brew test`, `brew audit --new --strict --online` and `brew style`. I reviewed the formula and those results before opening this PR. The commit carries no AI attribution trailer.

Built and tested locally on macOS 26.6.1 running arm64.

-----

New formula for simpleaf, the COMBINE-lab workflow driver for single-cell/single-nucleus RNA-seq and scATAC preprocessing (companion to `alevin-fry`, already in core).

`brew audit --new --strict --online` reports one remaining problem:

```
* GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)
```

The repo is at 67 stars / 6 forks. Submitting anyway because the tool is published and peer-reviewed (Bioinformatics, 2023: [btad614](https://doi.org/10.1093/bioinformatics/btad614)) and is packaged in Bioconda; happy to close if the maintainers would rather wait for the star threshold.

Two notes on the formula:

- `depends_on "cmake" => :build` is required because `anndata-hdf5` enables `hdf5-metno-sys`'s `static` feature unconditionally, so HDF5 is always built from vendored sources.
- `ENV["CC"]`/`ENV["CXX"]` are set to the real compilers: the vendored HDF5 build records `CMAKE_C_COMPILER` in its build-settings blob, which otherwise leaves Homebrew shim paths in the binary.

No runtime `depends_on` on the mappers: simpleaf resolves `piscem`/`alevin-fry` via `simpleaf set-paths` at runtime, `piscem` is not in core, and core's `alevin-fry` 0.16.2 is below simpleaf's `>=0.17.0` floor. Can follow up with a `piscem` formula and an `alevin-fry` bump in separate PRs if wanted.
