### PR TITLE
cyrus-sasl: add workarounds to build on more compilers

### DIFF
--- a/Formula/c/cyrus-sasl.rb
+++ b/Formula/c/cyrus-sasl.rb
@@ -38,12 +38,25 @@ class CyrusSasl < Formula
   uses_from_macos "libxcrypt"
 
   def install
-    with_env(NOCONFIGURE: 1) { system "./autogen.sh" } if build.head?
-    system "./configure",
-      "--disable-macos-framework",
-      "--disable-dependency-tracking",
-      "--disable-silent-rules",
-      "--prefix=#{prefix}"
+    # Workaround for missing time.h. Fixed upstream but backport would require autotools deps
+    # https://github.com/cyrusimap/cyrus-sasl/commit/266f0acf7f5e029afbb3e263437039e50cd6c262
+    # Also force C standard on newer GCC to avoid build failures
+    if build.stable?
+      odie "Remove workarounds!" if version > "2.1.28"
+      ENV.append_to_cflags "-include time.h"
+      if ENV.compiler.to_s.start_with?("gcc") && DevelopmentTools.gcc_version(ENV.compiler) >= 15
+        ENV.append "CFLAGS", "-std=gnu17"
+      end
+    end
+
+    args = %w[
+      --disable-macos-framework
+      --disable-sample
+      --disable-silent-rules
+    ]
+
+    configure = build.head? ? "./autogen.sh" : "./configure"
+    system configure, *args, *std_configure_args
     system "make", "install"
   end
 


### PR DESCRIPTION
* Can manually include time.h until https://github.com/cyrusimap/cyrus-sasl/commit/266f0acf7f5e029afbb3e263437039e50cd6c262 is released
* GNU17 seems to avoid most issues in GCC 15/16.
* Also adding `--disable-sample` as it uses K&R which isn't supported in C23 picked on newer Xcode.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
