### PR TITLE
container: build and install the k8s plugin

### DIFF
--- a/Formula/c/container.rb
+++ b/Formula/c/container.rb
@@ -4,6 +4,7 @@ class Container < Formula
   url "https://github.com/apple/container/archive/refs/tags/1.2.2.tar.gz"
   sha256 "61841d675a6542179aaa1b48ec00dc2ff8b888a58d9ec0d87fa279b30b9b5ced"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/apple/container.git", branch: "main"
 
   bottle do
@@ -39,6 +40,8 @@ class Container < Formula
       "container-runtime-linux" => { source: "RuntimeLinux",     entitlements: true  },
       "machine-apiserver"       => { source: "MachineAPIServer", entitlements: false,
                                      resources: ["init", "create-user.sh"] },
+      "k8s"                     => { source: "K8s",              entitlements: false,
+                                     resources: ["kindnet.yaml"] },
     }
     plugins.each do |bin_name, opts|
       plugin_dir = libexec/"container-plugins/#{bin_name}"

--- a/Formula/c/container.rb
+++ b/Formula/c/container.rb
@@ -8,7 +8,7 @@ class Container < Formula
   head "https://github.com/apple/container.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_tahoe: "3d0839a9ac3e8376bcd8b865fce165160b65d52237a34ce29c773cf814dc7f12"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe: "73abfead9c7f27b216ce4c325117bda5ebfce00ac10c4c7085bb05ba5fee8ab2"
   end
 
   depends_on xcode: ["26.0", :build]


### PR DESCRIPTION
-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [x] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

AI disclosure: prepared with Claude Code (claude-fable-5). I reviewed the diff, and the build/test/audit runs above were performed on my machine. I will answer review comments myself.

-----

The 1.2.2 release tarball ships a fifth plugin the formula does not build: `k8s` (added upstream in apple/container#2043), the local Kubernetes cluster support behind `container k8s`. Apple's signed installer pkg stages and signs it alongside the other plugins (see the upstream `Makefile` staging target), so `container k8s` works from a pkg install but is absent from a brew install.

This builds and installs it like the existing plugins: no entitlements, one resource (`kindnet.yaml`), signed with the same `com.apple.container.` identifier prefix the upstream Makefile uses. Revision bumped so existing installs pick the plugin up.

Verified locally on arm64 Tahoe: with the system services running, `container k8s --version` resolves the plugin from `libexec/container-plugins/k8s/` and reports the CLI version; `container k8s create --help` renders the plugin's help.
