### PR TITLE
pgstream: fix test for PostgreSQL 18.6 output_plugin_libraries restri…

### DIFF
--- a/Formula/p/pgstream.rb
+++ b/Formula/p/pgstream.rb
@@ -36,10 +36,11 @@ class Pgstream < Formula
 
     system pg_ctl, "initdb", "-D", testpath/"test"
     (testpath/"test/postgresql.conf").write <<~CONF, mode: "a+"
-      port = #{port}
-      shared_preload_libraries = 'wal2json'
-      wal_level = logical
-    CONF
+  port = #{port}
+  shared_preload_libraries = 'wal2json'
+  wal_level = logical
+  output_plugin_libraries = 'pgoutput, test_decoding, wal2json'
+CONF
     system pg_ctl, "start", "-D", testpath/"test", "-l", testpath/"log"
 
     begin


### PR DESCRIPTION
postgresql@18 18.6 introduced a new whitelist GUC, output_plugin_libraries,
   restricting logical decoding output plugins to pgoutput and test_decoding
   by default (CVE-2026-6471). pgstream's test uses the wal2json plugin, which
   is no longer implicitly allowed, causing:

   ERROR: library "wal2json" may not be used as an output plugin (SQLSTATE 42501)

   This adds wal2json to output_plugin_libraries in the test's postgresql.conf.

   Fixes the test-dependents failure blocking #298635.
   https://www.postgresql.org/docs/18/release-18-6.html

postgresql@18 18.6 restricts logical decoding output plugins to pgoutput and test_decoding by default (CVE-2026-6471). Add wal2json to output_plugin_libraries so pgstream's test can create a replication slot

-----

<!-- Do not tick a checkbox if you haven’t performed its action. Honesty is indispensable for a smooth review process. -->
<!-- Use [x] to mark item done before creation, or just click the checkboxes with device pointer after creation -->
<!-- In the following questions `<formula>` is the name of the formula you're editing. -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [ ] Is your test running fine `brew test <formula>`?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

<!-- If AI was used, explain below how it was used and how you verified the changes. Non-maintainers may only have one AI-assisted PR open at a time. See https://docs.brew.sh/Responsible-AI-Usage for guidance. -->

-----
