### PR TITLE
cuttlefish 3.0.0 (new formula)

### DIFF
--- a/Formula/c/cuttlefish.rb
+++ b/Formula/c/cuttlefish.rb
@@ -1,0 +1,32 @@
+class Cuttlefish < Formula
+  desc "Build compacted de Bruijn graphs from references or reads"
+  homepage "https://combine-lab.github.io/cuttlefish/"
+  url "https://github.com/COMBINE-lab/cuttlefish/archive/refs/tags/v3.0.0.tar.gz"
+  sha256 "8a6df5044d5daf26d2e728f74b4d0b241ae38e5c9bc76b4513e68b9b60d7cf78"
+  license "BSD-3-Clause"
+  head "https://github.com/COMBINE-lab/cuttlefish.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args(path: "crates/cuttlefish-rs-cli")
+  end
+
+  test do
+    seq = "ACGTTGCAATCGGATCCTAGGCATTACGGTTACCGATTCAGGCTAAGTCCATGGCATCAGT"
+
+    (testpath/"ref.fa").write <<~FASTA
+      >test
+      #{seq}
+    FASTA
+
+    system bin/"cuttlefish", "build", "--ref", "--seq", "ref.fa",
+           "-k", "31", "-t", "1", "-w", testpath/"work", "-o", testpath/"graph"
+
+    unitigs = (testpath/"graph.fa").read.lines.grep_v(/^>/).map(&:chomp)
+    assert_equal 1, unitigs.length
+    assert_equal seq.length, unitigs.first.length
+
+    assert_match version.to_s, shell_output("#{bin}/cuttlefish version")
+  end
+end

--- a/Formula/c/cuttlefish.rb
+++ b/Formula/c/cuttlefish.rb
@@ -6,6 +6,15 @@ class Cuttlefish < Formula
   license "BSD-3-Clause"
   head "https://github.com/COMBINE-lab/cuttlefish.git", branch: "main"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "a93b89acab8fbd217448566870e441543a2196f2a21587da14f98aa4e76bd84a"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "9bef53c8395475decf053cef4ca93e7312635b6ca382f724449abf7bc3935428"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "b6b0689c2e1c1a146be3c1c6b5fc04a03e197d2210609559ea90c460536c0247"
+    sha256 cellar: :any_skip_relocation, sonoma:        "004965e418d46e0812453bf920e536140b300284dfc5cac983ec70abee2b2625"
+    sha256 cellar: :any,                 arm64_linux:   "ae23e8f7c68e830a032dc97f4a7d5b34816a13493e9a99117a93e10620b5d339"
+    sha256 cellar: :any,                 x86_64_linux:  "bb73abcb100bd39d67ee0479ecef6e057c07ab8406aab90e548f7f3bf191db11"
+  end
+
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`?
- [x] Is your test running fine `brew test <formula>`?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- [ ] I did not use AI/LLM to create this PR, or I disclosed the tool/model below and reviewed its output; I did not attribute commits to AI and will answer maintainer questions and review comments myself without AI/LLM.

AI-assisted contribution by Claude Code (Claude Opus 5) of ~85% of the work: the AI wrote the formula and ran `brew install --build-from-source`, `brew test`, `brew audit --new --strict --online` and `brew style`. I reviewed the formula and those results before opening this PR. The commit carries no AI attribution trailer.

Built and tested locally on macOS 26.6.1 running arm64.

-----

New formula for Cuttlefish 3, a parallel external-memory tool for building uncolored and colored compacted de Bruijn graphs (RECOMB 2026; preprint [10.1101/2025.02.02.636161](https://doi.org/10.1101/2025.02.02.636161)).

Cuttlefish 3 is a Rust workspace and the binary lives in a workspace member, hence `std_cargo_args(path: "crates/cuttlefish-rs-cli")`. No non-Rust dependencies: zlib is the pure-Rust `zlib-rs` backend and the allocator is vendored jemalloc.

The test builds the graph of a single 61 bp reference at k=31 and checks the output holds exactly one unitig of that length.
