### PR TITLE
vapoursynth-bm3d: use pypi sdist

### DIFF
--- a/Formula/v/vapoursynth-bm3d.rb
+++ b/Formula/v/vapoursynth-bm3d.rb
@@ -1,8 +1,8 @@
 class VapoursynthBm3d < Formula
   desc "BM3D denoising filter for VapourSynth"
   homepage "https://github.com/HomeOfVapourSynthEvolution/VapourSynth-BM3D"
-  url "https://github.com/HomeOfVapourSynthEvolution/VapourSynth-BM3D/archive/refs/tags/r10.1.tar.gz"
-  sha256 "3a340c23f4d77559d7c766a2a14f4a1e408752a785958930eb4ca41e13392c85"
+  url "https://files.pythonhosted.org/packages/65/83/ecba54a88f9ec1df08a5ad8aa5ef8cd861fff7911018e821dee206b24289/vapoursynth_bm3d-10.1.tar.gz"
+  sha256 "f6cd25142008b1c4843e727bcc3746479198439ac800e258240c6ab0009ea115"
   license "MIT"
   revision 1
   head "https://github.com/HomeOfVapourSynthEvolution/VapourSynth-BM3D.git", branch: "master"


### PR DESCRIPTION
Switch for better immutability on source url. This is official package:
- https://github.com/HomeOfVapourSynthEvolution/VapourSynth-BM3D#installation

Contents are the same other than expected sdist PKG-INFO:
```
❯ diffoscope --exclude-directory-metadata=yes VapourSynth-BM3D-r10.1 vapoursynth_bm3d-10.1
--- VapourSynth-BM3D-r10.1
+++ vapoursynth_bm3d-10.1
├── file list
│ @@ -1,9 +1,10 @@
│  .github
│  .gitignore
│  LICENSE
│ +PKG-INFO
│  README.md
│  include
│  meson.build
│  msvc
│  pyproject.toml
│  source
```

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
