### PR TITLE
enchant: update checksum

### DIFF
--- a/Formula/e/enchant.rb
+++ b/Formula/e/enchant.rb
@@ -2,7 +2,7 @@ class Enchant < Formula
   desc "Spellchecker wrapping library"
   homepage "https://rrthomas.github.io/enchant/"
   url "https://github.com/rrthomas/enchant/releases/download/v2.8.19/enchant-2.8.19.tar.gz"
-  sha256 "8e7f6cb0c3b79be3146eb3ab93650484adbc59dae5f2c1958fde557080ba678c"
+  sha256 "c8d70991d544ee39274b96bd01d2858a009fe732ff43f2aaf605fd61ecd06f60"
   license "LGPL-2.1-or-later"
   compatibility_version 1
 

--- a/Formula/e/enchant.rb
+++ b/Formula/e/enchant.rb
@@ -7,12 +7,13 @@ class Enchant < Formula
   compatibility_version 1
 
   bottle do
-    sha256 arm64_tahoe:   "5ec902e43601663826459458de83b2163c4921d2fed40201fd0a0d01604801eb"
-    sha256 arm64_sequoia: "55be44a0b1487607c99ee9cf617932e001ad59ec12a7abce004a2636b6b47f58"
-    sha256 arm64_sonoma:  "96fef54beeb48e473300b8a480a373106d7723eb9abf786c8c698f7f78d97aa2"
-    sha256 sonoma:        "4cba9968d795a6b167db50d408bef8e3d0e5e0f82001d0ded07beef41631c557"
-    sha256 arm64_linux:   "e9836769f06b8a068c207e15a58ae776c302eefc51b00f0204e48d98cdac7ea2"
-    sha256 x86_64_linux:  "c386827efe68b7c4b4b3de3baf1aa6a9e014195160d9b4894bee371ce4557355"
+    rebuild 1
+    sha256 arm64_tahoe:   "7fcefb9245bb9bce42441e89b69747c7b74974a4e16d222909cd2b81d0ccc5f9"
+    sha256 arm64_sequoia: "fc26cd865f6f28e3305dc0fcab51fd803cc3cae53f321b499a05b8c3f73e6f1e"
+    sha256 arm64_sonoma:  "c6d162f6d320b3d868e22703d739b6a14e6b2744057a58ebddced0bceb9d53e6"
+    sha256 sonoma:        "4479b73669963a0e7fcea60b33a0306618185b30f3bc903f7e74852913fd4a77"
+    sha256 arm64_linux:   "dad8f77271bf16c3b2e12cece5db04f2fdc1182b3b2335e15ea7853e10e1b9f1"
+    sha256 x86_64_linux:  "ec963b8441c8604ed82ae63cb531cb0fa9b022f0a06f742736cb0970a27bed44"
   end
 
   depends_on "pkgconf" => :build


### PR DESCRIPTION
Tested locally on macOS 26.6.1

Upstream confirms that the v2.8.19 source tarball was replaced on July 13, 2026 to add missing gnulib files required for Windows builds.

Enchant repository's public release announcement: https://github.com/rrthomas/enchant/releases/tag/v2.8.19

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
