### PR TITLE
qrencode: build shared libs

### DIFF
--- a/Formula/g/google-authenticator-libpam.rb
+++ b/Formula/g/google-authenticator-libpam.rb
@@ -7,14 +7,12 @@ class GoogleAuthenticatorLibpam < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any,                 arm64_tahoe:   "bd5ef94f8320f6da49f1cfa681d63bb58d9578ced890f6b1c2811b5451755e0f"
-    sha256 cellar: :any,                 arm64_sequoia: "f2452e49e52b39b37fdbbdadc0d18cee36e55b0e75ccec2c46656597a7c839d5"
-    sha256 cellar: :any,                 arm64_sonoma:  "35fe2b51a3349de745e6d29f7debd894b6d2430933b3a39e7b0b32500a3ee945"
-    sha256 cellar: :any,                 arm64_ventura: "a74302d80e616251e9e877a99ec537d7fe8ac1d8054278df74c85bd84cb24436"
-    sha256 cellar: :any,                 sonoma:        "e8b04f1bb3a6d429869277493bde331a2423ebb8d4f79e59b2eda25f6878521d"
-    sha256 cellar: :any,                 ventura:       "31ab70bcbadee31ff695efad9503ad90d0041d0bae0168aaae4dfb72b4613f97"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "9a271e3a3354b737df9b52c0d00182d8a129c4bf4785fbcf024bedfaebbe9c60"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "664d3b02168d36aedad5165ad643a50686c1cc673b26333d119ffecc51ab92bc"
+    sha256 cellar: :any, arm64_tahoe:   "a17099cc9735309f5d725c89fdbba27bf1e1e935e1c2cd82e67a109af595cd9f"
+    sha256 cellar: :any, arm64_sequoia: "98e2cf64e941d7fa153e15a3ebd7998614442951fc5e99c9745c988b7b582ba0"
+    sha256 cellar: :any, arm64_sonoma:  "91f85a6f6b124ca0c30387349a957dd915234e7469b7044c506713661813fc1b"
+    sha256 cellar: :any, sonoma:        "7f7ec765e16362f48a27fedeb996113bd7c0bba024488c360ae700da6f0c946c"
+    sha256 cellar: :any, arm64_linux:   "66333f19942f381adffcc55fc75223e741722d667064bf9cdc8aab9c9c9d758f"
+    sha256 cellar: :any, x86_64_linux:  "fd5066487cb83cb932c4a534cc8e5de72a1462ac8bc01517680c7139cb50b4c3"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/g/google-authenticator-libpam.rb
+++ b/Formula/g/google-authenticator-libpam.rb
@@ -4,6 +4,7 @@ class GoogleAuthenticatorLibpam < Formula
   url "https://github.com/google/google-authenticator-libpam/archive/refs/tags/1.11.tar.gz"
   sha256 "3ee08a6dd46aace7dba1c88cf47e9cd267447ccd1cd8be1d5a05fd0e6816062d"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_tahoe:   "bd5ef94f8320f6da49f1cfa681d63bb58d9578ced890f6b1c2811b5451755e0f"

--- a/Formula/p/profanity.rb
+++ b/Formula/p/profanity.rb
@@ -4,6 +4,7 @@ class Profanity < Formula
   url "https://profanity-im.github.io/tarballs/profanity-0.18.2.tar.xz"
   sha256 "46964928742733fffcf8ca65d37ac0874c8ccd6270cbc065cb1013cee94e9e3b"
   license "GPL-3.0-or-later"
+  revision 1
   head "https://github.com/profanity-im/profanity.git", branch: "master"
 
   bottle do

--- a/Formula/p/profanity.rb
+++ b/Formula/p/profanity.rb
@@ -8,12 +8,12 @@ class Profanity < Formula
   head "https://github.com/profanity-im/profanity.git", branch: "master"
 
   bottle do
-    sha256 arm64_tahoe:   "db226be2bfadd4f947d10df20bd56515807400ab6a116f47f1b9f9e9e3c313c2"
-    sha256 arm64_sequoia: "34daf7682c6ab0225c7e3b3109bb885d19ee3d485aabf8ac7a592fca6b15bd3d"
-    sha256 arm64_sonoma:  "f8fd013b0c8194ebea2c3c266a8bc71a11a2ffb92d18e6fed8274089219ffca4"
-    sha256 sonoma:        "6d4951d4ac8850b111e550183091e3ef63d80c080ac32e97f62af9fbb51093bb"
-    sha256 arm64_linux:   "6e973dff83a86be94d0e5f976a32a113f438fb935ed8c52f3cefeb1c61eaf656"
-    sha256 x86_64_linux:  "39e42b641a2108c51dd846cc9f89d1c44bf935fc1b48deadee9eb5184c94b719"
+    sha256 arm64_tahoe:   "30b0296eed40de1140470010da6fe562574a802c6f41ff1848e519e897b7971f"
+    sha256 arm64_sequoia: "047d3d9b82750ac907046107803d465738dec5692b6180cc931f8b234cbe0940"
+    sha256 arm64_sonoma:  "509d59ceaab4bdf334f58e24af6391bc9b2151345b40ac95038299fd8399a36e"
+    sha256 sonoma:        "107b58f0db1b558f20f76e59633ebe6f628ebd7dd1a44406d62fee8c85e5551b"
+    sha256 arm64_linux:   "c1862ab73b74923268ae57e7ebc966cc5804bff0ae4b6eaf5023f28c74b07e86"
+    sha256 x86_64_linux:  "f3512d92fd693b0e65dcd9912c7166652f04d2cc9829d22fa76d5df04ae970d5"
   end
 
   depends_on "meson" => :build

--- a/Formula/q/qrencode.rb
+++ b/Formula/q/qrencode.rb
@@ -9,15 +9,12 @@ class Qrencode < Formula
   head "https://github.com/fukuchi/libqrencode.git", branch: "master"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_tahoe:   "43022662b77fc3e4181eb5b0d8e671f6208c9217c307073c2e76d4e5c98ea9f9"
-    sha256 cellar: :any,                 arm64_sequoia: "3fec9ad635eb185c133cca4e3ab3e8ab7c2094453c462c457b1e5624960bca35"
-    sha256 cellar: :any,                 arm64_sonoma:  "74e41b86ddec16b100ac17a756235f377b0e7b8990af8e37a66571b204db40c8"
-    sha256 cellar: :any,                 arm64_ventura: "01e05ae6c40b460ebc0dbba2fe76a4310ee538a692e7712dda77c07e18789ed8"
-    sha256 cellar: :any,                 sonoma:        "b9af340917ff148b24e48c24e5313423e16df56a99a7a612d0b23af59e2394b9"
-    sha256 cellar: :any,                 ventura:       "6995e471fbd7e8f9c3c507e7576ba53a5636fb329a049f61f54494b7b5d9fe2c"
-    sha256 cellar: :any_skip_relocation, arm64_linux:   "1a598b96cd3fa15c9c028d7c6d86f884ece57ac86feca9939e862b17a14143bf"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "181bcd364cef78e8be564a42859f3b431febc429fc3db940d5c06bb572493999"
+    sha256 cellar: :any, arm64_tahoe:   "52a9ea0465a3446c8b0930bbd7c0d5ac0c84c350992fe4937de39301758e2f20"
+    sha256 cellar: :any, arm64_sequoia: "8f2cb82a0924e1d5b2ce0f5edbc59884bfb35b5ab8a7dae5a7b3f362679e278a"
+    sha256 cellar: :any, arm64_sonoma:  "4f2202e6beb0a9526a4cda427da325a019a1eca2dcc60e6a3986c8221828a7da"
+    sha256 cellar: :any, sonoma:        "3e025adbdbbab93dcaf86de897a088fc123ce3e950d7de7ca5feb61918286671"
+    sha256 cellar: :any, arm64_linux:   "cca7bf38108300b9a5c9e0cec11fa387f789ca9191847a39e3a5fae13691858b"
+    sha256 cellar: :any, x86_64_linux:  "cc915641ac9e2b18c6973ea1c1396b2aa5fe53b3ad21104b5ebe1dcd52b39f55"
   end
 
   depends_on "cmake" => :build

--- a/Formula/q/qrencode.rb
+++ b/Formula/q/qrencode.rb
@@ -4,7 +4,8 @@ class Qrencode < Formula
   url "https://github.com/fukuchi/libqrencode/archive/refs/tags/v4.1.1.tar.gz"
   sha256 "5385bc1b8c2f20f3b91d258bf8ccc8cf62023935df2d2676b5b67049f31a049c"
   license "LGPL-2.1-or-later"
-  compatibility_version 1
+  revision 1
+  compatibility_version 2
   head "https://github.com/fukuchi/libqrencode.git", branch: "master"
 
   bottle do
@@ -24,7 +25,11 @@ class Qrencode < Formula
   depends_on "libpng"
 
   def install
-    args = %w[-DCMAKE_POLICY_VERSION_MINIMUM=3.5]
+    args = %W[
+      -DBUILD_SHARED_LIBS=ON
+      -DCMAKE_INSTALL_RPATH=#{rpath}
+      -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+    ]
     system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"


### PR DESCRIPTION
Revision bumps & compatibility version change as mixing older static-library-only `qrencode` with newer dynamically linked dependent will lead to broken linkage.

Specifically, if a user already has `brew install qrencode`, then a future `brew install profanity` needs to install newer `qrencode` to work.

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
